### PR TITLE
refactor(site/src/pages/AgentsPage): make chatStatus canonical in the query cache

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -10,8 +10,10 @@ import {
 import { buildOptimisticEditedMessage } from "./chatMessageEdits";
 import {
 	addChildToParentInCache,
+	applyServerChatStatusToCaches,
 	archiveChat,
 	CHAT_SUMMARY_STALE_MS,
+	cancelChatDetailPreservingStatus,
 	cancelChatListRefetches,
 	cancelChatMutationRefetches,
 	canonicalizeChatListFilters,
@@ -36,6 +38,9 @@ import {
 	invalidateChatListQueries,
 	invalidatePRStatusChatListQueries,
 	listFiltersFromKey,
+	mergeCommittedChatDetail,
+	mergeCommittedChatList,
+	mergeCommittedChatSearch,
 	mergeWatchedChatIntoCaches,
 	mergeWatchedChatSummary,
 	paginatedChatCostUsers,
@@ -43,11 +48,15 @@ import {
 	pinChat,
 	promoteChatQueuedMessage,
 	proposeChatTitle,
+	readCachedChatSnapshotVersion,
+	readCachedChatStatus,
 	removeChildFromParentInCache,
 	reorderPinnedChat,
+	rollbackOptimisticChatStatus,
 	selectSortedChatList,
 	setChatGroupRole,
 	setChatUserRole,
+	shouldApplyServerChatStatus,
 	TERMINAL_RUN_STATUSES,
 	unarchiveChat,
 	unpinChat,
@@ -56,6 +65,7 @@ import {
 	updateChatTitle,
 	updateChildInParentCache,
 	updateInfiniteChatsCache,
+	writeOptimisticChatStatus,
 } from "./chats";
 
 vi.mock("#/api/api", () => ({
@@ -64,6 +74,7 @@ vi.mock("#/api/api", () => ({
 			updateChat: vi.fn(),
 			createChat: vi.fn(),
 			deleteChatQueuedMessage: vi.fn(),
+			getChat: vi.fn(),
 			getChats: vi.fn(),
 			getChatCost: vi.fn(),
 			getChatCostSummary: vi.fn(),
@@ -3013,6 +3024,7 @@ describe("mergeWatchedChatSummary", () => {
 			title: "Stale title",
 			last_model_config_id: "model-new",
 			updated_at: "2025-01-01T00:05:00.000Z",
+			snapshot_version: 2,
 		});
 
 		expect(
@@ -3170,6 +3182,7 @@ describe("mergeWatchedChatSummary", () => {
 			status: "running",
 			last_model_config_id: "model-new",
 			updated_at: "2025-01-01T00:00:00.1203Z",
+			snapshot_version: 2,
 		});
 
 		expect(
@@ -3339,6 +3352,7 @@ describe("mergeWatchedChatSummary", () => {
 		const watchedChat = makeChat("chat-1", {
 			status: "waiting",
 			updated_at: "2025-01-01T00:05:00.000Z",
+			snapshot_version: 2,
 		});
 
 		expect(
@@ -3388,6 +3402,40 @@ describe("mergeWatchedChatSummary", () => {
 });
 
 describe("mergeWatchedChatIntoCaches", () => {
+	it("keeps each matched query's dataUpdatedAt", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		// A watch event pushes a subset of the fields, so it must not postpone
+		// the refetch that catches up the rest.
+		const seededUpdatedAt = 1_000;
+		const cachedChat = makeChat(chatId, {
+			status: "waiting",
+			snapshot_version: 1,
+		});
+		queryClient.setQueryData(chatKeys.detail(chatId), cachedChat, {
+			updatedAt: seededUpdatedAt,
+		});
+		queryClient.setQueryData(
+			chatKeys.list(),
+			{ pages: [[cachedChat]], pageParams: [0] },
+			{ updatedAt: seededUpdatedAt },
+		);
+
+		mergeWatchedChatIntoCaches(
+			queryClient,
+			makeChat(chatId, { status: "running", snapshot_version: 2 }),
+			{ eventKind: "status_change" },
+		);
+
+		expect(
+			queryClient.getQueryState(chatKeys.detail(chatId))?.dataUpdatedAt,
+		).toBe(seededUpdatedAt);
+		expect(queryClient.getQueryState(chatKeys.list())?.dataUpdatedAt).toBe(
+			seededUpdatedAt,
+		);
+		expect(readCachedChatStatus(queryClient, chatId)).toBe("running");
+	});
+
 	it("merges last_model_config_id into the root list cache and per-chat cache", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
@@ -3400,6 +3448,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 			status: "running",
 			last_model_config_id: "model-new",
 			updated_at: "2025-01-01T00:05:00.000Z",
+			snapshot_version: 2,
 		});
 
 		seedInfiniteChats(queryClient, [cachedChat]);
@@ -3440,6 +3489,7 @@ describe("mergeWatchedChatIntoCaches", () => {
 			status: "running",
 			last_model_config_id: "model-new",
 			updated_at: "2025-01-01T00:05:00.000Z",
+			snapshot_version: 2,
 		});
 
 		seedInfiniteChats(queryClient, [parent]);
@@ -3931,5 +3981,799 @@ describe(clearChatUnreadInCaches.name, () => {
 		clearChatUnreadInCaches(queryClient, "chat-1");
 
 		expect(queryClient.getQueryData(chatKeys.list())).toBe(before);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Chat status ordering
+// ---------------------------------------------------------------------------
+
+describe("shouldApplyServerChatStatus", () => {
+	it("applies a strictly newer version, rejects equal and older ones", () => {
+		expect(shouldApplyServerChatStatus(4, 5)).toBe(true);
+		expect(shouldApplyServerChatStatus(5, 5)).toBe(false);
+		expect(shouldApplyServerChatStatus(5, 4)).toBe(false);
+	});
+
+	it("coerces an absent version on either side to zero", () => {
+		// A raw comparison against undefined is false in both directions,
+		// which would reject every write instead of accepting the newer one.
+		expect(shouldApplyServerChatStatus(undefined, 5)).toBe(true);
+		expect(shouldApplyServerChatStatus(5, undefined)).toBe(false);
+		expect(shouldApplyServerChatStatus(undefined, undefined)).toBe(false);
+		expect(shouldApplyServerChatStatus(undefined, 0)).toBe(false);
+	});
+});
+
+describe("mergeCommittedChatDetail", () => {
+	it("applies a payload carrying a newer snapshot version", () => {
+		const prev = makeChat("chat-1", { status: "waiting", snapshot_version: 4 });
+		const next = makeChat("chat-1", { status: "running", snapshot_version: 5 });
+
+		expect(mergeCommittedChatDetail(prev, next)).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+	});
+
+	it("keeps the cached status and version when the payload is older", () => {
+		const prev = makeChat("chat-1", { status: "running", snapshot_version: 7 });
+		const next = makeChat("chat-1", {
+			status: "waiting",
+			snapshot_version: 5,
+			title: "Fresh title",
+		});
+
+		expect(mergeCommittedChatDetail(prev, next)).toMatchObject({
+			status: "running",
+			snapshot_version: 7,
+			// Everything the stale payload is still authoritative for is taken.
+			title: "Fresh title",
+		});
+	});
+
+	it("treats an equal version as a duplicate and keeps the cached status", () => {
+		const prev = makeChat("chat-1", { status: "running", snapshot_version: 5 });
+		const next = makeChat("chat-1", { status: "waiting", snapshot_version: 5 });
+
+		expect(mergeCommittedChatDetail(prev, next)).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+	});
+
+	it("preserves structural sharing for an unchanged payload", () => {
+		const prev = makeChat("chat-1", { status: "running", snapshot_version: 5 });
+		const next = makeChat("chat-1", { status: "running", snapshot_version: 5 });
+
+		// A custom structuralSharing replaces the default, so the merge has to
+		// call replaceEqualDeep itself or every consumer rerenders per fetch.
+		expect(mergeCommittedChatDetail(prev, next)).toBe(prev);
+	});
+
+	it("keeps an optimistic status against an equal-version payload", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+		writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		const prev = queryClient.getQueryData<TypesGen.Chat>(
+			chatKeys.detail("chat-1"),
+		);
+		const next = makeChat("chat-1", { status: "waiting", snapshot_version: 5 });
+
+		expect(mergeCommittedChatDetail(prev, next)).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+	});
+
+	it("drops the optimistic token when a newer server version lands", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+		writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		const prev = queryClient.getQueryData<TypesGen.Chat>(
+			chatKeys.detail("chat-1"),
+		);
+		const next = makeChat("chat-1", { status: "error", snapshot_version: 6 });
+
+		const merged = mergeCommittedChatDetail(prev, next);
+		expect(merged).toMatchObject({ status: "error", snapshot_version: 6 });
+		expect("__optimistic" in merged).toBe(false);
+	});
+
+	it("orders the children a parent payload embeds", () => {
+		const prev = makeChat("parent-1", {
+			children: [
+				makeChat("child-1", { status: "running", snapshot_version: 9 }),
+				makeChat("child-2", { status: "waiting", snapshot_version: 2 }),
+			],
+		});
+		const next = makeChat("parent-1", {
+			children: [
+				makeChat("child-1", {
+					status: "waiting",
+					snapshot_version: 8,
+					title: "Renamed child",
+				}),
+				makeChat("child-2", { status: "error", snapshot_version: 3 }),
+			],
+		});
+
+		const merged = mergeCommittedChatDetail(prev, next);
+
+		// A parent fetch issued before a child's status event must not regress
+		// that child, while a newer child status is still adopted.
+		expect(merged.children?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+			title: "Renamed child",
+		});
+		expect(merged.children?.[1]).toMatchObject({
+			status: "error",
+			snapshot_version: 3,
+		});
+	});
+});
+
+describe("chat detail structuralSharing", () => {
+	it("stops a stale refetch from regressing a newer cached status", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		// The socket already wrote version 9.
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, {
+				status: "running",
+				snapshot_version: 9,
+				title: "Old title",
+			}),
+		);
+		// The refetch in flight since before that carries version 8.
+		vi.mocked(API.experimental.getChat).mockResolvedValue(
+			makeChat(chatId, {
+				status: "waiting",
+				snapshot_version: 8,
+				title: "New title",
+			}),
+		);
+
+		// staleTime keeps a seeded entry fresh, so ask for the fetch explicitly.
+		await queryClient.fetchQuery({ ...chatDetail(chatId), staleTime: 0 });
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
+		).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+			title: "New title",
+		});
+	});
+
+	it("adopts a refetch carrying a newer snapshot version", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { status: "running", snapshot_version: 9 }),
+		);
+		vi.mocked(API.experimental.getChat).mockResolvedValue(
+			makeChat(chatId, { status: "waiting", snapshot_version: 10 }),
+		);
+
+		// staleTime keeps a seeded entry fresh, so ask for the fetch explicitly.
+		await queryClient.fetchQuery({ ...chatDetail(chatId), staleTime: 0 });
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
+		).toMatchObject({ status: "waiting", snapshot_version: 10 });
+	});
+});
+
+describe("mergeCommittedChatList", () => {
+	it("preserves newer cached statuses in rows and embedded children", () => {
+		const cachedChild = makeChat("child-1", {
+			status: "running",
+			snapshot_version: 9,
+		});
+		const prev = {
+			pages: [
+				[
+					makeChat("chat-1", { status: "running", snapshot_version: 9 }),
+					makeChat("parent-1", { children: [cachedChild] }),
+				],
+			],
+			pageParams: [0],
+		};
+		const next = {
+			pages: [
+				[
+					makeChat("chat-1", {
+						status: "waiting",
+						snapshot_version: 8,
+						title: "Renamed",
+					}),
+					makeChat("parent-1", {
+						children: [
+							makeChat("child-1", { status: "waiting", snapshot_version: 8 }),
+						],
+					}),
+				],
+			],
+			pageParams: [0],
+		};
+
+		const merged = mergeCommittedChatList(prev, next);
+
+		expect(merged.pages[0][0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+			title: "Renamed",
+		});
+		expect(merged.pages[0][1].children?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+		});
+	});
+
+	it("returns the cached data when nothing changed", () => {
+		const prev = {
+			pages: [[makeChat("chat-1", { status: "running", snapshot_version: 9 })]],
+			pageParams: [0],
+		};
+		const next = {
+			pages: [[makeChat("chat-1", { status: "running", snapshot_version: 9 })]],
+			pageParams: [0],
+		};
+
+		expect(mergeCommittedChatList(prev, next)).toBe(prev);
+	});
+
+	it("is wired into the list query, so a stale page cannot regress a row", async () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [
+			makeChat("chat-1", { status: "running", snapshot_version: 9 }),
+		]);
+		vi.mocked(API.experimental.getChats).mockResolvedValue([
+			makeChat("chat-1", {
+				status: "waiting",
+				snapshot_version: 8,
+				title: "Renamed",
+			}),
+		]);
+
+		await queryClient.fetchInfiniteQuery({
+			...infiniteChats(),
+			staleTime: 0,
+		});
+
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+			title: "Renamed",
+		});
+	});
+
+	it("orders against the most advanced copy of a duplicated row", () => {
+		// Pagination can place the same chat on two loaded pages. The stale
+		// copy must not become the baseline just by being scanned last.
+		const prev = {
+			pages: [
+				[makeChat("chat-1", { status: "running", snapshot_version: 9 })],
+				[makeChat("chat-1", { status: "waiting", snapshot_version: 3 })],
+			],
+			pageParams: [0, 1],
+		};
+		const next = {
+			pages: [
+				[makeChat("chat-1", { status: "waiting", snapshot_version: 8 })],
+				[makeChat("chat-1", { status: "waiting", snapshot_version: 8 })],
+			],
+			pageParams: [0, 1],
+		};
+
+		const merged = mergeCommittedChatList(prev, next);
+
+		expect(merged.pages[0][0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+		});
+		expect(merged.pages[1][0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+		});
+	});
+
+	it("keeps an optimistic status over a same-version duplicate", () => {
+		const queryClient = createTestQueryClient();
+		seedInfiniteChats(queryClient, [
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		]);
+		writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		const optimisticRow = queryClient.getQueryData<InfiniteData>(
+			chatKeys.list(),
+		)?.pages[0][0];
+		if (!optimisticRow) {
+			throw new Error("expected the seeded row");
+		}
+		const prev = {
+			pages: [
+				[optimisticRow],
+				[makeChat("chat-1", { status: "waiting", snapshot_version: 5 })],
+			],
+			pageParams: [0, 1],
+		};
+		const next = {
+			pages: [
+				[makeChat("chat-1", { status: "waiting", snapshot_version: 5 })],
+				[makeChat("chat-1", { status: "waiting", snapshot_version: 5 })],
+			],
+			pageParams: [0, 1],
+		};
+
+		expect(mergeCommittedChatList(prev, next).pages[0][0]).toMatchObject({
+			status: "running",
+		});
+	});
+});
+
+describe("mergeCommittedChatSearch", () => {
+	it("keeps a newer cached status and takes the rest of the payload", () => {
+		const prev = [
+			makeChat("chat-1", { status: "running", snapshot_version: 9 }),
+		];
+		const next = [
+			makeChat("chat-1", {
+				status: "waiting",
+				snapshot_version: 8,
+				title: "Renamed",
+			}),
+		];
+
+		expect(mergeCommittedChatSearch(prev, next)[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 9,
+			title: "Renamed",
+		});
+	});
+
+	it("is wired into the search query, so a stale response cannot regress a row", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatKeys.search("foo"), [
+			makeChat("chat-1", { status: "running", snapshot_version: 9 }),
+		]);
+		vi.mocked(API.experimental.getChats).mockResolvedValue([
+			makeChat("chat-1", { status: "waiting", snapshot_version: 8 }),
+		]);
+
+		await queryClient.fetchQuery({ ...chatSearch("foo"), staleTime: 0 });
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatKeys.search("foo"))?.[0],
+		).toMatchObject({ status: "running", snapshot_version: 9 });
+	});
+});
+
+describe("applyServerChatStatusToCaches", () => {
+	it("writes status and version to the detail, list rows, and children", () => {
+		const queryClient = createTestQueryClient();
+		const child = makeChat("child-1", { status: "waiting" });
+		seedInfiniteChats(queryClient, [
+			makeChat("chat-1", { status: "waiting" }),
+			makeChat("parent-1", { children: [child] }),
+		]);
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "waiting" }),
+		);
+
+		applyServerChatStatusToCaches(queryClient, "chat-1", "running", 5);
+		applyServerChatStatusToCaches(queryClient, "child-1", "error", 5);
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail("chat-1")),
+		).toMatchObject({ status: "running", snapshot_version: 5 });
+		const chats = readInfiniteChats(queryClient);
+		expect(chats?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+		expect(chats?.[1].children?.[0]).toMatchObject({
+			status: "error",
+			snapshot_version: 5,
+		});
+	});
+
+	it("rejects a status carrying an older version per cache layer", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "running", snapshot_version: 9 }),
+		);
+		seedInfiniteChats(queryClient, [
+			makeChat("chat-1", { status: "waiting", snapshot_version: 2 }),
+		]);
+
+		applyServerChatStatusToCaches(queryClient, "chat-1", "waiting", 5);
+
+		// The detail is already past version 5; the list row is not.
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail("chat-1")),
+		).toMatchObject({ status: "running", snapshot_version: 9 });
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			status: "waiting",
+			snapshot_version: 5,
+		});
+	});
+
+	it("keeps each matched query's dataUpdatedAt", () => {
+		const queryClient = createTestQueryClient();
+		// A distinctly old timestamp: a status write must not refresh the
+		// freshness budget the non-pushed fields depend on.
+		const seededUpdatedAt = 1_000;
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "waiting" }),
+			{ updatedAt: seededUpdatedAt },
+		);
+		queryClient.setQueryData(
+			chatKeys.list(),
+			{ pages: [[makeChat("chat-1", { status: "waiting" })]], pageParams: [0] },
+			{ updatedAt: seededUpdatedAt },
+		);
+
+		applyServerChatStatusToCaches(queryClient, "chat-1", "running", 5);
+
+		expect(
+			queryClient.getQueryState(chatKeys.detail("chat-1"))?.dataUpdatedAt,
+		).toBe(seededUpdatedAt);
+		expect(queryClient.getQueryState(chatKeys.list())?.dataUpdatedAt).toBe(
+			seededUpdatedAt,
+		);
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("running");
+	});
+
+	it("reads back the cached status and version", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "waiting" }),
+		);
+
+		applyServerChatStatusToCaches(queryClient, "chat-1", "running", 5);
+
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("running");
+		expect(readCachedChatSnapshotVersion(queryClient, "chat-1")).toBe(5);
+		expect(readCachedChatStatus(queryClient, undefined)).toBeNull();
+		expect(readCachedChatSnapshotVersion(queryClient, "missing")).toBe(0);
+	});
+
+	it("writes the child a loaded parent detail embeds", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(
+			chatKeys.detail("parent-1"),
+			makeChat("parent-1", {
+				children: [
+					makeChat("child-1", { status: "waiting", snapshot_version: 4 }),
+				],
+			}),
+		);
+
+		applyServerChatStatusToCaches(queryClient, "child-1", "running", 5);
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail("parent-1"))
+				?.children?.[0],
+		).toMatchObject({ status: "running", snapshot_version: 5 });
+	});
+
+	it("writes every cached search result", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatKeys.search("foo"), [
+			makeChat("chat-1", { status: "waiting", snapshot_version: 4 }),
+			makeChat("chat-2", { status: "waiting", snapshot_version: 4 }),
+		]);
+
+		applyServerChatStatusToCaches(queryClient, "chat-1", "running", 5);
+
+		const results = queryClient.getQueryData<TypesGen.Chat[]>(
+			chatKeys.search("foo"),
+		);
+		expect(results?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+		expect(results?.[1].status).toBe("waiting");
+	});
+
+	it("reports whether the chat's own detail took the status", () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(
+			chatKeys.detail("chat-1"),
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+
+		// Callers run stream side effects only for the status the open chat
+		// actually holds now.
+		expect(
+			applyServerChatStatusToCaches(queryClient, "chat-1", "running", 6),
+		).toBe(true);
+		expect(
+			applyServerChatStatusToCaches(queryClient, "chat-1", "waiting", 4),
+		).toBe(false);
+		expect(
+			applyServerChatStatusToCaches(queryClient, "chat-1", "waiting", 6),
+		).toBe(false);
+		expect(
+			applyServerChatStatusToCaches(
+				queryClient,
+				"chat-1",
+				"waiting",
+				undefined,
+			),
+		).toBe(false);
+		expect(
+			applyServerChatStatusToCaches(queryClient, "missing", "waiting", 9),
+		).toBe(false);
+	});
+});
+
+describe("cancelChatDetailPreservingStatus", () => {
+	it("keeps a status the socket wrote while the fetch was in flight", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { status: "waiting", snapshot_version: 4 }),
+		);
+		// A refetch that never resolves, so the cancel below reverts the query
+		// to the state it captured when this fetch started.
+		vi.mocked(API.experimental.getChat).mockImplementation(
+			() => new Promise<TypesGen.Chat>(() => {}),
+		);
+		const pendingFetch = queryClient.fetchQuery({
+			...chatDetail(chatId),
+			staleTime: 0,
+		});
+
+		applyServerChatStatusToCaches(queryClient, chatId, "running", 5);
+
+		await cancelChatDetailPreservingStatus(queryClient, chatId, () =>
+			queryClient.cancelQueries({
+				queryKey: chatKeys.detail(chatId),
+				exact: true,
+			}),
+		);
+		await pendingFetch.catch(() => undefined);
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
+		).toMatchObject({ status: "running", snapshot_version: 5 });
+	});
+
+	it("leaves a status newer than the snapshot alone", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(
+			chatKeys.detail(chatId),
+			makeChat(chatId, { status: "waiting", snapshot_version: 4 }),
+		);
+
+		await cancelChatDetailPreservingStatus(queryClient, chatId, async () => {
+			applyServerChatStatusToCaches(queryClient, chatId, "running", 6);
+		});
+
+		// The re-applied snapshot is older than what the cache holds, and equal
+		// or older versions lose.
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatId)),
+		).toMatchObject({ status: "running", snapshot_version: 6 });
+	});
+});
+
+describe("optimistic chat status", () => {
+	const seedChat = (queryClient: QueryClient, chat: TypesGen.Chat) => {
+		queryClient.setQueryData(chatKeys.detail(chat.id), chat);
+		seedInfiniteChats(queryClient, [chat]);
+	};
+
+	it("shows the status immediately without advancing the version", () => {
+		const queryClient = createTestQueryClient();
+		seedChat(
+			queryClient,
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+
+		writeOptimisticChatStatus(queryClient, "chat-1", "running");
+
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("running");
+		// The send-path fence reads this version; an optimistic write must not
+		// trip it.
+		expect(readCachedChatSnapshotVersion(queryClient, "chat-1")).toBe(5);
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+	});
+
+	it("rolls back to the status the server last reported", () => {
+		const queryClient = createTestQueryClient();
+		seedChat(
+			queryClient,
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+
+		const token = writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		rollbackOptimisticChatStatus(queryClient, "chat-1", token);
+
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("waiting");
+		expect(readInfiniteChats(queryClient)?.[0].status).toBe("waiting");
+	});
+
+	it("does not roll back once a newer server version arrived", () => {
+		const queryClient = createTestQueryClient();
+		seedChat(
+			queryClient,
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+
+		const token = writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		applyServerChatStatusToCaches(queryClient, "chat-1", "interrupting", 6);
+		rollbackOptimisticChatStatus(queryClient, "chat-1", token);
+
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("interrupting");
+		expect(readCachedChatSnapshotVersion(queryClient, "chat-1")).toBe(6);
+	});
+
+	it("does not roll back a superseding optimistic write", () => {
+		const queryClient = createTestQueryClient();
+		seedChat(
+			queryClient,
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+
+		const first = writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		writeOptimisticChatStatus(queryClient, "chat-1", "interrupting");
+		rollbackOptimisticChatStatus(queryClient, "chat-1", first);
+
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("interrupting");
+	});
+
+	it("rolls consecutive optimistic writes back to the server status", () => {
+		const queryClient = createTestQueryClient();
+		seedChat(
+			queryClient,
+			makeChat("chat-1", { status: "waiting", snapshot_version: 5 }),
+		);
+
+		writeOptimisticChatStatus(queryClient, "chat-1", "running");
+		const second = writeOptimisticChatStatus(
+			queryClient,
+			"chat-1",
+			"interrupting",
+		);
+		rollbackOptimisticChatStatus(queryClient, "chat-1", second);
+
+		expect(readCachedChatStatus(queryClient, "chat-1")).toBe("waiting");
+	});
+});
+
+describe("mergeWatchedChatSummary snapshot_version", () => {
+	it("adopts a status payload that only advances the version", () => {
+		const cachedChat = makeChat("chat-1", {
+			status: "running",
+			snapshot_version: 5,
+		});
+		const watchedChat = makeChat("chat-1", {
+			status: "running",
+			snapshot_version: 6,
+		});
+
+		const merged = mergeWatchedChatSummary(cachedChat, watchedChat, {
+			eventKind: "status_change",
+		});
+
+		// Swallowing this would leave the cached key behind the server's, so a
+		// later delayed event would compare against a superseded version.
+		expect(merged).not.toBe(cachedChat);
+		expect(merged.snapshot_version).toBe(6);
+	});
+
+	it("rejects a status payload carrying an older version", () => {
+		const cachedChat = makeChat("chat-1", {
+			status: "running",
+			snapshot_version: 7,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			status: "waiting",
+			snapshot_version: 5,
+			// updated_at is non-monotonic, so a newer timestamp on an older
+			// snapshot must not win.
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "status_change",
+			}),
+		).toMatchObject({ status: "running", snapshot_version: 7 });
+	});
+
+	it("adopts a newer status carried by a non-status event", () => {
+		const cachedChat = makeChat("chat-1", {
+			status: "running",
+			snapshot_version: 5,
+			title: "Old",
+			has_unread: false,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			status: "waiting",
+			snapshot_version: 9,
+			title: "New",
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		// Every watch payload is one coherent chat row, so the comparator is
+		// the only thing that has to hold. Unread stays scoped to the event
+		// that announces a transition.
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "title_change",
+			}),
+		).toMatchObject({
+			status: "waiting",
+			snapshot_version: 9,
+			title: "New",
+			has_unread: false,
+		});
+	});
+
+	it("keeps the cached status when a non-status event is older", () => {
+		const cachedChat = makeChat("chat-1", {
+			status: "running",
+			snapshot_version: 9,
+			title: "Old",
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			status: "waiting",
+			snapshot_version: 5,
+			title: "New",
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		// The version labels the status the entry holds, so a rejected status
+		// must not advance it either: that would strand the cached status
+		// behind a key no later payload can beat.
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "title_change",
+			}),
+		).toMatchObject({ status: "running", snapshot_version: 9, title: "New" });
+	});
+
+	it("marks unread only for a status_change on an inactive chat", () => {
+		const cachedChat = makeChat("chat-1", {
+			status: "running",
+			snapshot_version: 5,
+			has_unread: false,
+		});
+		const watchedChat = makeChat("chat-1", {
+			status: "waiting",
+			snapshot_version: 6,
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "status_change",
+				activeChatId: "chat-2",
+			}),
+		).toMatchObject({ status: "waiting", has_unread: true });
 	});
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -2,6 +2,7 @@ import {
 	type InfiniteData,
 	type QueryClient,
 	queryOptions,
+	replaceEqualDeep,
 	type UseInfiniteQueryOptions,
 } from "react-query";
 import {
@@ -134,7 +135,8 @@ export const chatKeys = {
 	debugRun: (chatId: string, runId: string) =>
 		[...chatKeys.debugRuns(chatId), runId] as const,
 
-	search: (q: string) => [...chatKeys.all, "search", { q }] as const,
+	searches: () => [...chatKeys.all, "search"] as const,
+	search: (q: string) => [...chatKeys.searches(), { q }] as const,
 	byWorkspacePrefix: () => [...chatKeys.all, "by-workspace"] as const,
 	byWorkspace: (workspaceIds: string[]) =>
 		[...chatKeys.byWorkspacePrefix(), workspaceIds.toSorted()] as const,
@@ -371,6 +373,582 @@ export const patchChatEverywhere = (
 const hasLoadedData = (query: { state: { data: unknown } }): boolean =>
 	query.state.data !== undefined;
 
+// ---------------------------------------------------------------------------
+// Chat status ordering
+//
+// Three writers change a chat's status: the per-chat stream socket, the global
+// watch socket, and every REST payload that carries a chat. `snapshot_version`
+// is the only key they share that orders those writes: the server bumps it
+// while holding the chat row lock, so version order is commit order.
+// `updated_at` cannot order status, it comes from transaction_timestamp() and
+// is evaluated before the lock, so it can invert against commit order.
+//
+// The cached `snapshot_version` is the version of the STATUS the entry holds,
+// not of the whole payload: a rejected payload's other fields are still
+// adopted, so advancing the version for them would strand the older status
+// with no way to correct it.
+// ---------------------------------------------------------------------------
+
+/**
+ * Coerces an absent `snapshot_version` to the zero version. Chats built before
+ * the field existed, and fixtures that omit it, still have to compare: every
+ * comparison against a raw `undefined` is false, which would silently reject
+ * every status write instead of accepting it.
+ */
+const chatSnapshotVersion = (version?: number): number => version ?? 0;
+
+/**
+ * Provenance of a status the client wrote ahead of the server. `token`
+ * identifies the write so its own rollback can tell whether it is still the
+ * latest one, and `previousStatus` is the status to restore, carried per cache
+ * entry because layers can hold different statuses.
+ */
+type OptimisticChatStatus = {
+	readonly token: number;
+	readonly previousStatus: TypesGen.ChatStatus;
+};
+
+/**
+ * A chat as held in the query cache. `__optimistic` is client-only provenance:
+ * it is colocated with the entry so it is garbage collected with it, and it is
+ * cleared as soon as a strictly newer server snapshot lands. It never appears
+ * on a payload from the server.
+ */
+type CachedChat = TypesGen.Chat & {
+	readonly __optimistic?: OptimisticChatStatus;
+};
+
+/**
+ * Narrows a cached payload to a chat record. The detail key is also the prefix
+ * of every per-chat sub-resource key, and `structuralSharing` is typed against
+ * `unknown`, so the shape has to be checked before a merge or a patch runs.
+ */
+const isCachedChat = (value: unknown): value is CachedChat =>
+	isPlainObject(value) &&
+	typeof value.id === "string" &&
+	typeof value.status === "string";
+
+type WritableCachedChat = TypesGen.Chat & {
+	__optimistic?: OptimisticChatStatus;
+};
+
+/**
+ * Orders a server-backed status against the one already cached.
+ *
+ * A server payload owns the status only when its `snapshot_version` is
+ * STRICTLY greater. Equal versions describe the same committed snapshot, so a
+ * duplicate is a no-op and an optimistic status pinned at that version
+ * survives until its request settles or rolls back. Older payloads lose.
+ *
+ * Polarity, spelled out because the guard this replaces reads the other way
+ * round: the old code accepted a watched status when
+ * `compareUpdatedAtInstants(cached, watched) <= 0`, that is when the CACHED
+ * instant was not newer than the incoming one. Here the incoming version must
+ * be greater than the cached one, which is the same direction with the equal
+ * case moved from accept to reject.
+ */
+export const shouldApplyServerChatStatus = (
+	cachedVersion: number | undefined,
+	incomingVersion: number | undefined,
+): boolean =>
+	chatSnapshotVersion(incomingVersion) > chatSnapshotVersion(cachedVersion);
+
+/**
+ * Builds the entry for an accepted server status. A strictly newer server
+ * snapshot supersedes any optimistic status, so the provenance token goes with
+ * it.
+ */
+const withServerChatStatus = (
+	chat: CachedChat,
+	status: TypesGen.ChatStatus,
+	snapshotVersion: number,
+): CachedChat => {
+	const next: WritableCachedChat = {
+		...chat,
+		status,
+		snapshot_version: snapshotVersion,
+	};
+	delete next.__optimistic;
+	return next;
+};
+
+/**
+ * Commit-time merge for a single chat, run from `structuralSharing` so it also
+ * covers the payloads react-query writes without asking: a resolving `queryFn`
+ * calls setData unconditionally, so a REST response issued before a socket
+ * status would otherwise regress it.
+ *
+ * Client writes are passed through: they carry the optimistic token and their
+ * writer already applied the ordering rules.
+ */
+const mergeCommittedChatStatus = (
+	prev: CachedChat | undefined,
+	next: CachedChat,
+): CachedChat => {
+	if (!prev || prev === next) {
+		return next;
+	}
+	if (next.__optimistic !== undefined) {
+		return next;
+	}
+	if (
+		shouldApplyServerChatStatus(prev.snapshot_version, next.snapshot_version)
+	) {
+		return next;
+	}
+	// Older or duplicate snapshot: keep the cached status, its version, and any
+	// optimistic provenance, take everything else from the fresh payload.
+	const preserved: CachedChat = {
+		...next,
+		status: prev.status,
+		snapshot_version: prev.snapshot_version,
+	};
+	return prev.__optimistic
+		? { ...preserved, __optimistic: prev.__optimistic }
+		: preserved;
+};
+
+/**
+ * Commit merge for the detail cache, covering the record and the children it
+ * embeds. A parent's detail payload carries its children's statuses, so a
+ * parent fetch issued before a child's status event would otherwise regress
+ * that child.
+ *
+ * A custom `structuralSharing` REPLACES the default one, so it has to call
+ * `replaceEqualDeep` itself. Skipping that would hand every consumer a brand
+ * new Chat object on each fetch.
+ */
+export const mergeCommittedChatDetail = (
+	prev: CachedChat | undefined,
+	next: CachedChat,
+): CachedChat => replaceEqualDeep(prev, mergeCommittedChatRecord(prev, next));
+
+const mergeCommittedChatRecord = (
+	prev: CachedChat | undefined,
+	next: CachedChat,
+): CachedChat => {
+	const merged = mergeCommittedChatStatus(prev, next);
+	const nextChildren = next.children;
+	if (!nextChildren?.length) {
+		return merged;
+	}
+	const cachedChildren = new Map(
+		(prev?.children ?? []).map((child) => [child.id, child]),
+	);
+	if (cachedChildren.size === 0) {
+		return merged;
+	}
+	let changed = false;
+	const children = nextChildren.map((child) => {
+		const mergedChild = mergeCommittedChatStatus(
+			cachedChildren.get(child.id),
+			child,
+		);
+		if (mergedChild !== child) {
+			changed = true;
+		}
+		return mergedChild;
+	});
+	return changed ? { ...merged, children } : merged;
+};
+
+// react-query types structuralSharing as (unknown, unknown) => unknown, so the
+// option is a thin adapter over the typed merge.
+const chatDetailStructuralSharing = (prev: unknown, next: unknown): unknown =>
+	isCachedChat(next)
+		? mergeCommittedChatDetail(isCachedChat(prev) ? prev : undefined, next)
+		: replaceEqualDeep(prev, next);
+
+/**
+ * Picks which of two cached copies of the same chat holds the status a
+ * committed payload has to be ordered against: the strictly newer version,
+ * and on a tie the optimistic one, whose status is the one on screen.
+ */
+const preferCachedChatStatus = (a: CachedChat, b: CachedChat): CachedChat => {
+	if (shouldApplyServerChatStatus(a.snapshot_version, b.snapshot_version)) {
+		return b;
+	}
+	if (shouldApplyServerChatStatus(b.snapshot_version, a.snapshot_version)) {
+		return a;
+	}
+	return b.__optimistic && !a.__optimistic ? b : a;
+};
+
+/**
+ * Indexes cached list rows and embedded children by id. Pagination can place
+ * the same chat on more than one loaded page, so the copy with the most
+ * advanced status wins rather than whichever page is scanned last.
+ */
+const indexChatsById = (
+	data: InfiniteChatsCacheData | undefined,
+): Map<string, CachedChat> => {
+	const byId = new Map<string, CachedChat>();
+	if (!isInfiniteChatsCacheData(data)) {
+		return byId;
+	}
+	const keepNewest = (chat: CachedChat) => {
+		const existing = byId.get(chat.id);
+		if (!existing || preferCachedChatStatus(existing, chat) === chat) {
+			byId.set(chat.id, chat);
+		}
+	};
+	for (const page of data.pages) {
+		for (const chat of page) {
+			keepNewest(chat);
+			for (const child of chat.children ?? []) {
+				keepNewest(child);
+			}
+		}
+	}
+	return byId;
+};
+
+/**
+ * The list version of {@link mergeCommittedChatDetail}. A list refetch also
+ * commits unconditionally, and its rows and embedded children hold the status
+ * a shared viewer's sidebar renders, so they need the same ordering the detail
+ * cache gets.
+ */
+export const mergeCommittedChatList = (
+	prev: InfiniteChatsCacheData | undefined,
+	next: InfiniteChatsCacheData,
+): InfiniteChatsCacheData => {
+	if (!prev || prev === next || !isInfiniteChatsCacheData(next)) {
+		return replaceEqualDeep(prev, next);
+	}
+	const cachedById = indexChatsById(prev);
+	if (cachedById.size === 0) {
+		return replaceEqualDeep(prev, next);
+	}
+	const mergeRow = (chat: CachedChat): CachedChat =>
+		mergeCommittedChatStatus(cachedById.get(chat.id), chat);
+	const merged: InfiniteChatsCacheData = {
+		...next,
+		pages: next.pages.map((page) =>
+			page.map((chat) => {
+				const mergedChat = mergeRow(chat);
+				if (!chat.children?.length) {
+					return mergedChat;
+				}
+				return { ...mergedChat, children: chat.children.map(mergeRow) };
+			}),
+		),
+	};
+	return replaceEqualDeep(prev, merged);
+};
+
+const chatListStructuralSharing = (prev: unknown, next: unknown): unknown =>
+	isInfiniteChatsCacheData(next)
+		? mergeCommittedChatList(
+				isInfiniteChatsCacheData(prev) ? prev : undefined,
+				next,
+			)
+		: replaceEqualDeep(prev, next);
+
+const isCachedChatArray = (value: unknown): value is CachedChat[] =>
+	Array.isArray(value) && value.every(isCachedChat);
+
+/**
+ * The search version of {@link mergeCommittedChatDetail}. Search results are a
+ * plain array under a sibling key, and the sidebar search panel renders the
+ * status each row carries, so a search response has to be ordered too.
+ */
+export const mergeCommittedChatSearch = (
+	prev: readonly CachedChat[] | undefined,
+	next: readonly CachedChat[],
+): readonly CachedChat[] => {
+	if (!prev || prev === next || prev.length === 0) {
+		return replaceEqualDeep(prev, next);
+	}
+	const cachedById = new Map(prev.map((chat) => [chat.id, chat]));
+	return replaceEqualDeep(
+		prev,
+		next.map((chat) => mergeCommittedChatStatus(cachedById.get(chat.id), chat)),
+	);
+};
+
+const chatSearchStructuralSharing = (prev: unknown, next: unknown): unknown =>
+	isCachedChatArray(next)
+		? mergeCommittedChatSearch(isCachedChatArray(prev) ? prev : undefined, next)
+		: replaceEqualDeep(prev, next);
+
+/** Applies `patch` to a chat held by a detail record, root or embedded child. */
+const patchChatInRecord = (
+	record: CachedChat,
+	chatId: string,
+	patch: (chat: CachedChat) => CachedChat,
+): CachedChat => {
+	if (record.id === chatId) {
+		return patch(record);
+	}
+	if (!record.children?.length) {
+		return record;
+	}
+	let changed = false;
+	const children = record.children.map((child) => {
+		if (child.id !== chatId) {
+			return child;
+		}
+		const patched = patch(child);
+		if (patched !== child) {
+			changed = true;
+		}
+		return patched;
+	});
+	return changed ? { ...record, children } : record;
+};
+
+/**
+ * Applies `patch` to the chat in every cache layer that can hold it, keeping
+ * each matched query's own `dataUpdatedAt`. The layers are the chat's own
+ * detail record, any loaded parent detail that embeds it as a child, every
+ * cached list variant's rows and embedded children, and every cached search
+ * result.
+ *
+ * The freshness stamp is preserved because the writers that use this push a
+ * subset of a chat's fields over a socket. Refreshing the stamp would postpone
+ * the refetch that catches up the fields the socket does not push. Mutation
+ * writes want the opposite and use {@link patchChatEverywhere}.
+ */
+const patchChatEverywherePreservingFreshness = (
+	queryClient: QueryClient,
+	chatId: string,
+	patch: (chat: CachedChat) => CachedChat,
+): void => {
+	// The details() prefix also matches every per-chat sub-resource key, so
+	// both the key length and the payload shape are checked.
+	const detailKeyLength = chatKeys.details().length + 1;
+	const detailQueries = queryClient.getQueriesData({
+		queryKey: chatKeys.details(),
+	});
+	for (const [queryKey, data] of detailQueries) {
+		if (queryKey.length !== detailKeyLength || !isCachedChat(data)) {
+			continue;
+		}
+		if (data.id !== chatId && !data.children?.some((c) => c.id === chatId)) {
+			continue;
+		}
+		queryClient.setQueryData<CachedChat | undefined>(
+			queryKey,
+			(record) => (record ? patchChatInRecord(record, chatId, patch) : record),
+			{ updatedAt: queryClient.getQueryState(queryKey)?.dataUpdatedAt },
+		);
+	}
+
+	const listQueries = queryClient.getQueriesData<InfiniteChatsCacheData>({
+		queryKey: chatKeys.lists(),
+	});
+	for (const [queryKey, data] of listQueries) {
+		if (!isInfiniteChatsCacheData(data)) {
+			continue;
+		}
+		queryClient.setQueryData<InfiniteChatsCacheData>(
+			queryKey,
+			(prev) => {
+				if (!isInfiniteChatsCacheData(prev)) {
+					return prev;
+				}
+				let changed = false;
+				const pages = prev.pages.map((page) => {
+					let pageChanged = false;
+					const nextPage = page.map((chat) => {
+						const patched = patchChatInRecord(chat, chatId, patch);
+						if (patched !== chat) {
+							pageChanged = true;
+						}
+						return patched;
+					});
+					if (!pageChanged) {
+						return page;
+					}
+					changed = true;
+					return nextPage;
+				});
+				return changed ? { ...prev, pages } : prev;
+			},
+			{ updatedAt: queryClient.getQueryState(queryKey)?.dataUpdatedAt },
+		);
+	}
+
+	const searchQueries = queryClient.getQueriesData({
+		queryKey: chatKeys.searches(),
+	});
+	for (const [queryKey, data] of searchQueries) {
+		if (!isCachedChatArray(data)) {
+			continue;
+		}
+		queryClient.setQueryData<CachedChat[]>(
+			queryKey,
+			(prev) => {
+				if (!isCachedChatArray(prev)) {
+					return prev;
+				}
+				let changed = false;
+				const next = prev.map((chat) => {
+					if (chat.id !== chatId) {
+						return chat;
+					}
+					const patched = patch(chat);
+					if (patched !== chat) {
+						changed = true;
+					}
+					return patched;
+				});
+				return changed ? next : prev;
+			},
+			{ updatedAt: queryClient.getQueryState(queryKey)?.dataUpdatedAt },
+		);
+	}
+};
+
+/**
+ * Writes a server-reported status into every cache layer, per layer ordered by
+ * `snapshot_version`. Status and version are written together so the next
+ * comparison is against the key of the status actually held.
+ *
+ * Returns whether the chat's own detail entry took the status. That entry is
+ * the one the open chat renders from, so it decides whether the caller may run
+ * the side effects that belong to an authoritative status: a superseded or
+ * versionless payload reports false and must leave stream state alone.
+ */
+export const applyServerChatStatusToCaches = (
+	queryClient: QueryClient,
+	chatId: string,
+	status: TypesGen.ChatStatus,
+	snapshotVersion: number | undefined,
+): boolean => {
+	const cachedDetail = queryClient.getQueryData<CachedChat>(
+		chatKeys.detail(chatId),
+	);
+	const accepted =
+		cachedDetail !== undefined &&
+		shouldApplyServerChatStatus(cachedDetail.snapshot_version, snapshotVersion);
+	patchChatEverywherePreservingFreshness(queryClient, chatId, (chat) =>
+		shouldApplyServerChatStatus(chat.snapshot_version, snapshotVersion)
+			? withServerChatStatus(chat, status, chatSnapshotVersion(snapshotVersion))
+			: chat,
+	);
+	return accepted;
+};
+
+/** Reads the status the cache holds for a chat, or null when it holds none. */
+export const readCachedChatStatus = (
+	queryClient: QueryClient,
+	chatId: string | undefined,
+): TypesGen.ChatStatus | null => {
+	if (!chatId) {
+		return null;
+	}
+	return (
+		queryClient.getQueryData<CachedChat>(chatKeys.detail(chatId))?.status ??
+		null
+	);
+};
+
+/** Reads the snapshot version the cache holds for a chat's status. */
+export const readCachedChatSnapshotVersion = (
+	queryClient: QueryClient,
+	chatId: string | undefined,
+): number => {
+	if (!chatId) {
+		return 0;
+	}
+	return chatSnapshotVersion(
+		queryClient.getQueryData<CachedChat>(chatKeys.detail(chatId))
+			?.snapshot_version,
+	);
+};
+
+let lastOptimisticChatStatusToken = 0;
+
+/**
+ * Writes a status the client expects the server to reach, so the running
+ * indicator appears without waiting for a round trip.
+ *
+ * The write deliberately does NOT advance `snapshot_version`: no server
+ * snapshot backs it, and advancing would make the send-path fence read its own
+ * write as a server response. Its provenance token lets the matching rollback
+ * tell whether it is still the write in effect. Returns the token.
+ */
+export const writeOptimisticChatStatus = (
+	queryClient: QueryClient,
+	chatId: string,
+	status: TypesGen.ChatStatus,
+): number => {
+	lastOptimisticChatStatusToken += 1;
+	const token = lastOptimisticChatStatusToken;
+	patchChatEverywherePreservingFreshness(queryClient, chatId, (chat) => ({
+		...chat,
+		status,
+		// Keep the status the server last reported, not the one an earlier
+		// optimistic write put there, so consecutive writes roll back to a
+		// server-backed value.
+		__optimistic: {
+			token,
+			previousStatus: chat.__optimistic?.previousStatus ?? chat.status,
+		},
+	}));
+	return token;
+};
+
+/**
+ * Undoes {@link writeOptimisticChatStatus} when its request failed. Restores
+ * only where that exact write is still the one in effect: a newer optimistic
+ * write replaced the token, and a strictly newer server status dropped it, and
+ * in both cases the cached status is no longer this write's to undo.
+ *
+ * The token is left in place. It is inert once the status matches the restored
+ * value again, and it keeps a same-version server payload from re-applying the
+ * status this rollback just took back.
+ */
+export const rollbackOptimisticChatStatus = (
+	queryClient: QueryClient,
+	chatId: string,
+	token: number,
+): void => {
+	patchChatEverywherePreservingFreshness(queryClient, chatId, (chat) => {
+		const optimistic = chat.__optimistic;
+		if (!optimistic || optimistic.token !== token) {
+			return chat;
+		}
+		if (chat.status === optimistic.previousStatus) {
+			return chat;
+		}
+		return { ...chat, status: optimistic.previousStatus };
+	});
+};
+
+/**
+ * Runs a detail-query cancellation without losing the status the cache holds.
+ *
+ * Cancelling a fetch reverts the query to the state it had when that fetch
+ * started, which silently undoes any status the socket wrote while the fetch
+ * was in flight. The status is re-applied afterwards through the same ordered
+ * write the socket uses, so it is a no-op when no revert happened: the
+ * re-applied version is then equal to the cached one, and equal versions lose.
+ *
+ * An optimistic status pinned at the cached version is not restored, because
+ * it is not server-backed and shares the version the revert restored. It
+ * self-heals when the request that wrote it reports its own status.
+ */
+export const cancelChatDetailPreservingStatus = async (
+	queryClient: QueryClient,
+	chatId: string,
+	cancel: () => Promise<void>,
+): Promise<void> => {
+	const cached = queryClient.getQueryData<CachedChat>(chatKeys.detail(chatId));
+	await cancel();
+	if (!cached) {
+		return;
+	}
+	applyServerChatStatusToCaches(
+		queryClient,
+		chatId,
+		cached.status,
+		cached.snapshot_version,
+	);
+};
+
 /**
  * Cancels the in-flight sidebar list and chat detail fetches that a
  * mutation's optimistic write would otherwise race, in parallel.
@@ -391,11 +969,13 @@ export const cancelChatMutationRefetches = (
 			queryKey: chatKeys.lists(),
 			predicate: hasLoadedData,
 		}),
-		queryClient.cancelQueries({
-			queryKey: chatKeys.detail(chatId),
-			exact: true,
-			predicate: hasLoadedData,
-		}),
+		cancelChatDetailPreservingStatus(queryClient, chatId, () =>
+			queryClient.cancelQueries({
+				queryKey: chatKeys.detail(chatId),
+				exact: true,
+				predicate: hasLoadedData,
+			}),
+		),
 	]);
 
 /**
@@ -702,9 +1282,11 @@ const diffStatusEqual = (
 /**
  * Merges event-scoped chat fields into a cached summary, using updated_at
  * as a stale guard while still adopting the latest DB-backed model config.
+ * Status is the exception: it is ordered by snapshot_version, the only key
+ * that agrees with commit order.
  */
 export const mergeWatchedChatSummary = (
-	cachedChat: TypesGen.Chat,
+	cachedChat: CachedChat,
 	watchedChat: TypesGen.Chat,
 	{ eventKind, activeChatId }: MergeWatchedChatOptions,
 ): TypesGen.Chat => {
@@ -719,8 +1301,21 @@ export const mergeWatchedChatSummary = (
 		watchedChat.updated_at,
 	);
 	const isFreshEnough = updatedAtComparison <= 0;
-	const nextStatus =
-		isFreshEnough && isStatusEvent ? watchedChat.status : cachedChat.status;
+	// Status keeps its own guard: updated_at is not monotonic, so it cannot
+	// order a status against one the per-chat socket already applied. Every
+	// event kind publishes a coherent chat row, so any of them may carry the
+	// status forward as long as the version comparator accepts it.
+	const appliesStatus = shouldApplyServerChatStatus(
+		cachedChat.snapshot_version,
+		watchedChat.snapshot_version,
+	);
+	const nextStatus = appliesStatus ? watchedChat.status : cachedChat.status;
+	// The version travels with the status it labels. A payload that only
+	// advances the version still has to advance the cached one, otherwise a
+	// later delayed event compares against a key that was already superseded.
+	const nextSnapshotVersion = appliesStatus
+		? chatSnapshotVersion(watchedChat.snapshot_version)
+		: cachedChat.snapshot_version;
 	// maybeGenerateChatTitle can publish a previously loaded chat snapshot, so
 	// apply title_change payloads even when the chat summary timestamp is older.
 	const nextTitle = isTitleEvent ? watchedChat.title : cachedChat.title;
@@ -759,8 +1354,10 @@ export const mergeWatchedChatSummary = (
 	const nextSummary = isChatSummaryEvent
 		? watchedChat.summary
 		: cachedChat.summary;
+	// Unread is a property of the status transition the server announced, not
+	// of a status picked up in passing, so it stays scoped to status_change.
 	const nextHasUnread =
-		isFreshEnough && isStatusEvent && watchedChat.id !== activeChatId
+		isStatusEvent && appliesStatus && watchedChat.id !== activeChatId
 			? true
 			: cachedChat.has_unread;
 	const nextUpdatedAt =
@@ -771,6 +1368,7 @@ export const mergeWatchedChatSummary = (
 	// against a timestamp that should already have been superseded.
 	if (
 		nextStatus === cachedChat.status &&
+		nextSnapshotVersion === cachedChat.snapshot_version &&
 		nextTitle === cachedChat.title &&
 		diffStatusEqual(nextDiffStatus, cachedChat.diff_status) &&
 		nextWorkspaceId === cachedChat.workspace_id &&
@@ -785,9 +1383,10 @@ export const mergeWatchedChatSummary = (
 		return cachedChat;
 	}
 
-	return {
+	const merged: WritableCachedChat = {
 		...cachedChat,
 		status: nextStatus,
+		snapshot_version: nextSnapshotVersion,
 		title: nextTitle,
 		diff_status: nextDiffStatus,
 		workspace_id: nextWorkspaceId,
@@ -799,44 +1398,29 @@ export const mergeWatchedChatSummary = (
 		updated_at: nextUpdatedAt,
 		context: nextContext,
 	};
+	if (appliesStatus) {
+		// A strictly newer server status supersedes an optimistic one.
+		delete merged.__optimistic;
+	}
+	return merged;
 };
 
 /**
- * Applies the same event-scoped merge and stale guard across the list,
- * parent-child, and per-chat caches, covering all three cache layers.
+ * Applies the same event-scoped merge and stale guard to every cache layer
+ * that can hold the chat: list rows, embedded children, detail records, and
+ * search results. Each write keeps its query's own `dataUpdatedAt`, because a
+ * watch event pushes a subset of the fields and must not postpone the refetch
+ * that catches up the rest.
  */
 export const mergeWatchedChatIntoCaches = (
 	queryClient: QueryClient,
 	watchedChat: TypesGen.Chat,
 	options: MergeWatchedChatOptions,
 ) => {
-	const mergeCachedChat = (cachedChat: TypesGen.Chat) =>
-		mergeWatchedChatSummary(cachedChat, watchedChat, options);
-
-	updateInfiniteChatsCache(queryClient, (chats) => {
-		let didUpdate = false;
-		const nextChats = chats.map((chat) => {
-			if (chat.id !== watchedChat.id) {
-				return chat;
-			}
-			const mergedChat = mergeCachedChat(chat);
-			if (mergedChat !== chat) {
-				didUpdate = true;
-			}
-			return mergedChat;
-		});
-		return didUpdate ? nextChats : chats;
-	});
-
-	updateChildInParentCache(queryClient, mergeCachedChat, watchedChat.id);
-	queryClient.setQueryData<TypesGen.Chat | undefined>(
-		chatKeys.detail(watchedChat.id),
-		(cachedChat) => {
-			if (!cachedChat) {
-				return cachedChat;
-			}
-			return mergeCachedChat(cachedChat);
-		},
+	patchChatEverywherePreservingFreshness(
+		queryClient,
+		watchedChat.id,
+		(cachedChat) => mergeWatchedChatSummary(cachedChat, watchedChat, options),
 	);
 };
 
@@ -1057,6 +1641,9 @@ export const infiniteChats = (filters?: InfiniteChatsFilters) => {
 		// fields the watch socket does not push.
 		staleTime: CHAT_SUMMARY_STALE_MS,
 		select: selectSortedChatList,
+		// Rows and embedded children carry status too, and a list refetch
+		// commits as unconditionally as the detail one does.
+		structuralSharing: chatListStructuralSharing,
 		retry: 3,
 	} satisfies UseInfiniteQueryOptions<TypesGen.Chat[]>;
 };
@@ -1069,6 +1656,9 @@ export const chatSearch = (q: string) =>
 				limit: CHAT_SEARCH_LIMIT,
 				q,
 			}),
+		// Search rows carry status too, and the response commits as
+		// unconditionally as the detail one does.
+		structuralSharing: chatSearchStructuralSharing,
 	});
 
 export const chat = (chatId: string) => ({
@@ -1079,6 +1669,9 @@ export const chat = (chatId: string) => ({
 	// children that the watch payloads do not fully cover.
 	staleTime: CHAT_SUMMARY_STALE_MS,
 	refetchOnWindowFocus: true,
+	// A resolving fetch commits unconditionally, so ordering the status it
+	// carries against the cached one has to happen at commit time.
+	structuralSharing: chatDetailStructuralSharing,
 });
 
 export const chatACL = (chatId: string) => ({

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -1,14 +1,22 @@
 import { act, renderHook } from "@testing-library/react";
 import { createRef } from "react";
+import { QueryClient } from "react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatMessage, ChatQueuedMessage } from "#/api/typesGenerated";
+import { applyServerChatStatusToCaches, chatKeys } from "#/api/queries/chats";
+import type {
+	Chat,
+	ChatMessage,
+	ChatQueuedMessage,
+} from "#/api/typesGenerated";
 import {
+	MockChat,
 	MockChatMessage,
 	MockChatQueuedMessage,
 } from "#/testHelpers/chatEntities";
 import { createDeferred } from "#/testHelpers/deferred";
 import { MockUserOwner, MockWorkspace } from "#/testHelpers/entities";
 import {
+	assertTurnStartedAfterSend,
 	buildInactiveChatQueueReconciliation,
 	draftInputStorageKeyPrefix,
 	getPersistedDraftInputValue,
@@ -181,7 +189,7 @@ describe("getPersistedDraftInputValue", () => {
 });
 
 describe("restoreOptimisticRequestSnapshot", () => {
-	it("restores queued messages, stream output, status, and stream error", () => {
+	it("restores queued messages, stream output, and stream error", () => {
 		const store = createChatStore();
 		store.setQueuedMessages([
 			{
@@ -191,14 +199,12 @@ describe("restoreOptimisticRequestSnapshot", () => {
 				content: [{ type: "text" as const, text: "queued" }],
 			},
 		]);
-		store.setChatStatus("running");
 		store.applyMessagePart({ type: "text", text: "partial response" });
 		store.setStreamError({ kind: "generic", message: "old error" });
 		const previousSnapshot = store.getSnapshot();
 
 		store.batch(() => {
 			store.setQueuedMessages([]);
-			store.setChatStatus("waiting");
 			store.clearStreamState();
 			store.clearStreamError();
 		});
@@ -209,7 +215,6 @@ describe("restoreOptimisticRequestSnapshot", () => {
 		expect(restoredSnapshot.queuedMessages).toEqual(
 			previousSnapshot.queuedMessages,
 		);
-		expect(restoredSnapshot.chatStatus).toBe(previousSnapshot.chatStatus);
 		expect(restoredSnapshot.streamState).toBe(previousSnapshot.streamState);
 		expect(restoredSnapshot.streamError).toEqual(previousSnapshot.streamError);
 	});
@@ -227,13 +232,29 @@ describe("runPromoteQueuedMessage", () => {
 		content: [{ type: "text", text }],
 	});
 
+	const seedChatDetail = (
+		queryClient: QueryClient,
+		status: Chat["status"],
+	): void => {
+		queryClient.setQueryData<Chat>(chatKeys.detail("chat-1"), {
+			...MockChat,
+			id: "chat-1",
+			status,
+			snapshot_version: 4,
+		});
+	};
+
+	const readCachedStatus = (queryClient: QueryClient): Chat | undefined =>
+		queryClient.getQueryData<Chat>(chatKeys.detail("chat-1"));
+
 	it("suppresses the promoted ID and removes it optimistically", async () => {
 		const store = createChatStore();
+		const queryClient = new QueryClient();
+		seedChatDetail(queryClient, "waiting");
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		const c = buildQueuedMessage(3, "C");
 		store.setQueuedMessages([a, b, c]);
-		store.setChatStatus("running");
 
 		const promote = vi.fn(async (_id: number) => undefined);
 		const clearChatErrorReason = vi.fn();
@@ -242,6 +263,7 @@ describe("runPromoteQueuedMessage", () => {
 		await runPromoteQueuedMessage({
 			id: b.id,
 			store,
+			queryClient,
 			promoteQueuedMessage: promote,
 			agentId: "chat-1",
 			clearChatErrorReason,
@@ -253,15 +275,19 @@ describe("runPromoteQueuedMessage", () => {
 		const snapshot = store.getSnapshot();
 		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id, c.id]);
 		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(true);
-		expect(snapshot.chatStatus).toBe("running");
+		const cached = readCachedStatus(queryClient);
+		expect(cached?.status).toBe("running");
+		// An optimistic write never advances the version.
+		expect(cached?.snapshot_version).toBe(4);
 	});
 
 	it("rolls back queue and status, clears suppression, and rethrows on API error", async () => {
 		const store = createChatStore();
+		const queryClient = new QueryClient();
+		seedChatDetail(queryClient, "waiting");
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		store.setQueuedMessages([a, b]);
-		store.setChatStatus("waiting");
 
 		const apiError = new Error("boom");
 		const promote = vi.fn(async (_id: number) => {
@@ -274,6 +300,7 @@ describe("runPromoteQueuedMessage", () => {
 			runPromoteQueuedMessage({
 				id: b.id,
 				store,
+				queryClient,
 				promoteQueuedMessage: promote,
 				agentId: "chat-1",
 				clearChatErrorReason,
@@ -285,8 +312,59 @@ describe("runPromoteQueuedMessage", () => {
 
 		const snapshot = store.getSnapshot();
 		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id, b.id]);
-		expect(snapshot.chatStatus).toBe("waiting");
+		expect(readCachedStatus(queryClient)?.status).toBe("waiting");
 		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
+	});
+});
+
+describe("assertTurnStartedAfterSend", () => {
+	const seedDetail = (queryClient: QueryClient, snapshotVersion: number) => {
+		queryClient.setQueryData<Chat>(chatKeys.detail("chat-1"), {
+			...MockChat,
+			id: "chat-1",
+			status: "waiting",
+			snapshot_version: snapshotVersion,
+		});
+	};
+
+	it("clears the stream and shows running when no server status landed", () => {
+		const queryClient = new QueryClient();
+		seedDetail(queryClient, 4);
+		const clearStreamState = vi.fn();
+
+		assertTurnStartedAfterSend({
+			store: { clearStreamState },
+			queryClient,
+			chatId: "chat-1",
+			snapshotVersionBeforeSend: 4,
+		});
+
+		expect(clearStreamState).toHaveBeenCalledTimes(1);
+		const cached = queryClient.getQueryData<Chat>(chatKeys.detail("chat-1"));
+		expect(cached?.status).toBe("running");
+		// An optimistic write never advances the version.
+		expect(cached?.snapshot_version).toBe(4);
+	});
+
+	it("does nothing when a server status landed during the request", () => {
+		const queryClient = new QueryClient();
+		seedDetail(queryClient, 4);
+		const clearStreamState = vi.fn();
+		// The socket reported the turn's real status while the POST was in
+		// flight; it is newer than anything this path can assert.
+		applyServerChatStatusToCaches(queryClient, "chat-1", "error", 5);
+
+		assertTurnStartedAfterSend({
+			store: { clearStreamState },
+			queryClient,
+			chatId: "chat-1",
+			snapshotVersionBeforeSend: 4,
+		});
+
+		expect(clearStreamState).not.toHaveBeenCalled();
+		expect(
+			queryClient.getQueryData<Chat>(chatKeys.detail("chat-1"))?.status,
+		).toBe("error");
 	});
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -41,11 +41,14 @@ import {
 	mcpServerConfigs,
 	patchChatEverywhere,
 	promoteChatQueuedMessage,
+	readCachedChatSnapshotVersion,
+	rollbackOptimisticChatStatus,
 	updateChatPlanMode,
 	updateChatWorkspace,
 	userChatDebugLogging,
 	userChatProviderConfigs,
 	userCompactionThresholds,
+	writeOptimisticChatStatus,
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
@@ -153,24 +156,25 @@ export function getPersistedDraftInputValue(
 	).text;
 }
 
-/** @internal Exported for testing. */
+/**
+ * Restores the transient store slices an optimistic request overwrote. Chat
+ * status is not among them: it lives in the query cache, and its rollback is
+ * token-scoped through `rollbackOptimisticChatStatus`.
+ *
+ * @internal Exported for testing.
+ */
 export const restoreOptimisticRequestSnapshot = (
 	store: Pick<
 		ChatStore,
-		| "batch"
-		| "setChatStatus"
-		| "setQueuedMessages"
-		| "setStreamError"
-		| "setStreamState"
+		"batch" | "setQueuedMessages" | "setStreamError" | "setStreamState"
 	>,
 	snapshot: Pick<
 		ChatStoreState,
-		"chatStatus" | "queuedMessages" | "streamError" | "streamState"
+		"queuedMessages" | "streamError" | "streamState"
 	>,
 ): void => {
 	store.batch(() => {
 		store.setQueuedMessages(snapshot.queuedMessages);
-		store.setChatStatus(snapshot.chatStatus);
 		store.setStreamState(snapshot.streamState);
 		store.setStreamError(snapshot.streamError);
 	});
@@ -195,13 +199,13 @@ export const runPromoteQueuedMessage = async (params: {
 		| "clearStreamError"
 		| "clearStreamState"
 		| "getSnapshot"
-		| "setChatStatus"
 		| "setQueuedMessages"
 		| "setStreamError"
 		| "setStreamState"
 		| "suppressQueuedMessageID"
 		| "unsuppressQueuedMessageID"
 	>;
+	queryClient: QueryClient;
 	promoteQueuedMessage: (id: number) => Promise<void>;
 	agentId: string | undefined;
 	clearChatErrorReason: (chatID: string) => void;
@@ -210,6 +214,7 @@ export const runPromoteQueuedMessage = async (params: {
 	const {
 		id,
 		store,
+		queryClient,
 		promoteQueuedMessage,
 		agentId,
 		clearChatErrorReason,
@@ -223,8 +228,10 @@ export const runPromoteQueuedMessage = async (params: {
 		);
 		store.clearStreamState();
 		store.clearStreamError();
-		store.setChatStatus("running");
 	});
+	const optimisticStatusToken = agentId
+		? writeOptimisticChatStatus(queryClient, agentId, "running")
+		: undefined;
 	if (agentId) {
 		clearChatErrorReason(agentId);
 	}
@@ -232,10 +239,43 @@ export const runPromoteQueuedMessage = async (params: {
 		await promoteQueuedMessage(id);
 	} catch (error) {
 		store.unsuppressQueuedMessageID(id);
+		if (agentId && optimisticStatusToken !== undefined) {
+			rollbackOptimisticChatStatus(queryClient, agentId, optimisticStatusToken);
+		}
 		restoreOptimisticRequestSnapshot(store, previousSnapshot);
 		handleUsageLimitError(error);
 		throw error;
 	}
+};
+
+/**
+ * Asserts the turn a send just started, unless the server already reported a
+ * status while the request was in flight.
+ *
+ * The cached snapshot version is the fence: optimistic writes never advance
+ * it, so a change means a server status landed during the request, and that
+ * status is newer than anything this path can claim.
+ *
+ * @internal Exported for testing.
+ */
+export const assertTurnStartedAfterSend = (params: {
+	store: Pick<ChatStore, "clearStreamState">;
+	queryClient: QueryClient;
+	chatId: string;
+	snapshotVersionBeforeSend: number;
+}): void => {
+	const { store, queryClient, chatId, snapshotVersionBeforeSend } = params;
+	if (
+		readCachedChatSnapshotVersion(queryClient, chatId) !==
+		snapshotVersionBeforeSend
+	) {
+		return;
+	}
+	store.clearStreamState();
+	// The server accepted the message, so it will start processing. A status
+	// event carries a newer snapshot version and supersedes this write,
+	// whichever status it reports.
+	writeOptimisticChatStatus(queryClient, chatId, "running");
 };
 
 const buildPromotedQueueReconciliation = (
@@ -1207,7 +1247,6 @@ const AgentChatPage: FC = () => {
 	const aiGatewayDisabled = !useAIGatewayEnabled();
 	const {
 		store,
-		acceptServerChatStatus,
 		clearStreamError,
 		setCacheQueuedMessages,
 		getCacheQueuedMessages,
@@ -1216,17 +1255,13 @@ const AgentChatPage: FC = () => {
 		chatID: agentId,
 		chatMessages: chatMessagesList,
 		chatRecord,
-		chatRecordUpdatedAt: chatQuery.dataUpdatedAt,
 		chatMessagesData,
 		chatQueuedMessages,
 		setChatErrorReason,
 		clearChatErrorReason,
 		aiGatewayDisabled,
 	});
-	const liveChatStatus =
-		useDurableChatStatus({ store, chatId: agentId }) ??
-		chatRecord?.status ??
-		null;
+	const liveChatStatus = useDurableChatStatus({ store, chatId: agentId });
 	const persistedError = getPersistedDetailError({
 		chatStatus: liveChatStatus,
 		chatRecord,
@@ -1418,6 +1453,7 @@ const AgentChatPage: FC = () => {
 		runPromoteQueuedMessage({
 			id,
 			store,
+			queryClient,
 			promoteQueuedMessage,
 			agentId,
 			clearChatErrorReason,
@@ -1641,11 +1677,20 @@ const AgentChatPage: FC = () => {
 			clearChatErrorReason(agentId);
 			clearStreamError();
 			store.clearStreamState();
-			store.setChatStatus("running");
+			const optimisticStatusToken = writeOptimisticChatStatus(
+				queryClient,
+				agentId,
+				"running",
+			);
 			scrollToBottomRef.current?.();
 			try {
 				await compact();
 			} catch (error) {
+				rollbackOptimisticChatStatus(
+					queryClient,
+					agentId,
+					optimisticStatusToken,
+				);
 				restoreOptimisticRequestSnapshot(store, previousSnapshot);
 				if (
 					isApiError(error) &&
@@ -1700,9 +1745,13 @@ const AgentChatPage: FC = () => {
 			clearStreamError();
 			store.batch(() => {
 				store.setQueuedMessages([]);
-				store.setChatStatus("running");
 				store.clearStreamState();
 			});
+			const optimisticStatusToken = writeOptimisticChatStatus(
+				queryClient,
+				agentId,
+				"running",
+			);
 			await submitEditAndScroll({
 				editMessage,
 				editArgs: {
@@ -1712,10 +1761,17 @@ const AgentChatPage: FC = () => {
 				},
 				scrollToBottom: scrollToBottomRef.current,
 				onError: (error) => {
+					rollbackOptimisticChatStatus(
+						queryClient,
+						agentId,
+						optimisticStatusToken,
+					);
 					restoreOptimisticRequestSnapshot(store, previousSnapshot);
 					handleUsageLimitError(error);
-					// Hook dispatch failures can park an idle chat in error before returning the request error.
-					acceptServerChatStatus();
+					// Hook dispatch failures can park an idle chat in error before
+					// returning the request error. The refetched detail carries a
+					// snapshot version, so the comparator decides whether it is
+					// newer than any status the socket delivered meanwhile.
 					void queryClient.invalidateQueries({
 						queryKey: chatKeys.detail(agentId),
 						exact: true,
@@ -1754,7 +1810,13 @@ const AgentChatPage: FC = () => {
 		// An errored-chat send may promote the queue head that existed when the request began.
 		const queuedMessagesBeforeSend = store.getSnapshot().queuedMessages;
 		const queueHeadIDBeforeSend = queuedMessagesBeforeSend[0]?.id;
-		const statusVersionBeforeSend = store.getServerChatStatusVersion();
+		// The cached snapshot version is the send-path fence: optimistic
+		// writes never advance it, so it changes only when the server
+		// reported a status during the request.
+		const snapshotVersionBeforeSend = readCachedChatSnapshotVersion(
+			queryClient,
+			agentId,
+		);
 
 		// Don't clear stream state before the POST completes.
 		// For queued sends the WebSocket status events handle
@@ -1765,8 +1827,10 @@ const AgentChatPage: FC = () => {
 			response = await sendMessage(request);
 		} catch (error) {
 			handleUsageLimitError(error);
-			// Hook dispatch failures can park an idle chat in error before returning the request error.
-			acceptServerChatStatus();
+			// Hook dispatch failures can park an idle chat in error before
+			// returning the request error. The refetched detail carries a
+			// snapshot version, so the comparator decides whether it is newer
+			// than any status the socket delivered meanwhile.
 			void queryClient.invalidateQueries({
 				queryKey: chatKeys.detail(agentId),
 				exact: true,
@@ -1776,16 +1840,12 @@ const AgentChatPage: FC = () => {
 		const isActiveChat = store.getActiveChatID() === agentId;
 		// Waiting for the WebSocket on non-queued sends leaves stale stream state visible.
 		if (!response.queued && isActiveChat) {
-			store.clearStreamState();
-			// Optimistically set status to "running" so the
-			// Thinking indicator appears immediately.
-			// The server accepted the message (not queued),
-			// so it will start processing. The WebSocket
-			// status:running event no-ops via the
-			// setChatStatus guard. If the server transitions
-			// to error/pending instead, the WebSocket event
-			// overrides this optimistic value.
-			store.setChatStatus("running");
+			assertTurnStartedAfterSend({
+				store,
+				queryClient,
+				chatId: agentId,
+				snapshotVersionBeforeSend,
+			});
 		}
 		// Upsert the full batch because a queued send can insert a promoted head below
 		// the highest cached ID, which a reconnect would skip.
@@ -1815,12 +1875,13 @@ const AgentChatPage: FC = () => {
 					setCacheQueuedMessages(reconciledQueue);
 					// A promoted head starts a turn, but any server status received during the
 					// request is newer and must win.
-					if (
-						isActiveChat &&
-						store.getServerChatStatusVersion() === statusVersionBeforeSend
-					) {
-						store.clearStreamState();
-						store.setChatStatus("running");
+					if (isActiveChat) {
+						assertTurnStartedAfterSend({
+							store,
+							queryClient,
+							chatId: agentId,
+							snapshotVersionBeforeSend,
+						});
 					}
 					if (isActiveChat && queueHeadIDBeforeSend !== undefined) {
 						void settlePromotedQueueHead(

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -855,13 +855,9 @@ const buildMessage = (
 ): TypesGen.ChatMessage =>
 	buildMessageWithContent(id, role, [{ type: "text", text }]);
 
-const buildStoreWithMessages = (
-	msgs: TypesGen.ChatMessage[],
-	status: TypesGen.ChatStatus = "waiting",
-) => {
+const buildStoreWithMessages = (msgs: TypesGen.ChatMessage[]) => {
 	const store = createChatStore();
 	store.replaceMessages(msgs);
-	store.setChatStatus(status);
 	return store;
 };
 
@@ -1103,7 +1099,6 @@ const resetScrollStoryStore = (
 	count = 80,
 ) => {
 	store.replaceMessages(buildLongConversation(count));
-	store.setChatStatus("waiting");
 };
 
 const inverseScrollStore = buildStoreWithMessages(buildLongConversation(80));
@@ -1430,7 +1425,6 @@ export const StickyUserMessageClipUpdatesWhilePinned: Story = {
 	render: () => <StoryAgentChatPageView store={stickyClipUpdateStore} />,
 	play: async ({ canvasElement }) => {
 		stickyClipUpdateStore.replaceMessages(buildTallStickyConversation(30));
-		stickyClipUpdateStore.setChatStatus("waiting");
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
 

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -19,6 +19,7 @@ import {
 	addChildToParentInCache,
 	applyChatArchiveStateToCaches,
 	archiveChat,
+	cancelChatDetailPreservingStatus,
 	cancelChatListRefetches,
 	chatKeys,
 	chatModelConfigs,
@@ -660,12 +661,19 @@ const AgentsPageLayout: FC = () => {
 					// already has data. Cancelling a first-time fetch
 					// reverts the query to pending/idle with no data
 					// and no retry, which AgentChatPage shows as
-					// "Chat not found".
+					// "Chat not found". A cancel also reverts the entry
+					// to its fetch-start state, so the helper re-applies
+					// any status the socket wrote meanwhile.
 					if (queryClient.getQueryData(chatKeys.detail(updatedChat.id))) {
-						void queryClient.cancelQueries({
-							queryKey: chatKeys.detail(updatedChat.id),
-							exact: true,
-						});
+						void cancelChatDetailPreservingStatus(
+							queryClient,
+							updatedChat.id,
+							() =>
+								queryClient.cancelQueries({
+									queryKey: chatKeys.detail(updatedChat.id),
+									exact: true,
+								}),
+						);
 					}
 
 					if (chatEvent.kind === "created") {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
-import { createChatStore, selectIsAwaitingFirstStreamChunk } from "./chatStore";
+import { createChatStore, selectIsPendingAssistantResponse } from "./chatStore";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -176,42 +176,6 @@ describe("upsertDurableMessage", () => {
 		// Same reference — no reorder needed because the map size
 		// didn't change and the ID already existed.
 		expect(store.getSnapshot().orderedMessageIDs).toBe(orderBefore);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// setChatStatus
-// ---------------------------------------------------------------------------
-
-describe("setChatStatus", () => {
-	it("updates chatStatus", () => {
-		const store = createChatStore();
-
-		store.setChatStatus("running");
-
-		expect(store.getSnapshot().chatStatus).toBe("running");
-	});
-
-	it("accepts null to clear the status", () => {
-		const store = createChatStore();
-		store.setChatStatus("running");
-
-		store.setChatStatus(null);
-
-		expect(store.getSnapshot().chatStatus).toBeNull();
-	});
-
-	it("does not notify when setting the same status", () => {
-		const store = createChatStore();
-		store.setChatStatus("running");
-
-		let notified = false;
-		store.subscribe(() => {
-			notified = true;
-		});
-		store.setChatStatus("running");
-
-		expect(notified).toBe(false);
 	});
 });
 
@@ -550,23 +514,6 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 
 		store.clearSuppressedQueuedMessageIDs();
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
-	});
-
-	it("counts every server status report, including repeats", () => {
-		const store = createChatStore();
-
-		expect(store.getServerChatStatusVersion()).toBe(0);
-
-		store.setChatStatus("running");
-		expect(store.getServerChatStatusVersion()).toBe(0);
-
-		store.applyServerChatStatus("error");
-		expect(store.getServerChatStatusVersion()).toBe(1);
-		expect(store.getSnapshot().chatStatus).toBe("error");
-
-		store.applyServerChatStatus("error");
-		expect(store.getServerChatStatusVersion()).toBe(2);
-		expect(store.getSnapshot().chatStatus).toBe("error");
 	});
 
 	it("restores a promoted head that a fresh snapshot still queues", () => {
@@ -937,11 +884,11 @@ describe("subscribe", () => {
 			callCount += 1;
 		});
 
-		store.setChatStatus("running");
+		store.setStreamError({ kind: "generic", message: "first" });
 		expect(callCount).toBe(1);
 
 		unsubscribe();
-		store.setChatStatus("error");
+		store.setStreamError({ kind: "generic", message: "second" });
 		expect(callCount).toBe(1);
 	});
 
@@ -956,7 +903,7 @@ describe("subscribe", () => {
 			countB += 1;
 		});
 
-		store.setChatStatus("running");
+		store.setStreamError({ kind: "generic", message: "boom" });
 
 		expect(countA).toBe(1);
 		expect(countB).toBe(1);
@@ -964,94 +911,58 @@ describe("subscribe", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectIsAwaitingFirstStreamChunk
+// selectIsPendingAssistantResponse
+//
+// The Thinking indicator is the conjunction of this selector and the cached
+// chat status; the status half is covered in durableChat.test.tsx.
 // ---------------------------------------------------------------------------
 
-describe("selectIsAwaitingFirstStreamChunk", () => {
-	it("returns true when running with no stream state and no assistant message", () => {
+describe("selectIsPendingAssistantResponse", () => {
+	it("returns true with no stream state and no assistant message", () => {
 		const store = createChatStore();
-		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
 
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
+		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(true);
 	});
 
 	it("returns false when the latest message is from the assistant", () => {
 		const store = createChatStore();
-		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
 		store.upsertDurableMessage(makeMessage(2, "assistant", "hi there"));
 
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(false);
 	});
 
 	it("returns false when stream state is present", () => {
 		const store = createChatStore();
-		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
 		store.applyMessagePart({ type: "text", text: "response" });
 
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(false);
 	});
 
-	it("returns false during waiting status when latest message is from user", () => {
+	it("returns true when the latest message is a tool result", () => {
 		const store = createChatStore();
-		store.setChatStatus("waiting");
-		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
-
-		// "waiting" means the chat is idle; nothing is generating,
-		// so no Thinking indicator should show.
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
-	});
-
-	it("returns false when chat status is null", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
-
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
-	});
-
-	it("returns true when latest message is a tool result during running", () => {
-		const store = createChatStore();
-		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
 		store.upsertDurableMessage(makeMessage(2, "assistant", "calling tool"));
 		store.upsertDurableMessage(makeMessage(3, "tool", "tool result"));
 
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
+		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(true);
 	});
 
-	it("returns true after optimistic send: clearStreamState + setChatStatus('running') + upsertDurableMessage", () => {
+	it("returns true after an optimistic send clears the settled turn", () => {
 		const store = createChatStore();
-		// Simulate a settled previous turn: assistant replied,
-		// then server transitioned to "waiting".
+		// A settled previous turn: the assistant replied last.
 		store.upsertDurableMessage(makeMessage(1, "user", "first question"));
 		store.upsertDurableMessage(makeMessage(2, "assistant", "first answer"));
-		store.setChatStatus("waiting");
 
-		// Verify baseline: not awaiting while idle.
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(false);
 
-		// Simulate handleSend after POST returns (non-queued).
-		// This is the exact sequence from AgentChatPage.tsx.
+		// The sequence handleSend runs once the POST returns (non-queued).
 		store.clearStreamState();
-		store.setChatStatus("running");
 		store.upsertDurableMessage(makeMessage(3, "user", "follow-up"));
 
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
-	});
-
-	it("returns true when WS delivers user message + status:running (fresh send)", () => {
-		const store = createChatStore();
-		// Simulate the WS batch: [message(user), status:running].
-		// This is the event order from the server when the user
-		// sends a message. The Thinking indicator must appear
-		// before the first stream chunk arrives.
-		store.upsertDurableMessage(makeMessage(1, "user", "sweet ty"));
-		store.setChatStatus("running");
-		store.clearStreamState();
-
-		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
+		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(true);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -29,14 +29,12 @@ const readInfiniteChats = (
 };
 
 import type { FC, PropsWithChildren } from "react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider, useQueryClient } from "react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat } from "#/testHelpers/chatEntities";
-import { createTestQueryClient } from "#/testHelpers/renderHelpers";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
-	selectChatStatus,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
@@ -196,13 +194,49 @@ const createMockSocket = (): MockSocket => {
 	};
 };
 
+/**
+ * Deliberately not the shared helper: that one uses gcTime 0, which evicts a
+ * cache entry seeded without an observer before the socket can write to it.
+ */
+const createTestQueryClient = (): QueryClient =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				gcTime: Number.POSITIVE_INFINITY,
+				refetchOnWindowFocus: false,
+				networkMode: "offlineFirst",
+			},
+		},
+	});
+
+/**
+ * In the app the chat detail query IS the record passed to useChatStore, and
+ * the socket writes status into that cache entry. Tests pass the record as a
+ * prop, so mirror it into the cache the way the query would.
+ */
+const useTestChatStore: typeof useChatStore = (options) => {
+	const queryClient = useQueryClient();
+	const chatRecord = options.chatRecord;
+	if (
+		chatRecord &&
+		queryClient.getQueryData(chatKeys.detail(chatRecord.id)) === undefined
+	) {
+		queryClient.setQueryData(chatKeys.detail(chatRecord.id), chatRecord);
+	}
+	return useChatStore(options);
+};
+
 const createWrapper =
 	(queryClient: QueryClient): FC<PropsWithChildren> =>
 	({ children }) => (
 		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 	);
 
-const buildChat = (chatID: string): TypesGen.Chat => ({
+const buildChat = (
+	chatID: string,
+	overrides?: Partial<TypesGen.Chat>,
+): TypesGen.Chat => ({
 	...MockChat,
 	id: chatID,
 	owner_id: "owner-1",
@@ -213,7 +247,26 @@ const buildChat = (chatID: string): TypesGen.Chat => ({
 	status: "running",
 	created_at: "2025-01-01T00:00:00.000Z",
 	updated_at: "2025-01-01T00:00:00.000Z",
+	snapshot_version: 1,
+	...overrides,
 });
+
+/**
+ * Chat status is canonical in the detail cache, so any test that asserts or
+ * depends on it has to seed the entry the socket writes into.
+ */
+const seedChatDetail = (
+	queryClient: QueryClient,
+	chat: TypesGen.Chat,
+): void => {
+	queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(chat.id), chat);
+};
+
+const readChatDetail = (
+	queryClient: QueryClient,
+	chatID: string,
+): TypesGen.Chat | undefined =>
+	queryClient.getQueryData<TypesGen.Chat>(chatKeys.detail(chatID));
 
 const buildMessage = (
 	chatID: string,
@@ -283,7 +336,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -356,7 +409,7 @@ describe("useChatStore", () => {
 
 		renderHook(
 			() =>
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -399,7 +452,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -497,7 +550,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -589,7 +642,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -650,7 +703,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -747,7 +800,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: initialMessages,
 					chatRecord: buildChat(chatID),
@@ -845,7 +898,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: initialMessages,
 					chatRecord: buildChat(chatID),
@@ -926,7 +979,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -999,7 +1052,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1093,7 +1146,7 @@ describe("useChatStore", () => {
 		};
 
 		const TestHarness: FC = () => {
-			const { store } = useChatStore({
+			const { store } = useTestChatStore({
 				chatID,
 				chatMessages: [existingMessage],
 				chatRecord: buildChat(chatID),
@@ -1165,7 +1218,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1238,7 +1291,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1285,6 +1338,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 2,
 				chat_id: chatID,
 				status: { status: "waiting" },
 			});
@@ -1352,7 +1406,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					queuedMessages: useDurableQueuedMessages({
 						store,
@@ -1431,7 +1485,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					queuedMessages: useChatSelector(store, selectQueuedMessages),
 				};
@@ -1504,7 +1558,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1575,7 +1629,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1649,7 +1703,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1760,7 +1814,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					streamState: useChatSelector(store, selectStreamState),
 				};
@@ -1829,7 +1883,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1883,7 +1937,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -1988,7 +2042,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -2098,7 +2152,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					streamState: useChatSelector(store, selectStreamState),
 				};
@@ -2187,7 +2241,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					queuedMessages: useChatSelector(store, selectQueuedMessages),
 				};
@@ -2241,7 +2295,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2281,6 +2335,7 @@ describe("useChatStore", () => {
 				},
 				{
 					type: "status",
+					snapshot_version: 3,
 					chat_id: chatID,
 					status: { status: "waiting" },
 				},
@@ -2295,24 +2350,15 @@ describe("useChatStore", () => {
 		});
 	});
 
-	it("applies a refetched status after acceptServerChatStatus", async () => {
-		const chatID = "chat-resync";
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-		const queryClient = createTestQueryClient();
-		const wrapper = createWrapper(queryClient);
-
-		const initialProps: { status: TypesGen.ChatStatus; updatedAt: number } = {
-			status: "waiting",
-			updatedAt: 1,
-		};
-		const { result, rerender } = renderHook(
-			({ status, updatedAt }: typeof initialProps) => {
-				const { store, acceptServerChatStatus } = useChatStore({
+	// Status ordering: snapshot_version is the shared key every writer
+	// compares against, so these cover apply / reject / duplicate.
+	const renderStatusHarness = (chatID: string, queryClient: QueryClient) =>
+		renderHook(
+			() => {
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
-					chatRecord: { ...buildChat(chatID), status },
-					chatRecordUpdatedAt: updatedAt,
+					chatRecord: buildChat(chatID),
 					chatMessagesData: {
 						messages: [],
 						queued_messages: [],
@@ -2323,12 +2369,27 @@ describe("useChatStore", () => {
 					clearChatErrorReason: vi.fn(),
 				});
 				return {
-					acceptServerChatStatus,
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
+					streamError: useChatSelector(store, selectStreamError),
 				};
 			},
-			{ wrapper, initialProps },
+			{ wrapper: createWrapper(queryClient) },
 		);
+
+	it("applies a status carrying a newer snapshot version", async () => {
+		const chatID = "chat-status-newer";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "waiting", snapshot_version: 4 }),
+		);
+		seedInfiniteChats(queryClient, [
+			buildChat(chatID, { status: "waiting", snapshot_version: 4 }),
+		]);
+
+		const { result } = renderStatusHarness(chatID, queryClient);
 
 		await waitFor(() => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
@@ -2338,41 +2399,464 @@ describe("useChatStore", () => {
 			mockSocket.emitData({
 				type: "status",
 				chat_id: chatID,
+				snapshot_version: 5,
+				status: { status: "running" },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+		expect(readChatDetail(queryClient, chatID)?.snapshot_version).toBe(5);
+		expect(readInfiniteChats(queryClient)?.[0]).toMatchObject({
+			status: "running",
+			snapshot_version: 5,
+		});
+	});
+
+	it("rejects a delayed status event carrying an older snapshot version", async () => {
+		const chatID = "chat-status-older";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "waiting", snapshot_version: 4 }),
+		);
+
+		const { result } = renderStatusHarness(chatID, queryClient);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				snapshot_version: 7,
 				status: { status: "running" },
 			});
 		});
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 		});
-		rerender({ status: "error", updatedAt: 1 });
-		expect(result.current.chatStatus).toBe("running");
 
 		act(() => {
-			result.current.acceptServerChatStatus();
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				snapshot_version: 5,
+				status: { status: "waiting" },
+			});
 		});
-		rerender({ status: "waiting", updatedAt: 1 });
-		expect(result.current.chatStatus).toBe("running");
-		rerender({ status: "error", updatedAt: 2 });
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("error");
+
+		expect(readChatDetail(queryClient, chatID)).toMatchObject({
+			status: "running",
+			snapshot_version: 7,
 		});
 	});
 
-	it("hydrates an unchanged status after a successful refetch", async () => {
-		const chatID = "chat-resync-same";
+	it("treats an equal-version status event as a duplicate no-op", async () => {
+		const chatID = "chat-status-duplicate";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "running", snapshot_version: 6 }),
+		);
+
+		renderStatusHarness(chatID, queryClient);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+		const before = readChatDetail(queryClient, chatID);
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				snapshot_version: 6,
+				status: { status: "waiting" },
+			});
+		});
+
+		// Same version, same snapshot: nothing to apply, not even a new object.
+		expect(readChatDetail(queryClient, chatID)).toBe(before);
+	});
+
+	it("keeps the detail query's dataUpdatedAt when a status lands", async () => {
+		const chatID = "chat-status-freshness";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "waiting", snapshot_version: 4 }),
+		);
+		const seededUpdatedAt = queryClient.getQueryState(
+			chatKeys.detail(chatID),
+		)?.dataUpdatedAt;
+
+		const { result } = renderStatusHarness(chatID, queryClient);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				snapshot_version: 5,
+				status: { status: "running" },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("running");
+		});
+		expect(
+			queryClient.getQueryState(chatKeys.detail(chatID))?.dataUpdatedAt,
+		).toBe(seededUpdatedAt);
+	});
+
+	it("reports a versionless transport error without writing chat status", async () => {
+		const chatID = "chat-transport-error";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "running", snapshot_version: 4 }),
+		);
+
+		const { result } = renderStatusHarness(chatID, queryClient);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: { message: "Subscription failed", retryable: false },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toEqual({
+				kind: "generic",
+				message: "Subscription failed",
+				retryable: false,
+			});
+		});
+		// No snapshot backs the failure, so the chat is still running.
+		expect(readChatDetail(queryClient, chatID)).toMatchObject({
+			status: "running",
+			snapshot_version: 4,
+		});
+	});
+
+	it("keeps buffered parts, retry state, and the error reason for a superseded status", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-status-superseded-effects";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "running", snapshot_version: 7 }),
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: buildChat(chatID, {
+						status: "running",
+						snapshot_version: 7,
+					}),
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					retryState: useChatSelector(store, selectRetryState),
+				};
+			},
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "retry",
+				chat_id: chatID,
+				retry: {
+					attempt: 2,
+					error: "upstream timeout",
+					kind: "timeout",
+					provider: "anthropic",
+					delay_ms: 5000,
+					retrying_at: "2025-01-01T00:01:00.000Z",
+				},
+			});
+		});
+		await act(async () => {});
+		expect(result.current.retryState).not.toBeNull();
+
+		// A delayed "waiting" from an older snapshot. The cache rejects it, so
+		// the turn it would end is not this chat's current one and its stream
+		// side effects must not run either.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				snapshot_version: 5,
+				status: { status: "waiting" },
+			});
+		});
+		await act(async () => {});
+
+		expect(clearChatErrorReason).not.toHaveBeenCalled();
+		expect(result.current.retryState).not.toBeNull();
+		expect(readChatDetail(queryClient, chatID)).toMatchObject({
+			status: "running",
+			snapshot_version: 7,
+		});
+
+		// Buffered parts survive the same rejected status, so the response
+		// keeps streaming.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						role: "assistant",
+						part: { type: "text", text: "still streaming" },
+					},
+				},
+				{
+					type: "status",
+					chat_id: chatID,
+					snapshot_version: 5,
+					status: { status: "waiting" },
+				},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "still streaming" },
+			]);
+		});
+
+		// An accepted status ends the turn, clearing the retry indicator that
+		// belonged to it.
+		act(() => {
+			mockSocket.emitData({
+				type: "retry",
+				chat_id: chatID,
+				retry: {
+					attempt: 3,
+					error: "upstream timeout",
+					kind: "timeout",
+					provider: "anthropic",
+					delay_ms: 5000,
+					retrying_at: "2025-01-01T00:02:00.000Z",
+				},
+			});
+		});
+		await act(async () => {});
+		expect(result.current.retryState).not.toBeNull();
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				snapshot_version: 8,
+				status: { status: "waiting" },
+			});
+		});
+		await waitFor(() => {
+			expect(result.current.retryState).toBeNull();
+		});
+	});
+
+	it("surfaces an error event sharing its status event's snapshot version", async () => {
+		const chatID = "chat-error-companion";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "running", snapshot_version: 7 }),
+		);
+		const setChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: buildChat(chatID, {
+						status: "running",
+						snapshot_version: 7,
+					}),
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		// The server emits the status transition and the error detailing it
+		// from one chat snapshot, so both carry the same version.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "status",
+					chat_id: chatID,
+					snapshot_version: 8,
+					status: { status: "error" },
+				},
+				{
+					type: "error",
+					chat_id: chatID,
+					snapshot_version: 8,
+					error: { message: "Upstream failed", retryable: false },
+				},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toMatchObject({
+				kind: "generic",
+				message: "Upstream failed",
+			});
+		});
+		expect(setChatErrorReason).toHaveBeenCalledWith(
+			chatID,
+			expect.objectContaining({ message: "Upstream failed" }),
+		);
+		expect(readChatDetail(queryClient, chatID)).toMatchObject({
+			status: "error",
+			snapshot_version: 8,
+		});
+	});
+
+	it("does not install a stream error for a superseded error event", async () => {
+		const chatID = "chat-error-superseded";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "running", snapshot_version: 7 }),
+		);
+
+		const { result } = renderStatusHarness(chatID, queryClient);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				snapshot_version: 5,
+				error: { message: "Old failure", retryable: false },
+			});
+		});
+
+		// The chat already moved past that snapshot, so the failure it reports
+		// is not the current one.
+		expect(result.current.streamError).toBeNull();
+		expect(readChatDetail(queryClient, chatID)).toMatchObject({
+			status: "running",
+			snapshot_version: 7,
+		});
+	});
+
+	it("rejects an older error event while the chat is already in error", async () => {
+		const chatID = "chat-error-older-than-error";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+		const queryClient = createTestQueryClient();
+		// A newer error snapshot already landed, so only its own companion may
+		// report a reason.
+		seedChatDetail(
+			queryClient,
+			buildChat(chatID, { status: "error", snapshot_version: 8 }),
+		);
+
+		const { result } = renderStatusHarness(chatID, queryClient);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				snapshot_version: 5,
+				error: { message: "Old failure", retryable: false },
+			});
+		});
+
+		expect(result.current.streamError).toBeNull();
+		expect(readChatDetail(queryClient, chatID)).toMatchObject({
+			status: "error",
+			snapshot_version: 8,
+		});
+	});
+
+	it("does not gate the socket on messages alone", async () => {
+		const chatID = "chat-first-fetch";
 		const mockSocket = createMockSocket();
 		mockWatchChatReturn(mockSocket);
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
-		const chatRecord = { ...buildChat(chatID), status: "error" as const };
 
-		const { result, rerender } = renderHook(
-			({ updatedAt }: { updatedAt: number }) => {
-				const { store, acceptServerChatStatus } = useChatStore({
+		const { rerender } = renderHook(
+			({ chatRecord }: { chatRecord: TypesGen.Chat | undefined }) => {
+				useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord,
-					chatRecordUpdatedAt: updatedAt,
 					chatMessagesData: {
 						messages: [],
 						queued_messages: [],
@@ -2382,155 +2866,25 @@ describe("useChatStore", () => {
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
 				});
-				return {
-					acceptServerChatStatus,
-					chatStatus: useChatSelector(store, selectChatStatus),
-				};
-			},
-			{ wrapper, initialProps: { updatedAt: 1 } },
-		);
-
-		await waitFor(() => {
-			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
-		});
-		act(() => {
-			mockSocket.emitData({
-				type: "status",
-				chat_id: chatID,
-				status: { status: "running" },
-			});
-		});
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("running");
-		});
-
-		act(() => {
-			result.current.acceptServerChatStatus();
-		});
-		expect(result.current.chatStatus).toBe("running");
-		rerender({ updatedAt: 2 });
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("error");
-		});
-	});
-
-	it("ignores a resync armed by a request from a chat the user left", async () => {
-		const leftChatID = "chat-resync-left";
-		const activeChatID = "chat-resync-active";
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-		const queryClient = createTestQueryClient();
-		const wrapper = createWrapper(queryClient);
-
-		const { result, rerender } = renderHook(
-			({ chatID, updatedAt }: { chatID: string; updatedAt: number }) => {
-				const { store, acceptServerChatStatus } = useChatStore({
-					chatID,
-					chatMessages: [],
-					chatRecord: { ...buildChat(chatID), status: "waiting" },
-					chatRecordUpdatedAt: updatedAt,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
-					chatQueuedMessages: [],
-					setChatErrorReason: () => {},
-					clearChatErrorReason: () => {},
-				});
-				return {
-					acceptServerChatStatus,
-					chatStatus: useChatSelector(store, selectChatStatus),
-				};
+				return null;
 			},
 			{
 				wrapper,
-				initialProps: { chatID: leftChatID, updatedAt: 1 },
+				initialProps: { chatRecord: undefined } as {
+					chatRecord: TypesGen.Chat | undefined;
+				},
 			},
 		);
 
-		await waitFor(() => {
-			expect(watchChat).toHaveBeenCalledWith(leftChatID, undefined);
-		});
-		// The in-flight request holds the callback from the render it started in.
-		const staleAcceptServerChatStatus = result.current.acceptServerChatStatus;
+		// Messages resolved, detail did not: a status event would have nowhere
+		// to land, so the socket stays closed.
+		expect(watchChat).not.toHaveBeenCalled();
 
-		rerender({ chatID: activeChatID, updatedAt: 5 });
-		await waitFor(() => {
-			expect(watchChat).toHaveBeenCalledWith(activeChatID, undefined);
-		});
-		act(() => {
-			mockSocket.emitData({
-				type: "status",
-				chat_id: activeChatID,
-				status: { status: "running" },
-			});
-		});
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("running");
-		});
-
-		act(() => {
-			staleAcceptServerChatStatus();
-		});
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("running");
-		});
-	});
-
-	it("keeps a websocket status delivered while the resync refetch is in flight", async () => {
-		const chatID = "chat-resync-ws-race";
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-		const queryClient = createTestQueryClient();
-		const wrapper = createWrapper(queryClient);
-		const chatRecord = { ...buildChat(chatID), status: "error" as const };
-
-		const { result, rerender } = renderHook(
-			({ updatedAt }: { updatedAt: number }) => {
-				const { store, acceptServerChatStatus } = useChatStore({
-					chatID,
-					chatMessages: [],
-					chatRecord,
-					chatRecordUpdatedAt: updatedAt,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
-					chatQueuedMessages: [],
-					setChatErrorReason: () => {},
-					clearChatErrorReason: () => {},
-				});
-				return {
-					acceptServerChatStatus,
-					chatStatus: useChatSelector(store, selectChatStatus),
-				};
-			},
-			{ wrapper, initialProps: { updatedAt: 1 } },
-		);
+		seedChatDetail(queryClient, buildChat(chatID));
+		rerender({ chatRecord: buildChat(chatID) });
 
 		await waitFor(() => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
-		});
-
-		act(() => {
-			result.current.acceptServerChatStatus();
-		});
-		act(() => {
-			mockSocket.emitData({
-				type: "status",
-				chat_id: chatID,
-				status: { status: "running" },
-			});
-		});
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("running");
-		});
-
-		rerender({ updatedAt: 2 });
-		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("running");
 		});
 	});
 
@@ -2548,7 +2902,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2562,7 +2916,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason,
 				});
 				return {
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 					streamError: useChatSelector(store, selectStreamError),
 					retryState: useChatSelector(store, selectRetryState),
 				};
@@ -2577,6 +2931,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
+				snapshot_version: 5,
 				chat_id: chatID,
 				error: {
 					message: "Rate limit exceeded",
@@ -2625,7 +2980,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2652,6 +3007,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
+				snapshot_version: 6,
 				chat_id: chatID,
 				error: { message: "  ", retryable: false },
 			});
@@ -2679,7 +3035,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2742,7 +3098,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2757,7 +3113,7 @@ describe("useChatStore", () => {
 				});
 				return {
 					retryState: useChatSelector(store, selectRetryState),
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -2797,6 +3153,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 7,
 				chat_id: chatID,
 				status: { status: "running" },
 			});
@@ -2822,7 +3179,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2906,7 +3263,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2920,7 +3277,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason,
 				});
 				return {
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 					subagentStatusOverrides: useChatSelector(
 						store,
 						selectSubagentStatusOverrides,
@@ -2937,6 +3294,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 8,
 				chat_id: subagentChatID,
 				status: { status: "waiting" },
 			});
@@ -2967,7 +3325,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -2981,7 +3339,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason,
 				});
 				return {
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 					reconnectState: useChatSelector(store, selectReconnectState),
 				};
 			},
@@ -3046,7 +3404,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -3121,7 +3479,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -3150,6 +3508,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
+				snapshot_version: 9,
 				chat_id: chatID,
 				error: { message: "Rate limit exceeded", retryable: false },
 			});
@@ -3196,7 +3555,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: { ...buildChat(chatID), status: "waiting" },
@@ -3210,7 +3569,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason: vi.fn(),
 				});
 				return {
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 					reconnectState: useChatSelector(store, selectReconnectState),
 				};
 			},
@@ -3243,7 +3602,7 @@ describe("useChatStore", () => {
 
 		renderHook(
 			() =>
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -3294,7 +3653,7 @@ describe("useChatStore", () => {
 
 		renderHook(
 			() =>
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: [msg],
 					chatRecord: buildChat(chatID),
@@ -3357,7 +3716,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -3480,7 +3839,7 @@ describe("useChatStore", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -3494,7 +3853,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason,
 				});
 				return {
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -3508,6 +3867,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 10,
 				chat_id: chatID,
 				status: { status: "running" },
 			});
@@ -3553,7 +3913,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
 				};
@@ -3622,7 +3982,7 @@ describe("useChatStore", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
 					queuedMessages: useChatSelector(store, selectQueuedMessages),
@@ -3729,11 +4089,11 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					store,
 					streamState: useChatSelector(store, selectStreamState),
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
 				};
 			},
@@ -3751,6 +4111,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 11,
 				chat_id: chatID,
 				status: { status: "running" },
 			});
@@ -3798,7 +4159,7 @@ describe("useChatStore", () => {
 		});
 	});
 
-	it("does not let a stale REST chatRecord.status override WS-delivered status", async () => {
+	it("ignores a stale chat record prop, the cache owns the status", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-stale-rest-status";
@@ -3812,7 +4173,7 @@ describe("useChatStore", () => {
 		// Start with a "running" chatRecord so the WS opens.
 		const { result, rerender } = renderHook(
 			(props: { chatRecord: TypesGen.Chat }) => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: props.chatRecord,
@@ -3842,10 +4203,11 @@ describe("useChatStore", () => {
 			expect(result.current.chatStatus).toBe("running");
 		});
 
-		// Deliver a status event over WS so wsStatusReceivedRef is set.
+		// Deliver a status event over the socket, which owns the cache entry.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 12,
 				chat_id: chatID,
 				status: { status: "running" },
 			});
@@ -3860,11 +4222,13 @@ describe("useChatStore", () => {
 			chatRecord: { ...buildChat(chatID), status: "waiting" },
 		});
 
-		// The store must ignore the stale REST value because the
-		// WS already delivered a status event for this chat.
+		// The chat record is no longer a status source: the socket wrote the
+		// status into the detail cache and only a newer snapshot version can
+		// replace it. Guards against reintroducing a REST-to-store hydration.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 		});
+		expect(readChatDetail(queryClient, chatID)?.snapshot_version).toBe(12);
 	});
 
 	it("preserves stream state when status transitions to waiting", async () => {
@@ -3882,7 +4246,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -3930,6 +4294,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 13,
 				chat_id: chatID,
 				status: { status: "waiting" },
 			});
@@ -3958,7 +4323,7 @@ describe("useChatStore", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -4007,6 +4372,7 @@ describe("useChatStore", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 14,
 				chat_id: chatID,
 				status: { status: "waiting" },
 			});
@@ -4056,7 +4422,7 @@ describe("thinking indicator event ordering", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: { ...buildChat(chatID), status: "running" },
@@ -4099,6 +4465,7 @@ describe("thinking indicator event ordering", () => {
 				},
 				{
 					type: "status",
+					snapshot_version: 15,
 					chat_id: chatID,
 					status: { status: "running" },
 				},
@@ -4142,7 +4509,7 @@ describe("thinking indicator event ordering", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: { ...buildChat(chatID), status: "running" },
@@ -4176,6 +4543,7 @@ describe("thinking indicator event ordering", () => {
 			mockSocket.emitDataBatch([
 				{
 					type: "status",
+					snapshot_version: 16,
 					chat_id: chatID,
 					status: { status: "running" },
 				},
@@ -4223,7 +4591,7 @@ describe("thinking indicator event ordering", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: { ...buildChat(chatID), status: "running" },
@@ -4262,6 +4630,7 @@ describe("thinking indicator event ordering", () => {
 				},
 				{
 					type: "status",
+					snapshot_version: 17,
 					chat_id: chatID,
 					status: { status: "waiting" },
 				},
@@ -4282,7 +4651,7 @@ describe("thinking indicator event ordering", () => {
 	});
 });
 
-describe("updateSidebarChat via stream events", () => {
+describe("sidebar cache writes from stream events", () => {
 	it("updates sidebar chat status on status stream event", async () => {
 		immediateAnimationFrame();
 
@@ -4301,7 +4670,7 @@ describe("updateSidebarChat via stream events", () => {
 			},
 		});
 		const initialChat = buildChat(chatID);
-		// Seed the chats list so updateSidebarChat can find it.
+		// Seed the chats list so the status write can find the row.
 		seedInfiniteChats(queryClient, [initialChat]);
 
 		const wrapper = createWrapper(queryClient);
@@ -4310,7 +4679,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
@@ -4323,7 +4692,7 @@ describe("updateSidebarChat via stream events", () => {
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
-				return { chatStatus: useChatSelector(store, selectChatStatus) };
+				return { chatStatus: useDurableChatStatus({ store, chatId: chatID }) };
 			},
 			{ wrapper },
 		);
@@ -4335,6 +4704,7 @@ describe("updateSidebarChat via stream events", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 18,
 				chat_id: chatID,
 				status: { status: "waiting" },
 			});
@@ -4372,7 +4742,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
@@ -4443,7 +4813,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
@@ -4456,7 +4826,7 @@ describe("updateSidebarChat via stream events", () => {
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
-				return { chatStatus: useChatSelector(store, selectChatStatus) };
+				return { chatStatus: useDurableChatStatus({ store, chatId: chatID }) };
 			},
 			{ wrapper },
 		);
@@ -4468,6 +4838,7 @@ describe("updateSidebarChat via stream events", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
+				snapshot_version: 19,
 				chat_id: chatID,
 				error: { message: "something went wrong", retryable: false },
 			});
@@ -4507,7 +4878,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: activeChat,
@@ -4532,6 +4903,7 @@ describe("updateSidebarChat via stream events", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 20,
 				chat_id: chatID,
 				status: { status: "waiting" },
 			});
@@ -4578,7 +4950,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
@@ -4647,7 +5019,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
@@ -4660,7 +5032,7 @@ describe("updateSidebarChat via stream events", () => {
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
-				return { chatStatus: useChatSelector(store, selectChatStatus) };
+				return { chatStatus: useDurableChatStatus({ store, chatId: chatID }) };
 			},
 			{ wrapper },
 		);
@@ -4672,6 +5044,7 @@ describe("updateSidebarChat via stream events", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
+				snapshot_version: 21,
 				chat_id: chatID,
 				status: { status: "waiting" },
 			});
@@ -4711,7 +5084,7 @@ describe("updateSidebarChat via stream events", () => {
 
 		renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
@@ -4724,7 +5097,7 @@ describe("updateSidebarChat via stream events", () => {
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
-				return { chatStatus: useChatSelector(store, selectChatStatus) };
+				return { chatStatus: useDurableChatStatus({ store, chatId: chatID }) };
 			},
 			{ wrapper },
 		);
@@ -4736,6 +5109,7 @@ describe("updateSidebarChat via stream events", () => {
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
+				snapshot_version: 22,
 				chat_id: chatID,
 				error: { message: "something broke", retryable: false },
 			});
@@ -4763,7 +5137,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: buildChat(chatID),
@@ -4849,7 +5223,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: buildChat(chatID),
@@ -4935,7 +5309,7 @@ describe("partsBuf cleanup on reconnect (Bug 2)", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: buildChat(chatID),
@@ -5074,7 +5448,7 @@ describe("store/cache desync protection", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
 					store,
@@ -5162,7 +5536,7 @@ describe("store/cache desync protection", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
 				};
@@ -5232,7 +5606,7 @@ describe("store/cache desync protection", () => {
 
 		const { result, rerender } = renderHook(
 			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useChatStore(options);
+				const { store } = useTestChatStore(options);
 				return {
 					store,
 					messagesByID: useChatSelector(store, selectMessagesByID),
@@ -5302,7 +5676,7 @@ describe("parse errors", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
@@ -5317,7 +5691,7 @@ describe("parse errors", () => {
 				});
 				return {
 					streamError: useChatSelector(store, selectStreamError),
-					chatStatus: useChatSelector(store, selectChatStatus),
+					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -5355,7 +5729,7 @@ describe("parse errors", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -5429,7 +5803,7 @@ describe("parse errors", () => {
 
 		const { result } = renderHook(
 			() => {
-				const { store } = useChatStore({
+				const { store } = useTestChatStore({
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
@@ -5532,7 +5906,7 @@ describe("message cache resync over the socket", () => {
 
 		renderHook(
 			() =>
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: [cachedMessage],
 					chatRecord: buildChat(chatID),
@@ -5589,7 +5963,7 @@ describe("message cache resync over the socket", () => {
 
 		renderHook(
 			() =>
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: cachedMessages,
 					chatRecord: buildChat(chatID),
@@ -5648,7 +6022,7 @@ describe("message cache resync over the socket", () => {
 
 		renderHook(
 			() =>
-				useChatStore({
+				useTestChatStore({
 					chatID,
 					chatMessages: [cachedMessage],
 					chatRecord: buildChat(chatID),

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -130,7 +130,6 @@ export type ChatStoreState = {
 	messagesByID: Map<number, TypesGen.ChatMessage>;
 	orderedMessageIDs: readonly number[];
 	streamState: StreamState | null;
-	chatStatus: TypesGen.ChatStatus | null;
 	streamError: ChatDetailError | null;
 	retryState: RetryState | null;
 	reconnectState: ReconnectState | null;
@@ -187,14 +186,8 @@ export type ChatStore = {
 	hasObservedQueuedMessageID: (id: number) => boolean;
 	setActiveChatID: (chatID: string | null) => void;
 	getActiveChatID: () => string | null;
-	// Counts server-reported status events, including repeats of the
-	// current value, so a caller can tell that the server spoke during a
-	// request even when the status did not change.
-	getServerChatStatusVersion: () => number;
-	applyServerChatStatus: (status: TypesGen.ChatStatus | null) => void;
 	unsuppressQueuedMessageID: (id: number) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
-	setChatStatus: (status: TypesGen.ChatStatus | null) => void;
 	setStreamState: (streamState: StreamState | null) => void;
 	setStreamError: (reason: ChatDetailError | null) => void;
 	clearStreamError: () => void;
@@ -215,7 +208,6 @@ const createInitialState = (): ChatStoreState => ({
 	messagesByID: new Map(),
 	orderedMessageIDs: [],
 	streamState: null,
-	chatStatus: null,
 	streamError: null,
 	retryState: null,
 	reconnectState: null,
@@ -231,7 +223,6 @@ export const createChatStore = (): ChatStore => {
 	// server event cannot trigger a re-render.
 	let observedQueuedMessageIDs = new Set<number>();
 	let queueConvergenceFence = 0;
-	let serverChatStatusVersion = 0;
 	let activeChatID: string | null = null;
 	const listeners = new Set<() => void>();
 
@@ -599,15 +590,6 @@ export const createChatStore = (): ChatStore => {
 				};
 			});
 		},
-		setChatStatus: (status) => {
-			if (state.chatStatus === status) {
-				return;
-			}
-			setState((current) => ({
-				...current,
-				chatStatus: status,
-			}));
-		},
 		setActiveChatID: (chatID) => {
 			if (activeChatID === chatID) {
 				return;
@@ -618,17 +600,6 @@ export const createChatStore = (): ChatStore => {
 			queueConvergenceFence++;
 		},
 		getActiveChatID: () => activeChatID,
-		getServerChatStatusVersion: () => serverChatStatusVersion,
-		applyServerChatStatus: (status) => {
-			serverChatStatusVersion++;
-			if (state.chatStatus === status) {
-				return;
-			}
-			setState((current) => ({
-				...current,
-				chatStatus: status,
-			}));
-		},
 		setStreamState: (streamState) => {
 			if (state.streamState === streamState) {
 				return;
@@ -768,7 +739,6 @@ export const selectOrderedMessageIDs = (state: ChatStoreState) =>
 export const selectStreamState = (state: ChatStoreState) => state.streamState;
 export const selectHasStreamState = (state: ChatStoreState) =>
 	state.streamState !== null;
-export const selectChatStatus = (state: ChatStoreState) => state.chatStatus;
 export const selectStreamError = (state: ChatStoreState) => state.streamError;
 export const selectQueuedMessages = (state: ChatStoreState) =>
 	state.queuedMessages;
@@ -788,20 +758,20 @@ const selectLatestDurableMessage = (
 		: state.messagesByID.get(latestMessageID);
 };
 
-export const selectIsAwaitingFirstStreamChunk = (
+/**
+ * True when the conversation is between turns: no stream output yet and the
+ * latest durable message is not an assistant reply. Deliberately primitive and
+ * status-free, the facade composes it with the cached chat status to decide
+ * whether to show the Thinking indicator.
+ */
+export const selectIsPendingAssistantResponse = (
 	state: ChatStoreState,
 ): boolean => {
-	const latestMessage = selectLatestDurableMessage(state);
-	const latestMessageNeedsAssistantResponse =
-		!latestMessage || latestMessage.role !== "assistant";
-	// Show the Thinking indicator when the store has no stream
-	// data yet, the chat is running, and the conversation is
-	// waiting for an assistant response (any non-assistant latest
-	// message).
-	if (state.streamState !== null || !latestMessageNeedsAssistantResponse) {
+	if (state.streamState !== null) {
 		return false;
 	}
-	return state.chatStatus === "running";
+	const latestMessage = selectLatestDurableMessage(state);
+	return !latestMessage || latestMessage.role !== "assistant";
 };
 
 export const useChatSelector = <T>(

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
@@ -1,12 +1,13 @@
-import { act, render, renderHook } from "@testing-library/react";
-import type { FC } from "react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import type { FC, PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { describe, expect, it } from "vitest";
+import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { MockChat } from "#/testHelpers/chatEntities";
 import {
 	type ChatStore,
 	createChatStore,
-	selectChatStatus,
-	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
@@ -21,6 +22,40 @@ import {
 } from "./durableChat";
 
 const CHAT_ID = "chat-1";
+
+const createTestQueryClient = (): QueryClient =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				refetchOnWindowFocus: false,
+				networkMode: "offlineFirst",
+			},
+		},
+	});
+
+/**
+ * The facade reads status from the detail cache, so every status assertion
+ * needs a seeded entry and a provider around the hook.
+ */
+const seedChatDetail = (
+	queryClient: QueryClient,
+	status: TypesGen.ChatStatus,
+	snapshotVersion = 1,
+): void => {
+	queryClient.setQueryData<TypesGen.Chat>(chatKeys.detail(CHAT_ID), {
+		...MockChat,
+		id: CHAT_ID,
+		status,
+		snapshot_version: snapshotVersion,
+	});
+};
+
+const createWrapper =
+	(queryClient: QueryClient): FC<PropsWithChildren> =>
+	({ children }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
 
 const buildMessage = (
 	id: number,
@@ -50,40 +85,35 @@ const buildTextPart = (text: string): TypesGen.ChatMessagePart => ({
 });
 
 describe("durableChat facade", () => {
-	it("matches the underlying store selectors", () => {
+	it("reads messages and the queue from the store and status from the cache", () => {
 		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "running");
 		const messages = [
 			buildMessage(1, "user", "hello"),
 			buildMessage(2, "assistant", "hi"),
 		];
 		store.replaceMessages(messages);
 		store.setQueuedMessages([buildQueuedMessage(10, "later")]);
-		store.setChatStatus("running");
 
-		const { result } = renderHook(() => ({
-			facadeStatus: useDurableChatStatus({ store, chatId: CHAT_ID }),
-			selectorStatus: useChatSelector(store, selectChatStatus),
-			facadeMessages: useDurableMessageList({ store, chatId: CHAT_ID }),
-			selectorMessagesByID: useChatSelector(store, selectMessagesByID),
-			selectorOrderedMessageIDs: useChatSelector(
-				store,
-				selectOrderedMessageIDs,
-			),
-			facadeCount: useDurableMessageCount({ store, chatId: CHAT_ID }),
-			facadeQueued: useDurableQueuedMessages({ store, chatId: CHAT_ID }),
-			selectorQueued: useChatSelector(store, selectQueuedMessages),
-			facadeAwaiting: useIsAwaitingFirstStreamChunk({
-				store,
-				chatId: CHAT_ID,
+		const { result } = renderHook(
+			() => ({
+				facadeStatus: useDurableChatStatus({ store, chatId: CHAT_ID }),
+				facadeMessages: useDurableMessageList({ store, chatId: CHAT_ID }),
+				selectorMessagesByID: useChatSelector(store, selectMessagesByID),
+				selectorOrderedMessageIDs: useChatSelector(
+					store,
+					selectOrderedMessageIDs,
+				),
+				facadeCount: useDurableMessageCount({ store, chatId: CHAT_ID }),
+				facadeQueued: useDurableQueuedMessages({ store, chatId: CHAT_ID }),
+				selectorQueued: useChatSelector(store, selectQueuedMessages),
 			}),
-			selectorAwaiting: useChatSelector(
-				store,
-				selectIsAwaitingFirstStreamChunk,
-			),
-		}));
+			{ wrapper: createWrapper(queryClient) },
+		);
 
 		const current = result.current;
-		expect(current.facadeStatus).toBe(current.selectorStatus);
+		expect(current.facadeStatus).toBe("running");
 		expect(current.facadeMessages).toEqual(
 			current.selectorOrderedMessageIDs.map((id) =>
 				current.selectorMessagesByID.get(id),
@@ -92,25 +122,61 @@ describe("durableChat facade", () => {
 		expect(current.facadeMessages).toEqual(messages);
 		expect(current.facadeCount).toBe(current.selectorMessagesByID.size);
 		expect(current.facadeQueued).toBe(current.selectorQueued);
-		expect(current.facadeAwaiting).toBe(current.selectorAwaiting);
 	});
 
-	it("keeps the message list reference stable when an unrelated field changes", () => {
+	it("returns null when no chat is selected", () => {
 		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "running");
+
+		const { result } = renderHook(
+			() => useDurableChatStatus({ store, chatId: undefined }),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		expect(result.current).toBeNull();
+	});
+
+	it("re-renders the status consumer when the cached status changes", async () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "waiting");
+
+		const { result } = renderHook(
+			() => useDurableChatStatus({ store, chatId: CHAT_ID }),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		expect(result.current).toBe("waiting");
+
+		seedChatDetail(queryClient, "running", 2);
+
+		await waitFor(() => {
+			expect(result.current).toBe("running");
+		});
+	});
+
+	it("keeps the message list reference stable when the status changes", async () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "waiting");
 		store.replaceMessages([buildMessage(1, "user", "hello")]);
 
-		const { result } = renderHook(() => ({
-			messages: useDurableMessageList({ store, chatId: CHAT_ID }),
-			status: useDurableChatStatus({ store, chatId: CHAT_ID }),
-		}));
+		const { result } = renderHook(
+			() => ({
+				messages: useDurableMessageList({ store, chatId: CHAT_ID }),
+				status: useDurableChatStatus({ store, chatId: CHAT_ID }),
+			}),
+			{ wrapper: createWrapper(queryClient) },
+		);
 
 		const firstMessages = result.current.messages;
 
-		act(() => {
-			store.setChatStatus("running");
-		});
+		seedChatDetail(queryClient, "running", 2);
 
-		expect(result.current.status).toBe("running");
+		await waitFor(() => {
+			expect(result.current.status).toBe("running");
+		});
 		expect(result.current.messages).toBe(firstMessages);
 
 		act(() => {
@@ -123,6 +189,7 @@ describe("durableChat facade", () => {
 
 	it("does not re-render a queued-message consumer on a message_part update", () => {
 		const store = createChatStore();
+		const queryClient = createTestQueryClient();
 		store.replaceMessages([buildMessage(1, "user", "hello")]);
 
 		let queueRenderCount = 0;
@@ -140,11 +207,12 @@ describe("durableChat facade", () => {
 			return null;
 		};
 
+		const Wrapper = createWrapper(queryClient);
 		render(
-			<>
+			<Wrapper>
 				<QueueProbe store={store} />
 				<MessageProbe store={store} />
-			</>,
+			</Wrapper>,
 		);
 
 		const queueBaseline = queueRenderCount;
@@ -158,20 +226,46 @@ describe("durableChat facade", () => {
 		expect(messageRenderCount).toBe(messageBaseline);
 	});
 
+	it("shows the Thinking indicator only while the cached status is running", async () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "waiting");
+		store.replaceMessages([buildMessage(1, "user", "hello")]);
+
+		const { result } = renderHook(
+			() => useIsAwaitingFirstStreamChunk({ store, chatId: CHAT_ID }),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		// The store half is satisfied (user message, no stream), the cached
+		// status is not.
+		expect(result.current).toBe(false);
+
+		seedChatDetail(queryClient, "running", 2);
+
+		await waitFor(() => {
+			expect(result.current).toBe(true);
+		});
+	});
+
 	it("re-renders the awaiting-first-chunk consumer only when the flag flips", () => {
 		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "running");
 		store.replaceMessages([buildMessage(1, "user", "hello")]);
-		store.setChatStatus("running");
 
 		let renderCount = 0;
-		const { result } = renderHook(() => {
-			const isAwaiting = useIsAwaitingFirstStreamChunk({
-				store,
-				chatId: CHAT_ID,
-			});
-			renderCount += 1;
-			return isAwaiting;
-		});
+		const { result } = renderHook(
+			() => {
+				const isAwaiting = useIsAwaitingFirstStreamChunk({
+					store,
+					chatId: CHAT_ID,
+				});
+				renderCount += 1;
+				return isAwaiting;
+			},
+			{ wrapper: createWrapper(queryClient) },
+		);
 
 		expect(result.current).toBe(true);
 		const baseline = renderCount;
@@ -196,14 +290,18 @@ describe("durableChat facade", () => {
 
 	it("re-renders the message-count consumer only when the count changes", () => {
 		const store = createChatStore();
+		const queryClient = createTestQueryClient();
 		store.replaceMessages([buildMessage(1, "user", "hello")]);
 
 		let renderCount = 0;
-		const { result } = renderHook(() => {
-			const count = useDurableMessageCount({ store, chatId: CHAT_ID });
-			renderCount += 1;
-			return count;
-		});
+		const { result } = renderHook(
+			() => {
+				const count = useDurableMessageCount({ store, chatId: CHAT_ID });
+				renderCount += 1;
+				return count;
+			},
+			{ wrapper: createWrapper(queryClient) },
+		);
 
 		expect(result.current).toBe(1);
 		const baseline = renderCount;

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
@@ -1,9 +1,10 @@
+import { useQuery } from "react-query";
+import { chat as chatDetailQuery } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	type ChatStore,
 	type ChatStoreState,
-	selectChatStatus,
-	selectIsAwaitingFirstStreamChunk,
+	selectIsPendingAssistantResponse,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
@@ -13,8 +14,8 @@ import {
 // Read facade for durable chat state (messages, queued messages, chat
 // status). Render consumers read durable state through these hooks so the
 // source can move from the store to the query cache without touching call
-// sites. Today every hook resolves to the store, so output is identical to
-// reading the selectors directly.
+// sites. Chat status resolves to the query cache, which is canonical for it;
+// messages and the queue still resolve to the store.
 //
 // Composition rule: `useChatSelector` feeds its selector result straight to
 // `useSyncExternalStore`, which compares snapshots with Object.is on every
@@ -24,9 +25,9 @@ import {
 // memoizes the derivation against the slices it reads.
 type DurableChatArgs = {
 	store: ChatStore;
-	// Accepted for the query key that will back these reads once durable
-	// state moves to the cache. Unused while the store is the source.
-	chatId?: string;
+	// Required, and explicitly undefined-able: the query key for the durable
+	// reads. Without a chat there is nothing to read.
+	chatId: string | undefined;
 };
 
 // Primitive selector so count consumers subscribe to the size only, not to
@@ -38,9 +39,20 @@ const isChatMessage = (
 	message: TypesGen.ChatMessage | undefined,
 ): message is TypesGen.ChatMessage => Boolean(message);
 
+// Module-level so the query result identity is stable across renders.
+const selectChatStatusFromDetail = (
+	chat: TypesGen.Chat | undefined,
+): TypesGen.ChatStatus | null => chat?.status ?? null;
+
 export const useDurableChatStatus = (
 	args: DurableChatArgs,
-): TypesGen.ChatStatus | null => useChatSelector(args.store, selectChatStatus);
+): TypesGen.ChatStatus | null =>
+	useQuery({
+		...chatDetailQuery(args.chatId ?? ""),
+		enabled: Boolean(args.chatId),
+		// Selecting the status keeps consumers off every other detail field.
+		select: selectChatStatusFromDetail,
+	}).data ?? null;
 
 // Flat, ascending message list. messagesByID and orderedMessageIDs stay
 // internal to the store; both durable sources agree on the flat shape.
@@ -76,8 +88,16 @@ export const useDurableQueuedMessages = (
 ): readonly TypesGen.ChatQueuedMessage[] =>
 	useChatSelector(args.store, selectQueuedMessages);
 
-// Delegates to the boolean selector, which reads only the latest message,
-// the chat status, and whether a stream exists. Composing it from the full
-// message list would widen the subscription to any content change.
-export const useIsAwaitingFirstStreamChunk = (args: DurableChatArgs): boolean =>
-	useChatSelector(args.store, selectIsAwaitingFirstStreamChunk);
+// Composed from two narrow primitives rather than one store selector: the
+// status now lives in the query cache, and widening the store subscription to
+// the message list or the stream state would re-render on every chunk.
+export const useIsAwaitingFirstStreamChunk = (
+	args: DurableChatArgs,
+): boolean => {
+	const isPendingAssistantResponse = useChatSelector(
+		args.store,
+		selectIsPendingAssistantResponse,
+	);
+	const chatStatus = useDurableChatStatus(args);
+	return isPendingAssistantResponse && chatStatus === "running";
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -11,7 +11,12 @@ import {
 	useQueryClient,
 } from "react-query";
 import { watchChat } from "#/api/api";
-import { chatKeys, updateInfiniteChatsCache } from "#/api/queries/chats";
+import {
+	applyServerChatStatusToCaches,
+	chatKeys,
+	readCachedChatSnapshotVersion,
+	readCachedChatStatus,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
@@ -79,17 +84,19 @@ const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => ({
 	retryingAt: retry.retrying_at.trim() || undefined,
 });
 
-const shouldSurfaceReconnectState = (state: ChatStoreState): boolean =>
+const shouldSurfaceReconnectState = (
+	state: ChatStoreState,
+	chatStatus: TypesGen.ChatStatus | null,
+): boolean =>
 	state.streamError === null &&
 	(state.streamState !== null ||
 		state.retryState !== null ||
-		isActiveChatStatus(state.chatStatus));
+		isActiveChatStatus(chatStatus));
 
 interface UseChatStoreOptions {
 	chatID: string | undefined;
 	chatMessages: readonly TypesGen.ChatMessage[] | undefined;
 	chatRecord: TypesGen.Chat | undefined;
-	chatRecordUpdatedAt?: number;
 	chatMessagesData: TypesGen.ChatMessagesResponse | undefined;
 	chatQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined;
 	setChatErrorReason: (chatID: string, reason: ChatDetailError) => void;
@@ -101,7 +108,6 @@ export const useChatStore = (
 	options: UseChatStoreOptions,
 ): {
 	store: ChatStore;
-	acceptServerChatStatus: () => void;
 	clearStreamError: () => void;
 	setCacheQueuedMessages: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
@@ -115,7 +121,6 @@ export const useChatStore = (
 		chatID,
 		chatMessages,
 		chatRecord,
-		chatRecordUpdatedAt = 0,
 		chatMessagesData,
 		chatQueuedMessages,
 		setChatErrorReason,
@@ -133,17 +138,6 @@ export const useChatStore = (
 	// messages are corrected when switching back to a chat whose
 	// queue was drained while the user was away.
 	const wsQueueUpdateReceivedRef = useRef(false);
-	// Tracks whether the WebSocket has delivered a status event for
-	// the current chat. Once true, the WS is the authoritative
-	// source for chatStatus and the REST-fetched chatRecord.status
-	// must not overwrite it. Without this guard, a React Query
-	// refetch (e.g. on window focus) can regress chatStatus to a
-	// stale value like "waiting", causing shouldApplyMessagePart()
-	// to drop all incoming parts.
-	const wsStatusReceivedRef = useRef(false);
-	const [pendingStatusResync, setPendingStatusResync] = useState(false);
-	const pendingStatusResyncUpdatedAtRef = useRef<number | null>(null);
-	const pendingStatusResyncVersionRef = useRef<number | null>(null);
 	const activeChatIDRef = useRef<string | null>(null);
 	const prevChatIDRef = useRef<string | undefined>(chatID);
 	// Snapshot of the chatMessages elements from the last sync effect
@@ -175,12 +169,15 @@ export const useChatStore = (
 	const setChatErrorReasonEvent = useEffectEvent(setChatErrorReason);
 	const clearChatErrorReasonEvent = useEffectEvent(clearChatErrorReason);
 
-	// True once the initial REST page has resolved for the current
-	// chat. The WebSocket effect gates on this so that
-	// lastMessageIdRef is populated before the socket opens;
-	// otherwise the server replays the entire message history as
-	// its snapshot, defeating pagination.
-	const initialDataLoaded = chatMessages !== undefined;
+	// True once the initial REST pages have resolved for the current chat. The
+	// WebSocket effect gates on this so lastMessageIdRef is populated before
+	// the socket opens (otherwise the server replays the entire message history
+	// as its snapshot, defeating pagination), and so the detail cache exists
+	// before the socket can write a status into it. Gating on a derived boolean
+	// rather than the chat record itself keeps every detail write from
+	// reconnecting the socket.
+	const initialDataLoaded =
+		chatMessages !== undefined && chatRecord !== undefined;
 
 	// Write WebSocket-delivered durable messages into the React
 	// Query infinite cache so that navigating away and back
@@ -315,42 +312,8 @@ export const useChatStore = (
 	}, [chatID, chatMessages, store]);
 
 	useEffect(() => {
-		if (pendingStatusResync) {
-			const armedAt = pendingStatusResyncUpdatedAtRef.current;
-			// dataUpdatedAt advances after a fetch even when structural sharing
-			// preserves chatRecord.
-			if (armedAt === null || chatRecordUpdatedAt <= armedAt) {
-				return;
-			}
-			// Preserve a websocket status delivered during the refetch instead of applying its response.
-			const wsAdvanced =
-				store.getServerChatStatusVersion() !==
-				pendingStatusResyncVersionRef.current;
-			if (!wsAdvanced) {
-				store.setChatStatus(chatRecord?.status ?? null);
-				wsStatusReceivedRef.current = false;
-			}
-			pendingStatusResyncUpdatedAtRef.current = null;
-			pendingStatusResyncVersionRef.current = null;
-			setPendingStatusResync(false);
-			return;
-		}
-		// Only hydrate from REST when the WebSocket hasn't delivered
-		// a status event yet. Once the WS is the authoritative
-		// source, a stale REST refetch must not overwrite the
-		// fresher WS-delivered value.
-		if (!wsStatusReceivedRef.current) {
-			store.setChatStatus(chatRecord?.status ?? null);
-		}
-	}, [chatRecord?.status, chatRecordUpdatedAt, store, pendingStatusResync]);
-
-	useEffect(() => {
 		queuedMessagesHydratedChatIDRef.current = null;
 		wsQueueUpdateReceivedRef.current = false;
-		wsStatusReceivedRef.current = false;
-		pendingStatusResyncUpdatedAtRef.current = null;
-		pendingStatusResyncVersionRef.current = null;
-		setPendingStatusResync(false);
 		store.setQueuedMessages([]);
 		// Suppression entries are scoped to the current chat; clear
 		// them on chat change so a stale promote suppression doesn't
@@ -391,28 +354,6 @@ export const useChatStore = (
 	}, [chatMessagesData, chatID, chatQueuedMessages, store]);
 
 	useEffect(() => {
-		const updateSidebarChat = (
-			updater: (chat: TypesGen.Chat) => TypesGen.Chat,
-		) => {
-			if (!chatID) {
-				return;
-			}
-			updateInfiniteChatsCache(queryClient, (chats) => {
-				let didUpdate = false;
-				const nextChats = chats.map((chat) => {
-					if (chat.id !== chatID) {
-						return chat;
-					}
-					const updated = updater(chat);
-					if (updated !== chat) {
-						didUpdate = true;
-					}
-					return updated;
-				});
-				return didUpdate ? nextChats : chats;
-			});
-		};
-
 		store.resetTransientState();
 		activeChatIDRef.current = chatID ?? null;
 		store.setActiveChatID(chatID ?? null);
@@ -444,9 +385,8 @@ export const useChatStore = (
 		let historyResetPending = false;
 		const historyReplacementBuf: TypesGen.ChatMessage[] = [];
 
-		const shouldApplyMessagePart = (): boolean => {
-			return store.getSnapshot().chatStatus !== "waiting";
-		};
+		const shouldApplyMessagePart = (): boolean =>
+			readCachedChatStatus(queryClient, activeChatID) !== "waiting";
 
 		const schedulePartsFlush = () => {
 			if (partsFlushTimer !== null || partsBuf.length === 0) {
@@ -643,20 +583,28 @@ export const useChatStore = (
 								continue;
 							}
 
-							wsStatusReceivedRef.current = true;
+							// Writes detail, parent details, list rows, embedded
+							// children, and search rows in one pass, each ordered
+							// against its own cached version. A superseded or
+							// versionless status is not this chat's current one,
+							// so its stream side effects must not run either.
+							if (
+								!applyServerChatStatusToCaches(
+									queryClient,
+									activeChatID,
+									nextStatus,
+									streamEvent.snapshot_version,
+								)
+							) {
+								continue;
+							}
 							store.clearRetryState();
-							store.applyServerChatStatus(nextStatus);
 							if (nextStatus === "waiting") {
 								discardBufferedParts();
 							}
 							if (nextStatus !== "error") {
-								clearChatErrorReasonEvent(chatID);
+								clearChatErrorReasonEvent(activeChatID);
 							}
-							updateSidebarChat((chat) =>
-								chat.status === nextStatus
-									? chat
-									: { ...chat, status: nextStatus },
-							);
 							continue;
 						}
 						case "error": {
@@ -664,14 +612,36 @@ export const useChatStore = (
 								kind: "generic",
 								message: "Chat processing failed.",
 							};
-							wsStatusReceivedRef.current = true;
-							store.applyServerChatStatus("error");
+							// An error without a snapshot version did not come from a
+							// committed chat snapshot (a subscription or transport
+							// failure), so it reports the failure without claiming the
+							// chat itself reached the error status.
+							const errorVersion = streamEvent.snapshot_version;
+							if (errorVersion !== undefined) {
+								const applied = applyServerChatStatusToCaches(
+									queryClient,
+									activeChatID,
+									"error",
+									errorVersion,
+								);
+								// The server stamps a status event and the error event
+								// detailing it with one snapshot version, and the status
+								// event is emitted first. So an equal-version error is the
+								// companion of an error status already applied, not a
+								// duplicate: the reason it carries is the only place the
+								// failure detail arrives. A strictly older error still
+								// loses, because the chat has moved past its snapshot.
+								const detailsAppliedErrorStatus =
+									readCachedChatStatus(queryClient, activeChatID) === "error" &&
+									readCachedChatSnapshotVersion(queryClient, activeChatID) ===
+										errorVersion;
+								if (!applied && !detailsAppliedErrorStatus) {
+									continue;
+								}
+							}
 							store.setStreamError(reason);
 							store.clearRetryState();
-							setChatErrorReasonEvent(chatID, reason);
-							updateSidebarChat((chat) =>
-								chat.status === "error" ? chat : { ...chat, status: "error" },
-							);
+							setChatErrorReasonEvent(activeChatID, reason);
 							continue;
 						}
 						case "retry": {
@@ -760,7 +730,12 @@ export const useChatStore = (
 				// interrupted active response work. Idle watcher
 				// reconnects stay silent.
 				const snapshot = store.getSnapshot();
-				if (shouldSurfaceReconnectState(snapshot)) {
+				if (
+					shouldSurfaceReconnectState(
+						snapshot,
+						readCachedChatStatus(queryClient, activeChatID),
+					)
+				) {
 					store.setReconnectState(reconnectState);
 				}
 			},
@@ -788,21 +763,6 @@ export const useChatStore = (
 		store,
 		clearStreamError: () => {
 			store.clearStreamError();
-		},
-		// A failed request can change server-side chat status while the
-		// socket is down, and the socket having already delivered a status
-		// otherwise makes the refetched one inert.
-		acceptServerChatStatus: () => {
-			// A request that resolves after the user navigates away belongs to
-			// the previous chat, whose freshness and status are unrelated to
-			// the one now displayed by this shared store.
-			if (store.getActiveChatID() !== (chatID ?? null)) {
-				return;
-			}
-			pendingStatusResyncUpdatedAtRef.current = chatRecordUpdatedAt;
-			pendingStatusResyncVersionRef.current =
-				store.getServerChatStatusVersion();
-			setPendingStatusResync(true);
 		},
 		setCacheQueuedMessages: (queuedMessages) => {
 			writeQueuedMessagesToCache(queryClient, chatID, queuedMessages);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
+import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import { MockChat } from "#/testHelpers/chatEntities";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -14,6 +16,15 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const CHAT_ID = "chat-page-content-stories";
+
+// Chat status is canonical in the detail cache, so a story that depends on it
+// seeds the entry rather than the store.
+const seededChatDetail = (status: TypesGen.ChatStatus) => [
+	{
+		key: chatKeys.detail(CHAT_ID),
+		data: { ...MockChat, id: CHAT_ID, status } satisfies TypesGen.Chat,
+	},
+];
 
 const buildMessage = (
 	id: number,
@@ -65,6 +76,7 @@ export const SpacerVisibleWhenNotStreaming: Story = {
 };
 
 export const DurableUnresolvedWorkspaceToolRuns: Story = {
+	parameters: { queries: seededChatDetail("running") },
 	render: () => {
 		const store = createChatStore();
 		store.replaceMessages([
@@ -78,7 +90,6 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 				},
 			]),
 		]);
-		store.setChatStatus("running");
 
 		return (
 			<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>


### PR DESCRIPTION
This is PR 5 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

Makes the query cache the source of truth for chat status. Adds a `snapshot_version` comparator and custom structural-sharing logic for details, lists, search, and embedded children, and a per-entry optimistic status provenance token. Per-chat and global sockets write ordered `{status, snapshot_version}`. Deletes the now-redundant store status state and guards (`wsStatusReceivedRef`, `pendingStatusResync`, `acceptServerChatStatus`, `serverChatStatusVersion`, store `chatStatus`). Adds `cancelChatDetailPreservingStatus` after review showed `cancelQueries(revert:true)` could revert away a WS status write, and corrects same-version `status:"error"` + companion `error` event handling. Rejected status events no longer clear retry state.

Depends on #27774

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- The cache is canonical for chat status; the store's status mirror is removed.
- `snapshot_version` (PR 4.5) is the ordering key; structural sharing is custom because the default would drop the version comparison.
- Reviewed by two independent reviewers; mergeable.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood