### PR TITLE
fix: add codersdk JSON response decoder for typed API endpoints

### DIFF
--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,5 +145,37 @@ func TestList(t *testing.T) {
 		require.NoError(t, json.Unmarshal(stdout.Bytes(), &workspaces))
 		require.Len(t, workspaces, 1)
 		require.Equal(t, sharedWorkspace.ID, workspaces[0].ID)
+	})
+
+	t.Run("HTMLResponse", func(t *testing.T) {
+		t.Parallel()
+		// Simulate an SSO portal or misconfigured reverse proxy that
+		// returns 200 OK with an HTML body instead of JSON.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("<!DOCTYPE html><html><head><title>Sign in</title></head><body>Sign in</body></html>"))
+		}))
+		defer srv.Close()
+
+		parsedURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+		client := codersdk.New(parsedURL)
+		client.SetSessionToken("test-token")
+
+		inv, root := clitest.New(t, "list")
+		clitest.SetupConfig(t, client, root)
+		err = inv.Run()
+		require.Error(t, err)
+
+		// The list command wraps the error, so errors.As must
+		// traverse the wrapping to find the SDK error.
+		var sdkErr *codersdk.Error
+		require.True(t, errors.As(err, &sdkErr))
+		require.Equal(t, http.StatusOK, sdkErr.StatusCode())
+		require.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+		require.Contains(t, sdkErr.Helper, "/api/v2")
+		require.NotContains(t, err.Error(), "invalid character")
+		require.NotContains(t, err.Error(), "unexpected status code")
 	})
 }

--- a/cli/whoami_test.go
+++ b/cli/whoami_test.go
@@ -2,12 +2,17 @@ package cli_test
 
 import (
 	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 func TestWhoami(t *testing.T) {
@@ -33,5 +38,35 @@ func TestWhoami(t *testing.T) {
 		require.NoError(t, err)
 		whoami := buf.String()
 		require.NotEmpty(t, whoami)
+	})
+
+	t.Run("HTMLResponse", func(t *testing.T) {
+		t.Parallel()
+		// Simulate an SSO portal or misconfigured reverse proxy that
+		// returns 200 OK with an HTML body instead of JSON.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("<!DOCTYPE html><html><head><title>Sign in</title></head><body>Sign in</body></html>"))
+		}))
+		defer srv.Close()
+
+		parsedURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+		client := codersdk.New(parsedURL)
+		client.SetSessionToken("test-token")
+
+		inv, root := clitest.New(t, "whoami")
+		clitest.SetupConfig(t, client, root)
+		err = inv.Run()
+		require.Error(t, err)
+
+		var sdkErr *codersdk.Error
+		require.True(t, errors.As(err, &sdkErr))
+		require.Equal(t, http.StatusOK, sdkErr.StatusCode())
+		require.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+		require.Contains(t, sdkErr.Helper, "/api/v2")
+		require.NotContains(t, err.Error(), "invalid character")
+		require.NotContains(t, err.Error(), "unexpected status code")
 	})
 }

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -494,9 +494,9 @@ func ReadBodyAsError(res *http.Response) error {
 	}
 }
 
-// jsonBodyExcerptLen bounds how much of an invalid response body is
-// buffered and included in error details by ReadBodyAsJSON.
-const jsonBodyExcerptLen = 512
+// jsonBodySniffLen bounds how much of a response body is retained while
+// decoding to identify HTML without buffering the entire response.
+const jsonBodySniffLen = 512
 
 // htmlResponseHelper suggests the most common causes of receiving HTML
 // from what should be a Coder API endpoint: a misconfigured Coder URL,
@@ -526,58 +526,67 @@ func ReadBodyAsJSON(res *http.Response, v any) error {
 		return xerrors.New("no response body to decode")
 	}
 
