### PR TITLE
refactor(site/src/pages/AgentsPage): make queued messages canonical in the query cache

### DIFF
--- a/site/src/api/queries/chatMessageEdits.ts
+++ b/site/src/api/queries/chatMessageEdits.ts
@@ -78,32 +78,28 @@ export const projectEditedConversationIntoCache = ({
 	currentData,
 	editedMessageId,
 	replacementMessage,
-	queuedMessages,
 }: {
 	currentData: InfiniteData<TypesGen.ChatMessagesResponse> | undefined;
 	editedMessageId: number;
 	replacementMessage?: TypesGen.ChatMessage;
-	queuedMessages?: readonly TypesGen.ChatQueuedMessage[];
 }): InfiniteData<TypesGen.ChatMessagesResponse> | undefined => {
 	if (!currentData?.pages?.length) {
 		return currentData;
 	}
 
+	// The queue is deliberately untouched. The edit clears the server queue,
+	// but hiding it optimistically is a read-time suppression marker: a cache
+	// clear here would need a rollback in `onError`, and that rollback would
+	// clobber a `queue_update` delivered while the edit was in flight.
 	const truncatedPages = currentData.pages.map((page, pageIndex) => {
 		const truncatedMessages = page.messages.filter(
 			(message) => message.id < editedMessageId,
 		);
-		const nextPage = {
-			...page,
-			...(pageIndex === 0 && queuedMessages !== undefined
-				? { queued_messages: queuedMessages }
-				: {}),
-		};
 		if (pageIndex !== 0 || !replacementMessage) {
-			return { ...nextPage, messages: truncatedMessages };
+			return { ...page, messages: truncatedMessages };
 		}
 		return {
-			...nextPage,
+			...page,
 			messages: upsertFirstPageMessage(truncatedMessages, replacementMessage),
 		};
 	});
@@ -122,6 +118,11 @@ export const projectEditedConversationIntoCache = ({
  * `onMutate` read the snapshot, so anything present now but absent from the
  * snapshot is re-inserted into page 0. IDs the snapshot already holds keep the
  * snapshot's copy, which is what undoes the optimistic replacement.
+ *
+ * The queue is never restored. The edit's optimistic hide is a read-time
+ * suppression marker rather than a cache write, so page 0 already carries
+ * whatever the server last reported, including a `queue_update` delivered
+ * mid-flight. Reinstating the snapshot's copy would clobber exactly that.
  */
 export const restoreEditedConversationInCache = ({
 	currentData,
@@ -133,6 +134,7 @@ export const restoreEditedConversationInCache = ({
 	if (!previousData.pages.length) {
 		return previousData;
 	}
+	const currentQueuedMessages = currentData?.pages?.[0]?.queued_messages;
 	const previousIDs = new Set(
 		previousData.pages.flatMap((page) =>
 			page.messages.map((message) => message.id),
@@ -141,17 +143,26 @@ export const restoreEditedConversationInCache = ({
 	const arrivedDuringFlight = (currentData?.pages ?? []).flatMap((page) =>
 		page.messages.filter((message) => !previousIDs.has(message.id)),
 	);
-	if (arrivedDuringFlight.length === 0) {
-		return previousData;
-	}
 	let messages = previousData.pages[0].messages;
 	for (const message of arrivedDuringFlight) {
 		messages = upsertFirstPageMessage(messages, message);
 	}
+	const queuedMessages =
+		currentQueuedMessages ?? previousData.pages[0].queued_messages;
+	if (
+		arrivedDuringFlight.length === 0 &&
+		queuedMessages === previousData.pages[0].queued_messages
+	) {
+		return previousData;
+	}
 	return {
 		...previousData,
 		pages: [
-			{ ...previousData.pages[0], messages },
+			{
+				...previousData.pages[0],
+				messages,
+				queued_messages: queuedMessages,
+			},
 			...previousData.pages.slice(1),
 		],
 	};

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -33,6 +33,7 @@ import {
 	chat as chatDetail,
 	chatKeys,
 	chatMessagesForInfiniteScroll,
+	chatQueueConvergence,
 	chatSearch,
 	clearChatUnreadInCaches,
 	createChat,
@@ -1636,7 +1637,7 @@ describe("mutation invalidation scope", () => {
 		expect(context?.previousData?.pages[0]?.messages).toHaveLength(5);
 	});
 
-	it("editChatMessage clears queued messages in cache during optimistic history edit", async () => {
+	it("editChatMessage leaves the cached queue alone during the optimistic edit", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
@@ -1663,10 +1664,64 @@ describe("mutation invalidation scope", () => {
 			req: editReq,
 		});
 
+		// The caller hides the queue with read-time suppression markers instead,
+		// so the cache keeps server truth and needs no rollback.
 		const data = queryClient.getQueryData<InfMessages>(
 			chatKeys.messages(chatId),
 		);
-		expect(data?.pages[0]?.queued_messages).toEqual([]);
+		expect(data?.pages[0]?.queued_messages).toEqual(queuedMessages);
+	});
+
+	it("editChatMessage keeps a queue update delivered while the edit was in flight", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+		const optimisticMessage = buildOptimisticMessage(
+			requireMessage(messages, 3),
+		);
+
+		queryClient.setQueryData<InfMessages>(chatKeys.messages(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		const context = await mutation.onMutate({
+			messageId: 3,
+			optimisticMessage,
+			req: editReq,
+		});
+
+		// The socket delivers a queue snapshot while the request is in flight.
+		const arrivedQueue = [makeQueuedMessage(chatId, 21)];
+		queryClient.setQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+			(current) =>
+				current
+					? {
+							...current,
+							pages: [
+								{ ...current.pages[0], queued_messages: arrivedQueue },
+								...current.pages.slice(1),
+							],
+						}
+					: current,
+		);
+
+		mutation.onError(
+			new Error("network failure"),
+			{ messageId: 3, optimisticMessage, req: editReq },
+			context,
+		);
+
+		const data = queryClient.getQueryData<InfMessages>(
+			chatKeys.messages(chatId),
+		);
+		expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
+			5, 4, 3, 2, 1,
+		]);
+		// The rollback restores the conversation without clobbering the queue.
+		expect(data?.pages[0]?.queued_messages).toEqual(arrivedQueue);
 	});
 
 	it("editChatMessage restores cache on error", async () => {
@@ -5110,5 +5165,64 @@ describe("messages cache write serialization", () => {
 				.getQueryData<InfMessages>(chatKeys.messages(chatId))
 				?.pages[0].messages.map((message) => message.id),
 		).toEqual([11, 10, 2, 1]);
+	});
+});
+
+describe("chatQueueConvergence", () => {
+	it("does not answer one promotion's convergence from another's request", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-convergence";
+		const first = createDeferred<TypesGen.ChatMessagesResponse>();
+		const second = createDeferred<TypesGen.ChatMessagesResponse>();
+		const responses = [first.promise, second.promise];
+		// An implementation rather than a once-queue: a leftover queued value
+		// would leak into the next test.
+		vi.mocked(API.experimental.getChatMessages).mockImplementation(
+			() => responses.shift() ?? Promise.reject(new Error("unexpected fetch")),
+		);
+
+		// Two promoting sends overlap. A shared key would let TanStack answer
+		// the second from the first's in-flight request, whose response was
+		// dispatched before the second promotion existed.
+		const settledFirst = queryClient.fetchQuery(
+			chatQueueConvergence(chatId, 1),
+		);
+		const settledSecond = queryClient.fetchQuery(
+			chatQueueConvergence(chatId, 2),
+		);
+		expect(API.experimental.getChatMessages).toHaveBeenCalledTimes(2);
+
+		first.resolve({ messages: [], queued_messages: [], has_more: false });
+		second.resolve({
+			messages: [],
+			queued_messages: [
+				{
+					id: 7,
+					chat_id: chatId,
+					created_at: "2025-01-01T00:10:07Z",
+					content: [{ type: "text", text: "queued 7" }],
+				},
+			],
+			has_more: false,
+		});
+
+		expect((await settledFirst).queued_messages).toEqual([]);
+		expect((await settledSecond).queued_messages).toHaveLength(1);
+	});
+
+	it("still deduplicates a repeat convergence for the same promotion", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-convergence";
+		const pending = createDeferred<TypesGen.ChatMessagesResponse>();
+		vi.mocked(API.experimental.getChatMessages).mockImplementation(
+			() => pending.promise,
+		);
+
+		const a = queryClient.fetchQuery(chatQueueConvergence(chatId, 1));
+		const b = queryClient.fetchQuery(chatQueueConvergence(chatId, 1));
+		expect(API.experimental.getChatMessages).toHaveBeenCalledTimes(1);
+
+		pending.resolve({ messages: [], queued_messages: [], has_more: false });
+		await Promise.all([a, b]);
 	});
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -126,8 +126,8 @@ export const chatKeys = {
 	messages: (chatId: string) =>
 		[...chatKeys.detail(chatId), "messages"] as const,
 	prompts: (chatId: string) => [...chatKeys.detail(chatId), "prompts"] as const,
-	queueConvergence: (chatId: string) =>
-		[...chatKeys.detail(chatId), "queue-convergence"] as const,
+	queueConvergence: (chatId: string, promotedId: number) =>
+		[...chatKeys.detail(chatId), "queue-convergence", promotedId] as const,
 	acl: (chatId: string) => [...chatKeys.detail(chatId), "acl"] as const,
 	diffContents: (chatId: string) =>
 		[...chatKeys.detail(chatId), "diff-contents"] as const,
@@ -1686,8 +1686,12 @@ const MESSAGES_PAGE_SIZE = 50;
 // The queued messages ride on the uncursored page of the messages endpoint,
 // so settling the queue after a promote needs its own request. Refetching
 // chatMessagesForInfiniteScroll would reload every page already scrolled.
-export const chatQueueConvergence = (chatId: string) => ({
-	queryKey: chatKeys.queueConvergence(chatId),
+// The key carries the promoted ID, not just the chat: two promoting sends can
+// overlap, and a shared key would let TanStack answer the second from the
+// first's in-flight request. That response was dispatched before the second
+// promotion existed, so it cannot settle it.
+export const chatQueueConvergence = (chatId: string, promotedId: number) => ({
+	queryKey: chatKeys.queueConvergence(chatId, promotedId),
 	queryFn: () => API.experimental.getChatMessages(chatId),
 	gcTime: 0,
 });
@@ -2454,7 +2458,6 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 					currentData,
 					editedMessageId: messageId,
 					replacementMessage: optimisticMessage,
-					queuedMessages: [],
 				}) ?? currentData,
 		});
 
@@ -2578,9 +2581,10 @@ export const deleteChatQueuedMessage = (
 			exact: true,
 		});
 		// The messages query is deliberately NOT invalidated. It is canonical
-		// for durable messages and only the socket writes them, so a refetch
-		// would capture the pages an in-flight socket write is amending. The
-		// caller removes the entry from `pages[0].queued_messages` itself.
+		// for durable messages and the queue, and only server-derived values are
+		// written to it, so a refetch would capture the pages an in-flight
+		// socket write is amending. The caller hides the entry with a read-time
+		// suppression marker, and the server's `queue_update` retires it.
 	},
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -6,7 +6,9 @@ import { applyServerChatStatusToCaches, chatKeys } from "#/api/queries/chats";
 import type {
 	Chat,
 	ChatMessage,
+	ChatMessagesResponse,
 	ChatQueuedMessage,
+	EditChatMessageRequest,
 } from "#/api/typesGenerated";
 import {
 	MockChat,
@@ -24,13 +26,16 @@ import {
 	reconcilePromotedQueueHead,
 	restoreOptimisticRequestSnapshot,
 	runDeleteQueuedMessage,
+	runGuardedChatTurn,
 	runPromoteQueuedMessage,
+	runQueueSuppressingEdit,
 	settlePromotedQueueHead,
 	submitEditAndScroll,
 	useConversationEditingState,
 	waitForPendingChatSettingsSyncs,
 } from "./AgentChatPage";
 import type { ChatMessageInputRef } from "./components/AgentChatInput";
+import { runExclusiveQueueMutation } from "./components/ChatConversation/chatQueueMutations";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import {
@@ -190,22 +195,14 @@ describe("getPersistedDraftInputValue", () => {
 });
 
 describe("restoreOptimisticRequestSnapshot", () => {
-	it("restores queued messages, stream output, and stream error", () => {
+	it("restores stream output and stream error but not the queue", () => {
 		const store = createChatStore();
-		store.setQueuedMessages([
-			{
-				id: 9,
-				chat_id: "chat-abc-123",
-				created_at: "2025-01-01T00:00:00.000Z",
-				content: [{ type: "text" as const, text: "queued" }],
-			},
-		]);
+		store.suppressQueuedMessageIDs([9]);
 		store.applyMessagePart({ type: "text", text: "partial response" });
 		store.setStreamError({ kind: "generic", message: "old error" });
 		const previousSnapshot = store.getSnapshot();
 
 		store.batch(() => {
-			store.setQueuedMessages([]);
 			store.clearStreamState();
 			store.clearStreamError();
 		});
@@ -213,11 +210,11 @@ describe("restoreOptimisticRequestSnapshot", () => {
 		restoreOptimisticRequestSnapshot(store, previousSnapshot);
 
 		const restoredSnapshot = store.getSnapshot();
-		expect(restoredSnapshot.queuedMessages).toEqual(
-			previousSnapshot.queuedMessages,
-		);
 		expect(restoredSnapshot.streamState).toBe(previousSnapshot.streamState);
 		expect(restoredSnapshot.streamError).toEqual(previousSnapshot.streamError);
+		// Queue markers are owned by the failing queue mutation, not by the
+		// whole-snapshot restore, so the restore must leave them alone.
+		expect(restoredSnapshot.suppressedQueuedMessageIDs.has(9)).toBe(true);
 	});
 });
 
@@ -248,14 +245,11 @@ describe("runPromoteQueuedMessage", () => {
 	const readCachedStatus = (queryClient: QueryClient): Chat | undefined =>
 		queryClient.getQueryData<Chat>(chatKeys.detail("chat-1"));
 
-	it("suppresses the promoted ID and removes it optimistically", async () => {
+	it("suppresses the promoted ID instead of writing the cache", async () => {
 		const store = createChatStore();
 		const queryClient = new QueryClient();
 		seedChatDetail(queryClient, "waiting");
-		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
-		const c = buildQueuedMessage(3, "C");
-		store.setQueuedMessages([a, b, c]);
 
 		const promote = vi.fn(async (_id: number) => undefined);
 		const clearChatErrorReason = vi.fn();
@@ -263,6 +257,7 @@ describe("runPromoteQueuedMessage", () => {
 
 		await runPromoteQueuedMessage({
 			id: b.id,
+			chatID: "chat-1",
 			store,
 			queryClient,
 			promoteQueuedMessage: promote,
@@ -273,22 +268,18 @@ describe("runPromoteQueuedMessage", () => {
 
 		expect(promote).toHaveBeenCalledWith(b.id);
 
-		const snapshot = store.getSnapshot();
-		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id, c.id]);
-		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(true);
 		const cached = readCachedStatus(queryClient);
 		expect(cached?.status).toBe("running");
 		// An optimistic write never advances the version.
 		expect(cached?.snapshot_version).toBe(4);
 	});
 
-	it("rolls back queue and status, clears suppression, and rethrows on API error", async () => {
+	it("unsuppresses and rolls back status on API error", async () => {
 		const store = createChatStore();
 		const queryClient = new QueryClient();
 		seedChatDetail(queryClient, "waiting");
-		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
-		store.setQueuedMessages([a, b]);
 
 		const apiError = new Error("boom");
 		const promote = vi.fn(async (_id: number) => {
@@ -300,6 +291,7 @@ describe("runPromoteQueuedMessage", () => {
 		await expect(
 			runPromoteQueuedMessage({
 				id: b.id,
+				chatID: "chat-1",
 				store,
 				queryClient,
 				promoteQueuedMessage: promote,
@@ -310,74 +302,226 @@ describe("runPromoteQueuedMessage", () => {
 		).rejects.toBe(apiError);
 
 		expect(handleUsageLimitError).toHaveBeenCalledWith(apiError);
-
-		const snapshot = store.getSnapshot();
-		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id, b.id]);
 		expect(readCachedStatus(queryClient)?.status).toBe("waiting");
-		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(
+			false,
+		);
 	});
 });
 
 describe("runDeleteQueuedMessage", () => {
-	const buildQueuedMessage = (id: number, text: string): ChatQueuedMessage => ({
-		...MockChatQueuedMessage,
-		id,
-		chat_id: "chat-1",
-		content: [{ type: "text", text }],
-	});
-
-	it("removes the entry from the store and the cached queue", async () => {
+	it("suppresses the entry without writing the cache", async () => {
 		const store = createChatStore();
-		const a = buildQueuedMessage(1, "A");
-		const b = buildQueuedMessage(2, "B");
-		store.setQueuedMessages([a, b]);
-		let cachedQueue: readonly ChatQueuedMessage[] | undefined = [a, b];
 		const deleteQueuedMessage = vi.fn(async (_id: number) => undefined);
 
 		await runDeleteQueuedMessage({
-			id: b.id,
+			id: 2,
+			chatID: "chat-1",
 			store,
 			deleteQueuedMessage,
-			getCacheQueuedMessages: () => cachedQueue,
-			setCacheQueuedMessages: (queuedMessages) => {
-				cachedQueue = queuedMessages;
-			},
 		});
 
-		expect(deleteQueuedMessage).toHaveBeenCalledWith(b.id);
-		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([a.id]);
-		// The mutation no longer invalidates the messages query, so without this
-		// write REST re-hydration would resurrect the deleted entry.
-		expect(cachedQueue?.map((m) => m.id)).toEqual([a.id]);
+		expect(deleteQueuedMessage).toHaveBeenCalledWith(2);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(2)).toBe(true);
 	});
 
-	it("restores both the store and the cached queue on failure", async () => {
+	it("suppresses before the request settles and unsuppresses on failure", async () => {
 		const store = createChatStore();
-		const a = buildQueuedMessage(1, "A");
-		const b = buildQueuedMessage(2, "B");
-		store.setQueuedMessages([a, b]);
-		let cachedQueue: readonly ChatQueuedMessage[] | undefined = [a, b];
 		const apiError = new Error("boom");
+		const pending = createDeferred<void>();
+
+		const deletion = runDeleteQueuedMessage({
+			id: 2,
+			chatID: "chat-1",
+			store,
+			deleteQueuedMessage: () => pending.promise,
+		});
+
+		// The marker is a store write, so the row is hidden immediately rather
+		// than waiting on the request or on a buffered cache write.
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(2)).toBe(true);
+
+		pending.reject(apiError);
+		await expect(deletion).rejects.toBe(apiError);
+
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(2)).toBe(false);
+	});
+
+	it("waits for the queue lock before placing its marker", async () => {
+		const store = createChatStore();
+		const blocker = createDeferred<void>();
+		const holder = runExclusiveQueueMutation("chat-1", () => blocker.promise);
+		const deleteQueuedMessage = vi.fn(async (_id: number) => undefined);
+
+		const deletion = runDeleteQueuedMessage({
+			id: 2,
+			chatID: "chat-1",
+			store,
+			deleteQueuedMessage,
+		});
+
+		// The operation does not own the queue yet, so it owns no markers
+		// either: its failure path must not be able to touch a marker the
+		// operation currently holding the lock relies on.
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(2)).toBe(false);
+		expect(deleteQueuedMessage).not.toHaveBeenCalled();
+
+		blocker.resolve();
+		await holder;
+		await deletion;
+
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(2)).toBe(true);
+	});
+
+	it("leaves a promotion veto it does not own after a failure", async () => {
+		const store = createChatStore();
+		const apiError = new Error("boom");
+		// A send promoted this row while the delete was queued behind it.
+		store.markQueuedMessagePromoted(2);
 
 		await expect(
 			runDeleteQueuedMessage({
-				id: b.id,
+				id: 2,
+				chatID: "chat-1",
 				store,
-				deleteQueuedMessage: async () => {
-					throw apiError;
-				},
-				getCacheQueuedMessages: () => cachedQueue,
-				setCacheQueuedMessages: (queuedMessages) => {
-					cachedQueue = queuedMessages;
-				},
+				deleteQueuedMessage: () => Promise.reject(apiError),
 			}),
 		).rejects.toBe(apiError);
 
-		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
-			a.id,
-			b.id,
-		]);
-		expect(cachedQueue?.map((m) => m.id)).toEqual([a.id, b.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(2)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(2)).toBe(true);
+	});
+});
+
+describe("runQueueSuppressingEdit", () => {
+	const chatID = "chat-1";
+	const buildQueuedMessage = (id: number, text: string): ChatQueuedMessage => ({
+		...MockChatQueuedMessage,
+		id,
+		chat_id: chatID,
+		content: [{ type: "text", text }],
+	});
+	const seedQueue = (
+		queryClient: QueryClient,
+		queuedMessages: readonly ChatQueuedMessage[],
+	): void => {
+		queryClient.setQueryData(chatKeys.messages(chatID), {
+			pages: [
+				{ messages: [], queued_messages: queuedMessages, has_more: false },
+			],
+			pageParams: [undefined],
+		});
+	};
+	const buildParams = (
+		store: ReturnType<typeof createChatStore>,
+		queryClient: QueryClient,
+		editMessage: (args: {
+			messageId: number;
+			req: EditChatMessageRequest;
+		}) => Promise<unknown>,
+	) => ({
+		chatID,
+		store,
+		queryClient,
+		editMessage,
+		editArgs: { messageId: 10, req: { content: [] } },
+		scrollToBottom: undefined,
+		clearChatErrorReason: vi.fn(),
+		clearStreamError: vi.fn(),
+		handleUsageLimitError: vi.fn(),
+	});
+
+	it("waits for the queue lock before capturing its markers", async () => {
+		const store = createChatStore();
+		const queryClient = new QueryClient();
+		const a = buildQueuedMessage(1, "A");
+		seedQueue(queryClient, [a]);
+		const blocker = createDeferred<void>();
+		const holder = runExclusiveQueueMutation(chatID, () => blocker.promise);
+		const editMessage = vi.fn(async () => undefined);
+
+		const edit = runQueueSuppressingEdit(
+			buildParams(store, queryClient, editMessage),
+		);
+
+		// The queue it would clear is still being changed by the operation that
+		// holds the lock, so nothing is captured or marked yet.
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+		expect(editMessage).not.toHaveBeenCalled();
+
+		blocker.resolve();
+		await holder;
+		await edit;
+
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+	});
+
+	it("leaves a promotion veto it does not own after a failure", async () => {
+		const store = createChatStore();
+		const queryClient = new QueryClient();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		seedQueue(queryClient, [a, b]);
+		// A send promoted A, so it is already hidden and not this edit's to
+		// unhide.
+		store.markQueuedMessagePromoted(a.id);
+		const apiError = new Error("boom");
+
+		await expect(
+			runQueueSuppressingEdit(
+				buildParams(store, queryClient, () => Promise.reject(apiError)),
+			),
+		).rejects.toBe(apiError);
+
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(
+			false,
+		);
+	});
+});
+
+describe("runGuardedChatTurn", () => {
+	it("refuses a second submission while the first waits for the queue lock", async () => {
+		const inFlightRef = { current: false };
+		const setInFlight = vi.fn();
+		const blocker = createDeferred<void>();
+		const holder = runExclusiveQueueMutation("chat-1", () => blocker.promise);
+		const send = vi.fn(async () => undefined);
+		const submit = () =>
+			runGuardedChatTurn({
+				inFlightRef,
+				setInFlight,
+				run: () => runExclusiveQueueMutation("chat-1", send),
+			});
+
+		// The mutation has not started, so nothing derived from its pending
+		// state can refuse the second submission.
+		const first = submit();
+		const second = submit();
+
+		blocker.resolve();
+		await Promise.all([holder, first, second]);
+
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(setInFlight.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it("accepts the next submission once the turn settles", async () => {
+		const inFlightRef = { current: false };
+		const run = vi.fn(async () => {
+			throw new Error("boom");
+		});
+
+		await expect(
+			runGuardedChatTurn({ inFlightRef, setInFlight: () => {}, run }),
+		).rejects.toThrow("boom");
+		expect(inFlightRef.current).toBe(false);
+
+		await expect(
+			runGuardedChatTurn({ inFlightRef, setInFlight: () => {}, run }),
+		).rejects.toThrow("boom");
+		expect(run).toHaveBeenCalledTimes(2);
 	});
 });
 
@@ -441,48 +585,23 @@ describe("reconcilePromotedQueueHead", () => {
 	const userMessage: ChatMessage = { ...MockChatMessage, id: 10, role: "user" };
 	const toolMessage: ChatMessage = { ...MockChatMessage, id: 9, role: "tool" };
 
-	it("suppresses the captured head and appends the queued tail", () => {
+	it("marks the captured head promoted and appends the queued tail", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		const tail = buildQueuedMessage(3, "C");
-		store.setQueuedMessages([a, b]);
 
 		const reconciled = reconcilePromotedQueueHead(
 			store,
+			[a, b],
 			[toolMessage, userMessage],
 			a.id,
 			tail,
 		);
 
-		const snapshot = store.getSnapshot();
-		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([b.id, tail.id]);
-		expect(snapshot.suppressedQueuedMessageIDs.has(a.id)).toBe(true);
 		expect(reconciled?.map((m) => m.id)).toEqual([b.id, tail.id]);
-	});
-
-	it("does not suppress the rotated head when a queue_update already applied", () => {
-		const store = createChatStore();
-		const a = buildQueuedMessage(1, "A");
-		const b = buildQueuedMessage(2, "B");
-		const c = buildQueuedMessage(3, "C");
-		store.setQueuedMessages([b, c]);
-
-		reconcilePromotedQueueHead(store, [userMessage], a.id, c);
-
-		const snapshot = store.getSnapshot();
-		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([b.id, c.id]);
-		expect(snapshot.suppressedQueuedMessageIDs.has(a.id)).toBe(true);
-		expect(snapshot.suppressedQueuedMessageIDs.has(b.id)).toBe(false);
-		expect(snapshot.suppressedQueuedMessageIDs.has(c.id)).toBe(false);
-
-		store.applyAuthoritativeQueuedMessages([a, b, c]);
-		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
-			b.id,
-			c.id,
-		]);
-		store.applyAuthoritativeQueuedMessages([b, c]);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
 	});
 
 	it("keeps the response tail when a stale snapshot arrived mid-request", () => {
@@ -492,10 +611,15 @@ describe("reconcilePromotedQueueHead", () => {
 		const c = buildQueuedMessage(3, "C");
 		// A pre-send snapshot lands while the POST is in flight; it cannot
 		// mention the tail the send just created.
-		store.setQueuedMessages([a]);
-		store.applyAuthoritativeQueuedMessages([a, b]);
+		store.acceptAuthoritativeQueueSnapshot([a, b], "socket");
 
-		const next = reconcilePromotedQueueHead(store, [userMessage], a.id, c);
+		const next = reconcilePromotedQueueHead(
+			store,
+			[a, b],
+			[userMessage],
+			a.id,
+			c,
+		);
 
 		expect(next?.map((m) => m.id)).toEqual([b.id, c.id]);
 	});
@@ -504,46 +628,43 @@ describe("reconcilePromotedQueueHead", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
 		const c = buildQueuedMessage(3, "C");
-		store.applyAuthoritativeQueuedMessages([a, c]);
-		store.applyAuthoritativeQueuedMessages([a]);
+		store.acceptAuthoritativeQueueSnapshot([a, c], "socket");
+		store.acceptAuthoritativeQueueSnapshot([a], "socket");
 
-		const next = reconcilePromotedQueueHead(store, [userMessage], a.id, c);
+		const next = reconcilePromotedQueueHead(store, [a], [userMessage], a.id, c);
 
 		expect(next).toEqual([]);
 	});
 
-	it("omits the response tail when a newer queue update was observed", () => {
+	it("omits the response tail when there is none", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
-		store.setQueuedMessages([a]);
 
 		const next = reconcilePromotedQueueHead(
 			store,
+			[a],
 			[userMessage],
 			a.id,
 			undefined,
 		);
 
 		expect(next).toEqual([]);
-		expect(store.getSnapshot().queuedMessages).toEqual([]);
 	});
 
 	it("does nothing when no user row was inserted", () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
-		store.setQueuedMessages([a]);
 
 		const reconciled = reconcilePromotedQueueHead(
 			store,
+			[a],
 			[toolMessage],
 			a.id,
 			buildQueuedMessage(2, "B"),
 		);
 
-		const snapshot = store.getSnapshot();
-		expect(snapshot.queuedMessages.map((m) => m.id)).toEqual([a.id]);
-		expect(snapshot.suppressedQueuedMessageIDs.size).toBe(0);
 		expect(reconciled).toBeUndefined();
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
 	it("does nothing when no head was captured before the send", () => {
@@ -551,15 +672,14 @@ describe("reconcilePromotedQueueHead", () => {
 
 		const reconciled = reconcilePromotedQueueHead(
 			store,
+			[],
 			[userMessage],
 			undefined,
 			buildQueuedMessage(1, "A"),
 		);
 
-		const snapshot = store.getSnapshot();
-		expect(snapshot.queuedMessages).toEqual([]);
-		expect(snapshot.suppressedQueuedMessageIDs.size).toBe(0);
 		expect(reconciled).toBeUndefined();
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 });
 
@@ -582,7 +702,6 @@ describe("buildInactiveChatQueueReconciliation", () => {
 
 		const next = buildInactiveChatQueueReconciliation(
 			[a, b, c],
-			[a, b],
 			[userMessage],
 			a.id,
 			undefined,
@@ -591,19 +710,17 @@ describe("buildInactiveChatQueueReconciliation", () => {
 		expect(next?.map((m) => m.id)).toEqual([b.id, c.id]);
 	});
 
-	it("falls back to the pre-send queue when nothing is cached", () => {
+	it("skips the write when the chat has no cached queue to amend", () => {
 		const a = buildQueuedMessage(1, "A");
-		const b = buildQueuedMessage(2, "B");
 
-		const next = buildInactiveChatQueueReconciliation(
-			undefined,
-			[a, b],
-			[userMessage],
-			a.id,
-			undefined,
-		);
-
-		expect(next?.map((m) => m.id)).toEqual([b.id]);
+		expect(
+			buildInactiveChatQueueReconciliation(
+				undefined,
+				[userMessage],
+				a.id,
+				undefined,
+			),
+		).toBeUndefined();
 	});
 });
 
@@ -615,56 +732,16 @@ describe("settlePromotedQueueHead", () => {
 	});
 	const chatID = "chat-abc-123";
 
-	it("restores a head the server still has queued", async () => {
-		const store = createChatStore();
-		const a = buildQueuedMessage(1, "A");
-		const b = buildQueuedMessage(2, "B");
-		store.setActiveChatID(chatID);
-		store.setQueuedMessages([b]);
-		store.markQueuedMessagePromoted(a.id);
-
-		const settled = await settlePromotedQueueHead(
-			store,
-			chatID,
-			a.id,
-			async () => ({ messages: [], has_more: false, queued_messages: [a, b] }),
-		);
-
-		expect(settled?.map((m) => m.id)).toEqual([a.id, b.id]);
-		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([
-			a.id,
-			b.id,
-		]);
-	});
-
-	it("leaves the queue alone when the fetch fails", async () => {
-		const store = createChatStore();
-		const a = buildQueuedMessage(1, "A");
-		const b = buildQueuedMessage(2, "B");
-		store.setActiveChatID(chatID);
-		store.setQueuedMessages([b]);
-		store.markQueuedMessagePromoted(a.id);
-
-		const settled = await settlePromotedQueueHead(store, chatID, a.id, () =>
-			Promise.reject(new Error("offline")),
-		);
-
-		expect(settled).toBeUndefined();
-		expect(store.getSnapshot().queuedMessages.map((m) => m.id)).toEqual([b.id]);
-		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
-	});
-
-	it("returns the filtered queue the store applied", async () => {
+	it("returns the RAW response and clears the head's markers", async () => {
 		const store = createChatStore();
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		const c = buildQueuedMessage(3, "C");
 		store.setActiveChatID(chatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
-		// An overlapping explicit promotion suppresses C, which the server has
-		// not deleted yet, so the caller must not cache it back.
-		store.suppressQueuedMessageID(c.id);
+		// An overlapping explicit promotion suppresses C. It stays suppressed,
+		// but the convergence response is written to the cache unfiltered.
+		store.suppressQueuedMessageIDs([c.id]);
 
 		const settled = await settlePromotedQueueHead(
 			store,
@@ -677,7 +754,98 @@ describe("settlePromotedQueueHead", () => {
 			}),
 		);
 
-		expect(settled?.map((m) => m.id)).toEqual([a.id, b.id]);
+		expect(settled?.map((m) => m.id)).toEqual([a.id, b.id, c.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(
+			false,
+		);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(c.id)).toBe(true);
+	});
+
+	it("ends the veto when the fetch fails and nothing was rejected", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setActiveChatID(chatID);
+		store.markQueuedMessagePromoted(a.id);
+
+		const settled = await settlePromotedQueueHead(store, chatID, a.id, () =>
+			Promise.reject(new Error("offline")),
+		);
+
+		// No snapshot was vetoed, so the cache still holds the projection the
+		// send wrote and there is nothing to write back.
+		expect(settled).toBeUndefined();
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(false);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "socket")).toBe(true);
+	});
+
+	it("restores the vetoed snapshot when a wrong guess fails to converge", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		const c = buildQueuedMessage(3, "C");
+		store.setActiveChatID(chatID);
+		// The send guessed A, but the server promoted another row and keeps
+		// reporting A as queued.
+		store.markQueuedMessagePromoted(a.id);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "socket")).toBe(
+			false,
+		);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b, c], "socket")).toBe(
+			false,
+		);
+
+		const settled = await settlePromotedQueueHead(store, chatID, a.id, () =>
+			Promise.reject(new Error("offline")),
+		);
+
+		// The veto ends AND hands back the newest snapshot it swallowed, so the
+		// caller can restore what the server last reported.
+		expect(settled?.map((m) => m.id)).toEqual([a.id, b.id, c.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(false);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(
+			false,
+		);
+		// Queue updates resume instead of being rejected forever.
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b, c], "socket")).toBe(
+			true,
+		);
+	});
+
+	it("disposes both markers when overlapping promotions share a response", async () => {
+		const store = createChatStore();
+		const a = buildQueuedMessage(1, "A");
+		const b = buildQueuedMessage(2, "B");
+		store.setActiveChatID(chatID);
+		const shared = createDeferred<ChatMessagesResponse>();
+
+		// The chat errored twice, so a second promoting send lands while the
+		// first convergence is still in flight and both settle from the same
+		// response, which predates the second promotion.
+		store.markQueuedMessagePromoted(a.id);
+		const first = settlePromotedQueueHead(
+			store,
+			chatID,
+			a.id,
+			() => shared.promise,
+		);
+		store.markQueuedMessagePromoted(b.id);
+		const second = settlePromotedQueueHead(
+			store,
+			chatID,
+			b.id,
+			() => shared.promise,
+		);
+
+		shared.resolve({ messages: [], has_more: false, queued_messages: [] });
+		await Promise.all([first, second]);
+
+		// The first completion advances the fence, which retires only its own
+		// marker. The second must not leave its marker vetoing every later
+		// snapshot.
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "socket")).toBe(true);
 	});
 
 	it("discards a response that resolves after navigating to another chat", async () => {
@@ -685,7 +853,6 @@ describe("settlePromotedQueueHead", () => {
 		const a = buildQueuedMessage(1, "A");
 		const b = buildQueuedMessage(2, "B");
 		store.setActiveChatID(chatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 
 		const settled = await settlePromotedQueueHead(
@@ -694,13 +861,11 @@ describe("settlePromotedQueueHead", () => {
 			a.id,
 			async () => {
 				store.setActiveChatID("chat-other");
-				store.setQueuedMessages([]);
 				return { messages: [], has_more: false, queued_messages: [a, b] };
 			},
 		);
 
 		expect(settled).toBeUndefined();
-		expect(store.getSnapshot().queuedMessages).toEqual([]);
 	});
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -84,12 +84,16 @@ import {
 	getParentChatID,
 	getWorkspaceAgent,
 } from "./components/ChatConversation/chatHelpers";
+import { runExclusiveQueueMutation } from "./components/ChatConversation/chatQueueMutations";
 import {
 	type ChatStore,
 	type ChatStoreState,
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
-import { useDurableChatStatus } from "./components/ChatConversation/durableChat";
+import {
+	readEffectiveQueuedMessages,
+	useDurableChatStatus,
+} from "./components/ChatConversation/durableChat";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
@@ -157,22 +161,17 @@ export function getPersistedDraftInputValue(
 /**
  * Restores the transient store slices an optimistic request overwrote. Chat
  * status is not among them: it lives in the query cache, and its rollback is
- * token-scoped through `rollbackOptimisticChatStatus`.
+ * token-scoped through `rollbackOptimisticChatStatus`. Neither is the queue:
+ * the cache is canonical for it, and an optimistic queue removal is a
+ * read-time marker the failing caller unsuppresses on its own.
  *
  * @internal Exported for testing.
  */
 export const restoreOptimisticRequestSnapshot = (
-	store: Pick<
-		ChatStore,
-		"batch" | "setQueuedMessages" | "setStreamError" | "setStreamState"
-	>,
-	snapshot: Pick<
-		ChatStoreState,
-		"queuedMessages" | "streamError" | "streamState"
-	>,
+	store: Pick<ChatStore, "batch" | "setStreamError" | "setStreamState">,
+	snapshot: Pick<ChatStoreState, "streamError" | "streamState">,
 ): void => {
 	store.batch(() => {
-		store.setQueuedMessages(snapshot.queuedMessages);
 		store.setStreamState(snapshot.streamState);
 		store.setStreamError(snapshot.streamError);
 	});
@@ -183,25 +182,27 @@ export const restoreOptimisticRequestSnapshot = (
  *
  * The promote endpoint returns 202 Accepted with no message body, so the
  * actual user message is delivered via SSE or the messages REST endpoint.
- * Suppress the promoted ID so the transient reordered queue published by
- * the running-case backend does not flash the message back into the
- * visible queue. Roll back queue, status, and suppression on API error.
+ * Suppressing the promoted ID is the whole optimistic update: it hides the row
+ * instantly, and it keeps hiding it through the transient reordered queue the
+ * running-case backend publishes before auto-promoting it. The cache is never
+ * written, so a failure only has to drop the marker, and a queue snapshot that
+ * lands mid-request is not clobbered by a rollback.
  *
  * @internal Exported for testing.
  */
 export const runPromoteQueuedMessage = async (params: {
 	id: number;
+	chatID: string | undefined;
 	store: Pick<
 		ChatStore,
 		| "batch"
 		| "clearStreamError"
 		| "clearStreamState"
 		| "getSnapshot"
-		| "setQueuedMessages"
 		| "setStreamError"
 		| "setStreamState"
-		| "suppressQueuedMessageID"
-		| "unsuppressQueuedMessageID"
+		| "suppressQueuedMessageIDs"
+		| "unsuppressQueuedMessageIDs"
 	>;
 	queryClient: QueryClient;
 	promoteQueuedMessage: (id: number) => Promise<void>;
@@ -211,6 +212,7 @@ export const runPromoteQueuedMessage = async (params: {
 }): Promise<void> => {
 	const {
 		id,
+		chatID,
 		store,
 		queryClient,
 		promoteQueuedMessage,
@@ -218,77 +220,74 @@ export const runPromoteQueuedMessage = async (params: {
 		clearChatErrorReason,
 		handleUsageLimitError,
 	} = params;
-	const previousSnapshot = store.getSnapshot();
-	store.batch(() => {
-		store.suppressQueuedMessageID(id);
-		store.setQueuedMessages(
-			previousSnapshot.queuedMessages.filter((message) => message.id !== id),
-		);
-		store.clearStreamState();
-		store.clearStreamError();
-	});
-	const optimisticStatusToken = agentId
-		? writeOptimisticChatStatus(queryClient, agentId, "running")
-		: undefined;
-	if (agentId) {
-		clearChatErrorReason(agentId);
-	}
-	try {
-		await promoteQueuedMessage(id);
-	} catch (error) {
-		store.unsuppressQueuedMessageID(id);
-		if (agentId && optimisticStatusToken !== undefined) {
-			rollbackOptimisticChatStatus(queryClient, agentId, optimisticStatusToken);
+	const run = async (): Promise<void> => {
+		const previousSnapshot = store.getSnapshot();
+		store.batch(() => {
+			store.suppressQueuedMessageIDs([id]);
+			store.clearStreamState();
+			store.clearStreamError();
+		});
+		const optimisticStatusToken = agentId
+			? writeOptimisticChatStatus(queryClient, agentId, "running")
+			: undefined;
+		if (agentId) {
+			clearChatErrorReason(agentId);
 		}
-		restoreOptimisticRequestSnapshot(store, previousSnapshot);
-		handleUsageLimitError(error);
-		throw error;
-	}
+		try {
+			await promoteQueuedMessage(id);
+		} catch (error) {
+			store.unsuppressQueuedMessageIDs([id]);
+			if (agentId && optimisticStatusToken !== undefined) {
+				rollbackOptimisticChatStatus(
+					queryClient,
+					agentId,
+					optimisticStatusToken,
+				);
+			}
+			restoreOptimisticRequestSnapshot(store, previousSnapshot);
+			handleUsageLimitError(error);
+			throw error;
+		}
+	};
+	// Markers and request together: a marker placed before the lock belongs to
+	// an operation that has not started, so its failure path could lift a marker
+	// another operation took ownership of meanwhile.
+	await (chatID ? runExclusiveQueueMutation(chatID, run) : run());
 };
 
 /**
  * Runs the optimistic queued-message deletion flow.
  *
- * The mutation no longer invalidates the messages query, so the deletion is
- * projected into both the store's visible queue and `pages[0].queued_messages`
- * of the messages cache. Skipping the cache write would leave the cached queue
- * stale, and REST re-hydration would resurrect the deleted entry. Both writes
- * roll back together on failure.
+ * The removal is a read-time suppression marker, not a cache write: the cache
+ * stays server-truthful, the row disappears from the visible queue instantly
+ * even while a pagination fetch is buffering cache writes, and a failure only
+ * unsuppresses. The server's own `queue_update` retires the marker by omitting
+ * the id.
  *
  * @internal Exported for testing.
  */
 export const runDeleteQueuedMessage = async (params: {
 	id: number;
-	store: Pick<ChatStore, "getSnapshot" | "setQueuedMessages">;
+	chatID: string | undefined;
+	store: Pick<
+		ChatStore,
+		"suppressQueuedMessageIDs" | "unsuppressQueuedMessageIDs"
+	>;
 	deleteQueuedMessage: (id: number) => Promise<void>;
-	getCacheQueuedMessages: () =>
-		| readonly TypesGen.ChatQueuedMessage[]
-		| undefined;
-	setCacheQueuedMessages: (
-		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
-	) => void;
 }): Promise<void> => {
-	const {
-		id,
-		store,
-		deleteQueuedMessage,
-		getCacheQueuedMessages,
-		setCacheQueuedMessages,
-	} = params;
-	const previousQueuedMessages = store.getSnapshot().queuedMessages;
-	const previousCacheQueuedMessages = getCacheQueuedMessages();
-	const nextQueuedMessages = previousQueuedMessages.filter(
-		(message) => message.id !== id,
-	);
-	store.setQueuedMessages(nextQueuedMessages);
-	setCacheQueuedMessages(nextQueuedMessages);
-	try {
-		await deleteQueuedMessage(id);
-	} catch (error) {
-		store.setQueuedMessages(previousQueuedMessages);
-		setCacheQueuedMessages(previousCacheQueuedMessages);
-		throw error;
-	}
+	const { id, chatID, store, deleteQueuedMessage } = params;
+	const run = async (): Promise<void> => {
+		store.suppressQueuedMessageIDs([id]);
+		try {
+			await deleteQueuedMessage(id);
+		} catch (error) {
+			// Lifts this operation's ordinary suppression only. If a send promoted
+			// the same ID meanwhile, that promotion veto is not ours to retire.
+			store.unsuppressQueuedMessageIDs([id]);
+			throw error;
+		}
+	};
+	await (chatID ? runExclusiveQueueMutation(chatID, run) : run());
 };
 
 /**
@@ -344,39 +343,48 @@ const buildPromotedQueueReconciliation = (
 	return tailPending ? [...remaining, queuedTail] : remaining;
 };
 
-// Prefer an inactive chat's cached queue so messages queued during the send
-// are not dropped; fall back when no cache exists.
+// The inactive-chat variant: no socket is watching, so nothing local can have
+// observed the tail yet, and the cached queue is the only baseline. Without a
+// cached queue there is no page 0 to amend, and re-entry refetches it.
 export const buildInactiveChatQueueReconciliation = (
 	cachedQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
-	queuedMessagesBeforeSend: readonly TypesGen.ChatQueuedMessage[],
 	insertedMessages: readonly TypesGen.ChatMessage[],
 	promotedHeadID: number | undefined,
 	queuedTail: TypesGen.ChatQueuedMessage | undefined,
 ): readonly TypesGen.ChatQueuedMessage[] | undefined =>
-	buildPromotedQueueReconciliation(
-		cachedQueuedMessages ?? queuedMessagesBeforeSend,
-		insertedMessages,
-		promotedHeadID,
-		queuedTail,
-		() => false,
-	);
+	cachedQueuedMessages === undefined
+		? undefined
+		: buildPromotedQueueReconciliation(
+				cachedQueuedMessages,
+				insertedMessages,
+				promotedHeadID,
+				queuedTail,
+				() => false,
+			);
 
-// Queue updates may rotate the head before the response arrives.
+/**
+ * Projects the queue a promoting send left behind: the canonical queue minus
+ * the head the server promoted, plus the tail the response returned. Both
+ * facts are server-confirmed, so the result is a server-DERIVED value the
+ * caller may write to the canonical cache. It is the one cache write the
+ * client originates, because a marker can only subtract and this one adds.
+ *
+ * Queue updates may rotate the head before the response arrives, so the
+ * promoted ID is a guess; `promotedQueuedMessageIDs` fences stale snapshots
+ * until the convergence fetch settles which row the server actually promoted.
+ */
 export const reconcilePromotedQueueHead = (
 	store: Pick<
 		ChatStore,
-		| "batch"
-		| "getSnapshot"
-		| "setQueuedMessages"
-		| "markQueuedMessagePromoted"
-		| "hasObservedQueuedMessageID"
+		"markQueuedMessagePromoted" | "hasObservedQueuedMessageID"
 	>,
+	canonicalQueuedMessages: readonly TypesGen.ChatQueuedMessage[],
 	insertedMessages: readonly TypesGen.ChatMessage[],
 	promotedHeadID: number | undefined,
 	queuedTail: TypesGen.ChatQueuedMessage | undefined,
 ): readonly TypesGen.ChatQueuedMessage[] | undefined => {
 	const next = buildPromotedQueueReconciliation(
-		store.getSnapshot().queuedMessages,
+		canonicalQueuedMessages,
 		insertedMessages,
 		promotedHeadID,
 		queuedTail,
@@ -385,41 +393,69 @@ export const reconcilePromotedQueueHead = (
 	if (!next || promotedHeadID === undefined) {
 		return next;
 	}
-	store.batch(() => {
-		// The promoted user row proves the server deleted its queue row.
-		store.markQueuedMessagePromoted(promotedHeadID);
-		store.setQueuedMessages(next);
-	});
+	// The promoted user row proves the server deleted its queue row.
+	store.markQueuedMessagePromoted(promotedHeadID);
 	return next;
 };
 
-const fetchChatMessages = (queryClient: QueryClient) => (chatID: string) =>
-	queryClient.fetchQuery(chatQueueConvergence(chatID));
+const fetchChatMessages =
+	(queryClient: QueryClient) => (chatID: string, promotedHeadID: number) =>
+		queryClient.fetchQuery(chatQueueConvergence(chatID, promotedHeadID));
 
-// A promoted head is suppressed locally, but another tab can queue or
-// promote concurrently, so only the server knows the resulting queue.
+// A promoted head is suppressed locally, but the client cannot compute the
+// server's head: the server promotes by `position ASC` while the client sees
+// the queue by `created_at ASC`, and a promote rewrites position without
+// touching created_at. Only the server knows the resulting queue, so the
+// convergence GET repairs a wrong guess. Returns the RAW response for the
+// caller to write; suppression stays a read-time concern.
+//
+// The veto the guess installed lasts exactly as long as this call, however it
+// ends. A failed fetch ends it and hands back whatever the veto rejected
+// meanwhile: leaving the marker up would reject every later snapshot that
+// still lists the guessed row, and clearing it alone would leave the queue
+// showing a value the rejected snapshots already contradicted. A response the
+// fence already superseded ends it the same way, because the fence only
+// guarantees that the markers of the convergence that MOVED it were retired,
+// not this one's.
 export const settlePromotedQueueHead = async (
 	store: Pick<
 		ChatStore,
-		"getQueueConvergenceFence" | "applyPromoteRefetchQueuedMessages"
+		| "getQueueConvergenceFence"
+		| "acceptQueueConvergence"
+		| "abandonQueueConvergence"
 	>,
 	chatID: string,
 	promotedHeadID: number,
-	fetchMessages: (chatID: string) => Promise<TypesGen.ChatMessagesResponse>,
+	fetchMessages: (
+		chatID: string,
+		promotedHeadID: number,
+	) => Promise<TypesGen.ChatMessagesResponse>,
 ): Promise<readonly TypesGen.ChatQueuedMessage[] | undefined> => {
 	const baselineFence = store.getQueueConvergenceFence();
 	let response: TypesGen.ChatMessagesResponse;
 	try {
-		response = await fetchMessages(chatID);
+		response = await fetchMessages(chatID, promotedHeadID);
 	} catch {
-		// Convergence is best effort; a later authoritative update can correct it.
-		return undefined;
+		return store.abandonQueueConvergence(chatID, promotedHeadID, baselineFence);
 	}
-	return store.applyPromoteRefetchQueuedMessages(
+	const queuedMessages = response.queued_messages ?? [];
+	if (
+		store.acceptQueueConvergence(
+			chatID,
+			promotedHeadID,
+			queuedMessages,
+			baselineFence,
+		)
+	) {
+		return queuedMessages;
+	}
+	// Superseded, so this response cannot settle the guess. Retire the marker
+	// anyway: at worst the promoted row flickers back for one snapshot, while
+	// leaving it would veto every snapshot listing it, forever.
+	return store.abandonQueueConvergence(
 		chatID,
 		promotedHeadID,
-		response.queued_messages ?? [],
-		baselineFence,
+		store.getQueueConvergenceFence(),
 	);
 };
 
@@ -456,6 +492,128 @@ export async function submitEditAndScroll({
 	// shifts between the old and truncated content.
 	scrollToBottom?.();
 }
+
+/**
+ * Runs the optimistic queue-clearing edit flow.
+ *
+ * An edit restarts the turn and clears the server queue, so the visible queue
+ * is hidden the same way a delete hides one row: read-time markers, never a
+ * cache write. A cache clear would need a rollback, and that rollback would
+ * clobber a `queue_update` that landed while the edit was in flight.
+ *
+ * Everything the operation owns runs INSIDE the queue lock, the marker
+ * capture included. Captured before FIFO ownership, the marker list would
+ * describe a queue another operation is still changing, and this failure path
+ * would then lift markers that operation owns.
+ *
+ * @internal Exported for testing.
+ */
+export const runQueueSuppressingEdit = (params: {
+	chatID: string;
+	store: ChatStore;
+	queryClient: QueryClient;
+	editMessage: (args: {
+		messageId: number;
+		optimisticMessage?: TypesGen.ChatMessage;
+		req: TypesGen.EditChatMessageRequest;
+	}) => Promise<unknown>;
+	editArgs: {
+		messageId: number;
+		optimisticMessage?: TypesGen.ChatMessage;
+		req: TypesGen.EditChatMessageRequest;
+	};
+	scrollToBottom: (() => void) | null | undefined;
+	clearChatErrorReason: (chatID: string) => void;
+	clearStreamError: () => void;
+	handleUsageLimitError: (error: unknown) => void;
+}): Promise<void> => {
+	const {
+		chatID,
+		store,
+		queryClient,
+		editMessage,
+		editArgs,
+		scrollToBottom,
+		clearChatErrorReason,
+		clearStreamError,
+		handleUsageLimitError,
+	} = params;
+	return runExclusiveQueueMutation(chatID, async () => {
+		const previousSnapshot = store.getSnapshot();
+		const suppressedForEdit = readEffectiveQueuedMessages(
+			queryClient,
+			store,
+			chatID,
+		).map((message) => message.id);
+		clearChatErrorReason(chatID);
+		clearStreamError();
+		store.batch(() => {
+			store.suppressQueuedMessageIDs(suppressedForEdit);
+			store.clearStreamState();
+		});
+		const optimisticStatusToken = writeOptimisticChatStatus(
+			queryClient,
+			chatID,
+			"running",
+		);
+		await submitEditAndScroll({
+			editMessage,
+			editArgs,
+			scrollToBottom,
+			onError: (error) => {
+				// Lifts this edit's ordinary suppression only; a send's promotion
+				// veto on the same ID belongs to that send's convergence.
+				store.unsuppressQueuedMessageIDs(suppressedForEdit);
+				rollbackOptimisticChatStatus(
+					queryClient,
+					chatID,
+					optimisticStatusToken,
+				);
+				restoreOptimisticRequestSnapshot(store, previousSnapshot);
+				handleUsageLimitError(error);
+				// Hook dispatch failures can park an idle chat in error before
+				// returning the request error. The refetched detail carries a
+				// snapshot version, so the comparator decides whether it is newer
+				// than any status the socket delivered meanwhile.
+				void queryClient.invalidateQueries({
+					queryKey: chatKeys.detail(chatID),
+					exact: true,
+				});
+			},
+		});
+	});
+};
+
+/**
+ * Runs a chat turn behind a synchronous in-flight guard.
+ *
+ * A submission occupies its chat's queue-position slot from the moment it is
+ * accepted, which is BEFORE its mutation reports pending: the request only
+ * starts once the queue lock is free. A second submission entering that
+ * window would send the same turn twice. The ref makes the guard synchronous,
+ * because a state update is invisible to a handler that already captured its
+ * closure; the setter mirrors it so the composer can disable.
+ *
+ * @internal Exported for testing.
+ */
+export const runGuardedChatTurn = async (params: {
+	inFlightRef: { current: boolean };
+	setInFlight: (inFlight: boolean) => void;
+	run: () => Promise<void>;
+}): Promise<void> => {
+	const { inFlightRef, setInFlight, run } = params;
+	if (inFlightRef.current) {
+		return;
+	}
+	inFlightRef.current = true;
+	setInFlight(true);
+	try {
+		await run();
+	} finally {
+		inFlightRef.current = false;
+		setInFlight(false);
+	}
+};
 
 /** @internal Exported for testing. */
 export const waitForPendingChatSettingsSyncs = async (
@@ -1177,19 +1335,6 @@ const AgentChatPage: FC = () => {
 		? selectDurableMessages(chatMessagesQuery.data)
 		: undefined;
 
-	// Queued messages are only in the first page (most recent).
-	const chatQueuedMessages = chatMessagesQuery.data?.pages[0]?.queued_messages;
-
-	// Build a synthetic ChatMessagesResponse from the flattened
-	// data for backward compat with useChatStore.
-	const chatMessagesData: TypesGen.ChatMessagesResponse | undefined =
-		chatMessagesList
-			? {
-					messages: chatMessagesList,
-					queued_messages: chatQueuedMessages ?? [],
-					has_more: chatMessagesQuery.data?.pages.at(-1)?.has_more ?? false,
-				}
-			: undefined;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
 	// Destructure mutation results directly so the React Compiler
@@ -1227,6 +1372,11 @@ const AgentChatPage: FC = () => {
 	const { mutateAsync: promoteQueuedMessage } = useMutation(
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
+	// A submission holds a queue-position slot from the moment it is
+	// accepted, which is BEFORE its mutation reports pending. See
+	// `runGuardedChatTurn`.
+	const chatTurnInFlightRef = useRef(false);
+	const [isChatTurnInFlight, setIsChatTurnInFlight] = useState(false);
 	const updateChatWorkspaceBase = updateChatWorkspace(queryClient);
 	const {
 		isPending: isUpdateChatWorkspacePending,
@@ -1279,15 +1429,13 @@ const AgentChatPage: FC = () => {
 	const {
 		store,
 		clearStreamError,
-		setCacheQueuedMessages,
-		getCacheQueuedMessages,
+		writeCanonicalQueuedMessages,
+		readCanonicalQueuedMessages,
 		upsertCacheMessages,
 	} = useChatStore({
 		chatID: agentId,
 		chatMessages: chatMessagesList,
 		chatRecord,
-		chatMessagesData,
-		chatQueuedMessages,
 		setChatErrorReason,
 		clearChatErrorReason,
 		aiGatewayDisabled,
@@ -1388,7 +1536,11 @@ const AgentChatPage: FC = () => {
 		hasUserFixableModelProviders,
 	});
 	const isSubmissionPending =
-		isSendPending || isEditPending || isInterruptPending || isCompactPending;
+		isSendPending ||
+		isEditPending ||
+		isInterruptPending ||
+		isCompactPending ||
+		isChatTurnInFlight;
 	const isChatSettingsPending =
 		isUpdateChatPlanModePending || isUpdateChatWorkspacePending;
 	const isInputDisabled =
@@ -1470,15 +1622,15 @@ const AgentChatPage: FC = () => {
 	const handleDeleteQueuedMessage = (id: number) =>
 		runDeleteQueuedMessage({
 			id,
+			chatID: agentId,
 			store,
 			deleteQueuedMessage,
-			getCacheQueuedMessages,
-			setCacheQueuedMessages,
 		});
 
 	const handlePromoteQueuedMessage = (id: number) =>
 		runPromoteQueuedMessage({
 			id,
+			chatID: agentId,
 			store,
 			queryClient,
 			promoteQueuedMessage,
@@ -1638,19 +1790,32 @@ const AgentChatPage: FC = () => {
 		return { content, hasContent: content.length > 0 };
 	}
 
-	async function submitChatTurn({
-		message,
-		attachments,
-		editedMessageID,
-		useComposerContent = true,
-		planModeSwitch,
-	}: {
+	type ChatTurnSubmission = {
 		message: string;
 		attachments?: readonly PendingAttachment[];
 		editedMessageID?: number;
 		useComposerContent?: boolean;
 		planModeSwitch?: PlanModeSwitch;
-	}) {
+	};
+
+	// Guards the whole turn, the queue lock wait included, so a second
+	// submission cannot slip past a mutation that has not started reporting
+	// pending yet.
+	function submitChatTurn(submission: ChatTurnSubmission): Promise<void> {
+		return runGuardedChatTurn({
+			inFlightRef: chatTurnInFlightRef,
+			setInFlight: setIsChatTurnInFlight,
+			run: () => runChatTurn(submission),
+		});
+	}
+
+	async function runChatTurn({
+		message,
+		attachments,
+		editedMessageID,
+		useComposerContent = true,
+		planModeSwitch,
+	}: ChatTurnSubmission) {
 		const { content, hasContent } = buildChatInputContent({
 			message,
 			attachments,
@@ -1756,19 +1921,10 @@ const AgentChatPage: FC = () => {
 						attachmentMediaTypes: buildAttachmentMediaTypes(attachments),
 					})
 				: undefined;
-			const previousSnapshot = store.getSnapshot();
-			clearChatErrorReason(agentId);
-			clearStreamError();
-			store.batch(() => {
-				store.setQueuedMessages([]);
-				store.clearStreamState();
-			});
-			const optimisticStatusToken = writeOptimisticChatStatus(
+			await runQueueSuppressingEdit({
+				chatID: agentId,
+				store,
 				queryClient,
-				agentId,
-				"running",
-			);
-			await submitEditAndScroll({
 				editMessage,
 				editArgs: {
 					messageId: editedMessageID,
@@ -1776,23 +1932,9 @@ const AgentChatPage: FC = () => {
 					req: request,
 				},
 				scrollToBottom: scrollToBottomRef.current,
-				onError: (error) => {
-					rollbackOptimisticChatStatus(
-						queryClient,
-						agentId,
-						optimisticStatusToken,
-					);
-					restoreOptimisticRequestSnapshot(store, previousSnapshot);
-					handleUsageLimitError(error);
-					// Hook dispatch failures can park an idle chat in error before
-					// returning the request error. The refetched detail carries a
-					// snapshot version, so the comparator decides whether it is
-					// newer than any status the socket delivered meanwhile.
-					void queryClient.invalidateQueries({
-						queryKey: chatKeys.detail(agentId),
-						exact: true,
-					});
-				},
+				clearChatErrorReason,
+				clearStreamError,
+				handleUsageLimitError,
 			});
 			if (editSelectedModelConfigID) {
 				localStorage.setItem(
@@ -1823,94 +1965,106 @@ const AgentChatPage: FC = () => {
 		clearStreamError();
 		scrollToBottomRef.current?.();
 
-		// An errored-chat send may promote the queue head that existed when the request began.
-		const queuedMessagesBeforeSend = store.getSnapshot().queuedMessages;
-		const queueHeadIDBeforeSend = queuedMessagesBeforeSend[0]?.id;
-		// The cached snapshot version is the send-path fence: optimistic
-		// writes never advance it, so it changes only when the server
-		// reported a status during the request.
-		const snapshotVersionBeforeSend = readCachedChatSnapshotVersion(
-			queryClient,
-			agentId,
-		);
-
-		// Don't clear stream state before the POST completes.
-		// For queued sends the WebSocket status events handle
-		// clearing; for non-queued sends we clear explicitly
-		// below. Clearing eagerly causes a visible cutoff.
-		let response: Awaited<ReturnType<typeof sendMessage>>;
-		try {
-			response = await sendMessage(request);
-		} catch (error) {
-			handleUsageLimitError(error);
-			// Hook dispatch failures can park an idle chat in error before
-			// returning the request error. The refetched detail carries a
-			// snapshot version, so the comparator decides whether it is newer
-			// than any status the socket delivered meanwhile.
-			void queryClient.invalidateQueries({
-				queryKey: chatKeys.detail(agentId),
-				exact: true,
-			});
-			throw error;
-		}
-		const isActiveChat = store.getActiveChatID() === agentId;
-		// Waiting for the WebSocket on non-queued sends leaves stale stream state visible.
-		if (!response.queued && isActiveChat) {
-			assertTurnStartedAfterSend({
-				store,
+		// The head capture and the reconciliation that depends on it run
+		// inside the queue-mutation lock: a delete or promote committing
+		// between them would make the server promote a different head than
+		// the one captured here.
+		await runExclusiveQueueMutation(agentId, async () => {
+			// An errored-chat send may promote the queue head that existed when
+			// the request began. Read the RAW canonical queue: the server
+			// promotes ITS head by position, which includes a row this client
+			// has suppressed but the server still has queued.
+			const queueHeadIDBeforeSend = readCanonicalQueuedMessages()?.[0]?.id;
+			// The cached snapshot version is the send-path fence: optimistic
+			// writes never advance it, so it changes only when the server
+			// reported a status during the request.
+			const snapshotVersionBeforeSend = readCachedChatSnapshotVersion(
 				queryClient,
-				chatId: agentId,
-				snapshotVersionBeforeSend,
-			});
-		}
-		// Upsert the full batch because a queued send can insert a promoted head below
-		// the highest cached ID, which a reconnect would skip.
-		const insertedMessages =
-			response.messages ?? (response.message ? [response.message] : []);
-		if (insertedMessages.length > 0) {
-			upsertCacheMessages(insertedMessages);
-			if (response.queued) {
-				const reconciledQueue = isActiveChat
-					? reconcilePromotedQueueHead(
-							store,
-							insertedMessages,
-							queueHeadIDBeforeSend,
-							response.queued_message,
-						)
-					: buildInactiveChatQueueReconciliation(
-							getCacheQueuedMessages(),
-							queuedMessagesBeforeSend,
-							insertedMessages,
-							queueHeadIDBeforeSend,
-							response.queued_message,
-						);
-				if (reconciledQueue) {
-					setCacheQueuedMessages(reconciledQueue);
-					// A promoted head starts a turn, but any server status received during the
-					// request is newer and must win.
-					if (isActiveChat) {
-						assertTurnStartedAfterSend({
-							store,
-							queryClient,
-							chatId: agentId,
-							snapshotVersionBeforeSend,
-						});
-					}
-					if (isActiveChat && queueHeadIDBeforeSend !== undefined) {
-						void settlePromotedQueueHead(
-							store,
-							agentId,
-							queueHeadIDBeforeSend,
-							fetchChatMessages(queryClient),
-						).then((settled) => {
-							if (settled) {
-								setCacheQueuedMessages(settled);
-							}
-						});
-					}
-				}
+				agentId,
+			);
+
+			// Don't clear stream state before the POST completes.
+			// For queued sends the WebSocket status events handle
+			// clearing; for non-queued sends we clear explicitly
+			// below. Clearing eagerly causes a visible cutoff.
+			let sendResponse: Awaited<ReturnType<typeof sendMessage>>;
+			try {
+				sendResponse = await sendMessage(request);
+			} catch (error) {
+				handleUsageLimitError(error);
+				// Hook dispatch failures can park an idle chat in error before
+				// returning the request error. The refetched detail carries a
+				// snapshot version, so the comparator decides whether it is newer
+				// than any status the socket delivered meanwhile.
+				void queryClient.invalidateQueries({
+					queryKey: chatKeys.detail(agentId),
+					exact: true,
+				});
+				throw error;
 			}
-		}
+			const isActiveChat = store.getActiveChatID() === agentId;
+			// Waiting for the WebSocket on non-queued sends leaves stale stream state visible.
+			if (!sendResponse.queued && isActiveChat) {
+				assertTurnStartedAfterSend({
+					store,
+					queryClient,
+					chatId: agentId,
+					snapshotVersionBeforeSend,
+				});
+			}
+			// Upsert the full batch because a queued send can insert a promoted head below
+			// the highest cached ID, which a reconnect would skip.
+			const insertedMessages =
+				sendResponse.messages ??
+				(sendResponse.message ? [sendResponse.message] : []);
+			if (insertedMessages.length === 0) {
+				return;
+			}
+			upsertCacheMessages(insertedMessages);
+			if (!sendResponse.queued) {
+				return;
+			}
+			const reconciledQueue = isActiveChat
+				? reconcilePromotedQueueHead(
+						store,
+						readCanonicalQueuedMessages() ?? [],
+						insertedMessages,
+						queueHeadIDBeforeSend,
+						sendResponse.queued_message,
+					)
+				: buildInactiveChatQueueReconciliation(
+						readCanonicalQueuedMessages(),
+						insertedMessages,
+						queueHeadIDBeforeSend,
+						sendResponse.queued_message,
+					);
+			if (!reconciledQueue) {
+				return;
+			}
+			writeCanonicalQueuedMessages(reconciledQueue);
+			// A promoted head starts a turn, but any server status received during the
+			// request is newer and must win.
+			if (isActiveChat) {
+				assertTurnStartedAfterSend({
+					store,
+					queryClient,
+					chatId: agentId,
+					snapshotVersionBeforeSend,
+				});
+			}
+			if (isActiveChat && queueHeadIDBeforeSend !== undefined) {
+				void settlePromotedQueueHead(
+					store,
+					agentId,
+					queueHeadIDBeforeSend,
+					fetchChatMessages(queryClient),
+				).then((settled) => {
+					if (settled) {
+						writeCanonicalQueuedMessages(settled);
+					}
+				});
+			}
+		});
 		if (selectedModelConfigID) {
 			localStorage.setItem(lastModelConfigIDStorageKey, selectedModelConfigID);
 		} else {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatQueueMutations.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatQueueMutations.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { createDeferred } from "#/testHelpers/deferred";
+import { runExclusiveQueueMutation } from "./chatQueueMutations";
+
+describe("runExclusiveQueueMutation", () => {
+	it("runs one queue-position mutation per chat at a time", async () => {
+		const chatID = "chat-serialize-1";
+		const order: string[] = [];
+		const first = createDeferred<void>();
+		const second = createDeferred<void>();
+
+		const firstRun = runExclusiveQueueMutation(chatID, async () => {
+			order.push("first:start");
+			await first.promise;
+			order.push("first:end");
+		});
+		const secondRun = runExclusiveQueueMutation(chatID, async () => {
+			order.push("second:start");
+			await second.promise;
+			order.push("second:end");
+		});
+
+		// The send captures the queue head inside its critical section, so the
+		// second mutation must not start until the first settles.
+		expect(order).toEqual(["first:start"]);
+
+		first.resolve();
+		await firstRun;
+		second.resolve();
+		await secondRun;
+
+		expect(order).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+		]);
+	});
+
+	it("keeps running after a predecessor rejects", async () => {
+		const chatID = "chat-serialize-2";
+		const failure = new Error("boom");
+
+		const failing = runExclusiveQueueMutation(chatID, () =>
+			Promise.reject(failure),
+		);
+		const following = runExclusiveQueueMutation(chatID, async () => "ok");
+
+		await expect(failing).rejects.toBe(failure);
+		await expect(following).resolves.toBe("ok");
+	});
+
+	it("does not serialize across chats", async () => {
+		const started: string[] = [];
+		const blocked = createDeferred<void>();
+
+		const blocking = runExclusiveQueueMutation("chat-a", async () => {
+			started.push("a");
+			await blocked.promise;
+		});
+		const other = runExclusiveQueueMutation("chat-b", async () => {
+			started.push("b");
+		});
+
+		await other;
+		expect(started).toEqual(["a", "b"]);
+
+		blocked.resolve();
+		await blocking;
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatQueueMutations.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatQueueMutations.ts
@@ -1,0 +1,42 @@
+/**
+ * Serializes the LOCAL mutations that change a chat's queue positions: send,
+ * edit, delete, and promote.
+ *
+ * A send on an errored chat promotes the server's queue head, but the response
+ * does not say which row that was, so the client captures the head it can see
+ * and reconciles against it. Letting a delete or a promote commit inside that
+ * window makes the capture describe a queue the server no longer has, so the
+ * reconciliation suppresses the wrong row until the convergence fetch repairs
+ * it. Running one queue-position request at a time per chat removes the
+ * overlap instead of tracking per-operation ownership.
+ *
+ * The critical section covers the WHOLE operation, its suppression markers
+ * included. A marker placed before the lock belongs to an operation that has
+ * not started yet, so its failure path can lift a marker the operation holding
+ * the lock is relying on. The cost is that an optimistic removal waits for the
+ * request ahead of it; the correctness of the promoted-head veto is worth more
+ * than shaving that wait.
+ */
+const pendingByChatID = new Map<string, Promise<unknown>>();
+
+export const runExclusiveQueueMutation = <T>(
+	chatID: string,
+	run: () => Promise<T>,
+): Promise<T> => {
+	const previous = pendingByChatID.get(chatID);
+	// Uncontended, which is the normal case: start now rather than a microtask
+	// later. Both arms of the chained form run `run`, because a failed
+	// predecessor must not strand the queue.
+	const result = previous ? previous.then(run, run) : run();
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	pendingByChatID.set(chatID, settled);
+	void settled.then(() => {
+		if (pendingByChatID.get(chatID) === settled) {
+			pendingByChatID.delete(chatID);
+		}
+	});
+	return result;
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -217,127 +217,189 @@ describe("setSubagentStatusOverride", () => {
 });
 
 // ---------------------------------------------------------------------------
-// setQueuedMessages
+// acceptAuthoritativeQueueSnapshot: the accept/reject gate
 // ---------------------------------------------------------------------------
 
-describe("setQueuedMessages", () => {
-	it("stores queued messages", () => {
-		const store = createChatStore();
-		const qm = makeQueuedMessage(10, "queued");
-
-		store.setQueuedMessages([qm]);
-
-		expect(store.getSnapshot().queuedMessages).toEqual([qm]);
-	});
-
-	it("treats undefined as empty array", () => {
-		const store = createChatStore();
-		store.setQueuedMessages([makeQueuedMessage(1, "q")]);
-
-		store.setQueuedMessages(undefined);
-
-		expect(store.getSnapshot().queuedMessages).toEqual([]);
-	});
-
-	it("does not notify when queued message IDs are unchanged", () => {
-		const store = createChatStore();
-		const qm = makeQueuedMessage(10, "queued");
-		store.setQueuedMessages([qm]);
-
-		let notified = false;
-		store.subscribe(() => {
-			notified = true;
-		});
-
-		// Different object reference, same ID.
-		store.setQueuedMessages([{ ...qm }]);
-
-		expect(notified).toBe(false);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// suppressQueuedMessageID / applyAuthoritativeQueuedMessages
-// ---------------------------------------------------------------------------
-
-describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
-	it("filters suppressed IDs from authoritative writes and auto-clears", () => {
+describe("acceptAuthoritativeQueueSnapshot", () => {
+	it("accepts an ordinary snapshot and keeps unrelated markers", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
-		store.setQueuedMessages([a, b, c]);
-		store.suppressQueuedMessageID(b.id);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(true);
-
-		// Running-case promotion only reorders the queue; the backend still reports the row.
-		store.applyAuthoritativeQueuedMessages([b, a, c]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([a.id, c.id]);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(true);
-
-		store.applyAuthoritativeQueuedMessages([a, c]);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(
-			false,
+		store.suppressQueuedMessageIDs([b.id]);
+		// The running-case promotion only reorders the queue, so the backend
+		// still reports the row and the marker has to keep hiding it.
+		expect(store.acceptAuthoritativeQueueSnapshot([b, a, c], "socket")).toBe(
+			true,
 		);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([a.id, c.id]);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(b.id)).toBe(true);
 	});
 
-	it("filters suppressed IDs from REST hydration via applyAuthoritativeQueuedMessages", () => {
+	it("clears a suppression marker the accepted snapshot omits", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
-		store.suppressQueuedMessageID(b.id);
-		// REST hydration delivers the unfiltered queue [B, A, C].
-		store.applyAuthoritativeQueuedMessages([b, a, c]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([a.id, c.id]);
+		store.suppressQueuedMessageIDs([b.id]);
+		store.acceptAuthoritativeQueueSnapshot([b, a, c], "socket");
+
+		expect(store.acceptAuthoritativeQueueSnapshot([a, c], "socket")).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
-	it("still applies newly queued messages while a suppressed message stays queued", () => {
+	it("keeps a marker for an id the snapshot never listed", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const d = makeQueuedMessage(4, "D");
 
-		store.setQueuedMessages([b]);
-		store.suppressQueuedMessageID(a.id);
-
-		store.applyAuthoritativeQueuedMessages([a, b, d]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id, d.id]);
+		store.suppressQueuedMessageIDs([a.id]);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b, d], "socket")).toBe(
+			true,
+		);
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(true);
 	});
 
-	it("ignores stale snapshots that still list a promoted message", () => {
+	it("rejects a stale snapshot that still lists a promoted message", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
-		store.setQueuedMessages([b, c]);
 		store.markQueuedMessagePromoted(a.id);
+		const fenceBefore = store.getQueueConvergenceFence();
 
-		store.applyAuthoritativeQueuedMessages([a, b]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id, c.id]);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "socket")).toBe(
+			false,
+		);
+		// A rejected snapshot advances nothing and retires nothing.
+		expect(store.getQueueConvergenceFence()).toBe(fenceBefore);
 		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
 
-		store.applyAuthoritativeQueuedMessages([b, c]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id, c.id]);
+		expect(store.acceptAuthoritativeQueueSnapshot([b, c], "socket")).toBe(true);
 		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("advances the fence once for the cache echo of its own write", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const fenceBefore = store.getQueueConvergenceFence();
+
+		expect(store.acceptAuthoritativeQueueSnapshot([a], "socket")).toBe(true);
+		const fenceAfterFirst = store.getQueueConvergenceFence();
+		expect(fenceAfterFirst).not.toBe(fenceBefore);
+
+		// Writing the accepted snapshot to the cache changes the cached value,
+		// so the write path arms the echo it is about to produce.
+		store.noteLocalQueueProjection([a]);
+
+		// The cache arm observing that write.
+		expect(store.acceptAuthoritativeQueueSnapshot([{ ...a }], "cache")).toBe(
+			true,
+		);
+		expect(store.getQueueConvergenceFence()).toBe(fenceAfterFirst);
+	});
+
+	it("does not arm a cache echo for the snapshot it accepts", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+
+		// Whether the write that follows changes the cached value is the write
+		// path's business, so the gate never arms an expectation of its own. A
+		// snapshot equal to what is already cached collapses on write and
+		// produces no observation to consume one.
+		expect(store.acceptAuthoritativeQueueSnapshot([a], "socket")).toBe(true);
+		store.markQueuedMessagePromoted(98);
+		const fenceBefore = store.getQueueConvergenceFence();
+
+		expect(store.acceptAuthoritativeQueueSnapshot([{ ...a }], "cache")).toBe(
+			true,
+		);
+		expect(store.getQueueConvergenceFence()).not.toBe(fenceBefore);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(98)).toBe(false);
+	});
+
+	it("does not re-gate a value the client projected into the cache itself", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.markQueuedMessagePromoted(a.id);
+		store.noteLocalQueueProjection([b]);
+		const fenceBefore = store.getQueueConvergenceFence();
+
+		// The cache arm observing the promoted-head projection must not treat it
+		// as a server snapshot, or it would retire the marker the send just set.
+		expect(store.acceptAuthoritativeQueueSnapshot([b], "cache")).toBe(true);
+		expect(store.getQueueConvergenceFence()).toBe(fenceBefore);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
+	});
+
+	it("gates a socket snapshot that repeats the projected value", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.markQueuedMessagePromoted(a.id);
+		store.noteLocalQueueProjection([b]);
+		const fenceBefore = store.getQueueConvergenceFence();
+
+		// Same value, but the server is the one saying it now: the projection
+		// is confirmed, so the promoted marker it protected has to retire and
+		// the fence has to move.
+		expect(store.acceptAuthoritativeQueueSnapshot([{ ...b }], "socket")).toBe(
+			true,
+		);
+		expect(store.getQueueConvergenceFence()).not.toBe(fenceBefore);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("gates a second cache observation of the projected value", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.markQueuedMessagePromoted(a.id);
+		store.noteLocalQueueProjection([b]);
+		store.acceptAuthoritativeQueueSnapshot([b], "cache");
+		const fenceAfterEcho = store.getQueueConvergenceFence();
+
+		// The expectation is consumed by the first observation. A page-0
+		// install carrying the same value afterwards is a server statement.
+		expect(store.acceptAuthoritativeQueueSnapshot([{ ...b }], "cache")).toBe(
+			true,
+		);
+		expect(store.getQueueConvergenceFence()).not.toBe(fenceAfterEcho);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+	});
+
+	it("rejects a promoted-listing snapshot before consuming the echo", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.noteLocalQueueProjection([a, b]);
+		store.markQueuedMessagePromoted(a.id);
+
+		// The veto outranks the echo: the projection is stale the moment a row
+		// it lists is confirmed promoted.
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "cache")).toBe(false);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
+	});
+
+	it("does not record a client-projected tail as server-observed", () => {
+		const store = createChatStore();
+		const tail = makeQueuedMessage(7, "tail");
+
+		store.noteLocalQueueProjection([tail]);
+		store.acceptAuthoritativeQueueSnapshot([tail], "cache");
+
+		// The send response returned this row; the server has not LISTED it in
+		// a queue snapshot, which is the question the reconciliation asks.
+		expect(store.hasObservedQueuedMessageID(tail.id)).toBe(false);
 	});
 
 	it("records queued IDs the server has reported", () => {
@@ -347,126 +409,126 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		const c = makeQueuedMessage(3, "C");
 
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
-		store.applyAuthoritativeQueuedMessages([a, b]);
+		store.acceptAuthoritativeQueueSnapshot([a, b], "socket");
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(true);
 		expect(store.hasObservedQueuedMessageID(b.id)).toBe(true);
 
-		store.applyAuthoritativeQueuedMessages([b]);
+		store.acceptAuthoritativeQueueSnapshot([b], "socket");
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(true);
-
-		store.setQueuedMessages([b, c]);
 		expect(store.hasObservedQueuedMessageID(c.id)).toBe(false);
 
 		store.clearSuppressedQueuedMessageIDs();
 		expect(store.hasObservedQueuedMessageID(a.id)).toBe(false);
 	});
+});
 
-	it("restores a promoted head that a fresh snapshot still queues", () => {
+// ---------------------------------------------------------------------------
+// acceptQueueConvergence
+// ---------------------------------------------------------------------------
+
+describe("acceptQueueConvergence", () => {
+	it("clears the promoted head's markers", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
 		expect(
-			store
-				.applyPromoteRefetchQueuedMessages(testChatID, a.id, [a, b], baseline)
-				?.map((message) => message.id),
-		).toEqual([a.id, b.id]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([a.id, b.id]);
+			store.acceptQueueConvergence(testChatID, a.id, [a, b], baseline),
+		).toBe(true);
 		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
 		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
 	});
 
-	it("ignores a promote refetch that a newer snapshot already superseded", () => {
+	it("leaves an unrelated suppression marker in place", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
+		store.markQueuedMessagePromoted(a.id);
+		// An overlapping explicit promotion suppresses C, which the server has
+		// not deleted yet, so it stays hidden at read time.
+		store.suppressQueuedMessageIDs([c.id]);
+
+		expect(
+			store.acceptQueueConvergence(
+				testChatID,
+				a.id,
+				[a, b, c],
+				store.getQueueConvergenceFence(),
+			),
+		).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(c.id)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(
+			false,
+		);
+	});
+
+	it("rejects a refetch that a newer snapshot already superseded", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
+
+		store.setActiveChatID(testChatID);
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
-		store.applyAuthoritativeQueuedMessages([b, c]);
+		store.acceptAuthoritativeQueueSnapshot([b, c], "socket");
 
 		expect(
-			store.applyPromoteRefetchQueuedMessages(
-				testChatID,
-				a.id,
-				[a, b],
-				baseline,
-			),
-		).toBeUndefined();
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id, c.id]);
+			store.acceptQueueConvergence(testChatID, a.id, [a, b], baseline),
+		).toBe(false);
+		// The accepted snapshot already retired the promoted marker.
 		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
 	});
 
-	it("still applies a promote refetch after a stale snapshot was discarded", () => {
+	it("still accepts a refetch after a stale snapshot was rejected", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
-		store.applyAuthoritativeQueuedMessages([a, b, c]);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b, c], "socket")).toBe(
+			false,
+		);
 
 		expect(
-			store.applyPromoteRefetchQueuedMessages(
-				testChatID,
-				a.id,
-				[b, c],
-				baseline,
-			),
-		).toEqual([b, c]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id, c.id]);
+			store.acceptQueueConvergence(testChatID, a.id, [b, c], baseline),
+		).toBe(true);
 	});
 
-	it("ignores a promote refetch that resolves after switching chats", () => {
+	it("rejects a refetch that resolves after switching chats", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
 		store.setActiveChatID("chat-other");
-		store.setQueuedMessages([]);
 
 		expect(
-			store.applyPromoteRefetchQueuedMessages(
-				testChatID,
-				a.id,
-				[a, b],
-				baseline,
-			),
-		).toBeUndefined();
-		expect(store.getSnapshot().queuedMessages).toEqual([]);
+			store.acceptQueueConvergence(testChatID, a.id, [a, b], baseline),
+		).toBe(false);
 	});
 
-	it("ignores a promote refetch spanning a round trip back to the same chat", () => {
+	it("rejects a refetch spanning a round trip back to the same chat", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 		const baseline = store.getQueueConvergenceFence();
 
@@ -474,101 +536,199 @@ describe("suppressQueuedMessageID / applyAuthoritativeQueuedMessages", () => {
 		store.setActiveChatID(testChatID);
 
 		expect(
-			store.applyPromoteRefetchQueuedMessages(
-				testChatID,
-				a.id,
-				[a, b],
-				baseline,
-			),
-		).toBeUndefined();
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id]);
+			store.acceptQueueConvergence(testChatID, a.id, [a, b], baseline),
+		).toBe(false);
 	});
 
-	it("ignores a promote refetch naming another chat even at a matching fence", () => {
+	it("rejects a refetch naming another chat even at a matching fence", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
 		store.markQueuedMessagePromoted(a.id);
 
 		expect(
-			store.applyPromoteRefetchQueuedMessages(
+			store.acceptQueueConvergence(
 				"chat-other",
 				a.id,
 				[a, b],
 				store.getQueueConvergenceFence(),
 			),
-		).toBeUndefined();
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([b.id]);
+		).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// suppression markers
+// ---------------------------------------------------------------------------
+
+describe("suppressQueuedMessageIDs / unsuppressQueuedMessageIDs", () => {
+	it("adds and removes IDs from the suppression set", () => {
+		const store = createChatStore();
+		store.suppressQueuedMessageIDs([42, 43]);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(42)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(43)).toBe(true);
+
+		store.unsuppressQueuedMessageIDs([42]);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(42)).toBe(false);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(43)).toBe(true);
 	});
 
-	it("returns the queue it applied, not the raw snapshot", () => {
+	it("does not notify when every ID is already suppressed", () => {
+		const store = createChatStore();
+		store.suppressQueuedMessageIDs([42]);
+
+		let notified = false;
+		store.subscribe(() => {
+			notified = true;
+		});
+
+		store.suppressQueuedMessageIDs([42]);
+		store.unsuppressQueuedMessageIDs([99]);
+
+		expect(notified).toBe(false);
+	});
+
+	it("keeps a promoted marker a failed queue operation does not own", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+
+		store.markQueuedMessagePromoted(a.id);
+		// A delete of the same ID failing after a send promoted it: the send
+		// owns the veto, and only its convergence may retire it.
+		store.unsuppressQueuedMessageIDs([a.id]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(a.id)).toBe(true);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(a.id)).toBe(true);
+
+		// The veto still stands, so the snapshot that still queues A is stale.
+		expect(store.acceptAuthoritativeQueueSnapshot([a], "socket")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// abandonQueueConvergence: the veto is bounded by its convergence fetch
+// ---------------------------------------------------------------------------
+
+describe("abandonQueueConvergence", () => {
+	it("returns the newest vetoed snapshot and resumes queue updates", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 		const c = makeQueuedMessage(3, "C");
 
 		store.setActiveChatID(testChatID);
-		store.setQueuedMessages([b]);
+		// A wrong head guess: the server never promoted A.
 		store.markQueuedMessagePromoted(a.id);
-		store.suppressQueuedMessageID(c.id);
 		const baseline = store.getQueueConvergenceFence();
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "socket")).toBe(
+			false,
+		);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b, c], "socket")).toBe(
+			false,
+		);
 
-		expect(
-			store
-				.applyPromoteRefetchQueuedMessages(
-					testChatID,
-					a.id,
-					[a, b, c],
-					baseline,
-				)
-				?.map((message) => message.id),
-		).toEqual([a.id, b.id]);
-		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([a.id, b.id]);
+		// The convergence fetch failed. The newest rejected snapshot is the last
+		// thing the server said, and nothing will resend it.
+		expect(store.abandonQueueConvergence(testChatID, a.id, baseline)).toEqual([
+			a,
+			b,
+			c,
+		]);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.size).toBe(0);
+		expect(store.getQueueConvergenceFence()).not.toBe(baseline);
+
+		// Later snapshots that still list the guessed head are accepted again.
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b, c], "socket")).toBe(
+			true,
+		);
 	});
 
-	it("unsuppressQueuedMessageID clears a promoted marker after a failed promotion", () => {
+	it("clears the marker with no corrective snapshot when nothing was vetoed", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
 		const b = makeQueuedMessage(2, "B");
 
+		store.setActiveChatID(testChatID);
 		store.markQueuedMessagePromoted(a.id);
-		store.unsuppressQueuedMessageID(a.id);
-		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		const baseline = store.getQueueConvergenceFence();
 
-		store.applyAuthoritativeQueuedMessages([a, b]);
+		// Nothing was rejected, so the cache still holds the projection the send
+		// wrote and there is no truth to restore.
 		expect(
-			store.getSnapshot().queuedMessages.map((message) => message.id),
-		).toEqual([a.id, b.id]);
+			store.abandonQueueConvergence(testChatID, a.id, baseline),
+		).toBeUndefined();
+		expect(store.getSnapshot().promotedQueuedMessageIDs.size).toBe(0);
+		expect(store.acceptAuthoritativeQueueSnapshot([a, b], "socket")).toBe(true);
 	});
 
-	it("unsuppressQueuedMessageID removes IDs from the suppression set", () => {
-		const store = createChatStore();
-		store.suppressQueuedMessageID(42);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(42)).toBe(true);
-		store.unsuppressQueuedMessageID(42);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(42)).toBe(false);
-	});
-
-	it("setQueuedMessages does not auto-clear suppression", () => {
+	it("keeps another send's promotion veto", () => {
 		const store = createChatStore();
 		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
 
-		store.suppressQueuedMessageID(99);
-		// setQueuedMessages is the optimistic path: it must not
-		// touch the suppression set, otherwise the optimistic write
-		// would lift suppression before the authoritative reordered
-		// queue arrives.
-		store.setQueuedMessages([a]);
-		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(99)).toBe(true);
+		store.setActiveChatID(testChatID);
+		store.markQueuedMessagePromoted(a.id);
+		store.markQueuedMessagePromoted(b.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		store.abandonQueueConvergence(testChatID, a.id, baseline);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(b.id)).toBe(true);
+	});
+
+	it("does nothing once a newer snapshot moved the fence", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.setActiveChatID(testChatID);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+		// This snapshot omits A, so it already retired the veto.
+		store.acceptAuthoritativeQueueSnapshot([b], "socket");
+		const fenceAfterAccept = store.getQueueConvergenceFence();
+
+		expect(
+			store.abandonQueueConvergence(testChatID, a.id, baseline),
+		).toBeUndefined();
+		expect(store.getQueueConvergenceFence()).toBe(fenceAfterAccept);
+	});
+
+	it("does nothing after switching chats", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+
+		store.setActiveChatID(testChatID);
+		store.markQueuedMessagePromoted(a.id);
+		const baseline = store.getQueueConvergenceFence();
+		store.acceptAuthoritativeQueueSnapshot([a, b], "socket");
+		store.setActiveChatID("chat-other");
+
+		expect(
+			store.abandonQueueConvergence(testChatID, a.id, baseline),
+		).toBeUndefined();
+	});
+
+	it("drops a vetoed snapshot a later acceptance superseded", () => {
+		const store = createChatStore();
+		const a = makeQueuedMessage(1, "A");
+		const b = makeQueuedMessage(2, "B");
+		const c = makeQueuedMessage(3, "C");
+
+		store.setActiveChatID(testChatID);
+		store.markQueuedMessagePromoted(a.id);
+		store.acceptAuthoritativeQueueSnapshot([a, b], "socket");
+		// Omits A, so it is accepted and retires the veto, and it is newer than
+		// the snapshot the veto rejected.
+		store.acceptAuthoritativeQueueSnapshot([b, c], "socket");
+		store.markQueuedMessagePromoted(b.id);
+		const baseline = store.getQueueConvergenceFence();
+
+		expect(
+			store.abandonQueueConvergence(testChatID, b.id, baseline),
+		).toBeUndefined();
 	});
 });
 
@@ -688,9 +848,9 @@ describe("resetTransientState", () => {
 		expect(state.subagentStatusOverrides.size).toBe(0);
 	});
 
-	it("preserves the queue", () => {
+	it("preserves the queue suppression markers", () => {
 		const store = createChatStore();
-		store.setQueuedMessages([makeQueuedMessage(10, "queued")]);
+		store.suppressQueuedMessageIDs([10]);
 		store.setStreamError({
 			kind: "generic",
 			message: "oops",
@@ -698,7 +858,7 @@ describe("resetTransientState", () => {
 
 		store.resetTransientState();
 
-		expect(store.getSnapshot().queuedMessages).toHaveLength(1);
+		expect(store.getSnapshot().suppressedQueuedMessageIDs.has(10)).toBe(true);
 	});
 
 	it("is a no-op when all transient state is already clean", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -60,7 +60,6 @@ import {
 	resolveOverlayStreamState,
 	selectFinalizingMessageID,
 	selectFinalizingStreamState,
-	selectQueuedMessages,
 	selectReconnectState,
 	selectRetryState,
 	selectStreamError,
@@ -241,11 +240,17 @@ const createTestQueryClient = (): QueryClient =>
 
 /**
  * In the app the infinite messages query IS the source of the durable
- * messages, and both the socket and every reader go through its cache entry.
- * Tests pass the flat list as a prop, so mirror it into the cache the way the
- * query would, unless the test seeded the entry itself.
+ * messages and the queue, and both the socket and every reader go through its
+ * cache entry. Tests pass the flat list as a prop, so mirror it into the cache
+ * the way the query would, unless the test seeded the entry itself.
  */
-const useTestChatStore: typeof useChatStore = (options) => {
+type TestChatStoreOptions = Parameters<typeof useChatStore>[0] & {
+	chatQueuedMessages?: readonly TypesGen.ChatQueuedMessage[];
+};
+
+const useTestChatStore = (
+	options: TestChatStoreOptions,
+): ReturnType<typeof useChatStore> => {
 	const queryClient = useQueryClient();
 	const chatRecord = options.chatRecord;
 	if (
@@ -389,11 +394,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -462,11 +462,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -505,11 +500,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -602,11 +592,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -694,11 +679,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -755,11 +735,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -852,11 +827,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: initialMessages,
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: initialMessages,
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -950,11 +920,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: initialMessages,
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: initialMessages,
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -1030,11 +995,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -1103,11 +1063,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -1181,7 +1136,7 @@ describe("useChatStore", () => {
 		};
 
 		const QueueProbe: FC<{ store: ChatStoreHandle }> = ({ store }) => {
-			useChatSelector(store, selectQueuedMessages);
+			useDurableQueuedMessages({ store, chatId: chatID });
 			queueRenderCount += 1;
 			return null;
 		};
@@ -1199,11 +1154,6 @@ describe("useChatStore", () => {
 				chatID,
 				chatMessages: [existingMessage],
 				chatRecord: buildChat(chatID),
-				chatMessagesData: {
-					messages: [existingMessage],
-					queued_messages: [],
-					has_more: false,
-				},
 				chatQueuedMessages: [],
 				setChatErrorReason,
 				clearChatErrorReason,
@@ -1271,11 +1221,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -1344,11 +1289,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -1428,7 +1368,7 @@ describe("useChatStore", () => {
 		});
 	});
 
-	it("does not restore stale queued messages after a stream queue_update", async () => {
+	it("renders the queue from the cache after a stream queue_update", async () => {
 		const chatID = "chat-1";
 		const existingMessage = buildMessage(chatID, 1, "user", "hello");
 		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
@@ -1439,23 +1379,17 @@ describe("useChatStore", () => {
 		const wrapper = createWrapper(queryClient);
 		const setChatErrorReason = vi.fn();
 		const clearChatErrorReason = vi.fn();
-		const initialOptions = {
-			chatID,
-			chatMessages: [existingMessage],
-			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: [existingMessage],
-				queued_messages: [queuedMessage],
-				has_more: false,
-			},
-			chatQueuedMessages: [queuedMessage],
-			setChatErrorReason,
-			clearChatErrorReason,
-		};
 
-		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useTestChatStore(options);
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatQueuedMessages: [queuedMessage],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
 				return {
 					queuedMessages: useDurableQueuedMessages({
 						store,
@@ -1463,10 +1397,7 @@ describe("useChatStore", () => {
 					}),
 				};
 			},
-			{
-				initialProps: initialOptions,
-				wrapper,
-			},
+			{ wrapper },
 		);
 
 		await waitFor(() => {
@@ -1484,26 +1415,17 @@ describe("useChatStore", () => {
 			});
 		});
 
+		// The store keeps no queue mirror, so the list can only be reading the
+		// cache the socket wrote.
 		await waitFor(() => {
 			expect(result.current.queuedMessages).toEqual([]);
 		});
-
-		rerender({
-			...initialOptions,
-			chatMessagesData: {
-				messages: [existingMessage],
-				queued_messages: [queuedMessage],
-				has_more: false,
-			},
-			chatQueuedMessages: [queuedMessage],
-		});
-
-		await waitFor(() => {
-			expect(result.current.queuedMessages).toEqual([]);
-		});
+		expect(
+			readMessagesCache(queryClient, chatID)?.pages[0]?.queued_messages,
+		).toEqual([]);
 	});
 
-	it("corrects stale queued messages from cache when switching back to a chat", async () => {
+	it("writes a queue_update snapshot into the cache verbatim", async () => {
 		const chatID = "chat-1";
 		const existingMessage = buildMessage(chatID, 1, "user", "hello");
 		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
@@ -1512,98 +1434,6 @@ describe("useChatStore", () => {
 
 		const queryClient = createTestQueryClient();
 		const wrapper = createWrapper(queryClient);
-		const setChatErrorReason = vi.fn();
-		const clearChatErrorReason = vi.fn();
-
-		// Start with queued messages from a stale React Query cache.
-		// This simulates coming back to a chat whose queue was drained
-		// server-side while the user was viewing a different chat.
-		const staleOptions = {
-			chatID,
-			chatMessages: [existingMessage],
-			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: [existingMessage],
-				queued_messages: [queuedMessage],
-				has_more: false,
-			},
-			chatQueuedMessages: [queuedMessage],
-			setChatErrorReason,
-			clearChatErrorReason,
-		};
-
-		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
-				const { store } = useTestChatStore(options);
-				return {
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
-				};
-			},
-			{
-				initialProps: staleOptions,
-				wrapper,
-			},
-		);
-
-		await waitFor(() => {
-			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
-		});
-		// Initially shows the stale queued message from cache.
-		expect(result.current.queuedMessages.map((m) => m.id)).toEqual([
-			queuedMessage.id,
-		]);
-
-		// Simulate the REST query refetching and returning fresh
-		// data with an empty queue (no queue_update from WS yet).
-		rerender({
-			...staleOptions,
-			chatMessagesData: {
-				messages: [existingMessage],
-				queued_messages: [],
-				has_more: false,
-			},
-			chatQueuedMessages: [],
-		});
-
-		// The store should accept the fresh REST data because the
-		// WebSocket hasn't sent a queue_update yet.
-		await waitFor(() => {
-			expect(result.current.queuedMessages).toEqual([]);
-		});
-	});
-
-	it("writes queue_update snapshots into the chat query cache", async () => {
-		const chatID = "chat-1";
-		const existingMessage = buildMessage(chatID, 1, "user", "hello");
-		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-
-		const queryClient = new QueryClient({
-			defaultOptions: {
-				queries: {
-					retry: false,
-					gcTime: Number.POSITIVE_INFINITY,
-					refetchOnWindowFocus: false,
-					networkMode: "offlineFirst",
-				},
-			},
-		});
-		const initialChatMessagesData: TypesGen.ChatMessagesResponse = {
-			messages: [existingMessage],
-			queued_messages: [queuedMessage],
-			has_more: false,
-		};
-		// The cache is InfiniteData<ChatMessagesResponse> after the
-		// migration to useInfiniteQuery for chat messages.
-		queryClient.setQueryData(chatKeys.messages(chatID), {
-			pages: [initialChatMessagesData],
-			pageParams: [undefined],
-		});
-
-		const wrapper = createWrapper(queryClient);
-		const setChatErrorReason = vi.fn();
-		const clearChatErrorReason = vi.fn();
 
 		const { result } = renderHook(
 			() => {
@@ -1611,85 +1441,16 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: initialChatMessagesData,
 					chatQueuedMessages: [queuedMessage],
-					setChatErrorReason,
-					clearChatErrorReason,
-				});
-				return {
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
-				};
-			},
-			{ wrapper },
-		);
-
-		await waitFor(() => {
-			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
-		});
-
-		act(() => {
-			mockSocket.emitData({
-				type: "queue_update",
-				chat_id: chatID,
-				queued_messages: [],
-			});
-		});
-
-		await waitFor(() => {
-			expect(result.current.queuedMessages).toEqual([]);
-		});
-		const cachedData = queryClient.getQueryData<{
-			pages: TypesGen.ChatMessagesResponse[];
-			pageParams: unknown[];
-		}>(chatKeys.messages(chatID));
-		expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
-	});
-
-	it("caches the filtered queue when a queue_update still contains a suppressed message", async () => {
-		const chatID = "chat-1";
-		const existingMessage = buildMessage(chatID, 1, "user", "hello");
-		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
-		const mockSocket = createMockSocket();
-		mockWatchChatReturn(mockSocket);
-
-		const queryClient = new QueryClient({
-			defaultOptions: {
-				queries: {
-					retry: false,
-					gcTime: Number.POSITIVE_INFINITY,
-					refetchOnWindowFocus: false,
-					networkMode: "offlineFirst",
-				},
-			},
-		});
-		const initialChatMessagesData: TypesGen.ChatMessagesResponse = {
-			messages: [existingMessage],
-			queued_messages: [queuedMessage],
-			has_more: false,
-		};
-		queryClient.setQueryData(chatKeys.messages(chatID), {
-			pages: [initialChatMessagesData],
-			pageParams: [undefined],
-		});
-
-		const wrapper = createWrapper(queryClient);
-		const setChatErrorReason = vi.fn();
-		const clearChatErrorReason = vi.fn();
-
-		const { result } = renderHook(
-			() => {
-				const { store } = useTestChatStore({
-					chatID,
-					chatMessages: [existingMessage],
-					chatRecord: buildChat(chatID),
-					chatMessagesData: initialChatMessagesData,
-					chatQueuedMessages: [queuedMessage],
-					setChatErrorReason,
-					clearChatErrorReason,
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
 				});
 				return {
 					store,
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: chatID,
+					}),
 				};
 			},
 			{ wrapper },
@@ -1699,8 +1460,10 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 		});
 
+		// The running-case promote: the row is hidden locally, but the server
+		// still reports it queued (reordered to the front) until it promotes it.
 		act(() => {
-			result.current.store.suppressQueuedMessageID(queuedMessage.id);
+			result.current.store.suppressQueuedMessageIDs([queuedMessage.id]);
 		});
 		act(() => {
 			mockSocket.emitData({
@@ -1713,11 +1476,209 @@ describe("useChatStore", () => {
 		await waitFor(() => {
 			expect(result.current.queuedMessages).toEqual([]);
 		});
-		const cachedData = queryClient.getQueryData<{
-			pages: TypesGen.ChatMessagesResponse[];
-			pageParams: unknown[];
-		}>(chatKeys.messages(chatID));
-		expect(cachedData?.pages[0]?.queued_messages).toEqual([]);
+		// Verbatim: the cache holds server truth and the marker hides the row.
+		expect(
+			readMessagesCache(queryClient, chatID)?.pages[0]?.queued_messages,
+		).toEqual([queuedMessage]);
+
+		// The server finally promotes it and omits it from the snapshot, which
+		// retires the marker.
+		act(() => {
+			mockSocket.emitData({
+				type: "queue_update",
+				chat_id: chatID,
+				queued_messages: [],
+			});
+		});
+
+		await waitFor(() => {
+			expect(
+				result.current.store.getSnapshot().suppressedQueuedMessageIDs.size,
+			).toBe(0);
+		});
+	});
+
+	it("keeps a queue update that lands while a removal marker is set", async () => {
+		const chatID = "chat-1";
+		const existingMessage = buildMessage(chatID, 1, "user", "hello");
+		const deleted = buildQueuedMessage(chatID, 10, "deleted");
+		const arrived = buildQueuedMessage(chatID, 11, "arrived");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatQueuedMessages: [deleted],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					store,
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: chatID,
+					}),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// The optimistic half of a delete: a marker, no cache write.
+		act(() => {
+			result.current.store.suppressQueuedMessageIDs([deleted.id]);
+		});
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([]);
+		});
+
+		// A queue_update for an unrelated enqueue lands mid-request. Nothing
+		// rolls back a snapshot here, so the new entry survives.
+		act(() => {
+			mockSocket.emitData({
+				type: "queue_update",
+				chat_id: chatID,
+				queued_messages: [deleted, arrived],
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([arrived]);
+		});
+		expect(
+			readMessagesCache(queryClient, chatID)?.pages[0]?.queued_messages,
+		).toEqual([deleted, arrived]);
+
+		// The delete fails, so the marker is dropped. No cache rollback runs,
+		// and the entry that arrived meanwhile is still there.
+		act(() => {
+			result.current.store.unsuppressQueuedMessageIDs([deleted.id]);
+		});
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([deleted, arrived]);
+		});
+	});
+
+	it("renders the retained cached queue when re-entering a chat", async () => {
+		const chatID = "chat-1";
+		const otherChatID = "chat-2";
+		const existingMessage = buildMessage(chatID, 1, "user", "hello");
+		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
+		mockWatchChatWithFreshSockets();
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const initialOptions: TestChatStoreOptions = {
+			chatID,
+			chatMessages: [existingMessage],
+			chatRecord: buildChat(chatID),
+			chatQueuedMessages: [queuedMessage],
+			setChatErrorReason: vi.fn(),
+			clearChatErrorReason: vi.fn(),
+		};
+
+		const { result, rerender } = renderHook(
+			(options: TestChatStoreOptions) => {
+				const { store } = useTestChatStore(options);
+				return {
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: options.chatID,
+					}),
+				};
+			},
+			{ initialProps: initialOptions, wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([queuedMessage]);
+		});
+
+		rerender({
+			...initialOptions,
+			chatID: otherChatID,
+			chatMessages: [],
+			chatRecord: buildChat(otherChatID),
+			chatQueuedMessages: [],
+		});
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([]);
+		});
+
+		// Re-entry within gcTime renders the retained cached queue for one
+		// socket round trip instead of an empty list. Accepted behavior change:
+		// the store no longer blanks a mirror on chat change. An evicted entry
+		// renders nothing until REST or the socket repopulates it, which is what
+		// the canonical-read projection test covers.
+		rerender(initialOptions);
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([queuedMessage]);
+		});
+	});
+
+	it("keeps a suppression marker across a socket reconnect", async () => {
+		const chatID = "chat-1";
+		const existingMessage = buildMessage(chatID, 1, "user", "hello");
+		const queuedMessage = buildQueuedMessage(chatID, 10, "queued");
+		const sockets = mockWatchChatWithFreshSockets();
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useTestChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatQueuedMessages: [queuedMessage],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					store,
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: chatID,
+					}),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(sockets.length).toBe(1);
+		});
+
+		act(() => {
+			result.current.store.suppressQueuedMessageIDs([queuedMessage.id]);
+		});
+		await waitFor(() => {
+			expect(result.current.queuedMessages).toEqual([]);
+		});
+
+		// onOpen fires before the reconnected socket replays its snapshot, so
+		// clearing markers there would flash a legitimately hidden row back in.
+		act(() => {
+			sockets[0].emitOpen();
+		});
+
+		expect(
+			result.current.store
+				.getSnapshot()
+				.suppressedQueuedMessageIDs.has(queuedMessage.id),
+		).toBe(true);
+		expect(result.current.queuedMessages).toEqual([]);
 	});
 
 	it("writes WebSocket message events into the chat query cache", async () => {
@@ -1756,7 +1717,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: initialChatMessagesData,
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -1851,11 +1811,6 @@ describe("useChatStore", () => {
 			chatID: chatID1,
 			chatMessages: [msg1] as TypesGen.ChatMessage[],
 			chatRecord: buildChat(chatID1),
-			chatMessagesData: {
-				messages: [msg1],
-				queued_messages: [] as TypesGen.ChatQueuedMessage[],
-				has_more: false,
-			},
 			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
 			setChatErrorReason,
 			clearChatErrorReason,
@@ -1900,11 +1855,6 @@ describe("useChatStore", () => {
 			chatID: chatID2,
 			chatMessages: [msg2],
 			chatRecord: buildChat(chatID2),
-			chatMessagesData: {
-				messages: [msg2],
-				queued_messages: [],
-				has_more: false,
-			},
 		});
 
 		await waitFor(() => {
@@ -1936,17 +1886,15 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [queuedMessage],
-						has_more: false,
-					},
 					chatQueuedMessages: [queuedMessage],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
 				return {
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: chatID,
+					}),
 				};
 			},
 			{ wrapper },
@@ -1990,11 +1938,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -2095,11 +2038,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -2189,11 +2127,6 @@ describe("useChatStore", () => {
 			chatID: chatID1,
 			chatMessages: [msg1] as TypesGen.ChatMessage[],
 			chatRecord: buildChat(chatID1),
-			chatMessagesData: {
-				messages: [msg1],
-				queued_messages: [] as TypesGen.ChatQueuedMessage[],
-				has_more: false,
-			},
 			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
 			setChatErrorReason,
 			clearChatErrorReason,
@@ -2238,11 +2171,6 @@ describe("useChatStore", () => {
 			chatID: chatID2,
 			chatMessages: [msg2],
 			chatRecord: buildChat(chatID2),
-			chatMessagesData: {
-				messages: [msg2],
-				queued_messages: [],
-				has_more: false,
-			},
 		});
 
 		await waitFor(() => {
@@ -2278,21 +2206,19 @@ describe("useChatStore", () => {
 			chatID: chatID1,
 			chatMessages: [msg1] as TypesGen.ChatMessage[],
 			chatRecord: buildChat(chatID1),
-			chatMessagesData: {
-				messages: [msg1],
-				queued_messages: [queuedMsg],
-				has_more: false,
-			},
 			chatQueuedMessages: [queuedMsg],
 			setChatErrorReason,
 			clearChatErrorReason,
 		};
 
 		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
+			(options: TestChatStoreOptions) => {
 				const { store } = useTestChatStore(options);
 				return {
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: options.chatID,
+					}),
 				};
 			},
 			{ initialProps: initialOptions, wrapper },
@@ -2314,16 +2240,11 @@ describe("useChatStore", () => {
 			chatID: chatID2,
 			chatMessages: [],
 			chatRecord: buildChat(chatID2),
-			chatMessagesData: {
-				messages: [],
-				queued_messages: [],
-				has_more: false,
-			},
 			chatQueuedMessages: [],
 		});
 
-		// After the switch, queued messages from chat-1 should NOT be
-		// visible — the store resets them on chatID change.
+		// After the switch, queued messages from chat-1 must NOT be visible:
+		// the facade reads the new chat's cache entry.
 		await waitFor(() => {
 			expect(watchChat).toHaveBeenCalledWith(chatID2, undefined);
 		});
@@ -2348,11 +2269,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -2408,11 +2324,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -2633,11 +2544,6 @@ describe("useChatStore", () => {
 						status: "running",
 						snapshot_version: 7,
 					}),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -2770,11 +2676,6 @@ describe("useChatStore", () => {
 						status: "running",
 						snapshot_version: 7,
 					}),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason: vi.fn(),
@@ -2906,11 +2807,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -2955,11 +2851,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3033,11 +2924,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3088,11 +2974,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3151,11 +3032,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3232,11 +3108,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3316,11 +3187,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3378,11 +3244,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3457,11 +3318,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3532,11 +3388,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3608,11 +3459,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: { ...buildChat(chatID), status: "waiting" },
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -3655,11 +3501,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -3706,11 +3547,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [msg],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [msg],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -3769,11 +3605,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3892,11 +3723,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -3951,22 +3777,20 @@ describe("useChatStore", () => {
 			chatID,
 			chatMessages: initialMessages,
 			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: initialMessages,
-				queued_messages: [queuedMsg],
-				has_more: false,
-			},
 			chatQueuedMessages: [queuedMsg],
 			setChatErrorReason,
 			clearChatErrorReason,
 		};
 
 		const { result, rerender } = renderHook(
-			(options: Parameters<typeof useChatStore>[0]) => {
+			(options: TestChatStoreOptions) => {
 				const { store } = useTestChatStore(options);
 				return {
 					messages: useDurableMessageList({ store, chatId: chatID }),
-					queuedMessages: useChatSelector(store, selectQueuedMessages),
+					queuedMessages: useDurableQueuedMessages({
+						store,
+						chatId: chatID,
+					}),
 				};
 			},
 			{ initialProps: initialOptions, wrapper },
@@ -4012,11 +3836,6 @@ describe("useChatStore", () => {
 			// Spread into a new array to reproduce the new reference a queue
 			// cache write hands to every reader.
 			chatMessages: [...initialMessages],
-			chatMessagesData: {
-				messages: [...initialMessages],
-				queued_messages: [],
-				has_more: false,
-			},
 			chatQueuedMessages: [],
 		});
 		await waitFor(() => {
@@ -4047,11 +3866,6 @@ describe("useChatStore", () => {
 			chatID,
 			chatMessages: initialMessages,
 			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: initialMessages,
-				queued_messages: [queuedMsg],
-				has_more: false,
-			},
 			chatQueuedMessages: [queuedMsg],
 			setChatErrorReason,
 			clearChatErrorReason,
@@ -4147,11 +3961,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: props.chatRecord,
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -4220,11 +4029,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4297,11 +4101,6 @@ describe("useChatStore", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4396,11 +4195,6 @@ describe("thinking indicator event ordering", () => {
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: { ...buildChat(chatID), status: "running" },
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4483,11 +4277,6 @@ describe("thinking indicator event ordering", () => {
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: { ...buildChat(chatID), status: "running" },
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4565,11 +4354,6 @@ describe("thinking indicator event ordering", () => {
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: { ...buildChat(chatID), status: "running" },
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4653,11 +4437,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4716,11 +4495,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4787,11 +4561,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4852,11 +4621,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: activeChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4924,11 +4688,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -4993,11 +4752,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -5058,11 +4812,6 @@ describe("sidebar cache writes from stream events", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: initialChat,
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -5164,13 +4913,6 @@ describe("stream-to-durable finalization handoff", () => {
 			chatID,
 			chatMessages: [...initialMessages],
 			chatRecord: buildChat(chatID),
-			chatMessagesData: {
-				messages: [...initialMessages].sort(
-					(left, right) => right.id - left.id,
-				),
-				queued_messages: [],
-				has_more: false,
-			},
 			chatQueuedMessages: [],
 			setChatErrorReason: vi.fn(),
 			clearChatErrorReason: vi.fn(),
@@ -5598,11 +5340,6 @@ describe("stream-to-durable finalization handoff", () => {
 					chatID: activeChatID,
 					chatMessages: [...initialMessages],
 					chatRecord: buildChat(activeChatID),
-					chatMessagesData: {
-						messages: [...initialMessages],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -5901,11 +5638,6 @@ describe("partsBuf cleanup on reconnect (Bug 2)", () => {
 					chatID,
 					chatMessages: [userMsg],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [userMsg],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6018,11 +5750,6 @@ describe("durable edit reconciliation through the cache", () => {
 					chatID,
 					chatMessages: [msg1, msg2, msg3],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [msg1, msg2, msg3],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6128,11 +5855,6 @@ describe("durable edit reconciliation through the cache", () => {
 					chatID,
 					chatMessages: [msg1, msg2, msg3],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [msg1, msg2, msg3],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6221,11 +5943,6 @@ describe("parse errors", () => {
 					chatID,
 					chatMessages: [],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -6274,11 +5991,6 @@ describe("parse errors", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -6348,11 +6060,6 @@ describe("parse errors", () => {
 					chatID,
 					chatMessages: [existingMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [existingMessage],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
@@ -6451,7 +6158,6 @@ describe("message cache resync over the socket", () => {
 					chatID,
 					chatMessages: [cachedMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: initialChatMessagesData,
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6508,7 +6214,6 @@ describe("message cache resync over the socket", () => {
 					chatID,
 					chatMessages: cachedMessages,
 					chatRecord: buildChat(chatID),
-					chatMessagesData: initialChatMessagesData,
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6567,7 +6272,6 @@ describe("message cache resync over the socket", () => {
 					chatID,
 					chatMessages: [cachedMessage],
 					chatRecord: buildChat(chatID),
-					chatMessagesData: initialChatMessagesData,
 					chatQueuedMessages: [queuedMessage],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6665,11 +6369,6 @@ describe("durable messages in the query cache", () => {
 					chatID,
 					chatMessages,
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [...chatMessages],
-						queued_messages: [],
-						has_more: false,
-					},
 					chatQueuedMessages: [],
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
@@ -6679,8 +6378,9 @@ describe("durable messages in the query cache", () => {
 			{ wrapper: createWrapper(queryClient) },
 		);
 
-	// Exposes the hook's queue cache writer next to the pagination handle, so a
-	// test can commit a queue write while a fetch is in flight.
+	// Exposes the hook's canonical queue writer next to the pagination handle,
+	// so a test can commit a server-derived queue write while a fetch is in
+	// flight.
 	const renderQueueHarness = (
 		queryClient: QueryClient,
 		chatID: string,
@@ -6692,20 +6392,15 @@ describe("durable messages in the query cache", () => {
 				const messagesQuery = useInfiniteQuery(
 					chatMessagesForInfiniteScroll(chatID),
 				);
-				const { setCacheQueuedMessages } = useTestChatStore({
+				const { store, writeCanonicalQueuedMessages } = useTestChatStore({
 					chatID,
 					chatMessages,
 					chatRecord: buildChat(chatID),
-					chatMessagesData: {
-						messages: [...chatMessages],
-						queued_messages: [...chatQueuedMessages],
-						has_more: false,
-					},
 					chatQueuedMessages,
 					setChatErrorReason: vi.fn(),
 					clearChatErrorReason: vi.fn(),
 				});
-				return { messagesQuery, setCacheQueuedMessages };
+				return { messagesQuery, store, writeCanonicalQueuedMessages };
 			},
 			{ wrapper: createWrapper(queryClient) },
 		);
@@ -6976,10 +6671,9 @@ describe("durable messages in the query cache", () => {
 	});
 
 	// The queue snapshot lives on page 0 of the same cache entry, so it needs the
-	// same serialization: a fetch that captured the pages before the delete
-	// would reinstall the deleted entry, and the store would not correct it
-	// because no queue_update arrived.
-	it("keeps a queued-message delete committed during an in-flight fetchNextPage", async () => {
+	// same serialization: a fetch that captured the pages before the write would
+	// reinstall the superseded queue.
+	it("keeps a server-derived queue write committed during an in-flight fetchNextPage", async () => {
 		const chatID = "chat-1";
 		const newest = buildMessage(chatID, 30, "assistant", "newest");
 		const keptQueued = buildQueuedMessage(chatID, 11, "kept");
@@ -7023,9 +6717,9 @@ describe("durable messages in the query cache", () => {
 			expect(API.experimental.getChatMessages).toHaveBeenCalled();
 		});
 
-		// The optimistic delete the queued-message mutation performs.
+		// The promoted-head send reconciliation's projected write.
 		act(() => {
-			result.current.setCacheQueuedMessages([keptQueued]);
+			result.current.writeCanonicalQueuedMessages([keptQueued]);
 		});
 		expect(
 			readMessagesCache(queryClient, chatID)?.pages[0].queued_messages,
@@ -7042,10 +6736,126 @@ describe("durable messages in the query cache", () => {
 
 		await waitFor(() => {
 			const cached = readMessagesCache(queryClient, chatID);
-			// The delete survives the fetch instead of resurrecting.
+			// The projection survives the fetch instead of being clobbered.
 			expect(cached?.pages[0].queued_messages).toEqual([keptQueued]);
 			expect(messageIDsPerPage(cached)).toEqual([[30], [20]]);
 		});
+	});
+
+	it("awaits no cache echo for a write that changes nothing", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const queued = buildQueuedMessage(chatID, 10, "queued");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[{ messages: [newest], queued_messages: [queued], has_more: false }],
+			[undefined],
+		);
+
+		const { result } = renderQueueHarness(
+			queryClient,
+			chatID,
+			[newest],
+			[queued],
+		);
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+		const store = result.current.store;
+
+		// A promoting send's marker, waiting on its own convergence.
+		act(() => {
+			store.markQueuedMessagePromoted(99);
+		});
+		// Convergence confirmed the guess, so the response equals the cached
+		// queue. Structural sharing collapses the write and the cache observer
+		// never fires, so there is no echo to await.
+		act(() => {
+			result.current.writeCanonicalQueuedMessages([queued]);
+		});
+		const fenceBefore = store.getQueueConvergenceFence();
+
+		// A genuine page-0 install carrying that same value is still a server
+		// statement and has to be gated.
+		act(() => {
+			store.acceptAuthoritativeQueueSnapshot([{ ...queued }], "cache");
+		});
+
+		expect(store.getQueueConvergenceFence()).not.toBe(fenceBefore);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(99)).toBe(false);
+	});
+
+	it("awaits no cache echo when convergence confirms the cached queue", async () => {
+		const chatID = "chat-1";
+		const newest = buildMessage(chatID, 30, "assistant", "newest");
+		const queued = buildQueuedMessage(chatID, 10, "queued");
+		const promotedHeadID = 99;
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createRetainedQueryClient();
+		seedMessagesCache(
+			queryClient,
+			chatID,
+			[{ messages: [newest], queued_messages: [queued], has_more: false }],
+			[undefined],
+		);
+
+		const { result } = renderQueueHarness(
+			queryClient,
+			chatID,
+			[newest],
+			[queued],
+		);
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 30);
+		});
+		const store = result.current.store;
+
+		// The send guessed this head and its convergence is in flight.
+		act(() => {
+			store.markQueuedMessagePromoted(promotedHeadID);
+		});
+		// The convergence path exactly as the page runs it: the response
+		// confirms the guess, so it equals the cached queue and its write
+		// changes nothing.
+		let settled: readonly TypesGen.ChatQueuedMessage[] | undefined;
+		act(() => {
+			const baselineFence = store.getQueueConvergenceFence();
+			settled = store.acceptQueueConvergence(
+				chatID,
+				promotedHeadID,
+				[queued],
+				baselineFence,
+			)
+				? [queued]
+				: undefined;
+			if (settled) {
+				result.current.writeCanonicalQueuedMessages(settled);
+			}
+		});
+		expect(settled).toBeDefined();
+
+		// A later send promotes another head and is waiting on its own
+		// convergence.
+		act(() => {
+			store.markQueuedMessagePromoted(98);
+		});
+		const fenceBefore = store.getQueueConvergenceFence();
+
+		// A genuine page-0 install carrying the same value is still a server
+		// statement: it omits 98, so it has to retire that marker.
+		act(() => {
+			store.acceptAuthoritativeQueueSnapshot([{ ...queued }], "cache");
+		});
+
+		expect(store.getQueueConvergenceFence()).not.toBe(fenceBefore);
+		expect(store.getSnapshot().promotedQueuedMessageIDs.has(98)).toBe(false);
 	});
 
 	it("replays a queue_update buffered during an in-flight fetchNextPage", async () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -30,12 +30,25 @@ export const chatMessagesEqualByValue = (
 	jsonValuesEqual(left.content, right.content) &&
 	jsonValuesEqual(left.usage, right.usage);
 
-export const chatQueuedMessagesEqualByID = (
+// Compares two queue snapshots by value. Deliberately not by ID alone: a
+// requeued edit keeps the ID and changes the content. Covers every field of
+// `ChatQueuedMessage`, so it agrees with the structural sharing the query
+// cache applies to a write.
+export const chatQueuedMessagesEqualByValue = (
 	left: readonly TypesGen.ChatQueuedMessage[],
 	right: readonly TypesGen.ChatQueuedMessage[],
 ): boolean =>
 	left.length === right.length &&
-	left.every((message, index) => message.id === right[index].id);
+	left.every((message, index) => {
+		const other = right[index];
+		return (
+			message.id === other.id &&
+			message.chat_id === other.chat_id &&
+			message.model_config_id === other.model_config_id &&
+			message.created_at === other.created_at &&
+			jsonValuesEqual(message.content, other.content)
+		);
+	});
 
 const retryStatesEqual = (
 	left: RetryState | null,
@@ -78,9 +91,11 @@ export const isActiveChatStatus = (
 ): boolean => status === "running" || status === "interrupting";
 
 /**
- * Transient chat state. Durable messages are NOT here: the query cache is
- * canonical for them, written only by the per-chat socket. What remains is the
- * streaming overlay, its finalization handoff, transport state, and the queue.
+ * Transient chat state. Durable messages and the durable queue are NOT here:
+ * the query cache is canonical for both, and only server-derived values are
+ * written to it. What remains is the streaming overlay, its finalization
+ * handoff, transport state, and the read-time reconciliation markers that hide
+ * queue rows the server has not caught up with yet.
  */
 export type ChatStoreState = {
 	streamState: StreamState | null;
@@ -95,17 +110,24 @@ export type ChatStoreState = {
 	streamError: ChatDetailError | null;
 	retryState: RetryState | null;
 	reconnectState: ReconnectState | null;
-	queuedMessages: readonly TypesGen.ChatQueuedMessage[];
-	// Hides queued IDs from the visible queue while the backend is
-	// in a transient state that would briefly include them. Used by
-	// the running-case promote, where the backend reorders the
-	// queued message to the front before auto-promoting it.
+	// Hides queued IDs from the visible queue while the cache still holds them.
+	// Markers only SUBTRACT at read time, so an optimistic removal never writes
+	// the cache and never needs a rollback. `chat_queued_messages.id` is a
+	// global bigserial, so a marker for an id the server never lists again is
+	// permanently inert.
 	suppressedQueuedMessageIDs: ReadonlySet<number>;
-	// IDs confirmed deleted from the queue because the send response
-	// contained their promoted user rows.
+	// IDs confirmed deleted from the queue because the send response contained
+	// their promoted user rows. A snapshot still listing one predates that
+	// deletion, so the gate rejects it.
 	promotedQueuedMessageIDs: ReadonlySet<number>;
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
 };
+
+/**
+ * Which arm of the queue gate delivered a snapshot. The socket arm gates the
+ * cache write itself; the cache arm observes a write that already happened.
+ */
+export type QueueSnapshotSource = "socket" | "cache";
 
 export type ChatStore = {
 	getSnapshot: () => ChatStoreState;
@@ -123,34 +145,64 @@ export type ChatStore = {
 	// cache. Ignores a different ID, so a stale completion cannot drop the
 	// overlay of a later turn.
 	completeStreamFinalization: (durableMessageID: number) => void;
-	setQueuedMessages: (
+	// Accept/reject gate every authoritative queue snapshot passes through.
+	// `source` names the arm that delivered it, because the two arms can do
+	// different things about a snapshot:
+	//   "socket": a `queue_update`. Its caller writes an accepted snapshot to
+	//     the cache VERBATIM and drops a rejected one, so the gate really is a
+	//     write gate here.
+	//   "cache": a page-0 value already installed in the query cache. The
+	//     observer runs AFTER the install, so rejecting cannot undo the write;
+	//     it only withholds the fence advance and the marker reconciliation.
+	// Suppression markers do the hiding at read time either way.
+	acceptAuthoritativeQueueSnapshot: (
 		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
-	) => void;
-	// Server-truthful queue snapshot, filtered through the
-	// suppression set. Use for SSE queue_update and REST hydration;
-	// optimistic writes go through setQueuedMessages so they don't
-	// lift suppression.
-	applyAuthoritativeQueuedMessages: (
-		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+		source: QueueSnapshotSource,
+	) => boolean;
+	// Arms the echo the cache arm of the gate is expected to report back once,
+	// for a write this client is making to the canonical queue. The WRITE PATH
+	// is the only caller: an expectation is owed only by a write that actually
+	// changes the cached value, and only the writer can know that. Arming for a
+	// no-op write would leave an expectation nothing consumes, and it would
+	// swallow the next genuine snapshot of that value.
+	noteLocalQueueProjection: (
+		queuedMessages: readonly TypesGen.ChatQueuedMessage[],
 	) => void;
 	// Advances when an accepted snapshot or active-chat change invalidates an
-	// in-flight convergence request. Discarded snapshots do not advance it.
+	// in-flight convergence request. Rejected snapshots do not advance it.
 	getQueueConvergenceFence: () => number;
-	// Applies a promotion refetch only while the chat and fence still match.
-	// Clears that ID's markers and returns the filtered queue for cache mirroring.
-	applyPromoteRefetchQueuedMessages: (
+	// Accepts a promotion refetch only while the chat and fence still match, and
+	// clears that ID's markers. The caller writes the RAW response to the cache;
+	// filtering stays at read time.
+	acceptQueueConvergence: (
 		chatID: string,
 		promotedID: number,
-		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+		queuedMessages: readonly TypesGen.ChatQueuedMessage[],
+		baselineFence: number,
+	) => boolean;
+	// Ends the promoted-head veto when its convergence fetch failed. The veto
+	// rests on a GUESS about which row the server promoted, so leaving it
+	// standing would reject every later snapshot that still lists that row and
+	// freeze the queue. Clearing the marker alone is not enough: the snapshots
+	// vetoed meanwhile were dropped and nothing re-delivers them, so this also
+	// returns the newest one for the caller to write back as the last thing the
+	// server said about the queue.
+	abandonQueueConvergence: (
+		chatID: string,
+		promotedID: number,
 		baselineFence: number,
 	) => readonly TypesGen.ChatQueuedMessage[] | undefined;
-	suppressQueuedMessageID: (id: number) => void;
+	suppressQueuedMessageIDs: (ids: readonly number[]) => void;
 	markQueuedMessagePromoted: (id: number) => void;
 	// Distinguishes a tail still in flight from one the server listed and later removed.
 	hasObservedQueuedMessageID: (id: number) => boolean;
 	setActiveChatID: (chatID: string | null) => void;
 	getActiveChatID: () => string | null;
-	unsuppressQueuedMessageID: (id: number) => void;
+	// Lifts ORDINARY suppression only. A promoted ID keeps both of its markers:
+	// the queue operation that suppressed an ID does not own the promotion veto
+	// a send placed on the same ID, and dropping that veto would let a stale
+	// snapshot resurrect a row the server already promoted.
+	unsuppressQueuedMessageIDs: (ids: readonly number[]) => void;
 	clearSuppressedQueuedMessageIDs: () => void;
 	setStreamState: (streamState: StreamState | null) => void;
 	setStreamError: (reason: ChatDetailError | null) => void;
@@ -175,7 +227,6 @@ const createInitialState = (): ChatStoreState => ({
 	streamError: null,
 	retryState: null,
 	reconnectState: null,
-	queuedMessages: [],
 	suppressedQueuedMessageIDs: new Set(),
 	promotedQueuedMessageIDs: new Set(),
 	subagentStatusOverrides: new Map(),
@@ -188,6 +239,16 @@ export const createChatStore = (): ChatStore => {
 	let observedQueuedMessageIDs = new Set<number>();
 	let queueConvergenceFence = 0;
 	let activeChatID: string | null = null;
+	// The value this client last wrote to the canonical cache and therefore
+	// expects the cache arm of the gate to report back once. It is NOT a
+	// general value-based dedupe: a later authoritative snapshot that happens
+	// to carry the same value is a real server statement and must be gated.
+	let expectedCacheEcho: readonly TypesGen.ChatQueuedMessage[] | null = null;
+	// The newest snapshot the promoted-head veto rejected. A rejected snapshot
+	// is dropped, and the server does not resend it, so this is the only
+	// corrective truth left if the convergence fetch that justifies the veto
+	// fails.
+	let vetoedQueueSnapshot: readonly TypesGen.ChatQueuedMessage[] | null = null;
 	const listeners = new Set<() => void>();
 
 	const emit = (): void => {
@@ -329,35 +390,48 @@ export const createChatStore = (): ChatStore => {
 		applyMessageParts,
 		beginStreamFinalization,
 		completeStreamFinalization,
-		setQueuedMessages: (queuedMessages) => {
-			const nextQueuedMessages = queuedMessages ?? [];
-			setState((current) => {
-				if (
-					chatQueuedMessagesEqualByID(
-						current.queuedMessages,
-						nextQueuedMessages,
-					)
-				) {
-					return current;
-				}
-				return { ...current, queuedMessages: nextQueuedMessages };
-			});
-		},
-		applyAuthoritativeQueuedMessages: (queuedMessages) => {
+		acceptAuthoritativeQueueSnapshot: (queuedMessages, source) => {
 			const incoming = queuedMessages ?? [];
-			for (const message of incoming) {
-				observedQueuedMessageIDs.add(message.id);
-			}
-			// A snapshot containing a confirmed promoted ID predates its queue
-			// deletion. Applying it would also drop newer queued messages, and
-			// counting it would discard the fresher refetch racing it.
+			// The veto runs FIRST, ahead of any short-circuit. A snapshot
+			// containing a confirmed promoted ID predates its queue deletion, so
+			// installing it would also drop the newer tail the send returned, and
+			// counting it would discard the convergence fetch racing it. Promoted
+			// markers exist only from the send reconciliation until the server
+			// catches up, so every other snapshot is accepted. Keep the newest
+			// rejected one: it is what the convergence failure path restores.
 			if (
 				incoming.some((message) =>
 					state.promotedQueuedMessageIDs.has(message.id),
 				)
 			) {
-				return;
+				vetoedQueueSnapshot = incoming;
+				return false;
 			}
+			// The cache arm is watching the write this client just made. Consuming
+			// the expectation once keeps that echo from advancing the fence a
+			// second time and stranding a convergence request that carries
+			// strictly newer information, while a genuine snapshot of the same
+			// value still passes through the full gate below.
+			if (
+				source === "cache" &&
+				expectedCacheEcho !== null &&
+				chatQueuedMessagesEqualByValue(expectedCacheEcho, incoming)
+			) {
+				expectedCacheEcho = null;
+				return true;
+			}
+			// Below the echo check, so a tail the CLIENT projected into the cache
+			// is never recorded as a row the server listed. The send
+			// reconciliation asks exactly that question about its own tail.
+			for (const message of incoming) {
+				observedQueuedMessageIDs.add(message.id);
+			}
+			vetoedQueueSnapshot = null;
+			// Any expectation still standing describes an older write, and the
+			// observer only ever reports the newest cached value. The write that
+			// follows an accepted socket snapshot arms a fresh one if it changes
+			// the cache.
+			expectedCacheEcho = null;
 			queueConvergenceFence++;
 			setState((current) => {
 				let nextSuppressed = current.suppressedQueuedMessageIDs;
@@ -376,34 +450,31 @@ export const createChatStore = (): ChatStore => {
 						nextSuppressed = copy;
 					}
 				}
-				const filtered =
-					nextSuppressed.size === 0
-						? incoming
-						: incoming.filter((message) => !nextSuppressed.has(message.id));
-				const sameQueue = chatQueuedMessagesEqualByID(
-					current.queuedMessages,
-					filtered,
-				);
-				const sameSuppressed =
-					nextSuppressed === current.suppressedQueuedMessageIDs;
+				// The veto above already proved this snapshot lists no promoted ID,
+				// so the server has caught up with every one of them.
 				const nextPromoted =
 					current.promotedQueuedMessageIDs.size === 0
 						? current.promotedQueuedMessageIDs
 						: new Set<number>();
-				const samePromoted = nextPromoted === current.promotedQueuedMessageIDs;
-				if (sameQueue && sameSuppressed && samePromoted) {
+				if (
+					nextSuppressed === current.suppressedQueuedMessageIDs &&
+					nextPromoted === current.promotedQueuedMessageIDs
+				) {
 					return current;
 				}
 				return {
 					...current,
-					queuedMessages: sameQueue ? current.queuedMessages : filtered,
 					suppressedQueuedMessageIDs: nextSuppressed,
 					promotedQueuedMessageIDs: nextPromoted,
 				};
 			});
+			return true;
+		},
+		noteLocalQueueProjection: (queuedMessages) => {
+			expectedCacheEcho = queuedMessages;
 		},
 		getQueueConvergenceFence: () => queueConvergenceFence,
-		applyPromoteRefetchQueuedMessages: (
+		acceptQueueConvergence: (
 			chatID,
 			promotedID,
 			queuedMessages,
@@ -413,45 +484,101 @@ export const createChatStore = (): ChatStore => {
 			// additionally keeps a response that names another chat out of the
 			// shared store even if its caller captured the fence incorrectly.
 			if (activeChatID !== chatID) {
+				return false;
+			}
+			if (queueConvergenceFence !== baselineFence) {
+				return false;
+			}
+			queueConvergenceFence++;
+			for (const message of queuedMessages) {
+				observedQueuedMessageIDs.add(message.id);
+			}
+			vetoedQueueSnapshot = null;
+			// The caller writes this response to the cache, and that write arms
+			// the echo if it changes anything. Arming here instead would arm one
+			// for a response that merely confirms the cached queue, which is the
+			// common case and produces no observation to consume it.
+			expectedCacheEcho = null;
+			setState((current) => {
+				if (
+					!current.suppressedQueuedMessageIDs.has(promotedID) &&
+					!current.promotedQueuedMessageIDs.has(promotedID)
+				) {
+					return current;
+				}
+				const suppressed = new Set(current.suppressedQueuedMessageIDs);
+				suppressed.delete(promotedID);
+				const promoted = new Set(current.promotedQueuedMessageIDs);
+				promoted.delete(promotedID);
+				return {
+					...current,
+					suppressedQueuedMessageIDs: suppressed,
+					promotedQueuedMessageIDs: promoted,
+				};
+			});
+			return true;
+		},
+		abandonQueueConvergence: (chatID, promotedID, baselineFence) => {
+			// Same guards as the accepting path. A moved fence or a changed chat
+			// means the markers this call would clear are already gone.
+			if (activeChatID !== chatID) {
 				return undefined;
 			}
 			if (queueConvergenceFence !== baselineFence) {
 				return undefined;
 			}
-			const incoming = queuedMessages ?? [];
+			const corrective = vetoedQueueSnapshot;
+			vetoedQueueSnapshot = null;
 			queueConvergenceFence++;
-			for (const message of incoming) {
-				observedQueuedMessageIDs.add(message.id);
+			if (corrective) {
+				for (const message of corrective) {
+					observedQueuedMessageIDs.add(message.id);
+				}
 			}
-			const suppressed = new Set(state.suppressedQueuedMessageIDs);
-			suppressed.delete(promotedID);
-			const promoted = new Set(state.promotedQueuedMessageIDs);
-			promoted.delete(promotedID);
-			const applied =
-				suppressed.size === 0
-					? incoming
-					: incoming.filter((message) => !suppressed.has(message.id));
-			setState((current) => ({
-				...current,
-				queuedMessages: chatQueuedMessagesEqualByID(
-					current.queuedMessages,
-					applied,
-				)
-					? current.queuedMessages
-					: applied,
-				suppressedQueuedMessageIDs: suppressed,
-				promotedQueuedMessageIDs: promoted,
-			}));
-			return applied;
+			setState((current) => {
+				const correctiveIDs = corrective
+					? new Set(corrective.map((message) => message.id))
+					: null;
+				const staleSuppressed = [...current.suppressedQueuedMessageIDs].filter(
+					(id) =>
+						id === promotedID ||
+						(correctiveIDs !== null && !correctiveIDs.has(id)),
+				);
+				if (
+					staleSuppressed.length === 0 &&
+					!current.promotedQueuedMessageIDs.has(promotedID)
+				) {
+					return current;
+				}
+				const suppressed = new Set(current.suppressedQueuedMessageIDs);
+				for (const id of staleSuppressed) {
+					suppressed.delete(id);
+				}
+				// Only this send's guess is retired. Another send's promotion still
+				// has its own convergence request in flight.
+				const promoted = new Set(current.promotedQueuedMessageIDs);
+				promoted.delete(promotedID);
+				return {
+					...current,
+					suppressedQueuedMessageIDs: suppressed,
+					promotedQueuedMessageIDs: promoted,
+				};
+			});
+			return corrective ?? undefined;
 		},
 		hasObservedQueuedMessageID: (id) => observedQueuedMessageIDs.has(id),
-		suppressQueuedMessageID: (id) => {
+		suppressQueuedMessageIDs: (ids) => {
 			setState((current) => {
-				if (current.suppressedQueuedMessageIDs.has(id)) {
+				const added = ids.filter(
+					(id) => !current.suppressedQueuedMessageIDs.has(id),
+				);
+				if (added.length === 0) {
 					return current;
 				}
 				const next = new Set(current.suppressedQueuedMessageIDs);
-				next.add(id);
+				for (const id of added) {
+					next.add(id);
+				}
 				return { ...current, suppressedQueuedMessageIDs: next };
 			});
 		},
@@ -474,27 +601,34 @@ export const createChatStore = (): ChatStore => {
 				};
 			});
 		},
-		unsuppressQueuedMessageID: (id) => {
+		unsuppressQueuedMessageIDs: (ids) => {
 			setState((current) => {
-				if (
-					!current.suppressedQueuedMessageIDs.has(id) &&
-					!current.promotedQueuedMessageIDs.has(id)
-				) {
+				// A promoted ID is skipped: its markers belong to the send that
+				// confirmed the promotion, and only that send's convergence may
+				// retire them. A failed delete or edit lifting them here would let
+				// a stale snapshot resurrect the row the server already promoted.
+				const removed = ids.filter(
+					(id) =>
+						current.suppressedQueuedMessageIDs.has(id) &&
+						!current.promotedQueuedMessageIDs.has(id),
+				);
+				if (removed.length === 0) {
 					return current;
 				}
 				const suppressed = new Set(current.suppressedQueuedMessageIDs);
-				suppressed.delete(id);
-				const promoted = new Set(current.promotedQueuedMessageIDs);
-				promoted.delete(id);
+				for (const id of removed) {
+					suppressed.delete(id);
+				}
 				return {
 					...current,
 					suppressedQueuedMessageIDs: suppressed,
-					promotedQueuedMessageIDs: promoted,
 				};
 			});
 		},
 		clearSuppressedQueuedMessageIDs: () => {
 			observedQueuedMessageIDs = new Set();
+			expectedCacheEcho = null;
+			vetoedQueueSnapshot = null;
 			setState((current) => {
 				if (
 					current.suppressedQueuedMessageIDs.size === 0 &&
@@ -706,8 +840,8 @@ export const resolveOverlayStreamState = (
 ): StreamState | null =>
 	streamState ?? (suppressFinalizedOverlay ? null : finalizingStreamState);
 export const selectStreamError = (state: ChatStoreState) => state.streamError;
-export const selectQueuedMessages = (state: ChatStoreState) =>
-	state.queuedMessages;
+export const selectSuppressedQueuedMessageIDs = (state: ChatStoreState) =>
+	state.suppressedQueuedMessageIDs;
 export const selectSubagentStatusOverrides = (state: ChatStoreState) =>
 	state.subagentStatusOverrides;
 export const selectRetryState = (state: ChatStoreState) => state.retryState;

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.test.tsx
@@ -12,10 +12,12 @@ import { MockChat } from "#/testHelpers/chatEntities";
 import {
 	type ChatStore,
 	createChatStore,
-	selectQueuedMessages,
+	selectSuppressedQueuedMessageIDs,
 	useChatSelector,
 } from "./chatStore";
 import {
+	readCanonicalQueuedMessages,
+	readEffectiveQueuedMessages,
 	shouldSuppressFinalizedOverlay,
 	useDurableChatStatus,
 	useDurableMessageCount,
@@ -64,21 +66,23 @@ const seedMessages = (
 	queryClient: QueryClient,
 	messages: readonly TypesGen.ChatMessage[],
 	extraPage?: readonly TypesGen.ChatMessage[],
+	queuedMessages: readonly TypesGen.ChatQueuedMessage[] = [],
 ): void => {
 	const toPage = (
 		pageMessages: readonly TypesGen.ChatMessage[],
 		hasMore: boolean,
+		pageQueuedMessages: readonly TypesGen.ChatQueuedMessage[] = [],
 	): TypesGen.ChatMessagesResponse => ({
 		messages: [...pageMessages].sort((left, right) => right.id - left.id),
-		queued_messages: [],
+		queued_messages: pageQueuedMessages,
 		has_more: hasMore,
 	});
 	queryClient.setQueryData<InfiniteData<TypesGen.ChatMessagesResponse>>(
 		chatKeys.messages(CHAT_ID),
 		{
 			pages: extraPage
-				? [toPage(messages, true), toPage(extraPage, false)]
-				: [toPage(messages, false)],
+				? [toPage(messages, true, queuedMessages), toPage(extraPage, false)]
+				: [toPage(messages, false, queuedMessages)],
 			pageParams: extraPage ? [undefined, messages[0]?.id] : [undefined],
 		},
 	);
@@ -118,7 +122,7 @@ const buildTextPart = (text: string): TypesGen.ChatMessagePart => ({
 });
 
 describe("durableChat facade", () => {
-	it("reads messages and status from the cache and the queue from the store", () => {
+	it("reads messages, status, and the queue from the cache", () => {
 		const store = createChatStore();
 		const queryClient = createTestQueryClient();
 		seedChatDetail(queryClient, "running");
@@ -126,8 +130,8 @@ describe("durableChat facade", () => {
 			buildMessage(1, "user", "hello"),
 			buildMessage(2, "assistant", "hi"),
 		];
-		seedMessages(queryClient, messages);
-		store.setQueuedMessages([buildQueuedMessage(10, "later")]);
+		const queued = buildQueuedMessage(10, "later");
+		seedMessages(queryClient, messages, undefined, [queued]);
 
 		const { result } = renderHook(
 			() => ({
@@ -135,7 +139,6 @@ describe("durableChat facade", () => {
 				facadeMessages: useDurableMessageList({ store, chatId: CHAT_ID }),
 				facadeCount: useDurableMessageCount({ store, chatId: CHAT_ID }),
 				facadeQueued: useDurableQueuedMessages({ store, chatId: CHAT_ID }),
-				selectorQueued: useChatSelector(store, selectQueuedMessages),
 			}),
 			{ wrapper: createWrapper(queryClient) },
 		);
@@ -145,7 +148,50 @@ describe("durableChat facade", () => {
 		// Ascending by ID, which is the only ordering signal a message carries.
 		expect(current.facadeMessages).toEqual(messages);
 		expect(current.facadeCount).toBe(messages.length);
-		expect(current.facadeQueued).toBe(current.selectorQueued);
+		expect(current.facadeQueued).toEqual([queued]);
+	});
+
+	it("hides a suppressed queued message without touching the cache", async () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		const kept = buildQueuedMessage(10, "kept");
+		const hidden = buildQueuedMessage(11, "hidden");
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")], undefined, [
+			kept,
+			hidden,
+		]);
+
+		const { result } = renderHook(
+			() => ({
+				queued: useDurableQueuedMessages({ store, chatId: CHAT_ID }),
+				suppressed: useChatSelector(store, selectSuppressedQueuedMessageIDs),
+			}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		expect(result.current.queued).toEqual([kept, hidden]);
+
+		act(() => {
+			store.suppressQueuedMessageIDs([hidden.id]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.queued).toEqual([kept]);
+		});
+		// The marker subtracts at read time; the cache still holds server truth.
+		expect(
+			queryClient.getQueryData<InfiniteData<TypesGen.ChatMessagesResponse>>(
+				chatKeys.messages(CHAT_ID),
+			)?.pages[0].queued_messages,
+		).toEqual([kept, hidden]);
+
+		act(() => {
+			store.unsuppressQueuedMessageIDs([hidden.id]);
+		});
+
+		await waitFor(() => {
+			expect(result.current.queued).toEqual([kept, hidden]);
+		});
 	});
 
 	it("deduplicates a cross-page copy, keeping the page 0 values", () => {
@@ -430,6 +476,41 @@ describe("durableChat facade", () => {
 			expect(result.current).toBe(2);
 		});
 		expect(renderCount).toBe(baseline + 1);
+	});
+});
+
+describe("queue read projections", () => {
+	it("keeps a suppressed head in the canonical read and out of the effective one", () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+		const head = buildQueuedMessage(10, "head");
+		const tail = buildQueuedMessage(11, "tail");
+		seedMessages(queryClient, [buildMessage(1, "user", "hello")], undefined, [
+			head,
+			tail,
+		]);
+		store.suppressQueuedMessageIDs([head.id]);
+
+		// The send captures the head from the canonical read because the server
+		// promotes ITS head by position, which still includes the hidden row.
+		expect(readCanonicalQueuedMessages(queryClient, CHAT_ID)).toEqual([
+			head,
+			tail,
+		]);
+		expect(readEffectiveQueuedMessages(queryClient, store, CHAT_ID)).toEqual([
+			tail,
+		]);
+	});
+
+	it("reports no canonical queue for a chat with no cache entry", () => {
+		const store = createChatStore();
+		const queryClient = createTestQueryClient();
+
+		expect(readCanonicalQueuedMessages(queryClient, CHAT_ID)).toBeUndefined();
+		expect(readCanonicalQueuedMessages(queryClient, undefined)).toBeUndefined();
+		expect(readEffectiveQueuedMessages(queryClient, store, CHAT_ID)).toEqual(
+			[],
+		);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/durableChat.ts
@@ -1,6 +1,8 @@
+import type { InfiniteData, QueryClient } from "react-query";
 import { useInfiniteQuery, useQuery } from "react-query";
 import {
 	chat as chatDetailQuery,
+	chatKeys,
 	chatMessagesForInfiniteScroll,
 	selectDurableMessageCount,
 	selectDurableMessages,
@@ -10,15 +12,15 @@ import type * as TypesGen from "#/api/typesGenerated";
 import {
 	type ChatStore,
 	selectHasStreamOverlay,
-	selectQueuedMessages,
+	selectSuppressedQueuedMessageIDs,
 	useChatSelector,
 } from "./chatStore";
 
 // Read facade for durable chat state (messages, queued messages, chat
 // status). Render consumers read durable state through these hooks so the
 // source can move from the store to the query cache without touching call
-// sites. Chat status and messages resolve to the query cache, which is
-// canonical for them; the queue still resolves to the store.
+// sites. Chat status, durable messages, and the queued messages all resolve
+// to the query cache, which is canonical for them.
 //
 // Composition rule: `useChatSelector` feeds its selector result straight to
 // `useSyncExternalStore`, which compares snapshots with Object.is on every
@@ -58,6 +60,65 @@ export const useDurableChatStatus = (
 	}).data ?? null;
 
 const EMPTY_MESSAGES: readonly TypesGen.ChatMessage[] = [];
+const EMPTY_QUEUED_MESSAGES: readonly TypesGen.ChatQueuedMessage[] = [];
+
+/**
+ * The queue travels with the messages response, so page 0 of the paginated
+ * messages cache is where it lives. Module level so react-query memoizes it
+ * per observer and structural sharing keeps the result reference stable.
+ */
+export const selectCanonicalQueuedMessages = (
+	data: InfiniteData<TypesGen.ChatMessagesResponse>,
+): readonly TypesGen.ChatQueuedMessage[] =>
+	data.pages[0]?.queued_messages ?? EMPTY_QUEUED_MESSAGES;
+
+/**
+ * The RAW queue as the server last reported it, including rows an optimistic
+ * removal has suppressed. Imperative readers that have to reason about the
+ * SERVER's queue use this: the server promotes its head by `position`, which
+ * includes a row the client is already hiding.
+ */
+export const readCanonicalQueuedMessages = (
+	queryClient: QueryClient,
+	chatId: string | undefined,
+): readonly TypesGen.ChatQueuedMessage[] | undefined => {
+	if (!chatId) {
+		return undefined;
+	}
+	return queryClient.getQueryData<
+		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
+	>(chatKeys.messages(chatId))?.pages[0]?.queued_messages;
+};
+
+/**
+ * The canonical queue minus the suppression markers: what the user is allowed
+ * to see. Optimistic removals never write the cache, so this subtraction is
+ * the only thing that hides them, and a failed mutation only has to drop the
+ * marker.
+ */
+export const selectEffectiveQueuedMessages = (
+	canonicalQueuedMessages: readonly TypesGen.ChatQueuedMessage[],
+	suppressedQueuedMessageIDs: ReadonlySet<number>,
+): readonly TypesGen.ChatQueuedMessage[] =>
+	suppressedQueuedMessageIDs.size === 0
+		? canonicalQueuedMessages
+		: canonicalQueuedMessages.filter(
+				(message) => !suppressedQueuedMessageIDs.has(message.id),
+			);
+
+/**
+ * Imperative counterpart of the render facade, for callers that hold a query
+ * client rather than a hook result.
+ */
+export const readEffectiveQueuedMessages = (
+	queryClient: QueryClient,
+	store: ChatStore,
+	chatId: string | undefined,
+): readonly TypesGen.ChatQueuedMessage[] =>
+	selectEffectiveQueuedMessages(
+		readCanonicalQueuedMessages(queryClient, chatId) ?? EMPTY_QUEUED_MESSAGES,
+		store.getSnapshot().suppressedQueuedMessageIDs,
+	);
 
 // Flat, ascending message list read from the canonical paginated cache.
 export const useDurableMessageList = (
@@ -91,8 +152,25 @@ export const shouldSuppressFinalizedOverlay = (
 
 export const useDurableQueuedMessages = (
 	args: DurableChatArgs,
-): readonly TypesGen.ChatQueuedMessage[] =>
-	useChatSelector(args.store, selectQueuedMessages);
+): readonly TypesGen.ChatQueuedMessage[] => {
+	const canonicalQueuedMessages =
+		useInfiniteQuery({
+			...chatMessagesForInfiniteScroll(args.chatId ?? ""),
+			enabled: Boolean(args.chatId),
+			select: selectCanonicalQueuedMessages,
+		}).data ?? EMPTY_QUEUED_MESSAGES;
+	const suppressedQueuedMessageIDs = useChatSelector(
+		args.store,
+		selectSuppressedQueuedMessageIDs,
+	);
+	// Combined in the hook body, never inside either selector: the store
+	// selector has to stay a raw slice and the query select has to stay module
+	// level, so this is the only place the two projections can meet.
+	return selectEffectiveQueuedMessages(
+		canonicalQueuedMessages,
+		suppressedQueuedMessageIDs,
+	);
+};
 
 // Composed from two narrow primitives rather than one selector over the whole
 // conversation: the role of the newest durable message is a primitive, and the

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -8,6 +8,7 @@ import {
 import {
 	type InfiniteData,
 	type QueryClient,
+	useInfiniteQuery,
 	useQueryClient,
 } from "react-query";
 import { watchChat } from "#/api/api";
@@ -18,6 +19,7 @@ import {
 import {
 	applyServerChatStatusToCaches,
 	chatKeys,
+	chatMessagesForInfiniteScroll,
 	readCachedChatSnapshotVersion,
 	readCachedChatStatus,
 } from "#/api/queries/chats";
@@ -30,10 +32,14 @@ import {
 	type ChatStore,
 	type ChatStoreState,
 	chatMessagesEqualByValue,
-	chatQueuedMessagesEqualByID,
+	chatQueuedMessagesEqualByValue,
 	createChatStore,
 	isActiveChatStatus,
 } from "./chatStore";
+import {
+	readCanonicalQueuedMessages,
+	selectCanonicalQueuedMessages,
+} from "./durableChat";
 import type { RetryState } from "./types";
 
 type ChatMessagesCacheData = InfiniteData<TypesGen.ChatMessagesResponse>;
@@ -129,15 +135,15 @@ const replaceMessagesInCacheData = (
  * Replaces the queue snapshot the messages cache carries on page 0. The queue
  * travels with the messages response, so it shares the cache entry, the fetch
  * serialization, and the initialized-cache requirement with durable messages.
+ *
+ * No equality guard: `setQueryData` runs `replaceEqualDeep`, so a deep-equal
+ * write collapses to the previous reference and notifies nothing.
  */
 const patchQueuedMessagesInCacheData = (
 	currentData: ChatMessagesCacheData,
 	queuedMessages: readonly TypesGen.ChatQueuedMessage[],
 ): ChatMessagesCacheData => {
 	const firstPage = currentData.pages[0];
-	if (chatQueuedMessagesEqualByID(firstPage.queued_messages, queuedMessages)) {
-		return currentData;
-	}
 	return {
 		...currentData,
 		pages: [
@@ -147,36 +153,44 @@ const patchQueuedMessagesInCacheData = (
 	};
 };
 
-// Prevents REST re-hydration from replaying a stale queue over the store. Goes
-// through the shared write coordinator: a queue delete or a queue_update
-// committed while a pagination fetch is in flight would otherwise be clobbered
-// by the pages that fetch captured, resurrecting the deleted entry.
+// The cache is canonical for the queue, so only SERVER-DERIVED values are
+// written here: an authoritative snapshot the gate accepted, or the
+// promoted-head send reconciliation's projection. Optimistic removals are
+// read-time markers instead and never reach this function.
+//
+// The SINGLE place the cache echo is armed. The cache arm of the gate would
+// otherwise re-gate this write when it observes it, retiring the markers the
+// write depends on. Only a write that CHANGES the cached value is owed an
+// echo: `setQueryData` collapses a deep-equal write through structural
+// sharing, so no observation follows it, and an expectation armed for one
+// would sit there and swallow the next genuine snapshot of that value. A
+// convergence response confirming a correct guess is exactly such a no-op
+// write, which is why neither the gate nor the convergence arms its own.
+//
+// Goes through the shared write coordinator: a queue snapshot committed while
+// a pagination fetch is in flight would otherwise be clobbered by the pages
+// that fetch captured, resurrecting entries the server already removed.
 const writeQueuedMessagesToCache = (
 	queryClient: QueryClient,
+	store: ChatStore,
 	chatID: string | undefined,
-	queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+	queuedMessages: readonly TypesGen.ChatQueuedMessage[],
 ): void => {
 	if (!chatID) {
 		return;
 	}
-	const nextQueuedMessages = queuedMessages ?? [];
+	const cachedQueue = readCanonicalQueuedMessages(queryClient, chatID);
+	if (
+		cachedQueue !== undefined &&
+		!chatQueuedMessagesEqualByValue(cachedQueue, queuedMessages)
+	) {
+		store.noteLocalQueueProjection(queuedMessages);
+	}
 	writeMessagesCache(queryClient, chatKeys.messages(chatID), {
 		kind: "queue",
 		apply: (currentData) =>
-			patchQueuedMessagesInCacheData(currentData, nextQueuedMessages),
+			patchQueuedMessagesInCacheData(currentData, queuedMessages),
 	});
-};
-
-const readQueuedMessagesFromCache = (
-	queryClient: QueryClient,
-	chatID: string | undefined,
-): readonly TypesGen.ChatQueuedMessage[] | undefined => {
-	if (!chatID) {
-		return undefined;
-	}
-	return queryClient.getQueryData<
-		InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-	>(chatKeys.messages(chatID))?.pages[0]?.queued_messages;
 };
 
 const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => ({
@@ -200,8 +214,6 @@ interface UseChatStoreOptions {
 	chatID: string | undefined;
 	chatMessages: readonly TypesGen.ChatMessage[] | undefined;
 	chatRecord: TypesGen.Chat | undefined;
-	chatMessagesData: TypesGen.ChatMessagesResponse | undefined;
-	chatQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined;
 	setChatErrorReason: (chatID: string, reason: ChatDetailError) => void;
 	clearChatErrorReason: (chatID: string) => void;
 	aiGatewayDisabled?: boolean;
@@ -212,10 +224,13 @@ export const useChatStore = (
 ): {
 	store: ChatStore;
 	clearStreamError: () => void;
-	setCacheQueuedMessages: (
-		queuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined,
+	// Writes a server-derived queue value into the canonical cache. Used by the
+	// promoted-head send reconciliation and its convergence response only.
+	writeCanonicalQueuedMessages: (
+		queuedMessages: readonly TypesGen.ChatQueuedMessage[],
 	) => void;
-	getCacheQueuedMessages: () =>
+	// The RAW cached queue, suppression markers included.
+	readCanonicalQueuedMessages: () =>
 		| readonly TypesGen.ChatQueuedMessage[]
 		| undefined;
 	upsertCacheMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
@@ -224,8 +239,6 @@ export const useChatStore = (
 		chatID,
 		chatMessages,
 		chatRecord,
-		chatMessagesData,
-		chatQueuedMessages,
 		setChatErrorReason,
 		clearChatErrorReason,
 		aiGatewayDisabled = false,
@@ -233,14 +246,6 @@ export const useChatStore = (
 
 	const queryClient = useQueryClient();
 	const [store] = useState(createChatStore);
-	const queuedMessagesHydratedChatIDRef = useRef<string | null>(null);
-	// Tracks whether the WebSocket has delivered a queue_update for the
-	// current chat. When true, the stream is the authoritative source
-	// and REST re-fetches must not overwrite the store. When false,
-	// REST data is allowed to re-hydrate so stale cached queued
-	// messages are corrected when switching back to a chat whose
-	// queue was drained while the user was away.
-	const wsQueueUpdateReceivedRef = useRef(false);
 	const activeChatIDRef = useRef<string | null>(null);
 
 	// Compute the last REST-fetched message ID so the stream can
@@ -324,46 +329,37 @@ export const useChatStore = (
 	);
 
 	useEffect(() => {
-		queuedMessagesHydratedChatIDRef.current = null;
-		wsQueueUpdateReceivedRef.current = false;
-		store.setQueuedMessages([]);
-		// Suppression entries are scoped to the current chat; clear
-		// them on chat change so a stale promote suppression doesn't
-		// hide queued messages in another chat.
-		store.clearSuppressedQueuedMessageIDs();
 		if (!chatID) {
 			return;
 		}
+		// Markers and the gate's snapshot bookkeeping describe the open chat, so
+		// they are dropped on the way out: a stale promote suppression must not
+		// hide a queued message in the chat opened next.
+		return () => {
+			store.clearSuppressedQueuedMessageIDs();
+		};
 	}, [chatID, store]);
 
+	// Cache arm of the authoritative-snapshot gate. A page-0 install is an
+	// authoritative queue snapshot too, so it has to advance the fence and
+	// reconcile the markers exactly like a `queue_update` does. It is a
+	// POST-INSTALL observer, not a write gate: by the time the effect runs the
+	// value IS the cached one, so a rejected snapshot stays installed and is
+	// only withheld from the fence and the markers, and kept as the corrective
+	// truth a failed convergence restores. The store consumes the echo of a
+	// write this client made, so observing the socket arm's own write does not
+	// double-advance the fence.
+	const cachedQueuedMessages = useInfiniteQuery({
+		...chatMessagesForInfiniteScroll(chatID ?? ""),
+		enabled: Boolean(chatID),
+		select: selectCanonicalQueuedMessages,
+	}).data;
 	useEffect(() => {
-		if (!chatID || !chatMessagesData) {
+		if (!chatID || cachedQueuedMessages === undefined) {
 			return;
 		}
-		// Allow re-hydration from REST as long as the WebSocket hasn't
-		// delivered a queue_update yet (which would be fresher). This
-		// ensures that when the user navigates back to a chat whose
-		// queued messages were drained server-side while they were
-		// away, the REST refetch corrects the stale cached state.
-		if (
-			queuedMessagesHydratedChatIDRef.current === chatID &&
-			wsQueueUpdateReceivedRef.current
-		) {
-			return;
-		}
-		queuedMessagesHydratedChatIDRef.current = chatID;
-		// An optimistic promotion cache write must not clear suppression before
-		// a stale pre-promotion queue_update arrives.
-		if (
-			chatQueuedMessagesEqualByID(
-				store.getSnapshot().queuedMessages,
-				chatQueuedMessages ?? [],
-			)
-		) {
-			return;
-		}
-		store.applyAuthoritativeQueuedMessages(chatQueuedMessages);
-	}, [chatMessagesData, chatID, chatQueuedMessages, store]);
+		store.acceptAuthoritativeQueueSnapshot(cachedQueuedMessages, "cache");
+	}, [cachedQueuedMessages, chatID, store]);
 
 	useEffect(() => {
 		store.resetTransientState();
@@ -591,20 +587,18 @@ export const useChatStore = (
 							}
 							continue;
 						}
-						case "queue_update":
-							wsQueueUpdateReceivedRef.current = true;
-							store.applyAuthoritativeQueuedMessages(
-								streamEvent.queued_messages,
-							);
-							// Cache the store's filtered queue, not the raw
-							// event, so a promoted message suppressed by the
-							// store cannot reappear on REST re-hydration.
-							writeQueuedMessagesToCache(
-								queryClient,
-								chatID,
-								store.getSnapshot().queuedMessages,
-							);
+						case "queue_update": {
+							// The gate decides; a rejected snapshot must not reach the
+							// cache. An accepted one is written VERBATIM, because the
+							// cache holds server truth and the suppression markers hide
+							// the transient rows at read time.
+							const snapshot = streamEvent.queued_messages ?? [];
+							if (!store.acceptAuthoritativeQueueSnapshot(snapshot, "socket")) {
+								continue;
+							}
+							writeQueuedMessagesToCache(queryClient, store, chatID, snapshot);
 							continue;
+						}
 						case "status": {
 							const nextStatus = streamEvent.status?.status;
 							if (!nextStatus) {
@@ -787,11 +781,11 @@ export const useChatStore = (
 		clearStreamError: () => {
 			store.clearStreamError();
 		},
-		setCacheQueuedMessages: (queuedMessages) => {
-			writeQueuedMessagesToCache(queryClient, chatID, queuedMessages);
+		writeCanonicalQueuedMessages: (queuedMessages) => {
+			writeQueuedMessagesToCache(queryClient, store, chatID, queuedMessages);
 		},
-		getCacheQueuedMessages: () =>
-			readQueuedMessagesFromCache(queryClient, chatID),
+		readCanonicalQueuedMessages: () =>
+			readCanonicalQueuedMessages(queryClient, chatID),
 		upsertCacheMessages,
 	};
 };


### PR DESCRIPTION
This is PR 7 of a stack fixing the Agents/chats feature's misuse of TanStack Query.

Makes cache page 0 canonical for the durable queue and removes the durable queue array from the store; suppression/promoted/observed markers and convergence metadata stay transient in the store/controller. Explicit delete/promote/edit removals become read-time markers instead of cache optimism, avoiding cache rollback races. Adds raw vs effective queue projections and an authoritative snapshot gate with socket and post-install REST arms, and serializes local queue-position operations. The convergence fetch/fence is kept because the server's queue head is ordered by `position` while clients see `created_at` (the next PR in the stack removes it). Fixes double-send while waiting for the queue lock, marker ownership collision, unbounded veto on convergence failure, and source-specific one-shot cache-echo dedupe.

Depends on #27776

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- Explicit queue removals are UI-only read-time markers, avoiding cache rollback races.
- The promoted-ID veto and echo gate survive here because they guard ordering between projections and stale snapshots, not identity guessing.
- Reviewed by two independent reviewers; mergeable.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood