### PR TITLE
fix(provisioner/terraform): sync version constants with the shipped binary

### DIFF
--- a/provisioner/terraform/install.go
+++ b/provisioner/terraform/install.go
@@ -22,10 +22,10 @@ var (
 	// when Terraform is not available on the system.
 	// NOTE: Keep this in sync with the version in scripts/Dockerfile.base.
 	// NOTE: Keep this in sync with the version in install.sh.
-	TerraformVersion = version.Must(version.NewVersion("1.14.5"))
+	TerraformVersion = version.Must(version.NewVersion("1.15.5"))
 
 	minTerraformVersion = version.Must(version.NewVersion("1.1.0"))
-	maxTerraformVersion = version.Must(version.NewVersion("1.14.9")) // use .9 to automatically allow patch releases
+	maxTerraformVersion = version.Must(version.NewVersion("1.15.9")) // use .9 to automatically allow patch releases
 
 	errTerraformMinorVersionMismatch = xerrors.New("Terraform binary minor version mismatch.")
 )


### PR DESCRIPTION
`provisioner/terraform/install.go` still pins `TerraformVersion` to 1.14.5 and `maxTerraformVersion` to 1.14.9, but the shipped binary has been Terraform 1.15.5 since v2.35.0. `scripts/Dockerfile.base`, `install.sh`, `mise.toml`, `mise.lock`, and `flake.nix` all track 1.15.5; only the Go constants were left behind, which makes the `NOTE: Keep this in sync with ...` comments on those constants false.

Two user-visible effects on the same release:

- Provisioner daemons that have a system Terraform log `installed terraform version newer than expected, you may experience bugs installed_version=1.15.5 max_version=1.14.9` on every startup. The check at [`provisioner/terraform/serve.go#L122-L126`](https://github.com/coder/coder/blob/79723db2d23b6b941e405a8d3c2200206e7e4cb4/provisioner/terraform/serve.go#L122-L126) is warn-only, so the 1.15.5 binary is used anyway and the warning is pure noise.
- Hosts *without* a system Terraform fall through to `Install()` at [`serve.go#L105`](https://github.com/coder/coder/blob/79723db2d23b6b941e405a8d3c2200206e7e4cb4/provisioner/terraform/serve.go#L105), which downloads `TerraformVersion`. So the same Coder version provisions with 1.15.5 in some environments and 1.14.5 in others.

This sets `TerraformVersion` to 1.15.5 and `maxTerraformVersion` to 1.15.9, keeping the existing `.9` convention that auto-allows patch releases. `minTerraformVersion` is unchanged. No other file needed updating; everything else already tracks 1.15.5.

This is a consistency fix, not a CVE remediation.

The divergence was already identified as [CRF-2 in the review of #27183](https://github.com/coder/coder/pull/27183#pullrequestreview-4685322854) (`provisioner/terraform/install.go:25`), which noted that leaving the constants behind means "a maintainer who trusts it could 'resync' install.sh/Dockerfile.base back to 1.14.5". That PR was closed for unrelated reasons; this change addresses only the drift.

Refs #27183
