### PR TITLE
perf(site/src/pages/AgentsPage): let the browser pin chat prompts and stop blurring the whole transcript

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -33,6 +33,7 @@ import {
 	ChatConversationSkeleton,
 	RightPanelSkeleton,
 } from "./components/AgentsSkeletons";
+import { ChatScrollElementsProvider } from "./components/ChatConversation/ChatScrollElementsContext";
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
@@ -421,6 +422,14 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	);
 	const visualExpanded = dragVisualExpanded ?? isRightPanelExpanded;
 	const internalScrollToBottomRef = useRef<(() => void) | null>(null);
+	// The scrollport and the transcript wrapper, which pinned prompts read and
+	// observe. Both are state, not refs, because a prompt's layout effect runs
+	// before either element's ref is attached.
+	const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(
+		null,
+	);
+	const [scrollContentElement, setScrollContentElement] =
+		useState<HTMLDivElement | null>(null);
 	const effectiveScrollToBottomRef =
 		scrollToBottomRef ?? internalScrollToBottomRef;
 
@@ -905,32 +914,42 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							key={agentId}
 							scrollContainerRef={scrollContainerRef}
 							scrollToBottomRef={effectiveScrollToBottomRef}
+							onScrollContainerElement={setScrollerElement}
 							isFetchingMoreMessages={isFetchingMoreMessages}
 							hasMoreMessages={hasMoreMessages}
 							onFetchMoreMessages={onFetchMoreMessages}
 							messageCount={messageCount}
 						>
-							<div className="px-4" data-chat-scroll-content>
-								<ChatPageTimeline
-									store={store}
-									persistedError={persistedError}
-									onEditUserMessage={
-										isOtherUserReadOnly
-											? undefined
-											: editing.handleEditUserMessage
-									}
-									editingMessageId={editing.editingMessageId}
-									urlTransform={urlTransform}
-									mcpServers={mcpServers}
-									onImplementPlan={
-										isOtherUserReadOnly ? undefined : onImplementPlan
-									}
-									onSendAskUserQuestionResponse={
-										isOtherUserReadOnly
-											? undefined
-											: canSendAskUserQuestionResponse
-									}
-								/>
+							<div
+								ref={setScrollContentElement}
+								className="px-4"
+								data-chat-scroll-content
+							>
+								<ChatScrollElementsProvider
+									scroller={scrollerElement}
+									content={scrollContentElement}
+								>
+									<ChatPageTimeline
+										store={store}
+										persistedError={persistedError}
+										onEditUserMessage={
+											isOtherUserReadOnly
+												? undefined
+												: editing.handleEditUserMessage
+										}
+										editingMessageId={editing.editingMessageId}
+										urlTransform={urlTransform}
+										mcpServers={mcpServers}
+										onImplementPlan={
+											isOtherUserReadOnly ? undefined : onImplementPlan
+										}
+										onSendAskUserQuestionResponse={
+											isOtherUserReadOnly
+												? undefined
+												: canSendAskUserQuestionResponse
+										}
+									/>
+								</ChatScrollElementsProvider>
 							</div>
 						</ChatScrollContainer>
 						<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatScrollElementsContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatScrollElementsContext.tsx
