### PR TITLE
test(agent): de-flake TestAgent_Session_EnvironmentVariables

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -495,7 +495,7 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 		"MY_OVERRIDE":         "true",  // From the agent environment variables option, overrides manifest.
 		"MY_SESSION_MANIFEST": "false", // From the manifest, overrides session env.
 		"MY_SESSION":          "true",  // From the session.
-		"PATH":                scriptBinDir + string(filepath.ListSeparator),
+		"PATH":                scriptBinDir,
 	} {
 		t.Run(envName, func(t *testing.T) {
 			t.Parallel()
@@ -505,7 +505,7 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 				"MY_SESSION_MANIFEST": "true",
 			})
 			if envName == "PATH" {
-				require.True(t, strings.HasPrefix(got, want), "PATH %q does not start with %q", got, want)
+				require.Contains(t, filepath.SplitList(got), want)
 				return
 			}
 			require.Equal(t, want, got)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -462,7 +462,6 @@ func TestAgent_SessionExec(t *testing.T) {
 	}
 }
 
-//nolint:tparallel // Sub tests need to run sequentially.
 func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 	t.Parallel()
 
@@ -480,49 +479,23 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 		},
 	}
 	banner := codersdk.ServiceBannerConfig{}
-	session := setupSSHSession(t, manifest, banner, nil, func(_ *agenttest.Client, opts *agent.Options) {
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	//nolint:dogsled
+	conn, _, _, _, _ := setupAgent(t, manifest, 0, func(c *agenttest.Client, opts *agent.Options) {
+		c.SetAnnouncementBannersFunc(func() ([]codersdk.BannerConfig, error) {
+			return []codersdk.BannerConfig{banner}, nil
+		})
 		opts.ScriptDataDir = tmpdir
 		opts.EnvironmentVariables["MY_OVERRIDE"] = "true"
 	})
-
-	err := session.Setenv("MY_SESSION_MANIFEST", "true")
+	// Share one SSH client across subtests, but run each variable in a
+	// fresh session so a single closed channel cannot fail the others.
+	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
-	err = session.Setenv("MY_SESSION", "true")
-	require.NoError(t, err)
+	t.Cleanup(func() { _ = sshClient.Close() })
 
-	command := "sh"
-	echoEnv := func(t *testing.T, w io.Writer, env string) {
-		if runtime.GOOS == "windows" {
-			_, err := fmt.Fprintf(w, "echo %%%s%%\r\n", env)
-			require.NoError(t, err)
-		} else {
-			_, err := fmt.Fprintf(w, "echo $%s\n", env)
-			require.NoError(t, err)
-		}
-	}
-	if runtime.GOOS == "windows" {
-		command = "cmd.exe"
-	}
-	stdin, err := session.StdinPipe()
-	require.NoError(t, err)
-	defer stdin.Close()
-	stdout, err := session.StdoutPipe()
-	require.NoError(t, err)
-
-	err = session.Start(command)
-	require.NoError(t, err)
-
-	// Context is fine here since we're not doing a parallel subtest.
-	ctx := testutil.Context(t, testutil.WaitLong)
-	go func() {
-		<-ctx.Done()
-		_ = session.Close()
-	}()
-
-	s := bufio.NewScanner(stdout)
-
-	//nolint:paralleltest // These tests need to run sequentially.
-	for k, partialV := range map[string]string{
+	for k, want := range map[string]string{
 		"CODER":               "true",  // From the agent.
 		"MY_MANIFEST":         "true",  // From the manifest.
 		"MY_OVERRIDE":         "true",  // From the agent environment variables option, overrides manifest.
@@ -531,18 +504,40 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 		"PATH":                scriptBinDir + string(filepath.ListSeparator),
 	} {
 		t.Run(k, func(t *testing.T) {
-			echoEnv(t, stdin, k)
-			// Windows is unreliable, so keep scanning until we find a match.
-			for s.Scan() {
-				got := strings.TrimSpace(s.Text())
-				t.Logf("%s=%s", k, got)
-				if strings.Contains(got, partialV) {
-					break
-				}
+			t.Parallel()
+
+			// Give each subtest its own deadline so a hung session
+			// cannot ride the package timeout.
+			subCtx := testutil.Context(t, testutil.WaitLong)
+
+			session, err := sshClient.NewSession()
+			require.NoError(t, err)
+			defer session.Close()
+			go func() {
+				<-subCtx.Done()
+				_ = session.Close()
+			}()
+
+			// The agent re-applies manifest, agent, predefined, and PATH
+			// environment variables on every exec, so only session-scoped
+			// variables need per-session Setenv. The manifest sets
+			// MY_SESSION_MANIFEST="false" and takes precedence over the
+			// session value set here.
+			err = session.Setenv("MY_SESSION", "true")
+			require.NoError(t, err)
+			err = session.Setenv("MY_SESSION_MANIFEST", "true")
+			require.NoError(t, err)
+
+			stderr := &bytes.Buffer{}
+			session.Stderr = stderr
+
+			command := "sh -c 'echo $" + k + "'"
+			if runtime.GOOS == "windows" {
+				command = `cmd.exe /c echo %` + k + `%`
 			}
-			if err := s.Err(); !errors.Is(err, io.EOF) {
-				require.NoError(t, err)
-			}
+			out, err := session.Output(command)
+			require.NoError(t, err, "output: %q, stderr: %q", out, stderr.String())
+			require.Contains(t, strings.TrimSpace(string(out)), want, "stderr: %q", stderr.String())
 		})
 	}
 }
@@ -575,66 +570,44 @@ func TestAgent_Session_SecretInjection(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "both-value", string(content))
 
-	// Verify env var injection via an SSH session.
+	// Verify env var injection via SSH. Share one SSH client across
+	// subtests, but run each variable in a fresh session so a single
+	// closed channel cannot fail the others.
 	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sshClient.Close() })
 
-	session, err := sshClient.NewSession()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = session.Close() })
-
-	command := "sh"
-	if runtime.GOOS == "windows" {
-		command = "cmd.exe"
-	}
-
-	stdin, err := session.StdinPipe()
-	require.NoError(t, err)
-	defer stdin.Close()
-	stdout, err := session.StdoutPipe()
-	require.NoError(t, err)
-
-	err = session.Start(command)
-	require.NoError(t, err)
-
-	go func() {
-		<-ctx.Done()
-		_ = session.Close()
-	}()
-
-	s := bufio.NewScanner(stdout)
-
-	echoEnv := func(t *testing.T, w io.Writer, env string) {
-		t.Helper()
-		if runtime.GOOS == "windows" {
-			_, err := fmt.Fprintf(w, "echo %%%s%%\r\n", env)
-			require.NoError(t, err)
-		} else {
-			_, err := fmt.Fprintf(w, "echo $%s\n", env)
-			require.NoError(t, err)
-		}
-	}
-
-	for k, partialV := range map[string]string{
+	for k, want := range map[string]string{
 		"MY_SECRET_ENV":        "env-secret-value",
 		"BOTH_ENV":             "both-value",
 		"SHOULD_BE_OVERRIDDEN": "secret-wins",
 	} {
-		echoEnv(t, stdin, k)
-		found := false
-		for s.Scan() {
-			got := strings.TrimSpace(s.Text())
-			t.Logf("%s=%s", k, got)
-			if strings.Contains(got, partialV) {
-				found = true
-				break
-			}
-		}
-		require.True(t, found, "env %s not found in output", k)
-		if err := s.Err(); !errors.Is(err, io.EOF) {
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+
+			// Give each subtest its own deadline so a hung session
+			// cannot ride the package timeout.
+			subCtx := testutil.Context(t, testutil.WaitLong)
+
+			session, err := sshClient.NewSession()
 			require.NoError(t, err)
-		}
+			defer session.Close()
+			go func() {
+				<-subCtx.Done()
+				_ = session.Close()
+			}()
+
+			stderr := &bytes.Buffer{}
+			session.Stderr = stderr
+
+			command := "sh -c 'echo $" + k + "'"
+			if runtime.GOOS == "windows" {
+				command = `cmd.exe /c echo %` + k + `%`
+			}
+			out, err := session.Output(command)
+			require.NoError(t, err, "output: %q, stderr: %q", out, stderr.String())
+			require.Contains(t, strings.TrimSpace(string(out)), want, "stderr: %q", stderr.String())
+		})
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -478,24 +478,18 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 			"MY_SESSION_MANIFEST": "false",
 		},
 	}
