### PR TITLE
fix: correct native usage-limit docs and spend UI details for 2.36

### DIFF
--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -116,10 +116,11 @@ none, if the template does not define any).
 
 ### Spend management
 
-The Spend page provides usage-only reporting for Coder Agents chats. The native
-usage-limit configuration UI has been removed from release 2.36, but values
-configured before upgrading remain stored and enforced. Existing native values
-are not migrated to AI Gateway budgets.
+The Spend page provides usage-only reporting for Coder Agents chats. As of
+release 2.36, native chat usage limits are no longer configurable or enforced.
+Values configured before upgrading remain stored, have no effect, and are not
+migrated to AI Gateway budgets. AI Gateway budgets are the only way to limit
+spend.
 
 Configure new AI Gateway budgets from group settings or through the generated
 group budget API. See [Spend Management](./usage-insights.md) for details.

--- a/docs/ai-coder/agents/platform-controls/usage-insights.md
+++ b/docs/ai-coder/agents/platform-controls/usage-insights.md
@@ -1,20 +1,17 @@
 # Spend Management
 
-Coder provides usage reporting for Coder Agents and two independent ways to
-limit spend on release 2.36: existing native chat usage limits and AI Gateway
-budgets.
+Coder provides usage reporting for Coder Agents and enforces spend through AI
+Gateway budgets on release 2.36.
 
 ## Native chat usage limits
 
-The native usage-limit configuration UI has been removed from release 2.36.
-Values configured before upgrading remain stored and enforced. Coder checks the
-user's current spend before processing each chat message and returns a **409
-Conflict** response when the applicable limit is reached.
+As of release 2.36, native chat usage limits are no longer configurable or
+enforced. Coder does not check previously configured values when processing
+chat messages. Values configured before upgrading remain stored, have no
+effect, and are not migrated to AI Gateway budgets.
 
-Existing native values are not migrated to AI Gateway budgets. To change spend
-controls after upgrading, configure new AI Gateway budgets. Native limits remain
-in effect until they are changed through the existing experimental API or
-removed in a later release.
+To limit spend, configure AI Gateway budgets. They are the only enforcement
+mechanism.
 
 ## AI Gateway budgets
 
@@ -49,3 +46,7 @@ for each user. It supports date range filtering, search, and pagination.
 
 Select a user to view summary cards and per-model and per-chat breakdowns. The
 Spend page does not configure native usage limits or AI Gateway budgets.
+
+> [!NOTE]
+> Automatic title generation uses lightweight models. Its token usage is not
+> included in usage reporting.

--- a/docs/ai-coder/ai-gateway/cost-controls.md
+++ b/docs/ai-coder/ai-gateway/cost-controls.md
@@ -270,9 +270,14 @@ see [Prometheus metrics](../../admin/integrations/prometheus.md).
 
 ## Migrate from Coder Agents Cost Control
 
-In release 2.36, the native Coder Agents usage-limit configuration UI is no
-longer available. Existing native values remain stored and enforced, and are not
+In release 2.36, native Coder Agents usage limits are no longer configurable
+or enforced. Existing native values remain stored, have no effect, and are not
 migrated to AI Gateway budgets.
