### PR TITLE
fix(coderd): reject workspace proxy hostname prefixes (#27544)

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -1562,6 +1562,16 @@ func TestProxyByHostname(t *testing.T) {
 			accessURL:        "https://two.coder.com",
 			wildcardHostname: "*--suffix.two.coder.com",
 		},
+		{
+			name:             "three",
+			accessURL:        "https://three.coder.com:8443",
+			wildcardHostname: "*.wildcard.three.coder.com",
+		},
+		{
+			name:             "four",
+			accessURL:        "https://four.coder.com/",
+			wildcardHostname: "*.wildcard.four.coder.com",
+		},
 	}
 	for _, p := range proxies {
 		dbgen.WorkspaceProxy(t, db, database.WorkspaceProxy{
@@ -1593,6 +1603,34 @@ func TestProxyByHostname(t *testing.T) {
 			matchProxyName:    "one",
 		},
 		{
+			name:              "MatchAccessURLWithPort",
+			testHostname:      "three.coder.com",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "three",
+		},
+		{
+			name:              "MatchAccessURLWithTrailingSlash",
+			testHostname:      "four.coder.com",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "four",
+		},
+		{
+			name:              "RejectAccessURLPrefix",
+			testHostname:      "one.coder",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "",
+		},
+		{
+			name:              "RejectAccessURLTLDPrefix",
+			testHostname:      "one.coder.co",
+			allowAccessURL:    true,
+			allowWildcardHost: false,
+			matchProxyName:    "",
+		},
+		{
 			name:              "MatchWildcard",
 			testHostname:      "something.wildcard.one.coder.com",
 			allowAccessURL:    true,
@@ -1600,11 +1638,25 @@ func TestProxyByHostname(t *testing.T) {
 			matchProxyName:    "one",
 		},
 		{
+			name:              "RejectWildcardHostnamePrefix",
+			testHostname:      "something.wildcard.one.coder",
+			allowAccessURL:    false,
+			allowWildcardHost: true,
+			matchProxyName:    "",
+		},
+		{
 			name:              "MatchSuffix",
 			testHostname:      "something--suffix.two.coder.com",
 			allowAccessURL:    true,
 			allowWildcardHost: true,
 			matchProxyName:    "two",
+		},
+		{
+			name:              "RejectSuffixHostnamePrefix",
+			testHostname:      "something--suffix.two.coder",
+			allowAccessURL:    false,
+			allowWildcardHost: true,
+			matchProxyName:    "",
 		},
 		{
 			name:              "ValidateHostname/1",

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -19773,7 +19773,7 @@ WHERE
 	(
 		(
 			$2 :: bool = true AND
-			url SIMILAR TO '[^:]*://' || $1 :: text || '([:/]?%)*'
+			url SIMILAR TO '[^:]*://' || $1 :: text || '([:/]%)*'
 		) OR
 		(
 			$3 :: bool = true AND

--- a/coderd/database/queries/proxies.sql
+++ b/coderd/database/queries/proxies.sql
@@ -120,7 +120,7 @@ WHERE
 	(
 		(
 			@allow_access_url :: bool = true AND
-			url SIMILAR TO '[^:]*://' || @hostname :: text || '([:/]?%)*'
+			url SIMILAR TO '[^:]*://' || @hostname :: text || '([:/]%)*'
 		) OR
 		(
 			@allow_wildcard_hostname :: bool = true AND

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -116,6 +116,15 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 			expectRedirect:   "https://proxy.test.coder.com/path",
 		},
 		{
+			name:             "RejectProxyAccessURLPrefix",
+			accessURL:        "https://test.coder.com",
+			appHostname:      "*.test.coder.com",
+			proxyURL:         "https://proxy.test.coder.com",
+			proxyAppHostname: "*.proxy.test.coder.com",
+			redirectURI:      "https://proxy.test.coder/path",
+			expectRedirect:   "",
+		},
+		{
 			name:             "ProxySubdomainOK",
 			accessURL:        "https://test.coder.com",
 			appHostname:      "*.test.coder.com",


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/27544 to `release/2.33`.

Original PR: #27544 — fix(coderd): reject workspace proxy hostname prefixes
Merge commit: 8cc7f2bb0e0b33199393cc3773c7d691bd2fbf6b

`release/2.33` is in the **Security Support** channel per the [release schedule](https://coder.com/docs/install/releases#release-schedule) and was the only in-scope branch still missing this security fix (2.29, 2.34, 2.35, and 2.36 were already backported via #27614, #27616, #27615, and #27613).

Refs: https://linear.app/codercom/issue/PLAT-384

---

_This backport PR was created by Coder Agents on behalf of @jdomeracki-coder._
