### PR TITLE
ci: broaden linkspector Stack Overflow ignore for weekly docs check

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -29,7 +29,6 @@ ignorePatterns:
   - pattern: "docs.github.com"
   - pattern: "claude.ai"
   - pattern: "splunk.com"
-  # Broadened from stackoverflow.com/questions: /a/ answer links also 403 from runner IPs
   - pattern: "stackoverflow.com"
   - pattern: "developer.hashicorp.com/terraform/language"
   - pattern: "platform.openai.com"

--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -29,7 +29,8 @@ ignorePatterns:
   - pattern: "docs.github.com"
   - pattern: "claude.ai"
   - pattern: "splunk.com"
-  - pattern: "stackoverflow.com/questions"
+  # Broadened from stackoverflow.com/questions: /a/ answer links also 403 from runner IPs
+  - pattern: "stackoverflow.com"
   - pattern: "developer.hashicorp.com/terraform/language"
   - pattern: "platform.openai.com"
   - pattern: "api.openai.com"


### PR DESCRIPTION
## Problem

The weekly docs link check ([`weekly-docs`](https://github.com/coder/coder/blob/main/.github/workflows/weekly-docs.yaml) -> [linkspector](https://github.com/UmbrellaDocs/linkspector)) is failing.

- **Failing run:** https://github.com/coder/coder/actions/runs/30805217850/job/91691078170
- **Broken link:** `https://stackoverflow.com/a/55570286` in `docs/admin/users/idp-sync.md` (line 576), reported `Status: 403`.

Stack Overflow returns `403` to the GitHub runner IPs (bot detection), so a valid link is flagged as broken. This is the same false-positive mode already handled for `npmjs.com`, `merriam-webster.com`, `splunk.com`, etc. in `.github/.linkspector.yml`.

## Fix / why a bare `stackoverflow.com` pattern

linkspector matches `ignorePatterns` as regex substrings against each URL. The config already ignored `stackoverflow.com/questions`, but the failing URL is an **answer** link (`/a/...`) that the `/questions` pattern does not cover, and it has no `www.` prefix, so a `www.stackoverflow.com` entry would not match it either.

Broadening to a bare `stackoverflow.com`:

- fixes the failing `/a/55570286` link;
- keeps the existing `/questions/...` link in `docs/about/contributing/frontend.md` covered (so the now-redundant `stackoverflow.com/questions` line is removed);
- also covers any `www.` variant.

## Validation

- Confirmed the `stackoverflow.com` regex matches `/a/`, `/questions/`, and `www.` variants; config parses; `typos` clean.
- The `weekly-docs` `pull_request` trigger is path-filtered to `docs/**`, so this `.github/`-only change does not auto-run linkspector here. Validated end-to-end via a manual `workflow_dispatch` on this branch, which passed: https://github.com/coder/coder/actions/runs/30829301773

<details>
<summary>Unrelated failing check: <code>Pixel / Review</code> (visual regression)</summary>

`Pixel / Review` reports failed visual tests ([build 6916](https://pixel.coder.com/@coder/coder/builds/6916)). This PR only edits `.github/.linkspector.yml` (link-checker config) and changes no UI, components, or rendered output, so these are pre-existing visual-baseline diffs / flakes unrelated to this change. All path-relevant required checks (`fmt`, `gen`, `lint`, `changes`, `title`, `Storybook`, `Flake Check`) pass.

</details>

Linear: [DOCS-606](https://linear.app/codercom/issue/DOCS-606/fix-weekly-docs-link-check-allowlist-stack-overflow-in-linkspector)

> This PR was created with AI assistance (Coder Agents).
