### PR TITLE
refactor(codersdk): use ReadBodyAsJSON in typed endpoints

### DIFF
--- a/codersdk/agentfirewall.go
+++ b/codersdk/agentfirewall.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -31,7 +30,7 @@ func (c *Client) AgentFirewallSessionByID(ctx context.Context, id uuid.UUID) (Ag
 		return AgentFirewallSession{}, ReadBodyAsError(res)
 	}
 	var session AgentFirewallSession
-	return session, json.NewDecoder(res.Body).Decode(&session)
+	return session, ReadBodyAsJSON(res, &session)
 }
 
 // AgentFirewallLog represents a single audit event from an agent firewall proxy.
@@ -101,5 +100,5 @@ func (c *Client) AgentFirewallSessionLogs(ctx context.Context, sessionID uuid.UU
 	}
 
 	var resp AgentFirewallSessionLogsResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -85,7 +85,7 @@ func (c *Client) GitSSHKey(ctx context.Context) (GitSSHKey, error) {
 	}
 
 	var gitSSHKey GitSSHKey
-	return gitSSHKey, json.NewDecoder(res.Body).Decode(&gitSSHKey)
+	return gitSSHKey, codersdk.ReadBodyAsJSON(res, &gitSSHKey)
 }
 
 type Metadata struct {
@@ -716,7 +716,7 @@ func (c *Client) PostLogSource(ctx context.Context, req PostLogSourceRequest) (c
 		return codersdk.WorkspaceAgentLogSource{}, codersdk.ReadBodyAsError(res)
 	}
 	var logSource codersdk.WorkspaceAgentLogSource
-	return logSource, json.NewDecoder(res.Body).Decode(&logSource)
+	return logSource, codersdk.ReadBodyAsJSON(res, &logSource)
 }
 
 type ExternalAuthResponse struct {
@@ -787,7 +787,7 @@ func (c *Client) ExternalAuth(ctx context.Context, req ExternalAuthRequest) (Ext
 	}
 
 	var authResp ExternalAuthResponse
-	return authResp, json.NewDecoder(res.Body).Decode(&authResp)
+	return authResp, codersdk.ReadBodyAsJSON(res, &authResp)
 }
 
 // LogsNotifyChannel returns the channel name responsible for notifying
@@ -1016,5 +1016,5 @@ func (c *Client) RefreshChatContext(ctx context.Context) (RefreshChatContextResp
 	}
 
 	var resp RefreshChatContextResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, codersdk.ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/agentsdk/aws.go
+++ b/codersdk/agentsdk/aws.go
@@ -2,7 +2,6 @@ package agentsdk
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 
@@ -100,5 +99,5 @@ func (a *AWSSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateRe
 		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
 	}
 	var resp AuthenticateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, codersdk.ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/agentsdk/azure.go
+++ b/codersdk/agentsdk/azure.go
@@ -63,5 +63,5 @@ func (a *AzureSessionTokenExchanger) exchange(ctx context.Context) (Authenticate
 		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
 	}
 	var resp AuthenticateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, codersdk.ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/agentsdk/google.go
+++ b/codersdk/agentsdk/google.go
@@ -2,7 +2,6 @@ package agentsdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -75,5 +74,5 @@ func (g *GoogleSessionTokenExchanger) exchange(ctx context.Context) (Authenticat
 		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
 	}
 	var resp AuthenticateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, codersdk.ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -361,7 +360,7 @@ func (c *Client) AIBridgeListSessions(ctx context.Context, filter AIBridgeListSe
 		return AIBridgeListSessionsResponse{}, ReadBodyAsError(res)
 	}
 	var resp AIBridgeListSessionsResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // AIBridgeGetSessionThreads returns a single session with expanded
@@ -388,7 +387,7 @@ func (c *Client) AIBridgeGetSessionThreads(ctx context.Context, sessionID string
 		return AIBridgeSessionThreadsResponse{}, ReadBodyAsError(res)
 	}
 	var resp AIBridgeSessionThreadsResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // AIBridgeListClients returns the distinct AI clients visible to the caller.
@@ -402,7 +401,7 @@ func (c *Client) AIBridgeListClients(ctx context.Context) ([]string, error) {
 		return nil, ReadBodyAsError(res)
 	}
 	var clients []string
-	return clients, json.NewDecoder(res.Body).Decode(&clients)
+	return clients, ReadBodyAsJSON(res, &clients)
 }
 
 // ExportOrganizationAISpend returns a CSV of per-user, per-group, per-model,
@@ -462,7 +461,7 @@ func (c *Client) GroupAIBudget(ctx context.Context, group uuid.UUID) (GroupAIBud
 		return GroupAIBudget{}, ReadBodyAsError(res)
 	}
 	var resp GroupAIBudget
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpsertGroupAIBudget creates or updates the AI spend budget for the given group.
@@ -480,7 +479,7 @@ func (c *Client) UpsertGroupAIBudget(ctx context.Context, group uuid.UUID, req U
 		return GroupAIBudget{}, ReadBodyAsError(res)
 	}
 	var resp GroupAIBudget
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteGroupAIBudget removes the AI spend budget for the given group.
@@ -531,7 +530,7 @@ func (c *Client) UserAIBudgetOverride(ctx context.Context, user uuid.UUID) (User
 		return UserAIBudgetOverride{}, ReadBodyAsError(res)
 	}
 	var resp UserAIBudgetOverride
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpsertUserAIBudgetOverride creates or updates the AI spend budget override for the given user.
@@ -549,7 +548,7 @@ func (c *Client) UpsertUserAIBudgetOverride(ctx context.Context, user uuid.UUID,
 		return UserAIBudgetOverride{}, ReadBodyAsError(res)
 	}
 	var resp UserAIBudgetOverride
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteUserAIBudgetOverride removes the AI spend budget override for the given user.
@@ -585,7 +584,7 @@ func (c *Client) UserAISpendStatus(ctx context.Context, user uuid.UUID) (UserAIS
 		return UserAISpendStatus{}, ReadBodyAsError(res)
 	}
 	var resp UserAISpendStatus
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // OrganizationGroupsAISpend returns AI spend for the given groups within the
@@ -612,7 +611,7 @@ func (c *Client) OrganizationGroupsAISpend(ctx context.Context, organization uui
 		return OrganizationGroupsAISpend{}, ReadBodyAsError(res)
 	}
 	var resp OrganizationGroupsAISpend
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GroupAISpend returns AI spend for the given group within the active budget
@@ -631,7 +630,7 @@ func (c *Client) GroupAISpend(ctx context.Context, group uuid.UUID) (GroupAISpen
 		return GroupAISpend{}, ReadBodyAsError(res)
 	}
 	var resp GroupAISpend
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GroupMembersAISpend returns AI spend attributed to the given group for the
@@ -658,5 +657,5 @@ func (c *Client) GroupMembersAISpend(ctx context.Context, group uuid.UUID, userI
 		return GroupMembersAISpend{}, ReadBodyAsError(res)
 	}
 	var resp GroupMembersAISpend
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/aigatewaykeys.go
+++ b/codersdk/aigatewaykeys.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -48,7 +47,7 @@ func (c *Client) CreateAIGatewayKey(ctx context.Context, req CreateAIGatewayKeyR
 		return CreateAIGatewayKeyResponse{}, ReadBodyAsError(res)
 	}
 	var resp CreateAIGatewayKeyResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // ListAIGatewayKeys lists all AI Gateway keys.
@@ -63,7 +62,7 @@ func (c *Client) ListAIGatewayKeys(ctx context.Context) ([]AIGatewayKey, error) 
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []AIGatewayKey
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteAIGatewayKey deletes an AI Gateway key by ID.

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -543,7 +543,7 @@ func (c *Client) AIProviders(ctx context.Context) ([]AIProvider, error) {
 		return nil, ReadBodyAsError(res)
 	}
 	var providers []AIProvider
-	return providers, json.NewDecoder(res.Body).Decode(&providers)
+	return providers, ReadBodyAsJSON(res, &providers)
 }
 
 // AIProvider fetches a single AI provider by ID or name.
@@ -557,7 +557,7 @@ func (c *Client) AIProvider(ctx context.Context, idOrName string) (AIProvider, e
 		return AIProvider{}, ReadBodyAsError(res)
 	}
 	var provider AIProvider
-	return provider, json.NewDecoder(res.Body).Decode(&provider)
+	return provider, ReadBodyAsJSON(res, &provider)
 }
 
 // CreateAIProvider creates a new AI provider.
@@ -571,7 +571,7 @@ func (c *Client) CreateAIProvider(ctx context.Context, req CreateAIProviderReque
 		return AIProvider{}, ReadBodyAsError(res)
 	}
 	var provider AIProvider
-	return provider, json.NewDecoder(res.Body).Decode(&provider)
+	return provider, ReadBodyAsJSON(res, &provider)
 }
 
 // UpdateAIProvider partially updates an AI provider identified by
@@ -586,7 +586,7 @@ func (c *Client) UpdateAIProvider(ctx context.Context, idOrName string, req Upda
 		return AIProvider{}, ReadBodyAsError(res)
 	}
 	var provider AIProvider
-	return provider, json.NewDecoder(res.Body).Decode(&provider)
+	return provider, ReadBodyAsJSON(res, &provider)
 }
 
 // DeleteAIProvider soft-deletes an AI provider identified by ID or

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -34,7 +33,7 @@ func (c *Client) CreateTask(ctx context.Context, user string, request CreateTask
 	}
 
 	var task Task
-	if err := json.NewDecoder(res.Body).Decode(&task); err != nil {
+	if err := ReadBodyAsJSON(res, &task); err != nil {
 		return Task{}, err
 	}
 
@@ -192,7 +191,7 @@ func (c *Client) Tasks(ctx context.Context, filter *TasksFilter) ([]Task, error)
 	}
 
 	var tres TasksListResponse
