### PR TITLE
fix: fix port assignment race from aigatewaystart_internal_test

### DIFF
--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -352,7 +352,7 @@ func (s *standaloneGateway) serve(ctx context.Context) error {
 	if err != nil {
 		return xerrors.Errorf("listen on %q: %w", s.httpAddress, err)
 	}
-	// serve runs once per gateway, so closing the latch here cannot repeat.
+	// serve runs once per gateway, so closing listenerReady only happens once.
 	s.httpAddr = listener.Addr()
 	close(s.listenerReady)
 

--- a/enterprise/cli/aigatewaystart.go
+++ b/enterprise/cli/aigatewaystart.go
@@ -274,6 +274,15 @@ type standaloneGateway struct {
 	drpcClosed             atomic.Bool
 	providerRefreshStopped atomic.Bool
 	listenerClosed         atomic.Bool
+
+	// httpAddr is the address the HTTP listener is bound to. It is valid once
+	// listenerReady is closed.
+	httpAddr net.Addr
+
+	// listenerReady is closed once the HTTP listener is bound. It stays open
+	// when binding fails.
+	listenerReady chan struct{}
+
 	// providersLoaded is an initial-load latch. Reconnects refresh providers
 	// through the watch loop without resetting readiness.
 	providersLoaded atomic.Bool
@@ -314,6 +323,8 @@ func newStandaloneGateway(params standaloneGatewayParams) (*standaloneGateway, e
 
 		logger:         params.logger,
 		providerLogger: providerLogger,
+
+		listenerReady: make(chan struct{}),
 	}
 	gateway.httpServer = &http.Server{
 		Handler:           newGatewayMux(gateway.daemon, gateway.ready, gatewayMiddleware(params.bridgeConfig, params.tracer)),
@@ -341,6 +352,9 @@ func (s *standaloneGateway) serve(ctx context.Context) error {
 	if err != nil {
 		return xerrors.Errorf("listen on %q: %w", s.httpAddress, err)
 	}
+	// serve runs once per gateway, so closing the latch here cannot repeat.
+	s.httpAddr = listener.Addr()
+	close(s.listenerReady)
 
 	serveErr := make(chan error, 1)
 	var serveWG sync.WaitGroup

--- a/enterprise/cli/aigatewaystart_internal_test.go
+++ b/enterprise/cli/aigatewaystart_internal_test.go
@@ -96,9 +96,8 @@ func (p *controlledShutdownPool) Shutdown(ctx context.Context) error {
 }
 
 type standaloneGatewayTestParams struct {
-	address string
-	params  standaloneGatewayParams
-	pool    *controlledShutdownPool
+	params standaloneGatewayParams
+	pool   *controlledShutdownPool
 }
 
 func newStandaloneGatewayTestParams(t *testing.T) *standaloneGatewayTestParams {
@@ -113,11 +112,9 @@ func newStandaloneGatewayTestParams(t *testing.T) *standaloneGatewayTestParams {
 	})
 
 	pool := &controlledShutdownPool{CachedBridgePool: cachedPool}
-	address := fmt.Sprintf("127.0.0.1:%d", testutil.RandomPort(t))
 	return &standaloneGatewayTestParams{
-		address: address,
 		params: standaloneGatewayParams{
-			httpAddress: address,
+			httpAddress: "127.0.0.1:0",
 
 			dialer: blockingStandaloneDaemonDialer,
 			pool:   pool,
@@ -280,27 +277,43 @@ func probeStatus(t *testing.T, gateway *standaloneGateway, path string) int {
 	return rec.Code
 }
 
-func TestAIGatewayStart_HealthBeforeProviders(t *testing.T) {
+func TestAIGatewayStart_HealthBeforeReady(t *testing.T) {
 	t.Parallel()
 
+	// Fake coderd that answers 503 so the daemon keeps retrying to connect.
+	coderSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(coderSrv.Close)
 	gatewayAddress := fmt.Sprintf("127.0.0.1:%d", testutil.RandomPort(t))
-	coderAddress := fmt.Sprintf("127.0.0.1:%d", testutil.RandomPort(t))
 
 	var root RootCmd
 	cmd, err := root.Command(root.enterpriseOnly())
 	require.NoError(t, err)
 	inv, _ := clitest.NewWithCommand(t, cmd,
-		"--url", "http://"+coderAddress,
+		"--url", coderSrv.URL,
 		"ai-gateway", "start",
 		"--key", "test-key",
 		"--http-address", gatewayAddress,
 	)
-	clitest.Start(t, inv.WithContext(testutil.Context(t, testutil.WaitShort)))
+	ctx := testutil.Context(t, testutil.WaitShort)
+	// Watch the command for an early exit so a clash on gatewayAddress is
+	// reported as a bind failure instead of a probe timeout.
+	cmdDone := make(chan error, 1)
+	clitest.StartWithAssert(t, inv.WithContext(ctx), func(_ *testing.T, err error) {
+		cmdDone <- err
+	})
 
+	// healthz check
 	client := &http.Client{Timeout: testutil.WaitShort}
 	baseURL := "http://" + gatewayAddress
-	require.Eventually(t, func() bool {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+healthzPath, nil)
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		select {
+		case err := <-cmdDone:
+			t.Fatalf("ai-gateway start exited before serving: %v", err)
+		default:
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+healthzPath, nil)
 		if err != nil {
 			return false
 		}
@@ -310,9 +323,10 @@ func TestAIGatewayStart_HealthBeforeProviders(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK
-	}, testutil.WaitShort, testutil.IntervalFast)
+	}, testutil.IntervalFast)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+readyzPath, nil)
+	// readyz check (unavailable due to no connection to coderd)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+readyzPath, nil)
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -334,7 +348,7 @@ func TestRunStandaloneGateway_ContextCanceled(t *testing.T) {
 	go func() {
 		runDone <- gateway.run(runCtx)
 	}()
-	requireListenerReady(t, test.address)
+	requireListening(testCtx, t, gateway, runDone)
 	cancelRun()
 
 	require.NoError(t, testutil.RequireReceive(testCtx, t, runDone))
@@ -399,11 +413,12 @@ func TestRunStandaloneGateway_ListenAndShutdownErrors(t *testing.T) {
 	test := newStandaloneGatewayTestParams(t)
 	shutdownErr := xerrors.New("pool shutdown failed")
 	test.pool.err = shutdownErr
-	listener, err := net.Listen("tcp", test.address)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = listener.Close()
 	})
+	test.params.httpAddress = listener.Addr().String()
 
 	err = runStandaloneGateway(testutil.Context(t, testutil.WaitShort), test.params)
 	require.NoError(t, listener.Close())
@@ -424,7 +439,11 @@ func TestStandaloneGatewayServe_ShutdownOrder(t *testing.T) {
 	daemon, err := aibridged.New(context.Background(), pool, blockingStandaloneDaemonDialer, logger, sdktrace.NewTracerProvider().Tracer("test"))
 	require.NoError(t, err)
 
-	httpAddress := fmt.Sprintf("127.0.0.1:%d", testutil.RandomPort(t))
+	httpAddress := "127.0.0.1:0"
+	// inFlightPath scopes the blocking handler to the request this test keeps in
+	// flight. Another test may probe a port the OS later assigns to this
+	// listener, and such traffic must not stand in for that request.
+	const inFlightPath = "/in-flight"
 	reloader := &failThenSucceedReloader{}
 	handlerStarted := make(chan struct{}, 1)
 	httpShutdownStarted := make(chan struct{}, 1)
@@ -432,7 +451,11 @@ func TestStandaloneGatewayServe_ShutdownOrder(t *testing.T) {
 	gateway := &standaloneGateway{
 		daemon: daemon,
 		httpServer: &http.Server{
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != inFlightPath {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
 				select {
 				case handlerStarted <- struct{}{}:
 				default:
@@ -446,6 +469,7 @@ func TestStandaloneGatewayServe_ShutdownOrder(t *testing.T) {
 		logger:         logger,
 		providerLogger: logger,
 		reloader:       reloader,
+		listenerReady:  make(chan struct{}),
 	}
 	gateway.httpServer.RegisterOnShutdown(func() {
 		httpShutdownStarted <- struct{}{}
@@ -457,12 +481,12 @@ func TestStandaloneGatewayServe_ShutdownOrder(t *testing.T) {
 		serveDone <- gateway.serve(serveCtx)
 	}()
 
+	listenAddress := requireListening(testCtx, t, gateway, serveDone)
 	require.Eventually(t, gateway.providersLoaded.Load, testutil.WaitShort, testutil.IntervalFast)
-	requireListenerReady(t, httpAddress)
 
 	requestDone := make(chan error, 1)
 	go func() {
-		req, err := http.NewRequestWithContext(testCtx, http.MethodGet, "http://"+httpAddress, nil)
+		req, err := http.NewRequestWithContext(testCtx, http.MethodGet, "http://"+listenAddress+inFlightPath, nil)
 		if err != nil {
 			requestDone <- err
 			return
@@ -498,18 +522,21 @@ func TestStandaloneGatewayServe_ShutdownOrder(t *testing.T) {
 	require.True(t, gateway.drpcClosed.Load(), "DRPC connection must close during daemon shutdown")
 }
 
-func requireListenerReady(t *testing.T, address string) {
+// requireListening waits until the gateway's HTTP listener is bound and returns
+// its resolved address. It reports the serve error, such as a port clash, rather
+// than leaving callers to time out on an unrelated assertion.
+func requireListening(ctx context.Context, t *testing.T, gateway *standaloneGateway, done <-chan error) string {
 	t.Helper()
 
-	ctx := testutil.Context(t, testutil.WaitShort)
-	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
-		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
-		if err != nil {
-			return false
-		}
-		_ = conn.Close()
-		return true
-	}, testutil.IntervalFast)
+	select {
+	case <-gateway.listenerReady:
+		return gateway.httpAddr.String()
+	case err := <-done:
+		t.Fatalf("gateway stopped before listening: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("gateway never started listening: %v", ctx.Err())
+	}
+	return ""
 }
 
 func newTestStandaloneDaemon(t *testing.T, logger slog.Logger) *aibridged.Server {


### PR DESCRIPTION
The AI Gateway tests reserved a port with `testutil.RandomPort`, which binds and closes `127.0.0.1:0`, then bound it later in `serve`.
If something took the port in between, `serve` failed at `net.Listen` and the error went unread, leaving only a 10s `Eventually` timeout.

The gateway now exposes its bound address via `httpAddr` and a `listenerReady` latch, so tests listen on port 0 and read the address afterwards. `requireListening` reports `serve`'s error where an address must still be fixed upfront.

`TestAIGatewayStart_HealthBeforeProviders` still uses `testutil.RandomPort` and may clash as it doesn't have access to `standaloneGateway` internals.

Closes https://github.com/coder/internal/issues/1633

<details>
<summary>CI failure</summary>

```text
=== FAIL: enterprise/cli TestStandaloneGatewayServe_ShutdownOrder (10.00s)
    aigatewaystart_internal_test.go:457:
        Error:          Condition never satisfied
```

Masked cause, reproduced under port churn: `listen tcp 127.0.0.1:37269: bind: address already in use`.

</details>

---
Investigated and authored with Coder Agents.