### PR TITLE
ci(.github): retry Go module downloads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -367,6 +367,9 @@ jobs:
       - name: Verify helm version
         run: helm version --short
 
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
+
       - name: make lint
         # Bound concurrent lint targets to keep peak memory below the runner limit.
         run: make --output-sync=line -j"$(nproc)" lint
@@ -982,6 +985,9 @@ jobs:
         env:
           NODE_OPTIONS: ${{ github.repository_owner == 'coder' && '--max_old_space_size=8192' || '' }}
         working-directory: site
+
+      - name: Download Go modules
+        run: ./.github/scripts/retry.sh -- go mod download
 
       - run: make site/e2e/bin/coder
         name: make coder


### PR DESCRIPTION
Closes CODAGT-878
Closes https://github.com/coder/internal/issues/1621

The Go module proxy failure in the linked issue is outside our control, but `lint` and `test-e2e` currently download modules during their `make` targets without any retry. Other CI jobs already wrap `go mod download` with `./.github/scripts/retry.sh`, so this just copies that precedent to both affected jobs.

