### PR TITLE
fix(coderd): distinguish missing and disabled chat model configs

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1002,10 +1002,11 @@ type userChatModelAvailability struct {
 type chatModelConfigUnavailableReason string
 
 const (
-	chatModelConfigAvailable                          chatModelConfigUnavailableReason = ""
-	chatModelConfigUnavailableModelNotFoundOrDisabled chatModelConfigUnavailableReason = "model_not_found_or_disabled"
-	chatModelConfigUnavailableProviderDisabled        chatModelConfigUnavailableReason = "provider_disabled"
-	chatModelConfigUnavailableCredentialsMissing      chatModelConfigUnavailableReason = "credentials_missing"
+	chatModelConfigAvailable                     chatModelConfigUnavailableReason = ""
+	chatModelConfigUnavailableModelNotFound      chatModelConfigUnavailableReason = "model_not_found"
+	chatModelConfigUnavailableModelDisabled      chatModelConfigUnavailableReason = "model_disabled"
+	chatModelConfigUnavailableProviderDisabled   chatModelConfigUnavailableReason = "provider_disabled"
+	chatModelConfigUnavailableCredentialsMissing chatModelConfigUnavailableReason = "credentials_missing"
 )
 
 // getUserChatProviderAvailability returns the enabled chat providers and models
@@ -1146,7 +1147,7 @@ func (api *API) userCanUseChatModelConfig(
 	modelConfigID uuid.UUID,
 ) (database.ChatModelConfig, chatModelConfigUnavailableReason, error) {
 	if modelConfigID == uuid.Nil {
-		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFound, nil
 	}
 	//nolint:gocritic // Non-admin users need deployment config validation.
 	model, err := api.Database.GetChatModelConfigByID(
@@ -1155,12 +1156,12 @@ func (api *API) userCanUseChatModelConfig(
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || httpapi.Is404Error(err) {
-			return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+			return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFound, nil
 		}
 		return database.ChatModelConfig{}, chatModelConfigAvailable, err
 	}
 	if !model.Enabled {
-		return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+		return database.ChatModelConfig{}, chatModelConfigUnavailableModelDisabled, nil
 	}
 
 	availability, err := api.getUserChatProviderAvailability(ctx, userID)
@@ -1184,7 +1185,7 @@ func (api *API) userCanUseChatModelConfig(
 	// Active configs always carry a provider FK (CHECK
 	// chat_model_configs_ai_provider_required_when_active), so an unset FK
 	// means the config is not usable.
-	return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFoundOrDisabled, nil
+	return database.ChatModelConfig{}, chatModelConfigUnavailableModelNotFound, nil
 }
 
 func (api *API) validateUserChatModelConfigAvailable(
@@ -1202,9 +1203,13 @@ func (api *API) validateUserChatModelConfigAvailable(
 	switch reason {
 	case chatModelConfigAvailable:
 		return modelConfig, 0, nil
-	case chatModelConfigUnavailableModelNotFoundOrDisabled:
+	case chatModelConfigUnavailableModelNotFound:
 		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
-			Message: "Invalid model_config_id: model config not found or disabled.",
+			Message: "Invalid model_config_id: model config not found.",
+		}
+	case chatModelConfigUnavailableModelDisabled:
+		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid model_config_id: model config is disabled. Contact your Coder administrator to enable it.",
 		}
 	case chatModelConfigUnavailableCredentialsMissing:
 		return database.ChatModelConfig{}, http.StatusBadRequest, &codersdk.Response{

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -500,7 +500,7 @@ func TestPostChats(t *testing.T) {
 			ModelConfigID: ptr.Ref(disabledConfig.ID),
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
-		require.Equal(t, "Invalid model_config_id: model config not found or disabled.", sdkErr.Message)
+		require.Equal(t, "Invalid model_config_id: model config is disabled. Contact your Coder administrator to enable it.", sdkErr.Message)
 	})
 
 	t.Run("ProviderDisabledModelConfigRejected", func(t *testing.T) {
@@ -9036,7 +9036,7 @@ func TestPatchChatMessage(t *testing.T) {
 			ModelConfigID: &unknownID,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
-		require.Equal(t, "Invalid model_config_id: model config not found or disabled.", sdkErr.Message)
+		require.Equal(t, "Invalid model_config_id: model config not found.", sdkErr.Message)
 	})
 
 	t.Run("ProviderDisabledModelConfigID", func(t *testing.T) {
@@ -13975,20 +13975,18 @@ func TestUserChatPersonalModelOverrides(t *testing.T) {
 				wantMessageSubstring: "Invalid model_config_id",
 			},
 			{
-				name:          "Unknown",
-				client:        memberClient,
-				userID:        member.ID,
-				modelConfigID: uuid.NewString(),
-				wantMessageSubstring: "Invalid model_config_id: model config " +
-					"not found or disabled.",
+				name:                 "Unknown",
+				client:               memberClient,
+				userID:               member.ID,
+				modelConfigID:        uuid.NewString(),
+				wantMessageSubstring: "Invalid model_config_id: model config not found.",
 			},
 			{
-				name:          "Disabled",
-				client:        memberClient,
-				userID:        member.ID,
-				modelConfigID: disabledModelConfig.ID.String(),
-				wantMessageSubstring: "Invalid model_config_id: model config " +
-					"not found or disabled.",
+				name:                 "Disabled",
+				client:               memberClient,
+				userID:               member.ID,
+				modelConfigID:        disabledModelConfig.ID.String(),
+				wantMessageSubstring: "Invalid model_config_id: model config is disabled.",
 			},
 			{
 				name:                 "ProviderDisabled",


### PR DESCRIPTION
`userCanUseChatModelConfig` returned `model_not_found_or_disabled` for both a model config that does not exist and one that exists but is disabled, so every caller got `Invalid model_config_id: model config not found or disabled.` and could not tell the two apart. A user who had just disabled a model in AI Settings saw the same message as a user passing an unknown UUID.

Split the reason into `model_not_found` and `model_disabled`, each with its own message. The fallback for a config with no provider FK maps to `model_not_found`: the `chat_model_configs_ai_provider_required_when_active` CHECK constraint means an unset FK implies the config is soft-deleted.

Two notes on the suggestions in the issue that I deliberately did not follow:

- No new `ChatErrorKind` was added. `ChatErrorKind` belongs to `coderd/x/chatd/chaterror`, which classifies upstream provider errors and feeds the chat stream and persisted chat state. This validation path returns a `codersdk.Response` and never produces a `ChatError`, so the constant would have no producer.
- The disabled message says "Contact your Coder administrator to enable it." rather than pointing at AI Settings, since the endpoint is reachable by members who cannot open that page. This matches the existing provider-disabled copy in `chaterror/message.go`.

The existing assertions in `exp_chats_test.go` that expected the shared message now assert the distinct ones, so the not-found and disabled cases are discriminated by the tests.

Closes #27290

---

This replaces #27499, which is unmergeable for a reason unrelated to the code. An accidental close/reopen there fired `contrib.yaml` on `pull_request_target: closed`, and `contributor-assistant/github-action` (`lock-pullrequest-aftermerge: true`) locked the conversation a few seconds after the reopen. Every subsequent `cla` run then fails with `Unable to create comment because issue is locked`, even though the signature is already recorded in `coder/cla`. I do not have the permissions to unlock it, so I am reopening on a clean thread. Same branch, rebased onto current `main`, identical diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