-	if err := json.NewDecoder(res.Body).Decode(&tres); err != nil {
+	if err := ReadBodyAsJSON(res, &tres); err != nil {
 		return nil, err
 	}
 
@@ -212,7 +211,7 @@ func (c *Client) TaskByID(ctx context.Context, id uuid.UUID) (Task, error) {
 	}
 
 	var task Task
-	if err := json.NewDecoder(res.Body).Decode(&task); err != nil {
+	if err := ReadBodyAsJSON(res, &task); err != nil {
 		return Task{}, err
 	}
 
@@ -234,7 +233,7 @@ func (c *Client) TaskByOwnerAndName(ctx context.Context, owner, ident string) (T
 	}
 
 	var task Task
-	if err := json.NewDecoder(res.Body).Decode(&task); err != nil {
+	if err := ReadBodyAsJSON(res, &task); err != nil {
 		return Task{}, err
 	}
 
@@ -346,7 +345,7 @@ func (c *Client) PauseTask(ctx context.Context, user string, id uuid.UUID) (Paus
 	}
 
 	var resp PauseTaskResponse
-	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+	if err := ReadBodyAsJSON(res, &resp); err != nil {
 		return PauseTaskResponse{}, err
 	}
 
@@ -369,7 +368,7 @@ func (c *Client) ResumeTask(ctx context.Context, user string, id uuid.UUID) (Res
 	}
 
 	var resp ResumeTaskResponse
-	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+	if err := ReadBodyAsJSON(res, &resp); err != nil {
 		return ResumeTaskResponse{}, err
 	}
 
@@ -415,7 +414,7 @@ func (c *Client) TaskLogs(ctx context.Context, user string, id uuid.UUID) (TaskL
 	}
 
 	var logs TaskLogsResponse
-	if err := json.NewDecoder(res.Body).Decode(&logs); err != nil {
+	if err := ReadBodyAsJSON(res, &logs); err != nil {
 		return TaskLogsResponse{}, xerrors.Errorf("decoding task logs response: %w", err)
 	}
 

--- a/codersdk/apikey.go
+++ b/codersdk/apikey.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -74,7 +73,7 @@ func (c *Client) CreateToken(ctx context.Context, userID string, req CreateToken
 	}
 
 	var apiKey GenerateAPIKeyResponse
-	return apiKey, json.NewDecoder(res.Body).Decode(&apiKey)
+	return apiKey, ReadBodyAsJSON(res, &apiKey)
 }
 
 // CreateAPIKey generates an API key for the user ID provided.
@@ -93,7 +92,7 @@ func (c *Client) CreateAPIKey(ctx context.Context, user string) (GenerateAPIKeyR
 	}
 
 	var apiKey GenerateAPIKeyResponse
-	return apiKey, json.NewDecoder(res.Body).Decode(&apiKey)
+	return apiKey, ReadBodyAsJSON(res, &apiKey)
 }
 
 type TokensFilter struct {
@@ -132,7 +131,7 @@ func (c *Client) Tokens(ctx context.Context, userID string, filter TokensFilter)
 		return nil, ReadBodyAsError(res)
 	}
 	apiKey := []APIKeyWithOwner{}
-	return apiKey, json.NewDecoder(res.Body).Decode(&apiKey)
+	return apiKey, ReadBodyAsJSON(res, &apiKey)
 }
 
 // APIKeyByID returns the api key by id.
@@ -146,7 +145,7 @@ func (c *Client) APIKeyByID(ctx context.Context, userID string, id string) (*API
 		return nil, ReadBodyAsError(res)
 	}
 	apiKey := &APIKey{}
-	return apiKey, json.NewDecoder(res.Body).Decode(apiKey)
+	return apiKey, ReadBodyAsJSON(res, apiKey)
 }
 
 // APIKeyByName returns the api key by name.
@@ -160,7 +159,7 @@ func (c *Client) APIKeyByName(ctx context.Context, userID string, name string) (
 		return nil, ReadBodyAsError(res)
 	}
 	apiKey := &APIKey{}
-	return apiKey, json.NewDecoder(res.Body).Decode(apiKey)
+	return apiKey, ReadBodyAsJSON(res, apiKey)
 }
 
 // DeleteAPIKey deletes API key by id.
@@ -201,5 +200,5 @@ func (c *Client) GetTokenConfig(ctx context.Context, userID string) (TokenConfig
 		return TokenConfig{}, ReadBodyAsError(res)
 	}
 	tokenConfig := TokenConfig{}
-	return tokenConfig, json.NewDecoder(res.Body).Decode(&tokenConfig)
+	return tokenConfig, ReadBodyAsJSON(res, &tokenConfig)
 }

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -274,7 +274,7 @@ func (c *Client) AuditLogs(ctx context.Context, req AuditLogsRequest) (AuditLogR
 	}
 
 	var logRes AuditLogResponse
-	err = json.NewDecoder(res.Body).Decode(&logRes)
+	err = ReadBodyAsJSON(res, &logRes)
 	if err != nil {
 		return AuditLogResponse{}, err
 	}

--- a/codersdk/authorization.go
+++ b/codersdk/authorization.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 )
 
@@ -71,5 +70,5 @@ func (c *Client) AuthCheck(ctx context.Context, req AuthorizationRequest) (Autho
 		return AuthorizationResponse{}, ReadBodyAsError(res)
 	}
 	var resp AuthorizationResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/connectionlog.go
+++ b/codersdk/connectionlog.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -125,7 +124,7 @@ func (c *Client) ConnectionLogs(ctx context.Context, req ConnectionLogsRequest) 
 	}
 
 	var logRes ConnectionLogResponse
-	err = json.NewDecoder(res.Body).Decode(&logRes)
+	err = ReadBodyAsJSON(res, &logRes)
 	if err != nil {
 		return ConnectionLogResponse{}, err
 	}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -579,7 +579,7 @@ func (c *Client) Entitlements(ctx context.Context) (Entitlements, error) {
 		return Entitlements{}, ReadBodyAsError(res)
 	}
 	var ent Entitlements
-	return ent, json.NewDecoder(res.Body).Decode(&ent)
+	return ent, ReadBodyAsJSON(res, &ent)
 }
 
 type PostgresAuth string
@@ -5213,7 +5213,7 @@ func (c *Client) DeploymentConfig(ctx context.Context) (*DeploymentConfig, error
 		Values:  conf,
 		Options: conf.Options(),
 	}
-	return resp, json.NewDecoder(res.Body).Decode(resp)
+	return resp, ReadBodyAsJSON(res, resp)
 }
 
 func (c *Client) DeploymentStats(ctx context.Context) (DeploymentStats, error) {
@@ -5228,7 +5228,7 @@ func (c *Client) DeploymentStats(ctx context.Context) (DeploymentStats, error) {
 	}
 
 	var df DeploymentStats
-	return df, json.NewDecoder(res.Body).Decode(&df)
+	return df, ReadBodyAsJSON(res, &df)
 }
 
 type AppearanceConfig struct {
@@ -5270,7 +5270,7 @@ func (c *Client) Appearance(ctx context.Context) (AppearanceConfig, error) {
 		return AppearanceConfig{}, ReadBodyAsError(res)
 	}
 	var cfg AppearanceConfig
-	return cfg, json.NewDecoder(res.Body).Decode(&cfg)
+	return cfg, ReadBodyAsJSON(res, &cfg)
 }
 
 func (c *Client) UpdateAppearance(ctx context.Context, appearance UpdateAppearanceConfig) error {
@@ -5347,7 +5347,7 @@ func (c *Client) BuildInfo(ctx context.Context) (BuildInfoResponse, error) {
 	}
 
 	var buildInfo BuildInfoResponse
-	return buildInfo, json.NewDecoder(res.Body).Decode(&buildInfo)
+	return buildInfo, ReadBodyAsJSON(res, &buildInfo)
 }
 
 type Experiment string
@@ -5452,7 +5452,7 @@ func (c *Client) Experiments(ctx context.Context) (Experiments, error) {
 		return nil, ReadBodyAsError(res)
 	}
 	var exp []Experiment
-	return exp, json.NewDecoder(res.Body).Decode(&exp)
+	return exp, ReadBodyAsJSON(res, &exp)
 }
 
 // AvailableExperiments is an expandable type that returns all safe experiments
@@ -5471,7 +5471,7 @@ func (c *Client) SafeExperiments(ctx context.Context) (AvailableExperiments, err
 		return AvailableExperiments{}, ReadBodyAsError(res)
 	}
 	var exp AvailableExperiments
-	return exp, json.NewDecoder(res.Body).Decode(&exp)
+	return exp, ReadBodyAsJSON(res, &exp)
 }
 
 type DAUsResponse struct {
@@ -5536,7 +5536,7 @@ func (c *Client) DeploymentDAUs(ctx context.Context, tzOffset int) (*DAUsRespons
 	}
 
 	var resp DAUsResponse
-	return &resp, json.NewDecoder(res.Body).Decode(&resp)
+	return &resp, ReadBodyAsJSON(res, &resp)
 }
 
 type AppHostResponse struct {
@@ -5562,7 +5562,7 @@ func (c *Client) AppHost(ctx context.Context) (AppHostResponse, error) {
 	}
 
 	var host AppHostResponse
-	return host, json.NewDecoder(res.Body).Decode(&host)
+	return host, ReadBodyAsJSON(res, &host)
 }
 
 type WorkspaceConnectionLatencyMS struct {
@@ -5644,7 +5644,7 @@ func (c *Client) SSHConfiguration(ctx context.Context) (SSHConfigResponse, error
 	}
 
 	var sshConfig SSHConfigResponse
-	return sshConfig, json.NewDecoder(res.Body).Decode(&sshConfig)
+	return sshConfig, ReadBodyAsJSON(res, &sshConfig)
 }
 
 type CryptoKeyFeature string

--- a/codersdk/externalauth.go
+++ b/codersdk/externalauth.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -143,7 +142,7 @@ func (c *Client) ExternalAuthDeviceByID(ctx context.Context, provider string) (E
 		return ExternalAuthDevice{}, ReadBodyAsError(res)
 	}
 	var extAuth ExternalAuthDevice
-	return extAuth, json.NewDecoder(res.Body).Decode(&extAuth)
+	return extAuth, ReadBodyAsJSON(res, &extAuth)
 }
 
 // ExchangeGitAuth exchanges a device code for an external auth token.
@@ -170,7 +169,7 @@ func (c *Client) ExternalAuthByID(ctx context.Context, provider string) (Externa
 		return ExternalAuth{}, ReadBodyAsError(res)
 	}
 	var extAuth ExternalAuth
-	return extAuth, json.NewDecoder(res.Body).Decode(&extAuth)
+	return extAuth, ReadBodyAsJSON(res, &extAuth)
 }
 
 // UnlinkExternalAuthByID deletes the external auth for the given provider by ID
@@ -186,7 +185,7 @@ func (c *Client) UnlinkExternalAuthByID(ctx context.Context, provider string) (D
 		return noRevoke, ReadBodyAsError(res)
 	}
 	var resp DeleteExternalAuthByIDResponse
-	err = json.NewDecoder(res.Body).Decode(&resp)
+	err = ReadBodyAsJSON(res, &resp)
 	if err != nil {
 		return noRevoke, err
 	}
@@ -205,5 +204,5 @@ func (c *Client) ListExternalAuths(ctx context.Context) (ListUserExternalAuthRes
 		return ListUserExternalAuthResponse{}, ReadBodyAsError(res)
 	}
 	var extAuth ListUserExternalAuthResponse
-	return extAuth, json.NewDecoder(res.Body).Decode(&extAuth)
+	return extAuth, ReadBodyAsJSON(res, &extAuth)
 }

--- a/codersdk/files.go
+++ b/codersdk/files.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,7 +35,7 @@ func (c *Client) Upload(ctx context.Context, contentType string, rd io.Reader) (
 		return UploadResponse{}, ReadBodyAsError(res)
 	}
 	var resp UploadResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // Download fetches a file by uploaded hash.

--- a/codersdk/gitsshkey.go
+++ b/codersdk/gitsshkey.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -34,7 +33,7 @@ func (c *Client) GitSSHKey(ctx context.Context, user string) (GitSSHKey, error) 
 	}
 
 	var gitsshkey GitSSHKey
-	return gitsshkey, json.NewDecoder(res.Body).Decode(&gitsshkey)
+	return gitsshkey, ReadBodyAsJSON(res, &gitsshkey)
 }
 
 // RegenerateGitSSHKey will create a new SSH key pair for the user and return it.