@@ -1,0 +1,42 @@
+import {
+	createContext,
+	type FC,
+	type PropsWithChildren,
+	useContext,
+} from "react";
+
+type ChatScrollElements = {
+	/** The scrollport a pinned prompt measures itself against. */
+	scroller: HTMLDivElement | null;
+	/**
+	 * The wrapper whose height follows the transcript. A growing transcript
+	 * changes neither the scrollport's box nor a prompt's own box, so this is
+	 * what a pinned prompt observes to keep its clip up to date.
+	 */
+	content: HTMLDivElement | null;
+};
+
+const ChatScrollElementsContext = createContext<ChatScrollElements>({
+	scroller: null,
+	content: null,
+});
+
+/**
+ * Hands the scrollport and the transcript wrapper to the prompts inside them.
+ * Both are elements of components above the prompt, and both are held as state
+ * rather than in a ref: a prompt's layout effect runs before its ancestors'
+ * refs are attached, so a ref would still be empty when the prompt first
+ * measures, and nothing would tell it to look again.
+ */
+export const ChatScrollElementsProvider: FC<
+	PropsWithChildren<ChatScrollElements>
+> = ({ scroller, content, children }) => {
+	return (
+		<ChatScrollElementsContext.Provider value={{ scroller, content }}>
+			{children}
+		</ChatScrollElementsContext.Provider>
+	);
+};
+
+export const useChatScrollElements = (): ChatScrollElements =>
+	useContext(ChatScrollElementsContext);

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -9,6 +9,7 @@ import {
 	Fragment,
 	memo,
 	type ReactNode,
+	useCallback,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -876,6 +877,18 @@ const StickyUserMessage = memo<{
 		const containerRef = useRef<HTMLDivElement>(null);
 		const spacerRef = useRef<HTMLDivElement>(null);
 
+		// The frosted band carries `backdrop-filter`, which is the most
+		// expensive thing in the transcript: 150 of them cost WebKit about 14ms
+		// per frame, because every forced style and layout update has to bring
+		// that many filtered layers up to date. Only the prompt in the
+		// scrollport can show a band, so only that prompt renders one.
+		const [showBand, setShowBand] = useState(false);
+		const bandInputs = useRef({ inView: false, tooTall: false });
+		const syncBand = useCallback(() => {
+			const { inView, tooTall } = bandInputs.current;
+			setShowBand(inView && !tooTall);
+		}, []);
+
 		// A layout effect, never a passive one: `ResizeObserver` delivers its
 		// first callback after layout and before the first paint, so the clip is
 		// correct on the frame the prompt first appears. Observing from a passive
@@ -934,6 +947,10 @@ const StickyUserMessage = memo<{
 				// Prompts taller than most of the scrollport are not worth
 				// pinning: they would cover the reply they belong to.
 				const tooTall = fullHeight > scrollerHeight * 0.75;
+				if (bandInputs.current.tooTall !== tooTall) {
+					bandInputs.current.tooTall = tooTall;
+					syncBand();
+				}
 				container.style.position = tooTall ? "relative" : "";
 				// A prompt that is not pinned never covers a sibling, and the
 				// stacking context the raised prompt opens changes how its text is
@@ -942,7 +959,6 @@ const StickyUserMessage = memo<{
 				if (tooTall) {
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");
-					container.style.setProperty("--fade-display", "none");
 					container.style.setProperty("--pin-slack", "0px");
 					spacer.style.height = "0px";
 					return;
@@ -963,15 +979,6 @@ const StickyUserMessage = memo<{
 								Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
 							);
 				container.style.setProperty("--fade-opacity", String(fade));
-				// The frosted band carries `backdrop-filter` and a mask. Both promote
-				// a compositing layer and open a stacking context even at zero
-				// opacity, which changes how the text under the band is antialiased,
-				// so it is kept out of rendering until the fade has something to
-				// show.
-				container.style.setProperty(
-					"--fade-display",
-					fade > 0 ? "block" : "none",
-				);
 				// `max-height` only shrinks the bubble, so the pinned box is the
 				// clipped bubble plus the action row, and the browser pushes it out
 				// when that box plus the gaps either side of the turn boundary
@@ -1022,7 +1029,28 @@ const StickyUserMessage = memo<{
 				observer.disconnect();
 				if (rafId !== null) cancelAnimationFrame(rafId);
 			};
-		}, []);
+		}, [syncBand]);
+
+		// Whether this prompt can show a band at all. `IntersectionObserver`
+		// answers that without reading geometry during the frame, so it adds no
+		// forced layout to a scroll.
+		useLayoutEffect(() => {
+			const container = containerRef.current;
+			if (!container) return;
+			const scroller = container.closest<HTMLElement>(".overflow-y-auto");
+			if (!scroller) return;
+			const observer = new IntersectionObserver(
+				(entries) => {
+					const inView = entries[entries.length - 1].isIntersecting;
+					if (bandInputs.current.inView === inView) return;
+					bandInputs.current.inView = inView;
+					syncBand();
+				},
+				{ root: scroller },
+			);
+			observer.observe(container);
+			return () => observer.disconnect();
+		}, [syncBand]);
 
 		const handleEditUserMessage = onEditUserMessage
 			? (
@@ -1060,22 +1088,21 @@ const StickyUserMessage = memo<{
 				>
 					{/* Frosted band below the clipped bubble. It reaches past the
 					    sticky box on purpose, so the fade covers the transcript
-					    scrolling underneath. Out of rendering until the fade has
-					    something to show: the blur and mask promote a layer whether
-					    or not the band is opaque. */}
-					<div
-						aria-hidden
-						className="pointer-events-none absolute inset-x-0 top-0 backdrop-blur-[1px] bg-surface-primary/15"
-						style={{
-							display: "var(--fade-display, none)",
-							opacity: "var(--fade-opacity, 0)",
-							height: "calc(var(--clip-h, 0px) + 48px)",
-							maskImage:
-								"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-							WebkitMaskImage:
-								"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-						}}
-					/>
+					    scrolling underneath. */}
+					{showBand && (
+						<div
+							aria-hidden
+							className="pointer-events-none absolute inset-x-0 top-0 backdrop-blur-[1px] bg-surface-primary/15"
+							style={{
+								opacity: "var(--fade-opacity, 0)",
+								height: "calc(var(--clip-h, 0px) + 48px)",
+								maskImage:
+									"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+								WebkitMaskImage:
+									"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+							}}
+						/>
+					)}
 					<ChatMessageItem
 						message={message}
 						parsed={parsed}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -9,7 +9,7 @@ import {
 	Fragment,
 	memo,
 	type ReactNode,
-	useCallback,
+	type Ref,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -53,6 +53,7 @@ import {
 	type PreviewTextAttachment,
 } from "./AttachmentBlocks";
 import { groupSequentialReadFileBlocks } from "./blockUtils";
+import { useChatScrollElements } from "./ChatScrollElementsContext";
 import { FileProbeProvider } from "./FileProbeContext";
 import {
 	buildDisplayMessages,
@@ -566,6 +567,10 @@ const ChatMessageItem = memo<{
 	// that fades text out toward the bottom. Used by the sticky
 	// overlay to indicate truncated content.
 	fadeFromBottom?: boolean;
+	// The clipped bubble and its unclipped content, forwarded to the user
+	// message so a pinned prompt can measure both.
+	bubbleRef?: Ref<HTMLDivElement>;
+	bodyRef?: Ref<HTMLDivElement>;
 	onImplementPlan?: () => Promise<void> | void;
 	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
@@ -592,6 +597,8 @@ const ChatMessageItem = memo<{
 		isAwaitingFirstStreamChunk = false,
 		isLastMessage = false,
 		fadeFromBottom = false,
+		bubbleRef,
+		bodyRef,
 		onImplementPlan,
 		onSendAskUserQuestionResponse,
 		isChatCompleted,
@@ -658,6 +665,8 @@ const ChatMessageItem = memo<{
 							markdown={parsed.markdown}
 							isEditing={editingMessageId === message.id}
 							fadeFromBottom={fadeFromBottom}
+							bubbleRef={bubbleRef}
+							bodyRef={bodyRef}
 							onImageClick={setPreviewImage}
 							onTextFileClick={setPreviewText}
 						/>
@@ -831,14 +840,8 @@ const FADE_RANGE = 40;
 const TURN_GAP = 8;
 
 /**
- * A turn's prompt. The section around it is the sticky containing block, so the
- * browser owns pinning and push-out; the only thing measured here is how much
- * of the bubble is still visible.
- *
- * The sticky box is deliberately only as tall as the visible bubble plus its
- * action row, because native push-out is driven by that height. The clipped
- * remainder is reproduced by a spacer outside the sticky box, which keeps the
- * section, and therefore the scroll geometry, at its full height.
+ * A turn's prompt. The sticky box's height drives native push-out, so it holds
+ * only the visible bubble, and the spacer outside it restores the turn's height.
  */
 const StickyUserMessage = memo<{
 	message: TypesGen.ChatMessage;
@@ -876,18 +879,18 @@ const StickyUserMessage = memo<{
 		};
 		const containerRef = useRef<HTMLDivElement>(null);
 		const spacerRef = useRef<HTMLDivElement>(null);
+		const bubbleRef = useRef<HTMLDivElement>(null);
+		const bodyRef = useRef<HTMLDivElement>(null);
+		const { scroller, content } = useChatScrollElements();
 
 		// The frosted band carries `backdrop-filter`, which is the most
 		// expensive thing in the transcript: 150 of them cost WebKit about 14ms
 		// per frame, because every forced style and layout update has to bring
 		// that many filtered layers up to date. Only the prompt in the
-		// scrollport can show a band, so only that prompt renders one.
-		const [showBand, setShowBand] = useState(false);
-		const bandInputs = useRef({ inView: false, tooTall: false });
-		const syncBand = useCallback(() => {
-			const { inView, tooTall } = bandInputs.current;
-			setShowBand(inView && !tooTall);
-		}, []);
+		// scrollport can show a band, and a prompt too tall to pin never fades.
+		const [inView, setInView] = useState(false);
+		const [tooTall, setTooTall] = useState(false);
+		const showBand = inView && !tooTall;
 
 		// A layout effect, never a passive one: `ResizeObserver` delivers its
 		// first callback after layout and before the first paint, so the clip is
@@ -897,17 +900,11 @@ const StickyUserMessage = memo<{
 			const sentinel = sentinelRef.current;
 			const container = containerRef.current;
 			const spacer = spacerRef.current;
-			if (!sentinel || !container || !spacer) return;
-			const scroller = sentinel.closest<HTMLElement>(".overflow-y-auto");
-			if (!scroller) return;
-			// The bubble carries `max-height`, so its own height reports the
-			// clipped size. Its inner body is never clipped, which is the only
-			// reliable source for the uncompressed height.
-			const body = container.querySelector<HTMLElement>(
-				"[data-turn-prompt-body]",
-			);
-			const bubble = body?.parentElement;
-			if (!body || !bubble) return;
+			const body = bodyRef.current;
+			const bubble = bubbleRef.current;
+			if (!sentinel || !container || !spacer || !body || !bubble || !scroller) {
+				return;
+			}
 
 			// The clip shrinks only the bubble's content box. The bubble's own
 			// padding and border, and the action row below it, keep their height,
@@ -916,6 +913,11 @@ const StickyUserMessage = memo<{
 			let rowHeight = 0;
 			let bodyHeight = 0;
 			let scrollerHeight = 0;
+			// Prompts taller than most of the scrollport are not worth pinning:
+			// they would cover the reply they belong to. Only a resize can change
+			// that, so it is settled while measuring and the band's state is set
+			// on the crossing alone, never per frame.
+			let tooTallNow = false;
 			const measure = () => {
 				const bubbleStyle = getComputedStyle(bubble);
 				bubbleChrome =
@@ -930,6 +932,12 @@ const StickyUserMessage = memo<{
 				);
 				bodyHeight = body.getBoundingClientRect().height;
 				scrollerHeight = scroller.clientHeight;
+				const next =
+					bodyHeight + bubbleChrome + rowHeight > scrollerHeight * 0.75;
+				if (next !== tooTallNow) {
+					tooTallNow = next;
+					setTooTall(next);
+				}
 			};
 
 			const update = () => {
@@ -944,19 +952,12 @@ const StickyUserMessage = memo<{
 					0,
 				);
 
-				// Prompts taller than most of the scrollport are not worth
-				// pinning: they would cover the reply they belong to.
-				const tooTall = fullHeight > scrollerHeight * 0.75;
-				if (bandInputs.current.tooTall !== tooTall) {
-					bandInputs.current.tooTall = tooTall;
-					syncBand();
-				}
-				container.style.position = tooTall ? "relative" : "";
+				container.style.position = tooTallNow ? "relative" : "";
 				// A prompt that is not pinned never covers a sibling, and the
 				// stacking context the raised prompt opens changes how its text is
 				// antialiased, so it is given up along with the pinning.
-				container.style.zIndex = tooTall ? "auto" : "";
-				if (tooTall) {
+				container.style.zIndex = tooTallNow ? "auto" : "";
+				if (tooTallNow) {
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");
 					container.style.setProperty("--pin-slack", "0px");
@@ -1000,19 +1001,24 @@ const StickyUserMessage = memo<{
 			// event, and the growth changes neither the scroller's own box nor
 			// the prompt body. The content wrapper is observed as well, so the
 			// clip keeps up with a streaming reply.
-			const content = sentinel.closest<HTMLElement>(
-				"[data-chat-scroll-content]",
-			);
 			let rafId: number | null = null;
+			let needsMeasure = false;
 			const schedule = () => {
 				if (rafId !== null) return;
 				rafId = requestAnimationFrame(() => {
 					rafId = null;
+					if (needsMeasure) {
+						needsMeasure = false;
+						measure();
+					}
 					update();
 				});
 			};
+			// `measure` reads computed style and three rects, and a window resize
+			// fires continuously while a window is dragged, so it waits for the
+			// frame rather than running per event.
 			const remeasure = () => {
-				measure();
+				needsMeasure = true;
 				schedule();
 			};
 			const observer = new ResizeObserver(remeasure);
@@ -1029,28 +1035,23 @@ const StickyUserMessage = memo<{
 				observer.disconnect();
 				if (rafId !== null) cancelAnimationFrame(rafId);
 			};
-		}, [syncBand]);
+		}, [scroller, content]);
 
 		// Whether this prompt can show a band at all. `IntersectionObserver`
 		// answers that without reading geometry during the frame, so it adds no
 		// forced layout to a scroll.
 		useLayoutEffect(() => {
 			const container = containerRef.current;
-			if (!container) return;
-			const scroller = container.closest<HTMLElement>(".overflow-y-auto");
-			if (!scroller) return;
+			if (!container || !scroller) return;
 			const observer = new IntersectionObserver(
 				(entries) => {
-					const inView = entries[entries.length - 1].isIntersecting;
-					if (bandInputs.current.inView === inView) return;
-					bandInputs.current.inView = inView;
-					syncBand();
+					setInView(entries[entries.length - 1].isIntersecting);
 				},
 				{ root: scroller },
 			);
 			observer.observe(container);
 			return () => observer.disconnect();
-		}, [syncBand]);
+		}, [scroller]);
 
 		const handleEditUserMessage = onEditUserMessage
 			? (
@@ -1106,6 +1107,8 @@ const StickyUserMessage = memo<{
 					<ChatMessageItem
 						message={message}
 						parsed={parsed}
+						bubbleRef={bubbleRef}
+						bodyRef={bodyRef}
 						onEditUserMessage={handleEditUserMessage}
 						editingMessageId={editingMessageId}
 						isAfterEditingMessage={isAfterEditingMessage}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -820,6 +820,25 @@ const ChatMessageItem = memo<{
 	},
 );
 
+const MIN_HEIGHT = 72;
+const STICKY_TOP = 8;
+const FADE_RANGE = 40;
+// The gap between a turn's last message and the next turn's sentinel, from the
+// timeline's `gap-2`. It sits between the pinned prompt's section edge and the
+// following section, so it belongs in the slack that keeps native push-out on
+// the same scroll offset as the visible bubble reaching the boundary.
+const TURN_GAP = 8;
+
+/**
+ * A turn's prompt. The section around it is the sticky containing block, so the
+ * browser owns pinning and push-out; the only thing measured here is how much
+ * of the bubble is still visible.
+ *
+ * The sticky box is deliberately only as tall as the visible bubble plus its
+ * action row, because native push-out is driven by that height. The clipped
+ * remainder is reproduced by a spacer outside the sticky box, which keeps the
+ * section, and therefore the scroll geometry, at its full height.
+ */
 const StickyUserMessage = memo<{
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
@@ -834,7 +853,6 @@ const StickyUserMessage = memo<{
 	nextUserMessageId?: number;
 	onJumpToUserMessage?: (messageId: number) => void;
 	registerSentinel?: (messageId: number, el: HTMLDivElement | null) => void;
-	getSentinel?: (messageId: number) => HTMLDivElement | null;
 	urlTransform?: UrlTransform;
 }>(
 	({
@@ -847,12 +865,8 @@ const StickyUserMessage = memo<{
 		nextUserMessageId,
 		onJumpToUserMessage,
 		registerSentinel,
-		getSentinel,
 		urlTransform,
 	}) => {
-		const [isStuck, setIsStuck] = useState(false);
-		const [isReady, setIsReady] = useState(false);
-		const [isTooTall, setIsTooTall] = useState(false);
 		const sentinelRef = useRef<HTMLDivElement>(null);
 		const messageId = message.id;
 		const setSentinelRef = (el: HTMLDivElement | null) => {
@@ -860,182 +874,138 @@ const StickyUserMessage = memo<{
 			registerSentinel?.(messageId, el);
 		};
 		const containerRef = useRef<HTMLDivElement>(null);
-		const updateFnRef = useRef<(() => void) | null>(null);
+		const spacerRef = useRef<HTMLDivElement>(null);
 
-		// The scroll handler below is installed once, so it resolves the
-		// neighbouring prompt's sentinel through a ref instead of the props it
-		// closed over at mount. Declared before that effect so the resolver is
-		// current whenever the handler runs.
-		const nextSentinelRef = useRef<() => HTMLDivElement | null>(() => null);
-		useLayoutEffect(() => {
-			nextSentinelRef.current = () =>
-				nextUserMessageId === undefined
-					? null
-					: (getSentinel?.(nextUserMessageId) ?? null);
-		}, [nextUserMessageId, getSentinel]);
-
-		// useLayoutEffect so isStuck and --clip-h are both resolved
-		// before the browser paints, avoiding a flash on load.
-		useLayoutEffect(() => {
-			const sentinel = sentinelRef.current;
-			if (!sentinel) return;
-			// Immediate check so the first paint is correct when the
-			// sentinel is already scrolled out of view.
-			const scroller = sentinel.closest(".overflow-y-auto");
-			if (scroller) {
-				const stuck =
-					sentinel.getBoundingClientRect().top <
-					scroller.getBoundingClientRect().top;
-				if (stuck) {
-					setIsStuck(true);
-				}
-			}
-			setIsReady(true);
-			const observer = new IntersectionObserver(
-				([entry]) => setIsStuck(!entry.isIntersecting),
-				{ threshold: 0 },
-			);
-			observer.observe(sentinel);
-			return () => observer.disconnect();
-		}, []);
-
-		// Sets a single CSS custom property (--clip-h) on the sticky
-		// container. All visual behaviour (max-height, mask fade) is
-		// driven by CSS using this variable.
+		// A layout effect, never a passive one: `ResizeObserver` delivers its
+		// first callback after layout and before the first paint, so the clip is
+		// correct on the frame the prompt first appears. Observing from a passive
+		// effect paints one frame with an unclipped prompt.
 		useLayoutEffect(() => {
 			const sentinel = sentinelRef.current;
 			const container = containerRef.current;
-			if (!sentinel || !container) return;
-			const scroller = sentinel.closest(
-				".overflow-y-auto",
-			) as HTMLElement | null;
+			const spacer = spacerRef.current;
+			if (!sentinel || !container || !spacer) return;
+			const scroller = sentinel.closest<HTMLElement>(".overflow-y-auto");
 			if (!scroller) return;
+			// The bubble carries `max-height`, so its own height reports the
+			// clipped size. Its inner body is never clipped, which is the only
+			// reliable source for the uncompressed height.
+			const body = container.querySelector<HTMLElement>(
+				"[data-turn-prompt-body]",
+			);
+			const bubble = body?.parentElement;
+			if (!body || !bubble) return;
 
-			const MIN_HEIGHT = 72;
-			const STICKY_TOP = 8;
+			// The clip shrinks only the bubble's content box. The bubble's own
+			// padding and border, and the action row below it, keep their height,
+			// so both are measured on resize rather than per frame.
+			let bubbleChrome = 0;
+			let rowHeight = 0;
+			let bodyHeight = 0;
+			let scrollerHeight = 0;
+			const measure = () => {
+				const bubbleStyle = getComputedStyle(bubble);
+				bubbleChrome =
+					Number.parseFloat(bubbleStyle.paddingTop) +
+					Number.parseFloat(bubbleStyle.paddingBottom) +
+					Number.parseFloat(bubbleStyle.borderTopWidth) +
+					Number.parseFloat(bubbleStyle.borderBottomWidth);
+				rowHeight = Math.max(
+					container.getBoundingClientRect().height -
+						bubble.getBoundingClientRect().height,
+					0,
+				);
+				bodyHeight = body.getBoundingClientRect().height;
+				scrollerHeight = scroller.clientHeight;
+			};
 
 			const update = () => {
-				// Read the scroller geometry on each tick. Caching it goes
-				// stale when the scroller moves or resizes without a window
-				// resize (for example the composer growing), which skews the
-				// clip height and push-up math.
 				const scrollerTop = scroller.getBoundingClientRect().top;
-				const scrollerHeight = scroller.clientHeight;
-				const fullHeight = container.offsetHeight;
+				const sentinelTop = sentinel.getBoundingClientRect().top;
+				const fullHeight = bodyHeight + bubbleChrome + rowHeight;
+				// Compression is measured from the pin line, the same edge the
+				// browser pins against, so compression starts exactly when
+				// pinning does.
+				const scrolledPast = Math.max(
+					scrollerTop + STICKY_TOP - sentinelTop,
+					0,
+				);
 
-				// Skip sticky behavior for messages that take up
-				// most of the visible area — accounting for the
-				// chat input and some breathing room.
+				// Prompts taller than most of the scrollport are not worth
+				// pinning: they would cover the reply they belong to.
 				const tooTall = fullHeight > scrollerHeight * 0.75;
-				setIsTooTall(tooTall);
+				container.style.position = tooTall ? "relative" : "";
 				if (tooTall) {
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");
-					container.style.top = `${STICKY_TOP}px`;
-
+					container.style.setProperty("--pin-slack", "0px");
+					spacer.style.height = "0px";
 					return;
 				}
-				const sentinelTop = sentinel.getBoundingClientRect().top;
-				const scrolledPast = scrollerTop - sentinelTop;
 
-				if (scrolledPast <= 0) {
-					// Always set a valid value so the overlay has the
-					// correct height immediately when isStuck flips.
-					container.style.setProperty("--clip-h", `${fullHeight}px`);
-					container.style.setProperty("--fade-opacity", "0");
-					container.style.top = `${STICKY_TOP}px`;
-
-					return;
-				}
-				const visible = Math.max(fullHeight - scrolledPast, MIN_HEIGHT);
-				container.style.setProperty("--clip-h", `${visible}px`);
-				// Only show the blur and gradient once the message
-				// is near its minimum compressed height. Ramp over
-				// the last 40px before MIN_HEIGHT so it doesn't pop.
-				const FADE_RANGE = 40;
-				const fade = Math.max(
-					0,
-					Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
+				// How much of the prompt is still shown. Never more than its own
+				// height, so a prompt shorter than the floor is left alone.
+				const visible = Math.min(
+					fullHeight,
+					Math.max(fullHeight - scrolledPast, MIN_HEIGHT),
 				);
-				container.style.setProperty("--fade-opacity", String(fade));
-				// Push-up effect: when the next user message's sentinel
-				// approaches the bottom of this sticky container, shift
-				// this container upward so it slides out of view — the
-				// same visual as the old section-boundary behavior.
-				const nextSentinel = nextSentinelRef.current();
-				if (nextSentinel) {
-					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
-					container.style.top = `${Math.min(STICKY_TOP, nextY - visible + STICKY_TOP)}px`;
-				} else {
-					container.style.top = `${STICKY_TOP}px`;
-				}
+				container.style.setProperty("--clip-h", `${visible}px`);
+				container.style.setProperty(
+					"--fade-opacity",
+					scrolledPast <= 0
+						? "0"
+						: String(
+								Math.max(
+									0,
+									Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
+								),
+							),
+				);
+				// `max-height` only shrinks the bubble, so the pinned box is the
+				// clipped bubble plus the action row, and the browser pushes it out
+				// when that box plus the gaps either side of the turn boundary
+				// reach the boundary. Push-out should instead start when the
+				// visible height reaches it, so the difference is given back as a
+				// negative bottom margin and re-added by the spacer, leaving the
+				// turn's total height untouched.
+				const pinnedHeight =
+					Math.min(bodyHeight + bubbleChrome, visible) + rowHeight;
+				container.style.setProperty(
+					"--pin-slack",
+					`${pinnedHeight + 2 * TURN_GAP - visible}px`,
+				);
+				spacer.style.height = `${fullHeight - visible + 2 * TURN_GAP}px`;
 			};
-			updateFnRef.current = update;
 
-			// Throttle to one update per animation frame so we don't
-			// do redundant work on high-refresh-rate displays.
+			// In `flex-col-reverse` the scroller stays at `scrollTop` 0 while
+			// pinned to the bottom, so a growing transcript fires no scroll
+			// event. The scroller and the prompt body are observed instead.
 			let rafId: number | null = null;
-			const onScroll = () => {
+			const schedule = () => {
 				if (rafId !== null) return;
 				rafId = requestAnimationFrame(() => {
 					rafId = null;
 					update();
 				});
 			};
-
-			// Re-run the visual update when the transcript height changes,
-			// for example a streaming response or several messages arriving
-			// at once. In flex-col-reverse the scrollTop stays at 0 while
-			// pinned to the bottom, so no scroll event fires; observing the
-			// content wrapper catches that growth instead.
-			//
-			// The scroller's firstElementChild is the flex spacer that pins
-			// content to the bottom. It collapses to 0px once the transcript
-			// overflows and then stops emitting resize callbacks, which is
-			// exactly when truncation is active, so observe the real content
-			// node (an ancestor of the sentinel) and fall back to the spacer
-			// only when the marker is absent.
-			const contentEl =
-				sentinel.closest<HTMLElement>("[data-chat-scroll-content]") ??
-				(scroller.firstElementChild as HTMLElement | null);
-			let contentRafId: number | null = null;
-			const contentObserver = contentEl
-				? new ResizeObserver(() => {
-						if (contentRafId !== null) return;
-						contentRafId = requestAnimationFrame(() => {
-							contentRafId = null;
-							update();
-						});
-					})
-				: null;
-			contentObserver?.observe(contentEl!);
-
-			scroller.addEventListener("scroll", onScroll, { passive: true });
-			window.addEventListener("resize", update);
+			const remeasure = () => {
+				measure();
+				schedule();
+			};
+			const observer = new ResizeObserver(remeasure);
+			observer.observe(scroller);
+			observer.observe(body);
+			scroller.addEventListener("scroll", schedule, { passive: true });
+			window.addEventListener("resize", remeasure);
+			measure();
 			update();
-			// Set immediately — both --clip-h and --overlay-ready are
-			// applied before the browser paints since we're in a
-			// useLayoutEffect.
-			container.style.setProperty("--overlay-ready", "1");
 			return () => {
-				scroller.removeEventListener("scroll", onScroll);
-				window.removeEventListener("resize", update);
-				contentObserver?.disconnect();
-				container.style.removeProperty("--overlay-ready");
+				scroller.removeEventListener("scroll", schedule);
+				window.removeEventListener("resize", remeasure);
+				observer.disconnect();
 				if (rafId !== null) cancelAnimationFrame(rafId);
-				if (contentRafId !== null) cancelAnimationFrame(contentRafId);
 			};
 		}, []);
-
-		// Re-run the height calculation synchronously whenever
-		// isStuck changes so --clip-h is correct on the same frame
-		// the overlay appears. Without this, the async
-		// IntersectionObserver + RAF-throttled scroll handler can
-		// leave a stale --clip-h for one paint.
-		// biome-ignore lint/correctness/useExhaustiveDependencies: isStuck is an intentional trigger
-		useLayoutEffect(() => {
-			updateFnRef.current?.();
-		}, [isStuck]);
 
 		const handleEditUserMessage = onEditUserMessage
 			? (
@@ -1067,93 +1037,42 @@ const StickyUserMessage = memo<{
 				/>
 				<div
 					ref={containerRef}
-					className={cn(
-						"relative px-3 -mx-3 -mt-2",
-						!isTooTall && "sticky z-10",
-						!isReady && "invisible",
-						isStuck && !isTooTall && "pointer-events-none",
-					)}
+					className="sticky top-2 z-10 px-3 -mx-3 -mt-2"
+					style={{ marginBottom: "calc(-1 * var(--pin-slack, 0px))" }}
+					data-turn-prompt
 				>
-					{/* Flow element: always in the DOM to preserve
-				    scroll layout. Hidden when stuck so the
-				    clipped overlay takes over visually. */}
+					{/* Frosted band below the clipped bubble. It reaches past the
+					    sticky box on purpose, so the fade covers the transcript
+					    scrolling underneath. */}
 					<div
-						className={
-							isStuck && !isTooTall ? undefined : "pointer-events-auto"
-						}
-						style={
-							isStuck && !isTooTall
-								? { opacity: "calc(1 - var(--overlay-ready, 0))" }
-								: undefined
-						}
-						// While the overlay copy is shown, drop the flow copy
-						// from the accessibility tree so the message and its
-						// hook notices aren't exposed twice.
-						aria-hidden={isStuck && !isTooTall ? true : undefined}
-						inert={isStuck && !isTooTall ? true : undefined}
-					>
-						<ChatMessageItem
-							message={message}
-							parsed={parsed}
-							onEditUserMessage={handleEditUserMessage}
-							editingMessageId={editingMessageId}
-							isAfterEditingMessage={isAfterEditingMessage}
-							prevUserMessageId={prevUserMessageId}
-							nextUserMessageId={nextUserMessageId}
-							onJumpToUserMessage={onJumpToUserMessage}
-							urlTransform={urlTransform}
-						/>
-					</div>
-
-					{/* Overlay: absolutely positioned, matching the
-				    sticky container. max-height + mask are driven
-				    entirely by the --clip-h CSS variable which the
-				    scroll handler sets on the container. */}
-					{isStuck && !isTooTall && (
-						<div
-							className="absolute inset-0"
-							style={{
-								opacity: "var(--overlay-ready, 0)",
-								contain: "layout style",
-							}}
-						>
-							{/* Blur layer: extends 48px beyond the
-						    clipped content so the frosted effect
-						    is visible around the bubble. Promoted
-						    to its own GPU layer via will-change. */}
-							<div
-								className="absolute inset-0 backdrop-blur-[1px] bg-surface-primary/15"
-								style={{
-									opacity: "var(--fade-opacity, 0)",
-									maxHeight: "calc(var(--clip-h, 100%) + 48px)",
-									willChange: "max-height, mask-image",
-									maskImage:
-										"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-									WebkitMaskImage:
-										"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-								}}
-							/>
-							{/* Content layer: px-3 matches the sticky
-							    container's padding so the overlay aligns
-							    with the flow element. will-change promotes
-							    to GPU layer. */}
-							<div className="relative px-3 pointer-events-auto will-change-[max-height]">
-								<ChatMessageItem
-									message={message}
-									parsed={parsed}
-									onEditUserMessage={handleEditUserMessage}
-									editingMessageId={editingMessageId}
-									isAfterEditingMessage={isAfterEditingMessage}
-									prevUserMessageId={prevUserMessageId}
-									nextUserMessageId={nextUserMessageId}
-									onJumpToUserMessage={onJumpToUserMessage}
-									urlTransform={urlTransform}
-									fadeFromBottom
-								/>
-							</div>
-						</div>
-					)}
+						aria-hidden
+						className="pointer-events-none absolute inset-x-0 top-0 backdrop-blur-[1px] bg-surface-primary/15"
+						style={{
+							opacity: "var(--fade-opacity, 0)",
+							height: "calc(var(--clip-h, 0px) + 48px)",
+							maskImage:
+								"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+							WebkitMaskImage:
+								"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+						}}
+					/>
+					<ChatMessageItem
+						message={message}
+						parsed={parsed}
+						onEditUserMessage={handleEditUserMessage}
+						editingMessageId={editingMessageId}
+						isAfterEditingMessage={isAfterEditingMessage}
+						prevUserMessageId={prevUserMessageId}
+						nextUserMessageId={nextUserMessageId}
+						onJumpToUserMessage={onJumpToUserMessage}
+						urlTransform={urlTransform}
+						fadeFromBottom
+					/>
 				</div>
+				{/* Replaces the height the clip removes from the sticky box, so
+				    the turn keeps its full height and the transcript below it
+				    does not move while the prompt compresses. */}
+				<div ref={spacerRef} aria-hidden className="-mt-2" />
 			</>
 		);
 	},
@@ -1282,8 +1201,6 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 				block: "start",
 			});
 		};
-		const getSentinel = (messageId: number) =>
-			sentinelsRef.current.get(messageId) ?? null;
 
 		const displayMessages = buildDisplayMessages(parsedMessages);
 		const lastInChainFlags = computeLastInChainFlags(displayMessages);
@@ -1373,11 +1290,14 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 					className="flex flex-col gap-2"
 				>
 					{turns.map((turn) => (
-						// `display: contents` keeps the turn wrapper out of layout, so
-						// grouping leaves both the spacing between messages and the
-						// containing block that `position: sticky` resolves against
-						// unchanged.
-						<section key={turn.key} className="contents" data-chat-turn>
+						// The section is the sticky containing block for its prompt, so
+						// the browser pins the prompt and pushes it out at the turn
+						// boundary without any scroll-driven position writes.
+						<section
+							key={turn.key}
+							className="flex flex-col gap-2"
+							data-chat-turn
+						>
 							{turn.prompt && (
 								<StickyUserMessage
 									message={turn.prompt.entry.message}
@@ -1395,7 +1315,6 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									}
 									onJumpToUserMessage={jumpToUserMessage}
 									registerSentinel={registerSentinel}
-									getSentinel={getSentinel}
 									urlTransform={urlTransform}
 								/>
 							)}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1044,24 +1044,27 @@ const StickyUserMessage = memo<{
 					fileBlocks?: readonly TypesGen.ChatMessagePart[],
 				) => {
 					onEditUserMessage(messageId, text, fileBlocks);
+					// One frame later, so the edited message has been laid out.
+					// `scroll-margin-top` on the sentinel lands it on the pin line.
 					requestAnimationFrame(() => {
-						const sentinel = sentinelRef.current;
-						if (!sentinel) return;
-						const scroller = sentinel.closest(
-							".overflow-y-auto",
-						) as HTMLElement | null;
-						if (!scroller) return;
-						const offset =
-							sentinel.getBoundingClientRect().top -
-							scroller.getBoundingClientRect().top;
-						scroller.scrollBy({ top: offset, behavior: "smooth" });
+						sentinelRef.current?.scrollIntoView({
+							behavior: "smooth",
+							block: "start",
+						});
 					});
 				}
 			: undefined;
 
 		return (
 			<>
-				<div ref={setSentinelRef} className="h-0" data-user-sentinel />
+				{/* `scroll-mt-2` matches the 8px pin line, so both the jump
+				    arrows and the post-edit scroll land the prompt exactly where
+				    it comes to rest when pinned. */}
+				<div
+					ref={setSentinelRef}
+					className="h-0 scroll-mt-2"
+					data-user-sentinel
+				/>
 				<div
 					ref={containerRef}
 					className={cn(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -935,6 +935,10 @@ const StickyUserMessage = memo<{
 				// pinning: they would cover the reply they belong to.
 				const tooTall = fullHeight > scrollerHeight * 0.75;
 				container.style.position = tooTall ? "relative" : "";
+				// A prompt that is not pinned never covers a sibling, and the
+				// stacking context the raised prompt opens changes how its text is
+				// antialiased, so it is given up along with the pinning.
+				container.style.zIndex = tooTall ? "auto" : "";
 				if (tooTall) {
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -986,7 +986,12 @@ const StickyUserMessage = memo<{
 
 			// In `flex-col-reverse` the scroller stays at `scrollTop` 0 while
 			// pinned to the bottom, so a growing transcript fires no scroll
-			// event. The scroller and the prompt body are observed instead.
+			// event, and the growth changes neither the scroller's own box nor
+			// the prompt body. The content wrapper is observed as well, so the
+			// clip keeps up with a streaming reply.
+			const content = sentinel.closest<HTMLElement>(
+				"[data-chat-scroll-content]",
+			);
 			let rafId: number | null = null;
 			const schedule = () => {
 				if (rafId !== null) return;
@@ -1002,6 +1007,7 @@ const StickyUserMessage = memo<{
 			const observer = new ResizeObserver(remeasure);
 			observer.observe(scroller);
 			observer.observe(body);
+			if (content) observer.observe(content);
 			scroller.addEventListener("scroll", schedule, { passive: true });
 			window.addEventListener("resize", remeasure);
 			measure();

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -938,6 +938,7 @@ const StickyUserMessage = memo<{
 				if (tooTall) {
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");
+					container.style.setProperty("--fade-display", "none");
 					container.style.setProperty("--pin-slack", "0px");
 					spacer.style.height = "0px";
 					return;
@@ -950,16 +951,22 @@ const StickyUserMessage = memo<{
 					Math.max(fullHeight - scrolledPast, MIN_HEIGHT),
 				);
 				container.style.setProperty("--clip-h", `${visible}px`);
-				container.style.setProperty(
-					"--fade-opacity",
+				const fade =
 					scrolledPast <= 0
-						? "0"
-						: String(
-								Math.max(
-									0,
-									Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
-								),
-							),
+						? 0
+						: Math.max(
+								0,
+								Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
+							);
+				container.style.setProperty("--fade-opacity", String(fade));
+				// The frosted band carries `backdrop-filter` and a mask. Both promote
+				// a compositing layer and open a stacking context even at zero
+				// opacity, which changes how the text under the band is antialiased,
+				// so it is kept out of rendering until the fade has something to
+				// show.
+				container.style.setProperty(
+					"--fade-display",
+					fade > 0 ? "block" : "none",
 				);
 				// `max-height` only shrinks the bubble, so the pinned box is the
 				// clipped bubble plus the action row, and the browser pushes it out
@@ -1043,11 +1050,14 @@ const StickyUserMessage = memo<{
 				>
 					{/* Frosted band below the clipped bubble. It reaches past the
 					    sticky box on purpose, so the fade covers the transcript
-					    scrolling underneath. */}
+					    scrolling underneath. Out of rendering until the fade has
+					    something to show: the blur and mask promote a layer whether
+					    or not the band is opaque. */}
 					<div
 						aria-hidden
 						className="pointer-events-none absolute inset-x-0 top-0 backdrop-blur-[1px] bg-surface-primary/15"
 						style={{
+							display: "var(--fade-display, none)",
 							opacity: "var(--fade-opacity, 0)",
 							height: "calc(var(--clip-h, 0px) + 48px)",
 							maskImage:

--- a/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
@@ -1,4 +1,4 @@
-import { type FC, Fragment } from "react";
+import { type FC, Fragment, type Ref } from "react";
 import { cn } from "#/utils/cn";
 import { Message, MessageContent } from "../ChatElements";
 import { FileReferenceChip } from "../ChatMessageInput/FileReferenceChip";
@@ -62,6 +62,10 @@ export const UserMessageContent: FC<{
 	markdown: string;
 	isEditing?: boolean;
 	fadeFromBottom?: boolean;
+	/** The clipped bubble, whose padding and border a pinned prompt measures. */
+	bubbleRef?: Ref<HTMLDivElement>;
+	/** The unclipped content, the only source of the prompt's full height. */
+	bodyRef?: Ref<HTMLDivElement>;
 	onImageClick?: (src: string) => void;
 	onTextFileClick?: (attachment: PreviewTextAttachment) => void;
 }> = ({
@@ -69,12 +73,15 @@ export const UserMessageContent: FC<{
 	markdown,
 	isEditing = false,
 	fadeFromBottom = false,
+	bubbleRef,
+	bodyRef,
 	onImageClick,
 	onTextFileClick,
 }) => {
 	return (
 		<Message className="w-fit max-w-[min(80vw,80%)]">
 			<MessageContent
+				ref={bubbleRef}
 				className={cn(
 					"rounded-lg border border-solid border-border-default bg-surface-secondary px-3 py-2 font-sans shadow-sm transition-shadow",
 					isEditing &&
@@ -85,7 +92,7 @@ export const UserMessageContent: FC<{
 					fadeFromBottom ? { maxHeight: "var(--clip-h, none)" } : undefined
 				}
 			>
-				<div className="flex flex-col gap-1.5" data-turn-prompt-body>
+				<div ref={bodyRef} className="flex flex-col gap-1.5">
 					{(displayState.hasUserMessageBody || displayState.hasFileBlocks) && (
 						<div className="flex items-start gap-2">
 							{displayState.hasUserMessageBody && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
@@ -85,7 +85,7 @@ export const UserMessageContent: FC<{
 					fadeFromBottom ? { maxHeight: "var(--clip-h, none)" } : undefined
 				}
 			>
-				<div className="flex flex-col gap-1.5">
+				<div className="flex flex-col gap-1.5" data-turn-prompt-body>
 					{(displayState.hasUserMessageBody || displayState.hasFileBlocks) && (
 						<div className="flex items-start gap-2">
 							{displayState.hasUserMessageBody && (

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -100,6 +100,10 @@ const ScrollToBottomButton: FC<{
 const ChatScrollContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
 	scrollToBottomRef: RefObject<(() => void) | null>;
+	// The scrollport itself, for descendants that have to read or observe it.
+	// A ref cannot serve them: their layout effects run before this element's
+	// ref is attached, so they need the element as state.
+	onScrollContainerElement?: (element: HTMLDivElement | null) => void;
 	isFetchingMoreMessages: boolean;
 	hasMoreMessages: boolean;
 	onFetchMoreMessages: () => void;
@@ -108,6 +112,7 @@ const ChatScrollContainer: FC<{
 }> = ({
 	scrollContainerRef,
 	scrollToBottomRef,
+	onScrollContainerElement,
 	isFetchingMoreMessages,
 	hasMoreMessages,
 	onFetchMoreMessages,
@@ -132,6 +137,7 @@ const ChatScrollContainer: FC<{
 	const setScrollContainer = (element: HTMLDivElement | null) => {
 		scrollContainerRef.current = element;
 		setScrollContainerElement(element);
+		onScrollContainerElement?.(element);
 		scrollToBottomRef.current = element ? scrollToBottom : null;
 	};
 


### PR DESCRIPTION
Stacked on #27673, which grouped the transcript into turn sections without changing behavior. This PR makes the browser do the work.

Sections become real containing blocks, so `position: sticky` handles pinning and push-out natively. That deletes the inline `top` computation, the neighbour lookup that existed only to serve it, `isStuck`, `isReady`, `--overlay-ready` and the `invisible` gate. Each prompt now renders one copy instead of a flow copy plus a clipped overlay copy, which also removes the `aria-hidden`/`inert` pair and the non-compositable `will-change` hints. Clipping stays on `max-height` with a sibling spacer outside the sticky box, because `clip-path` clips paint only and would have let native sticky push the prompt away roughly 204px early.

## The Safari half, which was not in the original diagnosis

The investigation that motivated this work used a Chromium trace: 902 forced layouts, 6.7s of a 12s recording, all from one call site. So the design targeted forced layout, and on Chromium it worked. It also would not have fixed Safari, where scrolling was reported as much worse, because Safari's cost was never in layout.

Measured per frame at 151 prompts: Chromium spends script 5.5ms, style 0.7ms, layout 0.8ms, paint and raster 3.7ms, composite 0.5ms. WebKit spends at least 20ms of a 36ms frame in paint and composite, about 14ms of it in `backdrop-filter` layers.

The cause is that a frame performs one forced style, layout and compositing update, and on WebKit the price of that update is set by how many blurred layers the transcript carries. Both halves are needed to make the frame expensive: suppressing paint gives a 16ms frame, rendering one band instead of 151 gives 22ms, removing the handler gives 17ms, and removing both gives 16ms, the vsync ceiling. Removing the layers is much easier than removing the forced update, so the frosted band is now mounted only while its prompt is inside the scrollport, via one `IntersectionObserver` per prompt. At 151 prompts that takes the number of rendered bands from 151 to the 2 or 3 turns a 900px scrollport actually holds.

## Why the restructure, and not something smaller

The obvious cheaper change is to keep the flat transcript, gate the frosted band by visibility, and skip the per frame work for prompts that are off screen. That was built and measured on `main`, and it does not get there. At 151 prompts, rows 2 to 5 being diagnostics with a feature deliberately broken:

| variant | WebKit | Chromium | what it is |
|---|---|---|---|
| main | 7 | 13.5 | 151 sticky boxes, 151 `top` writes per frame |
| band gating plus work gating | 9.5 | 21.5 | 151 sticky boxes, 26 writes per frame |
| the same, tighter gate | 10.25 | 30.5 | 151 sticky boxes, 1 to 3 writes per frame |
| the same, prompts not sticky | 13.25 | 38.25 | 151 static boxes, 26 writes per frame |
| the same, `top` write removed | 41 | 59.5 | 151 sticky boxes, 0 writes per frame |
| this PR | 46.5 | 61 | 151 sticky boxes in their own sections, no `top` ever written |

The cost is one inline `top` write per frame on an element whose sticky containing block is the entire 54,516px transcript, with 151 such elements sharing it. Cutting the number of writes from 26 to 1 buys 0.75 fps on WebKit; removing the write buys 31 more. Gating cannot reach zero, because the pinned prompt needs a new offset on every frame that scrolls. The only way to stop writing it is to let the browser do push-out, and that requires each turn to be the sticky containing block.

Two things worth noting from that table. This PR does **more** per frame JS than the gated variant, 294 rect reads and 442 property writes against 93 and 90, and is three times faster: per frame JS was never the bottleneck. And node count is not the differentiator either, since gating the band unmounts the duplicate copy with it: 10,547 nodes on main, 6,226 on the gated variant, 6,501 here.

## Results

Frame rate during continuous scrolling, one session, three runs per cell:

| prompts | tree | Chromium | WebKit | WebKit gap median | frames over 32ms |
|---|---|---|---|---|---|
| 151 | main | 14 | 7 | 166ms | 12 of 14 |
| 151 | #27673 | 14 | 7 | 166ms | 12 of 14 |
| 151 | this PR | **60** | **49** | **20ms** | **1 of 98** |
| 15 | #27673 | 61 | 49.5 | 19ms | 3 |
| 15 | this PR | 61 | **59** | 16ms | 1 |

Chromium at 151 prompts also goes from 78.6 forced layouts per frame to 4.2, 931ms of layout across 40 frames to 31ms, and 10,727 DOM nodes to 6,650.

## A shared scroll coordinator was planned, measured, and dropped

The design called for replacing the 151 per-prompt scroll listeners and observers with one coordinator per scroller, on the theory that batching O(N) reads and writes was the win. That theory is wrong, and the measurement is the reason this PR is ~150 lines smaller than planned.

WebKit at 151 prompts, coordinator emulated exactly in the existing handler:

| | per-prompt handler | coordinator |
|---|---|---|
| 151 bands | 28.5 | 30.5 |
| 1 band | **45** | 45.5 |

The band count is worth about 16 fps. The coordinator is worth about 0.5, inside a run spread of 41.5 to 47.5. On Chromium it moves script time from 3.79ms to 1.28ms per frame on an engine already using 7ms of a 16.7ms budget. Eliding 99.5% of the per frame property writes moved WebKit by one frame per second.

One property that must hold regardless: writing genuinely changing values to all 151 prompts every frame collapses both engines, WebKit to 7.5 fps and Chromium to 14. Today only the pinned prompt's values change.

## Intentional behavior changes

- Compression now begins at the pin line rather than the scroller's border edge, so at a fixed offset a mid-ramp prompt is about 7.6px more compressed than before. The old code started compressing 8px after pinning.
- A pinned prompt sits at exactly 8px. It was 7.25px in some cases, because the old code wrote a fractional `top`.
- Jump arrows and post-edit scrolling land the prompt on the pin line rather than at 0, via `scrollIntoView` plus `scroll-margin-top`, replacing the measured `scrollBy` delta. Post-edit scrolling never preserved scroll position; it always moved the edited prompt to the top.
- `--clip-h` is now fractional, because sizes come from rects rather than integer `offsetHeight`. This is what makes total `scrollHeight` land on exactly 6163 in the reference story.

Existing story coverage passes unchanged on all of the above: `ConversationTimeline.stories.tsx` 56/56 and `AgentChatPageView.stories.tsx` 50/50, including the five sticky stories. Those five still assert on internals and are rewritten to observable behavior in the follow-up, along with the wider scenario coverage.

**Elements reach the prompt through React, not the DOM.** The scrollport and the transcript wrapper are provided by the components that own them, and the bubble and its body are passed as refs, so the sticky code contains no `closest`, `querySelector` or `parentElement`. Those elements are held as **state**, not refs, and that is load-bearing: React attaches host refs and runs layout effects in one children-first traversal, so a prompt's layout effect runs before its ancestor scrollport's ref is attached. With refs in context the feature is silently dead on mount, measured as 0 bands, `--clip-h` unset and zero per frame work, with every check passing because nothing ran. Both elements are set from ref callbacks during the commit phase, which React flushes before paint, so a prompt's first painted frame is still clipped correctly.

<details>
<summary>Verification detail, engine caveats, and the superseded decision</summary>

**Engines.** Chromium 140, WebKit 26.0 and Firefox 141 from `mcr.microsoft.com/playwright:v1.55.1-noble`. Linux WebKit is WebCore but not macOS Safari: no CoreAnimation or Metal path, so it rasterises in software and absolute frame rates are pessimistic. The comparisons between variants within one session are the evidence; the absolute numbers are not Safari's. The original report of poor Safari scrolling came from a human on real Safari.

**Per construct hazard check on the final tree, WebKit at 151 prompts.** `mask-image: none` gives 45 fps, identical to baseline, so the mask is free. `max-height: none` gives 33 fps, worse, because unclipped prompts paint more text and grow scroll height from 54,249 to 80,799px. The one remaining band costs 2 to 4ms per frame, which is the feature working. Nothing else in the wiring behaves the way the 151 bands did.

**Behavior contract.** Verified on the final tree across all three engines: one prompt on the pin line at a time; Copy, Edit, Prev and Next reachable and hit-testing to themselves at every compression level; click-through below the clip line; exactly one copy of the prompt text in the accessibility tree and zero `inert` nodes; too-tall prompts fall back to `position: relative` with no pinning; clip drift zero at load, mid ramp, after transcript growth and after a nudge; section-bounded sticky works inside the two `display: contents` wrappers in the `column-reverse` scroller; `ResizeObserver` still lands before paint outside Chromium, with 0 of 4 WebKit loads stale; `scrollIntoView` plus `scroll-margin-top` lands the sentinel on the pin line; keyboard focus order is correct with a single copy. Turn height accounting is exact: container 98 plus margin -42 plus gap 8 plus spacer margin -8 plus spacer 220.38 equals the 276.38px uncompressed height, and total `scrollHeight` is 6163 before and after.

**Why this is one commit series rather than three PRs.** Landing "sections as real containing blocks" while keeping the old machinery is not behavior preserving: every off-screen header moves by exactly -220.375px, because a real containing block clamps a sticky box that is still full height while the clip is only an overlay. That is the same failure mode that ruled out `clip-path`. Real boxes and the single copy cannot be separated.

**Commit history note.** `96f1d10c59` gates the band with a `--fade-display` custom property and `1dbbafcc29` deletes that mechanism in favour of the `IntersectionObserver`. Both are kept because toggling `display` on a blurred element measured at about -10 fps on WebKit at 15 prompts, and that measurement is the reason the second approach exists.

**Superseded decision.** The design document's D7 specified the shared coordinator on the rationale that batching reads and writes was the win. That rationale is now measured false on WebKit and marginal on Chromium; D7 is marked superseded with the 2x2 and the single-variable runs, so the coordinator is not rebuilt later from the old reasoning. The original Chromium layout measurement was real, it was simply never Safari's bottleneck.

</details>

---

Generated with Coder Agents on behalf of @DanielleMaywood.