+
+> [!WARNING]
+> Spend limits previously configured under **Admin settings** > **AI** >
+> **Spend** are no longer enforced by Coder Agents. To enforce spend, set an
+> AI Gateway budget.
 
 Configure new AI Gateway budgets from the group settings page or use the API to
 [get](../../reference/api/enterprise.md#get-group-ai-budget),
@@ -282,14 +287,12 @@ budget.
 
 Expect the following differences:
 
-- Native limits and AI Gateway budgets are independent. A user can be subject to
-  both until native limits are removed in a later release.
 - AI Gateway has no deployment-wide default budget. Each group that needs a
   limit requires its own budget.
 - The UTC calendar month is the only budget period. Daily and weekly periods are
   not currently supported.
 - Users in several budgeted groups receive the highest budget by default. Native
-  Coder Agents usage limits apply the lowest group limit.
+  Coder Agents usage limits applied the lowest group limit.
 - Budgets cover priced AI Gateway traffic. Chat, IDE extensions, and CLI agents
   draw on the same budget when their provider and model are priced. See
   [How spend is estimated](#how-spend-is-estimated).

--- a/site/src/pages/AISettingsPage/SpendPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AISettingsPage/SpendPage/components/ChatCostSummaryView.tsx
@@ -1,4 +1,4 @@
-import { TriangleAlertIcon } from "lucide-react";
+import { InfoIcon, TriangleAlertIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { getErrorMessage } from "#/api/errors";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -157,6 +157,14 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</span>
 				</div>
 			)}
+
+			<div className="flex items-start gap-3 p-4 text-sm text-content-secondary">
+				<InfoIcon className="size-5 shrink-0" />
+				<span>
+					Automatic title generation uses lightweight models and is not included
+					in usage reporting.
+				</span>
+			</div>
 
 			{summary.by_model.length === 0 && summary.by_chat.length === 0 ? (
 				<p className="py-12 text-center text-content-secondary">

--- a/site/src/pages/GroupsPage/GroupMembersPage.tsx
+++ b/site/src/pages/GroupsPage/GroupMembersPage.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { EllipsisVerticalIcon, UserPlusIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
@@ -50,6 +49,7 @@ import {
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
 import { isEveryoneGroup } from "#/modules/groups";
+import { formatSpendResetLabel } from "#/utils/budget";
 import { cn } from "#/utils/cn";
 import { formatBudgetUSD } from "#/utils/currency";
 import { SpendEstimateDocsLink } from "./AICostControl";
@@ -114,9 +114,7 @@ const GroupMembersPage: FC = () => {
 	);
 	const aiBudgetNote = [
 		"Estimated monthly AI spend for this user.",
-		// Spend resets at period_end, rendered in the viewer's local time.
-		aiSpend &&
-			`Resets ${dayjs(aiSpend.period_end).format("MMM D, YYYY h:mm A")}.`,
+		aiSpend && `Resets ${formatSpendResetLabel(aiSpend.period_end)}.`,
 		// A $0 default still shows: it means no spending allowance.
 		groupBudget &&
 			`The group's default limit is ${formatBudgetUSD(groupBudget.spend_limit_micros)} per member.`,

--- a/site/src/utils/budget.test.ts
+++ b/site/src/utils/budget.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
 	clampPercentage,
 	formatSpendPeriodLabel,
+	formatSpendResetLabel,
 	getSeverity,
 	usageProgressPercentage,
 } from "./budget";
+
+// Pin a non-UTC zone so the UTC assertions fail if formatting falls back
+// to local time. Under UTC runners both implementations agree.
+process.env.TZ = "America/Los_Angeles";
 
 describe("formatSpendPeriodLabel", () => {
 	it("renders API timestamps in UTC with the year on the exclusive end", () => {
@@ -17,6 +22,12 @@ describe("formatSpendPeriodLabel", () => {
 		expect(
 			formatSpendPeriodLabel("2026-12-01T00:00:00Z", "2027-01-01T00:00:00Z"),
 		).toBe("December 1 - January 1, 2027");
+	});
+});
+
+describe("formatSpendResetLabel", () => {
+	it("renders the exclusive period_end in UTC", () => {
+		expect(formatSpendResetLabel("2026-08-01T00:00:00Z")).toBe("Aug 1, 2026");
 	});
 });
 

--- a/site/src/utils/budget.ts
+++ b/site/src/utils/budget.ts
@@ -19,6 +19,14 @@ export function formatSpendPeriodLabel(
 }
 
 /**
+ * Formats an AI budget window's exclusive period_end in UTC, e.g.
+ * "Aug 1, 2026", matching formatSpendPeriodLabel's convention.
+ */
+export function formatSpendResetLabel(periodEnd: string): string {
+	return dayjs.utc(periodEnd).format("MMM D, YYYY");
+}
+
+/**
  * Classifies usage against a budget. Returns "warning" once usage reaches 85%
  * of the budget and "exceeded" once it meets or passes the budget. A budget of
  * 0 is treated as exceeded as soon as anything is used.


### PR DESCRIPTION
Follow-up to #27825. Native chat usage-limit enforcement was already removed from `release/2.36` by #27599 (`checkUsageLimit` is a no-op), but the docs added in #27825 claimed stored native values are still enforced per message with a 409 response. This corrects the docs and folds in small spend UI fixes found during UAT.

## Docs

- State that native limits are no longer configurable or enforced as of release 2.36, stored values are inert and not migrated, and AI Gateway budgets are the only enforcement mechanism (`usage-insights.md`, `platform-controls/index.md`, `cost-controls.md`).
- Restore the warning that spend limits previously configured under Admin settings > AI > Spend are no longer enforced.
- Drop the migration bullet claiming users can be subject to both native limits and budgets.
- Restore the note that automatic title generation is not included in usage reporting.

## Frontend

- Render the group members page AI spend reset date in UTC via a shared `formatSpendResetLabel` helper, matching the budget period formatting elsewhere. Non-UTC viewers previously saw two different dates for one period.
- Pin a non-UTC timezone in `budget.test.ts` so CI fails if formatting falls back to local time (verified red under the old implementation).
- Restore the title-generation note on the cost summary, reworded for usage reporting.

> Mux prepared this PR on Mike's behalf.
