### PR TITLE
refactor(site): demui workspace build data and outdated tooltip

### DIFF
--- a/site/src/modules/workspaces/WorkspaceBuildData/WorkspaceBuildData.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildData/WorkspaceBuildData.tsx
@@ -40,12 +40,7 @@ export const WorkspaceBuildData: React.FC<WorkspaceBuildDataProps> = ({
 						build.transition === "start" && (
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<InfoIcon
-										css={(theme) => ({
-											color: theme.palette.info.light,
-										})}
-										className="size-icon-xs -mt-px"
-									/>
+									<InfoIcon className="text-content-secondary size-icon-xs -mt-px" />
 								</TooltipTrigger>
 								<TooltipContent side="bottom">
 									{buildReasonLabels[build.reason]}

--- a/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -1,5 +1,3 @@
-import { useTheme } from "@emotion/react";
-import Link from "@mui/material/Link";
 import { CircleAlertIcon, RotateCcwIcon } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
 import { useQuery } from "react-query";
@@ -17,6 +15,7 @@ import {
 	HelpPopoverTitle,
 	HelpPopoverTrigger,
 } from "#/components/HelpPopover/HelpPopover";
+import { Link } from "#/components/Link/Link";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
 import {
@@ -80,7 +79,6 @@ const WorkspaceOutdatedTooltipContent: FC<TooltipContentProps> = ({
 	isOpen,
 }) => {
 	const getLink = useLinks();
-	const theme = useTheme();
 	const { data: activeVersion } = useQuery({
 		...templateVersion(workspace.template_active_version_id),
 		enabled: isOpen,
@@ -120,7 +118,10 @@ const WorkspaceOutdatedTooltipContent: FC<TooltipContentProps> = ({
 								<Link
 									href={`${versionLink}/versions/${activeVersion.name}`}
 									target="_blank"
-									css={{ color: theme.palette.primary.light }}
+									rel="noreferrer"
+									size="sm"
+									className="p-0"
+									showExternalIcon={false}
 								>
 									{activeVersion.name}
 								</Link>


### PR DESCRIPTION
Replace Emotion `css` / `useTheme` and MUI `Link` in `WorkspaceBuildData` and `WorkspaceOutdatedTooltip` with Tailwind semantic classes and the shared `Link` component.