@@ -50,5 +49,5 @@ func (c *Client) RegenerateGitSSHKey(ctx context.Context, user string) (GitSSHKe
 	}
 
 	var gitsshkey GitSSHKey
-	return gitsshkey, json.NewDecoder(res.Body).Decode(&gitsshkey)
+	return gitsshkey, ReadBodyAsJSON(res, &gitsshkey)
 }

--- a/codersdk/groups.go
+++ b/codersdk/groups.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -66,7 +65,7 @@ func (c *Client) CreateGroup(ctx context.Context, orgID uuid.UUID, req CreateGro
 		return Group{}, ReadBodyAsError(res)
 	}
 	var resp Group
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GroupsByOrganization
@@ -115,7 +114,7 @@ func (c *Client) Groups(ctx context.Context, args GroupArguments) ([]Group, erro
 	}
 
 	var groups []Group
-	return groups, json.NewDecoder(res.Body).Decode(&groups)
+	return groups, ReadBodyAsJSON(res, &groups)
 }
 
 func (c *Client) GroupByOrgAndName(ctx context.Context, orgID uuid.UUID, name string) (Group, error) {
@@ -132,7 +131,7 @@ func (c *Client) GroupByOrgAndName(ctx context.Context, orgID uuid.UUID, name st
 		return Group{}, ReadBodyAsError(res)
 	}
 	var resp Group
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type GroupRequest struct {
@@ -164,7 +163,7 @@ func (c *Client) Group(ctx context.Context, group uuid.UUID, req GroupRequest) (
 		return Group{}, ReadBodyAsError(res)
 	}
 	var resp Group
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) GroupMembers(ctx context.Context, group uuid.UUID, req UsersRequest) (GroupMembersResponse, error) {
@@ -183,7 +182,7 @@ func (c *Client) GroupMembers(ctx context.Context, group uuid.UUID, req UsersReq
 		return GroupMembersResponse{}, ReadBodyAsError(res)
 	}
 	var resp GroupMembersResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type PatchGroupRequest struct {
@@ -209,7 +208,7 @@ func (c *Client) PatchGroup(ctx context.Context, group uuid.UUID, req PatchGroup
 		return Group{}, ReadBodyAsError(res)
 	}
 	var resp Group
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) DeleteGroup(ctx context.Context, group uuid.UUID) error {

--- a/codersdk/healthsdk/healthsdk.go
+++ b/codersdk/healthsdk/healthsdk.go
@@ -2,7 +2,6 @@ package healthsdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -64,7 +63,7 @@ func (c *HealthClient) DebugHealth(ctx context.Context) (HealthcheckReport, erro
 		return HealthcheckReport{}, codersdk.ReadBodyAsError(res)
 	}
 	var rpt HealthcheckReport
-	return rpt, json.NewDecoder(res.Body).Decode(&rpt)
+	return rpt, codersdk.ReadBodyAsJSON(res, &rpt)
 }
 
 func (c *HealthClient) HealthSettings(ctx context.Context) (HealthSettings, error) {
@@ -77,7 +76,7 @@ func (c *HealthClient) HealthSettings(ctx context.Context) (HealthSettings, erro
 		return HealthSettings{}, codersdk.ReadBodyAsError(res)
 	}
 	var settings HealthSettings
-	return settings, json.NewDecoder(res.Body).Decode(&settings)
+	return settings, codersdk.ReadBodyAsJSON(res, &settings)
 }
 
 func (c *HealthClient) PutHealthSettings(ctx context.Context, settings HealthSettings) error {

--- a/codersdk/idpsync.go
+++ b/codersdk/idpsync.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -51,7 +50,7 @@ func (c *Client) GroupIDPSyncSettings(ctx context.Context, orgID string) (GroupS
 		return GroupSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp GroupSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) PatchGroupIDPSyncSettings(ctx context.Context, orgID string, req GroupSyncSettings) (GroupSyncSettings, error) {
@@ -65,7 +64,7 @@ func (c *Client) PatchGroupIDPSyncSettings(ctx context.Context, orgID string, re
 		return GroupSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp GroupSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type PatchGroupIDPSyncConfigRequest struct {
@@ -85,7 +84,7 @@ func (c *Client) PatchGroupIDPSyncConfig(ctx context.Context, orgID string, req 
 		return GroupSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp GroupSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // If the same mapping is present in both Add and Remove, Remove will take presidence.
@@ -105,7 +104,7 @@ func (c *Client) PatchGroupIDPSyncMapping(ctx context.Context, orgID string, req
 		return GroupSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp GroupSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type RoleSyncSettings struct {
@@ -127,7 +126,7 @@ func (c *Client) RoleIDPSyncSettings(ctx context.Context, orgID string) (RoleSyn
 		return RoleSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp RoleSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) PatchRoleIDPSyncSettings(ctx context.Context, orgID string, req RoleSyncSettings) (RoleSyncSettings, error) {
@@ -141,7 +140,7 @@ func (c *Client) PatchRoleIDPSyncSettings(ctx context.Context, orgID string, req
 		return RoleSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp RoleSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type PatchRoleIDPSyncConfigRequest struct {
@@ -159,7 +158,7 @@ func (c *Client) PatchRoleIDPSyncConfig(ctx context.Context, orgID string, req P
 		return RoleSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp RoleSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // If the same mapping is present in both Add and Remove, Remove will take presidence.
@@ -179,7 +178,7 @@ func (c *Client) PatchRoleIDPSyncMapping(ctx context.Context, orgID string, req 
 		return RoleSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp RoleSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type OrganizationSyncSettings struct {
@@ -205,7 +204,7 @@ func (c *Client) OrganizationIDPSyncSettings(ctx context.Context) (OrganizationS
 		return OrganizationSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp OrganizationSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) PatchOrganizationIDPSyncSettings(ctx context.Context, req OrganizationSyncSettings) (OrganizationSyncSettings, error) {
@@ -219,7 +218,7 @@ func (c *Client) PatchOrganizationIDPSyncSettings(ctx context.Context, req Organ
 		return OrganizationSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp OrganizationSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type PatchOrganizationIDPSyncConfigRequest struct {
@@ -238,7 +237,7 @@ func (c *Client) PatchOrganizationIDPSyncConfig(ctx context.Context, req PatchOr
 		return OrganizationSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp OrganizationSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // If the same mapping is present in both Add and Remove, Remove will take presidence.
@@ -258,7 +257,7 @@ func (c *Client) PatchOrganizationIDPSyncMapping(ctx context.Context, req PatchO
 		return OrganizationSyncSettings{}, ReadBodyAsError(res)
 	}
 	var resp OrganizationSyncSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) GetAvailableIDPSyncFields(ctx context.Context) ([]string, error) {
@@ -272,7 +271,7 @@ func (c *Client) GetAvailableIDPSyncFields(ctx context.Context) ([]string, error
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []string
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) GetOrganizationAvailableIDPSyncFields(ctx context.Context, orgID string) ([]string, error) {
@@ -286,7 +285,7 @@ func (c *Client) GetOrganizationAvailableIDPSyncFields(ctx context.Context, orgI
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []string
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) GetIDPSyncFieldValues(ctx context.Context, claimField string) ([]string, error) {
@@ -302,7 +301,7 @@ func (c *Client) GetIDPSyncFieldValues(ctx context.Context, claimField string) (
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []string
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) GetOrganizationIDPSyncFieldValues(ctx context.Context, orgID string, claimField string) ([]string, error) {
@@ -318,5 +317,5 @@ func (c *Client) GetOrganizationIDPSyncFieldValues(ctx context.Context, orgID st
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []string
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/inboxnotification.go
+++ b/codersdk/inboxnotification.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -86,7 +85,7 @@ func (c *Client) ListInboxNotifications(ctx context.Context, req ListInboxNotifi
 	}
 
 	var listInboxNotificationsResponse ListInboxNotificationsResponse
-	return listInboxNotificationsResponse, json.NewDecoder(res.Body).Decode(&listInboxNotificationsResponse)
+	return listInboxNotificationsResponse, ReadBodyAsJSON(res, &listInboxNotificationsResponse)
 }
 
 type UpdateInboxNotificationReadStatusRequest struct {
@@ -114,7 +113,7 @@ func (c *Client) UpdateInboxNotificationReadStatus(ctx context.Context, notifID 
 	}
 
 	var resp UpdateInboxNotificationReadStatusResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) MarkAllInboxNotificationsAsRead(ctx context.Context) error {

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -131,7 +130,7 @@ func (c *Client) UserLatencyInsights(ctx context.Context, req UserLatencyInsight
 		return UserLatencyInsightsResponse{}, ReadBodyAsError(resp)
 	}
 	var result UserLatencyInsightsResponse
-	return result, json.NewDecoder(resp.Body).Decode(&result)
+	return result, ReadBodyAsJSON(resp, &result)
 }
 
 type UserActivityInsightsRequest struct {
@@ -163,7 +162,7 @@ func (c *Client) UserActivityInsights(ctx context.Context, req UserActivityInsig
 		return UserActivityInsightsResponse{}, ReadBodyAsError(resp)
 	}
 	var result UserActivityInsightsResponse
-	return result, json.NewDecoder(resp.Body).Decode(&result)
+	return result, ReadBodyAsJSON(resp, &result)
 }
 
 // TemplateInsightsResponse is the response from the template insights endpoint.
@@ -281,7 +280,7 @@ func (c *Client) TemplateInsights(ctx context.Context, req TemplateInsightsReque
 		return TemplateInsightsResponse{}, ReadBodyAsError(resp)
 	}
 	var result TemplateInsightsResponse
-	return result, json.NewDecoder(resp.Body).Decode(&result)
+	return result, ReadBodyAsJSON(resp, &result)
 }
 
 type GetUserStatusCountsResponse struct {
@@ -318,5 +317,5 @@ func (c *Client) GetUserStatusCounts(ctx context.Context, req GetUserStatusCount
 		return GetUserStatusCountsResponse{}, ReadBodyAsError(resp)
 	}
 	var result GetUserStatusCountsResponse
-	return result, json.NewDecoder(resp.Body).Decode(&result)
+	return result, ReadBodyAsJSON(resp, &result)
 }

--- a/codersdk/mcp.go
+++ b/codersdk/mcp.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -48,7 +47,7 @@ func (c *Client) MCPServerOAuth2DisconnectWithResponse(ctx context.Context, id u
 		return MCPServerOAuth2DisconnectResponse{}, ReadBodyAsError(res)
 	}
 	var resp MCPServerOAuth2DisconnectResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // MCPServerConfig represents an admin-configured MCP server.
@@ -184,7 +183,7 @@ func (c *Client) MCPServerConfigs(ctx context.Context) ([]MCPServerConfig, error
 		return nil, ReadBodyAsError(res)
 	}
 	var configs []MCPServerConfig
-	return configs, json.NewDecoder(res.Body).Decode(&configs)
+	return configs, ReadBodyAsJSON(res, &configs)
 }
 
 func (c *Client) MCPServerConfigByID(ctx context.Context, id uuid.UUID) (MCPServerConfig, error) {
@@ -197,7 +196,7 @@ func (c *Client) MCPServerConfigByID(ctx context.Context, id uuid.UUID) (MCPServ
 		return MCPServerConfig{}, ReadBodyAsError(res)
 	}
 	var config MCPServerConfig
-	return config, json.NewDecoder(res.Body).Decode(&config)
+	return config, ReadBodyAsJSON(res, &config)
 }
 
 func (c *Client) CreateMCPServerConfig(ctx context.Context, req CreateMCPServerConfigRequest) (MCPServerConfig, error) {
@@ -210,7 +209,7 @@ func (c *Client) CreateMCPServerConfig(ctx context.Context, req CreateMCPServerC
 		return MCPServerConfig{}, ReadBodyAsError(res)
 	}
 	var config MCPServerConfig
-	return config, json.NewDecoder(res.Body).Decode(&config)
+	return config, ReadBodyAsJSON(res, &config)
 }
 
 func (c *Client) UpdateMCPServerConfig(ctx context.Context, id uuid.UUID, req UpdateMCPServerConfigRequest) (MCPServerConfig, error) {
@@ -223,7 +222,7 @@ func (c *Client) UpdateMCPServerConfig(ctx context.Context, id uuid.UUID, req Up
 		return MCPServerConfig{}, ReadBodyAsError(res)
 	}
 	var config MCPServerConfig
-	return config, json.NewDecoder(res.Body).Decode(&config)
+	return config, ReadBodyAsJSON(res, &config)
 }
 
 func (c *Client) DeleteMCPServerConfig(ctx context.Context, id uuid.UUID) error {

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -52,7 +52,7 @@ func (c *Client) GetNotificationsSettings(ctx context.Context) (NotificationsSet
 		return NotificationsSettings{}, ReadBodyAsError(res)
 	}
 	var settings NotificationsSettings
-	return settings, json.NewDecoder(res.Body).Decode(&settings)
+	return settings, ReadBodyAsJSON(res, &settings)
 }
 
 // PutNotificationsSettings modifies the notifications settings, which currently just controls whether all

--- a/codersdk/oauth2.go
+++ b/codersdk/oauth2.go
@@ -56,7 +56,7 @@ func (c *Client) OAuth2ProviderApps(ctx context.Context, filter OAuth2ProviderAp
 		return []OAuth2ProviderApp{}, ReadBodyAsError(res)
 	}
 	var apps []OAuth2ProviderApp
-	return apps, json.NewDecoder(res.Body).Decode(&apps)
+	return apps, ReadBodyAsJSON(res, &apps)
 }
 
 // OAuth2ProviderApp returns an application configured to authenticate using
@@ -71,7 +71,7 @@ func (c *Client) OAuth2ProviderApp(ctx context.Context, id uuid.UUID) (OAuth2Pro
 		return OAuth2ProviderApp{}, ReadBodyAsError(res)
 	}
 	var apps OAuth2ProviderApp
-	return apps, json.NewDecoder(res.Body).Decode(&apps)
+	return apps, ReadBodyAsJSON(res, &apps)
 }
 
 type PostOAuth2ProviderAppRequest struct {
@@ -92,7 +92,7 @@ func (c *Client) PostOAuth2ProviderApp(ctx context.Context, app PostOAuth2Provid
 		return OAuth2ProviderApp{}, ReadBodyAsError(res)
 	}
 	var resp OAuth2ProviderApp
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type PutOAuth2ProviderAppRequest struct {
@@ -113,7 +113,7 @@ func (c *Client) PutOAuth2ProviderApp(ctx context.Context, id uuid.UUID, app Put
 		return OAuth2ProviderApp{}, ReadBodyAsError(res)
 	}
 	var resp OAuth2ProviderApp
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteOAuth2ProviderApp deletes an application, also invalidating any tokens
@@ -153,7 +153,7 @@ func (c *Client) OAuth2ProviderAppSecrets(ctx context.Context, appID uuid.UUID) 
 		return []OAuth2ProviderAppSecret{}, ReadBodyAsError(res)
 	}
 	var resp []OAuth2ProviderAppSecret
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // PostOAuth2ProviderAppSecret creates a new secret for an OAuth2 application.
@@ -168,7 +168,7 @@ func (c *Client) PostOAuth2ProviderAppSecret(ctx context.Context, appID uuid.UUI
 		return OAuth2ProviderAppSecretFull{}, ReadBodyAsError(res)
 	}
 	var resp OAuth2ProviderAppSecretFull
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteOAuth2ProviderAppSecret deletes a secret from an OAuth2 application,
@@ -209,7 +209,7 @@ func (c *Client) OAuth2ProviderSettings(ctx context.Context) (OAuth2ProviderSett
 		return OAuth2ProviderSettings{}, ReadBodyAsError(res)
 	}
 	var settings OAuth2ProviderSettings
-	return settings, json.NewDecoder(res.Body).Decode(&settings)
+	return settings, ReadBodyAsJSON(res, &settings)
 }
 
 // PutOAuth2ProviderSettings modifies the deployment-wide OAuth2 provider settings.
@@ -223,7 +223,7 @@ func (c *Client) PutOAuth2ProviderSettings(ctx context.Context, settings OAuth2P
 		return OAuth2ProviderSettings{}, ReadBodyAsError(res)
 	}
 	var updated OAuth2ProviderSettings
-	return updated, json.NewDecoder(res.Body).Decode(&updated)
+	return updated, ReadBodyAsJSON(res, &updated)
 }
 
 type OAuth2ProviderGrantType string
@@ -611,7 +611,7 @@ func (c *Client) PostOAuth2ClientRegistration(ctx context.Context, req OAuth2Cli
 		return OAuth2ClientRegistrationResponse{}, ReadBodyAsError(res)
 	}
 	var resp OAuth2ClientRegistrationResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GetOAuth2ClientConfiguration retrieves client configuration (RFC 7592)
@@ -628,7 +628,7 @@ func (c *Client) GetOAuth2ClientConfiguration(ctx context.Context, clientID stri
 		return OAuth2ClientConfiguration{}, ReadBodyAsError(res)
 	}
 	var resp OAuth2ClientConfiguration
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // PutOAuth2ClientConfiguration updates client configuration (RFC 7592)
@@ -645,7 +645,7 @@ func (c *Client) PutOAuth2ClientConfiguration(ctx context.Context, clientID stri
 		return OAuth2ClientConfiguration{}, ReadBodyAsError(res)
 	}
 	var resp OAuth2ClientConfiguration
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteOAuth2ClientConfiguration deletes client registration (RFC 7592)

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -270,7 +270,7 @@ func (c *Client) OrganizationByName(ctx context.Context, name string) (Organizat
 	}
 
 	var organization Organization
-	return organization, json.NewDecoder(res.Body).Decode(&organization)
+	return organization, ReadBodyAsJSON(res, &organization)
 }
 
 func (c *Client) Organizations(ctx context.Context) ([]Organization, error) {
@@ -285,7 +285,7 @@ func (c *Client) Organizations(ctx context.Context) ([]Organization, error) {
 	}
 
 	var organizations []Organization
-	return organizations, json.NewDecoder(res.Body).Decode(&organizations)
+	return organizations, ReadBodyAsJSON(res, &organizations)
 }
 
 func (c *Client) Organization(ctx context.Context, id uuid.UUID) (Organization, error) {
@@ -307,7 +307,7 @@ func (c *Client) CreateOrganization(ctx context.Context, req CreateOrganizationR
 	}
 
 	var org Organization
-	return org, json.NewDecoder(res.Body).Decode(&org)
+	return org, ReadBodyAsJSON(res, &org)
 }
 
 // UpdateOrganization will update information about the corresponding organization, based on
@@ -324,7 +324,7 @@ func (c *Client) UpdateOrganization(ctx context.Context, orgID string, req Updat
 	}
 
 	var organization Organization
-	return organization, json.NewDecoder(res.Body).Decode(&organization)
+	return organization, ReadBodyAsJSON(res, &organization)
 }
 
 // DeleteOrganization will remove the corresponding organization from the deployment, based on
@@ -360,7 +360,7 @@ func (c *Client) ProvisionerDaemons(ctx context.Context) ([]ProvisionerDaemon, e
 	}
 
 	var daemons []ProvisionerDaemon
-	return daemons, json.NewDecoder(res.Body).Decode(&daemons)
+	return daemons, ReadBodyAsJSON(res, &daemons)
 }
 
 type OrganizationProvisionerDaemonsOptions struct {
@@ -413,7 +413,7 @@ func (c *Client) OrganizationProvisionerDaemons(ctx context.Context, organizatio
 	}
 
 	var daemons []ProvisionerDaemon
-	return daemons, json.NewDecoder(res.Body).Decode(&daemons)
+	return daemons, ReadBodyAsJSON(res, &daemons)
 }
 
 type OrganizationProvisionerJobsOptions struct {
@@ -462,7 +462,7 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 	}
 
 	var jobs []ProvisionerJob
-	return jobs, json.NewDecoder(res.Body).Decode(&jobs)
+	return jobs, ReadBodyAsJSON(res, &jobs)
 }
 
 func (c *Client) OrganizationProvisionerJob(ctx context.Context, organizationID, jobID uuid.UUID) (job ProvisionerJob, err error) {
@@ -478,7 +478,7 @@ func (c *Client) OrganizationProvisionerJob(ctx context.Context, organizationID,
 	if res.StatusCode != http.StatusOK {
 		return job, ReadBodyAsError(res)
 	}
-	return job, json.NewDecoder(res.Body).Decode(&job)
+	return job, ReadBodyAsJSON(res, &job)
 }
 
 func joinSlice[T ~string](s []T) string {
@@ -514,7 +514,7 @@ func (c *Client) CreateTemplateVersion(ctx context.Context, organizationID uuid.
 	}
 
 	var templateVersion TemplateVersion
-	return templateVersion, json.NewDecoder(res.Body).Decode(&templateVersion)
+	return templateVersion, ReadBodyAsJSON(res, &templateVersion)
 }
 
 func (c *Client) TemplateVersionByOrganizationAndName(ctx context.Context, organizationID uuid.UUID, templateName, versionName string) (TemplateVersion, error) {
@@ -532,7 +532,7 @@ func (c *Client) TemplateVersionByOrganizationAndName(ctx context.Context, organ
 	}
 
 	var templateVersion TemplateVersion
-	return templateVersion, json.NewDecoder(res.Body).Decode(&templateVersion)
+	return templateVersion, ReadBodyAsJSON(res, &templateVersion)
 }
 
 // CreateTemplate creates a new template inside an organization.
@@ -551,7 +551,7 @@ func (c *Client) CreateTemplate(ctx context.Context, organizationID uuid.UUID, r
 	}
 
 	var template Template
-	return template, json.NewDecoder(res.Body).Decode(&template)
+	return template, ReadBodyAsJSON(res, &template)
 }
 
 // TemplatesByOrganization lists all templates inside of an organization.
@@ -570,7 +570,7 @@ func (c *Client) TemplatesByOrganization(ctx context.Context, organizationID uui
 	}
 
 	var templates []Template
-	return templates, json.NewDecoder(res.Body).Decode(&templates)
+	return templates, ReadBodyAsJSON(res, &templates)
 }
 
 type TemplateFilter struct {
@@ -631,7 +631,7 @@ func (c *Client) Templates(ctx context.Context, filter TemplateFilter) ([]Templa
 	}
 
 	var templates []Template
-	return templates, json.NewDecoder(res.Body).Decode(&templates)
+	return templates, ReadBodyAsJSON(res, &templates)
 }
 
 // TemplateByName finds a template inside the organization provided with a case-insensitive name.
@@ -653,7 +653,7 @@ func (c *Client) TemplateByName(ctx context.Context, organizationID uuid.UUID, n
 	}
 
 	var template Template
-	return template, json.NewDecoder(res.Body).Decode(&template)
+	return template, ReadBodyAsJSON(res, &template)
 }
 
 // CreateWorkspace creates a new workspace for the template specified.
@@ -676,5 +676,5 @@ func (c *Client) CreateUserWorkspace(ctx context.Context, user string, request C
 	}
 
 	var workspace Workspace
-	return workspace, json.NewDecoder(res.Body).Decode(&workspace)
+	return workspace, ReadBodyAsJSON(res, &workspace)
 }

--- a/codersdk/prebuilds.go
+++ b/codersdk/prebuilds.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 )
 
@@ -29,7 +28,7 @@ func (c *Client) GetPrebuildsSettings(ctx context.Context) (PrebuildsSettings, e
 		return PrebuildsSettings{}, ReadBodyAsError(res)
 	}
 	var settings PrebuildsSettings
-	return settings, json.NewDecoder(res.Body).Decode(&settings)
+	return settings, ReadBodyAsJSON(res, &settings)
 }
 
 // PutPrebuildsSettings modifies the prebuilds settings, which currently just controls whether all

--- a/codersdk/presets.go
+++ b/codersdk/presets.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -36,5 +35,5 @@ func (c *Client) TemplateVersionPresets(ctx context.Context, templateVersionID u
 		return nil, ReadBodyAsError(res)
 	}
 	var presets []Preset
-	return presets, json.NewDecoder(res.Body).Decode(&presets)
+	return presets, ReadBodyAsJSON(res, &presets)
 }

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -433,7 +432,7 @@ func (c *Client) CreateProvisionerKey(ctx context.Context, organizationID uuid.U
 		return CreateProvisionerKeyResponse{}, ReadBodyAsError(res)
 	}
 	var resp CreateProvisionerKeyResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // ListProvisionerKeys lists all provisioner keys for an organization.
@@ -451,7 +450,7 @@ func (c *Client) ListProvisionerKeys(ctx context.Context, organizationID uuid.UU
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []ProvisionerKey
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GetProvisionerKey returns the provisioner key.
@@ -471,7 +470,7 @@ func (c *Client) GetProvisionerKey(ctx context.Context, pk string) (ProvisionerK
 		return ProvisionerKey{}, ReadBodyAsError(res)
 	}
 	var resp ProvisionerKey
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // ListProvisionerKeyDaemons lists all provisioner keys with their associated daemons for an organization.
@@ -489,7 +488,7 @@ func (c *Client) ListProvisionerKeyDaemons(ctx context.Context, organizationID u
 		return nil, ReadBodyAsError(res)
 	}
 	var resp []ProvisionerKeyDaemons
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // DeleteProvisionerKey deletes a provisioner key.

--- a/codersdk/replicas.go
+++ b/codersdk/replicas.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -40,5 +39,5 @@ func (c *Client) Replicas(ctx context.Context) ([]Replica, error) {
 	}
 
 	var replicas []Replica
-	return replicas, json.NewDecoder(res.Body).Decode(&replicas)
+	return replicas, ReadBodyAsJSON(res, &replicas)
 }

--- a/codersdk/richparameters.go
+++ b/codersdk/richparameters.go
@@ -31,7 +31,7 @@ func (c *Client) EvaluateTemplateVersion(ctx context.Context, templateVersionID 
 	}
 
 	var dynResp DynamicParametersResponse
-	return dynResp, json.NewDecoder(res.Body).Decode(&dynResp)
+	return dynResp, ReadBodyAsJSON(res, &dynResp)
 }
 
 func ValidateNewWorkspaceParameters(richParameters []TemplateVersionParameter, buildParameters []WorkspaceBuildParameter) error {

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -107,7 +106,7 @@ func (c *Client) CreateOrganizationRole(ctx context.Context, role Role) (Role, e
 		return Role{}, ReadBodyAsError(res)
 	}
 	var r Role
-	return r, json.NewDecoder(res.Body).Decode(&r)
+	return r, ReadBodyAsJSON(res, &r)
 }
 
 // UpdateOrganizationRole will update an existing custom organization role
@@ -131,7 +130,7 @@ func (c *Client) UpdateOrganizationRole(ctx context.Context, role Role) (Role, e
 		return Role{}, ReadBodyAsError(res)
 	}
 	var r Role
-	return r, json.NewDecoder(res.Body).Decode(&r)
+	return r, ReadBodyAsJSON(res, &r)
 }
 
 // DeleteOrganizationRole will delete a custom organization role
@@ -159,7 +158,7 @@ func (c *Client) ListSiteRoles(ctx context.Context) ([]AssignableRoles, error) {
 		return nil, ReadBodyAsError(res)
 	}
 	var roles []AssignableRoles
-	return roles, json.NewDecoder(res.Body).Decode(&roles)
+	return roles, ReadBodyAsJSON(res, &roles)
 }
 
 // ListOrganizationRoles lists all assignable roles for a given organization.
@@ -173,7 +172,7 @@ func (c *Client) ListOrganizationRoles(ctx context.Context, org uuid.UUID) ([]As
 		return nil, ReadBodyAsError(res)
 	}
 	var roles []AssignableRoles
-	return roles, json.NewDecoder(res.Body).Decode(&roles)
+	return roles, ReadBodyAsJSON(res, &roles)
 }
 
 // CreatePermissions is a helper function to quickly build permissions.

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -78,7 +78,7 @@ func (c *Client) TemplateBuilderBases(ctx context.Context) (TemplateBuilderBases
 		return TemplateBuilderBasesResponse{}, ReadBodyAsError(res)
 	}
 	var resp TemplateBuilderBasesResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // TemplateBuilderModules returns the list of modules available for a given
@@ -98,7 +98,7 @@ func (c *Client) TemplateBuilderModules(ctx context.Context, base string) (Templ
 		return TemplateBuilderModulesResponse{}, ReadBodyAsError(res)
 	}
 	var resp TemplateBuilderModulesResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // TemplateBuilderComposeRequest is the request body for
@@ -196,5 +196,5 @@ func (c *Client) TemplateBuilderCreateTemplate(ctx context.Context, req Template
 		return TemplateBuilderCreateTemplateResponse{}, ReadBodyAsError(res)
 	}
 	var resp TemplateBuilderCreateTemplateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -306,7 +305,7 @@ func (c *Client) Template(ctx context.Context, template uuid.UUID) (Template, er
 		return Template{}, ReadBodyAsError(res)
 	}
 	var resp Template
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) ArchiveTemplateVersions(ctx context.Context, template uuid.UUID, all bool) (ArchiveTemplateVersionsResponse, error) {
@@ -324,7 +323,7 @@ func (c *Client) ArchiveTemplateVersions(ctx context.Context, template uuid.UUID
 		return ArchiveTemplateVersionsResponse{}, ReadBodyAsError(res)
 	}
 	var resp ArchiveTemplateVersionsResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 //nolint:revive
@@ -369,7 +368,7 @@ func (c *Client) UpdateTemplateMeta(ctx context.Context, templateID uuid.UUID, r
 		return Template{}, ReadBodyAsError(res)
 	}
 	var updated Template
-	return updated, json.NewDecoder(res.Body).Decode(&updated)
+	return updated, ReadBodyAsJSON(res, &updated)
 }
 
 func (c *Client) UpdateTemplateACL(ctx context.Context, templateID uuid.UUID, req UpdateTemplateACL) error {
@@ -405,7 +404,7 @@ func (c *Client) TemplateACLAvailable(ctx context.Context, templateID uuid.UUID,
 		return ACLAvailable{}, ReadBodyAsError(res)
 	}
 	var acl ACLAvailable
-	return acl, json.NewDecoder(res.Body).Decode(&acl)
+	return acl, ReadBodyAsJSON(res, &acl)
 }
 
 func (c *Client) TemplateACL(ctx context.Context, templateID uuid.UUID) (TemplateACL, error) {
@@ -418,7 +417,7 @@ func (c *Client) TemplateACL(ctx context.Context, templateID uuid.UUID) (Templat
 		return TemplateACL{}, ReadBodyAsError(res)
 	}
 	var acl TemplateACL
-	return acl, json.NewDecoder(res.Body).Decode(&acl)
+	return acl, ReadBodyAsJSON(res, &acl)
 }
 
 // UpdateActiveTemplateVersion updates the active template version to the ID provided.
@@ -458,7 +457,7 @@ func (c *Client) TemplateVersionsByTemplate(ctx context.Context, req TemplateVer
 		return nil, ReadBodyAsError(res)
 	}
 	var templateVersion []TemplateVersion
-	return templateVersion, json.NewDecoder(res.Body).Decode(&templateVersion)
+	return templateVersion, ReadBodyAsJSON(res, &templateVersion)
 }
 
 // TemplateVersionByName returns a template version by it's friendly name.
@@ -473,7 +472,7 @@ func (c *Client) TemplateVersionByName(ctx context.Context, template uuid.UUID, 
 		return TemplateVersion{}, ReadBodyAsError(res)
 	}
 	var templateVersion TemplateVersion
-	return templateVersion, json.NewDecoder(res.Body).Decode(&templateVersion)
+	return templateVersion, ReadBodyAsJSON(res, &templateVersion)
 }
 
 func (c *Client) TemplateDAUsLocalTZ(ctx context.Context, templateID uuid.UUID) (*DAUsResponse, error) {
@@ -496,7 +495,7 @@ func (c *Client) TemplateDAUs(ctx context.Context, templateID uuid.UUID, tzOffse
 	}
 
 	var resp DAUsResponse
-	return &resp, json.NewDecoder(res.Body).Decode(&resp)
+	return &resp, ReadBodyAsJSON(res, &resp)
 }
 
 // AgentStatsReportRequest is a WebSocket request by coderd
@@ -532,7 +531,7 @@ func (c *Client) StarterTemplates(ctx context.Context) ([]TemplateExample, error
 		return nil, ReadBodyAsError(res)
 	}
 	var templateExamples []TemplateExample
-	return templateExamples, json.NewDecoder(res.Body).Decode(&templateExamples)
+	return templateExamples, ReadBodyAsJSON(res, &templateExamples)
 }
 
 type InvalidatePresetsResponse struct {
@@ -563,5 +562,5 @@ func (c *Client) InvalidateTemplatePresets(ctx context.Context, template uuid.UU
 	}
 
 	var response InvalidatePresetsResponse
-	return response, json.NewDecoder(res.Body).Decode(&response)
+	return response, ReadBodyAsJSON(res, &response)
 }

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,7 +112,7 @@ func (c *Client) TemplateVersion(ctx context.Context, id uuid.UUID) (TemplateVer
 		return TemplateVersion{}, ReadBodyAsError(res)
 	}
 	var version TemplateVersion
-	return version, json.NewDecoder(res.Body).Decode(&version)
+	return version, ReadBodyAsJSON(res, &version)
 }
 
 // CancelTemplateVersion marks a template version job as canceled.
@@ -140,7 +139,7 @@ func (c *Client) TemplateVersionRichParameters(ctx context.Context, version uuid
 		return nil, ReadBodyAsError(res)
 	}
 	var params []TemplateVersionParameter
