### PR TITLE
refactor(site/src/pages/AgentsPage): make durable messages canonical in the query cache

### DIFF
--- a/site/src/api/queries/chatMessageEdits.ts
+++ b/site/src/api/queries/chatMessageEdits.ts
@@ -114,6 +114,49 @@ export const projectEditedConversationIntoCache = ({
 	};
 };
 
+/**
+ * Restores the pre-edit conversation after a failed edit, keeping messages that
+ * landed while the mutation was in flight.
+ *
+ * A plain snapshot restore would drop socket-delivered messages committed after
+ * `onMutate` read the snapshot, so anything present now but absent from the
+ * snapshot is re-inserted into page 0. IDs the snapshot already holds keep the
+ * snapshot's copy, which is what undoes the optimistic replacement.
+ */
+export const restoreEditedConversationInCache = ({
+	currentData,
+	previousData,
+}: {
+	currentData: InfiniteData<TypesGen.ChatMessagesResponse> | undefined;
+	previousData: InfiniteData<TypesGen.ChatMessagesResponse>;
+}): InfiniteData<TypesGen.ChatMessagesResponse> => {
+	if (!previousData.pages.length) {
+		return previousData;
+	}
+	const previousIDs = new Set(
+		previousData.pages.flatMap((page) =>
+			page.messages.map((message) => message.id),
+		),
+	);
+	const arrivedDuringFlight = (currentData?.pages ?? []).flatMap((page) =>
+		page.messages.filter((message) => !previousIDs.has(message.id)),
+	);
+	if (arrivedDuringFlight.length === 0) {
+		return previousData;
+	}
+	let messages = previousData.pages[0].messages;
+	for (const message of arrivedDuringFlight) {
+		messages = upsertFirstPageMessage(messages, message);
+	}
+	return {
+		...previousData,
+		pages: [
+			{ ...previousData.pages[0], messages },
+			...previousData.pages.slice(1),
+		],
+	};
+};
+
 export const reconcileEditedMessageInCache = ({
 	currentData,
 	optimisticMessageId,

--- a/site/src/api/queries/chatMessagesCache.ts
+++ b/site/src/api/queries/chatMessagesCache.ts
@@ -1,0 +1,145 @@
+import { hashKey, type InfiniteData, type QueryClient } from "react-query";
+import type * as TypesGen from "#/api/typesGenerated";
+
+type MessagesCacheData = InfiniteData<TypesGen.ChatMessagesResponse>;
+
+/**
+ * One write against a chat's messages cache.
+ *
+ * `apply` is an updater over whatever the cache holds when the write lands, not
+ * a precomputed snapshot, so a buffered write replayed after a fetch resolved
+ * amends the fetched pages instead of overwriting them.
+ */
+export type MessagesCacheWrite = {
+	// Names the write for dev diagnostics. Replay is FIFO regardless of kind.
+	kind: string;
+	apply: (currentData: MessagesCacheData) => MessagesCacheData;
+};
+
+type MessagesCacheCoordinator = {
+	buffered: MessagesCacheWrite[];
+	unsubscribe: (() => void) | null;
+};
+
+/**
+ * Per-query-client, per-chat write coordinators. A WeakMap keyed by the query
+ * client keeps test clients from leaking into each other and lets a discarded
+ * client be collected with its coordinators.
+ */
+const coordinators = new WeakMap<
+	QueryClient,
+	Map<string, MessagesCacheCoordinator>
+>();
+
+const coordinatorFor = (
+	queryClient: QueryClient,
+	queryKey: readonly unknown[],
+): MessagesCacheCoordinator => {
+	let byKey = coordinators.get(queryClient);
+	if (!byKey) {
+		byKey = new Map();
+		coordinators.set(queryClient, byKey);
+	}
+	const hash = hashKey(queryKey);
+	let coordinator = byKey.get(hash);
+	if (!coordinator) {
+		coordinator = { buffered: [], unsubscribe: null };
+		byKey.set(hash, coordinator);
+	}
+	return coordinator;
+};
+
+/**
+ * True while a fetch owns the cache entry.
+ *
+ * Checks `fetchStatus` rather than `isFetching` so a PAUSED fetch counts: the
+ * infinite-query behavior captured the existing pages before pausing and still
+ * installs them verbatim when it resumes, so a write applied during the pause
+ * would be discarded.
+ */
+const isMessagesFetchInFlight = (
+	queryClient: QueryClient,
+	queryKey: readonly unknown[],
+): boolean => {
+	const fetchStatus = queryClient.getQueryState(queryKey)?.fetchStatus;
+	return fetchStatus !== undefined && fetchStatus !== "idle";
+};
+
+const applyMessagesCacheWrite = (
+	queryClient: QueryClient,
+	queryKey: readonly unknown[],
+	write: MessagesCacheWrite,
+): void => {
+	queryClient.setQueryData<MessagesCacheData | undefined>(
+		queryKey,
+		(currentData) => {
+			if (!currentData?.pages?.length) {
+				// An initialized cache is required. Seeding a synthetic partial page
+				// would mark the query successful, and under staleTime: Infinity the
+				// first observer would treat that page as fresh and skip the initial
+				// history fetch, hiding everything the write did not carry.
+				if (process.env.NODE_ENV !== "production") {
+					console.warn(
+						`[chatMessagesCache] dropped a "${write.kind}" write: ` +
+							"the messages cache has no pages yet.",
+					);
+				}
+				return currentData;
+			}
+			return write.apply(currentData);
+		},
+	);
+};
+
+/**
+ * Writes to a chat's messages cache, serialized against fetches on the same
+ * cache entry.
+ *
+ * A fetch captures the pages when it starts and installs its result
+ * unconditionally, so anything written in between would be clobbered: a
+ * `fetchNextPage`, a deliberate refetch, and an invalidation-driven refetch all
+ * behave this way. While a fetch is in flight, writes buffer and replay in
+ * arrival order once it settles; the replay lands on top of the fetched pages.
+ *
+ * Cancelling the fetch instead would lose the write: `cancelQueries` defaults
+ * to `{ revert: true }` and restores the pre-fetch snapshot asynchronously.
+ *
+ * Every writer for a chat has to go through here, otherwise the ordering
+ * guarantee only covers part of the writes. Current writers: the per-chat
+ * socket (durable messages, history replacement, queue snapshots), the queued
+ * message mutations, and the message edit mutation.
+ */
+export const writeMessagesCache = (
+	queryClient: QueryClient,
+	queryKey: readonly unknown[],
+	write: MessagesCacheWrite,
+): void => {
+	const coordinator = coordinatorFor(queryClient, queryKey);
+	// A non-empty buffer means earlier writes are still waiting, so this one
+	// queues behind them even if the fetch already settled. Applying it now
+	// would reorder it ahead of them.
+	if (
+		coordinator.buffered.length === 0 &&
+		!isMessagesFetchInFlight(queryClient, queryKey)
+	) {
+		applyMessagesCacheWrite(queryClient, queryKey, write);
+		return;
+	}
+	coordinator.buffered.push(write);
+	if (coordinator.unsubscribe) {
+		return;
+	}
+	// The cache notifies after the fetch installs its data, so by the time this
+	// runs the resolved pages are already in place.
+	coordinator.unsubscribe = queryClient.getQueryCache().subscribe(() => {
+		if (isMessagesFetchInFlight(queryClient, queryKey)) {
+			return;
+		}
+		// Detach first so the replay's own cache events cannot re-enter.
+		coordinator.unsubscribe?.();
+		coordinator.unsubscribe = null;
+		for (const buffered of coordinator.buffered.splice(0)) {
+			applyMessagesCacheWrite(queryClient, queryKey, buffered);
+		}
+	});
+};

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1,4 +1,10 @@
-import { hashKey, MutationObserver, QueryClient } from "react-query";
+import {
+	hashKey,
+	type InfiniteData as InfiniteQueryData,
+	MutationObserver,
+	onlineManager,
+	QueryClient,
+} from "react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -7,7 +13,9 @@ import {
 	ERROR_STATUSES,
 	SUCCESS_STATUSES,
 } from "#/pages/AgentsPage/components/RightPanel/DebugPanel/debugPanelUtils";
+import { createDeferred } from "#/testHelpers/deferred";
 import { buildOptimisticEditedMessage } from "./chatMessageEdits";
+import { writeMessagesCache } from "./chatMessagesCache";
 import {
 	addChildToParentInCache,
 	applyServerChatStatusToCaches,
@@ -87,6 +95,7 @@ vi.mock("#/api/api", () => ({
 			getChatAdvisorConfig: vi.fn(),
 			updateChatAdvisorConfig: vi.fn(),
 			getChatACL: vi.fn(),
+			getChatMessages: vi.fn(),
 			updateChatACL: vi.fn(),
 		},
 	},
@@ -2016,7 +2025,7 @@ describe("mutation invalidation scope", () => {
 		).not.toBe(true);
 	});
 
-	it("deleteChatQueuedMessage invalidates only chat detail and messages", async () => {
+	it("deleteChatQueuedMessage invalidates only the chat detail", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		seedAllActiveQueries(queryClient, chatId);
@@ -2024,15 +2033,17 @@ describe("mutation invalidation scope", () => {
 		const mutation = deleteChatQueuedMessage(queryClient, chatId);
 		await mutation.onSuccess();
 
-		// These two should be invalidated (exact match).
 		expect(
 			queryClient.getQueryState(chatKeys.detail(chatId))?.isInvalidated,
 			"the chat detail should be invalidated",
 		).toBe(true);
+		// The messages query is canonical for durable messages and only the
+		// socket writes them, so the caller amends pages[0].queued_messages
+		// instead of refetching pages an in-flight socket write is amending.
 		expect(
 			queryClient.getQueryState(chatKeys.messages(chatId))?.isInvalidated,
-			"chat messages should be invalidated",
-		).toBe(true);
+			"chat messages should NOT be invalidated",
+		).not.toBe(true);
 
 		// Unrelated queries should NOT be touched.
 		for (const { label, key } of unrelatedKeys(chatId)) {
@@ -2048,6 +2059,198 @@ describe("mutation invalidation scope", () => {
 				?.isInvalidated,
 			"infinite chats should NOT be invalidated",
 		).not.toBe(true);
+	});
+
+	// The edit mutation shares the messages cache with the per-chat socket, and
+	// pagination stays enabled while it is in flight. Its writes go through the
+	// same serialization coordinator, otherwise a fetch that captured the
+	// optimistic pages reinstalls them over the response.
+	const startDeferredMessagesFetch = (
+		queryClient: QueryClient,
+		chatId: string,
+	) => {
+		const pending = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			pending.promise,
+		);
+		// staleTime: 0 because fetchNextPage and deliberate refetches bypass the
+		// query's Infinity staleTime the same way.
+		const fetched = queryClient.fetchInfiniteQuery({
+			...chatMessagesForInfiniteScroll(chatId),
+			staleTime: 0,
+		});
+		return { pending, fetched };
+	};
+
+	it("editChatMessage keeps the response reconciliation when a fetch resolves after it", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+		const optimisticMessage = buildOptimisticMessage(
+			requireMessage(messages, 3),
+		);
+		const responseMessage = {
+			...makeMsg(chatId, 9),
+			content: [{ type: "text" as const, text: "edited authoritative" }],
+		};
+
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		await mutation.onMutate({ messageId: 3, optimisticMessage, req: editReq });
+
+		const { pending, fetched } = startDeferredMessagesFetch(
+			queryClient,
+			chatId,
+		);
+		expect(
+			queryClient.getQueryState(chatKeys.messages(chatId))?.fetchStatus,
+		).toBe("fetching");
+
+		mutation.onSuccess(
+			{ message: responseMessage, deleted_message_ids: [3] },
+			{ messageId: 3, optimisticMessage, req: editReq },
+		);
+
+		// Buffered rather than written: the resolving fetch would discard it.
+		expect(
+			queryClient
+				.getQueryData<InfMessages>(chatKeys.messages(chatId))
+				?.pages[0].messages.map((message) => message.id),
+		).toEqual([3, 2, 1]);
+
+		pending.resolve({
+			messages: [requireMessage(messages, 2), requireMessage(messages, 1)],
+			queued_messages: [],
+			has_more: false,
+		});
+		await fetched;
+
+		// The reconciliation replays on top of the fetched page.
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
+		expect(data?.pages[0].messages.map((message) => message.id)).toEqual([
+			9, 2, 1,
+		]);
+	});
+
+	it("editChatMessage keeps the rollback when a fetch resolves after it", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+		const optimisticMessage = buildOptimisticMessage(
+			requireMessage(messages, 3),
+		);
+
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		const context = await mutation.onMutate({
+			messageId: 3,
+			optimisticMessage,
+			req: editReq,
+		});
+
+		const { pending, fetched } = startDeferredMessagesFetch(
+			queryClient,
+			chatId,
+		);
+
+		mutation.onError(
+			new Error("network failure"),
+			{ messageId: 3, optimisticMessage, req: editReq },
+			context,
+		);
+
+		// Buffered: applying it now would be discarded by the resolving fetch.
+		expect(
+			queryClient
+				.getQueryData<InfMessages>(chatKeys.messages(chatId))
+				?.pages[0].messages.map((message) => message.id),
+		).toEqual([3, 2, 1]);
+
+		pending.resolve({
+			messages: [requireMessage(messages, 2), requireMessage(messages, 1)],
+			queued_messages: [],
+			has_more: false,
+		});
+		await fetched;
+
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
+		expect(data?.pages[0].messages.map((message) => message.id)).toEqual([
+			5, 4, 3, 2, 1,
+		]);
+	});
+
+	it("editChatMessage rollback keeps messages delivered while the edit was in flight", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+		const optimisticMessage = buildOptimisticMessage(
+			requireMessage(messages, 3),
+		);
+		const websocketMessage = {
+			...makeMsg(chatId, 10),
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "assistant follow-up" }],
+		};
+
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		const context = await mutation.onMutate({
+			messageId: 3,
+			optimisticMessage,
+			req: editReq,
+		});
+
+		// The socket commits a durable message while the edit is in flight.
+		queryClient.setQueryData<InfMessages | undefined>(
+			chatKeys.messages(chatId),
+			(current) =>
+				current
+					? {
+							...current,
+							pages: [
+								{
+									...current.pages[0],
+									messages: [websocketMessage, ...current.pages[0].messages],
+								},
+								...current.pages.slice(1),
+							],
+						}
+					: current,
+		);
+
+		mutation.onError(
+			new Error("network failure"),
+			{ messageId: 3, optimisticMessage, req: editReq },
+			context,
+		);
+
+		// The pre-edit conversation is back AND the socket's message survived,
+		// with the edited message restored to its original content.
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
+		expect(data?.pages[0].messages.map((message) => message.id)).toEqual([
+			10, 5, 4, 3, 2, 1,
+		]);
+		expect(
+			data?.pages[0].messages.find((message) => message.id === 3)?.content,
+		).toEqual(requireMessage(messages, 3).content);
 	});
 });
 
@@ -4775,5 +4978,137 @@ describe("mergeWatchedChatSummary snapshot_version", () => {
 				activeChatId: "chat-2",
 			}),
 		).toMatchObject({ status: "waiting", has_unread: true });
+	});
+});
+
+describe("messages cache write serialization", () => {
+	type InfMessages = {
+		pages: TypesGen.ChatMessagesResponse[];
+		pageParams: (number | undefined)[];
+	};
+
+	const makeMessage = (chatId: string, id: number): TypesGen.ChatMessage => ({
+		id,
+		chat_id: chatId,
+		created_at: `2025-01-01T00:00:${String(id).padStart(2, "0")}Z`,
+		role: "user",
+		content: [{ type: "text", text: `msg ${id}` }],
+	});
+
+	const prependMessage =
+		(message: TypesGen.ChatMessage) =>
+		(currentData: InfiniteQueryData<TypesGen.ChatMessagesResponse>) => ({
+			...currentData,
+			pages: [
+				{
+					...currentData.pages[0],
+					messages: [message, ...currentData.pages[0].messages],
+				},
+				...currentData.pages.slice(1),
+			],
+		});
+
+	// A paused fetch already captured the pages it will install when it resumes,
+	// so it owns the cache entry just like a fetching one. A guard that only
+	// looked at `isFetching` would let a write through and lose it on resume.
+	it("buffers a write committed while a paused fetch owns the cache", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+			},
+		});
+		const chatId = "chat-paused";
+		const messages = [2, 1].map((id) => makeMessage(chatId, id));
+		const socketMessage = makeMessage(chatId, 10);
+
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const pending = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			pending.promise,
+		);
+
+		onlineManager.setOnline(false);
+		// mount() is what subscribes the client to the online manager, which is
+		// how a paused fetch resumes.
+		queryClient.mount();
+		try {
+			const fetched = queryClient.fetchInfiniteQuery({
+				...chatMessagesForInfiniteScroll(chatId),
+				staleTime: 0,
+			});
+			expect(
+				queryClient.getQueryState(chatKeys.messages(chatId))?.fetchStatus,
+			).toBe("paused");
+
+			writeMessagesCache(queryClient, chatKeys.messages(chatId), {
+				kind: "upsert",
+				apply: prependMessage(socketMessage),
+			});
+			expect(
+				queryClient
+					.getQueryData<InfMessages>(chatKeys.messages(chatId))
+					?.pages[0].messages.map((message) => message.id),
+			).toEqual([2, 1]);
+
+			onlineManager.setOnline(true);
+			pending.resolve({
+				messages,
+				queued_messages: [],
+				has_more: false,
+			});
+			await fetched;
+
+			expect(
+				queryClient
+					.getQueryData<InfMessages>(chatKeys.messages(chatId))
+					?.pages[0].messages.map((message) => message.id),
+			).toEqual([10, 2, 1]);
+		} finally {
+			onlineManager.setOnline(true);
+			queryClient.unmount();
+		}
+	});
+
+	it("replays buffered writes in arrival order", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-fifo";
+		const messages = [2, 1].map((id) => makeMessage(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const pending = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			pending.promise,
+		);
+		const fetched = queryClient.fetchInfiniteQuery({
+			...chatMessagesForInfiniteScroll(chatId),
+			staleTime: 0,
+		});
+
+		writeMessagesCache(queryClient, chatKeys.messages(chatId), {
+			kind: "upsert",
+			apply: prependMessage(makeMessage(chatId, 10)),
+		});
+		writeMessagesCache(queryClient, chatKeys.messages(chatId), {
+			kind: "upsert",
+			apply: prependMessage(makeMessage(chatId, 11)),
+		});
+
+		pending.resolve({ messages, queued_messages: [], has_more: false });
+		await fetched;
+
+		// 11 prepended after 10, so the later write ends up first.
+		expect(
+			queryClient
+				.getQueryData<InfMessages>(chatKeys.messages(chatId))
+				?.pages[0].messages.map((message) => message.id),
+		).toEqual([11, 10, 2, 1]);
 	});
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -15,7 +15,9 @@ import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
 import {
 	projectEditedConversationIntoCache,
 	reconcileEditedMessageInCache,
+	restoreEditedConversationInCache,
 } from "./chatMessageEdits";
+import { writeMessagesCache } from "./chatMessagesCache";
 
 export type ChatListPRStatusFilter = "draft" | "open" | "merged" | "closed";
 export type ChatListStatusFilter = "read" | "unread";
@@ -1717,6 +1719,75 @@ export const chatMessagesForInfiniteScroll = (chatId: string) => ({
 	staleTime: Number.POSITIVE_INFINITY,
 });
 
+type ChatMessagesInfiniteData = InfiniteData<TypesGen.ChatMessagesResponse>;
+
+/**
+ * Collapses the paginated history into one map keyed by message ID, keeping the
+ * FIRST occurrence of each ID. Pages arrive newest-first and page 0 is the most
+ * recent page, so first-occurrence-wins gives page 0 precedence over a stale
+ * copy left in an older page. The socket writer canonicalizes into page 0, so
+ * this is a defensive layer rather than the cache invariant.
+ */
+const collectDurableMessagesByID = (
+	data: ChatMessagesInfiniteData,
+): Map<number, TypesGen.ChatMessage> => {
+	const byID = new Map<number, TypesGen.ChatMessage>();
+	for (const page of data.pages) {
+		for (const message of page.messages) {
+			if (!byID.has(message.id)) {
+				byID.set(message.id, message);
+			}
+		}
+	}
+	return byID;
+};
+
+/**
+ * Query `select` producing the flat, ascending durable message list. Module
+ * level so react-query can memoize it per observer: an inline select is a new
+ * function every render, which re-runs the flatten and defeats the structural
+ * sharing that keeps the result reference stable.
+ *
+ * Deliberately NOT part of `chatMessagesForInfiniteScroll`: the pagination
+ * owner needs the raw pages, page params, and `hasNextPage`.
+ *
+ * `created_at` is shared across an insert batch, so only the ID orders the
+ * conversation.
+ */
+export const selectDurableMessages = (
+	data: ChatMessagesInfiniteData,
+): readonly TypesGen.ChatMessage[] =>
+	Array.from(collectDurableMessagesByID(data).values()).sort(
+		(left, right) => left.id - right.id,
+	);
+
+/**
+ * Numeric `select` so count consumers re-render on the deduplicated size only,
+ * never on message content.
+ */
+export const selectDurableMessageCount = (
+	data: ChatMessagesInfiniteData,
+): number => collectDurableMessagesByID(data).size;
+
+/**
+ * Primitive `select` returning the role of the newest durable message, or
+ * undefined for an empty history. Consumers compose it with the transient
+ * stream state instead of subscribing to the whole list.
+ */
+export const selectLatestDurableMessageRole = (
+	data: ChatMessagesInfiniteData,
+): TypesGen.ChatMessageRole | undefined => {
+	let latest: TypesGen.ChatMessage | undefined;
+	for (const page of data.pages) {
+		for (const message of page.messages) {
+			if (!latest || message.id > latest.id) {
+				latest = message;
+			}
+		}
+	}
+	return latest?.role;
+};
+
 // Cap requested prompts to keep the response small; well under the server-side maximum.
 const PROMPT_HISTORY_LIMIT = 500;
 
@@ -2371,16 +2442,21 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 			InfiniteData<TypesGen.ChatMessagesResponse>
 		>(chatKeys.messages(chatId));
 
-		queryClient.setQueryData<
-			InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-		>(chatKeys.messages(chatId), (current) =>
-			projectEditedConversationIntoCache({
-				currentData: current,
-				editedMessageId: messageId,
-				replacementMessage: optimisticMessage,
-				queuedMessages: [],
-			}),
-		);
+		// Every phase of the edit goes through the shared messages-cache
+		// coordinator, the same one the per-chat socket uses. A pagination fetch
+		// started after this projection captures the optimistic pages and
+		// installs them verbatim when it resolves, so an unserialized write here
+		// or in onSuccess/onError would be silently overwritten.
+		writeMessagesCache(queryClient, chatKeys.messages(chatId), {
+			kind: "edit-projection",
+			apply: (currentData) =>
+				projectEditedConversationIntoCache({
+					currentData,
+					editedMessageId: messageId,
+					replacementMessage: optimisticMessage,
+					queuedMessages: [],
+				}) ?? currentData,
+		});
 
 		return { previousData };
 	},
@@ -2389,10 +2465,17 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 		_variables: EditChatMessageMutationArgs,
 		context: EditChatMessageMutationContext | undefined,
 	) => {
-		// Restore the cache on failure so the user sees the
-		// original messages again.
-		if (context?.previousData) {
-			queryClient.setQueryData(chatKeys.messages(chatId), context.previousData);
+		// Restore the cache on failure so the user sees the original messages
+		// again. The restore keeps messages the socket delivered while the
+		// mutation was in flight instead of reverting to the snapshot verbatim,
+		// which would drop them.
+		const previousData = context?.previousData;
+		if (previousData) {
+			writeMessagesCache(queryClient, chatKeys.messages(chatId), {
+				kind: "edit-rollback",
+				apply: (currentData) =>
+					restoreEditedConversationInCache({ currentData, previousData }),
+			});
 		}
 		// Invalidate messages as a safety net: the restored snapshot
 		// may be missing WebSocket-delivered messages that arrived
@@ -2406,16 +2489,16 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 		response: TypesGen.EditChatMessageResponse,
 		variables: EditChatMessageMutationArgs,
 	) => {
-		queryClient.setQueryData<
-			InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-		>(chatKeys.messages(chatId), (current) =>
-			reconcileEditedMessageInCache({
-				currentData: current,
-				optimisticMessageId: variables.messageId,
-				responseMessages: response.messages ?? [response.message],
-				deletedMessageIds: response.deleted_message_ids,
-			}),
-		);
+		writeMessagesCache(queryClient, chatKeys.messages(chatId), {
+			kind: "edit-reconciliation",
+			apply: (currentData) =>
+				reconcileEditedMessageInCache({
+					currentData,
+					optimisticMessageId: variables.messageId,
+					responseMessages: response.messages ?? [response.message],
+					deletedMessageIds: response.deleted_message_ids,
+				}) ?? currentData,
+		});
 	},
 	onSettled: () => {
 		// Refresh chat metadata (status, title, etc.). The messages
@@ -2494,10 +2577,10 @@ export const deleteChatQueuedMessage = (
 			queryKey: chatKeys.detail(chatId),
 			exact: true,
 		});
-		await queryClient.invalidateQueries({
-			queryKey: chatKeys.messages(chatId),
-			exact: true,
-		});
+		// The messages query is deliberately NOT invalidated. It is canonical
+		// for durable messages and only the socket writes them, so a refetch
+		// would capture the pages an in-flight socket write is amending. The
+		// caller removes the entry from `pages[0].queued_messages` itself.
 	},
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -23,6 +23,7 @@ import {
 	getWorkspaceOptionsWithLinkedWorkspace,
 	reconcilePromotedQueueHead,
 	restoreOptimisticRequestSnapshot,
+	runDeleteQueuedMessage,
 	runPromoteQueuedMessage,
 	settlePromotedQueueHead,
 	submitEditAndScroll,
@@ -314,6 +315,69 @@ describe("runPromoteQueuedMessage", () => {
 		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id, b.id]);
 		expect(readCachedStatus(queryClient)?.status).toBe("waiting");
 		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
+	});
+});
+
+describe("runDeleteQueuedMessage", () => {
+	const buildQueuedMessage = (id: number, text: string): ChatQueuedMessage => ({
+		...MockChatQueuedMessage,
+		id,
+		chat_id: "chat-1",
+		content: [{ type: "text", text }],
+	});
+
+	it("removes the entry from the store and the cached queue", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setQueuedMessages([a, b]);
+		let cachedQueue: readonly ChatQueuedMessage[] | undefined = [a, b];
+		const deleteQueuedMessage = vi.fn(async (_id: number) => undefined);
+
+		await runDeleteQueuedMessage({
+			id: b.id,
+			store,
+			deleteQueuedMessage,
+			getCacheQueuedMessages: () => cachedQueue,
+			setCacheQueuedMessages: (queuedMessages) => {
+				cachedQueue = queuedMessages;
+			},
+		});
+
+		expect(deleteQueuedMessage).toHaveBeenCalledWith(b.id);
+		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([a.id]);
+		// The mutation no longer invalidates the messages query, so without this
+		// write REST re-hydration would resurrect the deleted entry.
+		expect(cachedQueue?.map((m) => m.id)).toEqual([a.id]);
+	});
+
+	it("restores both the store and the cached queue on failure", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setQueuedMessages([a, b]);
+		let cachedQueue: readonly ChatQueuedMessage[] | undefined = [a, b];
+		const apiError = new Error("boom");
+
+		await expect(
+			runDeleteQueuedMessage({
+				id: b.id,
+				store,
+				deleteQueuedMessage: async () => {
+					throw apiError;
+				},
+				getCacheQueuedMessages: () => cachedQueue,
+				setCacheQueuedMessages: (queuedMessages) => {
+					cachedQueue = queuedMessages;
+				},
+			}),
+		).rejects.toBe(apiError);
+
+		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
+			a.id,
+			b.id,
+		]);
+		expect(cachedQueue?.map((m) => m.id)).toEqual([a.id, b.id]);
 	});
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -43,6 +43,7 @@ import {
 	promoteChatQueuedMessage,
 	readCachedChatSnapshotVersion,
 	rollbackOptimisticChatStatus,
+	selectDurableMessages,
 	updateChatPlanMode,
 	updateChatWorkspace,
 	userChatDebugLogging,
@@ -88,10 +89,7 @@ import {
 	type ChatStoreState,
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
-import {
-	useDurableChatStatus,
-	useDurableMessageCount,
-} from "./components/ChatConversation/durableChat";
+import { useDurableChatStatus } from "./components/ChatConversation/durableChat";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
@@ -244,6 +242,51 @@ export const runPromoteQueuedMessage = async (params: {
 		}
 		restoreOptimisticRequestSnapshot(store, previousSnapshot);
 		handleUsageLimitError(error);
+		throw error;
+	}
+};
+
+/**
+ * Runs the optimistic queued-message deletion flow.
+ *
+ * The mutation no longer invalidates the messages query, so the deletion is
+ * projected into both the store's visible queue and `pages[0].queued_messages`
+ * of the messages cache. Skipping the cache write would leave the cached queue
+ * stale, and REST re-hydration would resurrect the deleted entry. Both writes
+ * roll back together on failure.
+ *
+ * @internal Exported for testing.
+ */
+export const runDeleteQueuedMessage = async (params: {
+	id: number;
+	store: Pick<ChatStore, "getSnapshot" | "setQueuedMessages">;
+	deleteQueuedMessage: (id: number) => Promise<void>;
+	getCacheQueuedMessages: () =>
+		| readonly TypesGen.ChatQueuedMessage[]
+		| undefined;
+	setCacheQueuedMessages: (
+		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+	) => void;
+}): Promise<void> => {
+	const {
+		id,
+		store,
+		deleteQueuedMessage,
+		getCacheQueuedMessages,
+		setCacheQueuedMessages,
+	} = params;
+	const previousQueuedMessages = store.getSnapshot().queuedMessages;
+	const previousCacheQueuedMessages = getCacheQueuedMessages();
+	const nextQueuedMessages = previousQueuedMessages.filter(
+		(message) => message.id !== id,
+	);
+	store.setQueuedMessages(nextQueuedMessages);
+	setCacheQueuedMessages(nextQueuedMessages);
+	try {
+		await deleteQueuedMessage(id);
+	} catch (error) {
+		store.setQueuedMessages(previousQueuedMessages);
+		setCacheQueuedMessages(previousCacheQueuedMessages);
 		throw error;
 	}
 };
@@ -1127,24 +1170,12 @@ const AgentChatPage: FC = () => {
 		return getDefaultMCPSelection(mcpServers);
 	})();
 
-	// Flatten paginated messages into chronological order.
-	// Pages arrive newest-first per page, and pages[0] is the
-	// most recent page.
-	const chatMessagesList = (() => {
-		const pages = chatMessagesQuery.data?.pages;
-		if (!pages || pages.length === 0) return undefined;
-		// Collect all messages and deduplicate by ID.
-		// Cross-page duplication can occur when upsertCacheMessages
-		// writes a message into page 0 while the same ID still
-		// exists in a later page. Last occurrence wins so the
-		// most up-to-date content is preserved.
-		const all = pages.flatMap((p) => p.messages);
-		const byID = new Map(all.map((m) => [m.id, m]));
-		const deduped = Array.from(byID.values());
-		// Sort ascending by ID for chronological order.
-		deduped.sort((a, b) => a.id - b.id);
-		return deduped;
-	})();
+	// Flatten paginated messages into chronological order with the same
+	// module-level select the durable read facade uses, so the page and the
+	// facade cannot disagree about the conversation.
+	const chatMessagesList = chatMessagesQuery.data
+		? selectDurableMessages(chatMessagesQuery.data)
+		: undefined;
 
 	// Queued messages are only in the first page (most recent).
 	const chatQueuedMessages = chatMessagesQuery.data?.pages[0]?.queued_messages;
@@ -1436,18 +1467,14 @@ const AgentChatPage: FC = () => {
 		);
 	};
 
-	const handleDeleteQueuedMessage = async (id: number) => {
-		const previousQueuedMessages = store.getSnapshot().queuedMessages;
-		store.setQueuedMessages(
-			previousQueuedMessages.filter((message) => message.id !== id),
-		);
-		try {
-			await deleteQueuedMessage(id);
-		} catch (error) {
-			store.setQueuedMessages(previousQueuedMessages);
-			throw error;
-		}
-	};
+	const handleDeleteQueuedMessage = (id: number) =>
+		runDeleteQueuedMessage({
+			id,
+			store,
+			deleteQueuedMessage,
+			getCacheQueuedMessages,
+			setCacheQueuedMessages,
+		});
 
 	const handlePromoteQueuedMessage = (id: number) =>
 		runPromoteQueuedMessage({
@@ -1533,28 +1560,17 @@ const AgentChatPage: FC = () => {
 				}
 			: undefined;
 
-	// Signal ready only after the store has synced fetched messages,
-	// so the DOM actually contains them when the parent scrolls.
+	// The query cache is canonical for durable messages, so a successful
+	// messages query means the DOM already carries them and the parent can
+	// scroll. There is no second source left to wait for.
 	const chatReadyFiredRef = useRef<string | null>(null);
-	const storeMessageCount = useDurableMessageCount({ store, chatId: agentId });
-	const fetchedMessageCount = chatMessagesList?.length ?? 0;
 	useEffect(() => {
-		if (
-			chatReadyFiredRef.current === agentId ||
-			!chatMessagesQuery.isSuccess ||
-			storeMessageCount < fetchedMessageCount
-		) {
+		if (chatReadyFiredRef.current === agentId || !chatMessagesQuery.isSuccess) {
 			return;
 		}
 		chatReadyFiredRef.current = agentId ?? null;
 		onChatReady();
-	}, [
-		onChatReady,
-		storeMessageCount,
-		fetchedMessageCount,
-		chatMessagesQuery.isSuccess,
-		agentId,
-	]);
+	}, [onChatReady, chatMessagesQuery.isSuccess, agentId]);
 
 	// Primitives extracted from proxy/workspace so the compiler
 	// tracks stable strings, not object identity.
@@ -1853,9 +1869,6 @@ const AgentChatPage: FC = () => {
 			response.messages ?? (response.message ? [response.message] : []);
 		if (insertedMessages.length > 0) {
 			upsertCacheMessages(insertedMessages);
-			if (isActiveChat) {
-				store.upsertDurableMessages(insertedMessages);
-			}
 			if (response.queued) {
 				const reconciledQueue = isActiveChat
 					? reconcilePromotedQueueHead(
@@ -2064,7 +2077,7 @@ const AgentChatPage: FC = () => {
 			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
 			isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
 			onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-			messageCount={storeMessageCount}
+			messageCount={chatMessagesList?.length ?? 0}
 			desktopChatId={desktopEnabled ? agentId : undefined}
 			mcpServers={mcpServers}
 			selectedMCPServerIds={effectiveMCPServerIds}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1,8 +1,15 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { type ComponentProps, type FC, useRef } from "react";
+import {
+	type ComponentProps,
+	type FC,
+	type PropsWithChildren,
+	useRef,
+} from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
+import { chatKeys, selectDurableMessages } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import { MockChat } from "#/testHelpers/chatEntities";
@@ -855,11 +862,63 @@ const buildMessage = (
 ): TypesGen.ChatMessage =>
 	buildMessageWithContent(id, role, [{ type: "text", text }]);
 
-const buildStoreWithMessages = (msgs: TypesGen.ChatMessage[]) => {
-	const store = createChatStore();
-	store.replaceMessages(msgs);
-	return store;
+// Durable messages are canonical in the query cache, so a story that needs a
+// transcript owns a QueryClient seeded with the pages the API would return and
+// provides it around the view. The store carries only the streaming overlay.
+type StoryChat = {
+	queryClient: QueryClient;
+	store: ReturnType<typeof createChatStore>;
+	setMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
+	getMessages: () => readonly TypesGen.ChatMessage[];
 };
+
+const createStoryChat = (
+	messages: readonly TypesGen.ChatMessage[],
+): StoryChat => {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				staleTime: Number.POSITIVE_INFINITY,
+				refetchInterval: false,
+				retry: false,
+			},
+		},
+	});
+	const setMessages = (next: readonly TypesGen.ChatMessage[]): void => {
+		queryClient.setQueryData(chatKeys.messages(AGENT_ID), {
+			// The API returns each page newest-first.
+			pages: [
+				{
+					messages: [...next].sort((left, right) => right.id - left.id),
+					queued_messages: [],
+					has_more: false,
+				},
+			],
+			pageParams: [undefined],
+		});
+	};
+	setMessages(messages);
+	return {
+		queryClient,
+		store: createChatStore(),
+		setMessages,
+		getMessages: () => {
+			const data = queryClient.getQueryData<
+				Parameters<typeof selectDurableMessages>[0]
+			>(chatKeys.messages(AGENT_ID));
+			return data ? selectDurableMessages(data) : [];
+		},
+	};
+};
+
+const WithStoryChat: FC<PropsWithChildren<{ chat: StoryChat }>> = ({
+	chat,
+	children,
+}) => (
+	<QueryClientProvider client={chat.queryClient}>
+		{children}
+	</QueryClientProvider>
+);
 
 const otherUserActionMessages: TypesGen.ChatMessage[] = [
 	buildMessage(1, "user", "Please review this plan."),
@@ -882,15 +941,18 @@ const otherUserActionMessages: TypesGen.ChatMessage[] = [
 		},
 	]),
 ];
+const otherUserActionChat = createStoryChat(otherUserActionMessages);
 
 export const OtherUserChatHidesInlineActions: Story = {
 	render: () => (
-		<StoryAgentChatPageView
-			chatOwner={{ username: "OtherUser", name: "Other User" }}
-			isInputDisabled
-			onImplementPlan={fn()}
-			store={buildStoreWithMessages(otherUserActionMessages)}
-		/>
+		<WithStoryChat chat={otherUserActionChat}>
+			<StoryAgentChatPageView
+				chatOwner={{ username: "OtherUser", name: "Other User" }}
+				isInputDisabled
+				onImplementPlan={fn()}
+				store={otherUserActionChat.store}
+			/>
+		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -922,19 +984,22 @@ const editingMessages = [
 	),
 	buildMessage(5, "user", "That was terrible, try again"),
 ];
+const editingChat = createStoryChat(editingMessages);
 
 /** Editing a message in the middle of the conversation — shows the warning
  *  border on the edited message, faded subsequent messages, and the editing
  *  banner + outline on the chat input. */
 export const EditingMessage: Story = {
 	render: () => (
-		<StoryAgentChatPageView
-			store={buildStoreWithMessages(editingMessages)}
-			editing={{
-				editingMessageId: 3,
-				editorInitialValue: "Now tell me a joke",
-			}}
-		/>
+		<WithStoryChat chat={editingChat}>
+			<StoryAgentChatPageView
+				store={editingChat.store}
+				editing={{
+					editingMessageId: 3,
+					editorInitialValue: "Now tell me a joke",
+				}}
+			/>
+		</WithStoryChat>
 	),
 };
 
@@ -1058,26 +1123,9 @@ const waitForIntersectionObserverTick = async () => {
 	});
 };
 
-/** Helper that extracts the current messages array from a store. */
-const getStoreMessages = (
-	store: ReturnType<typeof createChatStore>,
-): TypesGen.ChatMessage[] => {
-	const snapshot = store.getSnapshot();
-	const messages: TypesGen.ChatMessage[] = [];
-	for (const id of snapshot.orderedMessageIDs) {
-		const message = snapshot.messagesByID.get(id);
-		if (message) {
-			messages.push(message);
-		}
-	}
-	return messages;
-};
-
-const prependOlderMessages = (
-	store: ReturnType<typeof createChatStore>,
-	count: number,
-) => {
-	const existing = getStoreMessages(store);
+/** Helper that reads the current durable messages from a story's cache. */
+const prependOlderMessages = (chat: StoryChat, count: number) => {
+	const existing = chat.getMessages();
 	const oldestMessage = existing[0];
 	const oldestID = oldestMessage?.id ?? 1;
 	const olderMessages = Array.from({ length: count }, (_, index) => {
@@ -1089,21 +1137,21 @@ const prependOlderMessages = (
 				: `Older answer ${Math.abs(id)}.`;
 		return buildMessage(id, role, text);
 	});
-	store.replaceMessages([...olderMessages, ...existing]);
+	chat.setMessages([...olderMessages, ...existing]);
 };
 
-const resetScrollStoryStore = (
-	store: ReturnType<typeof createChatStore>,
+const resetScrollStoryChat = (
+	chat: StoryChat,
 	// Default to a transcript long enough to overflow the 600px decorator so the
 	// inverse-scroll stories exercise the fetch threshold immediately.
 	count = 80,
 ) => {
-	store.replaceMessages(buildLongConversation(count));
+	chat.setMessages(buildLongConversation(count));
 };
 
-const inverseScrollStore = buildStoreWithMessages(buildLongConversation(80));
+const inverseScrollChat = createStoryChat(buildLongConversation(80));
 const inverseScrollFetchSpy = fn(() => {
-	prependOlderMessages(inverseScrollStore, 10);
+	prependOlderMessages(inverseScrollChat, 10);
 });
 
 /**
@@ -1114,14 +1162,16 @@ export const InverseScrollLoadsOlderMessages: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
-		<StoryAgentChatPageView
-			store={inverseScrollStore}
-			hasMoreMessages
-			onFetchMoreMessages={inverseScrollFetchSpy}
-		/>
+		<WithStoryChat chat={inverseScrollChat}>
+			<StoryAgentChatPageView
+				store={inverseScrollChat.store}
+				hasMoreMessages
+				onFetchMoreMessages={inverseScrollFetchSpy}
+			/>
+		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
-		resetScrollStoryStore(inverseScrollStore);
+		resetScrollStoryChat(inverseScrollChat);
 		inverseScrollFetchSpy.mockClear();
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
@@ -1136,9 +1186,9 @@ export const InverseScrollLoadsOlderMessages: Story = {
 	},
 };
 
-const multiPageScrollStore = buildStoreWithMessages(buildLongConversation(80));
+const multiPageScrollChat = createStoryChat(buildLongConversation(80));
 const multiPageFetchSpy = fn(() => {
-	prependOlderMessages(multiPageScrollStore, 10);
+	prependOlderMessages(multiPageScrollChat, 10);
 });
 
 /**
@@ -1149,14 +1199,16 @@ export const InverseScrollCanLoadMultiplePages: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
-		<StoryAgentChatPageView
-			store={multiPageScrollStore}
-			hasMoreMessages
-			onFetchMoreMessages={multiPageFetchSpy}
-		/>
+		<WithStoryChat chat={multiPageScrollChat}>
+			<StoryAgentChatPageView
+				store={multiPageScrollChat.store}
+				hasMoreMessages
+				onFetchMoreMessages={multiPageFetchSpy}
+			/>
+		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
-		resetScrollStoryStore(multiPageScrollStore);
+		resetScrollStoryChat(multiPageScrollChat);
 		multiPageFetchSpy.mockClear();
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
@@ -1179,7 +1231,7 @@ export const InverseScrollCanLoadMultiplePages: Story = {
 	},
 };
 
-const scrollToBottomButtonStoryStore = buildStoreWithMessages(
+const scrollToBottomButtonStoryChat = createStoryChat(
 	buildLongConversation(80),
 );
 
@@ -1191,10 +1243,12 @@ export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
-		<StoryAgentChatPageView store={scrollToBottomButtonStoryStore} />
+		<WithStoryChat chat={scrollToBottomButtonStoryChat}>
+			<StoryAgentChatPageView store={scrollToBottomButtonStoryChat.store} />
+		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
-		resetScrollStoryStore(scrollToBottomButtonStoryStore);
+		resetScrollStoryChat(scrollToBottomButtonStoryChat);
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
@@ -1224,9 +1278,7 @@ export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
 	},
 };
 
-const scrollToBottomStoryStore = buildStoreWithMessages(
-	buildLongConversation(80),
-);
+const scrollToBottomStoryChat = createStoryChat(buildLongConversation(80));
 // Story objects live at module scope, so use a ref-shaped object instead of a
 // hook to capture the imperative callback across the render and play phases.
 const scrollToBottomStoryRef: { current: (() => void) | null } = {
@@ -1241,13 +1293,15 @@ export const ScrollToBottomRefStillWorks: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
-		<StoryAgentChatPageView
-			store={scrollToBottomStoryStore}
-			scrollToBottomRef={scrollToBottomStoryRef}
-		/>
+		<WithStoryChat chat={scrollToBottomStoryChat}>
+			<StoryAgentChatPageView
+				store={scrollToBottomStoryChat.store}
+				scrollToBottomRef={scrollToBottomStoryRef}
+			/>
+		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
-		resetScrollStoryStore(scrollToBottomStoryStore);
+		resetScrollStoryChat(scrollToBottomStoryChat);
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
@@ -1271,7 +1325,7 @@ export const ScrollToBottomRefStillWorks: Story = {
 	},
 };
 
-const messageOrderStore = buildStoreWithMessages([
+const messageOrderChat = createStoryChat([
 	buildMessage(1, "user", "Oldest message"),
 	buildMessage(2, "assistant", "Older response"),
 	buildMessage(3, "user", "Newer question"),
@@ -1284,7 +1338,11 @@ const messageOrderStore = buildStoreWithMessages([
 export const MessageOrderIsStillCorrect: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
-	render: () => <StoryAgentChatPageView store={messageOrderStore} />,
+	render: () => (
+		<WithStoryChat chat={messageOrderChat}>
+			<StoryAgentChatPageView store={messageOrderChat.store} />
+		</WithStoryChat>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const oldest = canvas.getByText("Oldest message");
@@ -1298,7 +1356,7 @@ export const MessageOrderIsStillCorrect: Story = {
 	},
 };
 
-const stickyPinningStore = buildStoreWithMessages(buildLongConversation(40));
+const stickyPinningChat = createStoryChat(buildLongConversation(40));
 
 /**
  * Regression guard for the StickyUserMessage push-up logic.
@@ -1317,9 +1375,13 @@ const stickyPinningStore = buildStoreWithMessages(buildLongConversation(40));
 export const StickyUserMessagePinsOnScroll: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
-	render: () => <StoryAgentChatPageView store={stickyPinningStore} />,
+	render: () => (
+		<WithStoryChat chat={stickyPinningChat}>
+			<StoryAgentChatPageView store={stickyPinningChat.store} />
+		</WithStoryChat>
+	),
 	play: async ({ canvasElement }) => {
-		resetScrollStoryStore(stickyPinningStore, 40);
+		resetScrollStoryChat(stickyPinningChat, 40);
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
@@ -1399,9 +1461,7 @@ const buildTallStickyConversation = (count: number): TypesGen.ChatMessage[] => {
 	return messages;
 };
 
-const stickyClipUpdateStore = buildStoreWithMessages(
-	buildTallStickyConversation(30),
-);
+const stickyClipUpdateChat = createStoryChat(buildTallStickyConversation(30));
 
 /**
  * Regression guard: the sticky truncation must stay in sync as the
@@ -1422,9 +1482,13 @@ const stickyClipUpdateStore = buildStoreWithMessages(
 export const StickyUserMessageClipUpdatesWhilePinned: Story = {
 	parameters: { pixel: { exclude: true } },
 	decorators: scrollStoryDecorators,
-	render: () => <StoryAgentChatPageView store={stickyClipUpdateStore} />,
+	render: () => (
+		<WithStoryChat chat={stickyClipUpdateChat}>
+			<StoryAgentChatPageView store={stickyClipUpdateChat.store} />
+		</WithStoryChat>
+	),
 	play: async ({ canvasElement }) => {
-		stickyClipUpdateStore.replaceMessages(buildTallStickyConversation(30));
+		stickyClipUpdateChat.setMessages(buildTallStickyConversation(30));
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
@@ -1488,8 +1552,8 @@ export const StickyUserMessageClipUpdatesWhilePinned: Story = {
 		// Grow the transcript at the newest end. While pinned, scrollTop stays
 		// at 0 so no scroll event fires; only the content ResizeObserver can
 		// drive the recompute.
-		stickyClipUpdateStore.replaceMessages([
-			...getStoreMessages(stickyClipUpdateStore),
+		stickyClipUpdateChat.setMessages([
+			...stickyClipUpdateChat.getMessages(),
 			buildMessage(31, "assistant", "Freshly streamed reply. ".repeat(80)),
 			buildMessage(32, "assistant", "More freshly streamed reply. ".repeat(80)),
 		]);

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -7,6 +7,8 @@ import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import {
+	resolveOverlayStreamState,
+	selectFinalizingStreamState,
 	selectReconnectState,
 	selectRetryState,
 	selectStreamError,
@@ -116,6 +118,10 @@ interface LiveStreamTailProps {
 	chatId?: string;
 	persistedError: ChatDetailError | undefined;
 	isTranscriptEmpty: boolean;
+	// Decided by the durable-reading parent, which reads the finalizing ID and
+	// the cache-backed message list in the same render. True once the finalized
+	// tail is readable from the durable list, so the overlay can drop it.
+	suppressFinalizedOverlay?: boolean;
 	subagentTitles: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
 	urlTransform?: UrlTransform;
@@ -127,12 +133,25 @@ export const LiveStreamTail = ({
 	chatId,
 	persistedError,
 	isTranscriptEmpty,
+	suppressFinalizedOverlay = false,
 	subagentTitles,
 	subagentVariants,
 	urlTransform,
 	mcpServers,
 }: LiveStreamTailProps) => {
 	const streamState = useChatSelector(store, selectStreamState);
+	const finalizingStreamState = useChatSelector(
+		store,
+		selectFinalizingStreamState,
+	);
+	// The finalizing snapshot bridges the handoff: the store notifies
+	// synchronously and the query cache a macrotask later, so dropping the
+	// overlay on the store notification alone would blank the tail for a frame.
+	const overlayStreamState = resolveOverlayStreamState(
+		streamState,
+		finalizingStreamState,
+		suppressFinalizedOverlay,
+	);
 	const streamError = useChatSelector(store, selectStreamError);
 	const retryState = useChatSelector(store, selectRetryState);
 	const reconnectState = useChatSelector(store, selectReconnectState);
@@ -145,11 +164,11 @@ export const LiveStreamTail = ({
 		selectSubagentStatusOverrides,
 	);
 	const streamTools = buildStreamTools(
-		streamState?.toolCalls,
-		streamState?.toolResults,
+		overlayStreamState?.toolCalls,
+		overlayStreamState?.toolResults,
 	);
 	const liveStatus = deriveLiveStatus({
-		streamState,
+		streamState: overlayStreamState,
 		retryState,
 		reconnectState,
 		streamError,
@@ -160,7 +179,7 @@ export const LiveStreamTail = ({
 	return (
 		<LiveStreamTailContent
 			isTranscriptEmpty={isTranscriptEmpty}
-			streamState={streamState}
+			streamState={overlayStreamState}
 			streamTools={streamTools}
 			liveStatus={liveStatus}
 			subagentTitles={subagentTitles}

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -1,24 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
-import { createChatStore, selectIsPendingAssistantResponse } from "./chatStore";
+import {
+	createChatStore,
+	selectHasStreamOverlay,
+	selectHasStreamState,
+} from "./chatStore";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const makeMessage = (
-	id: number,
-	role: string,
-	text: string,
-	chatID = "chat-1",
-): TypesGen.ChatMessage =>
-	({
-		id,
-		chat_id: chatID,
-		created_at: `2025-01-01T00:00:0${Math.max(Math.abs(id), 0)}.000Z`,
-		role,
-		content: [{ type: "text", text }],
-	}) as TypesGen.ChatMessage;
 
 const makeQueuedMessage = (
 	id: number,
@@ -33,151 +23,6 @@ const makeQueuedMessage = (
 	}) as TypesGen.ChatQueuedMessage;
 
 const testChatID = "chat-1";
-
-// ---------------------------------------------------------------------------
-// replaceMessages
-// ---------------------------------------------------------------------------
-
-describe("replaceMessages", () => {
-	it("populates messagesByID and orderedMessageIDs", () => {
-		const store = createChatStore();
-		const msg1 = makeMessage(1, "user", "first");
-		const msg2 = makeMessage(2, "assistant", "second");
-
-		store.replaceMessages([msg1, msg2]);
-
-		const state = store.getSnapshot();
-		expect(state.messagesByID.size).toBe(2);
-		expect(state.messagesByID.get(1)).toBe(msg1);
-		expect(state.messagesByID.get(2)).toBe(msg2);
-		expect(state.orderedMessageIDs).toEqual([1, 2]);
-	});
-
-	it("sorts messages by id when created_at disagrees with append order", () => {
-		const store = createChatStore();
-		const first = {
-			...makeMessage(1, "user", "first"),
-			created_at: "2025-01-01T00:00:05.000Z",
-		} as TypesGen.ChatMessage;
-		const second = {
-			...makeMessage(2, "assistant", "second"),
-			created_at: "2025-01-01T00:00:01.000Z",
-		} as TypesGen.ChatMessage;
-
-		// Insert in reverse order.
-		store.replaceMessages([second, first]);
-
-		expect(store.getSnapshot().orderedMessageIDs).toEqual([1, 2]);
-	});
-
-	it("treats undefined as empty array", () => {
-		const store = createChatStore();
-		store.replaceMessages([makeMessage(1, "user", "hello")]);
-
-		store.replaceMessages(undefined);
-
-		const state = store.getSnapshot();
-		expect(state.messagesByID.size).toBe(0);
-		expect(state.orderedMessageIDs).toEqual([]);
-	});
-
-	it("does not notify subscribers when content is unchanged", () => {
-		const store = createChatStore();
-		const msg = makeMessage(1, "user", "hello");
-		store.replaceMessages([msg]);
-
-		let notified = false;
-		store.subscribe(() => {
-			notified = true;
-		});
-
-		// Same object reference — maps compare equal by ref.
-		store.replaceMessages([msg]);
-
-		expect(notified).toBe(false);
-	});
-});
-
-describe("upsertDurableMessages", () => {
-	it("orders merged messages by id rather than by arrival", () => {
-		const store = createChatStore();
-		const sharedCreatedAt = "2025-01-01T00:00:00.000Z";
-		const withSharedCreatedAt = (
-			id: number,
-			role: string,
-		): TypesGen.ChatMessage => ({
-			...makeMessage(id, role, `message-${id}`),
-			created_at: sharedCreatedAt,
-		});
-
-		store.replaceMessages([
-			withSharedCreatedAt(3, "assistant"),
-			withSharedCreatedAt(4, "tool"),
-		]);
-		store.upsertDurableMessages([
-			withSharedCreatedAt(1, "user"),
-			withSharedCreatedAt(2, "assistant"),
-		]);
-
-		expect(store.getSnapshot().orderedMessageIDs).toEqual([1, 2, 3, 4]);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// upsertDurableMessage
-// ---------------------------------------------------------------------------
-
-describe("upsertDurableMessage", () => {
-	it("inserts a new message and reports isDuplicate=false, changed=true", () => {
-		const store = createChatStore();
-		const msg = makeMessage(1, "user", "hello");
-
-		const result = store.upsertDurableMessage(msg);
-
-		expect(result).toEqual({ isDuplicate: false, changed: true });
-		expect(store.getSnapshot().messagesByID.get(1)).toBe(msg);
-		expect(store.getSnapshot().orderedMessageIDs).toEqual([1]);
-	});
-
-	it("reports isDuplicate=true, changed=false for value-equal duplicate", () => {
-		const store = createChatStore();
-		const msg = makeMessage(1, "user", "hello");
-		store.upsertDurableMessage(msg);
-
-		// Different object reference, same field values.
-		const dup = makeMessage(1, "user", "hello");
-		const result = store.upsertDurableMessage(dup);
-
-		expect(result).toEqual({ isDuplicate: true, changed: false });
-	});
-
-	it("reports isDuplicate=true, changed=true when content differs", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "assistant", "draft"));
-
-		const updated = makeMessage(1, "assistant", "final");
-		const result = store.upsertDurableMessage(updated);
-
-		expect(result).toEqual({ isDuplicate: true, changed: true });
-		expect(store.getSnapshot().messagesByID.get(1)?.content).toEqual(
-			updated.content,
-		);
-	});
-
-	it("does not reorder when updating an existing message in place", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "user", "first"));
-		store.upsertDurableMessage(makeMessage(2, "assistant", "second"));
-		const orderBefore = store.getSnapshot().orderedMessageIDs;
-
-		// Update content of existing message (same ID, same map size).
-		store.upsertDurableMessage(makeMessage(2, "assistant", "edited"));
-
-		// Same reference — no reorder needed because the map size
-		// didn't change and the ID already existed.
-		expect(store.getSnapshot().orderedMessageIDs).toBe(orderBefore);
-	});
-});
 
 // ---------------------------------------------------------------------------
 // setStreamState
@@ -843,9 +688,8 @@ describe("resetTransientState", () => {
 		expect(state.subagentStatusOverrides.size).toBe(0);
 	});
 
-	it("preserves messages and queued messages", () => {
+	it("preserves the queue", () => {
 		const store = createChatStore();
-		store.replaceMessages([makeMessage(1, "user", "hello")]);
 		store.setQueuedMessages([makeQueuedMessage(10, "queued")]);
 		store.setStreamError({
 			kind: "generic",
@@ -854,9 +698,7 @@ describe("resetTransientState", () => {
 
 		store.resetTransientState();
 
-		const state = store.getSnapshot();
-		expect(state.messagesByID.size).toBe(1);
-		expect(state.queuedMessages).toHaveLength(1);
+		expect(store.getSnapshot().queuedMessages).toHaveLength(1);
 	});
 
 	it("is a no-op when all transient state is already clean", () => {
@@ -869,6 +711,121 @@ describe("resetTransientState", () => {
 		store.resetTransientState();
 
 		expect(notified).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// beginStreamFinalization
+//
+// The overlay hands off to the durable message that superseded it. The store
+// half is the lifecycle below; the suppression half (exact ID membership in
+// the cache-backed list) is covered in chatStore.test.tsx and
+// durableChat.test.tsx.
+// ---------------------------------------------------------------------------
+
+describe("beginStreamFinalization", () => {
+	it("moves the overlay into the finalizing snapshot and records the ID", () => {
+		const store = createChatStore();
+		store.applyMessagePart({ type: "text", text: "streamed answer" });
+		const overlay = store.getSnapshot().streamState;
+
+		store.beginStreamFinalization(42);
+
+		const state = store.getSnapshot();
+		expect(state.streamState).toBeNull();
+		expect(state.finalizingStreamState).toBe(overlay);
+		expect(state.finalizingMessageID).toBe(42);
+	});
+
+	it("starts a fresh stream state on the first part of the next turn", () => {
+		const store = createChatStore();
+		store.applyMessagePart({ type: "text", text: "first turn" });
+		store.beginStreamFinalization(42);
+
+		store.applyMessagePart({ type: "text", text: "second turn" });
+
+		const state = store.getSnapshot();
+		// The next turn's tokens must not accumulate into the finalized snapshot.
+		expect(state.streamState?.blocks).toEqual([
+			{ type: "response", text: "second turn" },
+		]);
+		expect(state.finalizingStreamState).toBeNull();
+		expect(state.finalizingMessageID).toBeNull();
+	});
+
+	it("keeps the finalizing snapshot when a part carries no renderable output", () => {
+		const store = createChatStore();
+		store.applyMessagePart({ type: "text", text: "first turn" });
+		store.beginStreamFinalization(42);
+
+		store.applyMessagePart({ type: "text", text: "   " });
+
+		const state = store.getSnapshot();
+		expect(state.streamState).toBeNull();
+		expect(state.finalizingMessageID).toBe(42);
+	});
+
+	it("drops a stale snapshot when there is no overlay to hand off", () => {
+		const store = createChatStore();
+		store.applyMessagePart({ type: "text", text: "first turn" });
+		store.beginStreamFinalization(42);
+
+		store.beginStreamFinalization(43);
+
+		const state = store.getSnapshot();
+		expect(state.finalizingStreamState).toBeNull();
+		expect(state.finalizingMessageID).toBeNull();
+	});
+
+	// The timeline reads this flag to decide between its streaming and completed
+	// presentations, so it has to stay true through the handoff window while the
+	// finalized tail is still rendered by the overlay.
+	it("reports a stream overlay while an active stream or a handoff is on screen", () => {
+		const store = createChatStore();
+		expect(selectHasStreamOverlay(store.getSnapshot())).toBe(false);
+
+		store.applyMessagePart({ type: "text", text: "streamed answer" });
+		expect(selectHasStreamOverlay(store.getSnapshot())).toBe(true);
+		expect(selectHasStreamState(store.getSnapshot())).toBe(true);
+
+		store.beginStreamFinalization(42);
+		// The active stream is gone, but the finalized tail is still on screen.
+		expect(selectHasStreamState(store.getSnapshot())).toBe(false);
+		expect(selectHasStreamOverlay(store.getSnapshot())).toBe(true);
+
+		store.clearStreamState();
+		expect(selectHasStreamOverlay(store.getSnapshot())).toBe(false);
+	});
+
+	it.each([
+		[
+			"clearStreamState",
+			(store: ReturnType<typeof createChatStore>) => store.clearStreamState(),
+		],
+		[
+			"resetTransportReplayState",
+			(store: ReturnType<typeof createChatStore>) =>
+				store.resetTransportReplayState(),
+		],
+		[
+			"resetTransientState",
+			(store: ReturnType<typeof createChatStore>) =>
+				store.resetTransientState(),
+		],
+		[
+			"setStreamState",
+			(store: ReturnType<typeof createChatStore>) => store.setStreamState(null),
+		],
+	])("%s clears the finalization handoff", (_label, clear) => {
+		const store = createChatStore();
+		store.applyMessagePart({ type: "text", text: "streamed answer" });
+		store.beginStreamFinalization(42);
+
+		clear(store);
+
+		const state = store.getSnapshot();
+		expect(state.finalizingStreamState).toBeNull();
+		expect(state.finalizingMessageID).toBeNull();
 	});
 });
 
@@ -907,79 +864,5 @@ describe("subscribe", () => {
 
 		expect(countA).toBe(1);
 		expect(countB).toBe(1);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// selectIsPendingAssistantResponse
-//
-// The Thinking indicator is the conjunction of this selector and the cached
-// chat status; the status half is covered in durableChat.test.tsx.
-// ---------------------------------------------------------------------------
-
-describe("selectIsPendingAssistantResponse", () => {
-	it("returns true with no stream state and no assistant message", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
-
-		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(true);
-	});
-
-	it("returns false when the latest message is from the assistant", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
-		store.upsertDurableMessage(makeMessage(2, "assistant", "hi there"));
-
-		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(false);
-	});
-
-	it("returns false when stream state is present", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
-		store.applyMessagePart({ type: "text", text: "response" });
-
-		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(false);
-	});
-
-	it("returns true when the latest message is a tool result", () => {
-		const store = createChatStore();
-		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
-		store.upsertDurableMessage(makeMessage(2, "assistant", "calling tool"));
-		store.upsertDurableMessage(makeMessage(3, "tool", "tool result"));
-
-		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(true);
-	});
-
-	it("returns true after an optimistic send clears the settled turn", () => {
-		const store = createChatStore();
-		// A settled previous turn: the assistant replied last.
-		store.upsertDurableMessage(makeMessage(1, "user", "first question"));
-		store.upsertDurableMessage(makeMessage(2, "assistant", "first answer"));
-
-		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(false);
-
-		// The sequence handleSend runs once the POST returns (non-queued).
-		store.clearStreamState();
-		store.upsertDurableMessage(makeMessage(3, "user", "follow-up"));
-
-		expect(selectIsPendingAssistantResponse(store.getSnapshot())).toBe(true);
-	});
-});
-
-describe("duplicate message deduplication", () => {
-	it("replaceMessages deduplicates orderedMessageIDs when input has duplicate IDs", () => {
-		const store = createChatStore();
-		const msg1 = makeMessage(1, "user", "hello");
-		const msg2 = makeMessage(2, "assistant", "hi");
-		// Simulate cross-page duplication: same ID appears twice.
-		const msg2Copy = makeMessage(2, "assistant", "hi");
-
-		store.replaceMessages([msg1, msg2, msg2Copy]);
-
-		const state = store.getSnapshot();
-		// Map deduplicates by key — only 2 unique entries.
-		expect(state.messagesByID.size).toBe(2);
-		// orderedMessageIDs MUST also have only 2 entries.
-		expect(state.orderedMessageIDs).toEqual([1, 2]);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1,4 +1,10 @@
-import { act, render, renderHook, waitFor } from "@testing-library/react";
+import {
+	act,
+	render,
+	renderHook,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { watchChat } from "#/api/api";
 import { chatKeys } from "#/api/queries/chats";
 
@@ -29,14 +35,31 @@ const readInfiniteChats = (
 };
 
 import type { FC, PropsWithChildren } from "react";
-import { QueryClient, QueryClientProvider, useQueryClient } from "react-query";
+import { useEffect } from "react";
+import {
+	QueryClient,
+	QueryClientProvider,
+	useInfiniteQuery,
+	useQueryClient,
+} from "react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import {
+	projectEditedConversationIntoCache,
+	reconcileEditedMessageInCache,
+} from "#/api/queries/chatMessageEdits";
+import {
+	chatMessagesForInfiniteScroll,
+	selectDurableMessages,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat } from "#/testHelpers/chatEntities";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
-	selectMessagesByID,
-	selectOrderedMessageIDs,
+	type ChatStore,
+	resolveOverlayStreamState,
+	selectFinalizingMessageID,
+	selectFinalizingStreamState,
 	selectQueuedMessages,
 	selectReconnectState,
 	selectRetryState,
@@ -47,6 +70,7 @@ import {
 	useChatStore,
 } from "./chatStore";
 import {
+	shouldSuppressFinalizedOverlay,
 	useDurableChatStatus,
 	useDurableMessageList,
 	useDurableQueuedMessages,
@@ -55,6 +79,11 @@ import {
 
 vi.mock("#/api/api", () => ({
 	watchChat: vi.fn(),
+	API: {
+		experimental: {
+			getChatMessages: vi.fn(),
+		},
+	},
 }));
 
 type MessageListener = (
@@ -211,9 +240,10 @@ const createTestQueryClient = (): QueryClient =>
 	});
 
 /**
- * In the app the chat detail query IS the record passed to useChatStore, and
- * the socket writes status into that cache entry. Tests pass the record as a
- * prop, so mirror it into the cache the way the query would.
+ * In the app the infinite messages query IS the source of the durable
+ * messages, and both the socket and every reader go through its cache entry.
+ * Tests pass the flat list as a prop, so mirror it into the cache the way the
+ * query would, unless the test seeded the entry itself.
  */
 const useTestChatStore: typeof useChatStore = (options) => {
 	const queryClient = useQueryClient();
@@ -223,6 +253,25 @@ const useTestChatStore: typeof useChatStore = (options) => {
 		queryClient.getQueryData(chatKeys.detail(chatRecord.id)) === undefined
 	) {
 		queryClient.setQueryData(chatKeys.detail(chatRecord.id), chatRecord);
+	}
+	if (
+		options.chatID &&
+		options.chatMessages &&
+		queryClient.getQueryData(chatKeys.messages(options.chatID)) === undefined
+	) {
+		queryClient.setQueryData(chatKeys.messages(options.chatID), {
+			pages: [
+				{
+					// The API returns each page newest-first.
+					messages: [...options.chatMessages].sort(
+						(left, right) => right.id - left.id,
+					),
+					queued_messages: options.chatQueuedMessages ?? [],
+					has_more: false,
+				},
+			],
+			pageParams: [undefined],
+		});
 	}
 	return useChatStore(options);
 };
@@ -467,8 +516,7 @@ describe("useChatStore", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					messagesByID: useChatSelector(store, selectMessagesByID),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -512,10 +560,10 @@ describe("useChatStore", () => {
 
 		await waitFor(() => {
 			expect(result.current.streamState).toBeNull();
-			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
-			expect(result.current.messagesByID.get(2)?.content).toEqual(
-				assistantMessage.content,
-			);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
+			expect(
+				result.current.messages.find((message) => message.id === 2)?.content,
+			).toEqual(assistantMessage.content);
 		});
 	});
 
@@ -565,7 +613,7 @@ describe("useChatStore", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -622,7 +670,7 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
 			expect(result.current.streamState).toBeNull();
 		});
 	});
@@ -718,7 +766,7 @@ describe("useChatStore", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -756,7 +804,7 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
 			expect(result.current.streamState?.blocks).toEqual([
 				{ type: "response", text: "fresh" },
 			]);
@@ -913,15 +961,14 @@ describe("useChatStore", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					messagesByID: useChatSelector(store, selectMessagesByID),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
 		);
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
 		});
 
 		// Frame 1: history_reset plus only part of the replacement
@@ -933,7 +980,7 @@ describe("useChatStore", () => {
 				{ type: "message", chat_id: chatID, message: replacementOne },
 			]);
 		});
-		expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+		expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
 
 		// Frame 2: the rest of the replacement, terminated by the
 		// preview_reset the server emits in the same sync.
@@ -945,13 +992,13 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
-			expect(result.current.messagesByID.get(1)?.content).toEqual(
-				replacementOne.content,
-			);
-			expect(result.current.messagesByID.get(2)?.content).toEqual(
-				replacementTwo.content,
-			);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
+			expect(
+				result.current.messages.find((message) => message.id === 1)?.content,
+			).toEqual(replacementOne.content);
+			expect(
+				result.current.messages.find((message) => message.id === 2)?.content,
+			).toEqual(replacementTwo.content);
 		});
 
 		const cached = queryClient.getQueryData<{
@@ -1123,7 +1170,7 @@ describe("useChatStore", () => {
 
 		let streamRenderCount = 0;
 		let queueRenderCount = 0;
-		let orderedIDsRenderCount = 0;
+		let durableMessagesRenderCount = 0;
 
 		type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
@@ -1139,9 +1186,11 @@ describe("useChatStore", () => {
 			return null;
 		};
 
-		const OrderedIDsProbe: FC<{ store: ChatStoreHandle }> = ({ store }) => {
-			useChatSelector(store, selectOrderedMessageIDs);
-			orderedIDsRenderCount += 1;
+		const DurableMessagesProbe: FC<{ store: ChatStoreHandle }> = ({
+			store,
+		}) => {
+			useDurableMessageList({ store, chatId: chatID });
+			durableMessagesRenderCount += 1;
 			return null;
 		};
 
@@ -1163,7 +1212,7 @@ describe("useChatStore", () => {
 				<>
 					<StreamProbe store={store} />
 					<QueueProbe store={store} />
-					<OrderedIDsProbe store={store} />
+					<DurableMessagesProbe store={store} />
 				</>
 			);
 		};
@@ -1180,7 +1229,7 @@ describe("useChatStore", () => {
 
 		const streamBaseline = streamRenderCount;
 		const queueBaseline = queueRenderCount;
-		const orderedIDsBaseline = orderedIDsRenderCount;
+		const durableMessagesBaseline = durableMessagesRenderCount;
 
 		act(() => {
 			mockSocket.emitData({
@@ -1200,7 +1249,7 @@ describe("useChatStore", () => {
 			expect(streamRenderCount).toBeGreaterThan(streamBaseline);
 		});
 		expect(queueRenderCount).toBe(queueBaseline);
-		expect(orderedIDsRenderCount).toBe(orderedIDsBaseline);
+		expect(durableMessagesRenderCount).toBe(durableMessagesBaseline);
 	});
 
 	it("applies batched message_part events from one payload", async () => {
@@ -1713,7 +1762,7 @@ describe("useChatStore", () => {
 					clearChatErrorReason,
 				});
 				return {
-					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -1733,7 +1782,7 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.orderedIDs).toContain(2);
+			expect(result.current.messages.map((m) => m.id)).toContain(2);
 		});
 
 		// The React Query cache should also contain the new message.
@@ -3149,7 +3198,7 @@ describe("useChatStore", () => {
 			});
 		});
 
-		// Transition to running — should clear retry state.
+		// Transition to running, which must clear retry state.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
@@ -3306,7 +3355,7 @@ describe("useChatStore", () => {
 			);
 		});
 		// Main chat status should remain "running" from the initial
-		// chatRecord — the subagent status event must not change it.
+		// chatRecord: the subagent status event must not change it.
 		expect(result.current.chatStatus).toBe("running");
 	});
 
@@ -3631,7 +3680,7 @@ describe("useChatStore", () => {
 			timeout: 3_000,
 		});
 
-		// Second disconnect — reconnect after 2s.
+		// Second disconnect, so the reconnect lands after 2s.
 		const socket2 = sockets[1]!;
 		act(() => socket2.emitClose());
 
@@ -3863,7 +3912,7 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
 		});
 
-		// Transition to running — should call clearChatErrorReason.
+		// Transition to running, which must call clearChatErrorReason.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
@@ -3875,74 +3924,6 @@ describe("useChatStore", () => {
 
 		await waitFor(() => {
 			expect(clearChatErrorReason).toHaveBeenCalledWith(chatID);
-		});
-	});
-
-	it("removes stale messages when refetched set is smaller (edit truncation)", async () => {
-		immediateAnimationFrame();
-
-		const chatID = "chat-edit-truncation";
-		const msg1 = buildMessage(chatID, 1, "user", "first");
-		const msg2 = buildMessage(chatID, 2, "assistant", "second");
-		const msg3 = buildMessage(chatID, 3, "user", "third");
-
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-
-		const queryClient = createTestQueryClient();
-		const wrapper = createWrapper(queryClient);
-		const setChatErrorReason = vi.fn();
-		const clearChatErrorReason = vi.fn();
-
-		const noQueued: TypesGen.ChatQueuedMessage[] = [];
-		const initialMessages = [msg1, msg2, msg3];
-
-		const initialOptions = {
-			chatID,
-			chatMessages: initialMessages,
-			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: initialMessages,
-				queued_messages: noQueued,
-				has_more: false,
-			},
-			chatQueuedMessages: noQueued,
-			setChatErrorReason,
-			clearChatErrorReason,
-		};
-
-		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useTestChatStore(options);
-				return {
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
-				};
-			},
-			{ initialProps: initialOptions, wrapper },
-		);
-
-		// All three messages should be in the store.
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
-		});
-
-		// Simulate a post-edit refetch that only returns the first
-		// message (server truncated messages 2 and 3).
-		rerender({
-			...initialOptions,
-			chatMessages: [msg1],
-			chatMessagesData: {
-				messages: [msg1],
-				queued_messages: [],
-				has_more: false,
-			},
-		});
-
-		// Messages 2 and 3 should be removed — replaceMessages should
-		// have been used instead of upsert because the store contained
-		// IDs not present in the fetched set.
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1]);
 		});
 	});
 
@@ -3984,7 +3965,7 @@ describe("useChatStore", () => {
 			(options: Parameters<typeof useChatStore>[0]) => {
 				const { store } = useTestChatStore(options);
 				return {
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 					queuedMessages: useChatSelector(store, selectQueuedMessages),
 				};
 			},
@@ -3992,7 +3973,7 @@ describe("useChatStore", () => {
 		);
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
 			expect(result.current.queuedMessages).toHaveLength(1);
 		});
 
@@ -4017,30 +3998,19 @@ describe("useChatStore", () => {
 			]);
 		});
 
-		// The promoted message should appear in the store and the
-		// queue should be empty. Before the fix, the queue_update
-		// caused updateChatQueuedMessages to mutate the React Query
-		// cache, giving chatMessages a new reference that triggered
-		// the sync effect. The effect detected the promoted message
-		// as a "stale entry" (present in store but not in the REST
-		// data) and called replaceMessages, wiping it.
+		// The promoted message must survive in the canonical cache with an
+		// empty queue. The socket is the only writer of durable messages, so a
+		// queue_update that rewrites the cached page must leave the promoted
+		// message in place.
 		//
-		// Now re-render so the updated query cache flows through
-		// the chatMessages prop (simulating React rerender after
-		// the query cache mutation).
+		// Re-render so the updated query cache flows through the props the way
+		// it does after a React Query cache mutation.
 		rerender({
 			...initialOptions,
-			// chatMessages still comes from REST (not refetched), so
-			// it only has [msg1, msg2]. The promoted message lives
-			// only in the store via the WebSocket delivery.
-			//
-			// Spread into a new array to simulate what actually
-			// happens: updateChatQueuedMessages mutates the React
-			// Query cache (changing queued_messages), which gives
-			// chatMessagesQuery.data a new reference, causing the
-			// chatMessagesList useMemo to return a new array with
-			// the same elements. The new reference triggers the
-			// sync effect.
+			// The REST props were not refetched, so they still carry only
+			// [msg1, msg2]: the promoted message arrived over the socket.
+			// Spread into a new array to reproduce the new reference a queue
+			// cache write hands to every reader.
 			chatMessages: [...initialMessages],
 			chatMessagesData: {
 				messages: [...initialMessages],
@@ -4050,7 +4020,7 @@ describe("useChatStore", () => {
 			chatQueuedMessages: [],
 		});
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
 			expect(result.current.queuedMessages).toHaveLength(0);
 		});
 	});
@@ -4094,14 +4064,14 @@ describe("useChatStore", () => {
 					store,
 					streamState: useChatSelector(store, selectStreamState),
 					chatStatus: useDurableChatStatus({ store, chatId: chatID }),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ initialProps: initialOptions, wrapper },
 		);
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
 		});
 
 		// Open the WebSocket and set the chat to running.
@@ -4151,7 +4121,7 @@ describe("useChatStore", () => {
 		// The stream state must survive: the promoted user message
 		// should not wipe the in-progress assistant stream.
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toContain(3);
+			expect(result.current.messages.map((m) => m.id)).toContain(3);
 			expect(result.current.streamState).not.toBeNull();
 			const blocks = result.current.streamState?.blocks ?? [];
 			const textBlock = blocks.find((b) => b.type === "response");
@@ -4338,7 +4308,7 @@ describe("useChatStore", () => {
 				});
 				return {
 					streamState: useChatSelector(store, selectStreamState),
-					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -4400,7 +4370,7 @@ describe("useChatStore", () => {
 		// should be in the message store.
 		await waitFor(() => {
 			expect(result.current.streamState).toBeNull();
-			expect(result.current.orderedIDs).toContain(2);
+			expect(result.current.messages.map((m) => m.id)).toContain(2);
 		});
 	});
 });
@@ -4756,7 +4726,7 @@ describe("sidebar cache writes from stream events", () => {
 					clearChatErrorReason,
 				});
 				return {
-					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -4778,7 +4748,7 @@ describe("sidebar cache writes from stream events", () => {
 			});
 		});
 
-		// The per-chat WebSocket does not write updated_at — only the
+		// The per-chat WebSocket does not write updated_at, only the
 		// global chat-list WebSocket delivers the authoritative server
 		// timestamp. Verify it stays at the original value.
 		await waitFor(() => {
@@ -4964,7 +4934,7 @@ describe("sidebar cache writes from stream events", () => {
 					clearChatErrorReason,
 				});
 				return {
-					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
 			{ wrapper },
@@ -5123,38 +5093,142 @@ describe("sidebar cache writes from stream events", () => {
 	});
 });
 
-describe("stream-to-durable transition (Bug 1)", () => {
-	it("does not render both stream state and durable message after assistant message commits", async () => {
+describe("stream-to-durable finalization handoff", () => {
+	type OverlayFrame = {
+		overlayText: string | null;
+		durableIDs: readonly number[];
+	};
+
+	const overlayTextOf = (
+		state: ReturnType<typeof selectStreamState>,
+	): string | null =>
+		state === null
+			? null
+			: state.blocks
+					.map((block) => ("text" in block ? block.text : ""))
+					.join("");
+
+	/**
+	 * Stands in for LiveStreamTail: subscribes to the store for the overlay and
+	 * takes the suppression decision from its durable-reading parent, resolving
+	 * the visible overlay with the production rule.
+	 */
+	const TailFrameProbe: FC<{
+		store: ChatStore;
+		durableIDs: readonly number[];
+		suppressFinalizedOverlay: boolean;
+		frames: OverlayFrame[];
+	}> = ({ store, durableIDs, suppressFinalizedOverlay, frames }) => {
+		const streamState = useChatSelector(store, selectStreamState);
+		const finalizingStreamState = useChatSelector(
+			store,
+			selectFinalizingStreamState,
+		);
+		const overlayText = overlayTextOf(
+			resolveOverlayStreamState(
+				streamState,
+				finalizingStreamState,
+				suppressFinalizedOverlay,
+			),
+		);
+		// Record the COMMITTED frame, so a render React discards never counts
+		// as something the user saw.
+		useEffect(() => {
+			frames.push({ overlayText, durableIDs });
+		});
+		return (
+			<>
+				<div data-testid="transcript">{durableIDs.join(",")}</div>
+				<div data-testid="tail">{overlayText ?? ""}</div>
+			</>
+		);
+	};
+
+	/**
+	 * Stands in for ChatPageTimeline: the only place the suppression decision is
+	 * made, reading the finalizing ID and the cache-backed durable list in the
+	 * same render.
+	 */
+	const FinalizationFrameHarness: FC<{
+		chatID: string;
+		initialMessages: readonly TypesGen.ChatMessage[];
+		frames: OverlayFrame[];
+		// Receives the pagination observer's fetchNextPage so a test can put a
+		// history fetch in flight, which forces socket cache writes to buffer.
+		paginationRef?: { current: (() => void) | null };
+	}> = ({ chatID, initialMessages, frames, paginationRef }) => {
+		const messagesQuery = useInfiniteQuery(
+			chatMessagesForInfiniteScroll(chatID),
+		);
+		const { store } = useTestChatStore({
+			chatID,
+			chatMessages: [...initialMessages],
+			chatRecord: buildChat(chatID),
+			chatMessagesData: {
+				messages: [...initialMessages].sort(
+					(left, right) => right.id - left.id,
+				),
+				queued_messages: [],
+				has_more: false,
+			},
+			chatQueuedMessages: [],
+			setChatErrorReason: vi.fn(),
+			clearChatErrorReason: vi.fn(),
+		});
+		const messages = useDurableMessageList({ store, chatId: chatID });
+		const finalizingMessageID = useChatSelector(
+			store,
+			selectFinalizingMessageID,
+		);
+		const suppressFinalizedOverlay = shouldSuppressFinalizedOverlay(
+			finalizingMessageID,
+			messages,
+		);
+		// Same retirement the production parent performs.
+		useEffect(() => {
+			if (suppressFinalizedOverlay && finalizingMessageID !== null) {
+				store.completeStreamFinalization(finalizingMessageID);
+			}
+		}, [store, suppressFinalizedOverlay, finalizingMessageID]);
+		const fetchNextPage = messagesQuery.fetchNextPage;
+		useEffect(() => {
+			if (paginationRef) {
+				paginationRef.current = () => {
+					void fetchNextPage();
+				};
+			}
+		}, [paginationRef, fetchNextPage]);
+		return (
+			<>
+				<div data-testid="finalizing">{finalizingMessageID ?? ""}</div>
+				<TailFrameProbe
+					store={store}
+					durableIDs={messages.map((message) => message.id)}
+					suppressFinalizedOverlay={suppressFinalizedOverlay}
+					frames={frames}
+				/>
+			</>
+		);
+	};
+
+	it("shows the finalized tail exactly once in every committed frame", async () => {
 		immediateAnimationFrame();
 
-		const chatID = "chat-b1-overlap";
+		const chatID = "chat-finalize-frames";
 		const userMsg = buildMessage(chatID, 1, "user", "hello");
 		const mockSocket = createMockSocket();
 		mockWatchChatReturn(mockSocket);
 
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
+		const frames: OverlayFrame[] = [];
 
-		const { result } = renderHook(
-			() => {
-				const { store } = useTestChatStore({
-					chatID,
-					chatMessages: [userMsg],
-					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
-					chatQueuedMessages: [],
-					setChatErrorReason: vi.fn(),
-					clearChatErrorReason: vi.fn(),
-				});
-				return {
-					streamState: useChatSelector(store, selectStreamState),
-					messages: useDurableMessageList({ store, chatId: chatID }),
-				};
-			},
+		render(
+			<FinalizationFrameHarness
+				chatID={chatID}
+				initialMessages={[userMsg]}
+				frames={frames}
+			/>,
 			{ wrapper },
 		);
 
@@ -5162,7 +5236,6 @@ describe("stream-to-durable transition (Bug 1)", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 		});
 
-		// Build up streaming content.
 		act(() => {
 			mockSocket.emitData({
 				type: "message_part",
@@ -5175,16 +5248,11 @@ describe("stream-to-durable transition (Bug 1)", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.streamState?.blocks).toEqual([
-				{ type: "response", text: "response" },
-			]);
+			expect(screen.getByTestId("tail").textContent).toBe("response");
 		});
 
-		// Commit the assistant message as durable. With the old
-		// code, streamState stayed non-null here because
-		// clearStreamState was deferred to a rAF. Both the
-		// durable message and the stream content coexisted,
-		// causing duplicate rendering.
+		// Finalize: the cache write and the store's finalization land in one
+		// batch, but the cache notification is a macrotask later.
 		act(() => {
 			mockSocket.emitData({
 				type: "message",
@@ -5193,62 +5261,53 @@ describe("stream-to-durable transition (Bug 1)", () => {
 			});
 		});
 
-		// The durable message must be present AND streamState
-		// must be null in the same snapshot.
 		await waitFor(() => {
-			expect(result.current.messages.map((m) => m.id)).toContain(2);
-			expect(result.current.messages.find((m) => m.id === 2)?.role).toBe(
-				"assistant",
-			);
-			expect(result.current.streamState).toBeNull();
+			expect(screen.getByTestId("transcript").textContent).toBe("1,2");
 		});
+
+		// From the first frame that rendered the streamed tail onward, the
+		// finalized content is visible in EXACTLY one place: the overlay, or the
+		// durable transcript. Equality of the two booleans means a double render
+		// (both) or a gap (neither).
+		const handoffFrames = frames.slice(
+			frames.findIndex((frame) => frame.overlayText === "response"),
+		);
+		expect(handoffFrames.length).toBeGreaterThan(1);
+		const badFrames = handoffFrames.filter(
+			(frame) =>
+				(frame.overlayText === "response") === frame.durableIDs.includes(2),
+		);
+		expect(badFrames).toEqual([]);
+
+		// The overlay ends cleared, with the durable message on screen, and the
+		// handoff is retired instead of lingering into the idle chat.
+		expect(screen.getByTestId("tail").textContent).toBe("");
+		await waitFor(() => {
+			expect(screen.getByTestId("finalizing").textContent).toBe("");
+		});
+		const lastFrame = frames.at(-1);
+		expect(lastFrame?.overlayText).toBeNull();
+		expect(lastFrame?.durableIDs).toContain(2);
 	});
 
-	it("no snapshot ever has both durable assistant and stream state", async () => {
+	it("starts a fresh overlay for the next turn instead of extending the finalized snapshot", async () => {
 		immediateAnimationFrame();
 
-		const chatID = "chat-b1-atomic";
-		const userMsg = buildMessage(chatID, 1, "user", "hi");
+		const chatID = "chat-finalize-next-turn";
+		const userMsg = buildMessage(chatID, 1, "user", "hello");
 		const mockSocket = createMockSocket();
 		mockWatchChatReturn(mockSocket);
 
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
+		const frames: OverlayFrame[] = [];
 
-		// Track every snapshot emitted to subscribers.
-		const snapshots: Array<{
-			hasStream: boolean;
-			hasDurableAssistant: boolean;
-		}> = [];
-
-		const { result } = renderHook(
-			() => {
-				const { store } = useTestChatStore({
-					chatID,
-					chatMessages: [userMsg],
-					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
-					chatQueuedMessages: [],
-					setChatErrorReason: vi.fn(),
-					clearChatErrorReason: vi.fn(),
-				});
-				const streamState = useChatSelector(store, selectStreamState);
-				const messages = useDurableMessageList({ store, chatId: chatID });
-				const hasDurableAssistant = messages.some(
-					(m) => m.role === "assistant",
-				);
-
-				snapshots.push({
-					hasStream: streamState !== null,
-					hasDurableAssistant,
-				});
-
-				return { streamState, messages };
-			},
+		render(
+			<FinalizationFrameHarness
+				chatID={chatID}
+				initialMessages={[userMsg]}
+				frames={frames}
+			/>,
 			{ wrapper },
 		);
 
@@ -5262,36 +5321,565 @@ describe("stream-to-durable transition (Bug 1)", () => {
 				chat_id: chatID,
 				message_part: {
 					role: "assistant",
-					part: { type: "text", text: "hello" },
+					part: { type: "text", text: "response" },
 				},
 			});
 		});
-
 		await waitFor(() => {
-			expect(result.current.streamState).not.toBeNull();
+			expect(screen.getByTestId("tail").textContent).toBe("response");
 		});
-
-		// Clear snapshot history before the critical transition.
-		snapshots.length = 0;
 
 		act(() => {
 			mockSocket.emitData({
 				type: "message",
 				chat_id: chatID,
-				message: buildMessage(chatID, 2, "assistant", "hello"),
+				message: buildMessage(chatID, 2, "assistant", "response"),
+			});
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("transcript").textContent).toBe("1,2");
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "next turn" },
+				},
 			});
 		});
 
 		await waitFor(() => {
-			expect(result.current.messages.some((m) => m.id === 2)).toBe(true);
+			expect(screen.getByTestId("tail").textContent).toBe("next turn");
 		});
 
-		// No snapshot should ever have BOTH a durable assistant
-		// message AND non-null stream state.
-		const overlapping = snapshots.filter(
-			(s) => s.hasStream && s.hasDurableAssistant,
+		// The finalized snapshot never accumulates the next turn's tokens, and
+		// the durable transcript keeps the finalized message.
+		expect(
+			frames.some((frame) => frame.overlayText?.includes("responsenext turn")),
+		).toBe(false);
+		expect(screen.getByTestId("transcript").textContent).toBe("1,2");
+	});
+
+	// The bridge earns its keep here: the cache write buffers behind the
+	// in-flight fetch, so the store records the finalization long before the
+	// durable message is readable. Clearing the overlay on the store
+	// notification alone would blank the tail until the fetch resolves.
+	it("keeps the finalized tail visible while its cache write waits behind an in-flight fetch", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-finalize-during-fetch";
+		const older = buildMessage(chatID, 30, "assistant", "older answer");
+		const userMsg = buildMessage(chatID, 31, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		queryClient.setQueryData(chatKeys.messages(chatID), {
+			pages: [
+				{
+					messages: [userMsg, older],
+					queued_messages: [],
+					has_more: true,
+				},
+			],
+			pageParams: [undefined],
+		});
+
+		const frames: OverlayFrame[] = [];
+		const paginationRef: { current: (() => void) | null } = {
+			current: null,
+		};
+
+		render(
+			<FinalizationFrameHarness
+				chatID={chatID}
+				initialMessages={[older, userMsg]}
+				frames={frames}
+				paginationRef={paginationRef}
+			/>,
+			{ wrapper },
 		);
-		expect(overlapping).toEqual([]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 31);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "response" },
+				},
+			});
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("tail").textContent).toBe("response");
+		});
+
+		const olderPage = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			olderPage.promise,
+		);
+		act(() => {
+			paginationRef.current?.();
+		});
+		await waitFor(() => {
+			expect(API.experimental.getChatMessages).toHaveBeenCalled();
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 32, "assistant", "response"),
+			});
+		});
+
+		// Buffered, so the durable list cannot show it yet, and the overlay has
+		// to carry the tail on its own.
+		expect(screen.getByTestId("transcript").textContent).toBe("30,31");
+		expect(screen.getByTestId("tail").textContent).toBe("response");
+
+		await act(async () => {
+			olderPage.resolve({
+				messages: [buildMessage(chatID, 20, "user", "older")],
+				queued_messages: [],
+				has_more: false,
+			});
+			await olderPage.promise;
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("transcript").textContent).toBe("20,30,31,32");
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("tail").textContent).toBe("");
+		});
+
+		const handoffFrames = frames.slice(
+			frames.findIndex((frame) => frame.overlayText === "response"),
+		);
+		const badFrames = handoffFrames.filter(
+			(frame) =>
+				(frame.overlayText === "response") === frame.durableIDs.includes(32),
+		);
+		expect(badFrames).toEqual([]);
+		await waitFor(() => {
+			expect(screen.getByTestId("finalizing").textContent).toBe("");
+		});
+	});
+
+	// The real backend sequence: the durable `message` and the `preview_reset`
+	// that retires its preview arrive in one frame, while a pagination fetch
+	// holds the durable write in the serialization buffer. The overlay is the
+	// only thing that can render the finalized turn until the fetch settles.
+	it("shows the finalized tail exactly once for a [message, preview_reset] batch during a fetch", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-finalize-preview-reset-frames";
+		const older = buildMessage(chatID, 30, "assistant", "older answer");
+		const userMsg = buildMessage(chatID, 31, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		queryClient.setQueryData(chatKeys.messages(chatID), {
+			pages: [
+				{ messages: [userMsg, older], queued_messages: [], has_more: true },
+			],
+			pageParams: [undefined],
+		});
+
+		const frames: OverlayFrame[] = [];
+		const paginationRef: { current: (() => void) | null } = { current: null };
+
+		render(
+			<FinalizationFrameHarness
+				chatID={chatID}
+				initialMessages={[older, userMsg]}
+				frames={frames}
+				paginationRef={paginationRef}
+			/>,
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 31);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "response" },
+				},
+			});
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("tail").textContent).toBe("response");
+		});
+
+		const olderPage = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			olderPage.promise,
+		);
+		act(() => {
+			paginationRef.current?.();
+		});
+		await waitFor(() => {
+			expect(API.experimental.getChatMessages).toHaveBeenCalled();
+		});
+
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "message",
+					chat_id: chatID,
+					message: buildMessage(chatID, 32, "assistant", "response"),
+				},
+				{ type: "preview_reset", chat_id: chatID },
+			]);
+		});
+
+		// The reset must not blank the tail: the durable write is buffered, so
+		// the transcript cannot show the finalized turn yet.
+		expect(screen.getByTestId("transcript").textContent).toBe("30,31");
+		expect(screen.getByTestId("tail").textContent).toBe("response");
+
+		await act(async () => {
+			olderPage.resolve({
+				messages: [buildMessage(chatID, 20, "user", "older")],
+				queued_messages: [],
+				has_more: false,
+			});
+			await olderPage.promise;
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("transcript").textContent).toBe("20,30,31,32");
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("tail").textContent).toBe("");
+		});
+
+		const handoffFrames = frames.slice(
+			frames.findIndex((frame) => frame.overlayText === "response"),
+		);
+		const badFrames = handoffFrames.filter(
+			(frame) =>
+				(frame.overlayText === "response") === frame.durableIDs.includes(32),
+		);
+		expect(badFrames).toEqual([]);
+		await waitFor(() => {
+			expect(screen.getByTestId("finalizing").textContent).toBe("");
+		});
+	});
+
+	// The finalizing snapshot is transient overlay state, so every path that
+	// drops the overlay drops it too. These drive the real socket events rather
+	// than the store methods, so a handler that forgets a path is caught.
+	const renderFinalizationLifecycle = (
+		chatID: string,
+		queryClient: QueryClient,
+		initialMessages: readonly TypesGen.ChatMessage[],
+	) =>
+		renderHook(
+			({ activeChatID }: { activeChatID: string }) => {
+				const { store } = useTestChatStore({
+					chatID: activeChatID,
+					chatMessages: [...initialMessages],
+					chatRecord: buildChat(activeChatID),
+					chatMessagesData: {
+						messages: [...initialMessages],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					finalizingMessageID: useChatSelector(
+						store,
+						selectFinalizingMessageID,
+					),
+					finalizingStreamState: useChatSelector(
+						store,
+						selectFinalizingStreamState,
+					),
+				};
+			},
+			{
+				wrapper: createWrapper(queryClient),
+				initialProps: { activeChatID: chatID },
+			},
+		);
+
+	it.each([
+		[
+			"history_reset",
+			(chatID: string) => ({
+				type: "history_reset" as const,
+				chat_id: chatID,
+			}),
+		],
+		[
+			"retry",
+			(chatID: string): TypesGen.ChatStreamEvent => ({
+				type: "retry" as const,
+				chat_id: chatID,
+				retry: {
+					attempt: 2,
+					error: "upstream timeout",
+					kind: "timeout",
+					provider: "anthropic",
+					delay_ms: 5000,
+					retrying_at: "2025-01-01T00:01:00.000Z",
+				},
+			}),
+		],
+	])("clears the finalization handoff on %s", async (_label, buildEvent) => {
+		immediateAnimationFrame();
+
+		const chatID = `chat-finalize-clear-${_label}`;
+		const userMsg = buildMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderFinalizationLifecycle(chatID, queryClient, [
+			userMsg,
+		]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "response" },
+				},
+			});
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 2, "assistant", "response"),
+			});
+		});
+		expect(result.current.finalizingMessageID).toBe(2);
+		expect(result.current.finalizingStreamState).not.toBeNull();
+
+		act(() => {
+			mockSocket.emitData(buildEvent(chatID));
+		});
+
+		expect(result.current.finalizingMessageID).toBeNull();
+		expect(result.current.finalizingStreamState).toBeNull();
+	});
+
+	// The backend emits the durable `message` for a snapshot and then the
+	// `preview_reset` that retires its preview. Clearing the overlay on that
+	// reset would strand the tail that just finalized, so a pending handoff
+	// survives it and is retired by identity instead.
+	it("keeps the finalization handoff across a preview_reset in a later frame", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-finalize-preview-reset";
+		const userMsg = buildMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderFinalizationLifecycle(chatID, queryClient, [
+			userMsg,
+		]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "response" },
+				},
+			});
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 2, "assistant", "response"),
+			});
+		});
+		expect(result.current.finalizingMessageID).toBe(2);
+
+		// A separate frame, so the handler cannot see the durable message in
+		// this batch and has to consult the store's pending handoff.
+		act(() => {
+			mockSocket.emitData({ type: "preview_reset", chat_id: chatID });
+		});
+
+		expect(result.current.finalizingMessageID).toBe(2);
+		expect(result.current.finalizingStreamState).not.toBeNull();
+	});
+
+	it("clears the overlay on a preview_reset with no handoff pending", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-preview-reset-no-handoff";
+		const userMsg = buildMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderFinalizationLifecycle(chatID, queryClient, [
+			userMsg,
+		]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "discarded preview" },
+				},
+			});
+		});
+		await waitFor(() => {
+			expect(result.current.streamState).not.toBeNull();
+		});
+
+		act(() => {
+			mockSocket.emitData({ type: "preview_reset", chat_id: chatID });
+		});
+
+		expect(result.current.streamState).toBeNull();
+		expect(result.current.finalizingMessageID).toBeNull();
+		expect(result.current.finalizingStreamState).toBeNull();
+	});
+
+	it("clears the finalization handoff when the chat changes", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-finalize-clear-switch";
+		const userMsg = buildMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const { result, rerender } = renderFinalizationLifecycle(
+			chatID,
+			queryClient,
+			[userMsg],
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "response" },
+				},
+			});
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 2, "assistant", "response"),
+			});
+		});
+		expect(result.current.finalizingMessageID).toBe(2);
+
+		rerender({ activeChatID: "chat-finalize-clear-switch-other" });
+
+		expect(result.current.finalizingMessageID).toBeNull();
+		expect(result.current.finalizingStreamState).toBeNull();
+	});
+
+	it("clears the finalization handoff when the socket reconnects", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-finalize-clear-reconnect";
+		const userMsg = buildMessage(chatID, 1, "user", "hello");
+		const firstSocket = createMockSocket();
+		mockWatchChatReturnOnce(firstSocket);
+
+		const queryClient = createTestQueryClient();
+		const { result } = renderFinalizationLifecycle(chatID, queryClient, [
+			userMsg,
+		]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			firstSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "response" },
+				},
+			});
+		});
+		act(() => {
+			firstSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 2, "assistant", "response"),
+			});
+		});
+		expect(result.current.finalizingMessageID).toBe(2);
+
+		act(() => {
+			firstSocket.emitError();
+		});
+		const secondSocket = createMockSocket();
+		mockWatchChatReturnOnce(secondSocket);
+		await waitFor(
+			() => {
+				expect(watchChat).toHaveBeenCalledTimes(2);
+			},
+			{ timeout: 3_000 },
+		);
+		act(() => {
+			secondSocket.emitOpen();
+		});
+
+		expect(result.current.finalizingMessageID).toBeNull();
+		expect(result.current.finalizingStreamState).toBeNull();
 	});
 });
 
@@ -5402,180 +5990,123 @@ describe("partsBuf cleanup on reconnect (Bug 2)", () => {
 	});
 });
 
-describe("store/cache desync protection", () => {
-	it("does not wipe a message added via upsertDurableMessage when a genuine refetch follows", async () => {
-		// RED TEST: Simulates what handleSend does today — it calls
-		// store.upsertDurableMessage without writing to the React
-		// Query cache. A subsequent rerender with new message refs
-		// (genuine refetch) should NOT wipe the store-only message.
-		immediateAnimationFrame();
-
-		const chatID = "chat-send-desync";
-		const msg1 = buildMessage(chatID, 1, "user", "hello");
-		const msg2 = buildMessage(chatID, 2, "assistant", "hi");
-		const msg3 = buildMessage(chatID, 3, "user", "follow-up");
-
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-
-		const queryClient = createTestQueryClient();
-		queryClient.setQueryData(chatKeys.messages(chatID), {
-			pages: [
-				{
-					messages: [msg2, msg1],
-					queued_messages: [],
-					has_more: false,
-				},
-			],
-			pageParams: [undefined],
-		});
-		const wrapper = createWrapper(queryClient);
-
-		const initialMessages = [msg1, msg2];
-		const initialOptions = {
-			chatID,
-			chatMessages: initialMessages,
-			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: initialMessages,
-				queued_messages: [],
-				has_more: false,
-			},
-			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
-			setChatErrorReason: vi.fn(),
-			clearChatErrorReason: vi.fn(),
-		};
-
-		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useTestChatStore(options);
-				return {
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
-					store,
-				};
-			},
-			{ initialProps: initialOptions, wrapper },
-		);
-
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
-		});
-
-		act(() => {
-			mockSocket.emitOpen();
-		});
-
-		// Simulate handleSend: write to store only, no cache write.
-		act(() => {
-			result.current.store.upsertDurableMessage(msg3);
-		});
-
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
-		});
-
-		// Genuine refetch: new object refs for msg1 and msg2,
-		// msg3 absent from the fetched set.
-		const msg1New = buildMessage(chatID, 1, "user", "hello");
-		const msg2New = buildMessage(chatID, 2, "assistant", "hi");
-		rerender({
-			...initialOptions,
-			chatMessages: [msg1New, msg2New],
-			chatMessagesData: {
-				messages: [msg1New, msg2New],
-				queued_messages: [],
-				has_more: false,
-			},
-		});
-
-		// msg3 was added to the store AFTER the last sync. It
-		// should NOT be classified as stale — it's new, not
-		// something the server removed.
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
-		});
-	});
-
-	it("still removes messages that were in the previous sync but are absent from a refetch (edit truncation)", async () => {
-		immediateAnimationFrame();
-
-		const chatID = "chat-edit-truncation";
-		const msg1 = buildMessage(chatID, 1, "user", "hello");
-		const msg2 = buildMessage(chatID, 2, "assistant", "hi");
-		const msg3 = buildMessage(chatID, 3, "user", "more");
-
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-
-		const queryClient = createTestQueryClient();
-		queryClient.setQueryData(chatKeys.messages(chatID), {
-			pages: [
-				{
-					messages: [msg3, msg2, msg1],
-					queued_messages: [],
-					has_more: false,
-				},
-			],
-			pageParams: [undefined],
-		});
-		const wrapper = createWrapper(queryClient);
-
-		const initialOptions = {
-			chatID,
-			chatMessages: [msg1, msg2, msg3],
-			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: [msg1, msg2, msg3],
-				queued_messages: [],
-				has_more: false,
-			},
-			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
-			setChatErrorReason: vi.fn(),
-			clearChatErrorReason: vi.fn(),
-		};
-
-		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useTestChatStore(options);
-				return {
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
-				};
-			},
-			{ initialProps: initialOptions, wrapper },
-		);
-
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
-		});
-
-		act(() => {
-			mockSocket.emitOpen();
-		});
-
-		// Simulate edit truncation: rerender with only msg1.
-		const msg1New = buildMessage(chatID, 1, "user", "hello");
-		rerender({
-			...initialOptions,
-			chatMessages: [msg1New],
-			chatMessagesData: {
-				messages: [msg1New],
-				queued_messages: [],
-				has_more: false,
-			},
-		});
-
-		// msg2 and msg3 WERE in the previous sync data and are
-		// now absent — they are genuinely stale (edit truncation)
-		// and should be removed.
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1]);
-		});
-	});
-
-	it("reflects optimistic and authoritative history-edit cache updates through the normal sync effect", async () => {
+describe("durable edit reconciliation through the cache", () => {
+	it("projects an optimistic edit and then the authoritative replacement", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-local-edit-sync";
+		const msg1 = buildMessage(chatID, 1, "user", "first");
+		const msg2 = buildMessage(chatID, 2, "assistant", "second");
+		const msg3 = buildMessage(chatID, 3, "user", "third");
+		const optimisticReplacement = {
+			...msg3,
+			content: [{ type: "text" as const, text: "edited draft" }],
+		};
+		// The backend soft-deletes the edited row and inserts a replacement with
+		// a NEW ID, so reconciliation is by ID plus deleted_message_ids.
+		const authoritativeReplacement = buildMessage(chatID, 9, "user", "edited");
+
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [msg1, msg2, msg3],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [msg1, msg2, msg3],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					messages: useDurableMessageList({ store, chatId: chatID }),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
+		});
+
+		act(() => {
+			mockSocket.emitOpen();
+		});
+
+		// Channel 1, first half: the optimistic projection truncates everything
+		// at or above the edited ID and reinstates the edited message.
+		act(() => {
+			queryClient.setQueryData(
+				chatKeys.messages(chatID),
+				(current: MessagesCache | undefined) =>
+					projectEditedConversationIntoCache({
+						currentData: current,
+						editedMessageId: msg3.id,
+						replacementMessage: optimisticReplacement,
+					}),
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
+			expect(
+				result.current.messages.find((message) => message.id === 3)?.content,
+			).toEqual(optimisticReplacement.content);
+		});
+
+		// Channel 1, second half: the response deletes the optimistic ID and
+		// inserts the server's replacement.
+		act(() => {
+			queryClient.setQueryData(
+				chatKeys.messages(chatID),
+				(current: MessagesCache | undefined) =>
+					reconcileEditedMessageInCache({
+						currentData: current,
+						optimisticMessageId: msg3.id,
+						responseMessages: [authoritativeReplacement],
+						deletedMessageIds: [msg3.id],
+					}),
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 9]);
+			expect(result.current.messages.some((message) => message.id === 3)).toBe(
+				false,
+			);
+			expect(
+				result.current.messages.find((message) => message.id === 9)?.content,
+			).toEqual(authoritativeReplacement.content);
+		});
+
+		// The socket echo of the same replacement is idempotent: the upsert is
+		// keyed by ID, so the list does not grow a second copy.
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: authoritativeReplacement,
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 9]);
+		});
+	});
+
+	it("stays idempotent when the socket echo arrives before the edit response", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-local-edit-echo-first";
 		const msg1 = buildMessage(chatID, 1, "user", "first");
 		const msg2 = buildMessage(chatID, 2, "assistant", "second");
 		const msg3 = buildMessage(chatID, 3, "user", "third");
@@ -5590,73 +6121,83 @@ describe("store/cache desync protection", () => {
 
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
-		const initialOptions = {
-			chatID,
-			chatMessages: [msg1, msg2, msg3],
-			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: [msg1, msg2, msg3],
-				queued_messages: [],
-				has_more: false,
-			},
-			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
-			setChatErrorReason: vi.fn(),
-			clearChatErrorReason: vi.fn(),
-		};
 
-		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useTestChatStore(options);
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [msg1, msg2, msg3],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [msg1, msg2, msg3],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
 				return {
-					store,
-					messagesByID: useChatSelector(store, selectMessagesByID),
-					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messages: useDurableMessageList({ store, chatId: chatID }),
 				};
 			},
-			{ initialProps: initialOptions, wrapper },
+			{ wrapper },
 		);
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3]);
 		});
 
 		act(() => {
 			mockSocket.emitOpen();
 		});
 
-		rerender({
-			...initialOptions,
-			chatMessages: [msg1, msg2, optimisticReplacement],
-			chatMessagesData: {
-				messages: [msg1, msg2, optimisticReplacement],
-				queued_messages: [],
-				has_more: false,
-			},
-		});
-
-		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
-			expect(result.current.messagesByID.get(3)?.content).toEqual(
-				optimisticReplacement.content,
+		act(() => {
+			queryClient.setQueryData(
+				chatKeys.messages(chatID),
+				(current: MessagesCache | undefined) =>
+					projectEditedConversationIntoCache({
+						currentData: current,
+						editedMessageId: msg3.id,
+						replacementMessage: optimisticReplacement,
+					}),
 			);
 		});
 
-		rerender({
-			...initialOptions,
-			chatMessages: [msg1, msg2, authoritativeReplacement],
-			chatMessagesData: {
-				messages: [msg1, msg2, authoritativeReplacement],
-				queued_messages: [],
-				has_more: false,
-			},
+		// Channel 2 wins the race: the socket echoes the server's replacement
+		// before the mutation response reconciles the optimistic ID away.
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: authoritativeReplacement,
+			});
 		});
 
 		await waitFor(() => {
-			expect(result.current.orderedMessageIDs).toEqual([1, 2, 9]);
-			expect(result.current.messagesByID.has(3)).toBe(false);
-			expect(result.current.messagesByID.get(9)?.content).toEqual(
-				authoritativeReplacement.content,
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 3, 9]);
+		});
+
+		act(() => {
+			queryClient.setQueryData(
+				chatKeys.messages(chatID),
+				(current: MessagesCache | undefined) =>
+					reconcileEditedMessageInCache({
+						currentData: current,
+						optimisticMessageId: msg3.id,
+						responseMessages: [authoritativeReplacement],
+						deletedMessageIds: [msg3.id],
+					}),
 			);
+		});
+
+		// The late response removes the optimistic row and re-inserts the same
+		// ID it already echoed, so the list neither duplicates nor loses it.
+		await waitFor(() => {
+			expect(result.current.messages.map((m) => m.id)).toEqual([1, 2, 9]);
+			expect(
+				result.current.messages.find((message) => message.id === 9)?.content,
+			).toEqual(authoritativeReplacement.content);
 		});
 	});
 });
