### PR TITLE
refactor(site/src/pages/AgentsPage): provide the chat store via context

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -86,13 +86,14 @@ import {
 import { runExclusiveQueueMutation } from "./components/ChatConversation/chatQueueMutations";
 import {
 	type ChatStore,
+	ChatStoreContext,
 	type ChatStoreState,
-	useChatStore,
 } from "./components/ChatConversation/chatStore";
 import {
 	readEffectiveQueuedMessages,
 	useDurableChatStatus,
 } from "./components/ChatConversation/durableChat";
+import { useChatStore } from "./components/ChatConversation/useChatStore";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
@@ -2067,101 +2068,102 @@ const AgentChatPage: FC = () => {
 	}
 
 	return (
-		<AgentChatPageView
-			key={agentId}
-			agentId={agentId}
-			sendShortcut={getAgentChatSendShortcut(
-				preferencesQuery.data?.agent_chat_send_shortcut,
-				preferencesQuery.isLoading,
-			)}
-			organizationId={chatQuery.data?.organization_id}
-			chatTitle={chatTitle}
-			parentChat={parentChat}
-			persistedError={persistedError}
-			isArchived={isArchived}
-			isSharedChat={isSharedChat}
-			chatOwner={chatOwner}
-			canShareChat={canShareChat}
-			workspace={workspace}
-			workspaceAgent={workspaceAgent}
-			chatBuildId={chatQuery.data?.build_id}
-			store={store}
-			editing={{ ...editing, handleEditUserMessage }}
-			effectiveSelectedModel={effectiveSelectedModel}
-			setSelectedModel={setSelectedModel}
-			modelOptions={modelOptions}
-			modelSelectorPlaceholder={modelSelectorPlaceholder}
-			modelSelectorHelp={modelSelectorHelp}
-			reasoningEffort={effectiveReasoningEffort}
-			onReasoningEffortChange={(value) => {
-				setSelectedReasoningEffort(value);
-				if (editing.editingMessageId !== null) {
-					isEditReasoningEffortDirtyRef.current = true;
+		<ChatStoreContext value={store}>
+			<AgentChatPageView
+				key={agentId}
+				agentId={agentId}
+				sendShortcut={getAgentChatSendShortcut(
+					preferencesQuery.data?.agent_chat_send_shortcut,
+					preferencesQuery.isLoading,
+				)}
+				organizationId={chatQuery.data?.organization_id}
+				chatTitle={chatTitle}
+				parentChat={parentChat}
+				persistedError={persistedError}
+				isArchived={isArchived}
+				isSharedChat={isSharedChat}
+				chatOwner={chatOwner}
+				canShareChat={canShareChat}
+				workspace={workspace}
+				workspaceAgent={workspaceAgent}
+				chatBuildId={chatQuery.data?.build_id}
+				editing={{ ...editing, handleEditUserMessage }}
+				effectiveSelectedModel={effectiveSelectedModel}
+				setSelectedModel={setSelectedModel}
+				modelOptions={modelOptions}
+				modelSelectorPlaceholder={modelSelectorPlaceholder}
+				modelSelectorHelp={modelSelectorHelp}
+				reasoningEffort={effectiveReasoningEffort}
+				onReasoningEffortChange={(value) => {
+					setSelectedReasoningEffort(value);
+					if (editing.editingMessageId !== null) {
+						isEditReasoningEffortDirtyRef.current = true;
+					}
+				}}
+				canConfigureAgentSetup={permissions.editDeploymentConfig}
+				providerCount={providerCount}
+				modelCount={modelCount}
+				unsupportedProviderNames={unsupportedProviderNames}
+				aiGatewayDisabled={aiGatewayDisabled}
+				hasModelOptions={hasModelOptions}
+				isModelCatalogLoading={isModelCatalogLoading}
+				planModeEnabled={planModeEnabled}
+				onPlanModeToggle={handlePlanModeToggle}
+				compressionThreshold={compressionThreshold}
+				isInputDisabled={isInputDisabled}
+				isSubmissionPending={isSubmissionPending}
+				isInterruptPending={isInterruptPending}
+				workspaceOptions={workspaceOptions}
+				selectedWorkspaceId={selectedWorkspaceId}
+				onWorkspaceChange={
+					canUpdateChatWorkspace ? handleWorkspaceChange : undefined
 				}
-			}}
-			canConfigureAgentSetup={permissions.editDeploymentConfig}
-			providerCount={providerCount}
-			modelCount={modelCount}
-			unsupportedProviderNames={unsupportedProviderNames}
-			aiGatewayDisabled={aiGatewayDisabled}
-			hasModelOptions={hasModelOptions}
-			isModelCatalogLoading={isModelCatalogLoading}
-			planModeEnabled={planModeEnabled}
-			onPlanModeToggle={handlePlanModeToggle}
-			compressionThreshold={compressionThreshold}
-			isInputDisabled={isInputDisabled}
-			isSubmissionPending={isSubmissionPending}
-			isInterruptPending={isInterruptPending}
-			workspaceOptions={workspaceOptions}
-			selectedWorkspaceId={selectedWorkspaceId}
-			onWorkspaceChange={
-				canUpdateChatWorkspace ? handleWorkspaceChange : undefined
-			}
-			isWorkspaceLoading={isWorkspaceLoading}
-			isSidebarCollapsed={isSidebarCollapsed}
-			onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-			showSidebarPanel={showSidebarPanel}
-			onSetShowSidebarPanel={handleSetShowSidebarPanel}
-			prNumber={prNumber}
-			diffStatusData={chatQuery.data?.diff_status}
-			debugLoggingEnabled={debugLoggingEnabled}
-			gitWatcher={gitWatcher}
-			sshCommand={sshCommand}
-			handleCommit={handleCommit}
-			handleInterrupt={handleInterrupt}
-			handleDeleteQueuedMessage={handleDeleteQueuedMessage}
-			handlePromoteQueuedMessage={handlePromoteQueuedMessage}
-			onImplementPlan={handleImplementPlan}
-			onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
-			handleArchiveAgentAction={handleArchiveAgentAction}
-			handleUnarchiveAgentAction={handleUnarchiveAgentAction}
-			handleArchiveAndDeleteWorkspaceAction={
-				handleArchiveAndDeleteWorkspaceAction
-			}
-			handlePinAgentAction={handlePinAgentAction}
-			handleUnpinAgentAction={handleUnpinAgentAction}
-			handleOpenRenameDialogAction={handleOpenRenameDialogAction}
-			isArchivingThisChat={
-				isArchiving &&
-				(archivingChatId === undefined || archivingChatId === agentId)
-			}
-			isPinned={(chatRecord?.pin_order ?? 0) > 0}
-			isChildChat={parentChatID !== undefined}
-			urlTransform={urlTransform}
-			scrollContainerRef={scrollContainerRef}
-			scrollToBottomRef={scrollToBottomRef}
-			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
-			isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
-			onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-			messageCount={chatMessagesList?.length ?? 0}
-			desktopChatId={desktopEnabled ? agentId : undefined}
-			mcpServers={mcpServers}
-			selectedMCPServerIds={effectiveMCPServerIds}
-			onMCPSelectionChange={handleMCPSelectionChange}
-			onMCPAuthComplete={handleMCPAuthComplete}
-			chatContext={chatQuery.data?.context}
-			workspaceSkills={workspaceSkillsFromChat(chatQuery.data)}
-		/>
+				isWorkspaceLoading={isWorkspaceLoading}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+				showSidebarPanel={showSidebarPanel}
+				onSetShowSidebarPanel={handleSetShowSidebarPanel}
+				prNumber={prNumber}
+				diffStatusData={chatQuery.data?.diff_status}
+				debugLoggingEnabled={debugLoggingEnabled}
+				gitWatcher={gitWatcher}
+				sshCommand={sshCommand}
+				handleCommit={handleCommit}
+				handleInterrupt={handleInterrupt}
+				handleDeleteQueuedMessage={handleDeleteQueuedMessage}
+				handlePromoteQueuedMessage={handlePromoteQueuedMessage}
+				onImplementPlan={handleImplementPlan}
+				onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
+				handleArchiveAgentAction={handleArchiveAgentAction}
+				handleUnarchiveAgentAction={handleUnarchiveAgentAction}
+				handleArchiveAndDeleteWorkspaceAction={
+					handleArchiveAndDeleteWorkspaceAction
+				}
+				handlePinAgentAction={handlePinAgentAction}
+				handleUnpinAgentAction={handleUnpinAgentAction}
+				handleOpenRenameDialogAction={handleOpenRenameDialogAction}
+				isArchivingThisChat={
+					isArchiving &&
+					(archivingChatId === undefined || archivingChatId === agentId)
+				}
+				isPinned={(chatRecord?.pin_order ?? 0) > 0}
+				isChildChat={parentChatID !== undefined}
+				urlTransform={urlTransform}
+				scrollContainerRef={scrollContainerRef}
+				scrollToBottomRef={scrollToBottomRef}
+				hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
+				isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
+				onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
+				messageCount={chatMessagesList?.length ?? 0}
+				desktopChatId={desktopEnabled ? agentId : undefined}
+				mcpServers={mcpServers}
+				selectedMCPServerIds={effectiveMCPServerIds}
+				onMCPSelectionChange={handleMCPSelectionChange}
+				onMCPAuthComplete={handleMCPAuthComplete}
+				chatContext={chatQuery.data?.context}
+				workspaceSkills={workspaceSkillsFromChat(chatQuery.data)}
+			/>
+		</ChatStoreContext>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -33,7 +33,10 @@ import {
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
 } from "./AgentChatPageView";
-import { createChatStore } from "./components/ChatConversation/chatStore";
+import {
+	ChatStoreContext,
+	createChatStore,
+} from "./components/ChatConversation/chatStore";
 import { useDurableMessageCount } from "./components/ChatConversation/durableChat";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
@@ -110,10 +113,9 @@ const agentsRouting = [
 // Wrapper component.
 //
 // Storybook's composeStory deep-merges meta.args into every story.
-// When meta.args contains many fn() mocks, Maps, and closure-bound
-// stores the merge hangs the browser. This wrapper builds fresh
-// default props on each render, accepting only the overrides each
-// story cares about.
+// When meta.args contains many fn() mocks and Maps the merge hangs
+// the browser. This wrapper builds fresh default props on each
+// render, accepting only the overrides each story cares about.
 // ---------------------------------------------------------------------------
 type StoryProps = Omit<
 	Partial<ComponentProps<typeof AgentChatPageView>>,
@@ -123,10 +125,10 @@ type StoryProps = Omit<
 };
 
 const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
-	const defaultStoreRef = useRef(createChatStore());
+	const storeRef = useRef(createChatStore());
 	const defaultScrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const defaultScrollToBottomRef = useRef<(() => void) | null>(null);
-	const store = overrides.store ?? defaultStoreRef.current;
+	const store = storeRef.current;
 	const agentId = overrides.agentId ?? AGENT_ID;
 	const messageCount = useDurableMessageCount({ store, chatId: agentId });
 
@@ -186,11 +188,14 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		providerCount: 1,
 		modelCount: 1,
 		...overrides,
-		store,
 		messageCount: overrides.messageCount ?? messageCount,
 		editing: buildEditing(editing),
 	};
-	return <AgentChatPageView {...props} />;
+	return (
+		<ChatStoreContext value={store}>
+			<AgentChatPageView {...props} />
+		</ChatStoreContext>
+	);
 };
 
 // ---------------------------------------------------------------------------
@@ -864,10 +869,9 @@ const buildMessage = (
 
 // Durable messages are canonical in the query cache, so a story that needs a
 // transcript owns a QueryClient seeded with the pages the API would return and
-// provides it around the view. The store carries only the streaming overlay.
+// provides it around the view.
 type StoryChat = {
 	queryClient: QueryClient;
-	store: ReturnType<typeof createChatStore>;
 	setMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
 	getMessages: () => readonly TypesGen.ChatMessage[];
 };
@@ -900,7 +904,6 @@ const createStoryChat = (
 	setMessages(messages);
 	return {
 		queryClient,
-		store: createChatStore(),
 		setMessages,
 		getMessages: () => {
 			const data = queryClient.getQueryData<
@@ -950,7 +953,6 @@ export const OtherUserChatHidesInlineActions: Story = {
 				chatOwner={{ username: "OtherUser", name: "Other User" }}
 				isInputDisabled
 				onImplementPlan={fn()}
-				store={otherUserActionChat.store}
 			/>
 		</WithStoryChat>
 	),
@@ -993,7 +995,6 @@ export const EditingMessage: Story = {
 	render: () => (
 		<WithStoryChat chat={editingChat}>
 			<StoryAgentChatPageView
-				store={editingChat.store}
 				editing={{
 					editingMessageId: 3,
 					editorInitialValue: "Now tell me a joke",
@@ -1164,7 +1165,6 @@ export const InverseScrollLoadsOlderMessages: Story = {
 	render: () => (
 		<WithStoryChat chat={inverseScrollChat}>
 			<StoryAgentChatPageView
-				store={inverseScrollChat.store}
 				hasMoreMessages
 				onFetchMoreMessages={inverseScrollFetchSpy}
 			/>
@@ -1201,7 +1201,6 @@ export const InverseScrollCanLoadMultiplePages: Story = {
 	render: () => (
 		<WithStoryChat chat={multiPageScrollChat}>
 			<StoryAgentChatPageView
-				store={multiPageScrollChat.store}
 				hasMoreMessages
 				onFetchMoreMessages={multiPageFetchSpy}
 			/>
@@ -1244,7 +1243,7 @@ export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
 	decorators: scrollStoryDecorators,
 	render: () => (
 		<WithStoryChat chat={scrollToBottomButtonStoryChat}>
-			<StoryAgentChatPageView store={scrollToBottomButtonStoryChat.store} />
+			<StoryAgentChatPageView />
 		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
@@ -1294,10 +1293,7 @@ export const ScrollToBottomRefStillWorks: Story = {
 	decorators: scrollStoryDecorators,
 	render: () => (
 		<WithStoryChat chat={scrollToBottomStoryChat}>
-			<StoryAgentChatPageView
-				store={scrollToBottomStoryChat.store}
-				scrollToBottomRef={scrollToBottomStoryRef}
-			/>
+			<StoryAgentChatPageView scrollToBottomRef={scrollToBottomStoryRef} />
 		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
@@ -1340,7 +1336,7 @@ export const MessageOrderIsStillCorrect: Story = {
 	decorators: scrollStoryDecorators,
 	render: () => (
 		<WithStoryChat chat={messageOrderChat}>
-			<StoryAgentChatPageView store={messageOrderChat.store} />
+			<StoryAgentChatPageView />
 		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
@@ -1377,7 +1373,7 @@ export const StickyUserMessagePinsOnScroll: Story = {
 	decorators: scrollStoryDecorators,
 	render: () => (
 		<WithStoryChat chat={stickyPinningChat}>
-			<StoryAgentChatPageView store={stickyPinningChat.store} />
+			<StoryAgentChatPageView />
 		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {
@@ -1484,7 +1480,7 @@ export const StickyUserMessageClipUpdatesWhilePinned: Story = {
 	decorators: scrollStoryDecorators,
 	render: () => (
 		<WithStoryChat chat={stickyClipUpdateChat}>
-			<StoryAgentChatPageView store={stickyClipUpdateChat.store} />
+			<StoryAgentChatPageView />
 		</WithStoryChat>
 	),
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -33,7 +33,6 @@ import {
 	ChatConversationSkeleton,
 	RightPanelSkeleton,
 } from "./components/AgentsSkeletons";
-import type { useChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
 import type { SkillMetadata } from "./components/ChatMessageInput/SkillsTriggerMenu";
@@ -71,8 +70,6 @@ import {
 	savePersistedSidebarTabId,
 } from "./utils/sidebarTabStorage";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
-
-type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
 type ChatOwnerInfo = {
 	name?: string;
@@ -125,9 +122,6 @@ interface AgentChatPageViewProps {
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
 	chatBuildId?: string;
-
-	// Store handle.
-	store: ChatStoreHandle;
 
 	// Editing state.
 	editing: EditingState;
@@ -326,7 +320,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	workspaceAgent,
 	workspace,
 	chatBuildId,
-	store,
 	editing,
 	effectiveSelectedModel,
 	setSelectedModel,
@@ -912,7 +905,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						>
 							<div className="px-4" data-chat-scroll-content>
 								<ChatPageTimeline
-									store={store}
 									chatId={agentId}
 									persistedError={persistedError}
 									onEditUserMessage={
@@ -938,7 +930,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							<ChatPageInput
 								organizationId={organizationId}
 								sendShortcut={sendShortcut}
-								store={store}
 								compressionThreshold={compressionThreshold}
 								onSend={editing.handleSendFromInput}
 								onDeleteQueuedMessage={handleDeleteQueuedMessage}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -61,7 +61,7 @@ import { pageTitle } from "#/utils/page";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import { emptyInputStorageKey } from "./components/AgentCreateForm";
 import { getChatCostTreeID } from "./components/ChatConversation/chatHelpers";
-import { isActiveChatStatus } from "./components/ChatConversation/chatStore";
+import { isActiveChatStatus } from "./components/ChatConversation/chatStatusHelpers";
 import {
 	ChatsSidebar,
 	isSettingsView,

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -15,7 +15,7 @@ import {
 	selectStreamState,
 	selectSubagentStatusOverrides,
 	useChatSelector,
-	type useChatStore,
+	useChatStoreContext,
 } from "./chatStore";
 import { useIsAwaitingFirstStreamChunk } from "./durableChat";
 import { deriveLiveStatus, type LiveStatusModel } from "./liveStatusModel";
@@ -29,8 +29,6 @@ const shouldRenderStreamingSection = (liveStatus: LiveStatusModel): boolean =>
 	liveStatus.phase === "retrying" ||
 	liveStatus.phase === "reconnecting" ||
 	liveStatus.hasAccumulatedOutput;
-
-type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
 interface LiveStreamTailContentProps {
 	isTranscriptEmpty: boolean;
@@ -114,7 +112,6 @@ export const LiveStreamTailContent = ({
 };
 
 interface LiveStreamTailProps {
-	store: ChatStoreHandle;
 	chatId?: string;
 	persistedError: ChatDetailError | undefined;
 	isTranscriptEmpty: boolean;
@@ -129,7 +126,6 @@ interface LiveStreamTailProps {
 }
 
 export const LiveStreamTail = ({
-	store,
 	chatId,
 	persistedError,
 	isTranscriptEmpty,
@@ -139,6 +135,7 @@ export const LiveStreamTail = ({
 	urlTransform,
 	mcpServers,
 }: LiveStreamTailProps) => {
+	const store = useChatStoreContext();
 	const streamState = useChatSelector(store, selectStreamState);
 	const finalizingStreamState = useChatSelector(
 		store,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -23,6 +23,10 @@ const normalizeProvider = (provider?: string): string | undefined => {
 	}
 };
 
+export const isActiveChatStatus = (
+	status: TypesGen.ChatStatus | null,
+): boolean => status === "running" || status === "interrupting";
+
 export const getErrorTitle = (
 	kind: TypesGen.ChatErrorKind,
 	mode: "retry" | "error",

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -139,11 +139,11 @@ describe("setRetryState / clearRetryState", () => {
 });
 
 // ---------------------------------------------------------------------------
-// setReconnectState / clearReconnectState
+// setReconnectState
 // ---------------------------------------------------------------------------
 
-describe("setReconnectState / clearReconnectState", () => {
-	it("stores and clears reconnect state", () => {
+describe("setReconnectState", () => {
+	it("stores reconnect state", () => {
 		const store = createChatStore();
 
 		store.setReconnectState({
@@ -156,20 +156,26 @@ describe("setReconnectState / clearReconnectState", () => {
 			delayMs: 3000,
 			retryingAt: "2025-01-01T00:00:30.000Z",
 		});
-
-		store.clearReconnectState();
-		expect(store.getSnapshot().reconnectState).toBeNull();
 	});
 
-	it("clearReconnectState is a no-op when already null", () => {
+	it("does not notify when setting an equal reconnect state", () => {
 		const store = createChatStore();
+		store.setReconnectState({
+			attempt: 2,
+			delayMs: 3000,
+			retryingAt: "2025-01-01T00:00:30.000Z",
+		});
 
 		let notified = false;
 		store.subscribe(() => {
 			notified = true;
 		});
-		store.clearReconnectState();
 
+		store.setReconnectState({
+			attempt: 2,
+			delayMs: 3000,
+			retryingAt: "2025-01-01T00:00:30.000Z",
+		});
 		expect(notified).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -57,6 +57,8 @@ import { MockChat } from "#/testHelpers/chatEntities";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
 	type ChatStore,
+	ChatStoreContext,
+	createChatStore,
 	resolveOverlayStreamState,
 	selectFinalizingMessageID,
 	selectFinalizingStreamState,
@@ -66,7 +68,7 @@ import {
 	selectStreamState,
 	selectSubagentStatusOverrides,
 	useChatSelector,
-	useChatStore,
+	useChatStoreContext,
 } from "./chatStore";
 import {
 	shouldSuppressFinalizedOverlay,
@@ -75,6 +77,7 @@ import {
 	useDurableQueuedMessages,
 	useIsAwaitingFirstStreamChunk,
 } from "./durableChat";
+import { useChatStore } from "./useChatStore";
 
 vi.mock("#/api/api", () => ({
 	watchChat: vi.fn(),
@@ -6850,5 +6853,43 @@ describe("durable messages in the query cache", () => {
 				readMessagesCache(queryClient, chatID)?.pages[0].queued_messages,
 			).toEqual([]);
 		});
+	});
+});
+
+describe("ChatStoreContext", () => {
+	it("gives a descendant selector the provided store", () => {
+		const store = createChatStore();
+		store.setStreamError({ kind: "generic", message: "provided store" });
+
+		const StreamErrorProbe: FC = () => {
+			const contextStore = useChatStoreContext();
+			const streamError = useChatSelector(contextStore, selectStreamError);
+			return <span>{streamError?.message ?? "no error"}</span>;
+		};
+
+		render(
+			<ChatStoreContext value={store}>
+				<StreamErrorProbe />
+			</ChatStoreContext>,
+		);
+
+		expect(screen.getByText("provided store")).toBeInTheDocument();
+	});
+
+	it("throws when a descendant reads the context without a provider", () => {
+		const BareProbe: FC = () => {
+			useChatStoreContext();
+			return null;
+		};
+
+		// React logs the expected render error; keep the output clean.
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		try {
+			expect(() => render(<BareProbe />)).toThrow();
+		} finally {
+			consoleError.mockRestore();
+		}
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -1,54 +1,12 @@
-import { useSyncExternalStore } from "react";
+import { createContext, useContext, useSyncExternalStore } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	type ChatDetailError,
 	chatDetailErrorsEqual,
 } from "../../utils/usageLimitMessage";
+import { chatQueuedMessagesEqualByValue } from "./chatValueEquality";
 import { applyMessagePartToStreamState } from "./streamState";
 import type { ReconnectState, RetryState, StreamState } from "./types";
-
-const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
-	if (left === right) {
-		return true;
-	}
-	try {
-		return JSON.stringify(left) === JSON.stringify(right);
-	} catch {
-		return false;
-	}
-};
-
-export const chatMessagesEqualByValue = (
-	left: TypesGen.ChatMessage,
-	right: TypesGen.ChatMessage,
-): boolean =>
-	left.id === right.id &&
-	left.chat_id === right.chat_id &&
-	left.model_config_id === right.model_config_id &&
-	left.created_at === right.created_at &&
-	left.role === right.role &&
-	jsonValuesEqual(left.content, right.content) &&
-	jsonValuesEqual(left.usage, right.usage);
-
-// Compares two queue snapshots by value. Deliberately not by ID alone: a
-// requeued edit keeps the ID and changes the content. Covers every field of
-// `ChatQueuedMessage`, so it agrees with the structural sharing the query
-// cache applies to a write.
-export const chatQueuedMessagesEqualByValue = (
-	left: readonly TypesGen.ChatQueuedMessage[],
-	right: readonly TypesGen.ChatQueuedMessage[],
-): boolean =>
-	left.length === right.length &&
-	left.every((message, index) => {
-		const other = right[index];
-		return (
-			message.id === other.id &&
-			message.chat_id === other.chat_id &&
-			message.model_config_id === other.model_config_id &&
-			message.created_at === other.created_at &&
-			jsonValuesEqual(message.content, other.content)
-		);
-	});
 
 const retryStatesEqual = (
 	left: RetryState | null,
@@ -85,10 +43,6 @@ const reconnectStatesEqual = (
 		left.retryingAt === right.retryingAt
 	);
 };
-
-export const isActiveChatStatus = (
-	status: TypesGen.ChatStatus | null,
-): boolean => status === "running" || status === "interrupting";
 
 /**
  * Transient chat state. Durable messages and the durable queue are NOT here:
@@ -186,7 +140,6 @@ export type ChatStore = {
 	setRetryState: (state: RetryState | null) => void;
 	clearRetryState: () => void;
 	setReconnectState: (state: ReconnectState | null) => void;
-	clearReconnectState: () => void;
 	clearStreamState: () => void;
 	resetTransportReplayState: () => void;
 	setSubagentStatusOverride: (
@@ -602,15 +555,6 @@ export const createChatStore = (): ChatStore => {
 				};
 			});
 		},
-		clearReconnectState: () => {
-			if (state.reconnectState === null) {
-				return;
-			}
-			setState((current) => ({
-				...current,
-				reconnectState: null,
-			}));
-		},
 		clearStreamState: () => {
 			if (
 				state.streamState === null &&
@@ -728,4 +672,18 @@ export const useChatSelector = <T>(
 	return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
 };
 
-export { useChatStore } from "./useChatStore";
+/**
+ * Publishes the handle the chat page created so descendants subscribe at the
+ * point of use instead of receiving it through props. Nullable rather than
+ * defaulted to a store: a default would let a subtree rendered outside the
+ * page read a second store nothing ever writes.
+ */
+export const ChatStoreContext = createContext<ChatStore | null>(null);
+
+export const useChatStoreContext = (): ChatStore => {
+	const store = useContext(ChatStoreContext);
+	if (!store) {
+		throw new Error("useChatStoreContext must be used within ChatStoreContext");
+	}
+	return store;
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatValueEquality.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatValueEquality.ts
@@ -1,0 +1,44 @@
+import type * as TypesGen from "#/api/typesGenerated";
+
+const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
+	if (left === right) {
+		return true;
+	}
+	try {
+		return JSON.stringify(left) === JSON.stringify(right);
+	} catch {
+		return false;
+	}
+};
+
+export const chatMessagesEqualByValue = (
+	left: TypesGen.ChatMessage,
+	right: TypesGen.ChatMessage,
+): boolean =>
+	left.id === right.id &&
+	left.chat_id === right.chat_id &&
+	left.model_config_id === right.model_config_id &&
+	left.created_at === right.created_at &&
+	left.role === right.role &&
+	jsonValuesEqual(left.content, right.content) &&
+	jsonValuesEqual(left.usage, right.usage);
+
+// Compares two queue snapshots by value. Deliberately not by ID alone: a
+// requeued edit keeps the ID and changes the content. Covers every field of
+// `ChatQueuedMessage`, so it agrees with the structural sharing the query
+// cache applies to a write.
+export const chatQueuedMessagesEqualByValue = (
+	left: readonly TypesGen.ChatQueuedMessage[],
+	right: readonly TypesGen.ChatQueuedMessage[],
+): boolean =>
+	left.length === right.length &&
+	left.every((message, index) => {
+		const other = right[index];
+		return (
+			message.id === other.id &&
+			message.chat_id === other.chat_id &&
+			message.model_config_id === other.model_config_id &&
+			message.created_at === other.created_at &&
+			jsonValuesEqual(message.content, other.content)
+		);
+	});

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -28,14 +28,16 @@ import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import { normalizeChatErrorPayload } from "./chatError";
+import { isActiveChatStatus } from "./chatStatusHelpers";
 import {
 	type ChatStore,
 	type ChatStoreState,
+	createChatStore,
+} from "./chatStore";
+import {
 	chatMessagesEqualByValue,
 	chatQueuedMessagesEqualByValue,
-	createChatStore,
-	isActiveChatStatus,
-} from "./chatStore";
+} from "./chatValueEquality";
 import {
 	readCanonicalQueuedMessages,
 	selectCanonicalQueuedMessages,
@@ -376,9 +378,9 @@ export const useChatStore = (
 		let disposed = false;
 
 		// Parts buffer lives at the effect scope so it persists
-		// across WebSocket messages. A rAF-based flush coalesces
+		// across WebSocket messages. A timer-based flush coalesces
 		// parts from multiple WS messages into a single render,
-		// capping stream renders to once per animation frame.
+		// capping stream renders to one per macrotask.
 		const partsBuf: TypesGen.ChatMessagePart[] = [];
 		let partsFlushTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -1,11 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type FC, type PropsWithChildren, useRef } from "react";
 import type { InfiniteData } from "react-query";
 import { expect, within } from "storybook/test";
 import { chatKeys } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat } from "#/testHelpers/chatEntities";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
-import { createChatStore } from "./ChatConversation/chatStore";
+import {
+	ChatStoreContext,
+	createChatStore,
+} from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
 import { ChatPageTimeline } from "./ChatPageContent";
 
@@ -17,6 +21,16 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const CHAT_ID = "chat-page-content-stories";
+
+// One store per mounted story, created once so the context value stays stable
+// across renders. These stories exercise durable rendering only, so the store
+// carries no streaming overlay.
+const WithChatStore: FC<PropsWithChildren> = ({ children }) => {
+	const storeRef = useRef(createChatStore());
+	return (
+		<ChatStoreContext value={storeRef.current}>{children}</ChatStoreContext>
+	);
+};
 
 const buildMessage = (
 	id: number,
@@ -71,11 +85,9 @@ export const SpacerVisibleWhenNotStreaming: Story = {
 		]),
 	},
 	render: () => (
-		<ChatPageTimeline
-			store={createChatStore()}
-			chatId={CHAT_ID}
-			persistedError={undefined}
-		/>
+		<WithChatStore>
+			<ChatPageTimeline chatId={CHAT_ID} persistedError={undefined} />
+		</WithChatStore>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -103,11 +115,9 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 	},
 	render: () => (
 		<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>
-			<ChatPageTimeline
-				store={createChatStore()}
-				chatId={CHAT_ID}
-				persistedError={undefined}
-			/>
+			<WithChatStore>
+				<ChatPageTimeline chatId={CHAT_ID} persistedError={undefined} />
+			</WithChatStore>
 		</ChatWorkspaceContext>
 	),
 	play: async ({ canvasElement }) => {
@@ -128,11 +138,9 @@ export const HiddenAssistantPlaceholderDoesNotRender: Story = {
 		]),
 	},
 	render: () => (
-		<ChatPageTimeline
-			store={createChatStore()}
-			chatId={CHAT_ID}
-			persistedError={undefined}
-		/>
+		<WithChatStore>
+			<ChatPageTimeline chatId={CHAT_ID} persistedError={undefined} />
+		</WithChatStore>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -198,11 +206,9 @@ export const MergedMessagesRenderInIDOrder: Story = {
 		],
 	},
 	render: () => (
-		<ChatPageTimeline
-			store={createChatStore()}
-			chatId={CHAT_ID}
-			persistedError={undefined}
-		/>
+		<WithChatStore>
+			<ChatPageTimeline chatId={CHAT_ID} persistedError={undefined} />
+		</WithChatStore>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -27,7 +27,7 @@ import {
 	selectHasStreamOverlay,
 	selectHasStreamState,
 	useChatSelector,
-	type useChatStore,
+	useChatStoreContext,
 } from "./ChatConversation/chatStore";
 import {
 	shouldSuppressFinalizedOverlay,
@@ -45,8 +45,6 @@ import {
 import { useOnRenderProfiler } from "./ChatConversation/useOnRenderProfiler";
 import type { ModelSelectorOption } from "./ChatElements";
 import type { SkillMetadata } from "./ChatMessageInput/SkillsTriggerMenu";
-
-type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
 // A resolved chat with no context (unpinned) or no resources authoritatively
 // has no workspace skills; only an unresolved chat leaves them unknown.
@@ -76,7 +74,6 @@ export const workspaceSkillsFromChat = (
 };
 
 interface ChatPageTimelineProps {
-	store: ChatStoreHandle;
 	chatId?: string;
 	persistedError: ChatDetailError | undefined;
 	onEditUserMessage?: (
@@ -92,7 +89,6 @@ interface ChatPageTimelineProps {
 }
 
 export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
-	store,
 	chatId,
 	persistedError,
 	onEditUserMessage,
@@ -102,6 +98,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	urlTransform,
 	mcpServers,
 }) => {
+	const store = useChatStoreContext();
 	const [chatFullWidth] = useChatFullWidth();
 	const messages = useDurableMessageList({ store, chatId });
 	const chatStatus = useDurableChatStatus({ store, chatId });
@@ -175,7 +172,6 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					showDesktopPreviews={false}
 				/>
 				<LiveStreamTail
-					store={store}
 					chatId={chatId}
 					persistedError={persistedError}
 					isTranscriptEmpty={parsedMessages.length === 0}
@@ -198,7 +194,6 @@ export type PendingAttachment = {
 interface ChatPageInputProps {
 	// Organization that owns this chat. Used to scope file uploads.
 	organizationId: string | undefined;
-	store: ChatStoreHandle;
 	compressionThreshold: number | undefined;
 	onSend: (
 		message: string,
@@ -277,7 +272,6 @@ interface ChatPageInputProps {
 
 export const ChatPageInput: FC<ChatPageInputProps> = ({
 	organizationId,
-	store,
 	compressionThreshold,
 	onSend,
 	sendShortcut,
@@ -333,6 +327,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	attachedWorkspace,
 	folder,
 }) => {
+	const store = useChatStoreContext();
 	const messages = useDurableMessageList({ store, chatId });
 	const hasStreamState = useChatSelector(store, selectHasStreamState);
 	const chatStatus = useDurableChatStatus({ store, chatId });


### PR DESCRIPTION
This is PR 9 (final) of a stack fixing the Agents/chats feature's misuse of TanStack Query.

After the earlier PRs, the store carries only transient chat state (streaming overlay, transport surface, queue reconciliation markers, subagent status overrides); durable chat state is canonical in the query cache. Its remaining cost was threading a `store` prop through `AgentChatPage` -> `AgentChatPageView` -> `ChatPageContent` -> `LiveStreamTail`/`ChatPageInput`. This PR publishes the stable per-page store through a `ChatStoreContext` (nullable, with a throwing accessor) provided inside `AgentChatPage` around the loaded `AgentChatPageView`, and lets descendant components read it at the point of use instead of receiving a prop. Also moves the value-equality helpers into `chatValueEquality.ts` and `isActiveChatStatus` into `chatStatusHelpers.ts`, deletes the dead `clearReconnectState` member and the `chatStore.ts` `useChatStore` re-export (breaking an existing import cycle), hoists story fixture stores out of inline renders, and corrects a stale rAF comment.

Render topology is unchanged: `AgentChatPage` still renders 0 times per text token.

Depends on #27778

<details>
<summary>Implementation plan and review notes (for reviewers)</summary>

- A fuller "delete the store, move to React state" design was considered and rejected: the store's synchronous read-after-write semantics (queue gate, `preview_reset` mid-batch read, reconciliation behind async locks) are load-bearing, and hook-owned state would put the per-token hot path on `AgentChatPage`, which today renders 0 times per token via selector subscriptions.
- The owner (`AgentChatPage`, `useChatToolInvalidations`) and the module-level imperative helpers keep explicit store handles; the `useDurable*` facade hooks keep an explicit store argument; descendant components read context.
- Reviewed by two independent reviewers; mergeable.

</details>

---

Generated by Coder Agents on behalf of @DanielleMaywood