-	return params, json.NewDecoder(res.Body).Decode(&params)
+	return params, ReadBodyAsJSON(res, &params)
 }
 
 // TemplateVersionExternalAuth returns authentication providers for the requested template version.
@@ -154,7 +153,7 @@ func (c *Client) TemplateVersionExternalAuth(ctx context.Context, version uuid.U
 		return nil, ReadBodyAsError(res)
 	}
 	var extAuth []TemplateVersionExternalAuth
-	return extAuth, json.NewDecoder(res.Body).Decode(&extAuth)
+	return extAuth, ReadBodyAsJSON(res, &extAuth)
 }
 
 // TemplateVersionResources returns resources a template version declares.
@@ -168,7 +167,7 @@ func (c *Client) TemplateVersionResources(ctx context.Context, version uuid.UUID
 		return nil, ReadBodyAsError(res)
 	}
 	var resources []WorkspaceResource
-	return resources, json.NewDecoder(res.Body).Decode(&resources)
+	return resources, ReadBodyAsJSON(res, &resources)
 }
 
 // TemplateVersionVariables returns resources a template version variables.
@@ -182,7 +181,7 @@ func (c *Client) TemplateVersionVariables(ctx context.Context, version uuid.UUID
 		return nil, ReadBodyAsError(res)
 	}
 	var variables []TemplateVersionVariable
