### PR TITLE
fix(site): reorder Switch thumb classes to restore translate offset

### DIFF
--- a/site/src/components/Switch/Switch.tsx
+++ b/site/src/components/Switch/Switch.tsx
@@ -34,8 +34,8 @@ const thumbVariants = cva(
 		variants: {
 			size: {
 				default:
-					"size-4 data-[state=checked]:translate-x-2.5 data-[state=unchecked]:-translate-x-1.5",
-				sm: "size-3 data-[state=checked]:translate-x-1.5 data-[state=unchecked]:-translate-x-1.5",
+					"data-[state=checked]:translate-x-2.5 data-[state=unchecked]:-translate-x-1.5 size-4",
+				sm: "data-[state=checked]:translate-x-1.5 data-[state=unchecked]:-translate-x-1.5 size-3",
 			},
 		},
 		defaultVariants: {


### PR DESCRIPTION
Closing: the reorder is a no-op. Tailwind class specificity comes from stylesheet order, not `className` order, so this produces byte-identical CSS. Root-causing the actual regression separately; the current thumb geometry has been in place since the Switch component was introduced in Dec 2024 (#15503).