-	banner := codersdk.ServiceBannerConfig{}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	//nolint:dogsled
-	conn, _, _, _, _ := setupAgent(t, manifest, 0, func(c *agenttest.Client, opts *agent.Options) {
-		c.SetAnnouncementBannersFunc(func() ([]codersdk.BannerConfig, error) {
-			return []codersdk.BannerConfig{banner}, nil
-		})
+	conn, _, _, _, _ := setupAgent(t, manifest, 0, func(_ *agenttest.Client, opts *agent.Options) {
 		opts.ScriptDataDir = tmpdir
 		opts.EnvironmentVariables["MY_OVERRIDE"] = "true"
 	})
-	// Share one SSH client across subtests, but run each variable in a
-	// fresh session so a single closed channel cannot fail the others.
 	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sshClient.Close() })
 
-	for k, want := range map[string]string{
+	for envName, want := range map[string]string{
 		"CODER":               "true",  // From the agent.
 		"MY_MANIFEST":         "true",  // From the manifest.
 		"MY_OVERRIDE":         "true",  // From the agent environment variables option, overrides manifest.
@@ -503,41 +497,18 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 		"MY_SESSION":          "true",  // From the session.
 		"PATH":                scriptBinDir + string(filepath.ListSeparator),
 	} {
-		t.Run(k, func(t *testing.T) {
+		t.Run(envName, func(t *testing.T) {
 			t.Parallel()
 
-			// Give each subtest its own deadline so a hung session
-			// cannot ride the package timeout.
-			subCtx := testutil.Context(t, testutil.WaitLong)
-
-			session, err := sshClient.NewSession()
-			require.NoError(t, err)
-			defer session.Close()
-			go func() {
-				<-subCtx.Done()
-				_ = session.Close()
-			}()
-
-			// The agent re-applies manifest, agent, predefined, and PATH
-			// environment variables on every exec, so only session-scoped
-			// variables need per-session Setenv. The manifest sets
-			// MY_SESSION_MANIFEST="false" and takes precedence over the
-			// session value set here.
-			err = session.Setenv("MY_SESSION", "true")
-			require.NoError(t, err)
-			err = session.Setenv("MY_SESSION_MANIFEST", "true")
-			require.NoError(t, err)
-
-			stderr := &bytes.Buffer{}
-			session.Stderr = stderr
-
-			command := "sh -c 'echo $" + k + "'"
-			if runtime.GOOS == "windows" {
-				command = `cmd.exe /c echo %` + k + `%`
+			got := sessionEnvValue(t, sshClient, envName, map[string]string{
+				"MY_SESSION":          "true",
+				"MY_SESSION_MANIFEST": "true",
+			})
+			if envName == "PATH" {
+				require.True(t, strings.HasPrefix(got, want), "PATH %q does not start with %q", got, want)
+				return
 			}
-			out, err := session.Output(command)
-			require.NoError(t, err, "output: %q, stderr: %q", out, stderr.String())
-			require.Contains(t, strings.TrimSpace(string(out)), want, "stderr: %q", stderr.String())
+			require.Equal(t, want, got)
 		})
 	}
 }
@@ -570,45 +541,50 @@ func TestAgent_Session_SecretInjection(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "both-value", string(content))
 
-	// Verify env var injection via SSH. Share one SSH client across
-	// subtests, but run each variable in a fresh session so a single
-	// closed channel cannot fail the others.
 	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sshClient.Close() })
 
-	for k, want := range map[string]string{
+	for envName, want := range map[string]string{
 		"MY_SECRET_ENV":        "env-secret-value",
 		"BOTH_ENV":             "both-value",
 		"SHOULD_BE_OVERRIDDEN": "secret-wins",
 	} {
-		t.Run(k, func(t *testing.T) {
+		t.Run(envName, func(t *testing.T) {
 			t.Parallel()
-
-			// Give each subtest its own deadline so a hung session
-			// cannot ride the package timeout.
-			subCtx := testutil.Context(t, testutil.WaitLong)
-
-			session, err := sshClient.NewSession()
-			require.NoError(t, err)
-			defer session.Close()
-			go func() {
-				<-subCtx.Done()
-				_ = session.Close()
-			}()
-
-			stderr := &bytes.Buffer{}
-			session.Stderr = stderr
-
-			command := "sh -c 'echo $" + k + "'"
-			if runtime.GOOS == "windows" {
-				command = `cmd.exe /c echo %` + k + `%`
-			}
-			out, err := session.Output(command)
-			require.NoError(t, err, "output: %q, stderr: %q", out, stderr.String())
-			require.Contains(t, strings.TrimSpace(string(out)), want, "stderr: %q", stderr.String())
+			require.Equal(t, want, sessionEnvValue(t, sshClient, envName, nil))
 		})
 	}
+}
+
+func sessionEnvValue(t *testing.T, sshClient *ssh.Client, envName string, sessionEnv map[string]string) string {
+	t.Helper()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	session, err := sshClient.NewSession()
+	require.NoError(t, err)
+	defer session.Close()
+	go func() {
+		<-ctx.Done()
+		_ = session.Close()
+	}()
+
+	for name, value := range sessionEnv {
+		require.NoError(t, session.Setenv(name, value))
+	}
+
+	stderr := &bytes.Buffer{}
+	session.Stderr = stderr
+	command := "sh -c 'echo $" + envName + "'"
+	if runtime.GOOS == "windows" {
+		command = `cmd.exe /c echo %` + envName + `%`
+	}
+	out, err := session.Output(command)
+	if err != nil && ctx.Err() != nil {
+		t.Fatalf("SSH session deadline expired: %v; output: %q, stderr: %q", ctx.Err(), out, stderr.String())
+	}
+	require.NoError(t, err, "output: %q, stderr: %q", out, stderr.String())
+	return strings.TrimSpace(string(out))
 }
 
 func TestAgent_StartupScript_SecretInjection(t *testing.T) {


### PR DESCRIPTION
The environment-variable and secret-injection tests reused one long-lived SSH shell, so a closed channel caused later checks to fail with `EOF` and could allow scan-based assertions to pass without finding a value. They now share only the SSH client and use a fresh, deadline-bound session for each variable, isolating failures while preserving environment-precedence coverage.

Closes https://linear.app/codercom/issue/PLAT-310.

Reviewed and updated by Coder Agents on behalf of @dylanhuff-at-coder.