-	return variables, json.NewDecoder(res.Body).Decode(&variables)
+	return variables, ReadBodyAsJSON(res, &variables)
 }
 
 // TemplateVersionLogsAfter streams logs for a template version that occurred after a specific log ID.
@@ -211,7 +210,7 @@ func (c *Client) CreateTemplateVersionDryRun(ctx context.Context, version uuid.U
 	}
 
 	var job ProvisionerJob
-	return job, json.NewDecoder(res.Body).Decode(&job)
+	return job, ReadBodyAsJSON(res, &job)
 }
 
 // TemplateVersionDryRun returns the current state of a template version dry-run
@@ -227,7 +226,7 @@ func (c *Client) TemplateVersionDryRun(ctx context.Context, version, job uuid.UU
 	}
 
 	var j ProvisionerJob
-	return j, json.NewDecoder(res.Body).Decode(&j)
+	return j, ReadBodyAsJSON(res, &j)
 }
 
 // TemplateVersionDryRunMatchedProvisioners returns the matched provisioners for a
@@ -243,7 +242,7 @@ func (c *Client) TemplateVersionDryRunMatchedProvisioners(ctx context.Context, v
 	}
 
 	var matched MatchedProvisioners
-	return matched, json.NewDecoder(res.Body).Decode(&matched)
+	return matched, ReadBodyAsJSON(res, &matched)
 }
 
 // TemplateVersionDryRunResources returns the resources of a finished template
@@ -259,7 +258,7 @@ func (c *Client) TemplateVersionDryRunResources(ctx context.Context, version, jo
 	}
 
 	var resources []WorkspaceResource
-	return resources, json.NewDecoder(res.Body).Decode(&resources)
+	return resources, ReadBodyAsJSON(res, &resources)
 }
 
 // TemplateVersionDryRunLogsAfter streams logs for a template version dry-run
@@ -298,7 +297,7 @@ func (c *Client) PreviousTemplateVersion(ctx context.Context, organization uuid.
 		return TemplateVersion{}, ReadBodyAsError(res)
 	}
 	var version TemplateVersion
-	return version, json.NewDecoder(res.Body).Decode(&version)
+	return version, ReadBodyAsJSON(res, &version)
 }
 
 func (c *Client) UpdateTemplateVersion(ctx context.Context, versionID uuid.UUID, req PatchTemplateVersionRequest) (TemplateVersion, error) {
@@ -311,5 +310,5 @@ func (c *Client) UpdateTemplateVersion(ctx context.Context, versionID uuid.UUID,
 		return TemplateVersion{}, ReadBodyAsError(res)
 	}
 	var version TemplateVersion
-	return version, json.NewDecoder(res.Body).Decode(&version)
+	return version, ReadBodyAsJSON(res, &version)
 }

--- a/codersdk/updatecheck.go
+++ b/codersdk/updatecheck.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 )
 
@@ -30,5 +29,5 @@ func (c *Client) UpdateCheck(ctx context.Context) (UpdateCheckResponse, error) {
 	}
 
 	var buildInfo UpdateCheckResponse
-	return buildInfo, json.NewDecoder(res.Body).Decode(&buildInfo)
+	return buildInfo, ReadBodyAsJSON(res, &buildInfo)
 }

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -499,7 +499,7 @@ func (c *Client) UserAutofillParameters(ctx context.Context, user string, templa
 	}
 
 	var params []UserParameter
-	return params, json.NewDecoder(res.Body).Decode(&params)
+	return params, ReadBodyAsJSON(res, &params)
 }
 
 // HasFirstUser returns whether the first user has been created.
@@ -538,7 +538,7 @@ func (c *Client) CreateFirstUser(ctx context.Context, req CreateFirstUserRequest
 		return CreateFirstUserResponse{}, ReadBodyAsError(res)
 	}
 	var resp CreateFirstUserResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // CreateUser
@@ -570,7 +570,7 @@ func (c *Client) CreateUserWithOrgs(ctx context.Context, req CreateUserRequestWi
 		return User{}, ReadBodyAsError(res)
 	}
 	var user User
-	return user, json.NewDecoder(res.Body).Decode(&user)
+	return user, ReadBodyAsJSON(res, &user)
 }
 
 // DeleteUser deletes a user.
@@ -599,7 +599,7 @@ func (c *Client) UpdateUserProfile(ctx context.Context, user string, req UpdateU
 		return User{}, ReadBodyAsError(res)
 	}
 	var resp User
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // ValidateUserPassword validates the complexity of a user password and that it is secured enough.
@@ -613,7 +613,7 @@ func (c *Client) ValidateUserPassword(ctx context.Context, req ValidateUserPassw
 		return ValidateUserPasswordResponse{}, ReadBodyAsError(res)
 	}
 	var resp ValidateUserPasswordResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpdateUserStatus sets the user status to the given status
@@ -638,7 +638,7 @@ func (c *Client) UpdateUserStatus(ctx context.Context, user string, status UserS
 	}
 
 	var resp User
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GetUserAppearanceSettings fetches the appearance settings for a user.
@@ -652,7 +652,7 @@ func (c *Client) GetUserAppearanceSettings(ctx context.Context, user string) (Us
 		return UserAppearanceSettings{}, ReadBodyAsError(res)
 	}
 	var resp UserAppearanceSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpdateUserAppearanceSettings updates the appearance settings for a user.
@@ -666,7 +666,7 @@ func (c *Client) UpdateUserAppearanceSettings(ctx context.Context, user string, 
 		return UserAppearanceSettings{}, ReadBodyAsError(res)
 	}
 	var resp UserAppearanceSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // GetUserPreferenceSettings fetches the preference settings for a user.
@@ -680,7 +680,7 @@ func (c *Client) GetUserPreferenceSettings(ctx context.Context, user string) (Us
 		return UserPreferenceSettings{}, ReadBodyAsError(res)
 	}
 	var resp UserPreferenceSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpdateUserPreferenceSettings updates the preference settings for a user.
@@ -694,7 +694,7 @@ func (c *Client) UpdateUserPreferenceSettings(ctx context.Context, user string, 
 		return UserPreferenceSettings{}, ReadBodyAsError(res)
 	}
 	var resp UserPreferenceSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpdateUserPassword updates a user password.
@@ -722,7 +722,7 @@ func (c *Client) PostOrganizationMember(ctx context.Context, organizationID uuid
 		return OrganizationMember{}, ReadBodyAsError(res)
 	}
 	var member OrganizationMember
-	return member, json.NewDecoder(res.Body).Decode(&member)
+	return member, ReadBodyAsJSON(res, &member)
 }
 
 // DeleteOrganizationMember removes a user from an organization
@@ -800,7 +800,7 @@ func (c *Client) OrganizationMember(ctx context.Context, organizationIdent, user
 		return OrganizationMemberWithUserData{}, ReadBodyAsError(res)
 	}
 	var member OrganizationMemberWithUserData
-	return member, json.NewDecoder(res.Body).Decode(&member)
+	return member, ReadBodyAsJSON(res, &member)
 }
 
 // OrganizationMembers lists all members in an organization
@@ -818,7 +818,7 @@ func (c *Client) OrganizationMembers(ctx context.Context, organizationID uuid.UU
 		return nil, ReadBodyAsError(res)
 	}
 	var members []OrganizationMemberWithUserData
-	return members, json.NewDecoder(res.Body).Decode(&members)
+	return members, ReadBodyAsJSON(res, &members)
 }
 
 // OrganizationMembers lists filtered and paginated members in an organization
@@ -837,7 +837,7 @@ func (c *Client) OrganizationMembersPaginated(ctx context.Context, organizationI
 		return PaginatedMembersResponse{}, ReadBodyAsError(res)
 	}
 	var membersRes PaginatedMembersResponse
-	return membersRes, json.NewDecoder(res.Body).Decode(&membersRes)
+	return membersRes, ReadBodyAsJSON(res, &membersRes)
 }
 
 // UpdateUserRoles grants the userID the specified roles.
@@ -852,7 +852,7 @@ func (c *Client) UpdateUserRoles(ctx context.Context, user string, req UpdateRol
 		return User{}, ReadBodyAsError(res)
 	}
 	var resp User
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpdateOrganizationMemberRoles grants the userID the specified roles in an org.
@@ -867,7 +867,7 @@ func (c *Client) UpdateOrganizationMemberRoles(ctx context.Context, organization
 		return OrganizationMember{}, ReadBodyAsError(res)
 	}
 	var member OrganizationMember
-	return member, json.NewDecoder(res.Body).Decode(&member)
+	return member, ReadBodyAsJSON(res, &member)
 }
 
 // UserRoles returns all roles the user has
@@ -881,7 +881,7 @@ func (c *Client) UserRoles(ctx context.Context, user string) (UserRoles, error) 
 		return UserRoles{}, ReadBodyAsError(res)
 	}
 	var roles UserRoles
-	return roles, json.NewDecoder(res.Body).Decode(&roles)
+	return roles, ReadBodyAsJSON(res, &roles)
 }
 
 // UserOIDCClaims returns the merged OIDC claims for the authenticated user.
@@ -895,7 +895,7 @@ func (c *Client) UserOIDCClaims(ctx context.Context) (OIDCClaimsResponse, error)
 		return OIDCClaimsResponse{}, ReadBodyAsError(res)
 	}
 	var resp OIDCClaimsResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // LoginWithPassword creates a session token authenticating with an email and password.
