### PR TITLE
refactor(site): demui CreateTemplatePage build logs drawer

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -116,6 +116,7 @@
 		"ufuzzy": "npm:@leeoniya/ufuzzy@1.0.10",
 		"unique-names-generator": "4.7.1",
 		"uuid": "14.0.0",
+		"vaul": "1.1.2",
 		"websocket-ts": "2.3.0",
 		"yup": "1.7.1"
 	},

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       uuid:
         specifier: 11.1.1
         version: 11.1.1
+      vaul:
+        specifier: 1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       websocket-ts:
         specifier: 2.3.0
         version: 2.3.0
@@ -6227,6 +6230,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==, tarball: https://registry.npmjs.org/vary/-/vary-1.1.2.tgz}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==, tarball: https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==, tarball: https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz}
@@ -12928,6 +12937,15 @@ snapshots:
       typescript: 6.0.2
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:

--- a/site/src/components/Drawer/Drawer.stories.tsx
+++ b/site/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { Button } from "#/components/Button/Button";
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from "./Drawer";
+
+const meta: Meta<typeof Drawer> = {
+	title: "components/Drawer",
+	component: Drawer,
+	args: {
+		children: (
+			<>
+				<DrawerTrigger asChild>
+					<Button>Open Drawer</Button>
+				</DrawerTrigger>
+				<DrawerContent>
+					<DrawerHeader>
+						<DrawerTitle>Example Drawer Title</DrawerTitle>
+						<DrawerDescription>Drawer description text</DrawerDescription>
+					</DrawerHeader>
+					<DrawerFooter>
+						<DrawerClose asChild>
+							<Button variant="outline">Cancel</Button>
+						</DrawerClose>
+						<Button>Submit</Button>
+					</DrawerFooter>
+				</DrawerContent>
+			</>
+		),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+export const OpenDrawer: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Open Drawer" }));
+	},
+};
+
+export const OpenRightDrawer: Story = {
+	args: {
+		direction: "right",
+		children: (
+			<>
+				<DrawerTrigger asChild>
+					<Button>Open Right Drawer</Button>
+				</DrawerTrigger>
+				<DrawerContent className="sm:max-w-md">
+					<DrawerHeader>
+						<DrawerTitle>Right-side drawer</DrawerTitle>
+						<DrawerDescription>
+							Drawers can open from any side via the direction prop.
+						</DrawerDescription>
+					</DrawerHeader>
+					<DrawerFooter>
+						<DrawerClose asChild>
+							<Button variant="outline">Close</Button>
+						</DrawerClose>
+					</DrawerFooter>
+				</DrawerContent>
+			</>
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Open Right Drawer" }),
+		);
+	},
+};

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,131 @@
+/**
+ * Copied from shadcn/ui on 08/04/2026
+ * @see {@link https://ui.shadcn.com/docs/components/drawer}
+ */
+import { Drawer as DrawerPrimitive } from "vaul";
+import { cn } from "#/utils/cn";
+
+export const Drawer: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Root>
+> = ({ shouldScaleBackground = true, ...props }) => {
+	return (
+		<DrawerPrimitive.Root
+			shouldScaleBackground={shouldScaleBackground}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerTrigger = DrawerPrimitive.Trigger;
+
+export const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerOverlay: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Overlay>
+> = ({ className, ...props }) => {
+	return (
+		<DrawerPrimitive.Overlay
+			className={cn(
+				`fixed inset-0 z-50 bg-overlay
+				data-[state=open]:animate-in data-[state=closed]:animate-out
+				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerContent: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Content>
+> = ({ className, children, ...props }) => {
+	return (
+		<DrawerPortal>
+			<DrawerOverlay />
+			<DrawerPrimitive.Content
+				className={cn(
+					"group/drawer-content fixed z-50 flex h-auto flex-col bg-surface-primary outline-none",
+					`data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0
+					data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh]
+					data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=top]:border-border`,
+					`data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0
+					data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh]
+					data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=bottom]:border-border`,
+					`data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0
+					data-[vaul-drawer-direction=right]:h-full data-[vaul-drawer-direction=right]:w-3/4
+					data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:border-border
+					data-[vaul-drawer-direction=right]:sm:max-w-sm`,
+					`data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0
+					data-[vaul-drawer-direction=left]:h-full data-[vaul-drawer-direction=left]:w-3/4
+					data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:border-border
+					data-[vaul-drawer-direction=left]:sm:max-w-sm`,
+					className,
+				)}
+				{...props}
+			>
+				<div
+					className={`mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-surface-tertiary
+					group-data-[vaul-drawer-direction=bottom]/drawer-content:block`}
+				/>
+				{children}
+			</DrawerPrimitive.Content>
+		</DrawerPortal>
+	);
+};
+
+export const DrawerHeader: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn(
+				`flex flex-col gap-0.5 p-4
+				group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center
+				group-data-[vaul-drawer-direction=top]/drawer-content:text-center
+				md:gap-1.5 md:text-left`,
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerTitle: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Title>
+> = ({ className, ...props }) => {
+	return (
+		<DrawerPrimitive.Title
+			className={cn(
+				"text-lg font-semibold leading-none tracking-tight text-content-primary",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerDescription: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Description>
+> = ({ className, ...props }) => {
+	return (
+		<DrawerPrimitive.Description
+			className={cn("text-sm text-content-secondary", className)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -1,9 +1,14 @@
-import Drawer from "@mui/material/Drawer";
 import { TriangleAlertIcon, XIcon } from "lucide-react";
 import type { FC } from "react";
 import { JobError } from "#/api/queries/templates";
 import type { TemplateVersion } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerTitle,
+} from "#/components/Drawer/Drawer";
 import { Loader } from "#/components/Loader/Loader";
 import { AlertVariant } from "#/modules/provisioners/ProvisionerAlert";
 import { ProvisionerStatusAlert } from "#/modules/provisioners/ProvisionerStatusAlert";
@@ -23,7 +28,8 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	templateVersion,
 	error,
 	variablesSectionRef,
-	...drawerProps
+	open,
+	onClose,
 }) => {
 	const logs = useWatchVersionLogs(templateVersion);
 
@@ -37,52 +43,66 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	const hasLogs = logs && logs.length > 0;
 
 	return (
-		<Drawer anchor="right" {...drawerProps}>
-			<div className="flex h-full w-[800px] flex-col">
-				<header
-					className="flex items-center justify-between border-b border-border px-6"
-					style={{ height: navHeight }}
-				>
-					<h3 className="m-0 text-base font-medium">Creating template...</h3>
-					<Button size="icon-lg" variant="subtle" onClick={drawerProps.onClose}>
-						<XIcon />
-						<span className="sr-only">Close build logs</span>
-					</Button>
-				</header>
+		<Drawer
+			open={open}
+			onOpenChange={(isOpen) => {
+				if (!isOpen) {
+					onClose();
+				}
+			}}
+			direction="right"
+		>
+			<DrawerContent className="!w-[min(800px,100%)] !max-w-full">
+				<div className="flex h-full flex-col">
+					<header
+						className="flex items-center justify-between border-b border-border px-6 bg-surface-secondary"
+						style={{ height: navHeight }}
+					>
+						<DrawerTitle className="m-0 text-base font-medium">
+							Creating template...
+						</DrawerTitle>
+						<DrawerClose asChild>
+							<Button size="icon-lg" variant="subtle">
+								<XIcon />
+								<span className="sr-only">Close build logs</span>
+							</Button>
+						</DrawerClose>
+					</header>
 
-				{isMissingVariables ? (
-					<MissingVariablesBanner
-						onFillVariables={() => {
-							variablesSectionRef.current?.scrollIntoView({
-								behavior: "smooth",
-							});
-							const firstVariableInput =
-								variablesSectionRef.current?.querySelector("input");
-							firstVariableInput?.focus();
-							drawerProps.onClose();
-						}}
-					/>
-				) : (
-					<>
-						{(matchingProvisioners === 0 || !hasLogs) && (
-							<ProvisionerStatusAlert
-								matchingProvisioners={matchingProvisioners}
-								availableProvisioners={availableProvisioners}
-								tags={templateVersion?.job.tags ?? {}}
-								variant={AlertVariant.Inline}
-							/>
-						)}
+					{isMissingVariables ? (
+						<MissingVariablesBanner
+							onFillVariables={() => {
+								variablesSectionRef.current?.scrollIntoView({
+									behavior: "smooth",
+								});
+								const firstVariableInput =
+									variablesSectionRef.current?.querySelector("input");
+								firstVariableInput?.focus();
+								onClose();
+							}}
+						/>
+					) : (
+						<>
+							{(matchingProvisioners === 0 || !hasLogs) && (
+								<ProvisionerStatusAlert
+									matchingProvisioners={matchingProvisioners}
+									availableProvisioners={availableProvisioners}
+									tags={templateVersion?.job.tags ?? {}}
+									variant={AlertVariant.Inline}
+								/>
+							)}
 
-						{hasLogs ? (
-							<section className="flex-1 overflow-auto bg-surface-primary">
-								<WorkspaceBuildLogs logs={logs} className="border-0" />
-							</section>
-						) : (
-							<Loader />
-						)}
-					</>
-				)}
-			</div>
+							{hasLogs ? (
+								<section className="flex-1 overflow-auto bg-surface-primary">
+									<WorkspaceBuildLogs logs={logs} className="border-0" />
+								</section>
+							) : (
+								<Loader />
+							)}
+						</>
+					)}
+				</div>
+			</DrawerContent>
 		</Drawer>
 	);
 };


### PR DESCRIPTION
Adds a shared shadcn/Vaul `Drawer` primitive and migrates Create Template `BuildLogsDrawer` off MUI.

Keeps the desktop panel at 800px and uses `min(800px, 100%)` so it stays within the viewport on mobile. Includes Storybook coverage for the new component exports.