### PR TITLE
test(coderd/x/chatd): accept query cancellation in subagent wait

### DIFF
--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -4237,7 +4237,8 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		_, _, err = server.awaitSubagentCompletion(
 			shortCtx, parent.ID, child.ID, 5*time.Second,
 		)
-		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorIs(t, shortCtx.Err(), context.DeadlineExceeded)
+		require.True(t, database.IsQueryCanceledError(err))
 	})
 
 	t.Run("ZeroTimeoutUsesDefault", func(t *testing.T) {


### PR DESCRIPTION
Closes CODAGT-877
Closes https://github.com/coder/internal/issues/1437

The linked flake happens because the context deadline can be observed as `context.DeadlineExceeded`, or as a PostgreSQL query cancellation when a database call is in flight. The fix is just to assert that the deadline expired and the returned error is a recognised query cancellation, rather than depending on which layer notices it first.