@@ -910,7 +910,7 @@ func (c *Client) LoginWithPassword(ctx context.Context, req LoginWithPasswordReq
 		return LoginWithPasswordResponse{}, ReadBodyAsError(res)
 	}
 	var resp LoginWithPasswordResponse
-	err = json.NewDecoder(res.Body).Decode(&resp)
+	err = ReadBodyAsJSON(res, &resp)
 	if err != nil {
 		return LoginWithPasswordResponse{}, err
 	}
@@ -965,7 +965,7 @@ func (c *Client) ConvertUserLoginType(ctx context.Context, user string, req Conv
 		return OAuthConversionResponse{}, ReadBodyAsError(res)
 	}
 	var resp OAuthConversionResponse
-	err = json.NewDecoder(res.Body).Decode(&resp)
+	err = ReadBodyAsJSON(res, &resp)
 	if err != nil {
 		return OAuthConversionResponse{}, err
 	}
@@ -1011,7 +1011,7 @@ func (c *Client) UserQuietHoursSchedule(ctx context.Context, userIdent string) (
 		return UserQuietHoursScheduleResponse{}, ReadBodyAsError(res)
 	}
 	var resp UserQuietHoursScheduleResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // UpdateUserQuietHoursSchedule updates the quiet hours settings for the user.
@@ -1026,7 +1026,7 @@ func (c *Client) UpdateUserQuietHoursSchedule(ctx context.Context, userIdent str
 		return UserQuietHoursScheduleResponse{}, ReadBodyAsError(res)
 	}
 	var resp UserQuietHoursScheduleResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // Users returns all users according to the request parameters. If no parameters are set,
@@ -1046,7 +1046,7 @@ func (c *Client) Users(ctx context.Context, req UsersRequest) (GetUsersResponse,
 	}
 
 	var usersRes GetUsersResponse
-	return usersRes, json.NewDecoder(res.Body).Decode(&usersRes)
+	return usersRes, ReadBodyAsJSON(res, &usersRes)
 }
 
 // OrganizationsByUser returns all organizations the user is a member of.
@@ -1060,7 +1060,7 @@ func (c *Client) OrganizationsByUser(ctx context.Context, user string) ([]Organi
 		return nil, ReadBodyAsError(res)
 	}
 	var orgs []Organization
-	return orgs, json.NewDecoder(res.Body).Decode(&orgs)
+	return orgs, ReadBodyAsJSON(res, &orgs)
 }
 
 func (c *Client) OrganizationByUserAndName(ctx context.Context, user string, name string) (Organization, error) {
@@ -1073,7 +1073,7 @@ func (c *Client) OrganizationByUserAndName(ctx context.Context, user string, nam
 		return Organization{}, ReadBodyAsError(res)
 	}
 	var org Organization
-	return org, json.NewDecoder(res.Body).Decode(&org)
+	return org, ReadBodyAsJSON(res, &org)
 }
 
 // AuthMethods returns types of authentication available to the user.
@@ -1089,5 +1089,5 @@ func (c *Client) AuthMethods(ctx context.Context) (AuthMethods, error) {
 	}
 
 	var userAuth AuthMethods
-	return userAuth, json.NewDecoder(res.Body).Decode(&userAuth)
+	return userAuth, ReadBodyAsJSON(res, &userAuth)
 }

--- a/codersdk/usersecrets.go
+++ b/codersdk/usersecrets.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -66,7 +65,7 @@ func (c *Client) CreateUserSecret(ctx context.Context, user string, req CreateUs
 		return UserSecret{}, ReadBodyAsError(res)
 	}
 	var secret UserSecret
-	return secret, json.NewDecoder(res.Body).Decode(&secret)
+	return secret, ReadBodyAsJSON(res, &secret)
 }
 
 func (c *Client) UserSecrets(ctx context.Context, user string) ([]UserSecret, error) {
@@ -79,7 +78,7 @@ func (c *Client) UserSecrets(ctx context.Context, user string) ([]UserSecret, er
 		return nil, ReadBodyAsError(res)
 	}
 	var secrets []UserSecret
-	return secrets, json.NewDecoder(res.Body).Decode(&secrets)
+	return secrets, ReadBodyAsJSON(res, &secrets)
 }
 
 // ImportUserSecretsRequest is the payload for the bulk secret import
@@ -103,7 +102,7 @@ func (c *Client) ImportUserSecrets(ctx context.Context, user string, req ImportU
 		return nil, ReadBodyAsError(res)
 	}
 	var secrets []UserSecret
-	return secrets, json.NewDecoder(res.Body).Decode(&secrets)
+	return secrets, ReadBodyAsJSON(res, &secrets)
 }
 
 func (c *Client) UserSecretByName(ctx context.Context, user string, name string) (UserSecret, error) {
@@ -116,7 +115,7 @@ func (c *Client) UserSecretByName(ctx context.Context, user string, name string)
 		return UserSecret{}, ReadBodyAsError(res)
 	}
 	var secret UserSecret
-	return secret, json.NewDecoder(res.Body).Decode(&secret)
+	return secret, ReadBodyAsJSON(res, &secret)
 }
 
 func (c *Client) UpdateUserSecret(ctx context.Context, user string, name string, req UpdateUserSecretRequest) (UserSecret, error) {
@@ -129,7 +128,7 @@ func (c *Client) UpdateUserSecret(ctx context.Context, user string, name string,
 		return UserSecret{}, ReadBodyAsError(res)
 	}
 	var secret UserSecret
-	return secret, json.NewDecoder(res.Body).Decode(&secret)
+	return secret, ReadBodyAsJSON(res, &secret)
 }
 
 func (c *Client) DeleteUserSecret(ctx context.Context, user string, name string) error {

--- a/codersdk/userskills.go
+++ b/codersdk/userskills.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +60,7 @@ func (c *ExperimentalClient) CreateUserSkill(ctx context.Context, user string, r
 		return UserSkill{}, ReadBodyAsError(res)
 	}
 	var skill UserSkill
-	return skill, json.NewDecoder(res.Body).Decode(&skill)
+	return skill, ReadBodyAsJSON(res, &skill)
 }
 
 // UserSkills lists user skill metadata for the specified user.
@@ -75,7 +74,7 @@ func (c *ExperimentalClient) UserSkills(ctx context.Context, user string) ([]Use
 		return nil, ReadBodyAsError(res)
 	}
 	var skills []UserSkillMetadata
-	return skills, json.NewDecoder(res.Body).Decode(&skills)
+	return skills, ReadBodyAsJSON(res, &skills)
 }
 
 // UserSkillByName returns a user skill by name.
@@ -89,7 +88,7 @@ func (c *ExperimentalClient) UserSkillByName(ctx context.Context, user string, n
 		return UserSkill{}, ReadBodyAsError(res)
 	}
 	var skill UserSkill
-	return skill, json.NewDecoder(res.Body).Decode(&skill)
+	return skill, ReadBodyAsJSON(res, &skill)
 }
 
 // UpdateUserSkill replaces a user skill's raw Markdown content.
@@ -103,7 +102,7 @@ func (c *ExperimentalClient) UpdateUserSkill(ctx context.Context, user string, n
 		return UserSkill{}, ReadBodyAsError(res)
 	}
 	var skill UserSkill
-	return skill, json.NewDecoder(res.Body).Decode(&skill)
+	return skill, ReadBodyAsJSON(res, &skill)
 }
 
 // DeleteUserSkill deletes a user skill by name.

--- a/codersdk/workspaceagentportshare.go
+++ b/codersdk/workspaceagentportshare.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -118,7 +117,7 @@ func (c *Client) GetWorkspaceAgentPortShares(ctx context.Context, workspaceID uu
 		return shares, ReadBodyAsError(res)
 	}
 
-	return shares, json.NewDecoder(res.Body).Decode(&shares)
+	return shares, ReadBodyAsJSON(res, &shares)
 }
 
 func (c *Client) UpsertWorkspaceAgentPortShare(ctx context.Context, workspaceID uuid.UUID, req UpsertWorkspaceAgentPortShareRequest) (WorkspaceAgentPortShare, error) {
@@ -132,7 +131,7 @@ func (c *Client) UpsertWorkspaceAgentPortShare(ctx context.Context, workspaceID 
 		return share, ReadBodyAsError(res)
 	}
 
-	return share, json.NewDecoder(res.Body).Decode(&share)
+	return share, ReadBodyAsJSON(res, &share)
 }
 
 func (c *Client) DeleteWorkspaceAgentPortShare(ctx context.Context, workspaceID uuid.UUID, req DeleteWorkspaceAgentPortShareRequest) error {

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -365,7 +365,7 @@ func (c *Client) WorkspaceAgent(ctx context.Context, id uuid.UUID) (WorkspaceAge
 		return WorkspaceAgent{}, ReadBodyAsError(res)
 	}
 	var workspaceAgent WorkspaceAgent
-	err = json.NewDecoder(res.Body).Decode(&workspaceAgent)
+	err = ReadBodyAsJSON(res, &workspaceAgent)
 	if err != nil {
 		return WorkspaceAgent{}, err
 	}
@@ -392,7 +392,7 @@ func (c *Client) IssueReconnectingPTYSignedToken(ctx context.Context, req IssueR
 		return IssueReconnectingPTYSignedTokenResponse{}, ReadBodyAsError(res)
 	}
 	var resp IssueReconnectingPTYSignedTokenResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 type WorkspaceAgentListeningPortsResponse struct {
@@ -421,7 +421,7 @@ func (c *Client) WorkspaceAgentListeningPorts(ctx context.Context, agentID uuid.
 		return WorkspaceAgentListeningPortsResponse{}, ReadBodyAsError(res)
 	}
 	var listeningPorts WorkspaceAgentListeningPortsResponse
-	return listeningPorts, json.NewDecoder(res.Body).Decode(&listeningPorts)
+	return listeningPorts, ReadBodyAsJSON(res, &listeningPorts)
 }
 
 // WorkspaceAgentDevcontainerStatus is the status of a devcontainer.
@@ -582,7 +582,7 @@ func (c *Client) WorkspaceAgentListContainers(ctx context.Context, agentID uuid.
 	}
 	var cr WorkspaceAgentListContainersResponse
 
-	return cr, json.NewDecoder(res.Body).Decode(&cr)
+	return cr, ReadBodyAsJSON(res, &cr)
 }
 
 func (c *Client) WatchWorkspaceAgentContainers(ctx context.Context, agentID uuid.UUID) (<-chan WorkspaceAgentListContainersResponse, io.Closer, error) {
@@ -643,7 +643,7 @@ func (c *Client) WorkspaceAgentRecreateDevcontainer(ctx context.Context, agentID
 		return Response{}, ReadBodyAsError(res)
 	}
 	var m Response
-	if err := json.NewDecoder(res.Body).Decode(&m); err != nil {
+	if err := ReadBodyAsJSON(res, &m); err != nil {
 		return Response{}, xerrors.Errorf("decode response body: %w", err)
 	}
 	return m, nil
@@ -679,7 +679,7 @@ func (c *Client) WorkspaceAgentLogsAfter(ctx context.Context, agentID uuid.UUID,
 		}
 
 		var logs []WorkspaceAgentLog
-		err = json.NewDecoder(resp.Body).Decode(&logs)
+		err = ReadBodyAsJSON(resp, &logs)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("decode startup logs: %w", err)
 		}

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -147,7 +146,7 @@ func (c *Client) WorkspaceBuild(ctx context.Context, id uuid.UUID) (WorkspaceBui
 		return WorkspaceBuild{}, ReadBodyAsError(res)
 	}
 	var workspaceBuild WorkspaceBuild
-	return workspaceBuild, json.NewDecoder(res.Body).Decode(&workspaceBuild)
+	return workspaceBuild, ReadBodyAsJSON(res, &workspaceBuild)
 }
 
 type CancelWorkspaceBuildStatus string
@@ -233,7 +232,7 @@ func (c *Client) WorkspaceBuildByUsernameAndWorkspaceNameAndBuildNumber(ctx cont
 		return WorkspaceBuild{}, ReadBodyAsError(res)
 	}
 	var workspaceBuild WorkspaceBuild
-	return workspaceBuild, json.NewDecoder(res.Body).Decode(&workspaceBuild)
+	return workspaceBuild, ReadBodyAsJSON(res, &workspaceBuild)
 }
 
 func (c *Client) WorkspaceBuildParameters(ctx context.Context, build uuid.UUID) ([]WorkspaceBuildParameter, error) {
@@ -246,7 +245,7 @@ func (c *Client) WorkspaceBuildParameters(ctx context.Context, build uuid.UUID) 
 		return nil, ReadBodyAsError(res)
 	}
 	var params []WorkspaceBuildParameter
-	return params, json.NewDecoder(res.Body).Decode(&params)
+	return params, ReadBodyAsJSON(res, &params)
 }
 
 type TimingStage string
@@ -313,5 +312,5 @@ func (c *Client) WorkspaceBuildTimings(ctx context.Context, build uuid.UUID) (Wo
 		return WorkspaceBuildTimings{}, ReadBodyAsError(res)
 	}
 	var timings WorkspaceBuildTimings
-	return timings, json.NewDecoder(res.Body).Decode(&timings)
+	return timings, ReadBodyAsJSON(res, &timings)
 }

--- a/codersdk/workspaceproxy.go
+++ b/codersdk/workspaceproxy.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -86,7 +85,7 @@ func (c *Client) CreateWorkspaceProxy(ctx context.Context, req CreateWorkspacePr
 		return UpdateWorkspaceProxyResponse{}, ReadBodyAsError(res)
 	}
 	var resp UpdateWorkspaceProxyResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) WorkspaceProxies(ctx context.Context) (RegionsResponse[WorkspaceProxy], error) {
@@ -104,7 +103,7 @@ func (c *Client) WorkspaceProxies(ctx context.Context) (RegionsResponse[Workspac
 	}
 
 	var proxies RegionsResponse[WorkspaceProxy]
-	return proxies, json.NewDecoder(res.Body).Decode(&proxies)
+	return proxies, ReadBodyAsJSON(res, &proxies)
 }
 
 type PatchWorkspaceProxy struct {
@@ -129,7 +128,7 @@ func (c *Client) PatchWorkspaceProxy(ctx context.Context, req PatchWorkspaceProx
 		return UpdateWorkspaceProxyResponse{}, ReadBodyAsError(res)
 	}
 	var resp UpdateWorkspaceProxyResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) DeleteWorkspaceProxyByName(ctx context.Context, name string) error {
@@ -168,7 +167,7 @@ func (c *Client) WorkspaceProxyByName(ctx context.Context, name string) (Workspa
 	}
 
 	var resp WorkspaceProxy
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 func (c *Client) WorkspaceProxyByID(ctx context.Context, id uuid.UUID) (WorkspaceProxy, error) {
@@ -217,5 +216,5 @@ func (c *Client) Regions(ctx context.Context) ([]Region, error) {
 	}
 
 	var regions RegionsResponse[Region]
-	return regions.Regions, json.NewDecoder(res.Body).Decode(&regions)
+	return regions.Regions, ReadBodyAsJSON(res, &regions)
 }

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -205,7 +205,7 @@ func (c *Client) getWorkspace(ctx context.Context, id uuid.UUID, opts ...Request
 		return Workspace{}, ReadBodyAsError(res)
 	}
 	var workspace Workspace
-	return workspace, json.NewDecoder(res.Body).Decode(&workspace)
+	return workspace, ReadBodyAsJSON(res, &workspace)
 }
 
 type WorkspaceBuildsRequest struct {
@@ -228,7 +228,7 @@ func (c *Client) WorkspaceBuilds(ctx context.Context, req WorkspaceBuildsRequest
 		return nil, ReadBodyAsError(res)
 	}
 	var workspaceBuild []WorkspaceBuild
-	return workspaceBuild, json.NewDecoder(res.Body).Decode(&workspaceBuild)
+	return workspaceBuild, ReadBodyAsJSON(res, &workspaceBuild)
 }
 
 // CreateWorkspaceBuild queues a new build to occur for a workspace.
@@ -242,7 +242,7 @@ func (c *Client) CreateWorkspaceBuild(ctx context.Context, workspace uuid.UUID, 
 		return WorkspaceBuild{}, ReadBodyAsError(res)
 	}
 	var workspaceBuild WorkspaceBuild
-	return workspaceBuild, json.NewDecoder(res.Body).Decode(&workspaceBuild)
+	return workspaceBuild, ReadBodyAsJSON(res, &workspaceBuild)
 }
 
 func (c *Client) WatchWorkspace(ctx context.Context, id uuid.UUID) (<-chan Workspace, error) {
@@ -643,7 +643,7 @@ func (c *Client) WorkspaceByOwnerAndName(ctx context.Context, owner string, name
 	}
 
 	var workspace Workspace
-	return workspace, json.NewDecoder(res.Body).Decode(&workspace)
+	return workspace, ReadBodyAsJSON(res, &workspace)
 }
 
 // SplitWorkspaceIdentifier splits an identifier into owner and
@@ -708,7 +708,7 @@ func (c *Client) WorkspaceQuota(ctx context.Context, organizationID string, user
 		return WorkspaceQuota{}, ReadBodyAsError(res)
 	}
 	var quota WorkspaceQuota
-	return quota, json.NewDecoder(res.Body).Decode(&quota)
+	return quota, ReadBodyAsJSON(res, &quota)
 }
 
 type ResolveAutostartResponse struct {
@@ -725,7 +725,7 @@ func (c *Client) ResolveAutostart(ctx context.Context, workspaceID string) (Reso
 		return ResolveAutostartResponse{}, ReadBodyAsError(res)
 	}
 	var response ResolveAutostartResponse
-	return response, json.NewDecoder(res.Body).Decode(&response)
+	return response, ReadBodyAsJSON(res, &response)
 }
 
 func (c *Client) FavoriteWorkspace(ctx context.Context, workspaceID uuid.UUID) error {
@@ -763,7 +763,7 @@ func (c *Client) WorkspaceTimings(ctx context.Context, id uuid.UUID) (WorkspaceB
 		return WorkspaceBuildTimings{}, ReadBodyAsError(res)
 	}
 	var timings WorkspaceBuildTimings
-	return timings, json.NewDecoder(res.Body).Decode(&timings)
+	return timings, ReadBodyAsJSON(res, &timings)
 }
 
 type WorkspaceACL struct {
@@ -814,7 +814,7 @@ func (c *Client) WorkspaceACL(ctx context.Context, workspaceID uuid.UUID) (Works
 		return WorkspaceACL{}, ReadBodyAsError(res)
 	}
 	var acl WorkspaceACL
-	return acl, json.NewDecoder(res.Body).Decode(&acl)
+	return acl, ReadBodyAsJSON(res, &acl)
 }
 
 type UpdateWorkspaceACL struct {
@@ -869,7 +869,7 @@ func (c *Client) WorkspaceExternalAgentCredentials(ctx context.Context, workspac
 		return ExternalAgentCredentials{}, ReadBodyAsError(res)
 	}
 	var credentials ExternalAgentCredentials
-	return credentials, json.NewDecoder(res.Body).Decode(&credentials)
+	return credentials, ReadBodyAsJSON(res, &credentials)
 }
 
 // WorkspaceBuildUpdate contains information about a workspace build state change.
@@ -941,5 +941,5 @@ func (c *Client) WorkspaceAvailableUsers(ctx context.Context, organizationID uui
 		return nil, ReadBodyAsError(res)
 	}
 	var users []MinimalUser
-	return users, json.NewDecoder(res.Body).Decode(&users)
+	return users, ReadBodyAsJSON(res, &users)
 }

--- a/codersdk/workspacesdk/workspacesdk.go
+++ b/codersdk/workspacesdk/workspacesdk.go
@@ -2,7 +2,6 @@ package workspacesdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -158,7 +157,7 @@ func (c *Client) AgentConnectionInfoGeneric(ctx context.Context) (AgentConnectio
 	}
 
 	var connInfo AgentConnectionInfo
-	return connInfo, json.NewDecoder(res.Body).Decode(&connInfo)
+	return connInfo, codersdk.ReadBodyAsJSON(res, &connInfo)
 }
 
 func (c *Client) AgentConnectionInfo(ctx context.Context, agentID uuid.UUID) (AgentConnectionInfo, error) {
@@ -172,7 +171,7 @@ func (c *Client) AgentConnectionInfo(ctx context.Context, agentID uuid.UUID) (Ag
 	}
 
 	var connInfo AgentConnectionInfo
-	return connInfo, json.NewDecoder(res.Body).Decode(&connInfo)
+	return connInfo, codersdk.ReadBodyAsJSON(res, &connInfo)
 }
 
 // AgentConnFunc returns a new connection to the specified agent. If release is

--- a/codersdk/workspacesharing.go
+++ b/codersdk/workspacesharing.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -56,7 +55,7 @@ func (c *Client) WorkspaceSharingSettings(ctx context.Context, orgID string) (Wo
 		return WorkspaceSharingSettings{}, ReadBodyAsError(res)
 	}
 	var resp WorkspaceSharingSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }
 
 // PatchWorkspaceSharingSettings modifies the workspace sharing settings for an organization.
@@ -71,5 +70,5 @@ func (c *Client) PatchWorkspaceSharingSettings(ctx context.Context, orgID string
 		return WorkspaceSharingSettings{}, ReadBodyAsError(res)
 	}
 	var resp WorkspaceSharingSettings
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return resp, ReadBodyAsJSON(res, &resp)
 }


### PR DESCRIPTION
This PR migrates 224 typed JSON response sites across 46 files to `codersdk.ReadBodyAsJSON`, so invalid 2xx bodies return structured errors while preserving URL credential redaction.

It intentionally excludes agent-direct HTTP, Azure IMDS, `UseNumber`, and chat paths; stacked on coder/coder#27804, with chat and lint follow-ups in coder/coder#27858 and coder/coder#27859. Refs coder/coder#27044.

Reviewed and updated by Coder Agents on behalf of @dylanhuff-at-coder.