### PR TITLE
docs: correct 2.35 stable version to v2.35.3

### DIFF
--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -135,7 +135,7 @@ kubectl create secret generic coder-db-url -n coder \
 1. Select a Coder version:
 
    - **Mainline**: `2.36.0`
-   - **Stable**: `2.34.6`
+   - **Stable**: `2.35.3`
 
    Learn more about release channels in the [Releases documentation](./releases/index.md).
 

--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -84,7 +84,7 @@ pages.
 | [2.32](https://coder.com/changelog/coder-2-32)   | April 14, 2026    | Not Supported            | [v2.32.10](https://github.com/coder/coder/releases/tag/v2.32.10) |
 | [2.33](https://coder.com/changelog/coder-2-33)   | May 05, 2026      | Not Supported            | [v2.33.11](https://github.com/coder/coder/releases/tag/v2.33.11) |
 | [2.34](https://coder.com/changelog/coder-2-34)   | June 02, 2026     | Security Support         | [v2.34.7](https://github.com/coder/coder/releases/tag/v2.34.7)   |
-| [2.35](https://coder.com/changelog/coder-2-35-1) | July 07, 2026     | Stable                   | [v2.35.2](https://github.com/coder/coder/releases/tag/v2.35.2)   |
+| [2.35](https://coder.com/changelog/coder-2-35-1) | July 07, 2026     | Stable                   | [v2.35.3](https://github.com/coder/coder/releases/tag/v2.35.3)   |
 | [2.36](https://coder.com/changelog/coder-2-36)   | August 04, 2026   | Mainline                 | [v2.36.0](https://github.com/coder/coder/releases/tag/v2.36.0)   |
 | 2.37                                             |                   | Not Released             | N/A                                                              |
 <!-- RELEASE_CALENDAR_END -->


### PR DESCRIPTION
## Summary

Follow-up to #27828, addressing review feedback from @matifali.

The automated `releasetui` update in #27828 promoted `2.36.0` to Mainline but
left two stale references to the 2.35 stable channel:

- `docs/install/rancher.md`: **Stable** was left at `2.34.6` instead of being
  promoted to the current 2.35 stable patch.
- `docs/install/releases/index.md`: the 2.35 row was marked **Stable** but its
  latest release still pointed at `v2.35.2`.

The latest 2.35 patch is `v2.35.3` (see the `v2.35.3` release tag), so both are
now updated accordingly.

## Changes

- `docs/install/rancher.md`: Stable `2.34.6` -> `2.35.3`
- `docs/install/releases/index.md`: 2.35 latest release `v2.35.2` -> `v2.35.3`

<details>
<summary>Review comments addressed</summary>

- `docs/install/rancher.md` (matifali): "A bit late, but shouldn't the stable be now 2.35.3?"
- `docs/install/releases/index.md` (matifali): "The latest stable is 2.35.3 and not 2.35.2"

</details>

> [!NOTE]
> This PR was generated by Coder Agents on behalf of @mtojek.