@@ -6052,6 +6593,522 @@ describe("message cache resync over the socket", () => {
 				pageParams: unknown[];
 			}>(chatKeys.messages(chatID));
 			expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
+		});
+	});
+});
+
+type MessagesCache = {
+	pages: TypesGen.ChatMessagesResponse[];
+	pageParams: unknown[];
+};
+
+const readMessagesCache = (
+	queryClient: QueryClient,
+	chatID: string,
+): MessagesCache | undefined =>
+	queryClient.getQueryData<MessagesCache>(chatKeys.messages(chatID));
+
+const messageIDsPerPage = (cache: MessagesCache | undefined): number[][] =>
+	cache?.pages.map((page) => page.messages.map((message) => message.id)) ?? [];
+
+const createDeferred = <T,>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} => {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+};
+
+// The query cache, not the store, is canonical for durable messages: the
+// socket is their single ordered writer, so its writes have to land in page 0
+// without leaving stale cross-page copies, and they must not be clobbered by a
+// paginating fetch that captured the pages before the write.
+describe("durable messages in the query cache", () => {
+	const createRetainedQueryClient = (): QueryClient =>
+		new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+
+	const seedMessagesCache = (
+		queryClient: QueryClient,
+		chatID: string,
+		pages: MessagesCache["pages"],
+		pageParams: MessagesCache["pageParams"],
+	): void => {
+		queryClient.setQueryData<MessagesCache>(chatKeys.messages(chatID), {
+			pages,
+			pageParams,
+		});
+	};
+
+	const renderMessagesHarness = (
+		queryClient: QueryClient,
+		chatID: string,
+		chatMessages: readonly TypesGen.ChatMessage[],
+	) =>
+		renderHook(
+			() => {
+				const messagesQuery = useInfiniteQuery(
+					chatMessagesForInfiniteScroll(chatID),
+				);
+				useTestChatStore({
+					chatID,
+					chatMessages,
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [...chatMessages],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return messagesQuery;
+			},
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+	// Exposes the hook's queue cache writer next to the pagination handle, so a
+	// test can commit a queue write while a fetch is in flight.
+	const renderQueueHarness = (
+		queryClient: QueryClient,
+		chatID: string,
+		chatMessages: readonly TypesGen.ChatMessage[],
+		chatQueuedMessages: readonly TypesGen.ChatQueuedMessage[],
+	) =>
+		renderHook(
+			() => {
+				const messagesQuery = useInfiniteQuery(
+					chatMessagesForInfiniteScroll(chatID),
+				);
+				const { setCacheQueuedMessages } = useTestChatStore({
+					chatID,
+					chatMessages,
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [...chatMessages],
+						queued_messages: [...chatQueuedMessages],
+						has_more: false,
+					},
+					chatQueuedMessages,
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return { messagesQuery, setCacheQueuedMessages };
+			},
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+	it("canonicalizes an updated message into page 0 and drops the older copy", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const staleOlder = buildMessage(chatID, 20, "user", "original");
+		const oldest = buildMessage(chatID, 10, "user", "oldest");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[
+				{ messages: [newest], queued_messages: [], has_more: true },
+				{ messages: [staleOlder, oldest], queued_messages: [], has_more: true },
+			],
+			[undefined, 30],
+		);
+
+		renderMessagesHarness(queryClient, chatID, [oldest, staleOlder, newest]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+
+		const revised = buildMessage(chatID, 20, "user", "revised");
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: revised,
+			});
+		});
+
+		await waitFor(() => {
+			const cached = readMessagesCache(queryClient, chatID);
+			// The authoritative values land in page 0 and the older page keeps
+			// only the IDs it still owns, so the flatten cannot resurrect the
+			// superseded copy.
+			expect(messageIDsPerPage(cached)).toEqual([[30, 20], [10]]);
+			expect(cached?.pages[0].messages[1]).toEqual(revised);
+			expect(cached?.pageParams).toEqual([undefined, 30]);
+			expect(
+				cached && selectDurableMessages(cached).map((message) => message.id),
+			).toEqual([10, 20, 30]);
+		});
+	});
+
+	it("drops a page emptied by the upsert together with its page param", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const staleOlder = buildMessage(chatID, 20, "user", "original");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[
+				{ messages: [newest], queued_messages: [], has_more: true },
+				{ messages: [staleOlder], queued_messages: [], has_more: true },
+			],
+			[undefined, 30],
+		);
+
+		const { result } = renderMessagesHarness(queryClient, chatID, [
+			staleOlder,
+			newest,
+		]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+		expect(result.current.hasNextPage).toBe(true);
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 20, "user", "revised"),
+			});
+		});
+
+		await waitFor(() => {
+			const cached = readMessagesCache(queryClient, chatID);
+			expect(messageIDsPerPage(cached)).toEqual([[30, 20]]);
+			expect(cached?.pageParams).toEqual([undefined]);
+		});
+		// An emptied last page would make getNextPageParam return undefined and
+		// strand the rest of the history, so the page goes away with its cursor.
+		expect(result.current.hasNextPage).toBe(true);
+	});
+
+	it("preserves page metadata and the queue when upserting a message", async () => {
+		const chatID = "chat-1";
+		const existing = buildMessage(chatID, 1, "user", "hello");
+		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[
+				{
+					messages: [existing],
+					queued_messages: [queuedMessage],
+					has_more: true,
+				},
+			],
+			[undefined],
+		);
+
+		renderMessagesHarness(queryClient, chatID, [existing]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: buildMessage(chatID, 2, "assistant", "hi"),
+			});
+		});
+
+		await waitFor(() => {
+			const cached = readMessagesCache(queryClient, chatID);
+			expect(messageIDsPerPage(cached)).toEqual([[2, 1]]);
+			expect(cached?.pages[0].queued_messages).toEqual([queuedMessage]);
+			expect(cached?.pages[0].has_more).toBe(true);
+		});
+	});
+
+	it("replays a socket append buffered during an in-flight fetchNextPage", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[{ messages: [newest], queued_messages: [], has_more: true }],
+			[undefined],
+		);
+
+		const { result } = renderMessagesHarness(queryClient, chatID, [newest]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+
+		// The fetch captures the pages as they are now and installs them
+		// unconditionally when it resolves.
+		const olderPage = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			olderPage.promise,
+		);
+		act(() => {
+			void result.current.fetchNextPage();
+		});
+		await waitFor(() => {
+			expect(API.experimental.getChatMessages).toHaveBeenCalled();
+		});
+
+		const committed = buildMessage(chatID, 31, "user", "committed mid-fetch");
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: committed,
+			});
+		});
+		// Buffered rather than written, so the resolving fetch cannot discard it.
+		expect(messageIDsPerPage(readMessagesCache(queryClient, chatID))).toEqual([
+			[30],
+		]);
+
+		await act(async () => {
+			olderPage.resolve({
+				messages: [buildMessage(chatID, 20, "user", "older")],
+				queued_messages: [],
+				has_more: false,
+			});
+			await olderPage.promise;
+		});
+
+		await waitFor(() => {
+			const cached = readMessagesCache(queryClient, chatID);
+			// Both survive: the fetched page and the socket write replayed on top.
+			expect(messageIDsPerPage(cached)).toEqual([[31, 30], [20]]);
+		});
+		expect(result.current.isFetchingNextPage).toBe(false);
+		// And it stays: nothing re-runs the clobbering install afterwards.
+		await waitFor(() => {
+			expect(
+				readMessagesCache(queryClient, chatID)?.pages[0].messages[0],
+			).toEqual(committed);
+		});
+	});
+
+	it("replays a history reset buffered during an in-flight fetchNextPage", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "stale answer");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[{ messages: [newest], queued_messages: [], has_more: true }],
+			[undefined],
+		);
+
+		const { result } = renderMessagesHarness(queryClient, chatID, [newest]);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+
+		const olderPage = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			olderPage.promise,
+		);
+		act(() => {
+			void result.current.fetchNextPage();
+		});
+		await waitFor(() => {
+			expect(API.experimental.getChatMessages).toHaveBeenCalled();
+		});
+
+		const replacement = buildMessage(chatID, 1, "user", "edited");
+		act(() => {
+			mockSocket.emitDataBatch([
+				{ type: "history_reset", chat_id: chatID },
+				{ type: "message", chat_id: chatID, message: replacement },
+				{ type: "preview_reset", chat_id: chatID },
+			]);
+		});
+
+		await act(async () => {
+			olderPage.resolve({
+				messages: [buildMessage(chatID, 20, "user", "older")],
+				queued_messages: [],
+				has_more: false,
+			});
+			await olderPage.promise;
+		});
+
+		await waitFor(() => {
+			const cached = readMessagesCache(queryClient, chatID);
+			// The replacement history is authoritative, so the page the fetch
+			// installed is superseded rather than merged.
+			expect(cached?.pages).toHaveLength(1);
+			expect(cached?.pages[0].messages).toEqual([replacement]);
+			expect(cached?.pageParams).toEqual([undefined]);
+		});
+	});
+
+	// The queue snapshot lives on page 0 of the same cache entry, so it needs the
+	// same serialization: a fetch that captured the pages before the delete
+	// would reinstall the deleted entry, and the store would not correct it
+	// because no queue_update arrived.
+	it("keeps a queued-message delete committed during an in-flight fetchNextPage", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const keptQueued = buildQueuedMessage(chatID, 11, "kept");
+		const deletedQueued = buildQueuedMessage(chatID, 10, "deleted");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[
+				{
+					messages: [newest],
+					queued_messages: [deletedQueued, keptQueued],
+					has_more: true,
+				},
+			],
+			[undefined],
+		);
+
+		const { result } = renderQueueHarness(
+			queryClient,
+			chatID,
+			[newest],
+			[deletedQueued, keptQueued],
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+
+		const olderPage = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			olderPage.promise,
+		);
+		act(() => {
+			void result.current.messagesQuery.fetchNextPage();
+		});
+		await waitFor(() => {
+			expect(API.experimental.getChatMessages).toHaveBeenCalled();
+		});
+
+		// The optimistic delete the queued-message mutation performs.
+		act(() => {
+			result.current.setCacheQueuedMessages([keptQueued]);
+		});
+		expect(
+			readMessagesCache(queryClient, chatID)?.pages[0].queued_messages,
+		).toEqual([deletedQueued, keptQueued]);
+
+		await act(async () => {
+			olderPage.resolve({
+				messages: [buildMessage(chatID, 20, "user", "older")],
+				queued_messages: [],
+				has_more: false,
+			});
+			await olderPage.promise;
+		});
+
+		await waitFor(() => {
+			const cached = readMessagesCache(queryClient, chatID);
+			// The delete survives the fetch instead of resurrecting.
+			expect(cached?.pages[0].queued_messages).toEqual([keptQueued]);
+			expect(messageIDsPerPage(cached)).toEqual([[30], [20]]);
+		});
+	});
+
+	it("replays a queue_update buffered during an in-flight fetchNextPage", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const queued = buildQueuedMessage(chatID, 10, "queued");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[{ messages: [newest], queued_messages: [queued], has_more: true }],
+			[undefined],
+		);
+
+		const { result } = renderQueueHarness(
+			queryClient,
+			chatID,
+			[newest],
+			[queued],
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+
+		const olderPage = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockReturnValueOnce(
+			olderPage.promise,
+		);
+		act(() => {
+			void result.current.messagesQuery.fetchNextPage();
+		});
+		await waitFor(() => {
+			expect(API.experimental.getChatMessages).toHaveBeenCalled();
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "queue_update",
+				chat_id: chatID,
+				queued_messages: [],
+			});
+		});
+		expect(
+			readMessagesCache(queryClient, chatID)?.pages[0].queued_messages,
+		).toEqual([queued]);
+
+		await act(async () => {
+			olderPage.resolve({
+				messages: [buildMessage(chatID, 20, "user", "older")],
+				queued_messages: [],
+				has_more: false,
+			});
+			await olderPage.promise;
+		});
+
+		await waitFor(() => {
+			expect(
+				readMessagesCache(queryClient, chatID)?.pages[0].queued_messages,
+			).toEqual([]);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -7,55 +7,6 @@ import {
 import { applyMessagePartToStreamState } from "./streamState";
 import type { ReconnectState, RetryState, StreamState } from "./types";
 
-const buildMessageMap = (
-	messages: readonly TypesGen.ChatMessage[],
-): Map<number, TypesGen.ChatMessage> =>
-	new Map(messages.map((message) => [message.id, message]));
-
-const buildOrderedMessageIDs = (
-	messages: readonly TypesGen.ChatMessage[],
-): readonly number[] => {
-	// created_at is shared across an insert batch, so only id tracks append order.
-	const sorted = messages.toSorted((left, right) => left.id - right.id);
-	// Deduplicate by ID. The input can contain duplicate IDs when
-	// cross-page duplication occurs in the React Query cache (e.g.
-	// upsertCacheMessages writes to page 0 while the same message
-	// still exists in a later page). The Map-based messagesByID
-	// already deduplicates, but orderedMessageIDs must match.
-	const seen = new Set<number>();
-	const orderedMessageIDs: number[] = [];
-	for (const message of sorted) {
-		if (seen.has(message.id)) continue;
-		seen.add(message.id);
-		orderedMessageIDs.push(message.id);
-	}
-	return orderedMessageIDs;
-};
-
-const mapsEqualByRef = <K, V>(left: Map<K, V>, right: Map<K, V>): boolean => {
-	if (left.size !== right.size) {
-		return false;
-	}
-	for (const [key, value] of left) {
-		if (!right.has(key) || right.get(key) !== value) {
-			return false;
-		}
-	}
-	return true;
-};
-
-const arraysEqual = <T>(left: readonly T[], right: readonly T[]): boolean => {
-	if (left.length !== right.length) {
-		return false;
-	}
-	for (let index = 0; index < left.length; index += 1) {
-		if (left[index] !== right[index]) {
-			return false;
-		}
-	}
-	return true;
-};
-
 const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
 	if (left === right) {
 		return true;
@@ -126,10 +77,21 @@ export const isActiveChatStatus = (
 	status: TypesGen.ChatStatus | null,
 ): boolean => status === "running" || status === "interrupting";
 
+/**
+ * Transient chat state. Durable messages are NOT here: the query cache is
+ * canonical for them, written only by the per-chat socket. What remains is the
+ * streaming overlay, its finalization handoff, transport state, and the queue.
+ */
 export type ChatStoreState = {
-	messagesByID: Map<number, TypesGen.ChatMessage>;
-	orderedMessageIDs: readonly number[];
 	streamState: StreamState | null;
+	// Snapshot of the overlay taken when its assistant message committed, plus
+	// that message's ID. It hands the tail over to the durable list without a
+	// gap: the cache notifies a macrotask after the store does, so the overlay
+	// has to keep rendering until the exact durable message is readable. It
+	// NEVER accumulates parts; the next turn's first part starts a fresh
+	// StreamState and drops it.
+	finalizingStreamState: StreamState | null;
+	finalizingMessageID: number | null;
 	streamError: ChatDetailError | null;
 	retryState: RetryState | null;
 	reconnectState: ReconnectState | null;
@@ -149,16 +111,18 @@ export type ChatStore = {
 	getSnapshot: () => ChatStoreState;
 	subscribe: (listener: () => void) => () => void;
 	batch: (fn: () => void) => void;
-	replaceMessages: (
-		messages: readonly TypesGen.ChatMessage[] | undefined,
-	) => void;
-	upsertDurableMessage: (message: TypesGen.ChatMessage) => {
-		isDuplicate: boolean;
-		changed: boolean;
-	};
-	upsertDurableMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
 	applyMessagePart: (part: TypesGen.ChatMessagePart) => void;
 	applyMessageParts: (parts: readonly TypesGen.ChatMessagePart[]) => void;
+	// Moves the current overlay into the finalizing snapshot and records the
+	// durable assistant message that superseded it. Call it AFTER writing that
+	// message to the cache, inside the same batch, so any reader woken by the
+	// store notification already sees that message, and complete the handoff
+	// when the message renders.
+	beginStreamFinalization: (durableMessageID: number) => void;
+	// Retires the handoff once the recorded durable message is readable from the
+	// cache. Ignores a different ID, so a stale completion cannot drop the
+	// overlay of a later turn.
+	completeStreamFinalization: (durableMessageID: number) => void;
 	setQueuedMessages: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
 	) => void;
@@ -205,9 +169,9 @@ export type ChatStore = {
 };
 
 const createInitialState = (): ChatStoreState => ({
-	messagesByID: new Map(),
-	orderedMessageIDs: [],
 	streamState: null,
+	finalizingStreamState: null,
+	finalizingMessageID: null,
 	streamError: null,
 	retryState: null,
 	reconnectState: null,
@@ -266,122 +230,34 @@ export const createChatStore = (): ChatStore => {
 		}
 	};
 
-	const replaceMessages = (
-		messages: readonly TypesGen.ChatMessage[] | undefined,
-	): void => {
-		const safeMessages = messages ?? [];
-		const nextMessagesByID = buildMessageMap(safeMessages);
-		const nextOrderedMessageIDs = buildOrderedMessageIDs(safeMessages);
-
-		// Fast-path: skip setState entirely when nothing changed.
-		if (
-			mapsEqualByRef(state.messagesByID, nextMessagesByID) &&
-			arraysEqual(state.orderedMessageIDs, nextOrderedMessageIDs)
-		) {
-			return;
-		}
-
-		setState((current) => {
-			// Re-check equality against `current` inside the updater
-			// to avoid overwriting a concurrent state change.
-			if (
-				mapsEqualByRef(current.messagesByID, nextMessagesByID) &&
-				arraysEqual(current.orderedMessageIDs, nextOrderedMessageIDs)
-			) {
-				return current;
-			}
-			return {
-				...current,
-				messagesByID: nextMessagesByID,
-				orderedMessageIDs: nextOrderedMessageIDs,
-			};
-		});
-	};
-
-	const upsertDurableMessage = (message: TypesGen.ChatMessage) => {
-		// Use `state` for the early-return guard so we can return
-		// the result synchronously. The actual mutation below uses
-		// `current` inside the updater to avoid overwriting a
-		// concurrent state change (TOCTOU).
-		const existing = state.messagesByID.get(message.id);
-		const isDuplicate = state.messagesByID.has(message.id);
-		if (existing && chatMessagesEqualByValue(existing, message)) {
-			return { isDuplicate, changed: false };
-		}
-
-		let actuallyChanged = false;
-		setState((current) => {
-			// Re-check inside the updater: another call may have
-			// already applied this exact message.
-			const curExisting = current.messagesByID.get(message.id);
-			if (curExisting && chatMessagesEqualByValue(curExisting, message)) {
-				return current;
-			}
-
-			actuallyChanged = true;
-
-			const nextMessagesByID = new Map(current.messagesByID);
-			nextMessagesByID.set(message.id, message);
-
-			const curIsDuplicate = current.messagesByID.has(message.id);
-			const needsReorder =
-				!curIsDuplicate || nextMessagesByID.size !== current.messagesByID.size;
-			const nextOrderedMessageIDs = needsReorder
-				? buildOrderedMessageIDs(Array.from(nextMessagesByID.values()))
-				: current.orderedMessageIDs;
-
-			return {
-				...current,
-				messagesByID: nextMessagesByID,
-				orderedMessageIDs: nextOrderedMessageIDs,
-			};
-		});
-		return { isDuplicate, changed: actuallyChanged };
-	};
-
-	// Bulk variant that applies all messages in a single pass —
-	// one Map copy and one sort instead of N copies and N sorts.
-	const upsertDurableMessages = (
-		messages: readonly TypesGen.ChatMessage[],
-	): void => {
-		if (messages.length === 0) {
-			return;
-		}
-		setState((current) => {
-			let nextMessagesByID: Map<number, TypesGen.ChatMessage> | null = null;
-			for (const message of messages) {
-				const map = nextMessagesByID ?? current.messagesByID;
-				const existing = map.get(message.id);
-				if (existing && chatMessagesEqualByValue(existing, message)) {
-					continue;
-				}
-				// Lazily copy the map on first actual change.
-				if (!nextMessagesByID) {
-					nextMessagesByID = new Map(current.messagesByID);
-				}
-				nextMessagesByID.set(message.id, message);
-			}
-			if (!nextMessagesByID) {
-				return current;
-			}
-			const needsReorder = nextMessagesByID.size !== current.messagesByID.size;
-			const nextOrderedMessageIDs = needsReorder
-				? buildOrderedMessageIDs(Array.from(nextMessagesByID.values()))
-				: current.orderedMessageIDs;
-			return {
-				...current,
-				messagesByID: nextMessagesByID,
-				orderedMessageIDs: nextOrderedMessageIDs,
-			};
-		});
-	};
-
 	const applyMessageParts = (parts: readonly TypesGen.ChatMessagePart[]) => {
 		if (parts.length === 0) {
 			return;
 		}
 
 		setState((current) => {
+			if (current.finalizingMessageID !== null) {
+				// These parts belong to the next turn, so they start a fresh
+				// StreamState instead of appending to the finalized snapshot.
+				let freshStreamState: StreamState | null = null;
+				for (const part of parts) {
+					freshStreamState = applyMessagePartToStreamState(
+						freshStreamState,
+						part,
+					);
+				}
+				// Nothing renderable arrived yet (empty or metadata-only parts), so
+				// the finalizing snapshot stays until the next turn has output.
+				if (freshStreamState === null) {
+					return current;
+				}
+				return {
+					...current,
+					streamState: freshStreamState,
+					finalizingStreamState: null,
+					finalizingMessageID: null,
+				};
+			}
 			let nextStreamState: StreamState | null = current.streamState;
 			for (const part of parts) {
 				nextStreamState = applyMessagePartToStreamState(nextStreamState, part);
@@ -396,6 +272,50 @@ export const createChatStore = (): ChatStore => {
 		});
 	};
 
+	const beginStreamFinalization = (durableMessageID: number): void => {
+		setState((current) => {
+			if (current.streamState === null) {
+				// No overlay to hand off. Any earlier snapshot is stale: its message
+				// committed in an earlier batch and is already in the cache.
+				if (
+					current.finalizingStreamState === null &&
+					current.finalizingMessageID === null
+				) {
+					return current;
+				}
+				return {
+					...current,
+					finalizingStreamState: null,
+					finalizingMessageID: null,
+				};
+			}
+			return {
+				...current,
+				streamState: null,
+				finalizingStreamState: current.streamState,
+				finalizingMessageID: durableMessageID,
+			};
+		});
+	};
+
+	// The handoff exists to bridge the window where the finalized message is not
+	// yet readable from the cache, so it ends as soon as it is. In the common
+	// case the cache write applies immediately and this runs in the same batch,
+	// leaving no handoff behind; a write buffered behind a fetch keeps the
+	// overlay until the replay lands.
+	const completeStreamFinalization = (durableMessageID: number): void => {
+		setState((current) => {
+			if (current.finalizingMessageID !== durableMessageID) {
+				return current;
+			}
+			return {
+				...current,
+				finalizingStreamState: null,
+				finalizingMessageID: null,
+			};
+		});
+	};
+
 	return {
 		getSnapshot: () => state,
 		subscribe: (listener) => {
@@ -405,11 +325,10 @@ export const createChatStore = (): ChatStore => {
 			};
 		},
 		batch,
-		replaceMessages,
-		upsertDurableMessage,
-		upsertDurableMessages,
 		applyMessagePart: (part) => applyMessageParts([part]),
 		applyMessageParts,
+		beginStreamFinalization,
+		completeStreamFinalization,
 		setQueuedMessages: (queuedMessages) => {
 			const nextQueuedMessages = queuedMessages ?? [];
 			setState((current) => {
@@ -601,16 +520,28 @@ export const createChatStore = (): ChatStore => {
 		},
 		getActiveChatID: () => activeChatID,
 		setStreamState: (streamState) => {
-			if (state.streamState === streamState) {
+			// An explicit overlay write is authoritative, so it also ends any
+			// pending finalization handoff.
+			if (
+				state.streamState === streamState &&
+				state.finalizingStreamState === null &&
+				state.finalizingMessageID === null
+			) {
 				return;
 			}
 			setState((current) => {
-				if (current.streamState === streamState) {
+				if (
+					current.streamState === streamState &&
+					current.finalizingStreamState === null &&
+					current.finalizingMessageID === null
+				) {
 					return current;
 				}
 				return {
 					...current,
 					streamState,
+					finalizingStreamState: null,
+					finalizingMessageID: null,
 				};
 			});
 		},
@@ -675,18 +606,26 @@ export const createChatStore = (): ChatStore => {
 			}));
 		},
 		clearStreamState: () => {
-			if (state.streamState === null) {
+			if (
+				state.streamState === null &&
+				state.finalizingStreamState === null &&
+				state.finalizingMessageID === null
+			) {
 				return;
 			}
 			setState((current) => ({
 				...current,
 				streamState: null,
+				finalizingStreamState: null,
+				finalizingMessageID: null,
 			}));
 		},
 		resetTransportReplayState: () => {
 			if (
 				state.reconnectState === null &&
 				state.streamState === null &&
+				state.finalizingStreamState === null &&
+				state.finalizingMessageID === null &&
 				state.streamError === null
 			) {
 				return;
@@ -695,6 +634,8 @@ export const createChatStore = (): ChatStore => {
 				...current,
 				reconnectState: null,
 				streamState: null,
+				finalizingStreamState: null,
+				finalizingMessageID: null,
 				streamError: null,
 			}));
 		},
@@ -714,6 +655,8 @@ export const createChatStore = (): ChatStore => {
 		resetTransientState: () => {
 			if (
 				state.streamState === null &&
+				state.finalizingStreamState === null &&
+				state.finalizingMessageID === null &&
 				state.streamError === null &&
 				state.retryState === null &&
 				state.reconnectState === null &&
@@ -724,6 +667,8 @@ export const createChatStore = (): ChatStore => {
 			setState((current) => ({
 				...current,
 				streamState: null,
+				finalizingStreamState: null,
+				finalizingMessageID: null,
 				streamError: null,
 				retryState: null,
 				reconnectState: null,
@@ -733,12 +678,33 @@ export const createChatStore = (): ChatStore => {
 	};
 };
 
-export const selectMessagesByID = (state: ChatStoreState) => state.messagesByID;
-export const selectOrderedMessageIDs = (state: ChatStoreState) =>
-	state.orderedMessageIDs;
 export const selectStreamState = (state: ChatStoreState) => state.streamState;
 export const selectHasStreamState = (state: ChatStoreState) =>
 	state.streamState !== null;
+/**
+ * True while EITHER an active overlay or a finalizing snapshot is on screen.
+ * Consumers that ask "is anything streaming visible" have to include the
+ * handoff window, otherwise a Thinking indicator flashes underneath the
+ * finalized tail.
+ */
+export const selectHasStreamOverlay = (state: ChatStoreState) =>
+	state.streamState !== null || state.finalizingMessageID !== null;
+export const selectFinalizingStreamState = (state: ChatStoreState) =>
+	state.finalizingStreamState;
+export const selectFinalizingMessageID = (state: ChatStoreState) =>
+	state.finalizingMessageID;
+
+/**
+ * Resolves which overlay snapshot the tail renders. The active stream wins; the
+ * finalizing snapshot bridges the handoff until the durable-reading parent
+ * reports that the finalized message is readable from the cache.
+ */
+export const resolveOverlayStreamState = (
+	streamState: StreamState | null,
+	finalizingStreamState: StreamState | null,
+	suppressFinalizedOverlay: boolean,
+): StreamState | null =>
+	streamState ?? (suppressFinalizedOverlay ? null : finalizingStreamState);
 export const selectStreamError = (state: ChatStoreState) => state.streamError;
 export const selectQueuedMessages = (state: ChatStoreState) =>
 	state.queuedMessages;
@@ -747,32 +713,6 @@ export const selectSubagentStatusOverrides = (state: ChatStoreState) =>
 export const selectRetryState = (state: ChatStoreState) => state.retryState;
 export const selectReconnectState = (state: ChatStoreState) =>
 	state.reconnectState;
-
-const selectLatestDurableMessage = (
-	state: ChatStoreState,
-): TypesGen.ChatMessage | undefined => {
-	const latestMessageID =
-		state.orderedMessageIDs[state.orderedMessageIDs.length - 1];
-	return latestMessageID === undefined
-		? undefined
-		: state.messagesByID.get(latestMessageID);
-};
-
-/**
- * True when the conversation is between turns: no stream output yet and the
- * latest durable message is not an assistant reply. Deliberately primitive and
- * status-free, the facade composes it with the cached chat status to decide
- * whether to show the Thinking indicator.
- */
-export const selectIsPendingAssistantResponse = (
-	state: ChatStoreState,
-): boolean => {
-	if (state.streamState !== null) {
-		return false;
-	}
-	const latestMessage = selectLatestDurableMessage(state);
-	return !latestMessage || latestMessage.role !== "assistant";
-};
 
 export const useChatSelector = <T>(
 	store: ChatStore,

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
@@ -1,6 +1,10 @@
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type { FC, PropsWithChildren } from "react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import {
+	type InfiniteData,
+	QueryClient,
+	QueryClientProvider,
+} from "react-query";
 import { describe, expect, it } from "vitest";
 import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -8,12 +12,11 @@ import { MockChat } from "#/testHelpers/chatEntities";
 import {
 	type ChatStore,
 	createChatStore,
-	selectMessagesByID,
-	selectOrderedMessageIDs,
 	selectQueuedMessages,
 	useChatSelector,
 } from "./chatStore";
 import {
+	shouldSuppressFinalizedOverlay,
 	useDurableChatStatus,
 	useDurableMessageCount,
 	useDurableMessageList,
@@ -28,6 +31,7 @@ const createTestQueryClient = (): QueryClient =>
 		defaultOptions: {
 			queries: {
 				retry: false,
+				gcTime: Number.POSITIVE_INFINITY,
 				refetchOnWindowFocus: false,
 				networkMode: "offlineFirst",
 			},
@@ -49,6 +53,35 @@ const seedChatDetail = (
 		status,
 		snapshot_version: snapshotVersion,
 	});
+};
+
+/**
+ * Durable messages are canonical in the paginated messages cache, so the facade
+ * reads whatever the socket and the REST pages put there. Seeding mirrors the
+ * API's newest-first page order.
+ */
+const seedMessages = (
+	queryClient: QueryClient,
+	messages: readonly TypesGen.ChatMessage[],
+	extraPage?: readonly TypesGen.ChatMessage[],
+): void => {
+	const toPage = (
+		pageMessages: readonly TypesGen.ChatMessage[],
+		hasMore: boolean,
+	): TypesGen.ChatMessagesResponse => ({
+		messages: [...pageMessages].sort((left, right) => right.id - left.id),
+		queued_messages: [],
+		has_more: hasMore,
+	});
+	queryClient.setQueryData<InfiniteData<TypesGen.ChatMessagesResponse>>(
+		chatKeys.messages(CHAT_ID),
+		{
+			pages: extraPage
+				? [toPage(messages, true), toPage(extraPage, false)]
+				: [toPage(messages, false)],
+			pageParams: extraPage ? [undefined, messages[0]?.id] : [undefined],
+		},
+	);
 };
 
 const createWrapper =
@@ -85,7 +118,7 @@ const buildTextPart = (text: string): TypesGen.ChatMessagePart => ({
 });
 
 describe("durableChat facade", () => {
-	it("reads messages and the queue from the store and status from the cache", () => {
+	it("reads messages and status from the cache and the queue from the store", () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
 		seedChatDetail(queryClient, "running");
@@ -93,18 +126,13 @@ describe("durableChat facade", () => {
 			buildMessage(1, "user", "hello"),
 			buildMessage(2, "assistant", "hi"),
 		];
-		store.replaceMessages(messages);
+		seedMessages(queryClient, messages);
 		store.setQueuedMessages([buildQueuedMessage(10, "later")]);
 
 		const { result } = renderHook(
 			() => ({
 				facadeStatus: useDurableChatStatus({ store, chatId: CHAT_ID }),
 				facadeMessages: useDurableMessageList({ store, chatId: CHAT_ID }),
-				selectorMessagesByID: useChatSelector(store, selectMessagesByID),
-				selectorOrderedMessageIDs: useChatSelector(
-					store,
-					selectOrderedMessageIDs,
-				),
 				facadeCount: useDurableMessageCount({ store, chatId: CHAT_ID }),
 				facadeQueued: useDurableQueuedMessages({ store, chatId: CHAT_ID }),
 				selectorQueued: useChatSelector(store, selectQueuedMessages),
@@ -114,14 +142,39 @@ describe("durableChat facade", () => {
 
 		const current = result.current;
 		expect(current.facadeStatus).toBe("running");
-		expect(current.facadeMessages).toEqual(
-			current.selectorOrderedMessageIDs.map((id) =>
-				current.selectorMessagesByID.get(id),
-			),
-		);
+		// Ascending by ID, which is the only ordering signal a message carries.
 		expect(current.facadeMessages).toEqual(messages);
-		expect(current.facadeCount).toBe(current.selectorMessagesByID.size);
+		expect(current.facadeCount).toBe(messages.length);
 		expect(current.facadeQueued).toBe(current.selectorQueued);
+	});
+
+	it("deduplicates a cross-page copy, keeping the page 0 values", () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		const canonical = buildMessage(2, "assistant", "revised");
+		seedMessages(
+			queryClient,
+			[buildMessage(3, "user", "newest"), canonical],
+			// An older page still holding a superseded copy of ID 2.
+			[
+				buildMessage(1, "user", "oldest"),
+				buildMessage(2, "assistant", "stale"),
+			],
+		);
+
+		const { result } = renderHook(
+			() => ({
+				messages: useDurableMessageList({ store, chatId: CHAT_ID }),
+				count: useDurableMessageCount({ store, chatId: CHAT_ID }),
+			}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		expect(result.current.messages.map((message) => message.id)).toEqual([
+			1, 2, 3,
+		]);
+		expect(result.current.messages[1]).toEqual(canonical);
+		expect(result.current.count).toBe(3);
 	});
 
 	it("returns null when no chat is selected", () => {
@@ -130,11 +183,17 @@ describe("durableChat facade", () => {
 		seedChatDetail(queryClient, "running");
 
 		const { result } = renderHook(
-			() => useDurableChatStatus({ store, chatId: undefined }),
+			() => ({
+				status: useDurableChatStatus({ store, chatId: undefined }),
+				messages: useDurableMessageList({ store, chatId: undefined }),
+				count: useDurableMessageCount({ store, chatId: undefined }),
+			}),
 			{ wrapper: createWrapper(queryClient) },
 		);
 
-		expect(result.current).toBeNull();
+		expect(result.current.status).toBeNull();
+		expect(result.current.messages).toEqual([]);
+		expect(result.current.count).toBe(0);
 	});
 
 	it("re-renders the status consumer when the cached status changes", async () => {
@@ -160,7 +219,7 @@ describe("durableChat facade", () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
 		seedChatDetail(queryClient, "waiting");
-		store.replaceMessages([buildMessage(1, "user", "hello")]);
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
 
 		const { result } = renderHook(
 			() => ({
@@ -179,18 +238,21 @@ describe("durableChat facade", () => {
 		});
 		expect(result.current.messages).toBe(firstMessages);
 
-		act(() => {
-			store.upsertDurableMessage(buildMessage(2, "assistant", "hi"));
-		});
+		seedMessages(queryClient, [
+			buildMessage(1, "user", "hello"),
+			buildMessage(2, "assistant", "hi"),
+		]);
 
+		await waitFor(() => {
+			expect(result.current.messages).toHaveLength(2);
+		});
 		expect(result.current.messages).not.toBe(firstMessages);
-		expect(result.current.messages).toHaveLength(2);
 	});
 
-	it("does not re-render a queued-message consumer on a message_part update", () => {
+	it("does not re-render message or queue consumers on a message_part update", () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
-		store.replaceMessages([buildMessage(1, "user", "hello")]);
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
 
 		let queueRenderCount = 0;
 		let messageRenderCount = 0;
@@ -230,15 +292,15 @@ describe("durableChat facade", () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
 		seedChatDetail(queryClient, "waiting");
-		store.replaceMessages([buildMessage(1, "user", "hello")]);
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
 
 		const { result } = renderHook(
 			() => useIsAwaitingFirstStreamChunk({ store, chatId: CHAT_ID }),
 			{ wrapper: createWrapper(queryClient) },
 		);
 
-		// The store half is satisfied (user message, no stream), the cached
-		// status is not.
+		// The cache half is satisfied (a user message is newest, no stream), the
+		// status half is not.
 		expect(result.current).toBe(false);
 
 		seedChatDetail(queryClient, "running", 2);
@@ -248,11 +310,52 @@ describe("durableChat facade", () => {
 		});
 	});
 
+	it("hides the Thinking indicator once the newest durable message is an assistant reply", async () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "running");
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
+
+		const { result } = renderHook(
+			() => useIsAwaitingFirstStreamChunk({ store, chatId: CHAT_ID }),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		expect(result.current).toBe(true);
+
+		seedMessages(queryClient, [
+			buildMessage(1, "user", "hello"),
+			buildMessage(2, "assistant", "hi"),
+		]);
+
+		await waitFor(() => {
+			expect(result.current).toBe(false);
+		});
+	});
+
+	it("hides the Thinking indicator while a finalizing overlay is still on screen", () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		seedChatDetail(queryClient, "running");
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
+		store.applyMessagePart(buildTextPart("streamed answer"));
+		// The durable message is not readable yet, so without counting the
+		// handoff the indicator would flash underneath the finalized tail.
+		store.beginStreamFinalization(2);
+
+		const { result } = renderHook(
+			() => useIsAwaitingFirstStreamChunk({ store, chatId: CHAT_ID }),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		expect(result.current).toBe(false);
+	});
+
 	it("re-renders the awaiting-first-chunk consumer only when the flag flips", () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
 		seedChatDetail(queryClient, "running");
-		store.replaceMessages([buildMessage(1, "user", "hello")]);
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
 
 		let renderCount = 0;
 		const { result } = renderHook(
@@ -288,10 +391,10 @@ describe("durableChat facade", () => {
 		expect(renderCount).toBe(baseline + 1);
 	});
 
-	it("re-renders the message-count consumer only when the count changes", () => {
+	it("re-renders the message-count consumer only when the count changes", async () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
-		store.replaceMessages([buildMessage(1, "user", "hello")]);
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")]);
 
 		let renderCount = 0;
 		const { result } = renderHook(
@@ -306,18 +409,69 @@ describe("durableChat facade", () => {
 		expect(result.current).toBe(1);
 		const baseline = renderCount;
 
-		act(() => {
-			store.upsertDurableMessage(buildMessage(1, "user", "hello edited"));
-		});
+		seedMessages(queryClient, [buildMessage(1, "user", "hello edited")]);
 
+		// The cache notified, but the deduplicated size did not change, so the
+		// numeric select keeps the consumer from re-rendering.
+		await waitFor(() => {
+			expect(
+				queryClient.getQueryState(chatKeys.messages(CHAT_ID))?.dataUpdateCount,
+			).toBe(2);
+		});
 		expect(result.current).toBe(1);
 		expect(renderCount).toBe(baseline);
 
-		act(() => {
-			store.upsertDurableMessage(buildMessage(2, "assistant", "hi"));
-		});
+		seedMessages(queryClient, [
+			buildMessage(1, "user", "hello edited"),
+			buildMessage(2, "assistant", "hi"),
+		]);
 
-		expect(result.current).toBe(2);
+		await waitFor(() => {
+			expect(result.current).toBe(2);
+		});
 		expect(renderCount).toBe(baseline + 1);
+	});
+});
+
+describe("shouldSuppressFinalizedOverlay", () => {
+	it("keeps the overlay while no finalization is in progress", () => {
+		expect(
+			shouldSuppressFinalizedOverlay(null, [
+				buildMessage(7, "assistant", "done"),
+			]),
+		).toBe(false);
+	});
+
+	it("suppresses the overlay once the exact finalized message is durable", () => {
+		expect(
+			shouldSuppressFinalizedOverlay(7, [
+				buildMessage(6, "user", "ask"),
+				buildMessage(7, "assistant", "done"),
+			]),
+		).toBe(true);
+	});
+
+	it("keeps the overlay while the finalized message is absent", () => {
+		expect(
+			shouldSuppressFinalizedOverlay(7, [
+				buildMessage(5, "user", "ask"),
+				buildMessage(6, "assistant", "earlier"),
+			]),
+		).toBe(false);
+	});
+
+	// A `maxDurableID >= finalizingMessageID` check would blank the tail here,
+	// which is why membership is by exact ID.
+	it("does not let a newer durable message suppress the overlay", () => {
+		expect(
+			shouldSuppressFinalizedOverlay(7, [
+				buildMessage(6, "user", "ask"),
+				buildMessage(9, "assistant", "newer"),
+			]),
+		).toBe(false);
+	});
+
+	it("keeps the overlay for an empty durable list", () => {
+		expect(shouldSuppressFinalizedOverlay(7, [])).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
@@ -1,12 +1,15 @@
-import { useQuery } from "react-query";
-import { chat as chatDetailQuery } from "#/api/queries/chats";
+import { useInfiniteQuery, useQuery } from "react-query";
+import {
+	chat as chatDetailQuery,
+	chatMessagesForInfiniteScroll,
+	selectDurableMessageCount,
+	selectDurableMessages,
+	selectLatestDurableMessageRole,
+} from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	type ChatStore,
-	type ChatStoreState,
-	selectIsPendingAssistantResponse,
-	selectMessagesByID,
-	selectOrderedMessageIDs,
+	selectHasStreamOverlay,
 	selectQueuedMessages,
 	useChatSelector,
 } from "./chatStore";
@@ -14,8 +17,8 @@ import {
 // Read facade for durable chat state (messages, queued messages, chat
 // status). Render consumers read durable state through these hooks so the
 // source can move from the store to the query cache without touching call
-// sites. Chat status resolves to the query cache, which is canonical for it;
-// messages and the queue still resolve to the store.
+// sites. Chat status and messages resolve to the query cache, which is
+// canonical for them; the queue still resolves to the store.
 //
 // Composition rule: `useChatSelector` feeds its selector result straight to
 // `useSyncExternalStore`, which compares snapshots with Object.is on every
@@ -23,21 +26,21 @@ import {
 // Read raw slices through `useChatSelector` and derive in the hook body,
 // never inside the selector. React Compiler covers this directory and
 // memoizes the derivation against the slices it reads.
+//
+// Query-observer rule: every durable-message read mounts its own observer on
+// `chatKeys.messages` with the SAME base options plus a module-level `select`,
+// so react-query can memoize the select per observer and structural sharing
+// keeps the result reference stable. The hooks MUST use `useInfiniteQuery`: a
+// plain `useQuery` observer on that key would fetch without
+// `infiniteQueryBehavior` and install a bare page in place of the pages.
+// Pagination stays with AgentChatPage; a facade observer never calls
+// `fetchNextPage` or `refetch`.
 type DurableChatArgs = {
 	store: ChatStore;
 	// Required, and explicitly undefined-able: the query key for the durable
 	// reads. Without a chat there is nothing to read.
 	chatId: string | undefined;
 };
-
-// Primitive selector so count consumers subscribe to the size only, not to
-// messagesByID identity.
-const selectMessageCount = (state: ChatStoreState): number =>
-	state.messagesByID.size;
-
-const isChatMessage = (
-	message: TypesGen.ChatMessage | undefined,
-): message is TypesGen.ChatMessage => Boolean(message);
 
 // Module-level so the query result identity is stable across renders.
 const selectChatStatusFromDetail = (
@@ -54,50 +57,60 @@ export const useDurableChatStatus = (
 		select: selectChatStatusFromDetail,
 	}).data ?? null;
 
-// Flat, ascending message list. messagesByID and orderedMessageIDs stay
-// internal to the store; both durable sources agree on the flat shape.
+const EMPTY_MESSAGES: readonly TypesGen.ChatMessage[] = [];
+
+// Flat, ascending message list read from the canonical paginated cache.
 export const useDurableMessageList = (
 	args: DurableChatArgs,
-): readonly TypesGen.ChatMessage[] => {
-	const messagesByID = useChatSelector(args.store, selectMessagesByID);
-	const orderedMessageIDs = useChatSelector(
-		args.store,
-		selectOrderedMessageIDs,
-	);
-
-	return orderedMessageIDs
-		.map((messageID) => {
-			const message = messagesByID.get(messageID);
-			if (!message && process.env.NODE_ENV !== "production") {
-				console.warn(
-					`[durableChat] orderedMessageIDs contains ID ${messageID} ` +
-						"not found in messagesByID. This may indicate a store/cache " +
-						"desync bug.",
-				);
-			}
-			return message;
-		})
-		.filter(isChatMessage);
-};
+): readonly TypesGen.ChatMessage[] =>
+	useInfiniteQuery({
+		...chatMessagesForInfiniteScroll(args.chatId ?? ""),
+		enabled: Boolean(args.chatId),
+		select: selectDurableMessages,
+	}).data ?? EMPTY_MESSAGES;
 
 export const useDurableMessageCount = (args: DurableChatArgs): number =>
-	useChatSelector(args.store, selectMessageCount);
+	useInfiniteQuery({
+		...chatMessagesForInfiniteScroll(args.chatId ?? ""),
+		enabled: Boolean(args.chatId),
+		select: selectDurableMessageCount,
+	}).data ?? 0;
+
+/**
+ * Decides whether the finalizing overlay snapshot must be dropped, for the
+ * durable-reading parent that holds both inputs in one render. Exact ID
+ * membership, never a `>=` comparison: a newer durable message must not
+ * suppress an overlay whose own finalized message has not landed in the cache.
+ */
+export const shouldSuppressFinalizedOverlay = (
+	finalizingMessageID: number | null,
+	messages: readonly TypesGen.ChatMessage[],
+): boolean =>
+	finalizingMessageID !== null &&
+	messages.some((message) => message.id === finalizingMessageID);
 
 export const useDurableQueuedMessages = (
 	args: DurableChatArgs,
 ): readonly TypesGen.ChatQueuedMessage[] =>
 	useChatSelector(args.store, selectQueuedMessages);
 
-// Composed from two narrow primitives rather than one store selector: the
-// status now lives in the query cache, and widening the store subscription to
-// the message list or the stream state would re-render on every chunk.
+// Composed from two narrow primitives rather than one selector over the whole
+// conversation: the role of the newest durable message is a primitive, and the
+// overlay flag keeps the indicator off screen while a tail is still rendering,
+// including the finalization handoff window.
 export const useIsAwaitingFirstStreamChunk = (
 	args: DurableChatArgs,
 ): boolean => {
-	const isPendingAssistantResponse = useChatSelector(
-		args.store,
-		selectIsPendingAssistantResponse,
-	);
+	const hasStreamOverlay = useChatSelector(args.store, selectHasStreamOverlay);
+	const latestDurableRole = useInfiniteQuery({
+		...chatMessagesForInfiniteScroll(args.chatId ?? ""),
+		enabled: Boolean(args.chatId),
+		select: selectLatestDurableMessageRole,
+	}).data;
 	const chatStatus = useDurableChatStatus(args);
-	return isPendingAssistantResponse && chatStatus === "running";
+	return (
+		!hasStreamOverlay &&
+		latestDurableRole !== "assistant" &&
+		chatStatus === "running"
+	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -12,6 +12,10 @@ import {
 } from "react-query";
 import { watchChat } from "#/api/api";
 import {
+	type MessagesCacheWrite,
+	writeMessagesCache,
+} from "#/api/queries/chatMessagesCache";
+import {
 	applyServerChatStatusToCaches,
 	chatKeys,
 	readCachedChatSnapshotVersion,
@@ -32,7 +36,121 @@ import {
 } from "./chatStore";
 import type { RetryState } from "./types";
 
-// Prevents REST re-hydration from replaying a stale queue over the store.
+type ChatMessagesCacheData = InfiniteData<TypesGen.ChatMessagesResponse>;
+
+/**
+ * Canonicalizes the incoming messages into page 0.
+ *
+ * Every incoming ID is removed from EVERY page first, so an in-place revision
+ * of a message that is also held by an older page cannot leave the stale copy
+ * behind. Page metadata (`has_more`, `queued_messages`) is preserved per page.
+ *
+ * A non-zero page emptied by that removal is dropped together with its page
+ * param: `getNextPageParam` reads the LAST page, so an empty last page would
+ * flip `hasNextPage` to false and strand the rest of the history. Dropping the
+ * page param alongside the page is safe because only `pageParams[0]` is reused
+ * on a refetch; later cursors are recomputed from the refetched pages.
+ */
+const upsertMessagesIntoCacheData = (
+	currentData: ChatMessagesCacheData,
+	incoming: readonly TypesGen.ChatMessage[],
+): ChatMessagesCacheData => {
+	const incomingByID = new Map<number, TypesGen.ChatMessage>();
+	for (const message of incoming) {
+		incomingByID.set(message.id, message);
+	}
+
+	const [firstPage, ...olderPages] = currentData.pages;
+	const firstPageByID = new Map(
+		firstPage.messages.map((message) => [message.id, message]),
+	);
+	const changesFirstPage = Array.from(incomingByID.values()).some((message) => {
+		const existing = firstPageByID.get(message.id);
+		return !existing || !chatMessagesEqualByValue(existing, message);
+	});
+	const hasOlderPageCopy = olderPages.some((page) =>
+		page.messages.some((message) => incomingByID.has(message.id)),
+	);
+	if (!changesFirstPage && !hasOlderPageCopy) {
+		return currentData;
+	}
+
+	const nextPages: TypesGen.ChatMessagesResponse[] = [];
+	const nextPageParams: unknown[] = [];
+	for (const [index, page] of olderPages.entries()) {
+		const kept = page.messages.filter(
+			(message) => !incomingByID.has(message.id),
+		);
+		if (kept.length === 0 && page.messages.length > 0) {
+			continue;
+		}
+		nextPages.push(
+			kept.length === page.messages.length ? page : { ...page, messages: kept },
+		);
+		// olderPages is offset by one from currentData.pages.
+		nextPageParams.push(currentData.pageParams[index + 1]);
+	}
+
+	// Newest first, matching the API's page order.
+	const nextFirstPageMessages = [
+		...firstPage.messages.filter((message) => !incomingByID.has(message.id)),
+		...incomingByID.values(),
+	].sort((left, right) => right.id - left.id);
+
+	return {
+		...currentData,
+		pages: [{ ...firstPage, messages: nextFirstPageMessages }, ...nextPages],
+		pageParams: [currentData.pageParams[0], ...nextPageParams],
+	};
+};
+
+/**
+ * Installs a replacement history as the only page. The socket sends the full
+ * replacement history after a `history_reset`, so every older page it
+ * superseded goes away with it; `pageParams` collapses to the uncursored
+ * initial page param.
+ */
+const replaceMessagesInCacheData = (
+	currentData: ChatMessagesCacheData,
+	messages: readonly TypesGen.ChatMessage[],
+): ChatMessagesCacheData => ({
+	...currentData,
+	pages: [
+		{
+			...currentData.pages[0],
+			messages: [...messages].sort((left, right) => right.id - left.id),
+			has_more: false,
+		},
+	],
+	pageParams: [undefined],
+});
+
+/**
+ * Replaces the queue snapshot the messages cache carries on page 0. The queue
+ * travels with the messages response, so it shares the cache entry, the fetch
+ * serialization, and the initialized-cache requirement with durable messages.
+ */
+const patchQueuedMessagesInCacheData = (
+	currentData: ChatMessagesCacheData,
+	queuedMessages: readonly TypesGen.ChatQueuedMessage[],
+): ChatMessagesCacheData => {
+	const firstPage = currentData.pages[0];
+	if (chatQueuedMessagesEqualByID(firstPage.queued_messages, queuedMessages)) {
+		return currentData;
+	}
+	return {
+		...currentData,
+		pages: [
+			{ ...firstPage, queued_messages: queuedMessages },
+			...currentData.pages.slice(1),
+		],
+	};
+};
+
+// Prevents REST re-hydration from replaying a stale queue over the store. Goes
+// through the shared write coordinator: a queue delete or a queue_update
+// committed while a pagination fetch is in flight would otherwise be clobbered
+// by the pages that fetch captured, resurrecting the deleted entry.
 const writeQueuedMessagesToCache = (
 	queryClient: QueryClient,
 	chatID: string | undefined,
@@ -42,25 +160,10 @@ const writeQueuedMessagesToCache = (
 		return;
 	}
 	const nextQueuedMessages = queuedMessages ?? [];
-	queryClient.setQueryData<
-		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-	>(chatKeys.messages(chatID), (currentData) => {
-		if (!currentData?.pages?.length) {
-			return currentData;
-		}
-		const firstPage = currentData.pages[0];
-		if (
-			chatQueuedMessagesEqualByID(firstPage.queued_messages, nextQueuedMessages)
-		) {
-			return currentData;
-		}
-		return {
-			...currentData,
-			pages: [
-				{ ...firstPage, queued_messages: nextQueuedMessages },
-				...currentData.pages.slice(1),
-			],
-		};
+	writeMessagesCache(queryClient, chatKeys.messages(chatID), {
+		kind: "queue",
+		apply: (currentData) =>
+			patchQueuedMessagesInCacheData(currentData, nextQueuedMessages),
 	});
 };
 
@@ -139,17 +242,6 @@ export const useChatStore = (
 	// queue was drained while the user was away.
 	const wsQueueUpdateReceivedRef = useRef(false);
 	const activeChatIDRef = useRef<string | null>(null);
-	const prevChatIDRef = useRef<string | undefined>(chatID);
-	// Snapshot of the chatMessages elements from the last sync effect
-	// run. Used to detect whether chatMessages actually changed (e.g.
-	// after a refetch producing new objects) vs. just getting a new
-	// array reference because an unrelated field like queued_messages
-	// was updated in the query cache. Element-level reference
-	// comparison works because the flattening step preserves message
-	// object references when only non-message fields change in the
-	// page, while a genuine refetch returns new objects from the
-	// server.
-	const lastSyncedMessagesRef = useRef<readonly TypesGen.ChatMessage[]>([]);
 
 	// Compute the last REST-fetched message ID so the stream can
 	// skip messages the client already has. We use a ref so the
@@ -180,51 +272,33 @@ export const useChatStore = (
 		chatMessages !== undefined && chatRecord !== undefined;
 
 	// Write WebSocket-delivered durable messages into the React
-	// Query infinite cache so that navigating away and back
-	// serves up-to-date data instead of the stale REST snapshot.
-	// Without this, the cache only contains messages from the
-	// last REST fetch, and structural sharing can suppress the
-	// refetch-driven store update when no new durable messages
-	// have been committed to the DB yet.
+	// Query infinite cache. The cache is canonical for durable
+	// messages and the socket is their single ordered writer.
+	//
+	// Every write goes through the shared per-chat coordinator in
+	// `chatMessagesCache`, which serializes it against fetches on the
+	// same cache entry (see that module for why). The queue writes
+	// and the edit mutation share the coordinator, so all writers to
+	// this entry are ordered against each other and against fetches.
+	const writeMessagesToCache = useCallback(
+		(write: MessagesCacheWrite) => {
+			if (!chatID) {
+				return;
+			}
+			writeMessagesCache(queryClient, chatKeys.messages(chatID), write);
+		},
+		[chatID, queryClient],
+	);
+
 	const upsertCacheMessages = useCallback(
 		(messages: readonly TypesGen.ChatMessage[]) => {
 			if (!chatID || messages.length === 0) {
 				return;
 			}
-			queryClient.setQueryData<
-				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatKeys.messages(chatID), (currentData) => {
-				if (!currentData?.pages?.length) {
-					return currentData;
-				}
-				const firstPage = currentData.pages[0];
-				const existingByID = new Map(firstPage.messages.map((m) => [m.id, m]));
-
-				let changed = false;
-				for (const msg of messages) {
-					const existing = existingByID.get(msg.id);
-					if (!existing || !chatMessagesEqualByValue(existing, msg)) {
-						changed = true;
-						existingByID.set(msg.id, msg);
-					}
-				}
-
-				if (!changed) {
-					return currentData;
-				}
-
-				// Sort descending to match the API page order
-				// (newest first).
-				const updatedMessages = Array.from(existingByID.values());
-				updatedMessages.sort((a, b) => b.id - a.id);
-
-				return {
-					...currentData,
-					pages: [
-						{ ...firstPage, messages: updatedMessages },
-						...currentData.pages.slice(1),
-					],
-				};
+			writeMessagesToCache({
+				kind: "upsert",
+				apply: (currentData) =>
+					upsertMessagesIntoCacheData(currentData, messages),
 			});
 			// Refresh the dedicated prompt-history cache when a user message arrives.
 			const hasNewUserPrompt = messages.some((msg) => msg.role === "user");
@@ -235,81 +309,19 @@ export const useChatStore = (
 				});
 			}
 		},
-		[chatID, queryClient],
+		[chatID, queryClient, writeMessagesToCache],
 	);
 
 	const replaceCacheMessages = useCallback(
 		(messages: readonly TypesGen.ChatMessage[]) => {
-			if (!chatID) {
-				return;
-			}
-			queryClient.setQueryData<
-				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatKeys.messages(chatID), (currentData) => {
-				if (!currentData?.pages?.length) {
-					return currentData;
-				}
-				const firstPage = currentData.pages[0];
-				const updatedMessages = [...messages].sort((a, b) => b.id - a.id);
-				return {
-					...currentData,
-					pages: [{ ...firstPage, messages: updatedMessages, has_more: false }],
-					pageParams: currentData.pageParams.slice(0, 1),
-				};
+			writeMessagesToCache({
+				kind: "replace",
+				apply: (currentData) =>
+					replaceMessagesInCacheData(currentData, messages),
 			});
 		},
-		[chatID, queryClient],
+		[writeMessagesToCache],
 	);
-
-	useEffect(() => {
-		store.batch(() => {
-			// When the active chat changes, clear stale messages
-			// immediately so the previous chat's messages aren't
-			// briefly visible while the new chat's query resolves.
-			if (prevChatIDRef.current !== chatID) {
-				prevChatIDRef.current = chatID;
-				lastSyncedMessagesRef.current = [];
-				store.replaceMessages([]);
-			}
-			// Merge REST-fetched messages into the store, preserving
-			// any messages the WebSocket delivered that haven't
-			// appeared in a REST page yet.
-			//
-			// If the fetched set is missing message IDs the store
-			// already has (e.g. after an edit truncation), a full
-			// replace is needed. We must only do this when the
-			// fetched messages actually changed (new elements from
-			// a refetch), not when an unrelated field like
-			// queued_messages caused the query data reference to
-			// update.
-			if (chatMessages) {
-				const prev = lastSyncedMessagesRef.current;
-				const contentChanged =
-					chatMessages.length !== prev.length ||
-					chatMessages.some((m, i) => m !== prev[i]);
-				lastSyncedMessagesRef.current = chatMessages;
-
-				const storeSnap = store.getSnapshot();
-				const fetchedIDs = new Set(chatMessages.map((m) => m.id));
-				// Only classify a store-held ID as stale if it was
-				// present in the PREVIOUS sync's fetched data. IDs
-				// added to the store after the last sync (for example
-				// by the WS handler) are new, not stale, and must not
-				// trigger the destructive replaceMessages path.
-				const prevIDs = new Set(prev.map((m) => m.id));
-				const hasStaleEntries =
-					contentChanged &&
-					storeSnap.orderedMessageIDs.some(
-						(id) => !fetchedIDs.has(id) && prevIDs.has(id),
-					);
-				if (hasStaleEntries) {
-					store.replaceMessages(chatMessages);
-				} else {
-					store.upsertDurableMessages(chatMessages);
-				}
-			}
-		});
-	}, [chatID, chatMessages, store]);
 
 	useEffect(() => {
 		queuedMessagesHydratedChatIDRef.current = null;
@@ -453,11 +465,13 @@ export const useChatStore = (
 			if (streamEvents.length === 0) {
 				return;
 			}
-			// Collect durable messages for bulk upsert so the
-			// entire batch produces one Map copy + one sort
-			// instead of N copies and N sorts.
+			// Collect durable messages for one bulk cache write so the
+			// entire batch produces a single query-cache notification.
 			const pendingMessages: TypesGen.ChatMessage[] = [];
-			let needsStreamReset = false;
+			// The newest assistant message committed in this batch. Its ID is the
+			// identity the overlay hands off to, so the tail stays on screen until
+			// exactly that message is readable from the durable cache.
+			let finalizedAssistantMessageID: number | undefined;
 
 			// Atomically swap in the buffered replacement history. Called
 			// when a boundary event signals the replacement run ended, so
@@ -469,7 +483,6 @@ export const useChatStore = (
 				}
 				historyResetPending = false;
 				const replacement = historyReplacementBuf.splice(0);
-				store.replaceMessages(replacement);
 				replaceCacheMessages(replacement);
 			};
 
@@ -509,7 +522,7 @@ export const useChatStore = (
 						historyResetPending = true;
 						historyReplacementBuf.length = 0;
 						pendingMessages.length = 0;
-						needsStreamReset = false;
+						finalizedAssistantMessageID = undefined;
 						continue;
 					}
 
@@ -522,7 +535,22 @@ export const useChatStore = (
 
 					if (streamEvent.type === "preview_reset") {
 						discardBufferedParts();
-						store.clearStreamState();
+						// The backend emits the durable `message` for a snapshot BEFORE
+						// the `preview_reset` that retires the preview, usually in the
+						// same frame. Clearing the overlay here would strand the tail
+						// that just finalized: the end-of-batch handoff would find no
+						// overlay to keep, and nothing would render the finalized turn
+						// until its cache write became readable. So when a handoff is
+						// pending, the handoff performs the clear instead: it moves the
+						// overlay into the finalizing snapshot keyed by that message's
+						// ID, which every clear path and the next turn's first part
+						// still retire.
+						const finalizationPending =
+							finalizedAssistantMessageID !== undefined ||
+							store.getSnapshot().finalizingMessageID !== null;
+						if (!finalizationPending) {
+							store.clearStreamState();
+						}
 						continue;
 					}
 
@@ -559,7 +587,7 @@ export const useChatStore = (
 								lastMessageIdRef.current = message.id;
 							}
 							if (message.role === "assistant") {
-								needsStreamReset = true;
+								finalizedAssistantMessageID = message.id;
 							}
 							continue;
 						}
@@ -663,22 +691,17 @@ export const useChatStore = (
 				// non-message_part event above, this is a no-op.
 				schedulePartsFlush();
 
-				// Bulk-upsert all collected durable messages in one
-				// pass: one Map copy + one sort instead of N each.
+				// Commit the batch's durable messages, then hand the overlay over to
+				// the message that superseded it: cache first so any reader woken by
+				// the store notification already sees that message. The handoff keeps
+				// the finalized tail on screen until the durable-reading component
+				// renders it, which is also what retires the handoff.
 				if (pendingMessages.length > 0) {
-					store.upsertDurableMessages(pendingMessages);
 					upsertCacheMessages(pendingMessages);
 				}
 
-				// Clear stream state atomically with the durable
-				// message commit so subscribers never see a
-				// snapshot where both the committed message and
-				// the streaming output coexist. Previously this
-				// was deferred to a requestAnimationFrame, which
-				// left a window where ConversationTimeline and
-				// LiveStreamTail rendered the same content.
-				if (needsStreamReset) {
-					store.clearStreamState();
+				if (finalizedAssistantMessageID !== undefined) {
+					store.beginStreamFinalization(finalizedAssistantMessageID);
 					// If more message_part events arrived in this
 					// batch after the durable message, they belong
 					// to the next turn. Apply them immediately so

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { InfiniteData } from "react-query";
 import { expect, within } from "storybook/test";
 import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -17,15 +18,6 @@ type Story = StoryObj<typeof meta>;
 
 const CHAT_ID = "chat-page-content-stories";
 
-// Chat status is canonical in the detail cache, so a story that depends on it
-// seeds the entry rather than the store.
-const seededChatDetail = (status: TypesGen.ChatStatus) => [
-	{
-		key: chatKeys.detail(CHAT_ID),
-		data: { ...MockChat, id: CHAT_ID, status } satisfies TypesGen.Chat,
-	},
-];
-
 const buildMessage = (
 	id: number,
 	role: TypesGen.ChatMessageRole,
@@ -38,36 +30,53 @@ const buildMessage = (
 	content,
 });
 
-const buildThinkingSpacerStore = () => {
-	const store = createChatStore();
-
-	store.replaceMessages([
-		buildMessage(1, "user", [{ type: "text", text: "Read the source files" }]),
-		buildMessage(2, "assistant", [
-			{
-				type: "reasoning",
-				text: "I should think before answering.",
-			},
-		]),
-		// A following message is needed so the spacer renders.
-		buildMessage(3, "user", [{ type: "text", text: "Any progress?" }]),
-	]);
-
-	return store;
-};
+// Durable messages and chat status are both canonical in the query cache, so a
+// story seeds those entries rather than the store. The store only carries the
+// transient streaming overlay.
+const seededChat = (
+	messages: readonly TypesGen.ChatMessage[],
+	status: TypesGen.ChatStatus = "waiting",
+) => [
+	{
+		key: chatKeys.detail(CHAT_ID),
+		data: { ...MockChat, id: CHAT_ID, status } satisfies TypesGen.Chat,
+	},
+	{
+		key: chatKeys.messages(CHAT_ID),
+		data: {
+			// Pages arrive newest-first from the API.
+			pages: [
+				{
+					messages: [...messages].sort((left, right) => right.id - left.id),
+					queued_messages: [],
+					has_more: false,
+				},
+			],
+			pageParams: [undefined],
+		} satisfies InfiniteData<TypesGen.ChatMessagesResponse>,
+	},
+];
 
 export const SpacerVisibleWhenNotStreaming: Story = {
-	render: () => {
-		const store = buildThinkingSpacerStore();
-
-		return (
-			<ChatPageTimeline
-				store={store}
-				chatId={CHAT_ID}
-				persistedError={undefined}
-			/>
-		);
+	parameters: {
+		queries: seededChat([
+			buildMessage(1, "user", [
+				{ type: "text", text: "Read the source files" },
+			]),
+			buildMessage(2, "assistant", [
+				{ type: "reasoning", text: "I should think before answering." },
+			]),
+			// A following message is needed so the spacer renders.
+			buildMessage(3, "user", [{ type: "text", text: "Any progress?" }]),
+		]),
 	},
+	render: () => (
+		<ChatPageTimeline
+			store={createChatStore()}
+			chatId={CHAT_ID}
+			persistedError={undefined}
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		canvas.getByRole("button", { name: /thinking/i });
@@ -76,31 +85,31 @@ export const SpacerVisibleWhenNotStreaming: Story = {
 };
 
 export const DurableUnresolvedWorkspaceToolRuns: Story = {
-	parameters: { queries: seededChatDetail("running") },
-	render: () => {
-		const store = createChatStore();
-		store.replaceMessages([
-			buildMessage(1, "user", [{ type: "text", text: "Create a workspace" }]),
-			buildMessage(2, "assistant", [
-				{
-					type: "tool-call",
-					tool_call_id: "create-workspace-call",
-					tool_name: "create_workspace",
-					args: { name: "dev" },
-				},
-			]),
-		]);
-
-		return (
-			<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>
-				<ChatPageTimeline
-					store={store}
-					chatId={CHAT_ID}
-					persistedError={undefined}
-				/>
-			</ChatWorkspaceContext>
-		);
+	parameters: {
+		queries: seededChat(
+			[
+				buildMessage(1, "user", [{ type: "text", text: "Create a workspace" }]),
+				buildMessage(2, "assistant", [
+					{
+						type: "tool-call",
+						tool_call_id: "create-workspace-call",
+						tool_name: "create_workspace",
+						args: { name: "dev" },
+					},
+				]),
+			],
+			"running",
+		),
 	},
+	render: () => (
+		<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>
+			<ChatPageTimeline
+				store={createChatStore()}
+				chatId={CHAT_ID}
+				persistedError={undefined}
+			/>
+		</ChatWorkspaceContext>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("Creating workspace…")).toBeInTheDocument();
@@ -110,24 +119,21 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 };
 
 export const HiddenAssistantPlaceholderDoesNotRender: Story = {
-	render: () => {
-		const store = createChatStore();
-
-		store.replaceMessages([
+	parameters: {
+		queries: seededChat([
 			buildMessage(1, "user", [{ type: "text", text: "Run the command" }]),
 			buildMessage(2, "assistant", [{ type: "text", text: "Done." }]),
 			buildMessage(3, "assistant", []),
 			buildMessage(4, "user", [{ type: "text", text: "Thanks!" }]),
-		]);
-
-		return (
-			<ChatPageTimeline
-				store={store}
-				chatId={CHAT_ID}
-				persistedError={undefined}
-			/>
-		);
+		]),
 	},
+	render: () => (
+		<ChatPageTimeline
+			store={createChatStore()}
+			chatId={CHAT_ID}
+			persistedError={undefined}
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.queryByText("Message has no renderable content.")).toBeNull();
@@ -141,37 +147,63 @@ export const HiddenAssistantPlaceholderDoesNotRender: Story = {
 	},
 };
 
+// One created_at for the whole batch, so the ID is the only ordering signal and
+// the page order the API returned cannot leak into the transcript.
+const batchCreatedAt = new Date(FIXTURE_NOW).toISOString();
+const batchedMessage = (
+	id: number,
+	role: TypesGen.ChatMessageRole,
+	text: string,
+): TypesGen.ChatMessage => ({
+	...buildMessage(id, role, [{ type: "text", text }]),
+	created_at: batchCreatedAt,
+});
+
 export const MergedMessagesRenderInIDOrder: Story = {
-	render: () => {
-		const store = createChatStore();
-		// One created_at for all four, so id is the only ordering signal.
-		const batchCreatedAt = new Date(FIXTURE_NOW).toISOString();
-		const batched = (
-			id: number,
-			role: TypesGen.ChatMessageRole,
-			text: string,
-		): TypesGen.ChatMessage => ({
-			...buildMessage(id, role, [{ type: "text", text }]),
-			created_at: batchCreatedAt,
-		});
-
-		store.replaceMessages([
-			batched(3, "user", "charlie"),
-			batched(4, "assistant", "delta"),
-		]);
-		store.upsertDurableMessages([
-			batched(1, "user", "alpha"),
-			batched(2, "assistant", "bravo"),
-		]);
-
-		return (
-			<ChatPageTimeline
-				store={store}
-				chatId={CHAT_ID}
-				persistedError={undefined}
-			/>
-		);
+	parameters: {
+		queries: [
+			{
+				key: chatKeys.detail(CHAT_ID),
+				data: {
+					...MockChat,
+					id: CHAT_ID,
+					status: "waiting",
+				} satisfies TypesGen.Chat,
+			},
+			{
+				key: chatKeys.messages(CHAT_ID),
+				data: {
+					// Deliberately unsorted, and split across pages.
+					pages: [
+						{
+							messages: [
+								batchedMessage(4, "assistant", "delta"),
+								batchedMessage(3, "user", "charlie"),
+							],
+							queued_messages: [],
+							has_more: true,
+						},
+						{
+							messages: [
+								batchedMessage(1, "user", "alpha"),
+								batchedMessage(2, "assistant", "bravo"),
+							],
+							queued_messages: [],
+							has_more: false,
+						},
+					],
+					pageParams: [undefined, 3],
+				} satisfies InfiniteData<TypesGen.ChatMessagesResponse>,
+			},
+		],
 	},
+	render: () => (
+		<ChatPageTimeline
+			store={createChatStore()}
+			chatId={CHAT_ID}
+			persistedError={undefined}
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByTestId("conversation-timeline")).toHaveTextContent(

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -23,11 +23,14 @@ import {
 import { ConversationTimeline } from "./ChatConversation/ConversationTimeline";
 import { getLatestContextUsage } from "./ChatConversation/chatHelpers";
 import {
+	selectFinalizingMessageID,
+	selectHasStreamOverlay,
 	selectHasStreamState,
 	useChatSelector,
 	type useChatStore,
 } from "./ChatConversation/chatStore";
 import {
+	shouldSuppressFinalizedOverlay,
 	useDurableChatStatus,
 	useDurableMessageList,
 	useDurableQueuedMessages,
@@ -102,12 +105,37 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	const [chatFullWidth] = useChatFullWidth();
 	const messages = useDurableMessageList({ store, chatId });
 	const chatStatus = useDurableChatStatus({ store, chatId });
-	const hasStream = useChatSelector(store, selectHasStreamState);
+	// The overlay flag, not just the active stream: during the finalization
+	// handoff the tail is still on screen, so the timeline must not switch to
+	// its completed presentation. Outside that window this equals
+	// `streamState !== null`, so nothing else changes.
+	const hasStream = useChatSelector(store, selectHasStreamOverlay);
+	const finalizingMessageID = useChatSelector(store, selectFinalizingMessageID);
 	const isAwaitingFirstStreamChunk = useIsAwaitingFirstStreamChunk({
 		store,
 		chatId,
 	});
 	const isChatCompleted = !hasStream;
+
+	// Suppression is decided here because this component reads BOTH sources in
+	// one render: the finalizing ID from the store and the durable list from the
+	// query cache. Exact ID membership, not a >= comparison: a newer durable
+	// message must not suppress an overlay whose own message has not landed yet.
+	const suppressFinalizedOverlay = shouldSuppressFinalizedOverlay(
+		finalizingMessageID,
+		messages,
+	);
+
+	// Retiring the handoff here, after the commit that rendered the finalized
+	// message, is what ends the overlay lifecycle: doing it when the cache write
+	// lands would drop the overlay a frame before this component re-renders with
+	// the durable message, and leaving it set would keep the timeline in its
+	// streaming presentation for an idle chat.
+	useEffect(() => {
+		if (suppressFinalizedOverlay && finalizingMessageID !== null) {
+			store.completeStreamFinalization(finalizingMessageID);
+		}
+	}, [store, suppressFinalizedOverlay, finalizingMessageID]);
 
 	const pendingToolCallIDs = getPendingToolCallIDs(messages, chatStatus);
 	const parsedMessages = parseMessagesWithMergedTools(messages, {
@@ -151,6 +179,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					chatId={chatId}
 					persistedError={persistedError}
 					isTranscriptEmpty={parsedMessages.length === 0}
+					suppressFinalizedOverlay={suppressFinalizedOverlay}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}
 					urlTransform={urlTransform}


### PR DESCRIPTION
This is PR 6 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

Makes the query cache canonical for durable messages and removes the store's durable message mirror (`messagesByID`, `orderedMessageIDs`, `replaceMessages`, `upsertDurableMessage(s)`, REST hydration reconciliation). Adds `chatMessagesCache.ts`, a per-chat/query-client buffer-and-replay coordinator that serializes cache writes against pagination and refetches, since durable messages have no version and correctness relies on one ordered WS writer plus that serialization. Cross-page canonicalization removes incoming IDs from all pages and inserts authoritative values into page 0 with first-page precedence. An identity-based stream finalization handoff (active overlay, finalizing overlay keyed by durable message ID, exact-ID visibility predicate) bridges the window where the finalized message is not yet readable from the cache. Queue writes and edit-mutation writes go through the same coordinator. Fixes `[message, preview_reset]` ordering.

Depends on #27775

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- Durable messages have no version, so correctness relies on one ordered WS writer plus buffer-and-replay serialization around pagination/refetches.
- The store keeps only transient stream/reconnect/retry/overlay state.
- Reviewed by two independent reviewers; mergeable.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood