### PR TITLE
fix(site): link spend page alert to cost control migration section

### DIFF
--- a/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
@@ -239,7 +239,9 @@ export const SpendPageView: FC<SpendPageViewProps> = ({
 								<AlertDescription>
 									Cost controls features will move to AI Governance in v2.36.{" "}
 									<Link
-										href={docs("/ai-coder/ai-gateway/cost-controls")}
+										href={docs(
+											"/ai-coder/ai-gateway/cost-controls#migrate-from-coder-agents-cost-control",
+										)}
 										target="_blank"
 										rel="noreferrer"
 									>

--- a/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/SpendPageView.tsx
@@ -235,9 +235,12 @@ export const SpendPageView: FC<SpendPageViewProps> = ({
 				>
 					{(userCtrl) => (
 						<div className="flex max-w-[1100px] flex-col gap-8">
-							<Alert severity="info">
+							<Alert severity="warning" prominent>
 								<AlertDescription>
-									Cost controls features will move to AI Governance in v2.36.{" "}
+									As of v2.36, AI Governance Cost Control replaces Coder Agents
+									Cost Control. The limits on this page are no longer enforced
+									and do not carry over. Recreate each limit as an AI Governance
+									budget to restore enforcement.{" "}
 									<Link
 										href={docs(
 											"/ai-coder/ai-gateway/cost-controls#migrate-from-coder-agents-cost-control",


### PR DESCRIPTION
The "Read more here" link in the spend page alert pointed at the top of the cost controls doc, which doesn't explain the v2.36 move to AI Governance.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                   
Point it at the `#migrate-from-coder-agents-cost-control` section instead: https://coder.com/docs/@main/ai-coder/ai-gateway/cost-controls#migrate-from-coder-agents-cost-control

Related to internal slack thread: https://codercom.slack.com/archives/C0AEHQGLW22/p1785747924721539