### PR TITLE
fix(site/src/pages/AgentsPage): stop attachment downloads from trapping iOS PWAs

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -57,6 +57,7 @@ const ATTACHMENT_FALLBACK_EXTENSIONS: Record<string, string> = {
 	"application/x-tar": "tar",
 	"application/xml": "xml",
 	"image/jpeg": "jpg",
+	"image/svg+xml": "svg",
 	"text/csv": "csv",
 	"text/markdown": "md",
 	"text/plain": "txt",
@@ -77,13 +78,6 @@ const getMediaTypeExtension = (mediaType: string): string | null => {
 		return mapped;
 	}
 	const [type, subtype = ""] = mediaType.split("/");
-	if (subtype.endsWith("+json")) {
-		return "json";
-	}
-	if (subtype.endsWith("+xml")) {
-		const base = subtype.slice(0, -"+xml".length);
-		return /^[a-z0-9]{1,8}$/i.test(base) ? base.toLowerCase() : "xml";
-	}
 	// Unmapped non-image subtypes are not assumed to be filename extensions.
 	return type === "image" && /^[a-z0-9]{1,8}$/i.test(subtype)
 		? subtype.toLowerCase()

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -4,12 +4,7 @@ import {
 	FileIcon,
 	FileTextIcon,
 } from "lucide-react";
-import {
-	type FC,
-	type MouseEvent as ReactMouseEvent,
-	type ReactNode,
-	useState,
-} from "react";
+import { type FC, type ReactNode, useState } from "react";
 import { Spinner } from "#/components/Spinner/Spinner";
 import {
 	Tooltip,
@@ -19,7 +14,6 @@ import {
 import { cn } from "#/utils/cn";
 import { useLatestAbortController } from "../../hooks/useLatestAbortController";
 import {
-	type AttachmentDownloadTarget,
 	type AttachmentFailure,
 	attachmentFailureFromError,
 	getChatFileURL,
@@ -180,61 +174,28 @@ const getAttachmentBadgeLabel = (
 	return extension === "file" ? "" : extension.toUpperCase();
 };
 
-const useAttachmentDownloadClick = (target: AttachmentDownloadTarget) => {
-	const [isPending, setIsPending] = useState(false);
-	// Prevents share sheets and error toasts from appearing after unmount.
-	const downloadRequest = useLatestAbortController();
-	const onClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
-		event.stopPropagation();
-		if (isPending) {
-			event.preventDefault();
-			return;
-		}
-		const controller = downloadRequest.start();
-		const pending = handleAttachmentDownloadClick(
-			event,
-			target,
-			controller.signal,
-		);
-		if (!pending) {
-			downloadRequest.clear(controller);
-			return;
-		}
-		setIsPending(true);
-		void pending.finally(() => {
-			if (downloadRequest.clear(controller)) {
-				setIsPending(false);
-			}
-		});
-	};
-	return { isPending, onClick };
-};
-
 const DownloadOverlay: FC<{
 	href: string;
 	displayName: string;
 	downloadName: string;
 	mediaType: string;
 }> = ({ href, displayName, downloadName, mediaType }) => {
-	const { isPending, onClick } = useAttachmentDownloadClick({
-		href,
-		fileName: downloadName,
-		mediaType,
-	});
 	return (
 		<a
 			href={href}
 			download={downloadName}
-			onClick={onClick}
+			onClick={(event) => {
+				event.stopPropagation();
+				void handleAttachmentDownloadClick(event, {
+					href,
+					fileName: downloadName,
+					mediaType,
+				});
+			}}
 			aria-label={`Download ${displayName}`}
-			aria-disabled={isPending}
 			className="invisible absolute right-1 top-1 flex size-6 items-center justify-center rounded bg-surface-primary/80 text-content-secondary opacity-0 shadow-sm backdrop-blur-sm transition-opacity hover:text-content-primary group-hover/attachment:visible group-hover/attachment:opacity-100 group-focus-within/attachment:visible group-focus-within/attachment:opacity-100 [@media(hover:none)]:visible [@media(hover:none)]:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
 		>
-			{isPending ? (
-				<Spinner size="sm" loading className="size-3.5" />
-			) : (
-				<DownloadIcon aria-hidden="true" className="size-3.5" />
-			)}
+			<DownloadIcon aria-hidden="true" className="size-3.5" />
 		</a>
 	);
 };
@@ -614,19 +575,20 @@ const FileCard: FC<{
 	const displayName = getAttachmentDisplayName(block);
 	const downloadName = getAttachmentDownloadName(block);
 	const badgeLabel = getAttachmentBadgeLabel(block);
-	const { isPending, onClick } = useAttachmentDownloadClick({
-		href,
-		fileName: downloadName,
-		mediaType: block.media_type,
-	});
 
 	return (
 		<a
 			href={href}
 			download={downloadName}
-			onClick={onClick}
+			onClick={(event) => {
+				event.stopPropagation();
+				void handleAttachmentDownloadClick(event, {
+					href,
+					fileName: downloadName,
+					mediaType: block.media_type,
+				});
+			}}
 			aria-label={`Download ${displayName}`}
-			aria-disabled={isPending}
 			className="inline-flex h-16 max-w-sm items-center gap-3 rounded-md border border-solid border-border-default bg-surface-tertiary px-3 py-2 no-underline transition-colors hover:bg-surface-quaternary"
 		>
 			<div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-surface-secondary">
@@ -647,18 +609,10 @@ const FileCard: FC<{
 				</div>
 				<div className="text-xs text-content-secondary">Download file</div>
 			</div>
-			{isPending ? (
-				<Spinner
-					size="sm"
-					loading
-					className="size-4 shrink-0 text-content-secondary"
-				/>
-			) : (
-				<DownloadIcon
-					aria-hidden="true"
-					className="size-4 shrink-0 text-content-secondary"
-				/>
-			)}
+			<DownloadIcon
+				aria-hidden="true"
+				className="size-4 shrink-0 text-content-secondary"
+			/>
 		</a>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -90,6 +90,13 @@ const getMediaTypeExtension = (mediaType: string): string | null => {
 		: null;
 };
 
+const getNameExtension = (name: string): string | null => {
+	const lastDot = name.lastIndexOf(".");
+	return lastDot > 0 && lastDot < name.length - 1
+		? name.slice(lastDot + 1)
+		: null;
+};
+
 const getAttachmentExtension = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,
 ): string => {
@@ -97,10 +104,9 @@ const getAttachmentExtension = (
 	if (mapped) {
 		return mapped;
 	}
-	const name = block.name?.trim();
-	const lastDot = name?.lastIndexOf(".") ?? -1;
-	if (name && lastDot > 0 && lastDot < name.length - 1) {
-		return sanitizeAttachmentExtension(name.slice(lastDot + 1));
+	const nameExtension = getNameExtension(block.name?.trim() ?? "");
+	if (nameExtension) {
+		return sanitizeAttachmentExtension(nameExtension);
 	}
 	return (
 		getMediaTypeExtension(block.media_type) ??
@@ -110,9 +116,6 @@ const getAttachmentExtension = (
 
 const isTextPreviewAttachmentMediaType = (mediaType: string): boolean =>
 	TEXT_ATTACHMENT_MEDIA_TYPES.has(mediaType);
-
-const isSuffixPreservingMediaType = (mediaType: string): boolean =>
-	mediaType.startsWith("text/");
 
 const getAttachmentHref = (block: FileAttachmentBlock): string | null => {
 	if (block.file_id) {
@@ -140,8 +143,6 @@ const getAttachmentDisplayName = (
 	return "Attached file";
 };
 
-const extensionAliases = new Set(["jpg:jpeg", "tiff:tif"]);
-
 const getAttachmentDownloadName = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,
 ): string => {
@@ -150,21 +151,12 @@ const getAttachmentDownloadName = (
 		const extension = getAttachmentExtension(block);
 		return extension === "file" ? "attachment" : `attachment.${extension}`;
 	}
+	// Kept even when the name's extension disagrees with the media type.
+	if (name.startsWith(".") || getNameExtension(name)) {
+		return name;
+	}
 	const mediaExtension = getMediaTypeExtension(block.media_type);
-	if (!mediaExtension || name.startsWith(".")) {
-		return name;
-	}
-	if (
-		isSuffixPreservingMediaType(block.media_type) &&
-		/\.[^.\s]+$/.test(name)
-	) {
-		return name;
-	}
-	const suffix = name.match(/\.([a-z0-9]{1,8})$/i)?.[1]?.toLowerCase();
-	return suffix === mediaExtension ||
-		extensionAliases.has(`${mediaExtension}:${suffix}`)
-		? name
-		: `${name}.${mediaExtension}`;
+	return mediaExtension ? `${name}.${mediaExtension}` : name;
 };
 
 const getAttachmentBadgeLabel = (

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -170,10 +170,18 @@ const getAttachmentDownloadName = (
 	// extension, so a name like "About Page Screenshot" or "report.final"
 	// would land as a generic file even when the media type is known.
 	const suffix = name.match(endsWithFileExtension)?.[1]?.toLowerCase();
+	if (suffix === undefined) {
+		return `${name}.${mediaExtension}`;
+	}
+	// text/plain is the server classifier's catch-all for source files
+	// (main.go, config.yaml), whose suffixes identify them better than
+	// .txt would, so any existing suffix is kept.
+	if (block.media_type === "text/plain") {
+		return name;
+	}
 	if (
-		suffix !== undefined &&
-		(suffix === mediaExtension ||
-			(extensionAliases[mediaExtension] ?? []).includes(suffix))
+		suffix === mediaExtension ||
+		(extensionAliases[mediaExtension] ?? []).includes(suffix)
 	) {
 		return name;
 	}

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -61,9 +61,13 @@ const ATTACHMENT_FALLBACK_EXTENSIONS: Record<string, string> = {
 	"application/vnd.openxmlformats-officedocument.wordprocessingml.document":
 		"docx",
 	"application/x-tar": "tar",
+	"application/xml": "xml",
 	"image/jpeg": "jpg",
+	"text/csv": "csv",
+	"text/html": "html",
 	"text/markdown": "md",
 	"text/plain": "txt",
+	"text/xml": "xml",
 };
 
 const sanitizeAttachmentExtension = (value: string): string => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -120,10 +120,7 @@ const isTextPreviewAttachmentMediaType = (mediaType: string): boolean =>
 	TEXT_ATTACHMENT_MEDIA_TYPES.has(mediaType);
 
 const isSuffixPreservingMediaType = (mediaType: string): boolean =>
-	mediaType.startsWith("text/") ||
-	mediaType === "application/json" ||
-	mediaType === "application/xml" ||
-	/\+(json|xml)$/i.test(mediaType);
+	mediaType.startsWith("text/");
 
 const getAttachmentHref = (block: FileAttachmentBlock): string | null => {
 	if (block.file_id) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -131,9 +131,10 @@ const endsWithFileExtension = /\.([a-z0-9]{1,8})$/i;
 // Alternate name suffixes that identify the same type as the canonical
 // media-type extension, so "photo.jpeg" is not renamed to "photo.jpeg.jpg".
 const extensionAliases: Record<string, readonly string[]> = {
-	jpg: ["jpeg"],
+	html: ["htm"],
+	jpg: ["jpeg", "jfif", "jpe", "pjpeg", "pjp"],
 	md: ["markdown"],
-	txt: ["text", "log"],
+	tiff: ["tif"],
 };
 
 // Returns the extension implied by the media type alone, ignoring the

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -64,10 +64,8 @@ const ATTACHMENT_FALLBACK_EXTENSIONS: Record<string, string> = {
 	"application/xml": "xml",
 	"image/jpeg": "jpg",
 	"text/csv": "csv",
-	"text/html": "html",
 	"text/markdown": "md",
 	"text/plain": "txt",
-	"text/xml": "xml",
 };
 
 const sanitizeAttachmentExtension = (value: string): string =>

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -172,10 +172,12 @@ const getAttachmentDownloadName = (
 	if (name.startsWith(".")) {
 		return name;
 	}
-	// text/plain is the server classifier's catch-all for source files
-	// (main.go, config.properties), whose suffixes identify them better
-	// than .txt would, so any dotted suffix is kept regardless of length.
-	if (block.media_type === "text/plain") {
+	// The server classifies text-like uploads (text/plain, markdown, CSV,
+	// JSON) by content while preserving their names, so an existing suffix
+	// (main.go, config.properties, map.geojson) identifies the file better
+	// than the canonical extension would. Keep any dotted suffix and only
+	// append the extension to extensionless names.
+	if (isTextPreviewAttachmentMediaType(block.media_type)) {
 		return /\.[^.\s]+$/.test(name) ? name : `${name}.${mediaExtension}`;
 	}
 	// iOS resolves the shared or saved file's type from the filename

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -4,7 +4,12 @@ import {
 	FileIcon,
 	FileTextIcon,
 } from "lucide-react";
-import { type FC, type ReactNode, useState } from "react";
+import {
+	type FC,
+	type MouseEvent as ReactMouseEvent,
+	type ReactNode,
+	useState,
+} from "react";
 import { Spinner } from "#/components/Spinner/Spinner";
 import {
 	Tooltip,
@@ -14,6 +19,7 @@ import {
 import { cn } from "#/utils/cn";
 import { useLatestAbortController } from "../../hooks/useLatestAbortController";
 import {
+	type AttachmentDownloadTarget,
 	type AttachmentFailure,
 	attachmentFailureFromError,
 	getChatFileURL,
@@ -181,29 +187,54 @@ const getAttachmentBadgeLabel = (
 	return extension === "file" ? "" : extension.toUpperCase();
 };
 
+// Suppresses repeated clicks while an intercepted iOS download is still
+// fetching, so a second tap cannot open a second share sheet or surface
+// a misleading error toast while the first sheet is open.
+const useAttachmentDownloadClick = (target: AttachmentDownloadTarget) => {
+	const [isPending, setIsPending] = useState(false);
+	const onClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
+		event.stopPropagation();
+		if (isPending) {
+			event.preventDefault();
+			return;
+		}
+		const pending = handleAttachmentDownloadClick(event, target);
+		if (pending) {
+			setIsPending(true);
+			void pending.finally(() => setIsPending(false));
+		}
+	};
+	return { isPending, onClick };
+};
+
 const DownloadOverlay: FC<{
 	href: string;
 	displayName: string;
 	downloadName: string;
 	mediaType: string;
-}> = ({ href, displayName, downloadName, mediaType }) => (
-	<a
-		href={href}
-		download={downloadName}
-		onClick={(event) => {
-			event.stopPropagation();
-			void handleAttachmentDownloadClick(event, {
-				href,
-				fileName: downloadName,
-				mediaType,
-			});
-		}}
-		aria-label={`Download ${displayName}`}
-		className="invisible absolute right-1 top-1 flex size-6 items-center justify-center rounded bg-surface-primary/80 text-content-secondary opacity-0 shadow-sm backdrop-blur-sm transition-opacity hover:text-content-primary group-hover/attachment:visible group-hover/attachment:opacity-100 group-focus-within/attachment:visible group-focus-within/attachment:opacity-100 [@media(hover:none)]:visible [@media(hover:none)]:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
-	>
-		<DownloadIcon aria-hidden="true" className="size-3.5" />
-	</a>
-);
+}> = ({ href, displayName, downloadName, mediaType }) => {
+	const { isPending, onClick } = useAttachmentDownloadClick({
+		href,
+		fileName: downloadName,
+		mediaType,
+	});
+	return (
+		<a
+			href={href}
+			download={downloadName}
+			onClick={onClick}
+			aria-label={`Download ${displayName}`}
+			aria-disabled={isPending}
+			className="invisible absolute right-1 top-1 flex size-6 items-center justify-center rounded bg-surface-primary/80 text-content-secondary opacity-0 shadow-sm backdrop-blur-sm transition-opacity hover:text-content-primary group-hover/attachment:visible group-hover/attachment:opacity-100 group-focus-within/attachment:visible group-focus-within/attachment:opacity-100 [@media(hover:none)]:visible [@media(hover:none)]:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+		>
+			{isPending ? (
+				<Spinner size="sm" loading className="size-3.5" />
+			) : (
+				<DownloadIcon aria-hidden="true" className="size-3.5" />
+			)}
+		</a>
+	);
+};
 
 const AttachmentPreviewFrame: FC<{
 	href: string | null;
@@ -580,20 +611,19 @@ const FileCard: FC<{
 	const displayName = getAttachmentDisplayName(block);
 	const downloadName = getAttachmentDownloadName(block);
 	const badgeLabel = getAttachmentBadgeLabel(block);
+	const { isPending, onClick } = useAttachmentDownloadClick({
+		href,
+		fileName: downloadName,
+		mediaType: block.media_type,
+	});
 
 	return (
 		<a
 			href={href}
 			download={downloadName}
-			onClick={(event) => {
-				event.stopPropagation();
-				void handleAttachmentDownloadClick(event, {
-					href,
-					fileName: downloadName,
-					mediaType: block.media_type,
-				});
-			}}
+			onClick={onClick}
 			aria-label={`Download ${displayName}`}
+			aria-disabled={isPending}
 			className="inline-flex h-16 max-w-sm items-center gap-3 rounded-md border border-solid border-border-default bg-surface-tertiary px-3 py-2 no-underline transition-colors hover:bg-surface-quaternary"
 		>
 			<div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-surface-secondary">
@@ -614,10 +644,18 @@ const FileCard: FC<{
 				</div>
 				<div className="text-xs text-content-secondary">Download file</div>
 			</div>
-			<DownloadIcon
-				aria-hidden="true"
-				className="size-4 shrink-0 text-content-secondary"
-			/>
+			{isPending ? (
+				<Spinner
+					size="sm"
+					loading
+					className="size-4 shrink-0 text-content-secondary"
+				/>
+			) : (
+				<DownloadIcon
+					aria-hidden="true"
+					className="size-4 shrink-0 text-content-secondary"
+				/>
+			)}
 		</a>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -233,16 +233,29 @@ const getAttachmentBadgeLabel = (
 // a misleading error toast while the first sheet is open.
 const useAttachmentDownloadClick = (target: AttachmentDownloadTarget) => {
 	const [isPending, setIsPending] = useState(false);
+	// Aborts on unmount so a slow fetch cannot surface the share sheet
+	// or an error toast after the user has navigated away.
+	const downloadRequest = useLatestAbortController();
 	const onClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
 		event.stopPropagation();
 		if (isPending) {
 			event.preventDefault();
 			return;
 		}
-		const pending = handleAttachmentDownloadClick(event, target);
+		const controller = downloadRequest.start();
+		const pending = handleAttachmentDownloadClick(
+			event,
+			target,
+			controller.signal,
+		);
 		if (pending) {
 			setIsPending(true);
-			void pending.finally(() => setIsPending(false));
+			void pending.finally(() => {
+				downloadRequest.clear(controller);
+				setIsPending(false);
+			});
+		} else {
+			downloadRequest.clear(controller);
 		}
 	};
 	return { isPending, onClick };

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -17,6 +17,7 @@ import {
 	type AttachmentFailure,
 	attachmentFailureFromError,
 	getChatFileURL,
+	handleAttachmentDownloadClick,
 	isAbortError,
 	probeAttachmentFailure,
 } from "../../utils/chatAttachments";
@@ -141,11 +142,19 @@ const DownloadOverlay: FC<{
 	href: string;
 	displayName: string;
 	downloadName: string;
-}> = ({ href, displayName, downloadName }) => (
+	mediaType: string;
+}> = ({ href, displayName, downloadName, mediaType }) => (
 	<a
 		href={href}
 		download={downloadName}
-		onClick={(event) => event.stopPropagation()}
+		onClick={(event) => {
+			event.stopPropagation();
+			void handleAttachmentDownloadClick(event, {
+				href,
+				fileName: downloadName,
+				mediaType,
+			});
+		}}
 		aria-label={`Download ${displayName}`}
 		className="invisible absolute right-1 top-1 flex size-6 items-center justify-center rounded bg-surface-primary/80 text-content-secondary opacity-0 shadow-sm backdrop-blur-sm transition-opacity hover:text-content-primary group-hover/attachment:visible group-hover/attachment:opacity-100 group-focus-within/attachment:visible group-focus-within/attachment:opacity-100 [@media(hover:none)]:visible [@media(hover:none)]:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
 	>
@@ -157,8 +166,9 @@ const AttachmentPreviewFrame: FC<{
 	href: string | null;
 	displayName: string;
 	downloadName: string;
+	mediaType: string;
 	children: ReactNode;
-}> = ({ href, displayName, downloadName, children }) => {
+}> = ({ href, displayName, downloadName, mediaType, children }) => {
 	return (
 		<div className="group/attachment relative inline-flex flex-col items-start">
 			{children}
@@ -167,6 +177,7 @@ const AttachmentPreviewFrame: FC<{
 					href={href}
 					displayName={displayName}
 					downloadName={downloadName}
+					mediaType={mediaType}
 				/>
 			) : null}
 		</div>
@@ -385,6 +396,7 @@ const RemoteTextAttachmentButton: FC<{
 			href={frameHref}
 			displayName={fileName ?? "Pasted text"}
 			downloadName={downloadName}
+			mediaType={mediaType ?? ""}
 		>
 			{button}
 		</AttachmentPreviewFrame>
@@ -530,7 +542,14 @@ const FileCard: FC<{
 		<a
 			href={href}
 			download={downloadName}
-			onClick={(event) => event.stopPropagation()}
+			onClick={(event) => {
+				event.stopPropagation();
+				void handleAttachmentDownloadClick(event, {
+					href,
+					fileName: downloadName,
+					mediaType: block.media_type,
+				});
+			}}
 			aria-label={`Download ${displayName}`}
 			className="inline-flex h-16 max-w-sm items-center gap-3 rounded-md border border-solid border-border-default bg-surface-tertiary px-3 py-2 no-underline transition-colors hover:bg-surface-quaternary"
 		>
@@ -616,6 +635,7 @@ export const AttachmentBlock: FC<{
 				href={href}
 				displayName={displayName}
 				downloadName={downloadName}
+				mediaType={block.media_type}
 			>
 				{button}
 			</AttachmentPreviewFrame>
@@ -641,6 +661,7 @@ export const AttachmentBlock: FC<{
 				href={href}
 				displayName={displayName}
 				downloadName={downloadName}
+				mediaType={block.media_type}
 			>
 				{image}
 			</AttachmentPreviewFrame>

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -116,10 +116,15 @@ const getAttachmentExtension = (
 const isTextPreviewAttachmentMediaType = (mediaType: string): boolean =>
 	TEXT_ATTACHMENT_MEDIA_TYPES.has(mediaType);
 
+// Text-like types whose payloads the server classifies by content while
+// preserving the name. Structured +json/+xml types (application/ld+json)
+// belong here too: their registered extensions (.jsonld) differ from the
+// base format's, so an existing suffix always wins.
 const isSuffixPreservingMediaType = (mediaType: string): boolean =>
 	mediaType.startsWith("text/") ||
 	mediaType === "application/json" ||
-	mediaType === "application/xml";
+	mediaType === "application/xml" ||
+	/\+(json|xml)$/i.test(mediaType);
 
 const getAttachmentHref = (block: FileAttachmentBlock): string | null => {
 	if (block.file_id) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -206,8 +206,9 @@ const useAttachmentDownloadClick = (target: AttachmentDownloadTarget) => {
 		}
 		setIsPending(true);
 		void pending.finally(() => {
-			downloadRequest.clear(controller);
-			setIsPending(false);
+			if (downloadRequest.clear(controller)) {
+				setIsPending(false);
+			}
 		});
 	};
 	return { isPending, onClick };

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -167,6 +167,11 @@ const getAttachmentDownloadName = (
 	if (mediaExtension === null) {
 		return name;
 	}
+	// Leading-dot names are dotfiles (.eslintrc, .gitignore) whose whole
+	// name carries the meaning; appending an extension would rename them.
+	if (name.startsWith(".")) {
+		return name;
+	}
 	// text/plain is the server classifier's catch-all for source files
 	// (main.go, config.properties), whose suffixes identify them better
 	// than .txt would, so any dotted suffix is kept regardless of length.

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -166,18 +166,18 @@ const getAttachmentDownloadName = (
 	if (mediaExtension === null) {
 		return name;
 	}
+	// text/plain is the server classifier's catch-all for source files
+	// (main.go, config.properties), whose suffixes identify them better
+	// than .txt would, so any dotted suffix is kept regardless of length.
+	if (block.media_type === "text/plain") {
+		return /\.[^.\s]+$/.test(name) ? name : `${name}.${mediaExtension}`;
+	}
 	// iOS resolves the shared or saved file's type from the filename
 	// extension, so a name like "About Page Screenshot" or "report.final"
 	// would land as a generic file even when the media type is known.
 	const suffix = name.match(endsWithFileExtension)?.[1]?.toLowerCase();
 	if (suffix === undefined) {
 		return `${name}.${mediaExtension}`;
-	}
-	// text/plain is the server classifier's catch-all for source files
-	// (main.go, config.yaml), whose suffixes identify them better than
-	// .txt would, so any existing suffix is kept.
-	if (block.media_type === "text/plain") {
-		return name;
 	}
 	if (
 		suffix === mediaExtension ||

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -90,7 +90,7 @@ const getMediaTypeExtension = (mediaType: string): string | null => {
 		const base = subtype.slice(0, -"+xml".length);
 		return /^[a-z0-9]{1,8}$/i.test(base) ? base.toLowerCase() : "xml";
 	}
-	// Only image subtypes reliably double as filename extensions.
+	// Unmapped non-image subtypes are not assumed to be filename extensions.
 	return type === "image" && /^[a-z0-9]{1,8}$/i.test(subtype)
 		? subtype.toLowerCase()
 		: null;
@@ -180,13 +180,9 @@ const getAttachmentBadgeLabel = (
 	return extension === "file" ? "" : extension.toUpperCase();
 };
 
-// Suppresses repeated clicks while an intercepted iOS download is still
-// fetching, so a second tap cannot open a second share sheet or surface
-// a misleading error toast while the first sheet is open.
 const useAttachmentDownloadClick = (target: AttachmentDownloadTarget) => {
 	const [isPending, setIsPending] = useState(false);
-	// Aborts on unmount so a slow fetch cannot surface the share sheet
-	// or an error toast after the user has navigated away.
+	// Prevents share sheets and error toasts from appearing after unmount.
 	const downloadRequest = useLatestAbortController();
 	const onClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
 		event.stopPropagation();

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -70,17 +70,21 @@ const ATTACHMENT_FALLBACK_EXTENSIONS: Record<string, string> = {
 	"text/xml": "xml",
 };
 
-const sanitizeAttachmentExtension = (value: string): string => {
-	const sanitized = value
+const sanitizeAttachmentExtension = (value: string): string =>
+	value
 		.replace(/[^a-z0-9]/gi, "")
 		.slice(0, 4)
-		.toLowerCase();
-	return sanitized || "file";
-};
+		.toLowerCase() || "file";
 
-// Structured MIME suffixes (RFC 6839) carry the real format before the
-// plus sign, so image/svg+xml maps to svg rather than a mangled subtype.
-const structuredSubtypeExtension = (subtype: string): string | null => {
+const getMediaTypeExtension = (mediaType: string): string | null => {
+	if (mediaType === "application/octet-stream") {
+		return null;
+	}
+	const mapped = ATTACHMENT_FALLBACK_EXTENSIONS[mediaType];
+	if (mapped) {
+		return mapped;
+	}
+	const [type, subtype = ""] = mediaType.split("/");
 	if (subtype.endsWith("+json")) {
 		return "json";
 	}
@@ -88,7 +92,10 @@ const structuredSubtypeExtension = (subtype: string): string | null => {
 		const base = subtype.slice(0, -"+xml".length);
 		return /^[a-z0-9]{1,8}$/i.test(base) ? base.toLowerCase() : "xml";
 	}
-	return null;
+	// Only image subtypes reliably double as filename extensions.
+	return type === "image" && /^[a-z0-9]{1,8}$/i.test(subtype)
+		? subtype.toLowerCase()
+		: null;
 };
 
 const getAttachmentExtension = (
@@ -98,28 +105,20 @@ const getAttachmentExtension = (
 	if (mapped) {
 		return mapped;
 	}
-	const trimmedName = block.name?.trim();
-	if (trimmedName) {
-		const lastDot = trimmedName.lastIndexOf(".");
-		// Keep dotfiles like `.env` out of the extension path, while still
-		// allowing ordinary `name.ext` filenames to contribute a fallback.
-		if (lastDot > 0 && lastDot < trimmedName.length - 1) {
-			return sanitizeAttachmentExtension(trimmedName.slice(lastDot + 1));
-		}
+	const name = block.name?.trim();
+	const lastDot = name?.lastIndexOf(".") ?? -1;
+	if (name && lastDot > 0 && lastDot < name.length - 1) {
+		return sanitizeAttachmentExtension(name.slice(lastDot + 1));
 	}
-	const subtype = block.media_type.split("/")[1] ?? "";
 	return (
-		structuredSubtypeExtension(subtype) ?? sanitizeAttachmentExtension(subtype)
+		getMediaTypeExtension(block.media_type) ??
+		sanitizeAttachmentExtension(block.media_type.split("/")[1] ?? "")
 	);
 };
 
 const isTextPreviewAttachmentMediaType = (mediaType: string): boolean =>
 	TEXT_ATTACHMENT_MEDIA_TYPES.has(mediaType);
 
-// Text-like types whose payloads the server classifies by content while
-// preserving the name. Structured +json/+xml types (application/ld+json)
-// belong here too: their registered extensions (.jsonld) differ from the
-// base format's, so an existing suffix always wins.
 const isSuffixPreservingMediaType = (mediaType: string): boolean =>
 	mediaType.startsWith("text/") ||
 	mediaType === "application/json" ||
@@ -152,38 +151,14 @@ const getAttachmentDisplayName = (
 	return "Attached file";
 };
 
-const endsWithFileExtension = /\.([a-z0-9]{1,8})$/i;
-
-// Alternate name suffixes that identify the same type as the canonical
-// media-type extension, so "photo.jpeg" is not renamed to "photo.jpeg.jpg".
-const extensionAliases: Record<string, readonly string[]> = {
-	jpg: ["jpeg", "jfif", "jpe", "pjpeg", "pjp"],
-	tiff: ["tif"],
-};
-
-// Returns the extension implied by the media type alone, ignoring the
-// attachment name. Null means the type carries no usable extension.
-const getMediaTypeExtension = (mediaType: string): string | null => {
-	if (mediaType === "application/octet-stream") {
-		return null;
-	}
-	const mapped = ATTACHMENT_FALLBACK_EXTENSIONS[mediaType];
-	if (mapped) {
-		return mapped;
-	}
-	const [type, subtype = ""] = mediaType.split("/");
-	const structured = structuredSubtypeExtension(subtype);
-	if (structured) {
-		return structured;
-	}
-	// Only image subtypes reliably double as filename extensions (png,
-	// gif, webp). Other subtypes are MIME names, not extensions
-	// (application/msword, audio/mpeg), so without an explicit mapping
-	// the attachment keeps its own name.
-	return type === "image" && /^[a-z0-9]{1,8}$/i.test(subtype)
-		? subtype.toLowerCase()
-		: null;
-};
+const extensionAliases = new Set([
+	"jpg:jpeg",
+	"jpg:jfif",
+	"jpg:jpe",
+	"jpg:pjpeg",
+	"jpg:pjp",
+	"tiff:tif",
+]);
 
 const getAttachmentDownloadName = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,
@@ -194,36 +169,20 @@ const getAttachmentDownloadName = (
 		return extension === "file" ? "attachment" : `attachment.${extension}`;
 	}
 	const mediaExtension = getMediaTypeExtension(block.media_type);
-	if (mediaExtension === null) {
+	if (!mediaExtension || name.startsWith(".")) {
 		return name;
-	}
-	// Leading-dot names are dotfiles (.eslintrc, .gitignore) whose whole
-	// name carries the meaning; appending an extension would rename them.
-	if (name.startsWith(".")) {
-		return name;
-	}
-	// The server classifies text-like uploads (text/*, JSON, XML) by
-	// content while preserving their names, so an existing suffix
-	// (main.go, map.geojson, schema.xsd) identifies the file better
-	// than the canonical extension would. Keep any dotted suffix and
-	// only append the extension to extensionless names.
-	if (isSuffixPreservingMediaType(block.media_type)) {
-		return /\.[^.\s]+$/.test(name) ? name : `${name}.${mediaExtension}`;
-	}
-	// iOS resolves the shared or saved file's type from the filename
-	// extension, so a name like "About Page Screenshot" or "report.final"
-	// would land as a generic file even when the media type is known.
-	const suffix = name.match(endsWithFileExtension)?.[1]?.toLowerCase();
-	if (suffix === undefined) {
-		return `${name}.${mediaExtension}`;
 	}
 	if (
-		suffix === mediaExtension ||
-		(extensionAliases[mediaExtension] ?? []).includes(suffix)
+		isSuffixPreservingMediaType(block.media_type) &&
+		/\.[^.\s]+$/.test(name)
 	) {
 		return name;
 	}
-	return `${name}.${mediaExtension}`;
+	const suffix = name.match(/\.([a-z0-9]{1,8})$/i)?.[1]?.toLowerCase();
+	return suffix === mediaExtension ||
+		extensionAliases.has(`${mediaExtension}:${suffix}`)
+		? name
+		: `${name}.${mediaExtension}`;
 };
 
 const getAttachmentBadgeLabel = (
@@ -253,15 +212,15 @@ const useAttachmentDownloadClick = (target: AttachmentDownloadTarget) => {
 			target,
 			controller.signal,
 		);
-		if (pending) {
-			setIsPending(true);
-			void pending.finally(() => {
-				downloadRequest.clear(controller);
-				setIsPending(false);
-			});
-		} else {
+		if (!pending) {
 			downloadRequest.clear(controller);
+			return;
 		}
+		setIsPending(true);
+		void pending.finally(() => {
+			downloadRequest.clear(controller);
+			setIsPending(false);
+		});
 	};
 	return { isPending, onClick };
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -120,23 +120,58 @@ const getAttachmentDisplayName = (
 	return "Attached file";
 };
 
-const endsWithFileExtension = /\.[a-z0-9]{1,8}$/i;
+const endsWithFileExtension = /\.([a-z0-9]{1,8})$/i;
+
+// Alternate name suffixes that identify the same type as the canonical
+// media-type extension, so "photo.jpeg" is not renamed to "photo.jpeg.jpg".
+const extensionAliases: Record<string, readonly string[]> = {
+	jpg: ["jpeg"],
+	md: ["markdown"],
+	txt: ["text", "log"],
+};
+
+// Returns the extension implied by the media type alone, ignoring the
+// attachment name. Null means the type carries no usable extension.
+const getMediaTypeExtension = (mediaType: string): string | null => {
+	if (mediaType === "application/octet-stream") {
+		return null;
+	}
+	const mapped = ATTACHMENT_FALLBACK_EXTENSIONS[mediaType];
+	if (mapped) {
+		return mapped;
+	}
+	const subtype = mediaType.split("/")[1] ?? "";
+	if (subtype.endsWith("+json")) {
+		return "json";
+	}
+	const sanitized = sanitizeAttachmentExtension(subtype);
+	return sanitized === "file" ? null : sanitized;
+};
 
 const getAttachmentDownloadName = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,
 ): string => {
 	const name = block.name?.trim();
-	const extension = getAttachmentExtension(block);
-	if (name) {
-		// iOS resolves the shared or saved file's type from the filename
-		// extension, so an extensionless name like "About Page Screenshot"
-		// would land as a generic file even when the media type is known.
-		if (endsWithFileExtension.test(name) || extension === "file") {
-			return name;
-		}
-		return `${name}.${extension}`;
+	if (!name) {
+		const extension = getAttachmentExtension(block);
+		return extension === "file" ? "attachment" : `attachment.${extension}`;
 	}
-	return extension === "file" ? "attachment" : `attachment.${extension}`;
+	const mediaExtension = getMediaTypeExtension(block.media_type);
+	if (mediaExtension === null) {
+		return name;
+	}
+	// iOS resolves the shared or saved file's type from the filename
+	// extension, so a name like "About Page Screenshot" or "report.final"
+	// would land as a generic file even when the media type is known.
+	const suffix = name.match(endsWithFileExtension)?.[1]?.toLowerCase();
+	if (
+		suffix !== undefined &&
+		(suffix === mediaExtension ||
+			(extensionAliases[mediaExtension] ?? []).includes(suffix))
+	) {
+		return name;
+	}
+	return `${name}.${mediaExtension}`;
 };
 
 const getAttachmentBadgeLabel = (

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -120,14 +120,22 @@ const getAttachmentDisplayName = (
 	return "Attached file";
 };
 
+const endsWithFileExtension = /\.[a-z0-9]{1,8}$/i;
+
 const getAttachmentDownloadName = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,
 ): string => {
 	const name = block.name?.trim();
-	if (name) {
-		return name;
-	}
 	const extension = getAttachmentExtension(block);
+	if (name) {
+		// iOS resolves the shared or saved file's type from the filename
+		// extension, so an extensionless name like "About Page Screenshot"
+		// would land as a generic file even when the media type is known.
+		if (endsWithFileExtension.test(name) || extension === "file") {
+			return name;
+		}
+		return `${name}.${extension}`;
+	}
 	return extension === "file" ? "attachment" : `attachment.${extension}`;
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -74,6 +74,19 @@ const sanitizeAttachmentExtension = (value: string): string => {
 	return sanitized || "file";
 };
 
+// Structured MIME suffixes (RFC 6839) carry the real format before the
+// plus sign, so image/svg+xml maps to svg rather than a mangled subtype.
+const structuredSubtypeExtension = (subtype: string): string | null => {
+	if (subtype.endsWith("+json")) {
+		return "json";
+	}
+	if (subtype.endsWith("+xml")) {
+		const base = subtype.slice(0, -"+xml".length);
+		return /^[a-z0-9]{1,8}$/i.test(base) ? base.toLowerCase() : "xml";
+	}
+	return null;
+};
+
 const getAttachmentExtension = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,
 ): string => {
@@ -91,10 +104,9 @@ const getAttachmentExtension = (
 		}
 	}
 	const subtype = block.media_type.split("/")[1] ?? "";
-	if (subtype.endsWith("+json")) {
-		return "json";
-	}
-	return sanitizeAttachmentExtension(subtype);
+	return (
+		structuredSubtypeExtension(subtype) ?? sanitizeAttachmentExtension(subtype)
+	);
 };
 
 const isTextPreviewAttachmentMediaType = (mediaType: string): boolean =>
@@ -148,11 +160,14 @@ const getMediaTypeExtension = (mediaType: string): string | null => {
 		return mapped;
 	}
 	const subtype = mediaType.split("/")[1] ?? "";
-	if (subtype.endsWith("+json")) {
-		return "json";
+	const structured = structuredSubtypeExtension(subtype);
+	if (structured) {
+		return structured;
 	}
-	const sanitized = sanitizeAttachmentExtension(subtype);
-	return sanitized === "file" ? null : sanitized;
+	// Only simple subtypes (png, gif, webp) map reliably onto an
+	// extension. Sanitizing structured or vendor subtypes would append
+	// a mangled suffix, so those keep the attachment's own name.
+	return /^[a-z0-9]{1,8}$/i.test(subtype) ? subtype.toLowerCase() : null;
 };
 
 const getAttachmentDownloadName = (

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -159,15 +159,18 @@ const getMediaTypeExtension = (mediaType: string): string | null => {
 	if (mapped) {
 		return mapped;
 	}
-	const subtype = mediaType.split("/")[1] ?? "";
+	const [type, subtype = ""] = mediaType.split("/");
 	const structured = structuredSubtypeExtension(subtype);
 	if (structured) {
 		return structured;
 	}
-	// Only simple subtypes (png, gif, webp) map reliably onto an
-	// extension. Sanitizing structured or vendor subtypes would append
-	// a mangled suffix, so those keep the attachment's own name.
-	return /^[a-z0-9]{1,8}$/i.test(subtype) ? subtype.toLowerCase() : null;
+	// Only image subtypes reliably double as filename extensions (png,
+	// gif, webp). Other subtypes are MIME names, not extensions
+	// (application/msword, audio/mpeg), so without an explicit mapping
+	// the attachment keeps its own name.
+	return type === "image" && /^[a-z0-9]{1,8}$/i.test(subtype)
+		? subtype.toLowerCase()
+		: null;
 };
 
 const getAttachmentDownloadName = (

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -116,6 +116,11 @@ const getAttachmentExtension = (
 const isTextPreviewAttachmentMediaType = (mediaType: string): boolean =>
 	TEXT_ATTACHMENT_MEDIA_TYPES.has(mediaType);
 
+const isSuffixPreservingMediaType = (mediaType: string): boolean =>
+	mediaType.startsWith("text/") ||
+	mediaType === "application/json" ||
+	mediaType === "application/xml";
+
 const getAttachmentHref = (block: FileAttachmentBlock): string | null => {
 	if (block.file_id) {
 		return getChatFileURL(block.file_id);
@@ -147,9 +152,7 @@ const endsWithFileExtension = /\.([a-z0-9]{1,8})$/i;
 // Alternate name suffixes that identify the same type as the canonical
 // media-type extension, so "photo.jpeg" is not renamed to "photo.jpeg.jpg".
 const extensionAliases: Record<string, readonly string[]> = {
-	html: ["htm"],
 	jpg: ["jpeg", "jfif", "jpe", "pjpeg", "pjp"],
-	md: ["markdown"],
 	tiff: ["tif"],
 };
 
@@ -194,12 +197,12 @@ const getAttachmentDownloadName = (
 	if (name.startsWith(".")) {
 		return name;
 	}
-	// The server classifies text-like uploads (text/plain, markdown, CSV,
-	// JSON) by content while preserving their names, so an existing suffix
-	// (main.go, config.properties, map.geojson) identifies the file better
-	// than the canonical extension would. Keep any dotted suffix and only
-	// append the extension to extensionless names.
-	if (isTextPreviewAttachmentMediaType(block.media_type)) {
+	// The server classifies text-like uploads (text/*, JSON, XML) by
+	// content while preserving their names, so an existing suffix
+	// (main.go, map.geojson, schema.xsd) identifies the file better
+	// than the canonical extension would. Keep any dotted suffix and
+	// only append the extension to extensionless names.
+	if (isSuffixPreservingMediaType(block.media_type)) {
 		return /\.[^.\s]+$/.test(name) ? name : `${name}.${mediaExtension}`;
 	}
 	// iOS resolves the shared or saved file's type from the filename

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -151,14 +151,7 @@ const getAttachmentDisplayName = (
 	return "Attached file";
 };
 
-const extensionAliases = new Set([
-	"jpg:jpeg",
-	"jpg:jfif",
-	"jpg:jpe",
-	"jpg:pjpeg",
-	"jpg:pjp",
-	"tiff:tif",
-]);
+const extensionAliases = new Set(["jpg:jpeg", "tiff:tif"]);
 
 const getAttachmentDownloadName = (
 	block: Pick<FileAttachmentBlock, "media_type" | "name">,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1299,6 +1299,35 @@ export const AssistantMessageWithUnnamedDownloadableFile: Story = {
 	},
 };
 
+export const AssistantMessageWithMismatchedExtensionFile: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Here are the release notes." },
+					{
+						type: "file",
+						media_type: "application/pdf",
+						file_id: "storybook-mismatched-notes",
+						name: "release-notes.txt",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const downloadLink = canvas.getByRole("link", {
+			name: "Download release-notes.txt",
+		});
+		expect(downloadLink).toHaveAttribute("download", "release-notes.txt");
+	},
+};
+
 const iosDownloadStoryArgs: Story["args"] = buildStoryArgs(
 	buildUserMessage({
 		text: "I attached the deployment report.",

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -192,29 +192,6 @@ const mockAttachmentFetch = () => {
 	});
 };
 
-// Read-only Navigator values must be shadowed with removable own properties.
-const overrideNavigatorForIOSStandalone = (
-	extras: Record<string, unknown> = {},
-): (() => void) => {
-	const overrides: Record<string, unknown> = {
-		userAgent:
-			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
-		standalone: true,
-		...extras,
-	};
-	for (const [key, value] of Object.entries(overrides)) {
-		Object.defineProperty(navigator, key, {
-			value,
-			configurable: true,
-		});
-	}
-	return () => {
-		for (const key of Object.keys(overrides)) {
-			Reflect.deleteProperty(navigator, key);
-		}
-	};
-};
-
 const buildTextPart = (text: string): TypesGen.ChatTextPart => ({
 	type: "text",
 	text,
@@ -1340,10 +1317,18 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const share = fn().mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
+		// Read-only Navigator values must be shadowed with removable own
+		// properties.
+		const overrides: Record<string, unknown> = {
+			userAgent:
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+			standalone: true,
 			share,
 			canShare: fn().mockReturnValue(true),
-		});
+		};
+		for (const [key, value] of Object.entries(overrides)) {
+			Object.defineProperty(navigator, key, { value, configurable: true });
+		}
 		try {
 			await userEvent.click(
 				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
@@ -1355,7 +1340,9 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 			expect(shared.files[0].type).toBe("application/pdf");
 			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(1);
 		} finally {
-			restoreNavigator();
+			for (const key of Object.keys(overrides)) {
+				Reflect.deleteProperty(navigator, key);
+			}
 		}
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -10,7 +10,6 @@ import {
 	within,
 } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
-import { withToaster } from "#/testHelpers/storybook";
 import { getChatFileURL } from "../../utils/chatAttachments";
 import { encodeInlineTextAttachment } from "../../utils/fetchTextAttachment";
 import { ConversationTimeline } from "./ConversationTimeline";
@@ -1336,241 +1335,25 @@ const iosDownloadStoryArgs: Story["args"] = buildStoryArgs(
 	}),
 );
 
-const setupIOSStandaloneDownload = (extras: Record<string, unknown>) => ({
-	open: spyOn(window, "open").mockReturnValue(null),
-	restoreNavigator: overrideNavigatorForIOSStandalone(extras),
-});
-
-const getIOSDownloadLink = (canvas: ReturnType<typeof within>) =>
-	canvas.getByRole("link", { name: "Download deployment-report.pdf" });
-
-const buildInlineDownloadStoryArgs = (
-	data: string,
-	name: string,
-): Story["args"] =>
-	buildStoryArgs({
-		...baseMessage,
-		id: 1,
-		role: "assistant",
-		content: [buildFilePart({ media_type: "image/png", data, name })],
-	});
-
-const getInlineDownloadLink = async (
-	canvas: ReturnType<typeof within>,
-	name: string,
-) => {
-	canvas.getByRole("button", { name: `View ${name}` }).focus();
-	return canvas.findByRole("link", { name: `Download ${name}` });
-};
-
 export const DownloadInIOSStandaloneSharesFile: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const share = fn().mockResolvedValue(undefined);
-		const { open, restoreNavigator } = setupIOSStandaloneDownload({
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
 			share,
 			canShare: fn().mockReturnValue(true),
 		});
 		try {
-			await userEvent.click(getIOSDownloadLink(canvas));
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
 			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
 			const shared: { files: File[] } = share.mock.calls[0][0];
 			expect(shared.files).toHaveLength(1);
 			expect(shared.files[0].name).toBe("deployment-report.pdf");
 			expect(shared.files[0].type).toBe("application/pdf");
 			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(1);
-			expect(open).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
-	decorators: [withToaster],
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn()
-			.mockRejectedValueOnce(
-				new DOMException("activation expired", "NotAllowedError"),
-			)
-			.mockResolvedValue(undefined);
-		const { open, restoreNavigator } = setupIOSStandaloneDownload({
-			share,
-			canShare: fn().mockReturnValue(true),
-		});
-		try {
-			await userEvent.click(getIOSDownloadLink(canvas));
-			// The toast renders in a portal outside the story canvas.
-			const saveButton = await screen.findByRole("button", { name: "Save" });
-			await userEvent.click(saveButton);
-			await waitFor(() => expect(share).toHaveBeenCalledTimes(2));
-			const shared: { files: File[] } = share.mock.calls[1][0];
-			expect(shared.files).toHaveLength(1);
-			expect(shared.files[0].name).toBe("deployment-report.pdf");
-			expect(open).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockResolvedValue(undefined);
-		const { restoreNavigator } = setupIOSStandaloneDownload({
-			share,
-			canShare: fn().mockReturnValue(true),
-		});
-		let releaseFetch = () => {};
-		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
-			() =>
-				new Promise<Response>((resolve) => {
-					releaseFetch = () =>
-						resolve(
-							new Response("pdf-bytes", {
-								headers: { "Content-Type": "application/pdf" },
-							}),
-						);
-				}),
-		);
-		try {
-			const downloadLink = getIOSDownloadLink(canvas);
-			await userEvent.click(downloadLink);
-			expect(downloadLink).toHaveAttribute("aria-disabled", "true");
-			await userEvent.click(downloadLink);
-			expect(fetchSpy).toHaveBeenCalledTimes(1);
-			releaseFetch();
-			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
-			await waitFor(() =>
-				expect(downloadLink).toHaveAttribute("aria-disabled", "false"),
-			);
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadInIOSStandaloneReportsPermanentShareFailure: Story = {
-	decorators: [withToaster],
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const { open, restoreNavigator } = setupIOSStandaloneDownload({
-			share: fn().mockRejectedValue(
-				new DOMException("share failed", "DataError"),
-			),
-			canShare: fn().mockReturnValue(true),
-		});
-		try {
-			await userEvent.click(getIOSDownloadLink(canvas));
-			await screen.findByText("Couldn't download deployment-report.pdf");
-			expect(
-				screen.queryByRole("button", { name: "Save" }),
-			).not.toBeInTheDocument();
-			expect(open).not.toHaveBeenCalled();
-			await userEvent.click(screen.getByRole("button", { name: "Open" }));
-			expect(open).toHaveBeenCalledWith(
-				getChatFileURL("storybook-ios-share-report"),
-				"_blank",
-				"noopener",
-			);
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-const inlineAttachmentStoryArgs = buildInlineDownloadStoryArgs(
-	TEST_PNG_B64,
-	"inline-screenshot.png",
-);
-
-export const DownloadInIOSStandaloneShowsErrorForCorruptInlineAttachment: Story =
-	{
-		decorators: [withToaster],
-		args: buildInlineDownloadStoryArgs(
-			"not-valid-base64",
-			"corrupt-screenshot.png",
-		),
-		play: async ({ canvasElement }) => {
-			const canvas = within(canvasElement);
-			const share = fn().mockResolvedValue(undefined);
-			const { open, restoreNavigator } = setupIOSStandaloneDownload({
-				share,
-				canShare: fn().mockReturnValue(true),
-			});
-			try {
-				const downloadLink = await getInlineDownloadLink(
-					canvas,
-					"corrupt-screenshot.png",
-				);
-				await userEvent.click(downloadLink);
-				await screen.findByText("Couldn't download corrupt-screenshot.png");
-				await screen.findByText("The attachment data could not be decoded.");
-				expect(share).not.toHaveBeenCalled();
-				expect(open).not.toHaveBeenCalled();
-			} finally {
-				restoreNavigator();
-			}
-		},
-	};
-
-export const DownloadInIOSStandaloneOpensInlineAttachmentInTab: Story = {
-	args: inlineAttachmentStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const { open, restoreNavigator } = setupIOSStandaloneDownload({
-			share: undefined,
-			canShare: undefined,
-		});
-		const fetchSpy = spyOn(globalThis, "fetch");
-		try {
-			const downloadLink = await getInlineDownloadLink(
-				canvas,
-				"inline-screenshot.png",
-			);
-			await userEvent.click(downloadLink);
-			expect(open).toHaveBeenCalledTimes(1);
-			const [blobUrl, target, features] = open.mock.calls[0];
-			expect(blobUrl).toMatch(/^blob:/);
-			expect(target).toBe("_blank");
-			expect(features).toBe("noopener");
-			expect(fetchSpy).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadInIOSStandaloneStaysQuietOnDismissedShare: Story = {
-	decorators: [withToaster],
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockRejectedValue(
-			new DOMException("dismissed", "AbortError"),
-		);
-		const { open, restoreNavigator } = setupIOSStandaloneDownload({
-			share,
-			canShare: fn().mockReturnValue(true),
-		});
-		try {
-			await userEvent.click(getIOSDownloadLink(canvas));
-			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
-			await waitFor(() => {
-				expect(
-					canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-				).toHaveAttribute("aria-disabled", "false");
-			});
-			expect(
-				screen.queryByText("Couldn't download deployment-report.pdf"),
-			).not.toBeInTheDocument();
-			expect(open).not.toHaveBeenCalled();
 		} finally {
 			restoreNavigator();
 		}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1348,6 +1348,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-json-1",
 						name: ".eslintrc",
 					},
+					{
+						type: "file",
+						media_type: "application/json",
+						file_id: "storybook-json-2",
+						name: "map.geojson",
+					},
 				],
 			},
 		]),
@@ -1404,6 +1410,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 			expect(
 				canvas.getByRole("link", { name: "Download .eslintrc" }),
 			).toHaveAttribute("download", ".eslintrc");
+		});
+		canvas.getByRole("button", { name: "View map.geojson" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download map.geojson" }),
+			).toHaveAttribute("download", "map.geojson");
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1376,6 +1376,18 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-odt-1",
 						name: "notes.odt",
 					},
+					{
+						type: "file",
+						media_type: "application/msword",
+						file_id: "storybook-doc-1",
+						name: "report.doc",
+					},
+					{
+						type: "file",
+						media_type: "audio/mpeg",
+						file_id: "storybook-mp3-1",
+						name: "song.mp3",
+					},
 				],
 			},
 		]),
@@ -1454,6 +1466,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 		expect(
 			canvas.getByRole("link", { name: "Download notes.odt" }),
 		).toHaveAttribute("download", "notes.odt");
+		expect(
+			canvas.getByRole("link", { name: "Download report.doc" }),
+		).toHaveAttribute("download", "report.doc");
+		expect(
+			canvas.getByRole("link", { name: "Download song.mp3" }),
+		).toHaveAttribute("download", "song.mp3");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -147,6 +147,10 @@ const ATTACHMENT_RESPONSES = new Map<string, AttachmentResponse>([
 		},
 	],
 	["storybook-text-error", { body: "Temporary failure", status: 503 }],
+	[
+		"storybook-ios-share-report",
+		{ status: 200, body: "pdf-bytes", contentType: "application/pdf" },
+	],
 ]);
 
 let attachmentFetchCounts = new Map<string, number>();
@@ -185,6 +189,31 @@ const mockAttachmentFetch = () => {
 
 		return originalFetch(input, init);
 	});
+};
+
+// Shadows the Navigator.prototype getters with own properties so the
+// download handler sees an iOS standalone PWA; the returned cleanup
+// restores the real values for subsequent stories.
+const overrideNavigatorForIOSStandalone = (
+	extras: Record<string, unknown> = {},
+): (() => void) => {
+	const overrides: Record<string, unknown> = {
+		userAgent:
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+		standalone: true,
+		...extras,
+	};
+	for (const [key, value] of Object.entries(overrides)) {
+		Object.defineProperty(window.navigator, key, {
+			value,
+			configurable: true,
+		});
+	}
+	return () => {
+		for (const key of Object.keys(overrides)) {
+			Reflect.deleteProperty(window.navigator, key);
+		}
+	};
 };
 
 const buildTextPart = (text: string): TypesGen.ChatTextPart => ({
@@ -1291,6 +1320,112 @@ export const AssistantMessageWithUnnamedDownloadableFile: Story = {
 		expect(
 			canvas.queryByRole("button", { name: "Copy message" }),
 		).not.toBeInTheDocument();
+	},
+};
+
+const iosDownloadStoryArgs: Story["args"] = {
+	...defaultArgs,
+	parsedMessages: parseMessagesWithMergedTools([
+		{
+			...baseMessage,
+			id: 1,
+			role: "user",
+			content: [
+				{ type: "text", text: "I attached the deployment report." },
+				{
+					type: "file",
+					media_type: "application/pdf",
+					file_id: "storybook-ios-share-report",
+					name: "deployment-report.pdf",
+				},
+			],
+		},
+	]),
+};
+
+/** In an iOS standalone PWA the download click hands the file to the share sheet. */
+export const DownloadInIOSStandaloneSharesFile: Story = {
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockResolvedValue(undefined);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+			const shared: { files: File[] } = share.mock.calls[0][0];
+			expect(shared.files).toHaveLength(1);
+			expect(shared.files[0].name).toBe("deployment-report.pdf");
+			expect(shared.files[0].type).toBe("application/pdf");
+			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(1);
+			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+/** Without file sharing, an iOS standalone PWA gets a dismissible tab instead of QuickLook. */
+export const DownloadInIOSStandaloneWithoutShareOpensTab: Story = {
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share: undefined,
+			canShare: undefined,
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			expect(open).toHaveBeenCalledWith(
+				getChatFileURL("storybook-ios-share-report"),
+				"_blank",
+				"noopener",
+			);
+			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(0);
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+/** Outside iOS standalone the anchor keeps its native download behavior. */
+export const DownloadOutsideIOSKeepsNativeAnchor: Story = {
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockResolvedValue(undefined);
+		Object.defineProperty(window.navigator, "share", {
+			value: share,
+			configurable: true,
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		// Block the real download navigation the test browser would start;
+		// capture phase runs before the component's handler and does not
+		// affect whether that handler intercepts the click.
+		const blockDownload = (event: Event) => event.preventDefault();
+		document.addEventListener("click", blockDownload, { capture: true });
+		try {
+			const downloadLink = canvas.getByRole("link", {
+				name: "Download deployment-report.pdf",
+			});
+			expect(downloadLink).toHaveAttribute("download", "deployment-report.pdf");
+			await userEvent.click(downloadLink);
+			expect(share).not.toHaveBeenCalled();
+			expect(open).not.toHaveBeenCalled();
+			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(0);
+		} finally {
+			document.removeEventListener("click", blockDownload, { capture: true });
+			Reflect.deleteProperty(window.navigator, "share");
+		}
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -152,6 +152,7 @@ const ATTACHMENT_RESPONSES = new Map<string, AttachmentResponse>([
 		"storybook-ios-share-report",
 		{ status: 200, body: "pdf-bytes", contentType: "application/pdf" },
 	],
+	["storybook-ios-error-report", { status: 500, body: "" }],
 ]);
 
 let attachmentFetchCounts = new Map<string, number>();
@@ -1289,7 +1290,7 @@ export const AssistantMessageWithImage: Story = {
 	},
 };
 
-export const ExtensionlessImageNameGainsDownloadExtension: Story = {
+export const DownloadNamesGainMediaTypeExtension: Story = {
 	args: {
 		...defaultArgs,
 		parsedMessages: buildMessages([
@@ -1298,12 +1299,24 @@ export const ExtensionlessImageNameGainsDownloadExtension: Story = {
 				id: 1,
 				role: "assistant",
 				content: [
-					{ type: "text", text: "Here is the screenshot:" },
+					{ type: "text", text: "Here are the files:" },
 					{
 						type: "file",
 						media_type: "image/png",
 						data: TEST_PNG_B64,
 						name: "About Page Screenshot",
+					},
+					{
+						type: "file",
+						media_type: "application/pdf",
+						file_id: "storybook-ios-share-report",
+						name: "report.final",
+					},
+					{
+						type: "file",
+						media_type: "application/pdf",
+						file_id: "storybook-unnamed-report",
+						name: "quarterly-report.pdf",
 					},
 				],
 			},
@@ -1320,9 +1333,18 @@ export const ExtensionlessImageNameGainsDownloadExtension: Story = {
 				canvas.getByRole("link", { name: "Download About Page Screenshot" }),
 			).toBeVisible();
 		});
+		// An extensionless name gains the media-type extension.
 		expect(
 			canvas.getByRole("link", { name: "Download About Page Screenshot" }),
 		).toHaveAttribute("download", "About Page Screenshot.png");
+		// A dotted qualifier is not mistaken for a file extension.
+		expect(
+			canvas.getByRole("link", { name: "Download report.final" }),
+		).toHaveAttribute("download", "report.final.pdf");
+		// A name that already carries the right extension is unchanged.
+		expect(
+			canvas.getByRole("link", { name: "Download quarterly-report.pdf" }),
+		).toHaveAttribute("download", "quarterly-report.pdf");
 	},
 };
 
@@ -1432,6 +1454,47 @@ export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
 			const shared: { files: File[] } = share.mock.calls[1][0];
 			expect(shared.files).toHaveLength(1);
 			expect(shared.files[0].name).toBe("deployment-report.pdf");
+			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+export const DownloadInIOSStandaloneShowsErrorToastOnFailedFetch: Story = {
+	decorators: [withToaster],
+	args: {
+		...defaultArgs,
+		parsedMessages: parseMessagesWithMergedTools([
+			{
+				...baseMessage,
+				id: 1,
+				role: "user",
+				content: [
+					{
+						type: "file",
+						media_type: "application/pdf",
+						file_id: "storybook-ios-error-report",
+						name: "deployment-report.pdf",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockResolvedValue(undefined);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			await screen.findByText("Couldn't download deployment-report.pdf");
+			expect(share).not.toHaveBeenCalled();
 			expect(open).not.toHaveBeenCalled();
 		} finally {
 			restoreNavigator();

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1516,6 +1516,37 @@ export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
 	},
 };
 
+export const DownloadInIOSStandaloneOffersTabForUnshareableFile: Story = {
+	decorators: [withToaster],
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockResolvedValue(undefined);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			// The one-byte probe passes; the real fetched file fails.
+			canShare: fn(({ files }: { files: File[] }) => files[0].size <= 1),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			const openButton = await screen.findByRole("button", { name: "Open" });
+			expect(share).not.toHaveBeenCalled();
+			expect(open).not.toHaveBeenCalled();
+			await userEvent.click(openButton);
+			expect(open).toHaveBeenCalledWith(
+				getChatFileURL("storybook-ios-share-report"),
+				"_blank",
+				"noopener",
+			);
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
 export const DownloadInIOSStandaloneShowsErrorToastOnFailedFetch: Story = {
 	decorators: [withToaster],
 	args: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1324,6 +1324,18 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-text-1",
 						name: "main.go",
 					},
+					{
+						type: "file",
+						media_type: "text/plain",
+						file_id: "storybook-text-2",
+						name: "config.properties",
+					},
+					{
+						type: "file",
+						media_type: "text/plain",
+						file_id: "storybook-text-3",
+						name: "meeting notes",
+					},
 				],
 			},
 		]),
@@ -1339,15 +1351,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 				canvas.getByRole("link", { name: "Download About Page Screenshot" }),
 			).toBeVisible();
 		});
-		// An extensionless name gains the media-type extension.
 		expect(
 			canvas.getByRole("link", { name: "Download About Page Screenshot" }),
 		).toHaveAttribute("download", "About Page Screenshot.png");
-		// A dotted qualifier is not mistaken for a file extension.
 		expect(
 			canvas.getByRole("link", { name: "Download report.final" }),
 		).toHaveAttribute("download", "report.final.pdf");
-		// A name that already carries the right extension is unchanged.
 		expect(
 			canvas.getByRole("link", { name: "Download quarterly-report.pdf" }),
 		).toHaveAttribute("download", "quarterly-report.pdf");
@@ -1359,6 +1368,18 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 			expect(
 				canvas.getByRole("link", { name: "Download main.go" }),
 			).toHaveAttribute("download", "main.go");
+		});
+		canvas.getByRole("button", { name: "View config.properties" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download config.properties" }),
+			).toHaveAttribute("download", "config.properties");
+		});
+		canvas.getByRole("button", { name: "View meeting notes" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download meeting notes" }),
+			).toHaveAttribute("download", "meeting notes.txt");
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1672,6 +1672,89 @@ export const DownloadInIOSStandaloneSharesInlineAttachment: Story = {
 	},
 };
 
+/** iOS blocks data: tabs, so the toast Open action uses a blob URL. */
+export const DownloadInIOSStandaloneOpensInlineAttachmentFromToast: Story = {
+	decorators: [withToaster],
+	args: inlineAttachmentStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share: fn().mockRejectedValue(
+				new DOMException("share failed", "DataError"),
+			),
+			canShare: fn().mockReturnValue(true),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		const fetchSpy = spyOn(globalThis, "fetch");
+		try {
+			canvas
+				.getByRole("button", { name: "View inline-screenshot.png" })
+				.focus();
+			const downloadLink = await canvas.findByRole("link", {
+				name: "Download inline-screenshot.png",
+			});
+			await userEvent.click(downloadLink);
+			await screen.findByText("Couldn't download inline-screenshot.png");
+			await userEvent.click(screen.getByRole("button", { name: "Open" }));
+			expect(open).toHaveBeenCalledTimes(1);
+			const [blobUrl, target, features] = open.mock.calls[0];
+			expect(blobUrl).toMatch(/^blob:/);
+			expect(target).toBe("_blank");
+			expect(features).toBe("noopener");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+export const DownloadInIOSStandaloneShowsErrorForCorruptInlineAttachment: Story =
+	{
+		decorators: [withToaster],
+		args: {
+			...defaultArgs,
+			parsedMessages: parseMessagesWithMergedTools([
+				{
+					...baseMessage,
+					id: 1,
+					role: "assistant",
+					content: [
+						{
+							type: "file",
+							media_type: "image/png",
+							data: "not-valid-base64",
+							name: "corrupt-screenshot.png",
+						},
+					],
+				},
+			]),
+		},
+		play: async ({ canvasElement }) => {
+			const canvas = within(canvasElement);
+			const share = fn().mockResolvedValue(undefined);
+			const restoreNavigator = overrideNavigatorForIOSStandalone({
+				share,
+				canShare: fn().mockReturnValue(true),
+			});
+			const open = spyOn(window, "open").mockReturnValue(null);
+			try {
+				canvas
+					.getByRole("button", { name: "View corrupt-screenshot.png" })
+					.focus();
+				const downloadLink = await canvas.findByRole("link", {
+					name: "Download corrupt-screenshot.png",
+				});
+				await userEvent.click(downloadLink);
+				await screen.findByText("Couldn't download corrupt-screenshot.png");
+				await screen.findByText("The attachment data could not be decoded.");
+				expect(share).not.toHaveBeenCalled();
+				expect(open).not.toHaveBeenCalled();
+			} finally {
+				restoreNavigator();
+			}
+		},
+	};
+
 /** iOS blocks data: tabs, so inline attachments open through a blob URL. */
 export const DownloadInIOSStandaloneOpensInlineAttachmentInTab: Story = {
 	args: inlineAttachmentStoryArgs,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -21,10 +21,6 @@ import type { ParsedMessageEntry } from "./types";
 const TEST_PNG_B64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4n539HwAHFwLVF8kc1wAAAABJRU5ErkJggg==";
 
-const TEST_SVG_B64 = btoa(
-	'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
-);
-
 const buildMessages = (messages: TypesGen.ChatMessage[]) =>
 	parseMessagesWithMergedTools(messages);
 
@@ -1294,226 +1290,6 @@ export const AssistantMessageWithImage: Story = {
 	},
 };
 
-export const DownloadNamesGainMediaTypeExtension: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "assistant",
-				content: [
-					{ type: "text", text: "Here are the files:" },
-					{
-						type: "file",
-						media_type: "image/png",
-						data: TEST_PNG_B64,
-						name: "About Page Screenshot",
-					},
-					{
-						type: "file",
-						media_type: "application/pdf",
-						file_id: "storybook-ios-share-report",
-						name: "report.final",
-					},
-					{
-						type: "file",
-						media_type: "application/pdf",
-						file_id: "storybook-unnamed-report",
-						name: "quarterly-report.pdf",
-					},
-					{
-						type: "file",
-						media_type: "text/plain",
-						file_id: "storybook-text-1",
-						name: "main.go",
-					},
-					{
-						type: "file",
-						media_type: "text/plain",
-						file_id: "storybook-text-2",
-						name: "config.properties",
-					},
-					{
-						type: "file",
-						media_type: "text/plain",
-						file_id: "storybook-text-3",
-						name: "meeting notes",
-					},
-					{
-						type: "file",
-						media_type: "image/jpeg",
-						data: TEST_PNG_B64,
-						name: "photo.jfif",
-					},
-					{
-						type: "file",
-						media_type: "application/json",
-						file_id: "storybook-json-1",
-						name: ".eslintrc",
-					},
-					{
-						type: "file",
-						media_type: "application/json",
-						file_id: "storybook-json-2",
-						name: "map.geojson",
-					},
-					{
-						type: "file",
-						media_type: "image/svg+xml",
-						data: TEST_SVG_B64,
-						name: "diagram.svg",
-					},
-					{
-						type: "file",
-						media_type: "image/svg+xml",
-						data: TEST_SVG_B64,
-						name: "architecture sketch",
-					},
-					{
-						type: "file",
-						media_type: "application/vnd.oasis.opendocument.text",
-						file_id: "storybook-odt-1",
-						name: "notes.odt",
-					},
-					{
-						type: "file",
-						media_type: "application/msword",
-						file_id: "storybook-doc-1",
-						name: "report.doc",
-					},
-					{
-						type: "file",
-						media_type: "audio/mpeg",
-						file_id: "storybook-mp3-1",
-						name: "song.mp3",
-					},
-					{
-						type: "file",
-						media_type: "application/xml",
-						file_id: "storybook-xml-1",
-						name: "build config",
-					},
-					{
-						type: "file",
-						media_type: "application/xml",
-						file_id: "storybook-xml-2",
-						name: "schema.xsd",
-					},
-					{
-						type: "file",
-						media_type: "text/csv",
-						file_id: "storybook-csv-1",
-						name: "export data",
-					},
-					{
-						type: "file",
-						media_type: "application/ld+json",
-						file_id: "storybook-jsonld-1",
-						name: "context.jsonld",
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const viewButton = canvas.getByRole("button", {
-			name: "View About Page Screenshot",
-		});
-		viewButton.focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download About Page Screenshot" }),
-			).toBeVisible();
-		});
-		expect(
-			canvas.getByRole("link", { name: "Download About Page Screenshot" }),
-		).toHaveAttribute("download", "About Page Screenshot.png");
-		expect(
-			canvas.getByRole("link", { name: "Download report.final" }),
-		).toHaveAttribute("download", "report.final.pdf");
-		expect(
-			canvas.getByRole("link", { name: "Download quarterly-report.pdf" }),
-		).toHaveAttribute("download", "quarterly-report.pdf");
-		// text/plain covers source files, so their suffixes are preserved.
-		// The overlay link joins the accessibility tree only while its
-		// attachment group has focus.
-		canvas.getByRole("button", { name: "View main.go" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download main.go" }),
-			).toHaveAttribute("download", "main.go");
-		});
-		canvas.getByRole("button", { name: "View config.properties" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download config.properties" }),
-			).toHaveAttribute("download", "config.properties");
-		});
-		canvas.getByRole("button", { name: "View meeting notes" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download meeting notes" }),
-			).toHaveAttribute("download", "meeting notes.txt");
-		});
-		canvas.getByRole("button", { name: "View photo.jfif" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download photo.jfif" }),
-			).toHaveAttribute("download", "photo.jfif");
-		});
-		canvas.getByRole("button", { name: "View .eslintrc" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download .eslintrc" }),
-			).toHaveAttribute("download", ".eslintrc");
-		});
-		canvas.getByRole("button", { name: "View map.geojson" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download map.geojson" }),
-			).toHaveAttribute("download", "map.geojson");
-		});
-		canvas.getByRole("button", { name: "View diagram.svg" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download diagram.svg" }),
-			).toHaveAttribute("download", "diagram.svg");
-		});
-		canvas.getByRole("button", { name: "View architecture sketch" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download architecture sketch" }),
-			).toHaveAttribute("download", "architecture sketch.svg");
-		});
-		expect(
-			canvas.getByRole("link", { name: "Download notes.odt" }),
-		).toHaveAttribute("download", "notes.odt");
-		expect(
-			canvas.getByRole("link", { name: "Download report.doc" }),
-		).toHaveAttribute("download", "report.doc");
-		expect(
-			canvas.getByRole("link", { name: "Download song.mp3" }),
-		).toHaveAttribute("download", "song.mp3");
-		expect(
-			canvas.getByRole("link", { name: "Download build config" }),
-		).toHaveAttribute("download", "build config.xml");
-		expect(
-			canvas.getByRole("link", { name: "Download schema.xsd" }),
-		).toHaveAttribute("download", "schema.xsd");
-		canvas.getByRole("button", { name: "View export data" }).focus();
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("link", { name: "Download export data" }),
-			).toHaveAttribute("download", "export data.csv");
-		});
-		expect(
-			canvas.getByRole("link", { name: "Download context.jsonld" }),
-		).toHaveAttribute("download", "context.jsonld");
-	},
-};
-
 export const AssistantMessageWithUnnamedDownloadableFile: Story = {
 	args: {
 		...defaultArgs,
@@ -1547,24 +1323,44 @@ export const AssistantMessageWithUnnamedDownloadableFile: Story = {
 	},
 };
 
-const iosDownloadStoryArgs: Story["args"] = {
-	...defaultArgs,
-	parsedMessages: parseMessagesWithMergedTools([
-		{
-			...baseMessage,
-			id: 1,
-			role: "user",
-			content: [
-				{ type: "text", text: "I attached the deployment report." },
-				{
-					type: "file",
-					media_type: "application/pdf",
-					file_id: "storybook-ios-share-report",
-					name: "deployment-report.pdf",
-				},
-			],
-		},
-	]),
+const iosDownloadStoryArgs: Story["args"] = buildStoryArgs(
+	buildUserMessage({
+		text: "I attached the deployment report.",
+		files: [
+			buildFilePart({
+				media_type: "application/pdf",
+				file_id: "storybook-ios-share-report",
+				name: "deployment-report.pdf",
+			}),
+		],
+	}),
+);
+
+const setupIOSStandaloneDownload = (extras: Record<string, unknown>) => ({
+	open: spyOn(window, "open").mockReturnValue(null),
+	restoreNavigator: overrideNavigatorForIOSStandalone(extras),
+});
+
+const getIOSDownloadLink = (canvas: ReturnType<typeof within>) =>
+	canvas.getByRole("link", { name: "Download deployment-report.pdf" });
+
+const buildInlineDownloadStoryArgs = (
+	data: string,
+	name: string,
+): Story["args"] =>
+	buildStoryArgs({
+		...baseMessage,
+		id: 1,
+		role: "assistant",
+		content: [buildFilePart({ media_type: "image/png", data, name })],
+	});
+
+const getInlineDownloadLink = async (
+	canvas: ReturnType<typeof within>,
+	name: string,
+) => {
+	canvas.getByRole("button", { name: `View ${name}` }).focus();
+	return canvas.findByRole("link", { name: `Download ${name}` });
 };
 
 export const DownloadInIOSStandaloneSharesFile: Story = {
@@ -1572,15 +1368,12 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const share = fn().mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
+		const { open, restoreNavigator } = setupIOSStandaloneDownload({
 			share,
 			canShare: fn().mockReturnValue(true),
 		});
-		const open = spyOn(window, "open").mockReturnValue(null);
 		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
+			await userEvent.click(getIOSDownloadLink(canvas));
 			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
 			const shared: { files: File[] } = share.mock.calls[0][0];
 			expect(shared.files).toHaveLength(1);
@@ -1594,45 +1387,12 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 	},
 };
 
-export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
-	decorators: [withToaster],
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn()
-			.mockRejectedValueOnce(
-				new DOMException("activation expired", "NotAllowedError"),
-			)
-			.mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
-			share,
-			canShare: fn().mockReturnValue(true),
-		});
-		const open = spyOn(window, "open").mockReturnValue(null);
-		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
-			// The toast renders in a portal outside the story canvas.
-			const saveButton = await screen.findByRole("button", { name: "Save" });
-			await userEvent.click(saveButton);
-			await waitFor(() => expect(share).toHaveBeenCalledTimes(2));
-			const shared: { files: File[] } = share.mock.calls[1][0];
-			expect(shared.files).toHaveLength(1);
-			expect(shared.files[0].name).toBe("deployment-report.pdf");
-			expect(open).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
 export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const share = fn().mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
+		const { restoreNavigator } = setupIOSStandaloneDownload({
 			share,
 			canShare: fn().mockReturnValue(true),
 		});
@@ -1649,9 +1409,7 @@ export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
 				}),
 		);
 		try {
-			const downloadLink = canvas.getByRole("link", {
-				name: "Download deployment-report.pdf",
-			});
+			const downloadLink = getIOSDownloadLink(canvas);
 			await userEvent.click(downloadLink);
 			expect(downloadLink).toHaveAttribute("aria-disabled", "true");
 			await userEvent.click(downloadLink);
@@ -1672,17 +1430,14 @@ export const DownloadInIOSStandaloneReportsPermanentShareFailure: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
+		const { open, restoreNavigator } = setupIOSStandaloneDownload({
 			share: fn().mockRejectedValue(
 				new DOMException("share failed", "DataError"),
 			),
 			canShare: fn().mockReturnValue(true),
 		});
-		const open = spyOn(window, "open").mockReturnValue(null);
 		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
+			await userEvent.click(getIOSDownloadLink(canvas));
 			await screen.findByText("Couldn't download deployment-report.pdf");
 			// Retrying a permanently failed share would fail identically,
 			// so the toast offers the dismissible tab instead of Save.
@@ -1702,199 +1457,30 @@ export const DownloadInIOSStandaloneReportsPermanentShareFailure: Story = {
 	},
 };
 
-export const DownloadInIOSStandaloneOffersTabForUnshareableFile: Story = {
-	decorators: [withToaster],
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
-			share,
-			// The one-byte probe passes; the real fetched file fails.
-			canShare: fn(({ files }: { files: File[] }) => files[0].size <= 1),
-		});
-		const open = spyOn(window, "open").mockReturnValue(null);
-		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
-			const openButton = await screen.findByRole("button", { name: "Open" });
-			expect(share).not.toHaveBeenCalled();
-			expect(open).not.toHaveBeenCalled();
-			await userEvent.click(openButton);
-			expect(open).toHaveBeenCalledWith(
-				getChatFileURL("storybook-ios-share-report"),
-				"_blank",
-				"noopener",
-			);
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadInIOSStandaloneShowsErrorToastOnFailedFetch: Story = {
-	decorators: [withToaster],
-	args: {
-		...defaultArgs,
-		parsedMessages: parseMessagesWithMergedTools([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [
-					{
-						type: "file",
-						media_type: "application/pdf",
-						file_id: "storybook-ios-error-report",
-						name: "deployment-report.pdf",
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
-			share,
-			canShare: fn().mockReturnValue(true),
-		});
-		const open = spyOn(window, "open").mockReturnValue(null);
-		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
-			await screen.findByText("Couldn't download deployment-report.pdf");
-			expect(share).not.toHaveBeenCalled();
-			expect(open).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-const inlineAttachmentStoryArgs: Story["args"] = {
-	...defaultArgs,
-	parsedMessages: parseMessagesWithMergedTools([
-		{
-			...baseMessage,
-			id: 1,
-			role: "assistant",
-			content: [
-				{
-					type: "file",
-					media_type: "image/png",
-					data: TEST_PNG_B64,
-					name: "inline-screenshot.png",
-				},
-			],
-		},
-	]),
-};
-
-/** Inline data: attachments cannot be fetched under the production CSP. */
-export const DownloadInIOSStandaloneSharesInlineAttachment: Story = {
-	args: inlineAttachmentStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockResolvedValue(undefined);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
-			share,
-			canShare: fn().mockReturnValue(true),
-		});
-		const fetchSpy = spyOn(globalThis, "fetch");
-		try {
-			canvas
-				.getByRole("button", { name: "View inline-screenshot.png" })
-				.focus();
-			const downloadLink = await canvas.findByRole("link", {
-				name: "Download inline-screenshot.png",
-			});
-			await userEvent.click(downloadLink);
-			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
-			const shared: { files: File[] } = share.mock.calls[0][0];
-			expect(shared.files[0].name).toBe("inline-screenshot.png");
-			expect(shared.files[0].type).toBe("image/png");
-			expect(fetchSpy).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-/** iOS blocks data: tabs, so the toast Open action uses a blob URL. */
-export const DownloadInIOSStandaloneOpensInlineAttachmentFromToast: Story = {
-	decorators: [withToaster],
-	args: inlineAttachmentStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
-			share: fn().mockRejectedValue(
-				new DOMException("share failed", "DataError"),
-			),
-			canShare: fn().mockReturnValue(true),
-		});
-		const open = spyOn(window, "open").mockReturnValue(null);
-		const fetchSpy = spyOn(globalThis, "fetch");
-		try {
-			canvas
-				.getByRole("button", { name: "View inline-screenshot.png" })
-				.focus();
-			const downloadLink = await canvas.findByRole("link", {
-				name: "Download inline-screenshot.png",
-			});
-			await userEvent.click(downloadLink);
-			await screen.findByText("Couldn't download inline-screenshot.png");
-			await userEvent.click(screen.getByRole("button", { name: "Open" }));
-			expect(open).toHaveBeenCalledTimes(1);
-			const [blobUrl, target, features] = open.mock.calls[0];
-			expect(blobUrl).toMatch(/^blob:/);
-			expect(target).toBe("_blank");
-			expect(features).toBe("noopener");
-			expect(fetchSpy).not.toHaveBeenCalled();
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
+const inlineAttachmentStoryArgs = buildInlineDownloadStoryArgs(
+	TEST_PNG_B64,
+	"inline-screenshot.png",
+);
 
 export const DownloadInIOSStandaloneShowsErrorForCorruptInlineAttachment: Story =
 	{
 		decorators: [withToaster],
-		args: {
-			...defaultArgs,
-			parsedMessages: parseMessagesWithMergedTools([
-				{
-					...baseMessage,
-					id: 1,
-					role: "assistant",
-					content: [
-						{
-							type: "file",
-							media_type: "image/png",
-							data: "not-valid-base64",
-							name: "corrupt-screenshot.png",
-						},
-					],
-				},
-			]),
-		},
+		args: buildInlineDownloadStoryArgs(
+			"not-valid-base64",
+			"corrupt-screenshot.png",
+		),
 		play: async ({ canvasElement }) => {
 			const canvas = within(canvasElement);
 			const share = fn().mockResolvedValue(undefined);
-			const restoreNavigator = overrideNavigatorForIOSStandalone({
+			const { open, restoreNavigator } = setupIOSStandaloneDownload({
 				share,
 				canShare: fn().mockReturnValue(true),
 			});
-			const open = spyOn(window, "open").mockReturnValue(null);
 			try {
-				canvas
-					.getByRole("button", { name: "View corrupt-screenshot.png" })
-					.focus();
-				const downloadLink = await canvas.findByRole("link", {
-					name: "Download corrupt-screenshot.png",
-				});
+				const downloadLink = await getInlineDownloadLink(
+					canvas,
+					"corrupt-screenshot.png",
+				);
 				await userEvent.click(downloadLink);
 				await screen.findByText("Couldn't download corrupt-screenshot.png");
 				await screen.findByText("The attachment data could not be decoded.");
@@ -1911,19 +1497,16 @@ export const DownloadInIOSStandaloneOpensInlineAttachmentInTab: Story = {
 	args: inlineAttachmentStoryArgs,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
+		const { open, restoreNavigator } = setupIOSStandaloneDownload({
 			share: undefined,
 			canShare: undefined,
 		});
-		const open = spyOn(window, "open").mockReturnValue(null);
 		const fetchSpy = spyOn(globalThis, "fetch");
 		try {
-			canvas
-				.getByRole("button", { name: "View inline-screenshot.png" })
-				.focus();
-			const downloadLink = await canvas.findByRole("link", {
-				name: "Download inline-screenshot.png",
-			});
+			const downloadLink = await getInlineDownloadLink(
+				canvas,
+				"inline-screenshot.png",
+			);
 			await userEvent.click(downloadLink);
 			expect(open).toHaveBeenCalledTimes(1);
 			const [blobUrl, target, features] = open.mock.calls[0];
@@ -1945,15 +1528,12 @@ export const DownloadInIOSStandaloneStaysQuietOnDismissedShare: Story = {
 		const share = fn().mockRejectedValue(
 			new DOMException("dismissed", "AbortError"),
 		);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
+		const { open, restoreNavigator } = setupIOSStandaloneDownload({
 			share,
 			canShare: fn().mockReturnValue(true),
 		});
-		const open = spyOn(window, "open").mockReturnValue(null);
 		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
+			await userEvent.click(getIOSDownloadLink(canvas));
 			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
 			// The spinner clearing marks the flow as settled.
 			await waitFor(() => {
@@ -1967,60 +1547,6 @@ export const DownloadInIOSStandaloneStaysQuietOnDismissedShare: Story = {
 			expect(open).not.toHaveBeenCalled();
 		} finally {
 			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadInIOSStandaloneWithoutShareOpensTab: Story = {
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const restoreNavigator = overrideNavigatorForIOSStandalone({
-			share: undefined,
-			canShare: undefined,
-		});
-		const open = spyOn(window, "open").mockReturnValue(null);
-		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
-			expect(open).toHaveBeenCalledWith(
-				getChatFileURL("storybook-ios-share-report"),
-				"_blank",
-				"noopener",
-			);
-			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(0);
-		} finally {
-			restoreNavigator();
-		}
-	},
-};
-
-export const DownloadOutsideIOSKeepsNativeAnchor: Story = {
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockResolvedValue(undefined);
-		Object.defineProperty(navigator, "share", {
-			value: share,
-			configurable: true,
-		});
-		const open = spyOn(window, "open").mockReturnValue(null);
-		// Prevent the test browser's native download without stopping the component handler.
-		const blockDownload = (event: Event) => event.preventDefault();
-		document.addEventListener("click", blockDownload, { capture: true });
-		try {
-			const downloadLink = canvas.getByRole("link", {
-				name: "Download deployment-report.pdf",
-			});
-			expect(downloadLink).toHaveAttribute("download", "deployment-report.pdf");
-			await userEvent.click(downloadLink);
-			expect(share).not.toHaveBeenCalled();
-			expect(open).not.toHaveBeenCalled();
-			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(0);
-		} finally {
-			document.removeEventListener("click", blockDownload, { capture: true });
-			Reflect.deleteProperty(navigator, "share");
 		}
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1533,12 +1533,18 @@ export const DownloadInIOSStandaloneReportsPermanentShareFailure: Story = {
 				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
 			);
 			await screen.findByText("Couldn't download deployment-report.pdf");
-			// A permanent failure gets a plain toast: retrying would fail
-			// identically, so no Save action is offered.
+			// Retrying a permanently failed share would fail identically,
+			// so the toast offers the dismissible tab instead of Save.
 			expect(
 				screen.queryByRole("button", { name: "Save" }),
 			).not.toBeInTheDocument();
 			expect(open).not.toHaveBeenCalled();
+			await userEvent.click(screen.getByRole("button", { name: "Open" }));
+			expect(open).toHaveBeenCalledWith(
+				getChatFileURL("storybook-ios-share-report"),
+				"_blank",
+				"noopener",
+			);
 		} finally {
 			restoreNavigator();
 		}
@@ -1611,6 +1617,53 @@ export const DownloadInIOSStandaloneShowsErrorToastOnFailedFetch: Story = {
 			await screen.findByText("Couldn't download deployment-report.pdf");
 			expect(share).not.toHaveBeenCalled();
 			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+/** Inline data: attachments cannot be fetched under the production CSP. */
+export const DownloadInIOSStandaloneSharesInlineAttachment: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: parseMessagesWithMergedTools([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [
+					{
+						type: "file",
+						media_type: "image/png",
+						data: TEST_PNG_B64,
+						name: "inline-screenshot.png",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockResolvedValue(undefined);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		const fetchSpy = spyOn(globalThis, "fetch");
+		try {
+			canvas
+				.getByRole("button", { name: "View inline-screenshot.png" })
+				.focus();
+			const downloadLink = await canvas.findByRole("link", {
+				name: "Download inline-screenshot.png",
+			});
+			await userEvent.click(downloadLink);
+			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+			const shared: { files: File[] } = share.mock.calls[0][0];
+			expect(shared.files[0].name).toBe("inline-screenshot.png");
+			expect(shared.files[0].type).toBe("image/png");
+			expect(fetchSpy).not.toHaveBeenCalled();
 		} finally {
 			restoreNavigator();
 		}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1318,6 +1318,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-unnamed-report",
 						name: "quarterly-report.pdf",
 					},
+					{
+						type: "file",
+						media_type: "text/plain",
+						file_id: "storybook-text-1",
+						name: "main.go",
+					},
 				],
 			},
 		]),
@@ -1345,6 +1351,15 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 		expect(
 			canvas.getByRole("link", { name: "Download quarterly-report.pdf" }),
 		).toHaveAttribute("download", "quarterly-report.pdf");
+		// text/plain covers source files, so their suffixes are preserved.
+		// The overlay link joins the accessibility tree only while its
+		// attachment group has focus.
+		canvas.getByRole("button", { name: "View main.go" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download main.go" }),
+			).toHaveAttribute("download", "main.go");
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -21,6 +21,10 @@ import type { ParsedMessageEntry } from "./types";
 const TEST_PNG_B64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4n539HwAHFwLVF8kc1wAAAABJRU5ErkJggg==";
 
+const TEST_SVG_B64 = btoa(
+	'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
+);
+
 const buildMessages = (messages: TypesGen.ChatMessage[]) =>
 	parseMessagesWithMergedTools(messages);
 
@@ -1354,6 +1358,24 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-json-2",
 						name: "map.geojson",
 					},
+					{
+						type: "file",
+						media_type: "image/svg+xml",
+						data: TEST_SVG_B64,
+						name: "diagram.svg",
+					},
+					{
+						type: "file",
+						media_type: "image/svg+xml",
+						data: TEST_SVG_B64,
+						name: "architecture sketch",
+					},
+					{
+						type: "file",
+						media_type: "application/vnd.oasis.opendocument.text",
+						file_id: "storybook-odt-1",
+						name: "notes.odt",
+					},
 				],
 			},
 		]),
@@ -1417,6 +1439,21 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 				canvas.getByRole("link", { name: "Download map.geojson" }),
 			).toHaveAttribute("download", "map.geojson");
 		});
+		canvas.getByRole("button", { name: "View diagram.svg" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download diagram.svg" }),
+			).toHaveAttribute("download", "diagram.svg");
+		});
+		canvas.getByRole("button", { name: "View architecture sketch" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download architecture sketch" }),
+			).toHaveAttribute("download", "architecture sketch.svg");
+		});
+		expect(
+			canvas.getByRole("link", { name: "Download notes.odt" }),
+		).toHaveAttribute("download", "notes.odt");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -204,14 +204,14 @@ const overrideNavigatorForIOSStandalone = (
 		...extras,
 	};
 	for (const [key, value] of Object.entries(overrides)) {
-		Object.defineProperty(window.navigator, key, {
+		Object.defineProperty(navigator, key, {
 			value,
 			configurable: true,
 		});
 	}
 	return () => {
 		for (const key of Object.keys(overrides)) {
-			Reflect.deleteProperty(window.navigator, key);
+			Reflect.deleteProperty(navigator, key);
 		}
 	};
 };
@@ -1403,7 +1403,7 @@ export const DownloadOutsideIOSKeepsNativeAnchor: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const share = fn().mockResolvedValue(undefined);
-		Object.defineProperty(window.navigator, "share", {
+		Object.defineProperty(navigator, "share", {
 			value: share,
 			configurable: true,
 		});
@@ -1424,7 +1424,7 @@ export const DownloadOutsideIOSKeepsNativeAnchor: Story = {
 			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(0);
 		} finally {
 			document.removeEventListener("click", blockDownload, { capture: true });
-			Reflect.deleteProperty(window.navigator, "share");
+			Reflect.deleteProperty(navigator, "share");
 		}
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1937,6 +1937,40 @@ export const DownloadInIOSStandaloneOpensInlineAttachmentInTab: Story = {
 	},
 };
 
+export const DownloadInIOSStandaloneStaysQuietOnDismissedShare: Story = {
+	decorators: [withToaster],
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockRejectedValue(
+			new DOMException("dismissed", "AbortError"),
+		);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+			// The spinner clearing marks the flow as settled.
+			await waitFor(() => {
+				expect(
+					canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+				).toHaveAttribute("aria-disabled", "false");
+			});
+			expect(
+				screen.queryByText("Couldn't download deployment-report.pdf"),
+			).not.toBeInTheDocument();
+			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
 export const DownloadInIOSStandaloneWithoutShareOpensTab: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1336,6 +1336,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-text-3",
 						name: "meeting notes",
 					},
+					{
+						type: "file",
+						media_type: "image/jpeg",
+						data: TEST_PNG_B64,
+						name: "photo.jfif",
+					},
 				],
 			},
 		]),
@@ -1380,6 +1386,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 			expect(
 				canvas.getByRole("link", { name: "Download meeting notes" }),
 			).toHaveAttribute("download", "meeting notes.txt");
+		});
+		canvas.getByRole("button", { name: "View photo.jfif" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download photo.jfif" }),
+			).toHaveAttribute("download", "photo.jfif");
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1342,6 +1342,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						data: TEST_PNG_B64,
 						name: "photo.jfif",
 					},
+					{
+						type: "file",
+						media_type: "application/json",
+						file_id: "storybook-json-1",
+						name: ".eslintrc",
+					},
 				],
 			},
 		]),
@@ -1392,6 +1398,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 			expect(
 				canvas.getByRole("link", { name: "Download photo.jfif" }),
 			).toHaveAttribute("download", "photo.jfif");
+		});
+		canvas.getByRole("button", { name: "View .eslintrc" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download .eslintrc" }),
+			).toHaveAttribute("download", ".eslintrc");
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1623,26 +1623,28 @@ export const DownloadInIOSStandaloneShowsErrorToastOnFailedFetch: Story = {
 	},
 };
 
+const inlineAttachmentStoryArgs: Story["args"] = {
+	...defaultArgs,
+	parsedMessages: parseMessagesWithMergedTools([
+		{
+			...baseMessage,
+			id: 1,
+			role: "assistant",
+			content: [
+				{
+					type: "file",
+					media_type: "image/png",
+					data: TEST_PNG_B64,
+					name: "inline-screenshot.png",
+				},
+			],
+		},
+	]),
+};
+
 /** Inline data: attachments cannot be fetched under the production CSP. */
 export const DownloadInIOSStandaloneSharesInlineAttachment: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: parseMessagesWithMergedTools([
-			{
-				...baseMessage,
-				id: 1,
-				role: "assistant",
-				content: [
-					{
-						type: "file",
-						media_type: "image/png",
-						data: TEST_PNG_B64,
-						name: "inline-screenshot.png",
-					},
-				],
-			},
-		]),
-	},
+	args: inlineAttachmentStoryArgs,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const share = fn().mockResolvedValue(undefined);
@@ -1663,6 +1665,37 @@ export const DownloadInIOSStandaloneSharesInlineAttachment: Story = {
 			const shared: { files: File[] } = share.mock.calls[0][0];
 			expect(shared.files[0].name).toBe("inline-screenshot.png");
 			expect(shared.files[0].type).toBe("image/png");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+/** iOS blocks data: tabs, so inline attachments open through a blob URL. */
+export const DownloadInIOSStandaloneOpensInlineAttachmentInTab: Story = {
+	args: inlineAttachmentStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share: undefined,
+			canShare: undefined,
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		const fetchSpy = spyOn(globalThis, "fetch");
+		try {
+			canvas
+				.getByRole("button", { name: "View inline-screenshot.png" })
+				.focus();
+			const downloadLink = await canvas.findByRole("link", {
+				name: "Download inline-screenshot.png",
+			});
+			await userEvent.click(downloadLink);
+			expect(open).toHaveBeenCalledTimes(1);
+			const [blobUrl, target, features] = open.mock.calls[0];
+			expect(blobUrl).toMatch(/^blob:/);
+			expect(target).toBe("_blank");
+			expect(features).toBe("noopener");
 			expect(fetchSpy).not.toHaveBeenCalled();
 		} finally {
 			restoreNavigator();

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1439,8 +1439,6 @@ export const DownloadInIOSStandaloneReportsPermanentShareFailure: Story = {
 		try {
 			await userEvent.click(getIOSDownloadLink(canvas));
 			await screen.findByText("Couldn't download deployment-report.pdf");
-			// Retrying a permanently failed share would fail identically,
-			// so the toast offers the dismissible tab instead of Save.
 			expect(
 				screen.queryByRole("button", { name: "Save" }),
 			).not.toBeInTheDocument();
@@ -1492,7 +1490,6 @@ export const DownloadInIOSStandaloneShowsErrorForCorruptInlineAttachment: Story 
 		},
 	};
 
-/** iOS blocks data: tabs, so inline attachments open through a blob URL. */
 export const DownloadInIOSStandaloneOpensInlineAttachmentInTab: Story = {
 	args: inlineAttachmentStoryArgs,
 	play: async ({ canvasElement }) => {
@@ -1535,7 +1532,6 @@ export const DownloadInIOSStandaloneStaysQuietOnDismissedShare: Story = {
 		try {
 			await userEvent.click(getIOSDownloadLink(canvas));
 			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
-			// The spinner clearing marks the flow as settled.
 			await waitFor(() => {
 				expect(
 					canvas.getByRole("link", { name: "Download deployment-report.pdf" }),

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1461,6 +1461,46 @@ export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
 	},
 };
 
+export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn().mockResolvedValue(undefined);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		let releaseFetch = () => {};
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+			() =>
+				new Promise<Response>((resolve) => {
+					releaseFetch = () =>
+						resolve(
+							new Response("pdf-bytes", {
+								headers: { "Content-Type": "application/pdf" },
+							}),
+						);
+				}),
+		);
+		try {
+			const downloadLink = canvas.getByRole("link", {
+				name: "Download deployment-report.pdf",
+			});
+			await userEvent.click(downloadLink);
+			expect(downloadLink).toHaveAttribute("aria-disabled", "true");
+			await userEvent.click(downloadLink);
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			releaseFetch();
+			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+			await waitFor(() =>
+				expect(downloadLink).toHaveAttribute("aria-disabled", "false"),
+			);
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
 export const DownloadInIOSStandaloneShowsErrorToastOnFailedFetch: Story = {
 	decorators: [withToaster],
 	args: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1388,6 +1388,18 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-mp3-1",
 						name: "song.mp3",
 					},
+					{
+						type: "file",
+						media_type: "application/xml",
+						file_id: "storybook-xml-1",
+						name: "build config",
+					},
+					{
+						type: "file",
+						media_type: "text/csv",
+						file_id: "storybook-csv-1",
+						name: "export data",
+					},
 				],
 			},
 		]),
@@ -1472,6 +1484,15 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 		expect(
 			canvas.getByRole("link", { name: "Download song.mp3" }),
 		).toHaveAttribute("download", "song.mp3");
+		expect(
+			canvas.getByRole("link", { name: "Download build config" }),
+		).toHaveAttribute("download", "build config.xml");
+		canvas.getByRole("button", { name: "View export data" }).focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download export data" }),
+			).toHaveAttribute("download", "export data.csv");
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1289,6 +1289,43 @@ export const AssistantMessageWithImage: Story = {
 	},
 };
 
+export const ExtensionlessImageNameGainsDownloadExtension: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Here is the screenshot:" },
+					{
+						type: "file",
+						media_type: "image/png",
+						data: TEST_PNG_B64,
+						name: "About Page Screenshot",
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const viewButton = canvas.getByRole("button", {
+			name: "View About Page Screenshot",
+		});
+		viewButton.focus();
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("link", { name: "Download About Page Screenshot" }),
+			).toBeVisible();
+		});
+		expect(
+			canvas.getByRole("link", { name: "Download About Page Screenshot" }),
+		).toHaveAttribute("download", "About Page Screenshot.png");
+	},
+};
+
 export const AssistantMessageWithUnnamedDownloadableFile: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -192,9 +192,7 @@ const mockAttachmentFetch = () => {
 	});
 };
 
-// Shadows the Navigator.prototype getters with own properties so the
-// download handler sees an iOS standalone PWA; the returned cleanup
-// restores the real values for subsequent stories.
+// Read-only Navigator values must be shadowed with removable own properties.
 const overrideNavigatorForIOSStandalone = (
 	extras: Record<string, unknown> = {},
 ): (() => void) => {
@@ -1344,7 +1342,6 @@ const iosDownloadStoryArgs: Story["args"] = {
 	]),
 };
 
-/** In an iOS standalone PWA the download click hands the file to the share sheet. */
 export const DownloadInIOSStandaloneSharesFile: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {
@@ -1372,7 +1369,6 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 	},
 };
 
-/** When user activation expires before share(), the error toast's Save action retries with a fresh gesture. */
 export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
 	decorators: [withToaster],
 	args: iosDownloadStoryArgs,
@@ -1406,7 +1402,6 @@ export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
 	},
 };
 
-/** Without file sharing, an iOS standalone PWA gets a dismissible tab instead of QuickLook. */
 export const DownloadInIOSStandaloneWithoutShareOpensTab: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {
@@ -1432,7 +1427,6 @@ export const DownloadInIOSStandaloneWithoutShareOpensTab: Story = {
 	},
 };
 
-/** Outside iOS standalone the anchor keeps its native download behavior. */
 export const DownloadOutsideIOSKeepsNativeAnchor: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {
@@ -1443,9 +1437,7 @@ export const DownloadOutsideIOSKeepsNativeAnchor: Story = {
 			configurable: true,
 		});
 		const open = spyOn(window, "open").mockReturnValue(null);
-		// Block the real download navigation the test browser would start;
-		// capture phase runs before the component's handler and does not
-		// affect whether that handler intercepts the click.
+		// Prevent the test browser's native download without stopping the component handler.
 		const blockDownload = (event: Event) => event.preventDefault();
 		document.addEventListener("click", blockDownload, { capture: true });
 		try {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -10,6 +10,7 @@ import {
 	within,
 } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
+import { withToaster } from "#/testHelpers/storybook";
 import { getChatFileURL } from "../../utils/chatAttachments";
 import { encodeInlineTextAttachment } from "../../utils/fetchTextAttachment";
 import { ConversationTimeline } from "./ConversationTimeline";
@@ -1364,6 +1365,40 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 			expect(shared.files[0].name).toBe("deployment-report.pdf");
 			expect(shared.files[0].type).toBe("application/pdf");
 			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(1);
+			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
+/** When user activation expires before share(), the error toast's Save action retries with a fresh gesture. */
+export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
+	decorators: [withToaster],
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn()
+			.mockRejectedValueOnce(
+				new DOMException("activation expired", "NotAllowedError"),
+			)
+			.mockResolvedValue(undefined);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			// The toast renders in a portal outside the story canvas.
+			const saveButton = await screen.findByRole("button", { name: "Save" });
+			await userEvent.click(saveButton);
+			await waitFor(() => expect(share).toHaveBeenCalledTimes(2));
+			const shared: { files: File[] } = share.mock.calls[1][0];
+			expect(shared.files).toHaveLength(1);
+			expect(shared.files[0].name).toBe("deployment-report.pdf");
 			expect(open).not.toHaveBeenCalled();
 		} finally {
 			restoreNavigator();

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1387,6 +1387,36 @@ export const DownloadInIOSStandaloneSharesFile: Story = {
 	},
 };
 
+export const DownloadInIOSStandaloneRecoversExpiredActivation: Story = {
+	decorators: [withToaster],
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const share = fn()
+			.mockRejectedValueOnce(
+				new DOMException("activation expired", "NotAllowedError"),
+			)
+			.mockResolvedValue(undefined);
+		const { open, restoreNavigator } = setupIOSStandaloneDownload({
+			share,
+			canShare: fn().mockReturnValue(true),
+		});
+		try {
+			await userEvent.click(getIOSDownloadLink(canvas));
+			// The toast renders in a portal outside the story canvas.
+			const saveButton = await screen.findByRole("button", { name: "Save" });
+			await userEvent.click(saveButton);
+			await waitFor(() => expect(share).toHaveBeenCalledTimes(2));
+			const shared: { files: File[] } = share.mock.calls[1][0];
+			expect(shared.files).toHaveLength(1);
+			expect(shared.files[0].name).toBe("deployment-report.pdf");
+			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
 export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
 	args: iosDownloadStoryArgs,
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1396,6 +1396,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 					},
 					{
 						type: "file",
+						media_type: "application/xml",
+						file_id: "storybook-xml-2",
+						name: "schema.xsd",
+					},
+					{
+						type: "file",
 						media_type: "text/csv",
 						file_id: "storybook-csv-1",
 						name: "export data",
@@ -1487,6 +1493,9 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 		expect(
 			canvas.getByRole("link", { name: "Download build config" }),
 		).toHaveAttribute("download", "build config.xml");
+		expect(
+			canvas.getByRole("link", { name: "Download schema.xsd" }),
+		).toHaveAttribute("download", "schema.xsd");
 		canvas.getByRole("button", { name: "View export data" }).focus();
 		await waitFor(() => {
 			expect(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1406,6 +1406,12 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 						file_id: "storybook-csv-1",
 						name: "export data",
 					},
+					{
+						type: "file",
+						media_type: "application/ld+json",
+						file_id: "storybook-jsonld-1",
+						name: "context.jsonld",
+					},
 				],
 			},
 		]),
@@ -1502,6 +1508,9 @@ export const DownloadNamesGainMediaTypeExtension: Story = {
 				canvas.getByRole("link", { name: "Download export data" }),
 			).toHaveAttribute("download", "export data.csv");
 		});
+		expect(
+			canvas.getByRole("link", { name: "Download context.jsonld" }),
+		).toHaveAttribute("download", "context.jsonld");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1516,6 +1516,35 @@ export const DownloadInIOSStandaloneSuppressesDuplicateClicks: Story = {
 	},
 };
 