-	// Buffer a bounded prefix of the body. It is used to sniff HTML
-	// bodies and to include an excerpt in error details without ever
-	// buffering the entire response.
-	prefix := make([]byte, jsonBodyExcerptLen)
-	n, err := io.ReadFull(res.Body, prefix)
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
-		return xerrors.Errorf("read response body: %w", err)
-	}
-	prefix = prefix[:n]
-
-	if len(prefix) == 0 {
-		return invalidBodyError(res, Response{
-			Message: "Received an empty response from the Coder API.",
-			Detail:  invalidBodyDetail(res, ""),
-		}, "", nil)
-	}
-
-	if isHTMLBody(parseMimeType(res.Header.Get("Content-Type")), prefix) {
+	mimeType := parseMimeType(res.Header.Get("Content-Type"))
+	if isHTMLMimeType(mimeType) {
 		return invalidBodyError(res, Response{
 			Message: "Received an HTML response instead of JSON from the Coder API.",
-			Detail:  invalidBodyDetail(res, sanitizeBodyExcerpt(prefix)),
+			Detail:  invalidBodyDetail(res),
 		}, htmlResponseHelper, nil)
 	}
 
-	body := io.MultiReader(bytes.NewReader(prefix), res.Body)
-	if err := json.NewDecoder(body).Decode(v); err != nil {
-		if !isJSONDecodeError(err) {
-			// Errors other than malformed JSON come from reading the
-			// body, e.g. a connection reset mid-response. Report them
-			// as read failures rather than an invalid API response.
-			return xerrors.Errorf("read response body: %w", err)
-		}
-		return invalidBodyError(res, Response{
-			Message: "Received an invalid JSON response from the Coder API.",
-			Detail:  fmt.Sprintf("decode body: %s, %s", err.Error(), invalidBodyDetail(res, sanitizeBodyExcerpt(prefix))),
-		}, "", err)
+	body := &responseBodyReader{Reader: res.Body}
+	prefix := &bodyPrefixWriter{}
+	err := json.NewDecoder(io.TeeReader(body, prefix)).Decode(v)
+	if err == nil {
+		return nil
 	}
-	return nil
+	if body.err != nil && errors.Is(err, body.err) {
+		return xerrors.Errorf("read response body: %w", err)
+	}
+	if len(prefix.bytes) == 0 && errors.Is(err, io.EOF) {
+		return invalidBodyError(res, Response{
+			Message: "Received an empty response from the Coder API.",
+			Detail:  invalidBodyDetail(res),
+		}, "", nil)
+	}
+	if isHTMLBody(mimeType, prefix.bytes) {
+		return invalidBodyError(res, Response{
+			Message: "Received an HTML response instead of JSON from the Coder API.",
+			Detail:  invalidBodyDetail(res),
+		}, htmlResponseHelper, nil)
+	}
+	return invalidBodyError(res, Response{
+		Message: "Received an invalid JSON response from the Coder API.",
+		Detail:  fmt.Sprintf("decode body: %s, %s", err.Error(), invalidBodyDetail(res)),
+	}, "", err)
 }
 
-// isJSONDecodeError reports whether err indicates a malformed JSON
-// body rather than a failure reading the body from the network.
-// Truncated bodies surface as io.ErrUnexpectedEOF from the decoder and
-// are treated as malformed since the two cases are indistinguishable.
-func isJSONDecodeError(err error) bool {
-	if _, ok := errors.AsType[*json.SyntaxError](err); ok {
-		return true
+// responseBodyReader records non-EOF read errors so decode errors from custom
+// JSON unmarshallers are not mistaken for transport failures.
+type responseBodyReader struct {
+	io.Reader
+	err error
+}
+
+func (r *responseBodyReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	if err != nil && !errors.Is(err, io.EOF) && r.err == nil {
+		r.err = err
 	}
-	if _, ok := errors.AsType[*json.UnmarshalTypeError](err); ok {
-		return true
+	return n, err
+}
+
+// bodyPrefixWriter retains only the beginning of a body while reporting every
+// byte as written so it can be used with io.TeeReader.
+type bodyPrefixWriter struct {
+	bytes []byte
+}
+
+func (w *bodyPrefixWriter) Write(p []byte) (int, error) {
+	if remaining := jsonBodySniffLen - len(w.bytes); remaining > 0 {
+		w.bytes = append(w.bytes, p[:min(remaining, len(p))]...)
 	}
-	return errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF)
+	return len(p), nil
 }
 
 // isHTMLBody reports whether a response body is HTML, either by its
@@ -587,7 +596,7 @@ func isJSONDecodeError(err error) bool {
 // XML are intentionally classified the same way since the remediation,
 // fixing the URL or the intermediary, is identical.
 func isHTMLBody(mimeType string, prefix []byte) bool {
-	if mimeType == "text/html" || mimeType == "application/xhtml+xml" {
+	if isHTMLMimeType(mimeType) {
 		return true
 	}
 	// Strip a UTF-8 byte order mark, which some intermediaries prepend
@@ -597,23 +606,13 @@ func isHTMLBody(mimeType string, prefix []byte) bool {
 	return len(trimmed) > 0 && trimmed[0] == '<'
 }
 
-// sanitizeBodyExcerpt makes a bounded body prefix safe to include in an
-// error message by dropping invalid UTF-8 and collapsing control
-// characters and whitespace runs into single spaces.
-func sanitizeBodyExcerpt(prefix []byte) string {
-	s := strings.ToValidUTF8(string(prefix), "")
-	s = strings.Map(func(r rune) rune {
-		if unicode.IsGraphic(r) {
-			return r
-		}
-		return ' '
-	}, s)
-	return strings.Join(strings.Fields(s), " ")
+func isHTMLMimeType(mimeType string) bool {
+	return mimeType == "text/html" || mimeType == "application/xhtml+xml"
 }
 
 // invalidBodyDetail describes an invalid response body and how it was
 // reached, for inclusion in an Error Detail.
-func invalidBodyDetail(res *http.Response, excerpt string) string {
+func invalidBodyDetail(res *http.Response) string {
 	var sb strings.Builder
 	if contentType := res.Header.Get("Content-Type"); contentType != "" {
 		_, _ = fmt.Fprintf(&sb, "content type %q", contentType)
@@ -622,9 +621,6 @@ func invalidBodyDetail(res *http.Response, excerpt string) string {
 	}
 	if orig := originalRequestURL(res); orig != "" && res.Request != nil && res.Request.URL != nil && orig != res.Request.URL.String() {
 		_, _ = fmt.Fprintf(&sb, ", after following redirects from %s", orig)
-	}
-	if excerpt != "" {
-		_, _ = fmt.Fprintf(&sb, ", body starts with: %s", excerpt)
 	}
 	return sb.String()
 }

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"unicode"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -493,14 +494,193 @@ func ReadBodyAsError(res *http.Response) error {
 	}
 }
 
+// jsonBodyExcerptLen bounds how much of an invalid response body is
+// buffered and included in error details by ReadBodyAsJSON.
+const jsonBodyExcerptLen = 512
+
+// htmlResponseHelper suggests the most common causes of receiving HTML
+// from what should be a Coder API endpoint: a misconfigured Coder URL,
+// or an intermediary such as a reverse proxy or SSO portal intercepting
+// API requests.
+const htmlResponseHelper = "Ensure the Coder URL is correct and that any reverse proxy or SSO in front of it passes /api/v2 requests through to Coder."
+
+// ReadBodyAsJSON decodes the response body as JSON into v. It is
+// intended for typed API endpoints whose accepted responses are always
+// JSON, replacing direct json.NewDecoder(res.Body).Decode(...) calls.
+// It must not be used for streaming or non-JSON endpoints such as
+// WebSockets, server-sent events, or file downloads.
+//
+// Bodies that are HTML, empty, or otherwise not valid JSON produce a
+// structured *Error describing the response instead of a bare decode
+// error such as "invalid character '<' looking for beginning of value".
+// Intermediaries like reverse proxies and SSO portals commonly return
+// such bodies with a 200 status code.
+//
+// Valid JSON is decoded even when an intermediary omits or mislabels
+// the Content-Type header. The exception is a Content-Type declaring
+// HTML, which is always reported as an invalid response since Coder
+// API endpoints never serve HTML. The caller remains responsible for
+// closing the response body.
+func ReadBodyAsJSON(res *http.Response, v any) error {
+	if res == nil || res.Body == nil {
+		return xerrors.New("no response body to decode")
+	}
+
+	// Buffer a bounded prefix of the body. It is used to sniff HTML
+	// bodies and to include an excerpt in error details without ever
+	// buffering the entire response.
+	prefix := make([]byte, jsonBodyExcerptLen)
+	n, err := io.ReadFull(res.Body, prefix)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return xerrors.Errorf("read response body: %w", err)
+	}
+	prefix = prefix[:n]
+
+	if len(prefix) == 0 {
+		return invalidBodyError(res, Response{
+			Message: "Received an empty response from the Coder API.",
+			Detail:  invalidBodyDetail(res, ""),
+		}, "", nil)
+	}
+
+	if isHTMLBody(parseMimeType(res.Header.Get("Content-Type")), prefix) {
+		return invalidBodyError(res, Response{
+			Message: "Received an HTML response instead of JSON from the Coder API.",
+			Detail:  invalidBodyDetail(res, sanitizeBodyExcerpt(prefix)),
+		}, htmlResponseHelper, nil)
+	}
+
+	body := io.MultiReader(bytes.NewReader(prefix), res.Body)
+	if err := json.NewDecoder(body).Decode(v); err != nil {
+		if !isJSONDecodeError(err) {
+			// Errors other than malformed JSON come from reading the
+			// body, e.g. a connection reset mid-response. Report them
+			// as read failures rather than an invalid API response.
+			return xerrors.Errorf("read response body: %w", err)
+		}
+		return invalidBodyError(res, Response{
+			Message: "Received an invalid JSON response from the Coder API.",
+			Detail:  fmt.Sprintf("decode body: %s, %s", err.Error(), invalidBodyDetail(res, sanitizeBodyExcerpt(prefix))),
+		}, "", err)
+	}
+	return nil
+}
+
+// isJSONDecodeError reports whether err indicates a malformed JSON
+// body rather than a failure reading the body from the network.
+// Truncated bodies surface as io.ErrUnexpectedEOF from the decoder and
+// are treated as malformed since the two cases are indistinguishable.
+func isJSONDecodeError(err error) bool {
+	if _, ok := errors.AsType[*json.SyntaxError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*json.UnmarshalTypeError](err); ok {
+		return true
+	}
+	return errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF)
+}
+
+// isHTMLBody reports whether a response body is HTML, either by its
+// media type or by starting with '<' after optional whitespace. Valid
+// JSON can never start with '<', so the sniff also identifies HTML
+// bodies mislabeled with a JSON content type. Markup bodies such as
+// XML are intentionally classified the same way since the remediation,
+// fixing the URL or the intermediary, is identical.
+func isHTMLBody(mimeType string, prefix []byte) bool {
+	if mimeType == "text/html" || mimeType == "application/xhtml+xml" {
+		return true
+	}
+	// Strip a UTF-8 byte order mark, which some intermediaries prepend
+	// to HTML error pages.
+	trimmed := bytes.TrimPrefix(prefix, []byte("\xef\xbb\xbf"))
+	trimmed = bytes.TrimLeftFunc(trimmed, unicode.IsSpace)
+	return len(trimmed) > 0 && trimmed[0] == '<'
+}
+
+// sanitizeBodyExcerpt makes a bounded body prefix safe to include in an
+// error message by dropping invalid UTF-8 and collapsing control
+// characters and whitespace runs into single spaces.
+func sanitizeBodyExcerpt(prefix []byte) string {
+	s := strings.ToValidUTF8(string(prefix), "")
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsGraphic(r) {
+			return r
+		}
+		return ' '
+	}, s)
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// invalidBodyDetail describes an invalid response body and how it was
+// reached, for inclusion in an Error Detail.
+func invalidBodyDetail(res *http.Response, excerpt string) string {
+	var sb strings.Builder
+	if contentType := res.Header.Get("Content-Type"); contentType != "" {
+		_, _ = fmt.Fprintf(&sb, "content type %q", contentType)
+	} else {
+		_, _ = sb.WriteString("no content type")
+	}
+	if orig := originalRequestURL(res); orig != "" && res.Request != nil && res.Request.URL != nil && orig != res.Request.URL.String() {
+		_, _ = fmt.Fprintf(&sb, ", after following redirects from %s", orig)
+	}
+	if excerpt != "" {
+		_, _ = fmt.Fprintf(&sb, ", body starts with: %s", excerpt)
+	}
+	return sb.String()
+}
+
+// originalRequestURL returns the URL of the first request in the
+// redirect chain that produced res, or "" when unknown. res.Request
+// itself is the final request after any redirects.
+func originalRequestURL(res *http.Response) string {
+	req := res.Request
+	for req != nil && req.Response != nil && req.Response.Request != nil {
+		req = req.Response.Request
+	}
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	return req.URL.String()
+}
+
+// invalidBodyError builds the *Error returned when a response with an
+// accepted status code does not contain the expected JSON body.
+func invalidBodyError(res *http.Response, response Response, helper string, cause error) *Error {
+	var requestMethod, requestURL string
+	if res.Request != nil {
+		requestMethod = res.Request.Method
+		if res.Request.URL != nil {
+			requestURL = res.Request.URL.String()
+		}
+	}
+	return &Error{
+		Response:    response,
+		statusCode:  res.StatusCode,
+		method:      requestMethod,
+		url:         requestURL,
+		contentType: res.Header.Get("Content-Type"),
+		cause:       cause,
+		invalidBody: true,
+		Helper:      helper,
+	}
+}
+
 // Error represents an unaccepted or invalid request to the API.
 // @typescript-ignore Error
 type Error struct {
 	Response
 
-	statusCode int
-	method     string
-	url        string
+	statusCode  int
+	method      string
+	url         string
+	contentType string
+	// cause is the underlying error, such as a JSON decode failure,
+	// exposed to errors.Is and errors.As via Unwrap.
+	cause error
+	// invalidBody marks errors for responses whose status code was
+	// accepted but whose body was not the expected JSON. Error() then
+	// describes the body rather than an unexpected status code.
+	invalidBody bool
 
 	Helper string
 }
@@ -517,6 +697,18 @@ func (e *Error) URL() string {
 	return e.url
 }
 
+// ContentType returns the Content-Type header of the response that
+// produced the error, when known.
+func (e *Error) ContentType() string {
+	return e.contentType
+}
+
+// Unwrap returns the underlying cause of the error, if any, such as the
+// JSON decode error for a response body that could not be decoded.
+func (e *Error) Unwrap() error {
+	return e.cause
+}
+
 func (e *Error) Friendly() string {
 	var sb strings.Builder
 	_, _ = fmt.Fprintf(&sb, "%s. %s", strings.TrimSuffix(e.Message, "."), e.Helper)
@@ -531,7 +723,11 @@ func (e *Error) Error() string {
 	if e.method != "" && e.url != "" {
 		_, _ = fmt.Fprintf(&builder, "%v %v: ", e.method, e.url)
 	}
-	_, _ = fmt.Fprintf(&builder, "unexpected status code %d: %s", e.statusCode, e.Message)
+	if e.invalidBody {
+		_, _ = fmt.Fprintf(&builder, "invalid API response (status code %d): %s", e.statusCode, e.Message)
+	} else {
+		_, _ = fmt.Fprintf(&builder, "unexpected status code %d: %s", e.statusCode, e.Message)
+	}
 	if e.Helper != "" {
 		_, _ = fmt.Fprintf(&builder, ": %s", e.Helper)
 	}

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -528,37 +528,39 @@ func ReadBodyAsJSON(res *http.Response, v any) error {
 
 	mimeType := parseMimeType(res.Header.Get("Content-Type"))
 	if isHTMLMimeType(mimeType) {
-		return invalidBodyError(res, Response{
-			Message: "Received an HTML response instead of JSON from the Coder API.",
-			Detail:  invalidBodyDetail(res),
-		}, htmlResponseHelper, nil)
+		return htmlBodyError(res)
 	}
 
 	body := &responseBodyReader{Reader: res.Body}
 	prefix := &bodyPrefixWriter{}
 	err := json.NewDecoder(io.TeeReader(body, prefix)).Decode(v)
-	if err == nil {
+	switch {
+	case err == nil:
 		return nil
-	}
-	if body.err != nil && errors.Is(err, body.err) {
+	case body.err != nil && errors.Is(err, body.err):
 		return xerrors.Errorf("read response body: %w", err)
-	}
-	if len(prefix.bytes) == 0 && errors.Is(err, io.EOF) {
+	case len(prefix.bytes) == 0 && errors.Is(err, io.EOF):
 		return invalidBodyError(res, Response{
 			Message: "Received an empty response from the Coder API.",
 			Detail:  invalidBodyDetail(res),
 		}, "", nil)
-	}
-	if isHTMLBody(mimeType, prefix.bytes) {
+	case isHTMLBody(mimeType, prefix.bytes):
+		return htmlBodyError(res)
+	default:
 		return invalidBodyError(res, Response{
-			Message: "Received an HTML response instead of JSON from the Coder API.",
-			Detail:  invalidBodyDetail(res),
-		}, htmlResponseHelper, nil)
+			Message: "Received an invalid JSON response from the Coder API.",
+			Detail:  fmt.Sprintf("decode body: %s, %s", err.Error(), invalidBodyDetail(res)),
+		}, "", err)
 	}
+}
+
+// htmlBodyError returns the structured *Error reported when the Coder API
+// response body is HTML rather than JSON.
+func htmlBodyError(res *http.Response) *Error {
 	return invalidBodyError(res, Response{
-		Message: "Received an invalid JSON response from the Coder API.",
-		Detail:  fmt.Sprintf("decode body: %s, %s", err.Error(), invalidBodyDetail(res)),
-	}, "", err)
+		Message: "Received an HTML response instead of JSON from the Coder API.",
+		Detail:  invalidBodyDetail(res),
+	}, htmlResponseHelper, nil)
 }
 
 // responseBodyReader records non-EOF read errors so decode errors from custom

--- a/codersdk/client_internal_test.go
+++ b/codersdk/client_internal_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 	"testing/iotest"
-	"unicode"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -415,11 +415,11 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 			name: "ValidJSONLargerThanSniffWindow",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", jsonCT)
-				_, _ = io.WriteString(w, `{"name":"`+strings.Repeat("a", 4*jsonBodyExcerptLen)+`"}`)
+				_, _ = io.WriteString(w, `{"name":"`+strings.Repeat("a", 4*jsonBodySniffLen)+`"}`)
 			},
 			assert: func(t *testing.T, v apiResponse, err error) {
 				require.NoError(t, err)
-				assert.Len(t, v.Name, 4*jsonBodyExcerptLen)
+				assert.Len(t, v.Name, 4*jsonBodySniffLen)
 			},
 		},
 		{
@@ -432,7 +432,7 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 				sdkErr := assertInvalidBody(t, err, "text/html; charset=utf-8")
 				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
 				assert.Contains(t, sdkErr.Helper, "/api/v2")
-				assert.Contains(t, sdkErr.Detail, "<!DOCTYPE html>")
+				assert.NotContains(t, sdkErr.Detail, "<!DOCTYPE html>")
 			},
 		},
 		{
@@ -472,7 +472,7 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 			assert: func(t *testing.T, _ apiResponse, err error) {
 				sdkErr := assertInvalidBody(t, err, "application/xml")
 				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
-				assert.Contains(t, sdkErr.Detail, "<?xml")
+				assert.NotContains(t, sdkErr.Detail, "<?xml")
 			},
 		},
 		{
@@ -495,8 +495,7 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 			assert: func(t *testing.T, _ apiResponse, err error) {
 				sdkErr := assertInvalidBody(t, err, jsonCT)
 				assert.Contains(t, sdkErr.Message, "invalid JSON response")
-				assert.Contains(t, sdkErr.Detail, `{"name": "hello"`)
-				// The decode cause is preserved on the error chain.
+				assert.NotContains(t, sdkErr.Detail, `{"name": "hello"`)
 				assert.Error(t, errors.Unwrap(sdkErr))
 			},
 		},
@@ -509,7 +508,7 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 			assert: func(t *testing.T, _ apiResponse, err error) {
 				sdkErr := assertInvalidBody(t, err, "text/plain; charset=utf-8")
 				assert.Contains(t, sdkErr.Message, "invalid JSON response")
-				assert.Contains(t, sdkErr.Detail, "upstream connect error")
+				assert.NotContains(t, sdkErr.Detail, "upstream connect error")
 			},
 		},
 		{
@@ -523,20 +522,14 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 			},
 		},
 		{
-			name: "ExcerptBoundedAndSanitized",
+			name: "BodyExcerptOmitted",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "text/html")
-				// A large body with control characters and invalid
-				// UTF-8 must produce a small, printable excerpt.
-				_, _ = io.WriteString(w, "<html>\x00\x07evil\r\n\tbody\xff "+strings.Repeat("a", 1024*1024))
+				_, _ = io.WriteString(w, "<html>secret-token")
 			},
 			assert: func(t *testing.T, _ apiResponse, err error) {
 				sdkErr := assertInvalidBody(t, err, "text/html")
-				assert.LessOrEqual(t, len(sdkErr.Detail), jsonBodyExcerptLen+256)
-				assert.Contains(t, sdkErr.Detail, "<html> evil body")
-				for _, r := range sdkErr.Detail {
-					assert.True(t, unicode.IsGraphic(r), "detail contains non-graphic character %q", r)
-				}
+				assert.NotContains(t, sdkErr.Detail, "secret-token")
 			},
 		},
 		{
@@ -588,6 +581,40 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 	})
 
 	//nolint:bodyclose // The response is constructed, not from a client.
+	t.Run("CompleteShortJSONDoesNotReadAhead", func(t *testing.T) {
+		t.Parallel()
+
+		errReadAhead := xerrors.New("unexpected read after JSON value")
+		body := io.MultiReader(
+			strings.NewReader(`{"name":"hello"}`),
+			iotest.ErrReader(errReadAhead),
+		)
+		res := newResponse(http.StatusOK, jsonCT, body)
+
+		var v apiResponse
+		require.NoError(t, ReadBodyAsJSON(res, &v))
+		require.Equal(t, "hello", v.Name)
+	})
+
+	//nolint:bodyclose // The response is constructed, not from a client.
+	t.Run("CustomUnmarshalError", func(t *testing.T) {
+		t.Parallel()
+
+		var v struct {
+			CreatedAt time.Time `json:"created_at"`
+		}
+		res := newResponse(http.StatusOK, jsonCT, `{"created_at":"invalid"}`)
+		requestURL, err := url.Parse("https://coder.example.com/api/v2/users/me")
+		require.NoError(t, err)
+		res.Request = &http.Request{Method: http.MethodGet, URL: requestURL}
+		err = ReadBodyAsJSON(res, &v)
+		sdkErr := assertInvalidBody(t, err, jsonCT)
+		require.Contains(t, sdkErr.Detail, "cannot parse")
+		require.Error(t, errors.Unwrap(sdkErr))
+		require.NotContains(t, err.Error(), "read response body")
+	})
+
+	//nolint:bodyclose // The response is constructed, not from a client.
 	t.Run("BodyReadError", func(t *testing.T) {
 		t.Parallel()
 
@@ -596,7 +623,7 @@ func Test_ReadBodyAsJSON(t *testing.T) {
 		// response.
 		errTransport := xerrors.New("connection reset by peer")
 		body := io.MultiReader(
-			strings.NewReader(`{"name":"`+strings.Repeat("a", 2*jsonBodyExcerptLen)),
+			strings.NewReader(`{"name":"`+strings.Repeat("a", 2*jsonBodySniffLen)),
 			iotest.ErrReader(errTransport),
 		)
 		res := newResponse(http.StatusOK, jsonCT, body)

--- a/codersdk/client_internal_test.go
+++ b/codersdk/client_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -14,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/iotest"
+	"unicode"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -343,6 +346,267 @@ func Test_readBodyAsError(t *testing.T) {
 			c.assert(t, err)
 		})
 	}
+}
+
+func Test_ReadBodyAsJSON(t *testing.T) {
+	t.Parallel()
+
+	type apiResponse struct {
+		Name string `json:"name"`
+	}
+
+	const htmlBody = `<!DOCTYPE html><html><head><title>Sign in</title></head><body>Sign in to continue</body></html>`
+
+	// assertInvalidBody asserts the fields shared by every error that
+	// ReadBodyAsJSON returns for a response with an unusable body.
+	assertInvalidBody := func(t *testing.T, err error, contentType string) *Error {
+		t.Helper()
+		sdkErr := assertSDKError(t, err)
+		assert.Equal(t, http.StatusOK, sdkErr.StatusCode())
+		assert.Equal(t, http.MethodGet, sdkErr.Method())
+		assert.NotEmpty(t, sdkErr.URL())
+		assert.Equal(t, contentType, sdkErr.ContentType())
+		assert.NotContains(t, err.Error(), "unexpected status code")
+		assert.ErrorContains(t, err, "invalid API response (status code 200)")
+		return sdkErr
+	}
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		assert  func(t *testing.T, v apiResponse, err error)
+	}{
+		{
+			name: "ValidJSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", jsonCT)
+				_, _ = io.WriteString(w, `{"name":"hello"}`)
+			},
+			assert: func(t *testing.T, v apiResponse, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, "hello", v.Name)
+			},
+		},
+		{
+			name: "ValidJSONWithoutContentType",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				// Intermediaries may strip or omit the Content-Type
+				// header even when the body is untouched JSON.
+				w.Header()["Content-Type"] = nil
+				_, _ = io.WriteString(w, `{"name":"hello"}`)
+			},
+			assert: func(t *testing.T, v apiResponse, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, "hello", v.Name)
+			},
+		},
+		{
+			name: "ValidJSONWithWrongContentType",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				_, _ = io.WriteString(w, `{"name":"hello"}`)
+			},
+			assert: func(t *testing.T, v apiResponse, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, "hello", v.Name)
+			},
+		},
+		{
+			name: "ValidJSONLargerThanSniffWindow",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", jsonCT)
+				_, _ = io.WriteString(w, `{"name":"`+strings.Repeat("a", 4*jsonBodyExcerptLen)+`"}`)
+			},
+			assert: func(t *testing.T, v apiResponse, err error) {
+				require.NoError(t, err)
+				assert.Len(t, v.Name, 4*jsonBodyExcerptLen)
+			},
+		},
+		{
+			name: "HTMLContentType",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = io.WriteString(w, htmlBody)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, "text/html; charset=utf-8")
+				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+				assert.Contains(t, sdkErr.Helper, "/api/v2")
+				assert.Contains(t, sdkErr.Detail, "<!DOCTYPE html>")
+			},
+		},
+		{
+			name: "HTMLMislabeledAsJSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", jsonCT)
+				_, _ = io.WriteString(w, "\n\t "+htmlBody)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, jsonCT)
+				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+				assert.Contains(t, sdkErr.Helper, "/api/v2")
+			},
+		},
+		{
+			name: "ValidJSONMislabeledAsHTML",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				// An HTML content type is authoritative: Coder API
+				// endpoints never serve HTML, so the body is not
+				// decoded even when it happens to be valid JSON.
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = io.WriteString(w, `{"name":"hello"}`)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, "text/html; charset=utf-8")
+				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+			},
+		},
+		{
+			name: "XMLBody",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				// Markup bodies such as XML error pages from load
+				// balancers are reported the same way as HTML.
+				w.Header().Set("Content-Type", "application/xml")
+				_, _ = io.WriteString(w, `<?xml version="1.0"?><error>denied</error>`)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, "application/xml")
+				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+				assert.Contains(t, sdkErr.Detail, "<?xml")
+			},
+		},
+		{
+			name: "HTMLWithByteOrderMark",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", jsonCT)
+				_, _ = io.WriteString(w, "\xef\xbb\xbf"+htmlBody)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, jsonCT)
+				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+			},
+		},
+		{
+			name: "MalformedJSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", jsonCT)
+				_, _ = io.WriteString(w, `{"name": "hello"`)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, jsonCT)
+				assert.Contains(t, sdkErr.Message, "invalid JSON response")
+				assert.Contains(t, sdkErr.Detail, `{"name": "hello"`)
+				// The decode cause is preserved on the error chain.
+				assert.Error(t, errors.Unwrap(sdkErr))
+			},
+		},
+		{
+			name: "PlainTextBody",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				_, _ = io.WriteString(w, "upstream connect error")
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, "text/plain; charset=utf-8")
+				assert.Contains(t, sdkErr.Message, "invalid JSON response")
+				assert.Contains(t, sdkErr.Detail, "upstream connect error")
+			},
+		},
+		{
+			name: "EmptyBody",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", jsonCT)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, jsonCT)
+				assert.Contains(t, sdkErr.Message, "empty response")
+			},
+		},
+		{
+			name: "ExcerptBoundedAndSanitized",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				// A large body with control characters and invalid
+				// UTF-8 must produce a small, printable excerpt.
+				_, _ = io.WriteString(w, "<html>\x00\x07evil\r\n\tbody\xff "+strings.Repeat("a", 1024*1024))
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, "text/html")
+				assert.LessOrEqual(t, len(sdkErr.Detail), jsonBodyExcerptLen+256)
+				assert.Contains(t, sdkErr.Detail, "<html> evil body")
+				for _, r := range sdkErr.Detail {
+					assert.True(t, unicode.IsGraphic(r), "detail contains non-graphic character %q", r)
+				}
+			},
+		},
+		{
+			name: "RedirectToHTML",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/login" {
+					http.Redirect(w, r, "/login", http.StatusFound)
+					return
+				}
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = io.WriteString(w, htmlBody)
+			},
+			assert: func(t *testing.T, _ apiResponse, err error) {
+				sdkErr := assertInvalidBody(t, err, "text/html; charset=utf-8")
+				assert.Contains(t, sdkErr.Message, "HTML response instead of JSON")
+				// The error reports the final URL after redirects and
+				// mentions the originally requested URL.
+				assert.Contains(t, sdkErr.URL(), "/login")
+				assert.Contains(t, sdkErr.Detail, "after following redirects from")
+				assert.Contains(t, sdkErr.Detail, "/api/v2/users/me")
+			},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(c.handler)
+			defer srv.Close()
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v2/users/me", nil)
+			require.NoError(t, err)
+			res, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			var v apiResponse
+			decodeErr := ReadBodyAsJSON(res, &v)
+			c.assert(t, v, decodeErr)
+		})
+	}
+
+	t.Run("NilResponse", func(t *testing.T) {
+		t.Parallel()
+
+		var v apiResponse
+		require.Error(t, ReadBodyAsJSON(nil, &v))
+	})
+
+	//nolint:bodyclose // The response is constructed, not from a client.
+	t.Run("BodyReadError", func(t *testing.T) {
+		t.Parallel()
+
+		// A transport failure while streaming the body past the sniff
+		// window must surface as a read error, not as an invalid API
+		// response.
+		errTransport := xerrors.New("connection reset by peer")
+		body := io.MultiReader(
+			strings.NewReader(`{"name":"`+strings.Repeat("a", 2*jsonBodyExcerptLen)),
+			iotest.ErrReader(errTransport),
+		)
+		res := newResponse(http.StatusOK, jsonCT, body)
+
+		var v apiResponse
+		err := ReadBodyAsJSON(res, &v)
+		require.ErrorIs(t, err, errTransport)
+		require.ErrorContains(t, err, "read response body")
+		require.NotContains(t, err.Error(), "invalid API response")
+	})
 }
 
 func assertSDKError(t *testing.T, err error) *Error {

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -996,7 +996,7 @@ func (c *Client) User(ctx context.Context, userIdent string) (User, error) {
 		return User{}, ReadBodyAsError(res)
 	}
 	var user User
-	return user, json.NewDecoder(res.Body).Decode(&user)
+	return user, ReadBodyAsJSON(res, &user)
 }
 
 // UserQuietHoursSchedule returns the quiet hours settings for the user. This

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -623,7 +623,7 @@ func (c *Client) Workspaces(ctx context.Context, filter WorkspaceFilter) (Worksp
 	}
 
 	var wres WorkspacesResponse
-	return wres, json.NewDecoder(res.Body).Decode(&wres)
+	return wres, ReadBodyAsJSON(res, &wres)
 }
 
 // WorkspaceByOwnerAndName returns a workspace by the owner's UUID and the workspace's name.


### PR DESCRIPTION
`coder whoami` and `coder list` can surface low-level JSON decode errors when a reverse proxy, SSO portal, or incorrect Coder URL returns HTML with a successful HTTP status.

Add a shared SDK JSON response decoder and use it for the user and workspace list endpoints so these commands return a structured, actionable API response error instead. Refs #27044

Reviewed and updated by Coder Agents on behalf of @dylanhuff-at-coder.