+export const DownloadInIOSStandaloneReportsPermanentShareFailure: Story = {
+	decorators: [withToaster],
+	args: iosDownloadStoryArgs,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const restoreNavigator = overrideNavigatorForIOSStandalone({
+			share: fn().mockRejectedValue(
+				new DOMException("share failed", "DataError"),
+			),
+			canShare: fn().mockReturnValue(true),
+		});
+		const open = spyOn(window, "open").mockReturnValue(null);
+		try {
+			await userEvent.click(
+				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
+			);
+			await screen.findByText("Couldn't download deployment-report.pdf");
+			// A permanent failure gets a plain toast: retrying would fail
+			// identically, so no Save action is offered.
+			expect(
+				screen.queryByRole("button", { name: "Save" }),
+			).not.toBeInTheDocument();
+			expect(open).not.toHaveBeenCalled();
+		} finally {
+			restoreNavigator();
+		}
+	},
+};
+
 export const DownloadInIOSStandaloneOffersTabForUnshareableFile: Story = {
 	decorators: [withToaster],
 	args: iosDownloadStoryArgs,

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -177,6 +177,21 @@ describe("handleAttachmentDownloadClick", () => {
 				action: expect.objectContaining({ label: "Save" }),
 			}),
 		);
+
+		const action: unknown = vi.mocked(toast.error).mock.calls[0][1]?.action;
+		if (
+			action === null ||
+			typeof action !== "object" ||
+			!("onClick" in action) ||
+			typeof action.onClick !== "function"
+		) {
+			throw new Error("expected the toast to carry a Save action");
+		}
+		action.onClick();
+		expect(share).toHaveBeenCalledTimes(2);
+		const first: { files: File[] } = share.mock.calls[0][0];
+		const retry: { files: File[] } = share.mock.calls[1][0];
+		expect(retry.files[0]).toBe(first.files[0]);
 	});
 
 	it("shows a plain failure toast after a permanent share failure", async () => {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -181,8 +181,6 @@ describe("handleAttachmentDownloadClick", () => {
 
 	it("shows a plain failure toast after a permanent share failure", async () => {
 		enterIOSStandalonePWA();
-		// jsdom's DOMException is not instanceof Error, so a plain Error
-		// stands in for permanent failures like DataError.
 		mockFileSharing(vi.fn().mockRejectedValue(new Error("share failed")));
 		mockAttachmentFetch();
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -16,10 +16,6 @@ import {
 
 describe("handleAttachmentDownloadClick", () => {
 	const overriddenNavigatorKeys = new Set<string>();
-	const originalURLDescriptors = new Map<
-		string,
-		PropertyDescriptor | undefined
-	>();
 	const iPhoneUserAgent =
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
 	const target = {
@@ -38,12 +34,12 @@ describe("handleAttachmentDownloadClick", () => {
 		overrideNavigator("standalone", true);
 	};
 
-	const mockFileSharing = (
-		share: ReturnType<typeof vi.fn>,
-		canShare: (data: { files: File[] }) => boolean = () => true,
-	) => {
+	const mockFileSharing = (share: ReturnType<typeof vi.fn>) => {
 		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn(canShare));
+		overrideNavigator(
+			"canShare",
+			vi.fn(() => true),
+		);
 	};
 
 	const mockAttachmentFetch = (body = "png-bytes", mediaType = "image/png") =>
@@ -53,28 +49,12 @@ describe("handleAttachmentDownloadClick", () => {
 				new Response(new Blob([body], { type: mediaType }), { status: 200 }),
 			);
 
-	const click = (downloadTarget = target, signal?: AbortSignal) => {
+	const click = (downloadTarget = target) => {
 		const event = { preventDefault: vi.fn() };
 		return {
 			event,
-			pending: handleAttachmentDownloadClick(event, downloadTarget, signal),
+			pending: handleAttachmentDownloadClick(event, downloadTarget),
 		};
-	};
-
-	const stubObjectURLs = () => {
-		const createObjectURL = vi.fn().mockReturnValue("blob:inline");
-		const revokeObjectURL = vi.fn();
-		for (const [key, value] of Object.entries({
-			createObjectURL,
-			revokeObjectURL,
-		})) {
-			originalURLDescriptors.set(
-				key,
-				Object.getOwnPropertyDescriptor(URL, key),
-			);
-			Object.defineProperty(URL, key, { value, configurable: true });
-		}
-		return { createObjectURL, revokeObjectURL };
 	};
 
 	afterEach(() => {
@@ -82,15 +62,6 @@ describe("handleAttachmentDownloadClick", () => {
 			Reflect.deleteProperty(navigator, key);
 		}
 		overriddenNavigatorKeys.clear();
-		for (const [key, descriptor] of originalURLDescriptors) {
-			if (descriptor) {
-				Object.defineProperty(URL, key, descriptor);
-			} else {
-				Reflect.deleteProperty(URL, key);
-			}
-		}
-		originalURLDescriptors.clear();
-		vi.useRealTimers();
 		vi.restoreAllMocks();
 		vi.mocked(toast.error).mockClear();
 	});
@@ -103,12 +74,10 @@ describe("handleAttachmentDownloadClick", () => {
 		],
 	])("keeps the native anchor download %s", (_label, setup) => {
 		setup();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		const { event, pending } = click();
 
 		expect(pending).toBeUndefined();
 		expect(event.preventDefault).not.toHaveBeenCalled();
-		expect(open).not.toHaveBeenCalled();
 	});
 
 	it("shares the fetched attachment in an iOS standalone PWA", async () => {
@@ -121,9 +90,7 @@ describe("handleAttachmentDownloadClick", () => {
 		await pending;
 
 		expect(event.preventDefault).toHaveBeenCalled();
-		expect(globalThis.fetch).toHaveBeenCalledWith(target.href, {
-			signal: undefined,
-		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(target.href);
 		const shared: { files: File[] } = share.mock.calls[0][0];
 		expect(shared.files).toHaveLength(1);
 		expect(shared.files[0]).toMatchObject({
@@ -132,32 +99,32 @@ describe("handleAttachmentDownloadClick", () => {
 		});
 	});
 
-	it("recognizes iPadOS with a macOS user agent", () => {
+	it("recognizes iPadOS with a macOS user agent", async () => {
 		overrideNavigator(
 			"userAgent",
 			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
 		);
 		overrideNavigator("maxTouchPoints", 5);
 		overrideNavigator("standalone", true);
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const share = vi.fn().mockResolvedValue(undefined);
+		mockFileSharing(share);
+		mockAttachmentFetch();
 
 		const { event, pending } = click();
+		await pending;
 
-		expect(pending).toBeUndefined();
 		expect(event.preventDefault).toHaveBeenCalled();
-		expect(open).toHaveBeenCalledWith(target.href, "_blank", "noopener");
+		expect(share).toHaveBeenCalledTimes(1);
 	});
 
-	it("opens a tab synchronously when file sharing is unavailable", () => {
+	it("keeps the native anchor when file sharing is unavailable", () => {
 		enterIOSStandalonePWA();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
 
 		const { event, pending } = click();
 
 		expect(pending).toBeUndefined();
-		expect(event.preventDefault).toHaveBeenCalled();
-		expect(open).toHaveBeenCalledWith(target.href, "_blank", "noopener");
+		expect(event.preventDefault).not.toHaveBeenCalled();
 		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
@@ -173,11 +140,10 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("shows the fetch failure without opening a late popup", async () => {
+	it("shows the fetch failure", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
 		mockFileSharing(share);
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response("nope", { status: 503 }),
 		);
@@ -185,7 +151,6 @@ describe("handleAttachmentDownloadClick", () => {
 		await click().pending;
 
 		expect(share).not.toHaveBeenCalled();
-		expect(open).not.toHaveBeenCalled();
 		expect(toast.error).toHaveBeenCalledWith(
 			"Couldn't download 01-agents-list.png",
 			{ description: "HTTP 503" },
@@ -214,20 +179,18 @@ describe("handleAttachmentDownloadClick", () => {
 		);
 	});
 
-	it("offers Open after a permanent share failure", async () => {
+	it("shows a plain failure toast after a permanent share failure", async () => {
 		enterIOSStandalonePWA();
-		mockFileSharing(
-			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
-		);
+		// jsdom's DOMException is not instanceof Error, so a plain Error
+		// stands in for permanent failures like DataError.
+		mockFileSharing(vi.fn().mockRejectedValue(new Error("share failed")));
 		mockAttachmentFetch();
 
 		await click().pending;
 
 		expect(toast.error).toHaveBeenCalledWith(
 			"Couldn't download 01-agents-list.png",
-			expect.objectContaining({
-				action: expect.objectContaining({ label: "Open" }),
-			}),
+			{ description: "share failed" },
 		);
 	});
 
@@ -252,130 +215,21 @@ describe("handleAttachmentDownloadClick", () => {
 		});
 	});
 
-	it("opens inline data through a temporary blob URL", () => {
+	it("shows a decode error for corrupt inline data", async () => {
 		enterIOSStandalonePWA();
-		const { createObjectURL, revokeObjectURL } = stubObjectURLs();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		vi.useFakeTimers();
+		const share = vi.fn().mockResolvedValue(undefined);
+		mockFileSharing(share);
 
-		const { pending } = click({
-			href: `data:image/png;base64,${btoa("png-bytes")}`,
-			fileName: "inline.png",
-			mediaType: "image/png",
-		});
-
-		expect(pending).toBeUndefined();
-		const decoded: File = createObjectURL.mock.calls[0][0];
-		expect(decoded).toMatchObject({ name: "inline.png", type: "image/png" });
-		expect(open).toHaveBeenCalledWith("blob:inline", "_blank", "noopener");
-		vi.runAllTimers();
-		expect(revokeObjectURL).toHaveBeenCalledWith("blob:inline");
-	});
-
-	it("shows a decode error for corrupt inline data", () => {
-		enterIOSStandalonePWA();
-		stubObjectURLs();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
-
-		click({
+		await click({
 			href: "data:image/png;base64,%%%",
 			fileName: "inline.png",
 			mediaType: "image/png",
-		});
+		}).pending;
 
-		expect(open).not.toHaveBeenCalled();
+		expect(share).not.toHaveBeenCalled();
 		expect(toast.error).toHaveBeenCalledWith("Couldn't download inline.png", {
 			description: "The attachment data could not be decoded.",
 		});
-	});
-
-	it("passes the abort signal through the fetch and suppresses abort UI", async () => {
-		enterIOSStandalonePWA();
-		const share = vi.fn().mockResolvedValue(undefined);
-		mockFileSharing(share);
-		vi.spyOn(globalThis, "fetch").mockImplementation(
-			(_input, init) =>
-				new Promise((_resolve, reject) => {
-					init?.signal?.addEventListener("abort", () =>
-						reject(new DOMException("aborted", "AbortError")),
-					);
-				}),
-		);
-		const controller = new AbortController();
-
-		const { pending } = click(target, controller.signal);
-		controller.abort();
-		await pending;
-
-		expect(share).not.toHaveBeenCalled();
-		expect(toast.error).not.toHaveBeenCalled();
-	});
-
-	it.each([
-		["the fetch resolves", false, 200],
-		["an HTTP error resolves", false, 503],
-		["the response body resolves", true, 200],
-	])("suppresses UI after unmount when %s", async (_label, abortInBlob, status) => {
-		enterIOSStandalonePWA();
-		const share = vi.fn().mockResolvedValue(undefined);
-		mockFileSharing(share);
-		const controller = new AbortController();
-		vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-			const response = new Response(
-				new Blob(["png-bytes"], { type: "image/png" }),
-				{ status },
-			);
-			if (abortInBlob) {
-				vi.spyOn(response, "blob").mockImplementation(async () => {
-					controller.abort();
-					return new Blob(["png-bytes"], { type: "image/png" });
-				});
-			} else {
-				controller.abort();
-			}
-			return response;
-		});
-
-		await click(target, controller.signal).pending;
-
-		expect(share).not.toHaveBeenCalled();
-		expect(toast.error).not.toHaveBeenCalled();
-	});
-
-	it("suppresses share rejection UI after unmount", async () => {
-		enterIOSStandalonePWA();
-		const controller = new AbortController();
-		const share = vi.fn().mockImplementation(() => {
-			controller.abort();
-			return Promise.reject(new DOMException("expired", "NotAllowedError"));
-		});
-		mockFileSharing(share);
-		mockAttachmentFetch();
-
-		await click(target, controller.signal).pending;
-
-		expect(share).toHaveBeenCalledTimes(1);
-		expect(toast.error).not.toHaveBeenCalled();
-	});
-
-	it("offers Open when the fetched file cannot be shared", async () => {
-		enterIOSStandalonePWA();
-		const share = vi.fn().mockResolvedValue(undefined);
-		mockFileSharing(share, ({ files }) => files[0].size <= 1);
-		mockAttachmentFetch();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
-
-		await click().pending;
-
-		expect(share).not.toHaveBeenCalled();
-		expect(open).not.toHaveBeenCalled();
-		expect(toast.error).toHaveBeenCalledWith(
-			"Couldn't download 01-agents-list.png",
-			expect.objectContaining({
-				description: "This file cannot be shared on this device.",
-				action: expect.objectContaining({ label: "Open" }),
-			}),
-		);
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -16,33 +16,51 @@ import {
 
 describe("handleAttachmentDownloadClick", () => {
 	const overriddenNavigatorKeys = new Set<string>();
-	const overrideNavigator = (key: string, value: unknown) => {
-		Object.defineProperty(navigator, key, {
-			value,
-			configurable: true,
-		});
-		overriddenNavigatorKeys.add(key);
-	};
-
+	const originalURLDescriptors = new Map<
+		string,
+		PropertyDescriptor | undefined
+	>();
 	const iPhoneUserAgent =
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
-
-	const enterIOSStandalonePWA = () => {
-		overrideNavigator("userAgent", iPhoneUserAgent);
-		overrideNavigator("standalone", true);
-	};
-
 	const target = {
 		href: "/api/experimental/chats/files/file-1",
 		fileName: "01-agents-list.png",
 		mediaType: "image/png",
 	};
 
-	// jsdom does not implement object URLs, so stub them on the URL constructor.
-	const originalURLDescriptors = new Map<
-		string,
-		PropertyDescriptor | undefined
-	>();
+	const overrideNavigator = (key: string, value: unknown) => {
+		Object.defineProperty(navigator, key, { value, configurable: true });
+		overriddenNavigatorKeys.add(key);
+	};
+
+	const enterIOSStandalonePWA = () => {
+		overrideNavigator("userAgent", iPhoneUserAgent);
+		overrideNavigator("standalone", true);
+	};
+
+	const mockFileSharing = (
+		share: ReturnType<typeof vi.fn>,
+		canShare: (data: { files: File[] }) => boolean = () => true,
+	) => {
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn(canShare));
+	};
+
+	const mockAttachmentFetch = (body = "png-bytes", mediaType = "image/png") =>
+		vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(
+				new Response(new Blob([body], { type: mediaType }), { status: 200 }),
+			);
+
+	const click = (downloadTarget = target, signal?: AbortSignal) => {
+		const event = { preventDefault: vi.fn() };
+		return {
+			event,
+			pending: handleAttachmentDownloadClick(event, downloadTarget, signal),
+		};
+	};
+
 	const stubObjectURLs = () => {
 		const createObjectURL = vi.fn().mockReturnValue("blob:inline");
 		const revokeObjectURL = vi.fn();
@@ -50,12 +68,10 @@ describe("handleAttachmentDownloadClick", () => {
 			createObjectURL,
 			revokeObjectURL,
 		})) {
-			if (!originalURLDescriptors.has(key)) {
-				originalURLDescriptors.set(
-					key,
-					Object.getOwnPropertyDescriptor(URL, key),
-				);
-			}
+			originalURLDescriptors.set(
+				key,
+				Object.getOwnPropertyDescriptor(URL, key),
+			);
 			Object.defineProperty(URL, key, { value, configurable: true });
 		}
 		return { createObjectURL, revokeObjectURL };
@@ -79,51 +95,44 @@ describe("handleAttachmentDownloadClick", () => {
 		vi.mocked(toast.error).mockClear();
 	});
 
-	it("keeps the native anchor download outside iOS", () => {
+	it.each([
+		["outside iOS", () => {}],
+		[
+			"in the iOS browser",
+			() => overrideNavigator("userAgent", iPhoneUserAgent),
+		],
+	])("keeps the native anchor download %s", (_label, setup) => {
+		setup();
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		const event = { preventDefault: vi.fn() };
+		const { event, pending } = click();
 
-		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		expect(pending).toBeUndefined();
 		expect(event.preventDefault).not.toHaveBeenCalled();
 		expect(open).not.toHaveBeenCalled();
 	});
 
-	it("keeps the native anchor download in the iOS browser", () => {
-		overrideNavigator("userAgent", iPhoneUserAgent);
-		const event = { preventDefault: vi.fn() };
-
-		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
-		expect(event.preventDefault).not.toHaveBeenCalled();
-	});
-
-	it("shares the attachment via the share sheet in an iOS standalone PWA", async () => {
+	it("shares the fetched attachment in an iOS standalone PWA", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(new Blob(["png-bytes"], { type: "image/png" }), {
-				status: 200,
-			}),
-		);
-		const event = { preventDefault: vi.fn() };
+		mockFileSharing(share);
+		mockAttachmentFetch();
 
-		await handleAttachmentDownloadClick(event, target);
+		const { event, pending } = click();
+		await pending;
 
 		expect(event.preventDefault).toHaveBeenCalled();
 		expect(globalThis.fetch).toHaveBeenCalledWith(target.href, {
 			signal: undefined,
 		});
-		expect(open).not.toHaveBeenCalled();
-		expect(share).toHaveBeenCalledTimes(1);
 		const shared: { files: File[] } = share.mock.calls[0][0];
 		expect(shared.files).toHaveLength(1);
-		expect(shared.files[0].name).toBe("01-agents-list.png");
-		expect(shared.files[0].type).toBe("image/png");
+		expect(shared.files[0]).toMatchObject({
+			name: "01-agents-list.png",
+			type: "image/png",
+		});
 	});
 
-	it("intercepts on iPadOS reporting a macOS user agent", () => {
+	it("recognizes iPadOS with a macOS user agent", () => {
 		overrideNavigator(
 			"userAgent",
 			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
@@ -131,20 +140,22 @@ describe("handleAttachmentDownloadClick", () => {
 		overrideNavigator("maxTouchPoints", 5);
 		overrideNavigator("standalone", true);
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		const event = { preventDefault: vi.fn() };
 
-		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		const { event, pending } = click();
+
+		expect(pending).toBeUndefined();
 		expect(event.preventDefault).toHaveBeenCalled();
-		expect(open).toHaveBeenCalled();
+		expect(open).toHaveBeenCalledWith(target.href, "_blank", "noopener");
 	});
 
-	it("falls back to a dismissible tab when file sharing is unavailable", () => {
+	it("opens a tab synchronously when file sharing is unavailable", () => {
 		enterIOSStandalonePWA();
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
-		const event = { preventDefault: vi.fn() };
 
-		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		const { event, pending } = click();
+
+		expect(pending).toBeUndefined();
 		expect(event.preventDefault).toHaveBeenCalled();
 		expect(open).toHaveBeenCalledWith(target.href, "_blank", "noopener");
 		expect(fetchSpy).not.toHaveBeenCalled();
@@ -152,33 +163,26 @@ describe("handleAttachmentDownloadClick", () => {
 
 	it("stays quiet when the user dismisses the share sheet", async () => {
 		enterIOSStandalonePWA();
-		overrideNavigator(
-			"share",
+		mockFileSharing(
 			vi.fn().mockRejectedValue(new DOMException("canceled", "AbortError")),
 		);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(new Blob(["png-bytes"], { type: "image/png" })),
-		);
-		const event = { preventDefault: vi.fn() };
+		mockAttachmentFetch();
 
-		await handleAttachmentDownloadClick(event, target);
+		await click().pending;
 
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("shows an error toast without a late popup when the download fetch fails", async () => {
+	it("shows the fetch failure without opening a late popup", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		mockFileSharing(share);
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response("nope", { status: 503 }),
 		);
-		const event = { preventDefault: vi.fn() };
 
-		await handleAttachmentDownloadClick(event, target);
+		await click().pending;
 
 		expect(share).not.toHaveBeenCalled();
 		expect(open).not.toHaveBeenCalled();
@@ -188,7 +192,7 @@ describe("handleAttachmentDownloadClick", () => {
 		);
 	});
 
-	it("offers a fresh-gesture retry when user activation expired during the fetch", async () => {
+	it("offers a Save retry when user activation expires", async () => {
 		enterIOSStandalonePWA();
 		const share = vi
 			.fn()
@@ -196,18 +200,11 @@ describe("handleAttachmentDownloadClick", () => {
 				new DOMException("activation expired", "NotAllowedError"),
 			)
 			.mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(new Blob(["png-bytes"], { type: "image/png" })),
-		);
-		const event = { preventDefault: vi.fn() };
+		mockFileSharing(share);
+		mockAttachmentFetch();
 
-		await handleAttachmentDownloadClick(event, target);
+		await click().pending;
 
-		// DownloadInIOSStandaloneRecoversExpiredActivation covers the Save click
-		// and retry through the real toast UI.
-		expect(share).toHaveBeenCalledTimes(1);
 		expect(toast.error).toHaveBeenCalledWith(
 			"Couldn't download 01-agents-list.png",
 			expect.objectContaining({
@@ -217,110 +214,70 @@ describe("handleAttachmentDownloadClick", () => {
 		);
 	});
 
-	it("offers a tab fallback instead of a retry for permanent share failures", async () => {
+	it("offers Open after a permanent share failure", async () => {
 		enterIOSStandalonePWA();
-		overrideNavigator(
-			"share",
+		mockFileSharing(
 			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
 		);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(new Blob(["png-bytes"], { type: "image/png" })),
-		);
-		const event = { preventDefault: vi.fn() };
+		mockAttachmentFetch();
 
-		await handleAttachmentDownloadClick(event, target);
+		await click().pending;
 
-		expect(toast.error).toHaveBeenCalledTimes(1);
-		expect(vi.mocked(toast.error).mock.calls[0][1]).toEqual(
+		expect(toast.error).toHaveBeenCalledWith(
+			"Couldn't download 01-agents-list.png",
 			expect.objectContaining({
 				action: expect.objectContaining({ label: "Open" }),
 			}),
 		);
 	});
 
-	it("shares inline data: attachments without fetching", async () => {
+	it("shares inline data without fetching", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		mockFileSharing(share);
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
-		const event = { preventDefault: vi.fn() };
-		const payload = btoa("png-bytes");
 
-		await handleAttachmentDownloadClick(event, {
-			href: `data:image/png;base64,${payload}`,
+		await click({
+			href: `data:image/png;base64,${btoa("png-bytes")}`,
 			fileName: "inline.png",
 			mediaType: "image/png",
-		});
+		}).pending;
 
 		expect(fetchSpy).not.toHaveBeenCalled();
-		expect(share).toHaveBeenCalledTimes(1);
 		const shared: { files: File[] } = share.mock.calls[0][0];
-		expect(shared.files[0].name).toBe("inline.png");
-		expect(shared.files[0].type).toBe("image/png");
-		expect(shared.files[0].size).toBe("png-bytes".length);
+		expect(shared.files[0]).toMatchObject({
+			name: "inline.png",
+			type: "image/png",
+			size: "png-bytes".length,
+		});
 	});
 
-	it("offers an Open fallback for data: hrefs on permanent share failure", async () => {
+	it("opens inline data through a temporary blob URL", () => {
 		enterIOSStandalonePWA();
-		overrideNavigator(
-			"share",
-			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
-		);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		const event = { preventDefault: vi.fn() };
+		const { createObjectURL, revokeObjectURL } = stubObjectURLs();
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		vi.useFakeTimers();
 
-		await handleAttachmentDownloadClick(event, {
+		const { pending } = click({
 			href: `data:image/png;base64,${btoa("png-bytes")}`,
 			fileName: "inline.png",
 			mediaType: "image/png",
 		});
 
-		// Clicking Open in the rendered toast is exercised in Storybook
-		// (DownloadInIOSStandaloneOpensInlineAttachmentFromToast).
-		expect(toast.error).toHaveBeenCalledWith(
-			"Couldn't download inline.png",
-			expect.objectContaining({
-				action: expect.objectContaining({ label: "Open" }),
-			}),
-		);
-	});
-
-	it("opens inline attachments through a blob tab when file sharing is unavailable", () => {
-		enterIOSStandalonePWA();
-		const { createObjectURL, revokeObjectURL } = stubObjectURLs();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		const fetchSpy = vi.spyOn(globalThis, "fetch");
-		vi.useFakeTimers();
-		const event = { preventDefault: vi.fn() };
-
-		expect(
-			handleAttachmentDownloadClick(event, {
-				href: `data:image/png;base64,${btoa("png-bytes")}`,
-				fileName: "inline.png",
-				mediaType: "image/png",
-			}),
-		).toBeUndefined();
-
-		expect(event.preventDefault).toHaveBeenCalled();
-		expect(fetchSpy).not.toHaveBeenCalled();
-		expect(createObjectURL).toHaveBeenCalledTimes(1);
+		expect(pending).toBeUndefined();
 		const decoded: File = createObjectURL.mock.calls[0][0];
-		expect(decoded.name).toBe("inline.png");
-		expect(decoded.type).toBe("image/png");
+		expect(decoded).toMatchObject({ name: "inline.png", type: "image/png" });
 		expect(open).toHaveBeenCalledWith("blob:inline", "_blank", "noopener");
 		vi.runAllTimers();
 		expect(revokeObjectURL).toHaveBeenCalledWith("blob:inline");
 	});
 
-	it("shows a decode error instead of a tab when undecodable inline data cannot be shared", () => {
+	it("shows a decode error for corrupt inline data", () => {
 		enterIOSStandalonePWA();
 		stubObjectURLs();
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		const event = { preventDefault: vi.fn() };
 
-		handleAttachmentDownloadClick(event, {
+		click({
 			href: "data:image/png;base64,%%%",
 			fileName: "inline.png",
 			mediaType: "image/png",
@@ -332,11 +289,10 @@ describe("handleAttachmentDownloadClick", () => {
 		});
 	});
 
-	it("stays quiet when the download is aborted mid-fetch", async () => {
+	it("passes the abort signal through the fetch and suppresses abort UI", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		mockFileSharing(share);
 		vi.spyOn(globalThis, "fetch").mockImplementation(
 			(_input, init) =>
 				new Promise((_resolve, reject) => {
@@ -346,13 +302,8 @@ describe("handleAttachmentDownloadClick", () => {
 				}),
 		);
 		const controller = new AbortController();
-		const event = { preventDefault: vi.fn() };
 
-		const pending = handleAttachmentDownloadClick(
-			event,
-			target,
-			controller.signal,
-		);
+		const { pending } = click(target, controller.signal);
 		controller.abort();
 		await pending;
 
@@ -360,65 +311,46 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("suppresses the share sheet when aborted after the fetch resolves", async () => {
+	it("suppresses sharing when unmounted after the fetch resolves", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		mockFileSharing(share);
 		const controller = new AbortController();
 		vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
 			controller.abort();
-			return new Response(new Blob(["png-bytes"], { type: "image/png" }), {
-				status: 200,
-			});
+			return new Response(new Blob(["png-bytes"], { type: "image/png" }));
 		});
-		const event = { preventDefault: vi.fn() };
 
-		await handleAttachmentDownloadClick(event, target, controller.signal);
+		await click(target, controller.signal).pending;
 
 		expect(share).not.toHaveBeenCalled();
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("suppresses share rejection UI when aborted while the sheet is pending", async () => {
+	it("suppresses share rejection UI after unmount", async () => {
 		enterIOSStandalonePWA();
 		const controller = new AbortController();
 		const share = vi.fn().mockImplementation(() => {
 			controller.abort();
 			return Promise.reject(new DOMException("expired", "NotAllowedError"));
 		});
-		overrideNavigator("share", share);
-		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(new Blob(["png-bytes"], { type: "image/png" }), {
-				status: 200,
-			}),
-		);
-		const event = { preventDefault: vi.fn() };
+		mockFileSharing(share);
+		mockAttachmentFetch();
 
-		await handleAttachmentDownloadClick(event, target, controller.signal);
+		await click(target, controller.signal).pending;
 
 		expect(share).toHaveBeenCalledTimes(1);
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("offers a tab fallback when the fetched file turns out unshareable", async () => {
+	it("offers Open when the fetched file cannot be shared", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
-		overrideNavigator("share", share);
-		overrideNavigator(
-			"canShare",
-			vi
-				.fn<(data: { files: File[] }) => boolean>()
-				.mockImplementation(({ files }) => files[0].size <= 1),
-		);
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(new Blob(["png-bytes"], { type: "image/png" })),
-		);
+		mockFileSharing(share, ({ files }) => files[0].size <= 1);
+		mockAttachmentFetch();
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		const event = { preventDefault: vi.fn() };
 
-		await handleAttachmentDownloadClick(event, target);
+		await click().pending;
 
 		expect(share).not.toHaveBeenCalled();
 		expect(open).not.toHaveBeenCalled();

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -171,6 +171,10 @@ describe("handleAttachmentDownloadClick", () => {
 
 		await handleAttachmentDownloadClick(event, target);
 
+		// Clicking the rendered Save button and verifying the second share
+		// attempt is covered by the DownloadInIOSStandaloneRecoversExpiredActivation
+		// Storybook interaction, which exercises the real toast UI.
+		expect(share).toHaveBeenCalledTimes(1);
 		expect(toast.error).toHaveBeenCalledWith(
 			"Couldn't download 01-agents-list.png",
 			expect.objectContaining({
@@ -178,16 +182,6 @@ describe("handleAttachmentDownloadClick", () => {
 				action: expect.objectContaining({ label: "Save" }),
 			}),
 		);
-		const action = vi.mocked(toast.error).mock.calls[0][1]?.action;
-		if (!action || typeof action !== "object" || !("onClick" in action)) {
-			throw new Error("expected the toast to carry a retry action");
-		}
-		// The handler ignores the click event, so an empty stand-in works.
-		action.onClick({} as React.MouseEvent<HTMLButtonElement, MouseEvent>);
-		expect(share).toHaveBeenCalledTimes(2);
-		expect(share).toHaveBeenLastCalledWith({
-			files: [expect.objectContaining({ name: "01-agents-list.png" })],
-		});
 	});
 
 	it("reports permanent share failures without a retry action", async () => {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -260,16 +260,13 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(shared.files[0].size).toBe("png-bytes".length);
 	});
 
-	it("offers a blob-backed Open fallback for data: hrefs on permanent share failure", async () => {
+	it("offers an Open fallback for data: hrefs on permanent share failure", async () => {
 		enterIOSStandalonePWA();
 		overrideNavigator(
 			"share",
 			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
 		);
 		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
-		const { createObjectURL, revokeObjectURL } = stubObjectURLs();
-		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		vi.useFakeTimers();
 		const event = { preventDefault: vi.fn() };
 
 		await handleAttachmentDownloadClick(event, {
@@ -278,17 +275,14 @@ describe("handleAttachmentDownloadClick", () => {
 			mediaType: "image/png",
 		});
 
-		expect(toast.error).toHaveBeenCalledTimes(1);
-		const options = vi.mocked(toast.error).mock.calls[0][1] as {
-			action: { label: string; onClick: () => void };
-		};
-		expect(options.action.label).toBe("Open");
-		options.action.onClick();
-		expect(createObjectURL).toHaveBeenCalledTimes(1);
-		expect(createObjectURL.mock.calls[0][0]).toBeInstanceOf(File);
-		expect(open).toHaveBeenCalledWith("blob:inline", "_blank", "noopener");
-		vi.runAllTimers();
-		expect(revokeObjectURL).toHaveBeenCalledWith("blob:inline");
+		// Clicking Open in the rendered toast is exercised in Storybook
+		// (DownloadInIOSStandaloneOpensInlineAttachmentFromToast).
+		expect(toast.error).toHaveBeenCalledWith(
+			"Couldn't download inline.png",
+			expect.objectContaining({
+				action: expect.objectContaining({ label: "Open" }),
+			}),
+		);
 	});
 
 	it("opens inline attachments through a blob tab when file sharing is unavailable", () => {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -154,6 +154,42 @@ describe("handleAttachmentDownloadClick", () => {
 		);
 	});
 
+	it("offers a fresh-gesture retry when user activation expired during the fetch", async () => {
+		enterIOSStandalonePWA();
+		const share = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new DOMException("activation expired", "NotAllowedError"),
+			)
+			.mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Blob(["png-bytes"], { type: "image/png" })),
+		);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			"Couldn't download 01-agents-list.png",
+			expect.objectContaining({
+				description: "The file is ready to save.",
+				action: expect.objectContaining({ label: "Save" }),
+			}),
+		);
+		const action = vi.mocked(toast.error).mock.calls[0][1]?.action;
+		if (!action || typeof action !== "object" || !("onClick" in action)) {
+			throw new Error("expected the toast to carry a retry action");
+		}
+		// The handler ignores the click event, so an empty stand-in works.
+		action.onClick({} as React.MouseEvent<HTMLButtonElement, MouseEvent>);
+		expect(share).toHaveBeenCalledTimes(2);
+		expect(share).toHaveBeenLastCalledWith({
+			files: [expect.objectContaining({ name: "01-agents-list.png" })],
+		});
+	});
+
 	it("skips sharing when the fetched file turns out unshareable", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -190,6 +190,26 @@ describe("handleAttachmentDownloadClick", () => {
 		});
 	});
 
+	it("reports permanent share failures without a retry action", async () => {
+		enterIOSStandalonePWA();
+		overrideNavigator(
+			"share",
+			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
+		);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Blob(["png-bytes"], { type: "image/png" })),
+		);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target);
+
+		expect(toast.error).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(toast.error).mock.calls[0][1]).not.toHaveProperty(
+			"action",
+		);
+	});
+
 	it("skips sharing when the fetched file turns out unshareable", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -9,7 +9,7 @@ import {
 describe("handleAttachmentDownloadClick", () => {
 	const overriddenNavigatorKeys = new Set<string>();
 	const overrideNavigator = (key: string, value: unknown) => {
-		Object.defineProperty(window.navigator, key, {
+		Object.defineProperty(navigator, key, {
 			value,
 			configurable: true,
 		});
@@ -32,7 +32,7 @@ describe("handleAttachmentDownloadClick", () => {
 
 	afterEach(() => {
 		for (const key of overriddenNavigatorKeys) {
-			Reflect.deleteProperty(window.navigator, key);
+			Reflect.deleteProperty(navigator, key);
 		}
 		overriddenNavigatorKeys.clear();
 		vi.restoreAllMocks();

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -311,14 +311,29 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("suppresses sharing when unmounted after the fetch resolves", async () => {
+	it.each([
+		["the fetch resolves", false, 200],
+		["an HTTP error resolves", false, 503],
+		["the response body resolves", true, 200],
+	])("suppresses UI after unmount when %s", async (_label, abortInBlob, status) => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
 		mockFileSharing(share);
 		const controller = new AbortController();
 		vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-			controller.abort();
-			return new Response(new Blob(["png-bytes"], { type: "image/png" }));
+			const response = new Response(
+				new Blob(["png-bytes"], { type: "image/png" }),
+				{ status },
+			);
+			if (abortInBlob) {
+				vi.spyOn(response, "blob").mockImplementation(async () => {
+					controller.abort();
+					return new Blob(["png-bytes"], { type: "image/png" });
+				});
+			} else {
+				controller.abort();
+			}
+			return response;
 		});
 
 		await click(target, controller.signal).pending;

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+	toast: {
+		error: vi.fn(),
+	},
+}));
+
+import { toast } from "sonner";
 import {
 	handleAttachmentDownloadClick,
 	isChatAttachmentFile,
@@ -36,6 +44,7 @@ describe("handleAttachmentDownloadClick", () => {
 		}
 		overriddenNavigatorKeys.clear();
 		vi.restoreAllMocks();
+		vi.mocked(toast.error).mockClear();
 	});
 
 	it("keeps the native anchor download outside iOS", () => {
@@ -117,15 +126,14 @@ describe("handleAttachmentDownloadClick", () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(new Blob(["png-bytes"], { type: "image/png" })),
 		);
-		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 		const event = { preventDefault: vi.fn() };
 
 		await handleAttachmentDownloadClick(event, target);
 
-		expect(warn).not.toHaveBeenCalled();
+		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	it("warns without a late popup when the download fetch fails", async () => {
+	it("shows an error toast without a late popup when the download fetch fails", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
 		overrideNavigator("share", share);
@@ -134,14 +142,16 @@ describe("handleAttachmentDownloadClick", () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response("nope", { status: 503 }),
 		);
-		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 		const event = { preventDefault: vi.fn() };
 
 		await handleAttachmentDownloadClick(event, target);
 
 		expect(share).not.toHaveBeenCalled();
 		expect(open).not.toHaveBeenCalled();
-		expect(warn).toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith(
+			"Couldn't download 01-agents-list.png",
+			{ description: "HTTP 503" },
+		);
 	});
 
 	it("skips sharing when the fetched file turns out unshareable", async () => {
@@ -157,13 +167,15 @@ describe("handleAttachmentDownloadClick", () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(new Blob(["png-bytes"], { type: "image/png" })),
 		);
-		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 		const event = { preventDefault: vi.fn() };
 
 		await handleAttachmentDownloadClick(event, target);
 
 		expect(share).not.toHaveBeenCalled();
-		expect(warn).toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith(
+			"Couldn't download 01-agents-list.png",
+			{ description: "This file cannot be shared on this device." },
+		);
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -183,7 +183,7 @@ describe("handleAttachmentDownloadClick", () => {
 		);
 	});
 
-	it("reports permanent share failures without a retry action", async () => {
+	it("offers a tab fallback instead of a retry for permanent share failures", async () => {
 		enterIOSStandalonePWA();
 		overrideNavigator(
 			"share",
@@ -198,8 +198,54 @@ describe("handleAttachmentDownloadClick", () => {
 		await handleAttachmentDownloadClick(event, target);
 
 		expect(toast.error).toHaveBeenCalledTimes(1);
-		expect(vi.mocked(toast.error).mock.calls[0][1]).not.toHaveProperty(
-			"action",
+		expect(vi.mocked(toast.error).mock.calls[0][1]).toEqual(
+			expect.objectContaining({
+				action: expect.objectContaining({ label: "Open" }),
+			}),
+		);
+	});
+
+	it("shares inline data: attachments without fetching", async () => {
+		enterIOSStandalonePWA();
+		const share = vi.fn().mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const event = { preventDefault: vi.fn() };
+		const payload = btoa("png-bytes");
+
+		await handleAttachmentDownloadClick(event, {
+			href: `data:image/png;base64,${payload}`,
+			fileName: "inline.png",
+			mediaType: "image/png",
+		});
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(share).toHaveBeenCalledTimes(1);
+		const shared: { files: File[] } = share.mock.calls[0][0];
+		expect(shared.files[0].name).toBe("inline.png");
+		expect(shared.files[0].type).toBe("image/png");
+		expect(shared.files[0].size).toBe("png-bytes".length);
+	});
+
+	it("keeps permanent share failure toasts for data: hrefs action-free", async () => {
+		enterIOSStandalonePWA();
+		overrideNavigator(
+			"share",
+			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
+		);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, {
+			href: `data:image/png;base64,${btoa("png-bytes")}`,
+			fileName: "inline.png",
+			mediaType: "image/png",
+		});
+
+		expect(toast.error).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(toast.error).mock.calls[0][1]).toEqual(
+			expect.objectContaining({ action: undefined }),
 		);
 	});
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -171,9 +171,8 @@ describe("handleAttachmentDownloadClick", () => {
 
 		await handleAttachmentDownloadClick(event, target);
 
-		// Clicking the rendered Save button and verifying the second share
-		// attempt is covered by the DownloadInIOSStandaloneRecoversExpiredActivation
-		// Storybook interaction, which exercises the real toast UI.
+		// DownloadInIOSStandaloneRecoversExpiredActivation covers the Save click
+		// and retry through the real toast UI.
 		expect(share).toHaveBeenCalledTimes(1);
 		expect(toast.error).toHaveBeenCalledWith(
 			"Couldn't download 01-agents-list.png",

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -203,7 +203,7 @@ describe("handleAttachmentDownloadClick", () => {
 		);
 	});
 
-	it("skips sharing when the fetched file turns out unshareable", async () => {
+	it("offers a tab fallback when the fetched file turns out unshareable", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);
 		overrideNavigator("share", share);
@@ -216,14 +216,19 @@ describe("handleAttachmentDownloadClick", () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(new Blob(["png-bytes"], { type: "image/png" })),
 		);
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		const event = { preventDefault: vi.fn() };
 
 		await handleAttachmentDownloadClick(event, target);
 
 		expect(share).not.toHaveBeenCalled();
+		expect(open).not.toHaveBeenCalled();
 		expect(toast.error).toHaveBeenCalledWith(
 			"Couldn't download 01-agents-list.png",
-			{ description: "This file cannot be shared on this device." },
+			expect.objectContaining({
+				description: "This file cannot be shared on this device.",
+				action: expect.objectContaining({ label: "Open" }),
+			}),
 		);
 	});
 });

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -1,9 +1,171 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	handleAttachmentDownloadClick,
 	isChatAttachmentFile,
 	renameChatFileForUpload,
 	sanitizeChatFileName,
 } from "./chatAttachments";
+
+describe("handleAttachmentDownloadClick", () => {
+	const overriddenNavigatorKeys = new Set<string>();
+	const overrideNavigator = (key: string, value: unknown) => {
+		Object.defineProperty(window.navigator, key, {
+			value,
+			configurable: true,
+		});
+		overriddenNavigatorKeys.add(key);
+	};
+
+	const iPhoneUserAgent =
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+
+	const enterIOSStandalonePWA = () => {
+		overrideNavigator("userAgent", iPhoneUserAgent);
+		overrideNavigator("standalone", true);
+	};
+
+	const target = {
+		href: "/api/experimental/chats/files/file-1",
+		fileName: "01-agents-list.png",
+		mediaType: "image/png",
+	};
+
+	afterEach(() => {
+		for (const key of overriddenNavigatorKeys) {
+			Reflect.deleteProperty(window.navigator, key);
+		}
+		overriddenNavigatorKeys.clear();
+		vi.restoreAllMocks();
+	});
+
+	it("keeps the native anchor download outside iOS", () => {
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const event = { preventDefault: vi.fn() };
+
+		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(open).not.toHaveBeenCalled();
+	});
+
+	it("keeps the native anchor download in the iOS browser", () => {
+		overrideNavigator("userAgent", iPhoneUserAgent);
+		const event = { preventDefault: vi.fn() };
+
+		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		expect(event.preventDefault).not.toHaveBeenCalled();
+	});
+
+	it("shares the attachment via the share sheet in an iOS standalone PWA", async () => {
+		enterIOSStandalonePWA();
+		const share = vi.fn().mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Blob(["png-bytes"], { type: "image/png" }), {
+				status: 200,
+			}),
+		);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target);
+
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(globalThis.fetch).toHaveBeenCalledWith(target.href);
+		expect(open).not.toHaveBeenCalled();
+		expect(share).toHaveBeenCalledTimes(1);
+		const shared: { files: File[] } = share.mock.calls[0][0];
+		expect(shared.files).toHaveLength(1);
+		expect(shared.files[0].name).toBe("01-agents-list.png");
+		expect(shared.files[0].type).toBe("image/png");
+	});
+
+	it("intercepts on iPadOS reporting a macOS user agent", () => {
+		overrideNavigator(
+			"userAgent",
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+		);
+		overrideNavigator("maxTouchPoints", 5);
+		overrideNavigator("standalone", true);
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const event = { preventDefault: vi.fn() };
+
+		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(open).toHaveBeenCalled();
+	});
+
+	it("falls back to a dismissible tab when file sharing is unavailable", () => {
+		enterIOSStandalonePWA();
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const event = { preventDefault: vi.fn() };
+
+		expect(handleAttachmentDownloadClick(event, target)).toBeUndefined();
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(open).toHaveBeenCalledWith(target.href, "_blank", "noopener");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("stays quiet when the user dismisses the share sheet", async () => {
+		enterIOSStandalonePWA();
+		overrideNavigator(
+			"share",
+			vi.fn().mockRejectedValue(new DOMException("canceled", "AbortError")),
+		);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Blob(["png-bytes"], { type: "image/png" })),
+		);
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target);
+
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("warns without a late popup when the download fetch fails", async () => {
+		enterIOSStandalonePWA();
+		const share = vi.fn().mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("nope", { status: 503 }),
+		);
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target);
+
+		expect(share).not.toHaveBeenCalled();
+		expect(open).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalled();
+	});
+
+	it("skips sharing when the fetched file turns out unshareable", async () => {
+		enterIOSStandalonePWA();
+		const share = vi.fn().mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator(
+			"canShare",
+			vi
+				.fn<(data: { files: File[] }) => boolean>()
+				.mockImplementation(({ files }) => files[0].size <= 1),
+		);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Blob(["png-bytes"], { type: "image/png" })),
+		);
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target);
+
+		expect(share).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalled();
+	});
+});
 
 describe("isChatAttachmentFile", () => {
 	it("accepts allowlisted MIME types", () => {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -38,11 +38,43 @@ describe("handleAttachmentDownloadClick", () => {
 		mediaType: "image/png",
 	};
 
+	// jsdom does not implement object URLs, so stub them on the URL constructor.
+	const originalURLDescriptors = new Map<
+		string,
+		PropertyDescriptor | undefined
+	>();
+	const stubObjectURLs = () => {
+		const createObjectURL = vi.fn().mockReturnValue("blob:inline");
+		const revokeObjectURL = vi.fn();
+		for (const [key, value] of Object.entries({
+			createObjectURL,
+			revokeObjectURL,
+		})) {
+			if (!originalURLDescriptors.has(key)) {
+				originalURLDescriptors.set(
+					key,
+					Object.getOwnPropertyDescriptor(URL, key),
+				);
+			}
+			Object.defineProperty(URL, key, { value, configurable: true });
+		}
+		return { createObjectURL, revokeObjectURL };
+	};
+
 	afterEach(() => {
 		for (const key of overriddenNavigatorKeys) {
 			Reflect.deleteProperty(navigator, key);
 		}
 		overriddenNavigatorKeys.clear();
+		for (const [key, descriptor] of originalURLDescriptors) {
+			if (descriptor) {
+				Object.defineProperty(URL, key, descriptor);
+			} else {
+				Reflect.deleteProperty(URL, key);
+			}
+		}
+		originalURLDescriptors.clear();
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 		vi.mocked(toast.error).mockClear();
 	});
@@ -228,13 +260,16 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(shared.files[0].size).toBe("png-bytes".length);
 	});
 
-	it("keeps permanent share failure toasts for data: hrefs action-free", async () => {
+	it("offers a blob-backed Open fallback for data: hrefs on permanent share failure", async () => {
 		enterIOSStandalonePWA();
 		overrideNavigator(
 			"share",
 			vi.fn().mockRejectedValue(new DOMException("share failed", "DataError")),
 		);
 		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		const { createObjectURL, revokeObjectURL } = stubObjectURLs();
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		vi.useFakeTimers();
 		const event = { preventDefault: vi.fn() };
 
 		await handleAttachmentDownloadClick(event, {
@@ -244,9 +279,61 @@ describe("handleAttachmentDownloadClick", () => {
 		});
 
 		expect(toast.error).toHaveBeenCalledTimes(1);
-		expect(vi.mocked(toast.error).mock.calls[0][1]).toEqual(
-			expect.objectContaining({ action: undefined }),
-		);
+		const options = vi.mocked(toast.error).mock.calls[0][1] as {
+			action: { label: string; onClick: () => void };
+		};
+		expect(options.action.label).toBe("Open");
+		options.action.onClick();
+		expect(createObjectURL).toHaveBeenCalledTimes(1);
+		expect(createObjectURL.mock.calls[0][0]).toBeInstanceOf(File);
+		expect(open).toHaveBeenCalledWith("blob:inline", "_blank", "noopener");
+		vi.runAllTimers();
+		expect(revokeObjectURL).toHaveBeenCalledWith("blob:inline");
+	});
+
+	it("opens inline attachments through a blob tab when file sharing is unavailable", () => {
+		enterIOSStandalonePWA();
+		const { createObjectURL, revokeObjectURL } = stubObjectURLs();
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		vi.useFakeTimers();
+		const event = { preventDefault: vi.fn() };
+
+		expect(
+			handleAttachmentDownloadClick(event, {
+				href: `data:image/png;base64,${btoa("png-bytes")}`,
+				fileName: "inline.png",
+				mediaType: "image/png",
+			}),
+		).toBeUndefined();
+
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(createObjectURL).toHaveBeenCalledTimes(1);
+		const decoded: File = createObjectURL.mock.calls[0][0];
+		expect(decoded.name).toBe("inline.png");
+		expect(decoded.type).toBe("image/png");
+		expect(open).toHaveBeenCalledWith("blob:inline", "_blank", "noopener");
+		vi.runAllTimers();
+		expect(revokeObjectURL).toHaveBeenCalledWith("blob:inline");
+	});
+
+	it("shows a decode error instead of a tab when undecodable inline data cannot be shared", () => {
+		enterIOSStandalonePWA();
+		stubObjectURLs();
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const event = { preventDefault: vi.fn() };
+
+		handleAttachmentDownloadClick(event, {
+			href: "data:image/png;base64,%%%",
+			fileName: "inline.png",
+			mediaType: "image/png",
+		});
+
+		expect(open).not.toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith("Couldn't download inline.png", {
+			description: "The attachment data could not be decoded.",
+		});
 	});
 
 	it("offers a tab fallback when the fetched file turns out unshareable", async () => {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -380,6 +380,28 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
+	it("suppresses share rejection UI when aborted while the sheet is pending", async () => {
+		enterIOSStandalonePWA();
+		const controller = new AbortController();
+		const share = vi.fn().mockImplementation(() => {
+			controller.abort();
+			return Promise.reject(new DOMException("expired", "NotAllowedError"));
+		});
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Blob(["png-bytes"], { type: "image/png" }), {
+				status: 200,
+			}),
+		);
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target, controller.signal);
+
+		expect(share).toHaveBeenCalledTimes(1);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
 	it("offers a tab fallback when the fetched file turns out unshareable", async () => {
 		enterIOSStandalonePWA();
 		const share = vi.fn().mockResolvedValue(undefined);

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -112,7 +112,9 @@ describe("handleAttachmentDownloadClick", () => {
 		await handleAttachmentDownloadClick(event, target);
 
 		expect(event.preventDefault).toHaveBeenCalled();
-		expect(globalThis.fetch).toHaveBeenCalledWith(target.href);
+		expect(globalThis.fetch).toHaveBeenCalledWith(target.href, {
+			signal: undefined,
+		});
 		expect(open).not.toHaveBeenCalled();
 		expect(share).toHaveBeenCalledTimes(1);
 		const shared: { files: File[] } = share.mock.calls[0][0];
@@ -328,6 +330,54 @@ describe("handleAttachmentDownloadClick", () => {
 		expect(toast.error).toHaveBeenCalledWith("Couldn't download inline.png", {
 			description: "The attachment data could not be decoded.",
 		});
+	});
+
+	it("stays quiet when the download is aborted mid-fetch", async () => {
+		enterIOSStandalonePWA();
+		const share = vi.fn().mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			(_input, init) =>
+				new Promise((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () =>
+						reject(new DOMException("aborted", "AbortError")),
+					);
+				}),
+		);
+		const controller = new AbortController();
+		const event = { preventDefault: vi.fn() };
+
+		const pending = handleAttachmentDownloadClick(
+			event,
+			target,
+			controller.signal,
+		);
+		controller.abort();
+		await pending;
+
+		expect(share).not.toHaveBeenCalled();
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it("suppresses the share sheet when aborted after the fetch resolves", async () => {
+		enterIOSStandalonePWA();
+		const share = vi.fn().mockResolvedValue(undefined);
+		overrideNavigator("share", share);
+		overrideNavigator("canShare", vi.fn().mockReturnValue(true));
+		const controller = new AbortController();
+		vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+			controller.abort();
+			return new Response(new Blob(["png-bytes"], { type: "image/png" }), {
+				status: 200,
+			});
+		});
+		const event = { preventDefault: vi.fn() };
+
+		await handleAttachmentDownloadClick(event, target, controller.signal);
+
+		expect(share).not.toHaveBeenCalled();
+		expect(toast.error).not.toHaveBeenCalled();
 	});
 
 	it("offers a tab fallback when the fetched file turns out unshareable", async () => {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -126,8 +126,8 @@ const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 			return;
 		}
 		if (errorHasName(error, "NotAllowedError")) {
-			// A slow fetch consumes the click's transient activation; the
-			// toast click provides the fresh gesture the retry needs.
+			// Fetching may outlast transient user activation. The toast action
+			// supplies a fresh gesture for the retry.
 			showDownloadFailure(fileName, {
 				description: "The file is ready to save.",
 				action: {
@@ -180,10 +180,8 @@ const shareAttachmentFile = async (
 };
 
 /**
- * Avoids iOS standalone PWA QuickLook, which can leave no way back to the
- * app, by routing the download through the share sheet. Everywhere else,
- * and on iOS devices without file sharing, the native anchor download
- * proceeds.
+ * Uses the share sheet in iOS standalone mode to avoid a QuickLook navigation
+ * with no reliable return path. Otherwise, the native anchor handles the download.
  */
 export const handleAttachmentDownloadClick = (
 	event: { preventDefault: () => void },

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -83,7 +83,7 @@ const canShareFile = (file: File): boolean =>
 	typeof navigator.canShare === "function" &&
 	navigator.canShare({ files: [file] });
 
-export type AttachmentDownloadTarget = {
+type AttachmentDownloadTarget = {
 	href: string;
 	fileName: string;
 	mediaType: string;
@@ -105,23 +105,6 @@ const showDownloadFailure = (
 	toast.error(`Couldn't download ${fileName}`, options);
 };
 
-// iOS blocks top-level data: navigation, so inline attachments open through
-// a short-lived blob URL instead of their data: href.
-const openAttachmentInTab = (href: string, file: File): void => {
-	if (!href.startsWith("data:")) {
-		open(href, "_blank", "noopener");
-		return;
-	}
-	const blobUrl = URL.createObjectURL(file);
-	open(blobUrl, "_blank", "noopener");
-	setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
-};
-
-const openFallbackAction = (target: AttachmentDownloadTarget, file: File) => ({
-	label: "Open",
-	onClick: () => openAttachmentInTab(target.href, file),
-});
-
 // Production CSP excludes data: from connect-src, so inline hrefs are
 // decoded locally instead.
 const fileFromDataURL = ({
@@ -137,34 +120,30 @@ const fileFromDataURL = ({
 		: null;
 };
 
-const shareFileViaSheet = (
-	file: File,
-	target: AttachmentDownloadTarget,
-	signal?: AbortSignal,
-): Promise<void> =>
+const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 	navigator.share({ files: [file] }).catch((error: unknown) => {
-		if (errorHasName(error, "AbortError") || signal?.aborted) {
+		if (errorHasName(error, "AbortError")) {
 			return;
 		}
 		if (errorHasName(error, "NotAllowedError")) {
-			showDownloadFailure(target.fileName, {
+			// A slow fetch consumes the click's transient activation; the
+			// toast click provides the fresh gesture the retry needs.
+			showDownloadFailure(fileName, {
 				description: "The file is ready to save.",
 				action: {
 					label: "Save",
-					onClick: () => void shareFileViaSheet(file, target),
+					onClick: () => void shareFileViaSheet(file, fileName),
 				},
 			});
 			return;
 		}
-		showDownloadFailure(target.fileName, {
+		showDownloadFailure(fileName, {
 			description: error instanceof Error ? error.message : undefined,
-			action: openFallbackAction(target, file),
 		});
 	});
 
 const shareAttachmentFile = async (
 	target: AttachmentDownloadTarget,
-	signal?: AbortSignal,
 ): Promise<void> => {
 	let file: File;
 	if (target.href.startsWith("data:")) {
@@ -178,10 +157,7 @@ const shareAttachmentFile = async (
 		file = decoded;
 	} else {
 		try {
-			const response = await fetch(target.href, { signal });
-			if (signal?.aborted) {
-				return;
-			}
+			const response = await fetch(target.href);
 			if (!response.ok) {
 				throw new Error(
 					response.statusText
@@ -194,58 +170,34 @@ const shareAttachmentFile = async (
 				type: blob.type || target.mediaType || "application/octet-stream",
 			});
 		} catch (error) {
-			if (errorHasName(error, "AbortError")) {
-				return;
-			}
 			showDownloadFailure(target.fileName, {
 				description: error instanceof Error ? error.message : undefined,
 			});
 			return;
 		}
 	}
-	if (signal?.aborted) {
-		return;
-	}
-	if (!canShareFile(file)) {
-		showDownloadFailure(target.fileName, {
-			description: "This file cannot be shared on this device.",
-			action: openFallbackAction(target, file),
-		});
-		return;
-	}
-	await shareFileViaSheet(file, target, signal);
+	await shareFileViaSheet(file, target.fileName);
 };
 
 /**
- * Avoids iOS standalone PWA QuickLook, which can leave no way back to the app.
- * Uses the share sheet when possible, or a dismissible tab when file sharing
- * is unavailable. Other environments keep native download behavior.
+ * Avoids iOS standalone PWA QuickLook, which can leave no way back to the
+ * app, by routing the download through the share sheet. Everywhere else,
+ * and on iOS devices without file sharing, the native anchor download
+ * proceeds.
  */
 export const handleAttachmentDownloadClick = (
 	event: { preventDefault: () => void },
 	target: AttachmentDownloadTarget,
-	signal?: AbortSignal,
 ): Promise<void> | undefined => {
 	if (!isIOS() || !isStandaloneDisplayMode()) {
 		return undefined;
 	}
-	event.preventDefault();
 	const probe = new File(["0"], target.fileName, { type: target.mediaType });
-	if (canShareFile(probe)) {
-		return shareAttachmentFile(target, signal);
+	if (!canShareFile(probe)) {
+		return undefined;
 	}
-	// Open the fallback tab during the click gesture to satisfy popup blockers.
-	const file = target.href.startsWith("data:")
-		? fileFromDataURL(target)
-		: probe;
-	if (file) {
-		openAttachmentInTab(target.href, file);
-	} else {
-		showDownloadFailure(target.fileName, {
-			description: "The attachment data could not be decoded.",
-		});
-	}
-	return undefined;
+	event.preventDefault();
+	return shareAttachmentFile(target);
 };
 
 // Filename extensions to list in the file-picker's `accept` attribute

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -89,12 +89,6 @@ type AttachmentDownloadTarget = {
 	mediaType: string;
 };
 
-const errorHasName = (error: unknown, name: string): boolean =>
-	typeof error === "object" &&
-	error !== null &&
-	"name" in error &&
-	error.name === name;
-
 const showDownloadFailure = (
 	fileName: string,
 	options: {
@@ -105,8 +99,6 @@ const showDownloadFailure = (
 	toast.error(`Couldn't download ${fileName}`, options);
 };
 
-// Production CSP excludes data: from connect-src, so inline hrefs are
-// decoded locally instead.
 const fileFromDataURL = ({
 	href,
 	fileName,
@@ -122,10 +114,10 @@ const fileFromDataURL = ({
 
 const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 	navigator.share({ files: [file] }).catch((error: unknown) => {
-		if (errorHasName(error, "AbortError")) {
+		if (error instanceof DOMException && error.name === "AbortError") {
 			return;
 		}
-		if (errorHasName(error, "NotAllowedError")) {
+		if (error instanceof DOMException && error.name === "NotAllowedError") {
 			// Fetching may outlast transient user activation. The toast action
 			// supplies a fresh gesture for the retry.
 			showDownloadFailure(fileName, {

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import { isApiErrorResponse } from "#/api/errors";
+import { getErrorMessage, isApiErrorResponse } from "#/api/errors";
 import { ChatAttachmentMediaTypes } from "#/api/typesGenerated";
 import { decodeDataURL } from "./dataUrls";
 
@@ -89,16 +89,6 @@ type AttachmentDownloadTarget = {
 	mediaType: string;
 };
 
-const showDownloadFailure = (
-	fileName: string,
-	options: {
-		description?: string;
-		action?: { label: string; onClick: () => void };
-	},
-): void => {
-	toast.error(`Couldn't download ${fileName}`, options);
-};
-
 const fileFromDataURL = ({
 	href,
 	fileName,
@@ -120,7 +110,7 @@ const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 		if (error instanceof DOMException && error.name === "NotAllowedError") {
 			// Fetching may outlast transient user activation. The toast action
 			// supplies a fresh gesture for the retry.
-			showDownloadFailure(fileName, {
+			toast.error(`Couldn't download ${fileName}`, {
 				description: "The file is ready to save.",
 				action: {
 					label: "Save",
@@ -129,8 +119,8 @@ const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 			});
 			return;
 		}
-		showDownloadFailure(fileName, {
-			description: error instanceof Error ? error.message : undefined,
+		toast.error(`Couldn't download ${fileName}`, {
+			description: getErrorMessage(error, "Sharing failed."),
 		});
 	});
 
@@ -141,7 +131,7 @@ const shareAttachmentFile = async (
 	if (target.href.startsWith("data:")) {
 		const decoded = fileFromDataURL(target);
 		if (!decoded) {
-			showDownloadFailure(target.fileName, {
+			toast.error(`Couldn't download ${target.fileName}`, {
 				description: "The attachment data could not be decoded.",
 			});
 			return;
@@ -162,8 +152,8 @@ const shareAttachmentFile = async (
 				type: blob.type || target.mediaType || "application/octet-stream",
 			});
 		} catch (error) {
-			showDownloadFailure(target.fileName, {
-				description: error instanceof Error ? error.message : undefined,
+			toast.error(`Couldn't download ${target.fileName}`, {
+				description: getErrorMessage(error, "The file could not be fetched."),
 			});
 			return;
 		}

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -124,8 +124,8 @@ const openFallbackAction = (target: AttachmentDownloadTarget, file: File) => ({
 	onClick: () => openAttachmentInTab(target.href, file),
 });
 
-// Production CSP limits connect-src to 'self', so inline data: hrefs
-// cannot be fetched and are decoded locally instead.
+// Production CSP excludes data: from connect-src, so inline hrefs are
+// decoded locally instead.
 const fileFromDataURL = ({
 	href,
 	fileName,
@@ -181,6 +181,9 @@ const shareAttachmentFile = async (
 	} else {
 		try {
 			const response = await fetch(target.href, { signal });
+			if (signal?.aborted) {
+				return;
+			}
 			if (!response.ok) {
 				throw new Error(
 					response.statusText
@@ -233,7 +236,7 @@ export const handleAttachmentDownloadClick = (
 	if (canShareFile(probe)) {
 		return shareAttachmentFile(target, signal);
 	}
-	// Opening before an await preserves the user activation required by popup blockers.
+	// Open the fallback tab during the click gesture to satisfy popup blockers.
 	const file = target.href.startsWith("data:")
 		? fileFromDataURL(target)
 		: probe;

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -171,11 +171,10 @@ const fileFromDataURL = (
 	});
 };
 
-const shareAttachmentFile = async ({
-	href,
-	fileName,
-	mediaType,
-}: AttachmentDownloadTarget): Promise<void> => {
+const shareAttachmentFile = async (
+	{ href, fileName, mediaType }: AttachmentDownloadTarget,
+	signal?: AbortSignal,
+): Promise<void> => {
 	let file: File;
 	if (href.startsWith("data:")) {
 		const decoded = fileFromDataURL(href, fileName, mediaType);
@@ -186,7 +185,7 @@ const shareAttachmentFile = async ({
 		file = decoded;
 	} else {
 		try {
-			const response = await fetch(href);
+			const response = await fetch(href, { signal });
 			if (!response.ok) {
 				throw new Error(
 					response.statusText
@@ -199,11 +198,19 @@ const shareAttachmentFile = async ({
 				type: blob.type || mediaType || "application/octet-stream",
 			});
 		} catch (error) {
+			// An aborted fetch means the attachment unmounted; the user is
+			// elsewhere, so no follow-up UI.
+			if (errorHasName(error, "AbortError")) {
+				return;
+			}
 			toast.error(`Couldn't download ${fileName}`, {
 				description: error instanceof Error ? error.message : undefined,
 			});
 			return;
 		}
+	}
+	if (signal?.aborted) {
+		return;
 	}
 	if (!canShareFiles([file])) {
 		// The pre-fetch probe can pass while the real file fails canShare
@@ -227,6 +234,7 @@ const shareAttachmentFile = async ({
 export const handleAttachmentDownloadClick = (
 	event: { preventDefault: () => void },
 	target: AttachmentDownloadTarget,
+	signal?: AbortSignal,
 ): Promise<void> | undefined => {
 	if (!isIOS() || !isStandaloneDisplayMode()) {
 		return undefined;
@@ -252,7 +260,7 @@ export const handleAttachmentDownloadClick = (
 		}
 		return undefined;
 	}
-	return shareAttachmentFile(target);
+	return shareAttachmentFile(target, signal);
 };
 
 // Filename extensions to list in the file-picker's `accept` attribute

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -82,7 +82,7 @@ const canShareFiles = (files: File[]): boolean =>
 	typeof navigator.canShare === "function" &&
 	navigator.canShare({ files });
 
-type AttachmentDownloadTarget = {
+export type AttachmentDownloadTarget = {
 	href: string;
 	fileName: string;
 	mediaType: string;

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -78,10 +78,10 @@ const isStandaloneDisplayMode = (): boolean => {
 	);
 };
 
-const canShareFiles = (files: File[]): boolean =>
+const canShareFile = (file: File): boolean =>
 	typeof navigator.share === "function" &&
 	typeof navigator.canShare === "function" &&
-	navigator.canShare({ files });
+	navigator.canShare({ files: [file] });
 
 export type AttachmentDownloadTarget = {
 	href: string;
@@ -97,98 +97,90 @@ const errorHasName = (error: unknown, name: string): boolean =>
 	"name" in error &&
 	error.name === name;
 
+const showDownloadFailure = (
+	fileName: string,
+	options: {
+		description?: string;
+		action?: { label: string; onClick: () => void };
+	},
+): void => {
+	toast.error(`Couldn't download ${fileName}`, options);
+};
+
 // iOS blocks top-level data: navigation, so inline attachments open through
 // a short-lived blob URL instead of their data: href.
-const openBlobFileInTab = (file: File): void => {
+const openAttachmentInTab = (href: string, file: File): void => {
+	if (!href.startsWith("data:")) {
+		open(href, "_blank", "noopener");
+		return;
+	}
 	const blobUrl = URL.createObjectURL(file);
 	open(blobUrl, "_blank", "noopener");
-	// Revoke after the new tab has had time to load the blob.
 	setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
 };
 
-const openAttachmentInTab = (href: string, file: File): void => {
-	if (href.startsWith("data:")) {
-		openBlobFileInTab(file);
-	} else {
-		open(href, "_blank", "noopener");
-	}
-};
-
-const openFallbackAction = (href: string, file: File) => ({
+const openFallbackAction = (target: AttachmentDownloadTarget, file: File) => ({
 	label: "Open",
-	onClick: () => openAttachmentInTab(href, file),
+	onClick: () => openAttachmentInTab(target.href, file),
 });
 
-const showDecodeFailureToast = (fileName: string): void => {
-	toast.error(`Couldn't download ${fileName}`, {
-		description: "The attachment data could not be decoded.",
-	});
+// Production CSP limits connect-src to 'self', so inline data: hrefs
+// cannot be fetched and are decoded locally instead.
+const fileFromDataURL = ({
+	href,
+	fileName,
+	mediaType,
+}: AttachmentDownloadTarget): File | null => {
+	const decoded = decodeDataURL(href);
+	return decoded
+		? new File([decoded.bytes], fileName, {
+				type: decoded.mediaType || mediaType || "application/octet-stream",
+			})
+		: null;
 };
 
 const shareFileViaSheet = (
 	file: File,
-	fileName: string,
-	href: string,
+	target: AttachmentDownloadTarget,
 	signal?: AbortSignal,
 ): Promise<void> =>
 	navigator.share({ files: [file] }).catch((error: unknown) => {
-		// A dismissed share sheet rejects with AbortError. An aborted
-		// signal means the attachment unmounted, so rejection UI would
-		// surface on an unrelated view.
 		if (errorHasName(error, "AbortError") || signal?.aborted) {
 			return;
 		}
-		// iOS transient activation can expire while the file is fetched.
-		// The toast action provides a fresh gesture, so only NotAllowedError gets a retry.
 		if (errorHasName(error, "NotAllowedError")) {
-			toast.error(`Couldn't download ${fileName}`, {
+			showDownloadFailure(target.fileName, {
 				description: "The file is ready to save.",
 				action: {
 					label: "Save",
-					onClick: () => void shareFileViaSheet(file, fileName, href),
+					onClick: () => void shareFileViaSheet(file, target),
 				},
 			});
 			return;
 		}
-		// The share itself failed permanently, but the file is in hand,
-		// so the dismissible tab remains a way to reach it.
-		toast.error(`Couldn't download ${fileName}`, {
+		showDownloadFailure(target.fileName, {
 			description: error instanceof Error ? error.message : undefined,
-			action: openFallbackAction(href, file),
+			action: openFallbackAction(target, file),
 		});
 	});
 
-// Production CSP limits connect-src to 'self', so inline data: hrefs
-// cannot be fetched and are decoded locally instead.
-const fileFromDataURL = (
-	href: string,
-	fileName: string,
-	fallbackMediaType: string,
-): File | null => {
-	const decoded = decodeDataURL(href);
-	if (!decoded) {
-		return null;
-	}
-	return new File([decoded.bytes], fileName, {
-		type: decoded.mediaType || fallbackMediaType || "application/octet-stream",
-	});
-};
-
 const shareAttachmentFile = async (
-	{ href, fileName, mediaType }: AttachmentDownloadTarget,
+	target: AttachmentDownloadTarget,
 	signal?: AbortSignal,
 ): Promise<void> => {
 	let file: File;
-	if (href.startsWith("data:")) {
-		const decoded = fileFromDataURL(href, fileName, mediaType);
+	if (target.href.startsWith("data:")) {
+		const decoded = fileFromDataURL(target);
 		if (!decoded) {
-			showDecodeFailureToast(fileName);
+			showDownloadFailure(target.fileName, {
+				description: "The attachment data could not be decoded.",
+			});
 			return;
 		}
 		file = decoded;
 	} else {
 		try {
-			const response = await fetch(href, { signal });
+			const response = await fetch(target.href, { signal });
 			if (!response.ok) {
 				throw new Error(
 					response.statusText
@@ -197,16 +189,14 @@ const shareAttachmentFile = async (
 				);
 			}
 			const blob = await response.blob();
-			file = new File([blob], fileName, {
-				type: blob.type || mediaType || "application/octet-stream",
+			file = new File([blob], target.fileName, {
+				type: blob.type || target.mediaType || "application/octet-stream",
 			});
 		} catch (error) {
-			// An aborted fetch means the attachment unmounted; the user is
-			// elsewhere, so no follow-up UI.
 			if (errorHasName(error, "AbortError")) {
 				return;
 			}
-			toast.error(`Couldn't download ${fileName}`, {
+			showDownloadFailure(target.fileName, {
 				description: error instanceof Error ? error.message : undefined,
 			});
 			return;
@@ -215,18 +205,14 @@ const shareAttachmentFile = async (
 	if (signal?.aborted) {
 		return;
 	}
-	if (!canShareFiles([file])) {
-		// The pre-fetch probe can pass while the real file fails canShare
-		// (for example over the size limit). The native anchor action was
-		// already prevented, so offer the dismissible-tab fallback through
-		// a fresh gesture.
-		toast.error(`Couldn't download ${fileName}`, {
+	if (!canShareFile(file)) {
+		showDownloadFailure(target.fileName, {
 			description: "This file cannot be shared on this device.",
-			action: openFallbackAction(href, file),
+			action: openFallbackAction(target, file),
 		});
 		return;
 	}
-	await shareFileViaSheet(file, fileName, href, signal);
+	await shareFileViaSheet(file, target, signal);
 };
 
 /**
@@ -244,26 +230,21 @@ export const handleAttachmentDownloadClick = (
 	}
 	event.preventDefault();
 	const probe = new File(["0"], target.fileName, { type: target.mediaType });
-	if (!canShareFiles([probe])) {
-		// Open synchronously; after an await the user activation that
-		// popup blockers require may already be consumed.
-		if (!target.href.startsWith("data:")) {
-			open(target.href, "_blank", "noopener");
-			return undefined;
-		}
-		const decoded = fileFromDataURL(
-			target.href,
-			target.fileName,
-			target.mediaType,
-		);
-		if (decoded) {
-			openBlobFileInTab(decoded);
-		} else {
-			showDecodeFailureToast(target.fileName);
-		}
-		return undefined;
+	if (canShareFile(probe)) {
+		return shareAttachmentFile(target, signal);
 	}
-	return shareAttachmentFile(target, signal);
+	// Opening before an await preserves the user activation required by popup blockers.
+	const file = target.href.startsWith("data:")
+		? fileFromDataURL(target)
+		: probe;
+	if (file) {
+		openAttachmentInTab(target.href, file);
+	} else {
+		showDownloadFailure(target.fileName, {
+			description: "The attachment data could not be decoded.",
+		});
+	}
+	return undefined;
 };
 
 // Filename extensions to list in the file-picker's `accept` attribute

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -1,3 +1,4 @@
+import { toast } from "sonner";
 import { isApiErrorResponse } from "#/api/errors";
 import { ChatAttachmentMediaTypes } from "#/api/typesGenerated";
 
@@ -106,7 +107,9 @@ const shareAttachmentFile = async ({
 			type: blob.type || mediaType || "application/octet-stream",
 		});
 		if (!canShareFiles([file])) {
-			console.warn("Attachment cannot be shared:", fileName);
+			toast.error(`Couldn't download ${fileName}`, {
+				description: "This file cannot be shared on this device.",
+			});
 			return;
 		}
 		await navigator.share({ files: [file] });
@@ -122,7 +125,9 @@ const shareAttachmentFile = async ({
 		) {
 			return;
 		}
-		console.warn("Failed to share attachment:", error);
+		toast.error(`Couldn't download ${fileName}`, {
+			description: error instanceof Error ? error.message : "Tap to try again.",
+		});
 	}
 };
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -96,7 +96,21 @@ const errorHasName = (error: unknown, name: string): boolean =>
 	"name" in error &&
 	error.name === name;
 
-const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
+// iOS blocks top-level data: navigation, so the Open fallback is only
+// offered for hrefs a new tab can actually load.
+const openFallbackAction = (href: string) =>
+	href.startsWith("data:")
+		? undefined
+		: {
+				label: "Open",
+				onClick: () => void open(href, "_blank", "noopener"),
+			};
+
+const shareFileViaSheet = (
+	file: File,
+	fileName: string,
+	href: string,
+): Promise<void> =>
 	navigator.share({ files: [file] }).catch((error: unknown) => {
 		// A dismissed share sheet rejects with AbortError.
 		if (errorHasName(error, "AbortError")) {
@@ -109,15 +123,42 @@ const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 				description: "The file is ready to save.",
 				action: {
 					label: "Save",
-					onClick: () => void shareFileViaSheet(file, fileName),
+					onClick: () => void shareFileViaSheet(file, fileName, href),
 				},
 			});
 			return;
 		}
+		// The share itself failed permanently, but the file was fetched,
+		// so the dismissible tab remains a way to reach it.
 		toast.error(`Couldn't download ${fileName}`, {
 			description: error instanceof Error ? error.message : undefined,
+			action: openFallbackAction(href),
 		});
 	});
+
+// Production CSP limits connect-src to 'self', so inline data: hrefs
+// cannot be fetched and are decoded locally instead.
+const fileFromDataURL = (
+	href: string,
+	fileName: string,
+	fallbackMediaType: string,
+): File | null => {
+	const match = /^data:([^,]*?)(;base64)?,(.*)$/.exec(href);
+	if (!match) {
+		return null;
+	}
+	const [, type, isBase64, payload] = match;
+	try {
+		const bytes = isBase64
+			? Uint8Array.from(atob(payload), (char) => char.charCodeAt(0))
+			: new TextEncoder().encode(decodeURIComponent(payload));
+		return new File([bytes], fileName, {
+			type: type || fallbackMediaType || "application/octet-stream",
+		});
+	} catch {
+		return null;
+	}
+};
 
 const shareAttachmentFile = async ({
 	href,
@@ -125,24 +166,35 @@ const shareAttachmentFile = async ({
 	mediaType,
 }: AttachmentDownloadTarget): Promise<void> => {
 	let file: File;
-	try {
-		const response = await fetch(href);
-		if (!response.ok) {
-			throw new Error(
-				response.statusText
-					? `${response.status} ${response.statusText}`
-					: `HTTP ${response.status}`,
-			);
+	if (href.startsWith("data:")) {
+		const decoded = fileFromDataURL(href, fileName, mediaType);
+		if (!decoded) {
+			toast.error(`Couldn't download ${fileName}`, {
+				description: "The attachment data could not be decoded.",
+			});
+			return;
 		}
-		const blob = await response.blob();
-		file = new File([blob], fileName, {
-			type: blob.type || mediaType || "application/octet-stream",
-		});
-	} catch (error) {
-		toast.error(`Couldn't download ${fileName}`, {
-			description: error instanceof Error ? error.message : undefined,
-		});
-		return;
+		file = decoded;
+	} else {
+		try {
+			const response = await fetch(href);
+			if (!response.ok) {
+				throw new Error(
+					response.statusText
+						? `${response.status} ${response.statusText}`
+						: `HTTP ${response.status}`,
+				);
+			}
+			const blob = await response.blob();
+			file = new File([blob], fileName, {
+				type: blob.type || mediaType || "application/octet-stream",
+			});
+		} catch (error) {
+			toast.error(`Couldn't download ${fileName}`, {
+				description: error instanceof Error ? error.message : undefined,
+			});
+			return;
+		}
 	}
 	if (!canShareFiles([file])) {
 		// The pre-fetch probe can pass while the real file fails canShare
@@ -151,14 +203,11 @@ const shareAttachmentFile = async ({
 		// a fresh gesture.
 		toast.error(`Couldn't download ${fileName}`, {
 			description: "This file cannot be shared on this device.",
-			action: {
-				label: "Open",
-				onClick: () => void open(href, "_blank", "noopener"),
-			},
+			action: openFallbackAction(href),
 		});
 		return;
 	}
-	await shareFileViaSheet(file, fileName);
+	await shareFileViaSheet(file, fileName, href);
 };
 
 /**

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { isApiErrorResponse } from "#/api/errors";
 import { ChatAttachmentMediaTypes } from "#/api/typesGenerated";
+import { decodeDataURL } from "./dataUrls";
 
 const undisplayableAttachmentDetail = "File exists but could not be displayed.";
 
@@ -161,21 +162,13 @@ const fileFromDataURL = (
 	fileName: string,
 	fallbackMediaType: string,
 ): File | null => {
-	const match = /^data:([^,]*?)(;base64)?,(.*)$/.exec(href);
-	if (!match) {
+	const decoded = decodeDataURL(href);
+	if (!decoded) {
 		return null;
 	}
-	const [, type, isBase64, payload] = match;
-	try {
-		const bytes = isBase64
-			? Uint8Array.from(atob(payload), (char) => char.charCodeAt(0))
-			: new TextEncoder().encode(decodeURIComponent(payload));
-		return new File([bytes], fileName, {
-			type: type || fallbackMediaType || "application/octet-stream",
-		});
-	} catch {
-		return null;
-	}
+	return new File([decoded.bytes], fileName, {
+		type: decoded.mediaType || fallbackMediaType || "application/octet-stream",
+	});
 };
 
 const shareAttachmentFile = async ({

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -72,8 +72,7 @@ const isIOS = (): boolean =>
 const isStandaloneDisplayMode = (): boolean => {
 	const nav: IOSNavigator = navigator;
 	return (
-		window.matchMedia("(display-mode: standalone)").matches ||
-		nav.standalone === true
+		matchMedia("(display-mode: standalone)").matches || nav.standalone === true
 	);
 };
 
@@ -147,7 +146,7 @@ export const handleAttachmentDownloadClick = (
 	if (!canShareFiles([probe])) {
 		// Open synchronously; after an await the user activation that
 		// popup blockers require may already be consumed.
-		window.open(target.href, "_blank", "noopener");
+		open(target.href, "_blank", "noopener");
 		return undefined;
 	}
 	return shareAttachmentFile(target);

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -89,8 +89,6 @@ export type AttachmentDownloadTarget = {
 	mediaType: string;
 };
 
-// Web Share failures are DOMExceptions, which are not Error subclasses
-// in jsdom, so match names structurally instead of via instanceof.
 const errorHasName = (error: unknown, name: string): boolean =>
 	typeof error === "object" &&
 	error !== null &&

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -129,10 +129,13 @@ const shareFileViaSheet = (
 	file: File,
 	fileName: string,
 	href: string,
+	signal?: AbortSignal,
 ): Promise<void> =>
 	navigator.share({ files: [file] }).catch((error: unknown) => {
-		// A dismissed share sheet rejects with AbortError.
-		if (errorHasName(error, "AbortError")) {
+		// A dismissed share sheet rejects with AbortError. An aborted
+		// signal means the attachment unmounted, so rejection UI would
+		// surface on an unrelated view.
+		if (errorHasName(error, "AbortError") || signal?.aborted) {
 			return;
 		}
 		// iOS transient activation can expire while the file is fetched.
@@ -223,7 +226,7 @@ const shareAttachmentFile = async (
 		});
 		return;
 	}
-	await shareFileViaSheet(file, fileName, href);
+	await shareFileViaSheet(file, fileName, href, signal);
 };
 
 /**

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -88,11 +88,42 @@ type AttachmentDownloadTarget = {
 	mediaType: string;
 };
 
+// Share failures are DOMExceptions, which are not Error subclasses in
+// every engine, so match names structurally instead of instanceof.
+const errorHasName = (error: unknown, name: string): boolean =>
+	typeof error === "object" &&
+	error !== null &&
+	"name" in error &&
+	error.name === name;
+
+const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
+	navigator.share({ files: [file] }).catch((error: unknown) => {
+		// A dismissed share sheet rejects with AbortError.
+		if (errorHasName(error, "AbortError")) {
+			return;
+		}
+		// A slow fetch can outlive iOS's transient user activation, making
+		// share() reject with NotAllowedError. The toast action click is a
+		// fresh gesture, so retrying from it shares the already-fetched file.
+		toast.error(`Couldn't download ${fileName}`, {
+			description: errorHasName(error, "NotAllowedError")
+				? "The file is ready to save."
+				: error instanceof Error
+					? error.message
+					: undefined,
+			action: {
+				label: "Save",
+				onClick: () => void shareFileViaSheet(file, fileName),
+			},
+		});
+	});
+
 const shareAttachmentFile = async ({
 	href,
 	fileName,
 	mediaType,
 }: AttachmentDownloadTarget): Promise<void> => {
+	let file: File;
 	try {
 		const response = await fetch(href);
 		if (!response.ok) {
@@ -103,32 +134,22 @@ const shareAttachmentFile = async ({
 			);
 		}
 		const blob = await response.blob();
-		const file = new File([blob], fileName, {
+		file = new File([blob], fileName, {
 			type: blob.type || mediaType || "application/octet-stream",
 		});
-		if (!canShareFiles([file])) {
-			toast.error(`Couldn't download ${fileName}`, {
-				description: "This file cannot be shared on this device.",
-			});
-			return;
-		}
-		await navigator.share({ files: [file] });
 	} catch (error) {
-		// A dismissed share sheet rejects with an AbortError DOMException,
-		// which is not an Error subclass in every engine, so match the
-		// name structurally instead of using isAbortError.
-		if (
-			typeof error === "object" &&
-			error !== null &&
-			"name" in error &&
-			error.name === "AbortError"
-		) {
-			return;
-		}
 		toast.error(`Couldn't download ${fileName}`, {
-			description: error instanceof Error ? error.message : "Tap to try again.",
+			description: error instanceof Error ? error.message : undefined,
 		});
+		return;
 	}
+	if (!canShareFiles([file])) {
+		toast.error(`Couldn't download ${fileName}`, {
+			description: "This file cannot be shared on this device.",
+		});
+		return;
+	}
+	await shareFileViaSheet(file, fileName);
 };
 
 /**

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -88,8 +88,8 @@ type AttachmentDownloadTarget = {
 	mediaType: string;
 };
 
-// Share failures are DOMExceptions, which are not Error subclasses in
-// every engine, so match names structurally instead of instanceof.
+// Web Share failures are DOMExceptions, which are not Error subclasses
+// in jsdom, so match names structurally instead of via instanceof.
 const errorHasName = (error: unknown, name: string): boolean =>
 	typeof error === "object" &&
 	error !== null &&
@@ -102,11 +102,8 @@ const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 		if (errorHasName(error, "AbortError")) {
 			return;
 		}
-		// A slow fetch can outlive iOS's transient user activation, making
-		// share() reject with NotAllowedError. The toast action click is a
-		// fresh gesture, so retrying from it shares the already-fetched
-		// file. Other rejections would fail a retry identically, so they
-		// get no action.
+		// iOS transient activation can expire while the file is fetched.
+		// The toast action provides a fresh gesture, so only NotAllowedError gets a retry.
 		if (errorHasName(error, "NotAllowedError")) {
 			toast.error(`Couldn't download ${fileName}`, {
 				description: "The file is ready to save.",
@@ -157,12 +154,9 @@ const shareAttachmentFile = async ({
 };
 
 /**
- * iOS home-screen web apps open `<a download>` targets in a QuickLook
- * preview with no dismiss chrome, leaving the app stuck until it is
- * killed. Intercept those clicks and hand the file to the native share
- * sheet (Save to Files / Save Image) instead; when file sharing is
- * unavailable, open a dismissible in-app browser tab. Everywhere else
- * the anchor's native download behavior is kept.
+ * Avoids iOS standalone PWA QuickLook, which can leave no way back to the app.
+ * Uses the share sheet when possible, or a dismissible tab when file sharing
+ * is unavailable. Other environments keep native download behavior.
  */
 export const handleAttachmentDownloadClick = (
 	event: { preventDefault: () => void },

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -104,17 +104,21 @@ const shareFileViaSheet = (file: File, fileName: string): Promise<void> =>
 		}
 		// A slow fetch can outlive iOS's transient user activation, making
 		// share() reject with NotAllowedError. The toast action click is a
-		// fresh gesture, so retrying from it shares the already-fetched file.
+		// fresh gesture, so retrying from it shares the already-fetched
+		// file. Other rejections would fail a retry identically, so they
+		// get no action.
+		if (errorHasName(error, "NotAllowedError")) {
+			toast.error(`Couldn't download ${fileName}`, {
+				description: "The file is ready to save.",
+				action: {
+					label: "Save",
+					onClick: () => void shareFileViaSheet(file, fileName),
+				},
+			});
+			return;
+		}
 		toast.error(`Couldn't download ${fileName}`, {
-			description: errorHasName(error, "NotAllowedError")
-				? "The file is ready to save."
-				: error instanceof Error
-					? error.message
-					: undefined,
-			action: {
-				label: "Save",
-				onClick: () => void shareFileViaSheet(file, fileName),
-			},
+			description: error instanceof Error ? error.message : undefined,
 		});
 	});
 

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -96,15 +96,33 @@ const errorHasName = (error: unknown, name: string): boolean =>
 	"name" in error &&
 	error.name === name;
 
-// iOS blocks top-level data: navigation, so the Open fallback is only
-// offered for hrefs a new tab can actually load.
-const openFallbackAction = (href: string) =>
-	href.startsWith("data:")
-		? undefined
-		: {
-				label: "Open",
-				onClick: () => void open(href, "_blank", "noopener"),
-			};
+// iOS blocks top-level data: navigation, so inline attachments open through
+// a short-lived blob URL instead of their data: href.
+const openBlobFileInTab = (file: File): void => {
+	const blobUrl = URL.createObjectURL(file);
+	open(blobUrl, "_blank", "noopener");
+	// Revoke after the new tab has had time to load the blob.
+	setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+};
+
+const openAttachmentInTab = (href: string, file: File): void => {
+	if (href.startsWith("data:")) {
+		openBlobFileInTab(file);
+	} else {
+		open(href, "_blank", "noopener");
+	}
+};
+
+const openFallbackAction = (href: string, file: File) => ({
+	label: "Open",
+	onClick: () => openAttachmentInTab(href, file),
+});
+
+const showDecodeFailureToast = (fileName: string): void => {
+	toast.error(`Couldn't download ${fileName}`, {
+		description: "The attachment data could not be decoded.",
+	});
+};
 
 const shareFileViaSheet = (
 	file: File,
@@ -128,11 +146,11 @@ const shareFileViaSheet = (
 			});
 			return;
 		}
-		// The share itself failed permanently, but the file was fetched,
+		// The share itself failed permanently, but the file is in hand,
 		// so the dismissible tab remains a way to reach it.
 		toast.error(`Couldn't download ${fileName}`, {
 			description: error instanceof Error ? error.message : undefined,
-			action: openFallbackAction(href),
+			action: openFallbackAction(href, file),
 		});
 	});
 
@@ -169,9 +187,7 @@ const shareAttachmentFile = async ({
 	if (href.startsWith("data:")) {
 		const decoded = fileFromDataURL(href, fileName, mediaType);
 		if (!decoded) {
-			toast.error(`Couldn't download ${fileName}`, {
-				description: "The attachment data could not be decoded.",
-			});
+			showDecodeFailureToast(fileName);
 			return;
 		}
 		file = decoded;
@@ -203,7 +219,7 @@ const shareAttachmentFile = async ({
 		// a fresh gesture.
 		toast.error(`Couldn't download ${fileName}`, {
 			description: "This file cannot be shared on this device.",
-			action: openFallbackAction(href),
+			action: openFallbackAction(href, file),
 		});
 		return;
 	}
@@ -227,7 +243,20 @@ export const handleAttachmentDownloadClick = (
 	if (!canShareFiles([probe])) {
 		// Open synchronously; after an await the user activation that
 		// popup blockers require may already be consumed.
-		open(target.href, "_blank", "noopener");
+		if (!target.href.startsWith("data:")) {
+			open(target.href, "_blank", "noopener");
+			return undefined;
+		}
+		const decoded = fileFromDataURL(
+			target.href,
+			target.fileName,
+			target.mediaType,
+		);
+		if (decoded) {
+			openBlobFileInTab(decoded);
+		} else {
+			showDecodeFailureToast(target.fileName);
+		}
 		return undefined;
 	}
 	return shareAttachmentFile(target);

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -62,6 +62,97 @@ export async function probeAttachmentFailure(
 	return classifyAttachmentFailureResponse(response);
 }
 
+type IOSNavigator = Navigator & { standalone?: boolean };
+
+const isIOS = (): boolean =>
+	/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+	// iPadOS 13+ reports a macOS user agent; the touchscreen is the tell.
+	(navigator.userAgent.includes("Mac") && navigator.maxTouchPoints > 1);
+
+const isStandaloneDisplayMode = (): boolean => {
+	const nav: IOSNavigator = navigator;
+	return (
+		window.matchMedia("(display-mode: standalone)").matches ||
+		nav.standalone === true
+	);
+};
+
+const canShareFiles = (files: File[]): boolean =>
+	typeof navigator.share === "function" &&
+	typeof navigator.canShare === "function" &&
+	navigator.canShare({ files });
+
+type AttachmentDownloadTarget = {
+	href: string;
+	fileName: string;
+	mediaType: string;
+};
+
+const shareAttachmentFile = async ({
+	href,
+	fileName,
+	mediaType,
+}: AttachmentDownloadTarget): Promise<void> => {
+	try {
+		const response = await fetch(href);
+		if (!response.ok) {
+			throw new Error(
+				response.statusText
+					? `${response.status} ${response.statusText}`
+					: `HTTP ${response.status}`,
+			);
+		}
+		const blob = await response.blob();
+		const file = new File([blob], fileName, {
+			type: blob.type || mediaType || "application/octet-stream",
+		});
+		if (!canShareFiles([file])) {
+			console.warn("Attachment cannot be shared:", fileName);
+			return;
+		}
+		await navigator.share({ files: [file] });
+	} catch (error) {
+		// A dismissed share sheet rejects with an AbortError DOMException,
+		// which is not an Error subclass in every engine, so match the
+		// name structurally instead of using isAbortError.
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"name" in error &&
+			error.name === "AbortError"
+		) {
+			return;
+		}
+		console.warn("Failed to share attachment:", error);
+	}
+};
+
+/**
+ * iOS home-screen web apps open `<a download>` targets in a QuickLook
+ * preview with no dismiss chrome, leaving the app stuck until it is
+ * killed. Intercept those clicks and hand the file to the native share
+ * sheet (Save to Files / Save Image) instead; when file sharing is
+ * unavailable, open a dismissible in-app browser tab. Everywhere else
+ * the anchor's native download behavior is kept.
+ */
+export const handleAttachmentDownloadClick = (
+	event: { preventDefault: () => void },
+	target: AttachmentDownloadTarget,
+): Promise<void> | undefined => {
+	if (!isIOS() || !isStandaloneDisplayMode()) {
+		return undefined;
+	}
+	event.preventDefault();
+	const probe = new File(["0"], target.fileName, { type: target.mediaType });
+	if (!canShareFiles([probe])) {
+		// Open synchronously; after an await the user activation that
+		// popup blockers require may already be consumed.
+		window.open(target.href, "_blank", "noopener");
+		return undefined;
+	}
+	return shareAttachmentFile(target);
+};
+
 // Filename extensions to list in the file-picker's `accept` attribute
 // alongside the MIME types. Browsers and operating systems do not always
 // map these extensions to a registered MIME type (Markdown is the common

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -145,8 +145,16 @@ const shareAttachmentFile = async ({
 		return;
 	}
 	if (!canShareFiles([file])) {
+		// The pre-fetch probe can pass while the real file fails canShare
+		// (for example over the size limit). The native anchor action was
+		// already prevented, so offer the dismissible-tab fallback through
+		// a fresh gesture.
 		toast.error(`Couldn't download ${fileName}`, {
 			description: "This file cannot be shared on this device.",
+			action: {
+				label: "Open",
+				onClick: () => void open(href, "_blank", "noopener"),
+			},
 		});
 		return;
 	}

--- a/site/src/pages/AgentsPage/utils/chatDraftAttachmentStorage.ts
+++ b/site/src/pages/AgentsPage/utils/chatDraftAttachmentStorage.ts
@@ -282,8 +282,7 @@ const fileFromDataURL = (
 	metadata: { fileName: string; fileType: string; lastModified: number },
 ): File | null => {
 	const decoded = decodeDataURL(payload);
-	// Stored records are always base64 (fileToDataURL uses FileReader),
-	// so anything else is corruption.
+	// FileReader stores drafts as base64, so other encodings indicate corruption.
 	if (!decoded?.isBase64) {
 		return null;
 	}

--- a/site/src/pages/AgentsPage/utils/chatDraftAttachmentStorage.ts
+++ b/site/src/pages/AgentsPage/utils/chatDraftAttachmentStorage.ts
@@ -1,3 +1,5 @@
+import { decodeDataURL } from "./dataUrls";
+
 type ChatDraftAttachmentRecord = {
 	clientId: string;
 	fileName: string;
@@ -279,35 +281,23 @@ const fileFromDataURL = (
 	payload: string,
 	metadata: { fileName: string; fileType: string; lastModified: number },
 ): File | null => {
-	const commaIndex = payload.indexOf(",");
-	if (commaIndex === -1 || !payload.startsWith("data:")) {
+	const decoded = decodeDataURL(payload);
+	// Stored records are always base64 (fileToDataURL uses FileReader),
+	// so anything else is corruption.
+	if (!decoded?.isBase64) {
 		return null;
 	}
-	const header = payload.slice(0, commaIndex);
-	if (!header.toLowerCase().includes(";base64")) {
-		return null;
-	}
-	const payloadMediaType = header.slice("data:".length).split(";")[0];
 	if (
 		metadata.fileType &&
-		payloadMediaType &&
-		payloadMediaType.toLowerCase() !== metadata.fileType.toLowerCase()
+		decoded.mediaType &&
+		decoded.mediaType.toLowerCase() !== metadata.fileType.toLowerCase()
 	) {
 		return null;
 	}
-	try {
-		const binary = atob(payload.slice(commaIndex + 1));
-		const bytes = new Uint8Array(binary.length);
-		for (let index = 0; index < binary.length; index++) {
-			bytes[index] = binary.charCodeAt(index);
-		}
-		return new File([bytes], metadata.fileName, {
-			type: metadata.fileType,
-			lastModified: metadata.lastModified,
-		});
-	} catch {
-		return null;
-	}
+	return new File([decoded.bytes], metadata.fileName, {
+		type: metadata.fileType,
+		lastModified: metadata.lastModified,
+	});
 };
 
 const fileForRecord = (record: ChatDraftAttachmentRecord): File | null => {

--- a/site/src/pages/AgentsPage/utils/dataUrls.ts
+++ b/site/src/pages/AgentsPage/utils/dataUrls.ts
@@ -4,19 +4,25 @@ type DecodedDataURL = {
 	bytes: Uint8Array<ArrayBuffer>;
 };
 
+// Data URLs are decoded by hand because the production CSP excludes data:
+// from connect-src (so fetch cannot read them) and the Safari 16 support
+// baseline predates Uint8Array.fromBase64.
 export const decodeDataURL = (url: string): DecodedDataURL | null => {
-	const match = /^data:([^,]*?)(;base64)?,(.*)$/i.exec(url);
-	if (!match) {
+	const commaIndex = url.indexOf(",");
+	const scheme = url.slice(0, "data:".length).toLowerCase();
+	if (scheme !== "data:" || commaIndex === -1) {
 		return null;
 	}
-	const [, header, isBase64, payload] = match;
+	const params = url.slice("data:".length, commaIndex).split(";");
+	const payload = url.slice(commaIndex + 1);
+	const isBase64 = params.at(-1)?.toLowerCase() === "base64";
 	try {
 		const bytes = isBase64
 			? Uint8Array.from(atob(payload), (char) => char.charCodeAt(0))
 			: new TextEncoder().encode(decodeURIComponent(payload));
 		return {
-			mediaType: header.split(";")[0].trim(),
-			isBase64: Boolean(isBase64),
+			mediaType: params[0].trim(),
+			isBase64,
 			bytes,
 		};
 	} catch {

--- a/site/src/pages/AgentsPage/utils/dataUrls.ts
+++ b/site/src/pages/AgentsPage/utils/dataUrls.ts
@@ -1,0 +1,25 @@
+type DecodedDataURL = {
+	mediaType: string;
+	isBase64: boolean;
+	bytes: Uint8Array<ArrayBuffer>;
+};
+
+export const decodeDataURL = (url: string): DecodedDataURL | null => {
+	const match = /^data:([^,]*?)(;base64)?,(.*)$/i.exec(url);
+	if (!match) {
+		return null;
+	}
+	const [, header, isBase64, payload] = match;
+	try {
+		const bytes = isBase64
+			? Uint8Array.from(atob(payload), (char) => char.charCodeAt(0))
+			: new TextEncoder().encode(decodeURIComponent(payload));
+		return {
+			mediaType: header.split(";")[0].trim(),
+			isBase64: Boolean(isBase64),
+			bytes,
+		};
+	} catch {
+		return null;
+	}
+};


### PR DESCRIPTION
On iOS, tapping an attachment download link inside the installed (standalone) PWA hands the file to QuickLook, which renders on top of the app with no reliable way back. Users had to force-quit the PWA to recover.

## Approach

In iOS standalone mode, when the device supports file sharing, the download click is intercepted and the fetched attachment is handed to the native share sheet (`navigator.share` with a `File`), where the user can pick Save to Files or any other target. This is the platform-intended path for saving files from a PWA; no library covers it (FileSaver.js is broken in iOS PWAs, and browser-fs-access falls back to the same broken anchor path).

Everything else keeps native behavior:

- Non-iOS platforms and regular iOS Safari tabs keep the plain `<a download>` anchor.
- iOS standalone devices without file sharing keep the anchor too.
- Inline `data:` attachments are decoded locally because the production CSP (`connect-src 'self'`) blocks fetching them.

## Error model

Deliberately small: a share-sheet dismissal (`AbortError`) is silent, an expired click gesture (`NotAllowedError`, which happens when the fetch outlasts transient activation) shows a toast whose Save action retries with a fresh gesture, and any other failure shows a plain error toast.

An earlier revision carried pending-state tracking, abort-signal threading through unmount, and a blob-URL tab fallback; those guards were removed on purpose to keep the change proportionate to the defect.

Also hardens chat file uploads slightly: filenames are sanitized before upload and the file-picker `accept` attribute mirrors the server's attachment allowlist.

## Testing

- Storybook interaction tests cover the share happy path and native-anchor behavior; unit tests cover the intercept gate (including iPadOS detection), failure toasts, retry action, and inline-data decode.
- Validated on an iPhone against a dev deployment: share sheet opens, Save to Files works, and the app remains usable afterwards.

> Mux implemented this on Mike's behalf.

<!-- mux-attribution: model=claude-sonnet-4-5 thinking=high -->
