### PR TITLE
feat: support public (secretless, PKCE-only) OAuth2 clients at the handler layer

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14824,7 +14824,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Client secret, required if grant_type=authorization_code",
+                        "description": "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.",
                         "name": "client_secret",
                         "in": "formData"
                     },
@@ -14832,6 +14832,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Authorization code, required if grant_type=authorization_code",
                         "name": "code",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636. This is the only client authentication a public client has.",
+                        "name": "code_verifier",
                         "in": "formData"
                     },
                     {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13156,7 +13156,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Client secret, required if grant_type=authorization_code",
+						"description": "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.",
 						"name": "client_secret",
 						"in": "formData"
 					},
@@ -13164,6 +13164,12 @@
 						"type": "string",
 						"description": "Authorization code, required if grant_type=authorization_code",
 						"name": "code",
+						"in": "formData"
+					},
+					{
+						"type": "string",
+						"description": "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636. This is the only client authentication a public client has.",
+						"name": "code_verifier",
 						"in": "formData"
 					},
 					{

--- a/coderd/database/constants.go
+++ b/coderd/database/constants.go
@@ -10,3 +10,23 @@ import (
 // for use as a uuid.UUID. Both must agree; tests pin the value to the
 // codersdk constant so the two cannot drift.
 var PrebuildsSystemUserID = uuid.MustParse(codersdk.PrebuildsSystemUserID)
+
+// Values stored in oauth2_provider_apps.client_type, as plain strings for
+// comparison against the nullable column.
+//
+// Converted from the codersdk constants rather than redeclared, so the value
+// registration writes and the value OAuth2ProviderApp.IsPublic reads back
+// cannot disagree. That divergence would fail closed anyway (the app would read
+// as confidential and demand a secret it was never issued), but it would fail
+// visibly to a client rather than here.
+//
+// What this does not protect against is the two constants colliding on the same
+// value, which would make IsPublic true for confidential apps. Nothing in the
+// type system can catch that; the tests that pin these spellings to the wire
+// values do, so do not delete them as redundant:
+// TestOAuth2ClientRegistrationRequest_DetermineClientType and
+// TestCreateDynamicClientRegistration_ClientType.
+const (
+	OAuth2ProviderAppClientTypeConfidential = string(codersdk.OAuth2ClientTypeConfidential)
+	OAuth2ProviderAppClientTypePublic       = string(codersdk.OAuth2ClientTypePublic)
+)

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -1733,7 +1733,7 @@ func OAuth2ProviderApp(t testing.TB, db database.Store, seed database.OAuth2Prov
 		Icon:                    takeFirst(seed.Icon, ""),
 		CallbackURL:             takeFirst(seed.CallbackURL, "http://localhost"),
 		RedirectUris:            takeFirstSlice(seed.RedirectUris, []string{}),
-		ClientType:              takeFirst(seed.ClientType, "confidential"),
+		ClientType:              takeFirst(seed.ClientType, database.OAuth2ProviderAppClientTypeConfidential),
 		DynamicallyRegistered:   takeFirst(seed.DynamicallyRegistered, sql.NullBool{Bool: false, Valid: true}),
 		ClientIDIssuedAt:        takeFirst(seed.ClientIDIssuedAt, sql.NullTime{}),
 		ClientSecretExpiresAt:   takeFirst(seed.ClientSecretExpiresAt, sql.NullTime{}),

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -685,6 +685,14 @@ func (OAuth2ProviderApp) RBACObject() rbac.Object {
 	return rbac.ResourceOauth2App
 }
 
+// IsPublic reports whether the app is a public (secretless, PKCE-only)
+// OAuth2 client per RFC 7591 §2 / OAuth 2.1 §2.1, as opposed to confidential.
+// An unset or unrecognized client type reads as confidential, so an app can
+// never skip client authentication by accident.
+func (a OAuth2ProviderApp) IsPublic() bool {
+	return a.ClientType == OAuth2ProviderAppClientTypePublic
+}
+
 func (a GetOAuth2ProviderAppsByUserIDRow) RBACObject() rbac.Object {
 	return a.OAuth2ProviderApp.RBACObject()
 }

--- a/coderd/database/modelmethods_internal_test.go
+++ b/coderd/database/modelmethods_internal_test.go
@@ -221,6 +221,37 @@ func TestWorkspaceACLDisabled(t *testing.T) {
 	})
 }
 
+// TestOAuth2ProviderAppIsPublic pins IsPublic's contract directly, since it is
+// what decides whether the token endpoint validates a client secret at all.
+// Only the exact string "public" may read as public: anything else, including
+// an unset column or a differently-cased value, must read as confidential so
+// that a garbled value cannot silently skip client authentication.
+func TestOAuth2ProviderAppIsPublic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		clientType string
+		want       bool
+	}{
+		{clientType: "public", want: true},
+		{clientType: "confidential", want: false},
+		{clientType: "", want: false},
+		{clientType: "Public", want: false},
+		{clientType: "PUBLIC", want: false},
+		{clientType: " public", want: false},
+		{clientType: "public ", want: false},
+		{clientType: "bogus", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.clientType, func(t *testing.T) {
+			t.Parallel()
+			app := OAuth2ProviderApp{ClientType: tt.clientType}
+			require.Equal(t, tt.want, app.IsPublic())
+		})
+	}
+}
+
 // Helpers
 func requirePermission(t *testing.T, s rbac.Scope, resource string, action policy.Action) {
 	t.Helper()

--- a/coderd/oauth2.go
+++ b/coderd/oauth2.go
@@ -147,8 +147,9 @@ func (api *API) postOAuth2ProviderAppAuthorize() http.HandlerFunc {
 // @Produce json
 // @Tags Enterprise
 // @Param client_id formData string false "Client ID, required if grant_type=authorization_code"
-// @Param client_secret formData string false "Client secret, required if grant_type=authorization_code"
+// @Param client_secret formData string false "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret."
 // @Param code formData string false "Authorization code, required if grant_type=authorization_code"
+// @Param code_verifier formData string false "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636. This is the only client authentication a public client has."
 // @Param refresh_token formData string false "Refresh token, required if grant_type=refresh_token"
 // @Param grant_type formData codersdk.OAuth2ProviderGrantType true "Grant type"
 // @Success 200 {object} oauth2.Token

--- a/coderd/oauth2_security_test.go
+++ b/coderd/oauth2_security_test.go
@@ -267,6 +267,19 @@ func TestOAuth2PrivilegeEscalation(t *testing.T) {
 				ClientName:              fmt.Sprintf("native-app-3-%d", time.Now().UnixNano()),
 				TokenEndpointAuthMethod: "none", // Required for public clients
 			},
+			{
+				// Bare custom schemes (no reverse-domain notation) are the
+				// schemes real native apps register with the OS, and PKCE,
+				// not the scheme's spelling, is what secures the redirect.
+				RedirectURIs:            []string{"vscode://coder.authenticate"},
+				ClientName:              fmt.Sprintf("native-app-vscode-%d", time.Now().UnixNano()),
+				TokenEndpointAuthMethod: "none",
+			},
+			{
+				RedirectURIs:            []string{"jetbrains://coder-callback"},
+				ClientName:              fmt.Sprintf("native-app-jetbrains-%d", time.Now().UnixNano()),
+				TokenEndpointAuthMethod: "none",
+			},
 		}
 
 		for i, req := range validCustomSchemeRequests {

--- a/coderd/oauth2_test.go
+++ b/coderd/oauth2_test.go
@@ -498,6 +498,11 @@ func TestOAuth2ProviderTokenExchange(t *testing.T) {
 			var verifier string
 			if test.defaultCode != nil {
 				code = *test.defaultCode
+				// These subtests exercise malformed/expired code_
+				// handling; the code lookup fails before code_verifier is
+				// ever compared, but it still has to satisfy RFC 7636
+				// §4.1's format floor to reach that point.
+				verifier = strings.Repeat("a", 43)
 			} else {
 				var err error
 				code, verifier, err = authorizationFlow(ctx, userClient, valid)

--- a/coderd/oauth2_test.go
+++ b/coderd/oauth2_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/oauth2provider"
 	"github.com/coder/coder/v2/coderd/oauth2provider/oauth2providertest"
 	"github.com/coder/coder/v2/coderd/userpassword"
@@ -616,6 +617,101 @@ func TestOAuth2ProviderTokenExchangeCodeBelongsToDifferentApp(t *testing.T) {
 	require.ErrorContains(t, err, "The authorization code is invalid or expired")
 }
 
+// TestOAuth2ProviderTokenExchangePublicClientCodeBelongsToDifferentApp is the
+// public-client counterpart to the test above. A public client presents no
+// secret, so the secret-ownership check never runs and the code-ownership
+// check is the only thing binding the exchange to the app identified by
+// client_id. Two public clients sharing a redirect URI is the common case for
+// native apps, which makes this the scenario the check has to hold in.
+func TestOAuth2ProviderTokenExchangePublicClientCodeBelongsToDifferentApp(t *testing.T) {
+	t.Parallel()
+
+	ownerClient := coderdtest.New(t, nil)
+	owner := coderdtest.CreateFirstUser(t, ownerClient)
+	oauth2providertest.EnableDCR(t, ownerClient)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// Both apps are public, so neither has a secret and the code-ownership
+	// check is the only thing binding the exchange to an app.
+	const sharedCallback = "http://localhost:8080/callback"
+	appA := oauth2providertest.RegisterPublicClient(ctx, t, ownerClient, "public-code-owner", sharedCallback)
+	appB := oauth2providertest.RegisterPublicClient(ctx, t, ownerClient, "public-code-thief", sharedCallback)
+
+	userClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+
+	authURL := ownerClient.URL.JoinPath("/oauth2/authorize").String()
+	tokenURL := ownerClient.URL.JoinPath("/oauth2/tokens").String()
+
+	cfgA := &oauth2.Config{
+		ClientID: appA.ClientID,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		RedirectURL: sharedCallback,
+		Scopes:      []string{},
+	}
+	code, verifier, err := authorizationFlow(ctx, userClient, cfgA)
+	require.NoError(t, err)
+
+	// Redeem appA's code under appB's client_id, with no secret and a valid
+	// PKCE verifier. Everything except the code's own app_id lines up.
+	cfgB := &oauth2.Config{
+		ClientID: appB.ClientID,
+		Endpoint: oauth2.Endpoint{
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		RedirectURL: sharedCallback,
+		Scopes:      []string{},
+	}
+	_, err = cfgB.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", verifier))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "The authorization code is invalid or expired")
+
+	// PKCE is the only client authentication a public client has, so exercise
+	// its failure branches here rather than only on confidential apps. The
+	// verification currently sits outside the if !isPublic block, so a later
+	// change that moved it inside would leave every confidential test passing
+	// while public clients lost authentication entirely.
+	//
+	// An empty or under-length verifier fails the RFC 7636 §4.1 format check
+	// in extractTokenRequest before the PKCE hash comparison ever runs, so it
+	// surfaces as invalid_request rather than the hash-mismatch invalid_grant
+	// below. This lets a client that sent a malformed verifier tell that
+	// apart from one that sent a wrong-but-well-formed verifier. A malformed
+	// verifier never reaches authorizationCodeGrant, so it does not consume
+	// the code.
+	_, err = cfgA.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", ""))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "code_verifier")
+
+	// RFC 7636 §4.1 sets a 43-character floor. A one-character verifier
+	// hashes to a well-formed challenge, so only a length check refuses it;
+	// it fails the same format check as the empty verifier above, and
+	// likewise leaves the code unconsumed.
+	_, err = cfgA.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", "a"))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "code_verifier")
+
+	// A well-formed verifier that simply doesn't hash to the stored challenge
+	// passes the format check and reaches the PKCE comparison, which rejects
+	// it as invalid_grant. RFC 6749 §10.5 requires codes to be single-use, so
+	// unlike the two format failures above, this consumes the code: without
+	// that, a leaked code could be replayed with unlimited further guesses.
+	wrongVerifier, _ := oauth2providertest.GeneratePKCE(t)
+	_, err = cfgA.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", wrongVerifier))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "The PKCE code verifier is invalid")
+
+	// The code was consumed by the failed PKCE comparison above, so even the
+	// verifier that would have matched can no longer redeem it.
+	_, err = cfgA.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", verifier))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "The authorization code is invalid or expired")
+}
+
 func TestOAuth2ProviderTokenRefresh(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -1045,6 +1141,129 @@ func TestOAuth2ProviderRevokeCrossApp(t *testing.T) {
 			err = userClient.RevokeOAuth2Token(ctx, apps.Default.ID, tokenUnderTest)
 			require.NoError(t, err)
 			require.False(t, sessionWorks(), "same-app revoke must end the session")
+		})
+	}
+}
+
+// TestOAuth2PublicClientTokenLifecycle exercises refresh and revocation for a
+// public client, whose tokens are the first with a NULL app_secret_id.
+//
+// The confidential-client tests all mint tokens with a real secret, so the
+// refresh path that carries dbToken.AppSecretID forward and the two revocation
+// ownership checks in revoke.go were only ever run against a non-NULL value.
+// This PR's premise is that revocation ownership moved onto app_id precisely so
+// a secretless token can still be revoked, and that claim needs a test. Without
+// one, reintroducing a join through app_secret_id would break public clients
+// only, and the suite would stay green.
+func TestOAuth2PublicClientTokenLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// tokenFor selects which token to revoke, covering both
+		// revokeRefreshTokenInTx and revokeAPIKeyInTx.
+		tokenFor func(*oauth2.Token) string
+	}{
+		{
+			name:     "AccessToken",
+			tokenFor: func(tok *oauth2.Token) string { return tok.AccessToken },
+		},
+		{
+			name:     "RefreshToken",
+			tokenFor: func(tok *oauth2.Token) string { return tok.RefreshToken },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			db, pubsub := dbtestutil.NewDB(t)
+			ownerClient := coderdtest.New(t, &coderdtest.Options{
+				Database: db,
+				Pubsub:   pubsub,
+			})
+			owner := coderdtest.CreateFirstUser(t, ownerClient)
+			oauth2providertest.EnableDCR(t, ownerClient)
+
+			const callback = "http://localhost:8080/callback"
+			app := oauth2providertest.RegisterPublicClient(ctx, t, ownerClient, "public-lifecycle", callback)
+			otherApp := oauth2providertest.RegisterPublicClient(ctx, t, ownerClient, "public-lifecycle-other", callback)
+
+			appID, err := uuid.Parse(app.ClientID)
+			require.NoError(t, err)
+			otherAppID, err := uuid.Parse(otherApp.ClientID)
+			require.NoError(t, err)
+
+			userClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+
+			cfg := &oauth2.Config{
+				ClientID: app.ClientID,
+				Endpoint: oauth2.Endpoint{
+					AuthURL:   ownerClient.URL.JoinPath("/oauth2/authorize").String(),
+					TokenURL:  ownerClient.URL.JoinPath("/oauth2/tokens").String(),
+					AuthStyle: oauth2.AuthStyleInParams,
+				},
+				RedirectURL: callback,
+				Scopes:      []string{},
+			}
+
+			code, verifier, err := authorizationFlow(ctx, userClient, cfg)
+			require.NoError(t, err)
+			token, err := cfg.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", verifier))
+			require.NoError(t, err)
+			require.NotEmpty(t, token.RefreshToken)
+
+			// Confirm the precondition this test exists for: the minted row
+			// really does have a NULL app_secret_id, with app_id carrying the
+			// ownership that revocation depends on.
+			assertSecretlessToken := func(accessToken string) {
+				t.Helper()
+				keyID, _, err := httpmw.SplitAPIToken(accessToken)
+				require.NoError(t, err)
+				// This is the raw store handle, not the dbauthz-wrapped one the
+				// server uses, so no authorization layer is in the path and no
+				// system actor is needed.
+				dbToken, err := db.GetOAuth2ProviderAppTokenByAPIKeyID(ctx, keyID)
+				require.NoError(t, err)
+				require.False(t, dbToken.AppSecretID.Valid, "public client token must have a NULL app_secret_id")
+				require.Equal(t, appID, dbToken.AppID)
+			}
+			assertSecretlessToken(token.AccessToken)
+
+			// Refresh carries AppSecretID forward untouched, so the refreshed
+			// row must still be secretless and still owned by the same app.
+			refreshCfg := *cfg
+			refreshed, err := refreshCfg.TokenSource(ctx, &oauth2.Token{
+				RefreshToken: token.RefreshToken,
+				Expiry:       time.Now().Add(-time.Hour),
+			}).Token()
+			require.NoError(t, err)
+			require.NotEmpty(t, refreshed.AccessToken)
+			assertSecretlessToken(refreshed.AccessToken)
+
+			sessionWorks := func() bool {
+				checkClient := codersdk.New(userClient.URL)
+				checkClient.SetSessionToken(refreshed.AccessToken)
+				_, err := checkClient.User(ctx, codersdk.Me)
+				return err == nil
+			}
+			require.True(t, sessionWorks(), "refreshed public-client session should be valid")
+
+			tokenUnderTest := test.tokenFor(refreshed)
+
+			// A different app must not be able to revoke it, and per RFC 7009
+			// must not learn that it exists.
+			err = userClient.RevokeOAuth2Token(ctx, otherAppID, tokenUnderTest)
+			require.NoError(t, err, "cross-app revoke must appear to succeed per RFC 7009")
+			require.True(t, sessionWorks(), "cross-app revoke must not end the session")
+
+			// The issuing app must be able to revoke it, with no secret to join
+			// through. This is the claim app_id was promoted for.
+			err = userClient.RevokeOAuth2Token(ctx, appID, tokenUnderTest)
+			require.NoError(t, err)
+			require.False(t, sessionWorks(), "public client must be able to revoke its own token")
 		})
 	}
 }

--- a/coderd/oauth2_test.go
+++ b/coderd/oauth2_test.go
@@ -151,6 +151,29 @@ func TestOAuth2ProviderAppSecrets(t *testing.T) {
 		_, err = client.OAuth2ProviderAppSecrets(ctx, apps.Default.ID)
 		require.Error(t, err)
 	})
+
+	t.Run("RejectsPublicClient", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		oauth2providertest.EnableDCR(t, client)
+		app := oauth2providertest.RegisterPublicClient(ctx, t, client, "app-secrets-public", "http://localhost:8080/callback")
+		appID, err := uuid.Parse(app.ClientID)
+		require.NoError(t, err)
+
+		// A public client authenticates with PKCE alone, so minting a secret
+		// would hand an operator a credential the token endpoint never
+		// checks, and one whose deletion looks like a kill switch but
+		// revokes nothing.
+		//nolint:gocritic // OAauth2 app management requires owner permission.
+		_, err = client.PostOAuth2ProviderAppSecret(ctx, appID)
+		require.Error(t, err)
+
+		//nolint:gocritic // OAauth2 app management requires owner permission.
+		secrets, err := client.OAuth2ProviderAppSecrets(ctx, appID)
+		require.NoError(t, err)
+		require.Empty(t, secrets)
+	})
 }
 
 func TestOAuth2ProviderTokenExchange(t *testing.T) {

--- a/coderd/oauth2provider/app_secrets.go
+++ b/coderd/oauth2provider/app_secrets.go
@@ -53,6 +53,21 @@ func CreateAppSecret(db database.Store, auditor *audit.Auditor, logger slog.Logg
 			})
 		)
 		defer commitAudit()
+
+		// A public client authenticates with PKCE alone, so the token endpoint
+		// never validates a secret for one. Minting a secret anyway would hand
+		// an operator a credential that does nothing, and worse, one whose
+		// deletion looks like a kill switch: for a confidential app deleting a
+		// secret cascades its tokens away, but a public client's tokens carry a
+		// NULL app_secret_id, so deleting it revokes nothing.
+		if app.IsPublic() {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Cannot create a client secret for a public OAuth2 app.",
+				Detail:  "Public clients authenticate with PKCE and have no client secret. The client type is fixed at registration.",
+			})
+			return
+		}
+
 		secret, err := GenerateSecret()
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/coderd/oauth2provider/apps.go
+++ b/coderd/oauth2provider/apps.go
@@ -92,7 +92,7 @@ func CreateApp(db database.Store, accessURL *url.URL, auditor *audit.Auditor, lo
 			Icon:                    req.Icon,
 			CallbackURL:             req.CallbackURL,
 			RedirectUris:            []string{},
-			ClientType:              "confidential",
+			ClientType:              database.OAuth2ProviderAppClientTypeConfidential,
 			DynamicallyRegistered:   sql.NullBool{Bool: false, Valid: true},
 			ClientIDIssuedAt:        sql.NullTime{},
 			ClientSecretExpiresAt:   sql.NullTime{},

--- a/coderd/oauth2provider/authorize.go
+++ b/coderd/oauth2provider/authorize.go
@@ -54,12 +54,24 @@ func extractAuthorizeParams(r *http.Request, callbackURL *url.URL) (authorizePar
 		codeChallengeMethod: p.String(vals, "", "code_challenge_method"),
 	}
 
-	// PKCE is required for authorization code flow requests.
-	if params.responseType == codersdk.OAuth2ProviderResponseTypeCode && params.codeChallenge == "" {
-		p.Errors = append(p.Errors, codersdk.ValidationError{
-			Field:  "code_challenge",
-			Detail: `Query param "code_challenge" is required and cannot be empty`,
-		})
+	// PKCE is required for authorization code flow requests. Reject a
+	// malformed code_challenge here (RFC 7636 §4.4.1) rather than storing it
+	// verbatim and failing later at token exchange, where the error would
+	// point at the code_verifier instead of the parameter that was actually
+	// invalid.
+	if params.responseType == codersdk.OAuth2ProviderResponseTypeCode {
+		switch {
+		case params.codeChallenge == "":
+			p.Errors = append(p.Errors, codersdk.ValidationError{
+				Field:  "code_challenge",
+				Detail: `Query param "code_challenge" is required and cannot be empty`,
+			})
+		case !ValidPKCEFormat(params.codeChallenge):
+			p.Errors = append(p.Errors, codersdk.ValidationError{
+				Field:  "code_challenge",
+				Detail: "must be 43 to 128 characters from the unreserved character set [A-Za-z0-9-._~]",
+			})
+		}
 	}
 
 	// Validate resource indicator syntax (RFC 8707): must be absolute URI without fragment

--- a/coderd/oauth2provider/metadata.go
+++ b/coderd/oauth2provider/metadata.go
@@ -28,15 +28,20 @@ func GetAuthorizationServerMetadata(db database.Store, accessURL *url.URL) http.
 		}
 
 		metadata := codersdk.OAuth2AuthorizationServerMetadata{
-			Issuer:                            accessURL.String(),
-			AuthorizationEndpoint:             accessURL.JoinPath("/oauth2/authorize").String(),
-			TokenEndpoint:                     accessURL.JoinPath("/oauth2/tokens").String(),
-			RevocationEndpoint:                accessURL.JoinPath("/oauth2/revoke").String(), // RFC 7009
-			ResponseTypesSupported:            []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode},
-			GrantTypesSupported:               []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeRefreshToken},
-			CodeChallengeMethodsSupported:     []codersdk.OAuth2PKCECodeChallengeMethod{codersdk.OAuth2PKCECodeChallengeMethodS256},
-			ScopesSupported:                   rbac.ExternalScopeNames(),
-			TokenEndpointAuthMethodsSupported: []codersdk.OAuth2TokenEndpointAuthMethod{codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic, codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost},
+			Issuer:                        accessURL.String(),
+			AuthorizationEndpoint:         accessURL.JoinPath("/oauth2/authorize").String(),
+			TokenEndpoint:                 accessURL.JoinPath("/oauth2/tokens").String(),
+			RevocationEndpoint:            accessURL.JoinPath("/oauth2/revoke").String(), // RFC 7009
+			ResponseTypesSupported:        []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode},
+			GrantTypesSupported:           []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeRefreshToken},
+			CodeChallengeMethodsSupported: []codersdk.OAuth2PKCECodeChallengeMethod{codersdk.OAuth2PKCECodeChallengeMethodS256},
+			ScopesSupported:               rbac.ExternalScopeNames(),
+			// Derived from the same list Valid() uses, so discovery cannot
+			// advertise a method registration rejects, or hide one it accepts.
+			// Not gated on dcrEnabled: disabling registration stops new public
+			// clients being created but does not stop existing ones exchanging
+			// tokens, so the method remains supported.
+			TokenEndpointAuthMethodsSupported: codersdk.AllOAuth2TokenEndpointAuthMethods(),
 		}
 		if dcrEnabled {
 			metadata.RegistrationEndpoint = accessURL.JoinPath("/oauth2/register").String() // RFC 7591

--- a/coderd/oauth2provider/metadata_test.go
+++ b/coderd/oauth2provider/metadata_test.go
@@ -42,6 +42,9 @@ func TestOAuth2AuthorizationServerMetadata(t *testing.T) {
 	require.Contains(t, metadata.GrantTypesSupported, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
 	require.Contains(t, metadata.GrantTypesSupported, codersdk.OAuth2ProviderGrantTypeRefreshToken)
 	require.Contains(t, metadata.CodeChallengeMethodsSupported, codersdk.OAuth2PKCECodeChallengeMethodS256)
+	// Public (secretless, PKCE-only) clients must be advertised so they can
+	// discover that Coder will accept a "none" auth method.
+	require.Contains(t, metadata.TokenEndpointAuthMethodsSupported, codersdk.OAuth2TokenEndpointAuthMethodNone)
 	// Supported scopes are published from the curated catalog
 	require.Equal(t, rbac.ExternalScopeNames(), metadata.ScopesSupported)
 }

--- a/coderd/oauth2provider/oauth2providertest/fixtures.go
+++ b/coderd/oauth2provider/oauth2providertest/fixtures.go
@@ -13,8 +13,16 @@ const (
 	// TestResourceURI is used for testing resource parameter
 	TestResourceURI = "https://api.example.com"
 
-	// Invalid PKCE verifier for negative testing
-	InvalidCodeVerifier = "wrong-verifier"
+	// InvalidCodeVerifier is well-formed (43 characters, RFC 7636 §4.1's
+	// unreserved set) but does not hash to any issued challenge, so it
+	// exercises the PKCE comparison failure (invalid_grant) rather than the
+	// length/charset check (invalid_request).
+	InvalidCodeVerifier = "wrong-verifier-that-is-well-formed-43-chars"
+
+	// MalformedCodeVerifier is below RFC 7636 §4.1's 43-character floor, so
+	// it exercises the length/charset check (invalid_request) instead of the
+	// PKCE comparison.
+	MalformedCodeVerifier = "too-short"
 )
 
 // OAuth2ErrorTypes contains standard OAuth2 error codes

--- a/coderd/oauth2provider/oauth2providertest/helpers.go
+++ b/coderd/oauth2provider/oauth2providertest/helpers.go
@@ -4,6 +4,7 @@
 package oauth2providertest
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -75,6 +76,25 @@ func CreateTestOAuth2App(t *testing.T, client *codersdk.Client) (*codersdk.OAuth
 	require.NoError(t, err, "failed to create OAuth2 app secret")
 
 	return &app, secret.ClientSecretFull
+}
+
+// RegisterPublicClient registers a public (secretless, PKCE-only) OAuth2 client
+// via RFC 7591 dynamic registration, the only way to create one. This is the
+// public counterpart to CreateTestOAuth2App. The caller must call EnableDCR
+// first, and needs owner-level permissions to do so.
+func RegisterPublicClient(ctx context.Context, t *testing.T, client *codersdk.Client, name, redirectURI string) codersdk.OAuth2ClientRegistrationResponse {
+	t.Helper()
+
+	resp, err := client.PostOAuth2ClientRegistration(ctx, codersdk.OAuth2ClientRegistrationRequest{
+		RedirectURIs:            []string{redirectURI},
+		ClientName:              fmt.Sprintf("%s-%s", name, testutil.MustRandString(t, 10)),
+		TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethodNone,
+	})
+	require.NoError(t, err, "failed to register public OAuth2 client")
+	// A public client is issued no secret. Asserting it here means every caller
+	// inherits the check rather than restating it.
+	require.Empty(t, resp.ClientSecret, "public client must not be issued a secret")
+	return resp
 }
 
 // EnableDCR turns on dynamic client registration for the deployment.

--- a/coderd/oauth2provider/oauth2providertest/oauth2_test.go
+++ b/coderd/oauth2provider/oauth2providertest/oauth2_test.go
@@ -189,6 +189,39 @@ func TestOAuth2WithoutPKCEIsRejected(t *testing.T) {
 	)
 }
 
+// TestOAuth2MalformedCodeChallengeIsRejected verifies that a code_challenge
+// below the RFC 7636 §4.1 length floor is rejected at the authorization
+// request, rather than being stored and only failing once a client attempts
+// to exchange the resulting code.
+func TestOAuth2MalformedCodeChallengeIsRejected(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: false,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	app, _ := oauth2providertest.CreateTestOAuth2App(t, client)
+	t.Cleanup(func() {
+		oauth2providertest.CleanupOAuth2App(t, client, app.ID)
+	})
+
+	state := oauth2providertest.GenerateState(t)
+
+	authParams := oauth2providertest.AuthorizeParams{
+		ClientID:            app.ID.String(),
+		ResponseType:        "code",
+		RedirectURI:         oauth2providertest.TestRedirectURI,
+		State:               state,
+		CodeChallenge:       "too-short",
+		CodeChallengeMethod: "S256",
+	}
+
+	oauth2providertest.AuthorizeOAuth2AppExpectingError(
+		t, client, client.URL.String(), authParams, http.StatusBadRequest,
+	)
+}
+
 func TestOAuth2TokenExchangeClientSecretBasic(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/oauth2provider/oauth2providertest/oauth2_test.go
+++ b/coderd/oauth2provider/oauth2providertest/oauth2_test.go
@@ -158,6 +158,67 @@ func TestOAuth2InvalidPKCE(t *testing.T) {
 	)
 }
 
+// TestOAuth2PKCEFailureConsumesCode verifies that a code_verifier that fails
+// the PKCE hash comparison consumes the authorization code (RFC 6749 §10.5:
+// codes are single-use). Without this, a leaked code could be replayed with
+// unlimited further code_verifier guesses for the rest of its lifetime.
+func TestOAuth2PKCEFailureConsumesCode(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: false,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	app, clientSecret := oauth2providertest.CreateTestOAuth2App(t, client)
+	t.Cleanup(func() {
+		oauth2providertest.CleanupOAuth2App(t, client, app.ID)
+	})
+
+	codeVerifier, codeChallenge := oauth2providertest.GeneratePKCE(t)
+	state := oauth2providertest.GenerateState(t)
+
+	authParams := oauth2providertest.AuthorizeParams{
+		ClientID:            app.ID.String(),
+		ResponseType:        "code",
+		RedirectURI:         oauth2providertest.TestRedirectURI,
+		State:               state,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: "S256",
+	}
+
+	code := oauth2providertest.AuthorizeOAuth2App(t, client, client.URL.String(), authParams)
+	require.NotEmpty(t, code, "should receive authorization code")
+
+	// Attempt the exchange with a well-formed but wrong verifier. This fails
+	// the PKCE hash comparison (invalid_grant) and must consume the code.
+	failedParams := oauth2providertest.TokenExchangeParams{
+		GrantType:    "authorization_code",
+		Code:         code,
+		ClientID:     app.ID.String(),
+		ClientSecret: clientSecret,
+		CodeVerifier: oauth2providertest.InvalidCodeVerifier,
+		RedirectURI:  oauth2providertest.TestRedirectURI,
+	}
+	oauth2providertest.PerformTokenExchangeExpectingError(
+		t, client.URL.String(), failedParams, oauth2providertest.OAuth2ErrorTypes.InvalidGrant,
+	)
+
+	// The correct verifier can no longer redeem the code: the failed PKCE
+	// comparison above already consumed it.
+	retryParams := oauth2providertest.TokenExchangeParams{
+		GrantType:    "authorization_code",
+		Code:         code,
+		ClientID:     app.ID.String(),
+		ClientSecret: clientSecret,
+		CodeVerifier: codeVerifier,
+		RedirectURI:  oauth2providertest.TestRedirectURI,
+	}
+	oauth2providertest.PerformTokenExchangeExpectingError(
+		t, client.URL.String(), retryParams, oauth2providertest.OAuth2ErrorTypes.InvalidGrant,
+	)
+}
+
 // TestOAuth2MalformedCodeVerifierIsRejected verifies that a code_verifier
 // below the RFC 7636 §4.1 length floor is rejected as invalid_request,
 // distinct from a well-formed verifier that fails the PKCE hash comparison

--- a/coderd/oauth2provider/oauth2providertest/oauth2_test.go
+++ b/coderd/oauth2provider/oauth2providertest/oauth2_test.go
@@ -158,6 +158,52 @@ func TestOAuth2InvalidPKCE(t *testing.T) {
 	)
 }
 
+// TestOAuth2MalformedCodeVerifierIsRejected verifies that a code_verifier
+// below the RFC 7636 §4.1 length floor is rejected as invalid_request,
+// distinct from a well-formed verifier that fails the PKCE hash comparison
+// (invalid_grant, covered by TestOAuth2InvalidPKCE).
+func TestOAuth2MalformedCodeVerifierIsRejected(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: false,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	app, clientSecret := oauth2providertest.CreateTestOAuth2App(t, client)
+	t.Cleanup(func() {
+		oauth2providertest.CleanupOAuth2App(t, client, app.ID)
+	})
+
+	_, codeChallenge := oauth2providertest.GeneratePKCE(t)
+	state := oauth2providertest.GenerateState(t)
+
+	authParams := oauth2providertest.AuthorizeParams{
+		ClientID:            app.ID.String(),
+		ResponseType:        "code",
+		RedirectURI:         oauth2providertest.TestRedirectURI,
+		State:               state,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: "S256",
+	}
+
+	code := oauth2providertest.AuthorizeOAuth2App(t, client, client.URL.String(), authParams)
+	require.NotEmpty(t, code, "should receive authorization code")
+
+	tokenParams := oauth2providertest.TokenExchangeParams{
+		GrantType:    "authorization_code",
+		Code:         code,
+		ClientID:     app.ID.String(),
+		ClientSecret: clientSecret,
+		CodeVerifier: oauth2providertest.MalformedCodeVerifier,
+		RedirectURI:  oauth2providertest.TestRedirectURI,
+	}
+
+	oauth2providertest.PerformTokenExchangeExpectingError(
+		t, client.URL.String(), tokenParams, oauth2providertest.OAuth2ErrorTypes.InvalidRequest,
+	)
+}
+
 // TestOAuth2WithoutPKCEIsRejected verifies that authorization requests without
 // a code_challenge are rejected now that PKCE is mandatory.
 func TestOAuth2WithoutPKCEIsRejected(t *testing.T) {

--- a/coderd/oauth2provider/pkce.go
+++ b/coderd/oauth2provider/pkce.go
@@ -18,14 +18,13 @@ const (
 // directly, and a code_challenge because the S256 method that produces it
 // (base64url(SHA256(verifier))) always yields a string within these bounds.
 //
-// The length floor is the whole point. PKCE is the only client authentication
-// some clients have, and the challenge travels in the authorization request
-// URL while the code travels in the redirect, both of which land in browser
-// history, referrer headers, and proxy logs. An attacker holding those
+// The length floor matters because the challenge and code both travel
+// through the authorization URL and redirect, landing in browser history,
+// referrer headers, and proxy logs. An attacker who recovers either one
 // brute-forces the verifier offline at whatever entropy the client chose,
-// where no server-side rate limit applies. A client that sends a
-// one-character verifier has set a one-character password, and the server
-// should refuse it rather than accept whatever the client picked. The same
+// with no server-side rate limit to slow them down. A client secret also
+// authenticates the token request today, but public clients (#27873) will
+// rely on this bound alone, so it must hold on its own merit. The same
 // bound on code_challenge keeps a malformed value from being persisted
 // verbatim and failing late, at token exchange, instead of at the
 // authorization request where RFC 7636 §4.4.1 expects it to be rejected.

--- a/coderd/oauth2provider/pkce.go
+++ b/coderd/oauth2provider/pkce.go
@@ -12,8 +12,11 @@ const (
 	pkceVerifierMaxLength = 128
 )
 
-// ValidPKCEVerifier reports whether a code_verifier meets RFC 7636 §4.1: 43 to
-// 128 characters of the unreserved set [A-Za-z0-9-._~].
+// ValidPKCEFormat reports whether s meets RFC 7636 §4.1: 43 to 128 characters
+// of the unreserved set [A-Za-z0-9-._~]. RFC 7636 gives code_verifier and
+// code_challenge the same ABNF, so this check applies to both: a code_verifier
+// directly, and a code_challenge because the S256 method that produces it
+// (base64url(SHA256(verifier))) always yields a string within these bounds.
 //
 // The length floor is the whole point. PKCE is the only client authentication
 // some clients have, and the challenge travels in the authorization request
@@ -22,12 +25,15 @@ const (
 // brute-forces the verifier offline at whatever entropy the client chose,
 // where no server-side rate limit applies. A client that sends a
 // one-character verifier has set a one-character password, and the server
-// should refuse it rather than accept whatever the client picked.
-func ValidPKCEVerifier(verifier string) bool {
-	if len(verifier) < pkceVerifierMinLength || len(verifier) > pkceVerifierMaxLength {
+// should refuse it rather than accept whatever the client picked. The same
+// bound on code_challenge keeps a malformed value from being persisted
+// verbatim and failing late, at token exchange, instead of at the
+// authorization request where RFC 7636 §4.4.1 expects it to be rejected.
+func ValidPKCEFormat(s string) bool {
+	if len(s) < pkceVerifierMinLength || len(s) > pkceVerifierMaxLength {
 		return false
 	}
-	for _, r := range verifier {
+	for _, r := range s {
 		switch {
 		case r >= 'A' && r <= 'Z',
 			r >= 'a' && r <= 'z',

--- a/coderd/oauth2provider/pkce.go
+++ b/coderd/oauth2provider/pkce.go
@@ -6,6 +6,40 @@ import (
 	"encoding/base64"
 )
 
+// PKCE code verifier bounds from RFC 7636 §4.1.
+const (
+	pkceVerifierMinLength = 43
+	pkceVerifierMaxLength = 128
+)
+
+// ValidPKCEVerifier reports whether a code_verifier meets RFC 7636 §4.1: 43 to
+// 128 characters of the unreserved set [A-Za-z0-9-._~].
+//
+// The length floor is the whole point. PKCE is the only client authentication
+// some clients have, and the challenge travels in the authorization request
+// URL while the code travels in the redirect, both of which land in browser
+// history, referrer headers, and proxy logs. An attacker holding those
+// brute-forces the verifier offline at whatever entropy the client chose,
+// where no server-side rate limit applies. A client that sends a
+// one-character verifier has set a one-character password, and the server
+// should refuse it rather than accept whatever the client picked.
+func ValidPKCEVerifier(verifier string) bool {
+	if len(verifier) < pkceVerifierMinLength || len(verifier) > pkceVerifierMaxLength {
+		return false
+	}
+	for _, r := range verifier {
+		switch {
+		case r >= 'A' && r <= 'Z',
+			r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '-', r == '.', r == '_', r == '~':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // VerifyPKCE verifies that the code_verifier matches the code_challenge
 // using the S256 method as specified in RFC 7636.
 func VerifyPKCE(challenge, verifier string) bool {

--- a/coderd/oauth2provider/pkce_test.go
+++ b/coderd/oauth2provider/pkce_test.go
@@ -126,7 +126,7 @@ func TestValidatePKCECodeChallengeMethod(t *testing.T) {
 	}
 }
 
-func TestValidPKCEVerifier(t *testing.T) {
+func TestValidPKCEFormat(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -198,7 +198,7 @@ func TestValidPKCEVerifier(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.expectValid, oauth2provider.ValidPKCEVerifier(tt.verifier))
+			require.Equal(t, tt.expectValid, oauth2provider.ValidPKCEFormat(tt.verifier))
 		})
 	}
 }

--- a/coderd/oauth2provider/pkce_test.go
+++ b/coderd/oauth2provider/pkce_test.go
@@ -145,26 +145,22 @@ func TestValidPKCEFormat(t *testing.T) {
 			expectValid: false,
 		},
 		{
-			name: "OneBelowMinLength",
-			// 42 characters, one short of the RFC 7636 §4.1 floor.
+			name:        "OneBelowMinLength",
 			verifier:    strings.Repeat("a", 42),
 			expectValid: false,
 		},
 		{
-			name: "AtMinLength",
-			// 43 characters, the RFC 7636 §4.1 floor.
+			name:        "AtMinLength",
 			verifier:    strings.Repeat("a", 43),
 			expectValid: true,
 		},
 		{
-			name: "AtMaxLength",
-			// 128 characters, the RFC 7636 §4.1 ceiling.
+			name:        "AtMaxLength",
 			verifier:    strings.Repeat("a", 128),
 			expectValid: true,
 		},
 		{
-			name: "OneAboveMaxLength",
-			// 129 characters, one past the RFC 7636 §4.1 ceiling.
+			name:        "OneAboveMaxLength",
 			verifier:    strings.Repeat("a", 129),
 			expectValid: false,
 		},

--- a/coderd/oauth2provider/pkce_test.go
+++ b/coderd/oauth2provider/pkce_test.go
@@ -3,6 +3,7 @@ package oauth2provider_test
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -121,6 +122,83 @@ func TestValidatePKCECodeChallengeMethod(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestValidPKCEVerifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		verifier    string
+		expectValid bool
+	}{
+		{
+			name:        "Empty",
+			verifier:    "",
+			expectValid: false,
+		},
+		{
+			name:        "OneCharacter",
+			verifier:    "a",
+			expectValid: false,
+		},
+		{
+			name: "OneBelowMinLength",
+			// 42 characters, one short of the RFC 7636 §4.1 floor.
+			verifier:    strings.Repeat("a", 42),
+			expectValid: false,
+		},
+		{
+			name: "AtMinLength",
+			// 43 characters, the RFC 7636 §4.1 floor.
+			verifier:    strings.Repeat("a", 43),
+			expectValid: true,
+		},
+		{
+			name: "AtMaxLength",
+			// 128 characters, the RFC 7636 §4.1 ceiling.
+			verifier:    strings.Repeat("a", 128),
+			expectValid: true,
+		},
+		{
+			name: "OneAboveMaxLength",
+			// 129 characters, one past the RFC 7636 §4.1 ceiling.
+			verifier:    strings.Repeat("a", 129),
+			expectValid: false,
+		},
+		{
+			name:        "AllowedCharacters",
+			verifier:    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+			expectValid: true,
+		},
+		{
+			name:        "PlusIsRejected",
+			verifier:    strings.Repeat("a", 42) + "+",
+			expectValid: false,
+		},
+		{
+			name:        "SlashIsRejected",
+			verifier:    strings.Repeat("a", 42) + "/",
+			expectValid: false,
+		},
+		{
+			name:        "EqualsIsRejected",
+			verifier:    strings.Repeat("a", 42) + "=",
+			expectValid: false,
+		},
+		{
+			name:        "SpaceIsRejected",
+			verifier:    strings.Repeat("a", 42) + " ",
+			expectValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expectValid, oauth2provider.ValidPKCEVerifier(tt.verifier))
 		})
 	}
 }

--- a/coderd/oauth2provider/registration.go
+++ b/coderd/oauth2provider/registration.go
@@ -72,13 +72,22 @@ func CreateDynamicClientRegistration(db database.Store, accessURL *url.URL, audi
 		// Apply defaults
 		req = req.ApplyDefaults()
 
-		// Generate client credentials
+		clientType := req.DetermineClientType()
+		isPublic := clientType == codersdk.OAuth2ClientTypePublic
+
+		// Generate client credentials. Public clients authenticate with PKCE
+		// alone and never receive a secret (RFC 7591 §2, OAuth 2.1 §2.1).
 		clientID := uuid.New()
-		clientSecret, hashedSecret, err := generateClientCredentials()
-		if err != nil {
-			writeOAuth2RegistrationError(ctx, rw, http.StatusInternalServerError,
-				"server_error", "Failed to generate client credentials")
-			return
+		var clientSecret string
+		var hashedSecret []byte
+		if !isPublic {
+			var err error
+			clientSecret, hashedSecret, err = generateClientCredentials()
+			if err != nil {
+				writeOAuth2RegistrationError(ctx, rw, http.StatusInternalServerError,
+					"server_error", "Failed to generate client credentials")
+				return
+			}
 		}
 
 		// Generate registration access token for RFC 7592 management
@@ -92,35 +101,72 @@ func CreateDynamicClientRegistration(db database.Store, accessURL *url.URL, audi
 		// Store in database - use system context since this is a public endpoint
 		now := dbtime.Now()
 		clientName := req.GenerateClientName()
-		//nolint:gocritic // OAuth2 system context — dynamic registration is a public endpoint
-		app, err := db.InsertOAuth2ProviderApp(dbauthz.AsSystemOAuth2(ctx), database.InsertOAuth2ProviderAppParams{
-			ID:                      clientID,
-			CreatedAt:               now,
-			UpdatedAt:               now,
-			Name:                    clientName,
-			Icon:                    req.LogoURI,
-			CallbackURL:             req.RedirectURIs[0], // Primary redirect URI
-			RedirectUris:            req.RedirectURIs,
-			ClientType:              req.DetermineClientType(),
-			DynamicallyRegistered:   sql.NullBool{Bool: true, Valid: true},
-			ClientIDIssuedAt:        sql.NullTime{Time: now, Valid: true},
-			ClientSecretExpiresAt:   sql.NullTime{}, // No expiration for now
-			GrantTypes:              slice.ToStrings(req.GrantTypes),
-			ResponseTypes:           slice.ToStrings(req.ResponseTypes),
-			TokenEndpointAuthMethod: sql.NullString{String: string(req.TokenEndpointAuthMethod), Valid: true},
-			Scope:                   sql.NullString{String: req.Scope, Valid: true},
-			Contacts:                req.Contacts,
-			ClientUri:               sql.NullString{String: req.ClientURI, Valid: req.ClientURI != ""},
-			LogoUri:                 sql.NullString{String: req.LogoURI, Valid: req.LogoURI != ""},
-			TosUri:                  sql.NullString{String: req.TOSURI, Valid: req.TOSURI != ""},
-			PolicyUri:               sql.NullString{String: req.PolicyURI, Valid: req.PolicyURI != ""},
-			JwksUri:                 sql.NullString{String: req.JWKSURI, Valid: req.JWKSURI != ""},
-			Jwks:                    pqtype.NullRawMessage{RawMessage: req.JWKS, Valid: len(req.JWKS) > 0},
-			SoftwareID:              sql.NullString{String: req.SoftwareID, Valid: req.SoftwareID != ""},
-			SoftwareVersion:         sql.NullString{String: req.SoftwareVersion, Valid: req.SoftwareVersion != ""},
-			RegistrationAccessToken: hashedRegToken,
-			RegistrationClientUri:   sql.NullString{String: fmt.Sprintf("%s/oauth2/clients/%s", accessURL.String(), clientID), Valid: true},
-		})
+		// The app and its secret are written in one transaction. A partial
+		// write would commit an app that can never authenticate, and which
+		// still holds a registration access token.
+		var app database.OAuth2ProviderApp
+		err = db.InTx(func(tx database.Store) error {
+			var err error
+			//nolint:gocritic // OAuth2 system context, dynamic registration is a public endpoint
+			app, err = tx.InsertOAuth2ProviderApp(dbauthz.AsSystemOAuth2(ctx), database.InsertOAuth2ProviderAppParams{
+				ID:                      clientID,
+				CreatedAt:               now,
+				UpdatedAt:               now,
+				Name:                    clientName,
+				Icon:                    req.LogoURI,
+				CallbackURL:             req.RedirectURIs[0], // Primary redirect URI
+				RedirectUris:            req.RedirectURIs,
+				ClientType:              string(clientType),
+				DynamicallyRegistered:   sql.NullBool{Bool: true, Valid: true},
+				ClientIDIssuedAt:        sql.NullTime{Time: now, Valid: true},
+				ClientSecretExpiresAt:   sql.NullTime{}, // No expiration for now
+				GrantTypes:              slice.ToStrings(req.GrantTypes),
+				ResponseTypes:           slice.ToStrings(req.ResponseTypes),
+				TokenEndpointAuthMethod: sql.NullString{String: string(req.TokenEndpointAuthMethod), Valid: true},
+				Scope:                   sql.NullString{String: req.Scope, Valid: true},
+				Contacts:                req.Contacts,
+				ClientUri:               sql.NullString{String: req.ClientURI, Valid: req.ClientURI != ""},
+				LogoUri:                 sql.NullString{String: req.LogoURI, Valid: req.LogoURI != ""},
+				TosUri:                  sql.NullString{String: req.TOSURI, Valid: req.TOSURI != ""},
+				PolicyUri:               sql.NullString{String: req.PolicyURI, Valid: req.PolicyURI != ""},
+				JwksUri:                 sql.NullString{String: req.JWKSURI, Valid: req.JWKSURI != ""},
+				Jwks:                    pqtype.NullRawMessage{RawMessage: req.JWKS, Valid: len(req.JWKS) > 0},
+				SoftwareID:              sql.NullString{String: req.SoftwareID, Valid: req.SoftwareID != ""},
+				SoftwareVersion:         sql.NullString{String: req.SoftwareVersion, Valid: req.SoftwareVersion != ""},
+				RegistrationAccessToken: hashedRegToken,
+				// JoinPath, not Sprintf: an access URL configured with a
+				// trailing slash would otherwise mint "//oauth2/clients/{id}"
+				// and hand it to the client as its management endpoint.
+				RegistrationClientUri: sql.NullString{String: accessURL.JoinPath("/oauth2/clients", clientID.String()).String(), Valid: true},
+			})
+			if err != nil {
+				return xerrors.Errorf("insert oauth2 provider app: %w", err)
+			}
+
+			if isPublic {
+				return nil
+			}
+
+			// Create client secret - parse the formatted secret to get components
+			parsedSecret, err := ParseFormattedSecret(clientSecret)
+			if err != nil {
+				return xerrors.Errorf("parse generated secret: %w", err)
+			}
+
+			//nolint:gocritic // OAuth2 system context, dynamic registration is a public endpoint
+			_, err = tx.InsertOAuth2ProviderAppSecret(dbauthz.AsSystemOAuth2(ctx), database.InsertOAuth2ProviderAppSecretParams{
+				ID:            uuid.New(),
+				CreatedAt:     now,
+				SecretPrefix:  []byte(parsedSecret.Prefix),
+				HashedSecret:  hashedSecret,
+				DisplaySecret: createDisplaySecret(clientSecret),
+				AppID:         clientID,
+			})
+			if err != nil {
+				return xerrors.Errorf("insert oauth2 provider app secret: %w", err)
+			}
+			return nil
+		}, nil)
 		if err != nil {
 			logger.Error(ctx, "failed to store oauth2 client registration",
 				slog.Error(err),
@@ -129,29 +175,6 @@ func CreateDynamicClientRegistration(db database.Store, accessURL *url.URL, audi
 				slog.F("redirect_uris", req.RedirectURIs))
 			writeOAuth2RegistrationError(ctx, rw, http.StatusInternalServerError,
 				"server_error", "Failed to store client registration")
-			return
-		}
-
-		// Create client secret - parse the formatted secret to get components
-		parsedSecret, err := ParseFormattedSecret(clientSecret)
-		if err != nil {
-			writeOAuth2RegistrationError(ctx, rw, http.StatusInternalServerError,
-				"server_error", "Failed to parse generated secret")
-			return
-		}
-
-		//nolint:gocritic // OAuth2 system context — dynamic registration is a public endpoint
-		_, err = db.InsertOAuth2ProviderAppSecret(dbauthz.AsSystemOAuth2(ctx), database.InsertOAuth2ProviderAppSecretParams{
-			ID:            uuid.New(),
-			CreatedAt:     now,
-			SecretPrefix:  []byte(parsedSecret.Prefix),
-			HashedSecret:  hashedSecret,
-			DisplaySecret: createDisplaySecret(clientSecret),
-			AppID:         clientID,
-		})
-		if err != nil {
-			writeOAuth2RegistrationError(ctx, rw, http.StatusInternalServerError,
-				"server_error", "Failed to store client secret")
 			return
 		}
 
@@ -176,7 +199,7 @@ func CreateDynamicClientRegistration(db database.Store, accessURL *url.URL, audi
 			SoftwareVersion:         app.SoftwareVersion.String,
 			GrantTypes:              slice.StringEnums[codersdk.OAuth2ProviderGrantType](app.GrantTypes),
 			ResponseTypes:           slice.StringEnums[codersdk.OAuth2ProviderResponseType](app.ResponseTypes),
-			TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethod(app.TokenEndpointAuthMethod.String),
+			TokenEndpointAuthMethod: reportedAuthMethod(app),
 			Scope:                   app.Scope.String,
 			Contacts:                app.Contacts,
 			RegistrationAccessToken: registrationToken,
@@ -239,7 +262,7 @@ func GetClientConfiguration(db database.Store) http.HandlerFunc {
 			SoftwareVersion:         app.SoftwareVersion.String,
 			GrantTypes:              slice.StringEnums[codersdk.OAuth2ProviderGrantType](app.GrantTypes),
 			ResponseTypes:           slice.StringEnums[codersdk.OAuth2ProviderResponseType](app.ResponseTypes),
-			TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethod(app.TokenEndpointAuthMethod.String),
+			TokenEndpointAuthMethod: reportedAuthMethod(app),
 			Scope:                   app.Scope.String,
 			Contacts:                app.Contacts,
 			RegistrationAccessToken: "", // RFC 7592: Not returned in GET responses for security
@@ -311,17 +334,49 @@ func UpdateClientConfiguration(db database.Store, auditor *audit.Auditor, logger
 			return
 		}
 
+		// A client's type is fixed at registration (RFC 7592 §2.2 permits
+		// rejecting metadata the server will not accept). Flipping it would
+		// either drop the secret requirement for a client that has one, or mark
+		// a client confidential when it has no secret and no way to be issued
+		// one.
+		//
+		// The first conjunct only rejects an update that actually changes the
+		// auth method, which lets a legacy row whose two columns disagree still
+		// manage itself. IsPublic is the reader for the stored column so an
+		// unrecognized value is treated as confidential here exactly as it is at
+		// the token endpoint.
+		storedMethod := codersdk.OAuth2TokenEndpointAuthMethod(existingApp.TokenEndpointAuthMethod.String)
+		requestedClientType := req.DetermineClientType()
+		if req.TokenEndpointAuthMethod != storedMethod &&
+			(requestedClientType == codersdk.OAuth2ClientTypePublic) != existingApp.IsPublic() {
+			logger.Warn(ctx, "rejected oauth2 client type change",
+				slog.F("client_id", clientID.String()),
+				slog.F("stored_token_endpoint_auth_method", existingApp.TokenEndpointAuthMethod.String),
+				slog.F("requested_token_endpoint_auth_method", string(req.TokenEndpointAuthMethod)),
+				slog.F("stored_client_type", existingApp.ClientType))
+			writeOAuth2RegistrationError(ctx, rw, http.StatusBadRequest,
+				"invalid_client_metadata",
+				fmt.Sprintf("token_endpoint_auth_method cannot move an existing client between public and confidential (stored %q, requested %q); the client type is fixed at registration, so register a new client instead",
+					existingApp.TokenEndpointAuthMethod.String, string(req.TokenEndpointAuthMethod)))
+			return
+		}
+
 		// Update app in database
 		now := dbtime.Now()
 		//nolint:gocritic // OAuth2 system context — RFC 7592 client configuration endpoint
 		updatedApp, err := db.UpdateOAuth2ProviderAppByClientID(dbauthz.AsSystemOAuth2(ctx), database.UpdateOAuth2ProviderAppByClientIDParams{
-			ID:                      clientID,
-			UpdatedAt:               now,
-			Name:                    req.GenerateClientName(),
-			Icon:                    req.LogoURI,
-			CallbackURL:             req.RedirectURIs[0], // Primary redirect URI
-			RedirectUris:            req.RedirectURIs,
-			ClientType:              req.DetermineClientType(),
+			ID:           clientID,
+			UpdatedAt:    now,
+			Name:         req.GenerateClientName(),
+			Icon:         req.LogoURI,
+			CallbackURL:  req.RedirectURIs[0], // Primary redirect URI
+			RedirectUris: req.RedirectURIs,
+			// Carried through verbatim. The guard above rejects a request that
+			// would change the type, so re-deriving it here could only ever
+			// differ for a legacy row whose stored type and auth method
+			// disagree, silently converting it to public while it still holds a
+			// secret.
+			ClientType:              existingApp.ClientType,
 			ClientSecretExpiresAt:   sql.NullTime{}, // No expiration for now
 			GrantTypes:              slice.ToStrings(req.GrantTypes),
 			ResponseTypes:           slice.ToStrings(req.ResponseTypes),
@@ -363,7 +418,7 @@ func UpdateClientConfiguration(db database.Store, auditor *audit.Auditor, logger
 			SoftwareVersion:         updatedApp.SoftwareVersion.String,
 			GrantTypes:              slice.StringEnums[codersdk.OAuth2ProviderGrantType](updatedApp.GrantTypes),
 			ResponseTypes:           slice.StringEnums[codersdk.OAuth2ProviderResponseType](updatedApp.ResponseTypes),
-			TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethod(updatedApp.TokenEndpointAuthMethod.String),
+			TokenEndpointAuthMethod: reportedAuthMethod(updatedApp),
 			Scope:                   updatedApp.Scope.String,
 			Contacts:                updatedApp.Contacts,
 			RegistrationAccessToken: "", // RFC 7592: Not returned for security
@@ -514,6 +569,29 @@ func RequireRegistrationAccessToken(db database.Store) func(http.Handler) http.H
 }
 
 // Helper functions for RFC 7591 Dynamic Client Registration
+
+// reportedAuthMethod returns the token_endpoint_auth_method to report for an
+// app, which is the stored value unless it contradicts the client type.
+//
+// The token endpoint enforces on client_type, so reporting a stored method that
+// disagrees with it would tell a client to authenticate in a way the server
+// will not accept. Clients registered before the type was derived from the
+// method can disagree, because the method was persisted verbatim while the type
+// was always "confidential": such an app is stored confidential with a method of
+// "none", and reporting "none" tells it to drop a secret its exchange still
+// requires. Reporting the enforced behavior instead also lets the row repair
+// itself, since the client's next PUT sends back a method that matches.
+func reportedAuthMethod(app database.OAuth2ProviderApp) codersdk.OAuth2TokenEndpointAuthMethod {
+	stored := codersdk.OAuth2TokenEndpointAuthMethod(app.TokenEndpointAuthMethod.String)
+	if stored.Valid() && (codersdk.ClientTypeFor(stored) == codersdk.OAuth2ClientTypePublic) == app.IsPublic() {
+		return stored
+	}
+	if app.IsPublic() {
+		return codersdk.OAuth2TokenEndpointAuthMethodNone
+	}
+	// RFC 7591 §2 default for a client that authenticates with a secret.
+	return codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic
+}
 
 // generateClientCredentials generates a client secret for OAuth2 apps
 func generateClientCredentials() (plaintext string, hashed []byte, err error) {

--- a/coderd/oauth2provider/registration_test.go
+++ b/coderd/oauth2provider/registration_test.go
@@ -2,16 +2,25 @@ package oauth2provider_test
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/oauth2provider"
 	"github.com/coder/coder/v2/coderd/tracing"
@@ -94,6 +103,519 @@ func TestCreateDynamicClientRegistration_DCREnabled(t *testing.T) {
 			require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &errResp))
 			require.Equal(t, "invalid_request", errResp["error"])
 			require.Contains(t, errResp["error_description"], "disabled")
+		})
+	}
+}
+
+// TestCreateDynamicClientRegistration_ClientType verifies that whether a
+// client_secret is minted, and what client_type is persisted, follows the
+// requested token_endpoint_auth_method (RFC 7591 §2, OAuth 2.1 §2.1).
+func TestCreateDynamicClientRegistration_ClientType(t *testing.T) {
+	t.Parallel()
+
+	accessURL, err := url.Parse("https://oauth2-registration-client-type-test.example.com")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		req  codersdk.OAuth2ClientRegistrationRequest
+
+		wantClientType string
+		wantSecret     bool
+	}{
+		{
+			name: "DefaultAuthMethodIsConfidential",
+			req: codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs: []string{"https://example.com/callback"},
+			},
+			wantClientType: "confidential",
+			wantSecret:     true,
+		},
+		{
+			name: "ClientSecretPostIsConfidential",
+			req: codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs:            []string{"https://example.com/callback"},
+				TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost,
+			},
+			wantClientType: "confidential",
+			wantSecret:     true,
+		},
+		{
+			name: "NoneIsPublicWithNoSecret",
+			req: codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs:            []string{"https://example.com/callback"},
+				TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethodNone,
+			},
+			wantClientType: "public",
+			wantSecret:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			db, _ := dbtestutil.NewDB(t)
+			require.NoError(t, db.UpsertOAuth2DCREnabled(ctx, true))
+
+			logger := slogtest.Make(t, nil)
+			auditor := audit.NewNop()
+			handler := tracing.StatusWriterMiddleware(oauth2provider.CreateDynamicClientRegistration(db, accessURL, &auditor, logger))
+
+			body, err := json.Marshal(tt.req)
+			require.NoError(t, err)
+
+			r := httptest.NewRequest(http.MethodPost, "/oauth2/register", bytes.NewReader(body)).WithContext(ctx)
+			r.Header.Set("Content-Type", "application/json")
+			rw := httptest.NewRecorder()
+
+			handler.ServeHTTP(rw, r)
+			require.Equal(t, http.StatusCreated, rw.Code)
+
+			var resp codersdk.OAuth2ClientRegistrationResponse
+			require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &resp))
+
+			// RFC 7591 §3.2.1: client_secret is omitted entirely for a client
+			// that was not issued one. Assert against the raw body, because a
+			// decoded struct cannot tell an absent key from a present empty
+			// one, and key presence is exactly what a client branches on. The
+			// docs promise the field is absent, so that is what to pin.
+			var rawBody map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &rawBody))
+			if tt.wantSecret {
+				require.Contains(t, rawBody, "client_secret")
+				require.NotEmpty(t, resp.ClientSecret)
+			} else {
+				require.NotContains(t, rawBody, "client_secret")
+			}
+
+			clientID, err := uuid.Parse(resp.ClientID)
+			require.NoError(t, err)
+
+			app, err := db.GetOAuth2ProviderAppByClientID(ctx, clientID)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantClientType, app.ClientType)
+
+			secrets, err := db.GetOAuth2ProviderAppSecretsByAppID(ctx, clientID)
+			require.NoError(t, err)
+			if tt.wantSecret {
+				require.Len(t, secrets, 1)
+			} else {
+				require.Empty(t, secrets)
+			}
+		})
+	}
+}
+
+// TestCreateDynamicClientRegistration_Transaction verifies that the app insert
+// and the secret insert share a single database transaction, so a failure
+// partway through can't leave a permanently committed, orphaned app row with
+// no matching secret.
+//
+// A mock store is used because the failure needs to be injected between the
+// two inserts, which isn't reachable through the public registration API
+// against a real database (the failing insert's unique secret_prefix is
+// generated internally and can't be forced to collide from the outside).
+// mDB.EXPECT().InTx(...).Times(1) is the key assertion: it fails the test if
+// the two inserts are ever changed back to being independent, unwrapped
+// db.InsertX calls, since that path never calls InTx at all.
+func TestCreateDynamicClientRegistration_Transaction(t *testing.T) {
+	t.Parallel()
+
+	accessURL, err := url.Parse("https://oauth2-registration-tx-test.example.com")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		secretInsertErr error
+		wantStatus      int
+	}{
+		{
+			name:       "BothInsertsShareOneTransaction",
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:            "SecretInsertFailureFailsTheWholeRegistration",
+			secretInsertErr: xerrors.New("simulated secret insert failure"),
+			wantStatus:      http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			ctrl := gomock.NewController(t)
+			mDB := dbmock.NewMockStore(ctrl)
+			// A separate handle for the transaction, so a call made on the
+			// outer store is distinguishable from one made on tx.
+			mTx := dbmock.NewMockStore(ctrl)
+
+			mDB.EXPECT().GetOAuth2DCREnabled(gomock.Any()).Return(true, nil).Times(1)
+
+			mDB.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(f func(database.Store) error, _ *database.TxOptions) error {
+					return f(mTx)
+				},
+			).Times(1)
+
+			// Both expectations live on mTx, not mDB, and that is the
+			// assertion. An insert issued on the outer store, whether after
+			// InTx returns or from inside the closure against the wrong
+			// handle, lands on mDB, which has no expectation for it, so
+			// gomock fails the unexpected call. Registering both on a single
+			// mock makes inside and outside the transaction indistinguishable
+			// and the test then passes either way, which is the trap the
+			// project's own InTx rule exists to catch
+			// (.claude/docs/DATABASE.md).
+			appCall := mTx.EXPECT().InsertOAuth2ProviderApp(gomock.Any(), gomock.Any()).
+				Return(database.OAuth2ProviderApp{
+					ID:         uuid.New(),
+					ClientType: database.OAuth2ProviderAppClientTypeConfidential,
+				}, nil).
+				Times(1)
+
+			secretCall := mTx.EXPECT().InsertOAuth2ProviderAppSecret(gomock.Any(), gomock.Any()).
+				Return(database.OAuth2ProviderAppSecret{}, tt.secretInsertErr).
+				Times(1)
+
+			// The secret insert can only run after the app insert, matching
+			// registration.go's literal ordering inside the InTx closure.
+			gomock.InOrder(appCall, secretCall)
+
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: tt.secretInsertErr != nil})
+			auditor := audit.NewNop()
+			handler := tracing.StatusWriterMiddleware(oauth2provider.CreateDynamicClientRegistration(mDB, accessURL, &auditor, logger))
+
+			req := codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs: []string{"https://example.com/callback"},
+			}
+			body, err := json.Marshal(req)
+			require.NoError(t, err)
+
+			r := httptest.NewRequest(http.MethodPost, "/oauth2/register", bytes.NewReader(body)).WithContext(ctx)
+			r.Header.Set("Content-Type", "application/json")
+			rw := httptest.NewRecorder()
+
+			handler.ServeHTTP(rw, r)
+			require.Equal(t, tt.wantStatus, rw.Code)
+		})
+	}
+}
+
+// TestCreateDynamicClientRegistration_PublicClientSkipsSecretInsert verifies
+// that a public client's registration issues no InsertOAuth2ProviderAppSecret
+// call at all, rather than inserting a row with an empty secret.
+func TestCreateDynamicClientRegistration_PublicClientSkipsSecretInsert(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	accessURL, err := url.Parse("https://oauth2-registration-public-tx-test.example.com")
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	mDB := dbmock.NewMockStore(ctrl)
+	mTx := dbmock.NewMockStore(ctrl)
+
+	mDB.EXPECT().GetOAuth2DCREnabled(gomock.Any()).Return(true, nil).Times(1)
+	mDB.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(f func(database.Store) error, _ *database.TxOptions) error {
+			return f(mTx)
+		},
+	).Times(1)
+	mTx.EXPECT().InsertOAuth2ProviderApp(gomock.Any(), gomock.Any()).
+		Return(database.OAuth2ProviderApp{
+			ID:         uuid.New(),
+			ClientType: database.OAuth2ProviderAppClientTypePublic,
+		}, nil).
+		Times(1)
+	// The absence of an InsertOAuth2ProviderAppSecret expectation on either
+	// handle is the assertion: gomock fails on an unexpected call. This only
+	// holds because the two handles are distinct, so a secret insert issued
+	// anywhere is unexpected rather than absorbed by a shared expectation.
+
+	logger := slogtest.Make(t, nil)
+	auditor := audit.NewNop()
+	handler := tracing.StatusWriterMiddleware(oauth2provider.CreateDynamicClientRegistration(mDB, accessURL, &auditor, logger))
+
+	req := codersdk.OAuth2ClientRegistrationRequest{
+		RedirectURIs:            []string{"https://example.com/callback"},
+		TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethodNone,
+	}
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "/oauth2/register", bytes.NewReader(body)).WithContext(ctx)
+	r.Header.Set("Content-Type", "application/json")
+	rw := httptest.NewRecorder()
+
+	handler.ServeHTTP(rw, r)
+	require.Equal(t, http.StatusCreated, rw.Code)
+}
+
+// TestUpdateClientConfiguration_ClientTypeIsImmutable verifies that an
+// RFC 7592 update cannot move a registered client between public and
+// confidential. Allowing it would either drop the secret requirement for a
+// client that has a secret, or mark a client confidential when it has no
+// secret and no way to be issued one, permanently breaking its token
+// exchange. Switching between the two confidential auth methods stays
+// allowed, since it changes nothing about how the client authenticates.
+func TestUpdateClientConfiguration_ClientTypeIsImmutable(t *testing.T) {
+	t.Parallel()
+
+	accessURL, err := url.Parse("https://oauth2-registration-immutable-type-test.example.com")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		registerAs codersdk.OAuth2TokenEndpointAuthMethod
+		updateTo   codersdk.OAuth2TokenEndpointAuthMethod
+		// omitAuthMethod sends the update with no token_endpoint_auth_method at
+		// all, which ApplyDefaults rewrites to client_secret_basic before the
+		// guard sees it. updateTo is ignored when set.
+		omitAuthMethod    bool
+		wantStatus        int
+		wantFinalCallback string
+		// wantClientType is deliberately a bare literal rather than the
+		// database constant: it pins the value actually stored in the column,
+		// so it must fail if that spelling ever changes. Fixtures that set
+		// state use the constant instead.
+		wantClientType string
+	}{
+		{
+			name:           "ConfidentialToPublicIsRejected",
+			registerAs:     codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic,
+			updateTo:       codersdk.OAuth2TokenEndpointAuthMethodNone,
+			wantStatus:     http.StatusBadRequest,
+			wantClientType: "confidential",
+		},
+		{
+			name:           "PublicToConfidentialIsRejected",
+			registerAs:     codersdk.OAuth2TokenEndpointAuthMethodNone,
+			updateTo:       codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic,
+			wantStatus:     http.StatusBadRequest,
+			wantClientType: "public",
+		},
+		{
+			// RFC 7592 makes PUT a full replacement, so an omitted auth method
+			// defaults to client_secret_basic and moves a public client to
+			// confidential, which is rejected. The rejection is correct; what
+			// matters is that it is reported in terms the caller can act on,
+			// since they never sent the field named in the error.
+			name:           "PublicWithOmittedAuthMethodIsRejected",
+			registerAs:     codersdk.OAuth2TokenEndpointAuthMethodNone,
+			omitAuthMethod: true,
+			wantStatus:     http.StatusBadRequest,
+			wantClientType: "public",
+		},
+		{
+			// Both are confidential, so the guard must not fire.
+			name:              "BasicToPostIsAllowed",
+			registerAs:        codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic,
+			updateTo:          codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost,
+			wantStatus:        http.StatusOK,
+			wantFinalCallback: "https://example.com/updated-callback",
+			wantClientType:    "confidential",
+		},
+		{
+			// A confidential client omitting the field is unaffected, because
+			// the default it lands on is also confidential. Pinned so the
+			// asymmetry with the public case above stays visible.
+			name:              "ConfidentialWithOmittedAuthMethodIsAllowed",
+			registerAs:        codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost,
+			omitAuthMethod:    true,
+			wantStatus:        http.StatusOK,
+			wantFinalCallback: "https://example.com/updated-callback",
+			wantClientType:    "confidential",
+		},
+		{
+			name:              "PublicToPublicIsAllowed",
+			registerAs:        codersdk.OAuth2TokenEndpointAuthMethodNone,
+			updateTo:          codersdk.OAuth2TokenEndpointAuthMethodNone,
+			wantStatus:        http.StatusOK,
+			wantFinalCallback: "https://example.com/updated-callback",
+			wantClientType:    "public",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			db, _ := dbtestutil.NewDB(t)
+			require.NoError(t, db.UpsertOAuth2DCREnabled(ctx, true))
+
+			logger := slogtest.Make(t, nil)
+			auditor := audit.NewNop()
+
+			// Register the client first, so the update runs against a real
+			// persisted client_type rather than a hand-built fixture.
+			createHandler := tracing.StatusWriterMiddleware(oauth2provider.CreateDynamicClientRegistration(db, accessURL, &auditor, logger))
+			createBody, err := json.Marshal(codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs:            []string{"https://example.com/callback"},
+				TokenEndpointAuthMethod: tt.registerAs,
+			})
+			require.NoError(t, err)
+
+			createReq := httptest.NewRequest(http.MethodPost, "/oauth2/register", bytes.NewReader(createBody)).WithContext(ctx)
+			createReq.Header.Set("Content-Type", "application/json")
+			createRW := httptest.NewRecorder()
+			createHandler.ServeHTTP(createRW, createReq)
+			require.Equal(t, http.StatusCreated, createRW.Code)
+
+			var created codersdk.OAuth2ClientRegistrationResponse
+			require.NoError(t, json.Unmarshal(createRW.Body.Bytes(), &created))
+			clientID, err := uuid.Parse(created.ClientID)
+			require.NoError(t, err)
+
+			updateHandler := tracing.StatusWriterMiddleware(oauth2provider.UpdateClientConfiguration(db, &auditor, logger))
+			updateReqBody := codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs: []string{"https://example.com/updated-callback"},
+			}
+			if !tt.omitAuthMethod {
+				updateReqBody.TokenEndpointAuthMethod = tt.updateTo
+			}
+			updateBody, err := json.Marshal(updateReqBody)
+			require.NoError(t, err)
+
+			// The handler reads client_id via chi.URLParam, which normally
+			// comes from the router in coderd.go.
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("client_id", clientID.String())
+			updateCtx := context.WithValue(ctx, chi.RouteCtxKey, rctx)
+
+			updateReq := httptest.NewRequest(http.MethodPut, "/oauth2/clients/"+clientID.String(), bytes.NewReader(updateBody)).WithContext(updateCtx)
+			updateReq.Header.Set("Content-Type", "application/json")
+			updateRW := httptest.NewRecorder()
+			updateHandler.ServeHTTP(updateRW, updateReq)
+			require.Equal(t, tt.wantStatus, updateRW.Code)
+
+			app, err := db.GetOAuth2ProviderAppByClientID(ctx, clientID)
+			require.NoError(t, err)
+
+			// client_type is what IsPublic() reads to decide whether the token
+			// endpoint validates a secret, so it must be unchanged whether the
+			// update was accepted or rejected.
+			require.Equal(t, tt.wantClientType, app.ClientType)
+
+			if tt.wantStatus != http.StatusOK {
+				var errResp map[string]string
+				require.NoError(t, json.Unmarshal(updateRW.Body.Bytes(), &errResp))
+				require.Equal(t, "invalid_client_metadata", errResp["error"])
+				// The error code alone cannot distinguish this guard from
+				// req.Validate() failing, which returns the same one, and
+				// neither can the untouched row below. The description is the
+				// only field that tells them apart, so assert on it: a change
+				// that made "none" fail validation outright would otherwise
+				// leave these cases green while testing something else.
+				require.Contains(t, errResp["error_description"], "cannot move an existing client between public and confidential")
+				// It must also name what the server actually compared, since
+				// the caller may never have sent the field.
+				require.Contains(t, errResp["error_description"], "client_secret_basic")
+				// The rejection must leave the whole update unapplied, not
+				// just the client_type field.
+				require.Equal(t, "https://example.com/callback", app.CallbackURL)
+				return
+			}
+
+			require.Equal(t, tt.wantFinalCallback, app.CallbackURL)
+			wantMethod := tt.updateTo
+			if tt.omitAuthMethod {
+				// ApplyDefaults substitutes the RFC 7591 default.
+				wantMethod = codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic
+			}
+			require.Equal(t, string(wantMethod), app.TokenEndpointAuthMethod.String)
+		})
+	}
+}
+
+// TestUpdateClientConfiguration_LegacyAuthMethodMismatch covers clients that
+// registered before client_type was derived from token_endpoint_auth_method.
+// Registration persisted the requested auth method verbatim while hardcoding
+// client_type to "confidential", and "none" has always passed validation, so
+// apps stored as confidential with an auth method of "none" exist in any
+// deployment where a native or MCP client self-registered. That is the exact
+// population public clients are for.
+//
+// Such a client must still be able to manage its registration. Comparing only
+// the derived client type would reject it forever, including when it resends
+// the metadata GET reports, leaving re-registration as the only recovery. It
+// must also not be silently converted to public, since it holds a secret that
+// would stop being required.
+func TestUpdateClientConfiguration_LegacyAuthMethodMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		updateTo codersdk.OAuth2TokenEndpointAuthMethod
+	}{
+		{
+			// The read-modify-write shape: echo back what GET reports.
+			name:     "ResendingStoredAuthMethodIsAccepted",
+			updateTo: codersdk.OAuth2TokenEndpointAuthMethodNone,
+		},
+		{
+			// Moving to a secret-based method matches the stored confidential
+			// type, so it is allowed and repairs the divergence.
+			name:     "MovingToSecretBasedMethodIsAccepted",
+			updateTo: codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			db, _ := dbtestutil.NewDB(t)
+			require.NoError(t, db.UpsertOAuth2DCREnabled(ctx, true))
+
+			legacy := dbgen.OAuth2ProviderApp(t, db, database.OAuth2ProviderApp{
+				CallbackURL:             "https://example.com/callback",
+				RedirectUris:            []string{"https://example.com/callback"},
+				ClientType:              database.OAuth2ProviderAppClientTypeConfidential,
+				TokenEndpointAuthMethod: sql.NullString{String: "none", Valid: true},
+				DynamicallyRegistered:   sql.NullBool{Bool: true, Valid: true},
+			})
+			// Registration minted a secret unconditionally back then.
+			_ = dbgen.OAuth2ProviderAppSecret(t, db, database.OAuth2ProviderAppSecret{AppID: legacy.ID})
+
+			logger := slogtest.Make(t, nil)
+			auditor := audit.NewNop()
+			handler := tracing.StatusWriterMiddleware(oauth2provider.UpdateClientConfiguration(db, &auditor, logger))
+
+			body, err := json.Marshal(codersdk.OAuth2ClientRegistrationRequest{
+				RedirectURIs:            []string{"https://example.com/updated-callback"},
+				TokenEndpointAuthMethod: tt.updateTo,
+			})
+			require.NoError(t, err)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("client_id", legacy.ID.String())
+			r := httptest.NewRequest(http.MethodPut, "/oauth2/clients/"+legacy.ID.String(),
+				bytes.NewReader(body)).WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+			r.Header.Set("Content-Type", "application/json")
+			rw := httptest.NewRecorder()
+
+			handler.ServeHTTP(rw, r)
+			require.Equal(t, http.StatusOK, rw.Code, "body: %s", rw.Body.String())
+
+			app, err := db.GetOAuth2ProviderAppByClientID(ctx, legacy.ID)
+			require.NoError(t, err)
+			require.Equal(t, "https://example.com/updated-callback", app.CallbackURL)
+			require.Equal(t, string(tt.updateTo), app.TokenEndpointAuthMethod.String)
+
+			// The update must not convert the client to public. It still holds
+			// a secret, and IsPublic() reading "public" here would stop the
+			// token endpoint from requiring it.
+			require.Equal(t, "confidential", app.ClientType)
+			require.False(t, app.IsPublic())
+			secrets, err := db.GetOAuth2ProviderAppSecretsByAppID(ctx, legacy.ID)
+			require.NoError(t, err)
+			require.Len(t, secrets, 1)
 		})
 	}
 }

--- a/coderd/oauth2provider/revoke.go
+++ b/coderd/oauth2provider/revoke.go
@@ -139,8 +139,9 @@ func revokeRefreshTokenInTx(ctx context.Context, db database.Store, token string
 		return xerrors.Errorf("invalid refresh token")
 	}
 
-	// Verify ownership directly via app_id, avoiding a join through
-	// app_secret_id, which is not always present.
+	// Verify ownership. AppID is populated directly on the token row for
+	// both public and confidential clients, so this doesn't need to join
+	// through app_secret_id, which is NULL for public clients.
 	if dbToken.AppID != appID {
 		return ErrTokenNotBelongsToClient
 	}
@@ -195,8 +196,10 @@ func revokeAPIKeyInTx(ctx context.Context, db database.Store, token string, appI
 		return xerrors.Errorf("get oauth2 provider app token by api key id: %w", err)
 	}
 
-	// Verify the token belongs to the requesting app directly via app_id,
-	// avoiding a join through app_secret_id, which is not always present.
+	// Verify the token belongs to the requesting app. AppID is populated
+	// directly on the token row for both public and confidential clients,
+	// so this doesn't need to join through app_secret_id, which is NULL
+	// for public clients.
 	if dbToken.AppID != appID {
 		return ErrTokenNotBelongsToClient
 	}

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -41,7 +41,12 @@ var (
 	errConflictingClientAuth = xerrors.New("conflicting client authentication")
 )
 
-func extractTokenRequest(r *http.Request, callbackURL *url.URL) (codersdk.OAuth2TokenRequest, []codersdk.ValidationError, error) {
+// The app is passed whole rather than as a pre-derived boolean so that
+// IsPublic remains the only reader of client_type. A bool parameter would also
+// be a revive flag-parameter violation.
+func extractTokenRequest(r *http.Request, callbackURL *url.URL, app database.OAuth2ProviderApp) (codersdk.OAuth2TokenRequest, []codersdk.ValidationError, error) {
+	isPublic := app.IsPublic()
+
 	p := httpapi.NewQueryParamParser()
 	err := r.ParseForm()
 	if err != nil {
@@ -93,7 +98,9 @@ func extractTokenRequest(r *http.Request, callbackURL *url.URL) (codersdk.OAuth2
 				Detail: "Parameter \"client_id\" is required and cannot be empty",
 			})
 		}
-		if req.ClientSecret == "" {
+		// Public clients have no secret; PKCE is their client
+		// authentication (RFC 7591 §2, OAuth 2.1 §2.1).
+		if !isPublic && req.ClientSecret == "" {
 			p.Errors = append(p.Errors, codersdk.ValidationError{
 				Field:  "client_secret",
 				Detail: "Parameter \"client_secret\" is required and cannot be empty",
@@ -147,7 +154,7 @@ func Tokens(db database.Store, lifetimes codersdk.SessionLifetime) http.HandlerF
 			return
 		}
 
-		req, validationErrs, err := extractTokenRequest(r, callbackURL)
+		req, validationErrs, err := extractTokenRequest(r, callbackURL, app)
 		if err != nil {
 			if errors.Is(err, errConflictingClientAuth) {
 				httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, "Conflicting client credentials between Authorization header and request body")
@@ -253,32 +260,40 @@ func revokeOAuth2CodeOnPKCEFailure(ctx context.Context, db database.Store, codeI
 }
 
 func authorizationCodeGrant(ctx context.Context, db database.Store, app database.OAuth2ProviderApp, lifetimes codersdk.SessionLifetime, req codersdk.OAuth2TokenRequest) (codersdk.OAuth2TokenResponse, error) {
-	// Validate the client secret.
-	secret, err := ParseFormattedSecret(req.ClientSecret)
-	if err != nil {
-		return codersdk.OAuth2TokenResponse{}, errBadSecret
-	}
-	//nolint:gocritic // OAuth2 system context — users cannot read secrets
-	dbSecret, err := db.GetOAuth2ProviderAppSecretByPrefix(dbauthz.AsSystemOAuth2(ctx), []byte(secret.Prefix))
-	if errors.Is(err, sql.ErrNoRows) {
-		return codersdk.OAuth2TokenResponse{}, errBadSecret
-	}
-	if err != nil {
-		return codersdk.OAuth2TokenResponse{}, err
-	}
+	isPublic := app.IsPublic()
 
-	equalSecret := apikey.ValidateHash(dbSecret.HashedSecret, secret.Secret)
-	if !equalSecret {
-		return codersdk.OAuth2TokenResponse{}, errBadSecret
-	}
+	// Validate the client secret. Public clients have none to validate; the
+	// PKCE verification below is their only client authentication, which
+	// makes the code ownership check further down load-bearing rather than
+	// defense in depth.
+	var dbSecret database.OAuth2ProviderAppSecret
+	if !isPublic {
+		secret, err := ParseFormattedSecret(req.ClientSecret)
+		if err != nil {
+			return codersdk.OAuth2TokenResponse{}, errBadSecret
+		}
+		//nolint:gocritic // OAuth2 system context, users cannot read secrets
+		dbSecret, err = db.GetOAuth2ProviderAppSecretByPrefix(dbauthz.AsSystemOAuth2(ctx), []byte(secret.Prefix))
+		if errors.Is(err, sql.ErrNoRows) {
+			return codersdk.OAuth2TokenResponse{}, errBadSecret
+		}
+		if err != nil {
+			return codersdk.OAuth2TokenResponse{}, err
+		}
 
-	// The secret must belong to the app identified by the request's
-	// client_id, which is otherwise unauthenticated at this point (it is
-	// parsed straight from the request with no verification). Without this
-	// check, a valid secret for one app could mint a token attributed to a
-	// different app.
-	if dbSecret.AppID != app.ID {
-		return codersdk.OAuth2TokenResponse{}, errBadSecret
+		equalSecret := apikey.ValidateHash(dbSecret.HashedSecret, secret.Secret)
+		if !equalSecret {
+			return codersdk.OAuth2TokenResponse{}, errBadSecret
+		}
+
+		// The secret must belong to the app identified by the request's
+		// client_id, which is otherwise unauthenticated at this point (it is
+		// parsed straight from the request with no verification). Without this
+		// check, a valid secret for one app could mint a token attributed to a
+		// different app.
+		if dbSecret.AppID != app.ID {
+			return codersdk.OAuth2TokenResponse{}, errBadSecret
+		}
 	}
 
 	// Validate the authorization code.
@@ -412,6 +427,11 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 			return xerrors.Errorf("insert oauth2 access token: %w", err)
 		}
 
+		// Public clients have no secret, so their tokens reference none.
+		var appSecretID uuid.NullUUID
+		if !isPublic {
+			appSecretID = uuid.NullUUID{UUID: dbSecret.ID, Valid: true}
+		}
 		_, err = tx.InsertOAuth2ProviderAppToken(ctx, database.InsertOAuth2ProviderAppTokenParams{
 			ID:          uuid.New(),
 			CreatedAt:   dbtime.Now(),
@@ -419,7 +439,7 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 			HashPrefix:  []byte(refreshToken.Prefix),
 			RefreshHash: refreshToken.Hashed,
 			AppID:       dbCode.AppID,
-			AppSecretID: uuid.NullUUID{UUID: dbSecret.ID, Valid: true},
+			AppSecretID: appSecretID,
 			APIKeyID:    newKey.ID,
 			UserID:      dbCode.UserID,
 			Audience:    dbCode.ResourceUri,

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -97,6 +97,17 @@ func extractTokenRequest(r *http.Request, callbackURL *url.URL) (codersdk.OAuth2
 				Detail: "Parameter \"client_secret\" is required and cannot be empty",
 			})
 		}
+		// A code_verifier outside RFC 7636 §4.1's bounds is a syntax error
+		// (RFC 6749 §5.2), distinct from a well-formed verifier that fails the
+		// PKCE hash comparison in authorizationCodeGrant, which RFC 7636 §4.6
+		// maps to invalid_grant instead. Checking it here, alongside the other
+		// syntax validation, keeps the two failure modes distinguishable.
+		if !ValidPKCEFormat(req.CodeVerifier) {
+			p.Errors = append(p.Errors, codersdk.ValidationError{
+				Field:  "code_verifier",
+				Detail: "must be 43 to 128 characters from the unreserved character set [A-Za-z0-9-._~] (RFC 7636 §4.1)",
+			})
+		}
 	}
 
 	// Validate redirect URI - errors are added to p.Errors.
@@ -158,6 +169,18 @@ func Tokens(db database.Store, lifetimes codersdk.SessionLifetime) http.HandlerF
 					return
 				}
 			}
+
+			// A malformed code_verifier gets its own message so a client that
+			// sent a well-formed but wrong verifier (rejected later, as
+			// invalid_grant, by the PKCE hash comparison) can tell the two
+			// failures apart instead of retrying the same bad verifier forever.
+			if slices.ContainsFunc(validationErrs, func(validationError codersdk.ValidationError) bool {
+				return validationError.Field == "code_verifier"
+			}) {
+				httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, "The code_verifier parameter must be 43 to 128 characters from the unreserved character set [A-Za-z0-9-._~] (RFC 7636 §4.1)")
+				return
+			}
+
 			// Generic invalid request for other validation errors
 			httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, "The request is missing required parameters or is otherwise malformed")
 			return
@@ -277,15 +300,12 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 		}
 	}
 
-	// PKCE is mandatory for all authorization code flows
-	// (OAuth 2.1). Verify the code verifier against the stored
-	// challenge.
-	// Reject a verifier outside RFC 7636 §4.1's bounds before comparing it. A
-	// short verifier hashes to a valid-looking challenge, so the comparison
-	// below cannot tell a well-formed secret from a one-character one.
-	if !ValidPKCEFormat(req.CodeVerifier) {
-		return codersdk.OAuth2TokenResponse{}, errInvalidPKCE
-	}
+	// PKCE is mandatory for all authorization code flows (OAuth 2.1). Verify
+	// the code verifier against the stored challenge. extractTokenRequest
+	// already rejected a malformed verifier as invalid_request, so
+	// req.CodeVerifier is guaranteed to meet RFC 7636 §4.1's bounds here; a
+	// mismatch below is a wrong-but-well-formed verifier, RFC 7636 §4.6's
+	// invalid_grant case.
 	if !dbCode.CodeChallenge.Valid || dbCode.CodeChallenge.String == "" {
 		// Code was issued without a challenge — should not happen
 		// with authorize endpoint enforcement, but defend in depth.

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -283,7 +283,7 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 	// Reject a verifier outside RFC 7636 §4.1's bounds before comparing it. A
 	// short verifier hashes to a valid-looking challenge, so the comparison
 	// below cannot tell a well-formed secret from a one-character one.
-	if !ValidPKCEVerifier(req.CodeVerifier) {
+	if !ValidPKCEFormat(req.CodeVerifier) {
 		return codersdk.OAuth2TokenResponse{}, errInvalidPKCE
 	}
 	if !dbCode.CodeChallenge.Valid || dbCode.CodeChallenge.String == "" {

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -13,12 +13,14 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/apikey"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/httpmw/loggermw"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -234,6 +236,22 @@ func Tokens(db database.Store, lifetimes codersdk.SessionLifetime) http.HandlerF
 	}
 }
 
+// revokeOAuth2CodeOnPKCEFailure deletes a code that failed PKCE verification
+// so it cannot be replayed with further code_verifier guesses (RFC 6749
+// §10.5). Deletion failure does not change the response returned to the
+// caller: surfacing it as a different error would let a caller distinguish
+// "delete succeeded" from "delete failed," defeating the point of revoking
+// the code in the first place. It is instead noted on the request's log line
+// so operators can see it happened.
+func revokeOAuth2CodeOnPKCEFailure(ctx context.Context, db database.Store, codeID uuid.UUID) {
+	//nolint:gocritic // OAuth2 system context, no authenticated user during token exchange
+	if err := db.DeleteOAuth2ProviderAppCodeByID(dbauthz.AsSystemOAuth2(ctx), codeID); err != nil {
+		if rlogger := loggermw.RequestLoggerFromContext(ctx); rlogger != nil {
+			rlogger.WithFields(slog.F("oauth2_pkce_failure_code_revoke_error", err.Error()))
+		}
+	}
+}
+
 func authorizationCodeGrant(ctx context.Context, db database.Store, app database.OAuth2ProviderApp, lifetimes codersdk.SessionLifetime, req codersdk.OAuth2TokenRequest) (codersdk.OAuth2TokenResponse, error) {
 	// Validate the client secret.
 	secret, err := ParseFormattedSecret(req.ClientSecret)
@@ -306,12 +324,19 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 	// req.CodeVerifier is guaranteed to meet RFC 7636 §4.1's bounds here; a
 	// mismatch below is a wrong-but-well-formed verifier, RFC 7636 §4.6's
 	// invalid_grant case.
+	//
+	// RFC 6749 §10.5 requires codes to be single-use. A code that survives a
+	// failed PKCE check would otherwise let a leaked code (the exact threat
+	// PKCE defends against) be replayed with different code_verifier guesses
+	// for the rest of its lifetime, unthrottled.
 	if !dbCode.CodeChallenge.Valid || dbCode.CodeChallenge.String == "" {
 		// Code was issued without a challenge — should not happen
 		// with authorize endpoint enforcement, but defend in depth.
+		revokeOAuth2CodeOnPKCEFailure(ctx, db, dbCode.ID)
 		return codersdk.OAuth2TokenResponse{}, errInvalidPKCE
 	}
 	if !VerifyPKCE(dbCode.CodeChallenge.String, req.CodeVerifier) {
+		revokeOAuth2CodeOnPKCEFailure(ctx, db, dbCode.ID)
 		return codersdk.OAuth2TokenResponse{}, errInvalidPKCE
 	}
 

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -330,7 +330,7 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 	// PKCE defends against) be replayed with different code_verifier guesses
 	// for the rest of its lifetime, unthrottled.
 	if !dbCode.CodeChallenge.Valid || dbCode.CodeChallenge.String == "" {
-		// Code was issued without a challenge — should not happen
+		// Code was issued without a challenge, which should not happen
 		// with authorize endpoint enforcement, but defend in depth.
 		revokeOAuth2CodeOnPKCEFailure(ctx, db, dbCode.ID)
 		return codersdk.OAuth2TokenResponse{}, errInvalidPKCE

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -280,7 +280,10 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 	// PKCE is mandatory for all authorization code flows
 	// (OAuth 2.1). Verify the code verifier against the stored
 	// challenge.
-	if req.CodeVerifier == "" {
+	// Reject a verifier outside RFC 7636 §4.1's bounds before comparing it. A
+	// short verifier hashes to a valid-looking challenge, so the comparison
+	// below cannot tell a well-formed secret from a one-character one.
+	if !ValidPKCEVerifier(req.CodeVerifier) {
 		return codersdk.OAuth2TokenResponse{}, errInvalidPKCE
 	}
 	if !dbCode.CodeChallenge.Valid || dbCode.CodeChallenge.String == "" {

--- a/coderd/oauth2provider/tokens_internal_test.go
+++ b/coderd/oauth2provider/tokens_internal_test.go
@@ -318,7 +318,10 @@ func TestExtractAuthorizeParams_Scopes(t *testing.T) {
 			query.Set("response_type", "code")
 			query.Set("client_id", "test-client")
 			query.Set("redirect_uri", "http://localhost:3000/callback")
-			query.Set("code_challenge", "test-challenge")
+			// This test only exercises scope parsing, but code_challenge is
+			// still required for response_type=code and must satisfy the
+			// RFC 7636 §4.1 length floor, so use a valid-length value.
+			query.Set("code_challenge", strings.Repeat("a", 43))
 			if tc.scopeParam != "" {
 				query.Set("scope", tc.scopeParam)
 			}
@@ -338,6 +341,74 @@ func TestExtractAuthorizeParams_Scopes(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, validationErrs)
 			require.Equal(t, tc.expectedScopes, params.scope)
+		})
+	}
+}
+
+// TestExtractAuthorizeParams_CodeChallengeFormat ensures a code_challenge is
+// rejected at the authorization request (RFC 7636 §4.4.1) when it does not
+// meet the same length and character bounds as a code_verifier, rather than
+// being stored and failing later at token exchange.
+func TestExtractAuthorizeParams_CodeChallengeFormat(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		codeChallenge string
+		expectValid   bool
+	}{
+		{
+			name:          "ValidLength",
+			codeChallenge: strings.Repeat("a", 43),
+			expectValid:   true,
+		},
+		{
+			name:          "TooShort",
+			codeChallenge: strings.Repeat("a", 42),
+			expectValid:   false,
+		},
+		{
+			name:          "TooLong",
+			codeChallenge: strings.Repeat("a", 129),
+			expectValid:   false,
+		},
+		{
+			name:          "DisallowedCharacter",
+			codeChallenge: strings.Repeat("a", 42) + "+",
+			expectValid:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			callbackURL, err := url.Parse("http://localhost:3000/callback")
+			require.NoError(t, err)
+
+			query := url.Values{}
+			query.Set("response_type", "code")
+			query.Set("client_id", "test-client")
+			query.Set("redirect_uri", "http://localhost:3000/callback")
+			query.Set("code_challenge", tc.codeChallenge)
+
+			reqURL, err := url.Parse("http://localhost:8080/oauth2/authorize?" + query.Encode())
+			require.NoError(t, err)
+
+			req := &http.Request{
+				Method: http.MethodGet,
+				URL:    reqURL,
+			}
+
+			_, validationErrs, err := extractAuthorizeParams(req, callbackURL)
+			if tc.expectValid {
+				require.NoError(t, err)
+				require.Empty(t, validationErrs)
+			} else {
+				require.Error(t, err)
+				require.Len(t, validationErrs, 1)
+				require.Equal(t, "code_challenge", validationErrs[0].Field)
+			}
 		})
 	}
 }

--- a/coderd/oauth2provider/tokens_internal_test.go
+++ b/coderd/oauth2provider/tokens_internal_test.go
@@ -3,11 +3,13 @@ package oauth2provider
 import (
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -16,6 +18,16 @@ import (
 func parseScopes(scope string) []string {
 	return strings.Fields(strings.TrimSpace(scope))
 }
+
+// Named app fixtures for extractTokenRequest, whose behavior depends only on
+// the client type. Passing these rather than a zero-value app means the call
+// sites state which client type they mean instead of relying on the zero value
+// reading as confidential. IsPublic's handling of unset and unrecognized values
+// is pinned directly in database.TestOAuth2ProviderAppIsPublic.
+var (
+	confidentialApp = database.OAuth2ProviderApp{ClientType: database.OAuth2ProviderAppClientTypeConfidential}
+	publicApp       = database.OAuth2ProviderApp{ClientType: database.OAuth2ProviderAppClientTypePublic}
+)
 
 // TestExtractTokenParams_Scopes tests OAuth2 scope parameter parsing
 // to ensure RFC 6749 compliance where scopes are space-delimited
@@ -127,7 +139,7 @@ func TestExtractTokenParams_Scopes(t *testing.T) {
 			}
 
 			// Extract token request
-			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL, confidentialApp)
 
 			// Verify no errors occurred
 			require.NoError(t, err, "extractTokenRequest should not return error for: %s", tc.description)
@@ -190,7 +202,7 @@ func TestExtractTokenParams_ScopesURLEncoded(t *testing.T) {
 			}
 
 			// Extract token request
-			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL, confidentialApp)
 
 			// Verify no errors
 			require.NoError(t, err)
@@ -273,7 +285,7 @@ func TestExtractTokenParams_ScopesEdgeCases(t *testing.T) {
 				Form:     form,
 			}
 
-			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL, confidentialApp)
 
 			require.NoError(t, err, "extractTokenRequest should not error for: %s", tc.description)
 			require.Empty(t, validationErrs)
@@ -448,6 +460,98 @@ func TestExtractAuthorizeParams_TokenResponseTypeDoesNotRequirePKCE(t *testing.T
 	require.Equal(t, codersdk.OAuth2ProviderResponseTypeToken, params.responseType)
 }
 
+// TestExtractTokenRequest_ClientSecretRequirement verifies that client_secret
+// is only required for the authorization_code grant when the app is
+// confidential. Public clients authenticate with PKCE alone. client_id is
+// always required, regardless of client type.
+func TestExtractTokenRequest_ClientSecretRequirement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		app  database.OAuth2ProviderApp
+		// clientID/clientSecret are omitted from the form entirely when
+		// empty, rather than sent as empty strings, to match how a real
+		// client request is built.
+		clientID       string
+		clientSecret   string
+		wantErrorField string // Empty means no validation error is expected.
+	}{
+		{
+			name:           "ConfidentialClientMissingSecretIsRejected",
+			app:            confidentialApp,
+			clientID:       "test-client",
+			wantErrorField: "client_secret",
+		},
+		{
+			name:         "ConfidentialClientWithSecretIsAccepted",
+			app:          confidentialApp,
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+		},
+		{
+			name:     "PublicClientMissingSecretIsAccepted",
+			app:      publicApp,
+			clientID: "test-client",
+		},
+		{
+			// A public client that sends a secret anyway is accepted; the
+			// secret is simply never checked (RFC 6749 §2.3.1).
+			name:         "PublicClientWithSecretIsAccepted",
+			app:          publicApp,
+			clientID:     "test-client",
+			clientSecret: "unnecessary-secret",
+		},
+		{
+			name:           "PublicClientMissingClientIDIsRejected",
+			app:            publicApp,
+			wantErrorField: "client_id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			callbackURL, err := url.Parse("http://localhost:3000/callback")
+			require.NoError(t, err)
+
+			form := url.Values{}
+			form.Set("grant_type", "authorization_code")
+			form.Set("code", "test-code")
+			// This test only exercises client_secret requirements, but
+			// code_verifier is validated unconditionally for this grant type,
+			// so use a value that satisfies the RFC 7636 §4.1 length floor.
+			form.Set("code_verifier", strings.Repeat("a", 43))
+			if tc.clientID != "" {
+				form.Set("client_id", tc.clientID)
+			}
+			if tc.clientSecret != "" {
+				form.Set("client_secret", tc.clientSecret)
+			}
+
+			req := &http.Request{
+				Method:   http.MethodPost,
+				PostForm: form,
+				Form:     form,
+			}
+
+			_, validationErrs, err := extractTokenRequest(req, callbackURL, tc.app)
+
+			if tc.wantErrorField == "" {
+				require.NoError(t, err)
+				require.Empty(t, validationErrs)
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, slices.ContainsFunc(validationErrs, func(v codersdk.ValidationError) bool {
+				return v.Field == tc.wantErrorField
+			}), "expected a validation error for field %q, got: %+v", tc.wantErrorField, validationErrs)
+		})
+	}
+}
+
 // TestRefreshTokenGrant_Scopes tests that scopes can be requested during refresh
 func TestRefreshTokenGrant_Scopes(t *testing.T) {
 	t.Parallel()
@@ -468,7 +572,7 @@ func TestRefreshTokenGrant_Scopes(t *testing.T) {
 		Form:     form,
 	}
 
-	tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+	tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL, confidentialApp)
 
 	require.NoError(t, err)
 	require.Empty(t, validationErrs)

--- a/coderd/oauth2provider/tokens_internal_test.go
+++ b/coderd/oauth2provider/tokens_internal_test.go
@@ -110,6 +110,10 @@ func TestExtractTokenParams_Scopes(t *testing.T) {
 			form.Set("client_id", "test-client")
 			form.Set("client_secret", "test-secret")
 			form.Set("code", "test-code")
+			// This test only exercises scope parsing, but code_verifier is
+			// validated unconditionally for this grant type, so use a value
+			// that satisfies the RFC 7636 §4.1 length floor.
+			form.Set("code_verifier", strings.Repeat("a", 43))
 			if tc.scopeParam != "" {
 				form.Set("scope", tc.scopeParam)
 			}
@@ -147,22 +151,22 @@ func TestExtractTokenParams_ScopesURLEncoded(t *testing.T) {
 	}{
 		{
 			name:           "PlusEncodedSpaces",
-			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&scope=scope1+scope2+scope3",
+			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&code_verifier=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&scope=scope1+scope2+scope3",
 			expectedScopes: []string{"scope1", "scope2", "scope3"},
 		},
 		{
 			name:           "PercentEncodedSpaces",
-			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&scope=scope1%20scope2%20scope3",
+			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&code_verifier=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&scope=scope1%20scope2%20scope3",
 			expectedScopes: []string{"scope1", "scope2", "scope3"},
 		},
 		{
 			name:           "MixedEncoding",
-			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&scope=scope1+scope2%20scope3",
+			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&code_verifier=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&scope=scope1+scope2%20scope3",
 			expectedScopes: []string{"scope1", "scope2", "scope3"},
 		},
 		{
 			name:           "ColonEncodedInScope",
-			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&scope=coder%3Aworkspace.create+coder%3Aworkspace.operate",
+			rawQuery:       "grant_type=authorization_code&client_id=test&client_secret=secret&code=code&code_verifier=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&scope=coder%3Aworkspace.create+coder%3Aworkspace.operate",
 			expectedScopes: []string{"coder:workspace.create", "coder:workspace.operate"},
 		},
 	}
@@ -216,6 +220,7 @@ func TestExtractTokenParams_ScopesEdgeCases(t *testing.T) {
 				form.Set("client_id", "test-client")
 				form.Set("client_secret", "test-secret")
 				form.Set("code", "test-code")
+				form.Set("code_verifier", strings.Repeat("a", 43))
 				return form
 			},
 			expectedScopes: []string{},
@@ -229,6 +234,7 @@ func TestExtractTokenParams_ScopesEdgeCases(t *testing.T) {
 				form.Set("client_id", "test-client")
 				form.Set("client_secret", "test-secret")
 				form.Set("code", "test-code")
+				form.Set("code_verifier", strings.Repeat("a", 43))
 				form.Set("scope", "   ")
 				return form
 			},
@@ -244,6 +250,7 @@ func TestExtractTokenParams_ScopesEdgeCases(t *testing.T) {
 				form.Set("client_id", "test-client")
 				form.Set("client_secret", "test-secret")
 				form.Set("code", "test-code")
+				form.Set("code_verifier", strings.Repeat("a", 43))
 				form.Set("scope", longScope)
 				return form
 			},

--- a/codersdk/oauth2.go
+++ b/codersdk/oauth2.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -269,11 +270,36 @@ const (
 	OAuth2TokenEndpointAuthMethodNone              OAuth2TokenEndpointAuthMethod = "none"
 )
 
-func (m OAuth2TokenEndpointAuthMethod) Valid() bool {
-	switch m {
-	case OAuth2TokenEndpointAuthMethodClientSecretBasic,
+// AllOAuth2TokenEndpointAuthMethods returns every accepted token endpoint auth
+// method. Both Valid() and the discovery metadata are derived from it, so what
+// registration accepts and what /.well-known advertises cannot drift apart.
+func AllOAuth2TokenEndpointAuthMethods() []OAuth2TokenEndpointAuthMethod {
+	return []OAuth2TokenEndpointAuthMethod{
+		OAuth2TokenEndpointAuthMethodClientSecretBasic,
 		OAuth2TokenEndpointAuthMethodClientSecretPost,
-		OAuth2TokenEndpointAuthMethodNone:
+		OAuth2TokenEndpointAuthMethodNone,
+	}
+}
+
+func (m OAuth2TokenEndpointAuthMethod) Valid() bool {
+	return slices.Contains(AllOAuth2TokenEndpointAuthMethods(), m)
+}
+
+// OAuth2ClientType is how a client authenticates at the token endpoint
+// (RFC 7591 §2, OAuth 2.1 §2.1). A confidential client authenticates with a
+// secret; a public client authenticates with PKCE alone. It is derived from
+// the requested token_endpoint_auth_method and stored on the app, and the
+// token endpoint reads it to decide whether a client secret is required.
+type OAuth2ClientType string
+
+const (
+	OAuth2ClientTypeConfidential OAuth2ClientType = "confidential"
+	OAuth2ClientTypePublic       OAuth2ClientType = "public"
+)
+
+func (t OAuth2ClientType) Valid() bool {
+	switch t {
+	case OAuth2ClientTypeConfidential, OAuth2ClientTypePublic:
 		return true
 	}
 	return false
@@ -527,14 +553,27 @@ func (req OAuth2ClientRegistrationRequest) ApplyDefaults() OAuth2ClientRegistrat
 	return req
 }
 
-// DetermineClientType determines if client is public or confidential
-func (*OAuth2ClientRegistrationRequest) DetermineClientType() string {
-	// For now, default to confidential
-	// In the future, we might detect based on:
-	// - token_endpoint_auth_method == "none" -> public
-	// - application_type == "native" -> might be public
-	// - Other heuristics
-	return "confidential"
+// DetermineClientType determines if client is public or confidential, based
+// on the requested token_endpoint_auth_method (RFC 7591 §2, OAuth 2.1 §2.1).
+//
+// Only "none" reads as public; every other value, including an omitted one,
+// reads as confidential, so this is safe to call before ApplyDefaults(). A
+// caller that also compares the request's auth method against a stored one must
+// apply defaults first, or an omitted field compares as "" and looks like a
+// change the client did not request.
+func (req *OAuth2ClientRegistrationRequest) DetermineClientType() OAuth2ClientType {
+	return ClientTypeFor(req.TokenEndpointAuthMethod)
+}
+
+// ClientTypeFor maps a token endpoint auth method to the client type it
+// implies. This is the single owner of that mapping: registration derives the
+// stored client_type from it, and redirect URI validation uses it to pick which
+// RFC 8252 rules apply, so the two cannot disagree about what "public" means.
+func ClientTypeFor(method OAuth2TokenEndpointAuthMethod) OAuth2ClientType {
+	if method == OAuth2TokenEndpointAuthMethodNone {
+		return OAuth2ClientTypePublic
+	}
+	return OAuth2ClientTypeConfidential
 }
 
 // GenerateClientName generates a client name if not provided

--- a/codersdk/oauth2_test.go
+++ b/codersdk/oauth2_test.go
@@ -1,0 +1,71 @@
+package codersdk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// TestOAuth2ClientRegistrationRequest_DetermineClientType verifies that the
+// client type is derived from the requested token_endpoint_auth_method
+// (RFC 7591 §2, OAuth 2.1 §2.1), not hardcoded to "confidential".
+func TestOAuth2ClientRegistrationRequest_DetermineClientType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// authMethod is the requested token_endpoint_auth_method.
+		authMethod codersdk.OAuth2TokenEndpointAuthMethod
+		// applyDefaults runs ApplyDefaults() before DetermineClientType(),
+		// matching the real request path where an omitted auth method is
+		// defaulted to "client_secret_basic" before this check ever runs.
+		applyDefaults bool
+		expectedType  string
+	}{
+		{
+			name:         "NoneIsPublic",
+			authMethod:   codersdk.OAuth2TokenEndpointAuthMethodNone,
+			expectedType: "public",
+		},
+		{
+			name:         "ClientSecretBasicIsConfidential",
+			authMethod:   codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic,
+			expectedType: "confidential",
+		},
+		{
+			name:         "ClientSecretPostIsConfidential",
+			authMethod:   codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost,
+			expectedType: "confidential",
+		},
+		{
+			// An omitted auth method must not be read as public. Without
+			// ApplyDefaults the empty string also falls through to
+			// confidential, so this is safe in either order, but the real
+			// path always defaults first.
+			name:          "OmittedDefaultsToConfidentialAfterApplyDefaults",
+			applyDefaults: true,
+			expectedType:  "confidential",
+		},
+		{
+			name:         "OmittedIsConfidentialWithoutApplyDefaults",
+			expectedType: "confidential",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := codersdk.OAuth2ClientRegistrationRequest{
+				TokenEndpointAuthMethod: tt.authMethod,
+			}
+			if tt.applyDefaults {
+				req = req.ApplyDefaults()
+				require.Equal(t, codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic, req.TokenEndpointAuthMethod)
+			}
+			require.Equal(t, tt.expectedType, string(req.DetermineClientType()))
+		})
+	}
+}

--- a/codersdk/oauth2_validation.go
+++ b/codersdk/oauth2_validation.go
@@ -167,17 +167,14 @@ func validateRedirectURIs(uris []string, clientType OAuth2ClientType) error {
 					}
 				}
 			}
-		} else {
-			// Custom scheme validation for public clients (RFC 8252 section 7.1)
-			if isPublicClient {
-				// For public clients, custom schemes should follow RFC 8252 recommendations
-				// Should be reverse domain notation based on domain under their control
-				if !isValidCustomScheme(uri.Scheme) {
-					return xerrors.Errorf("redirect URI at index %d: custom scheme %s should use reverse domain notation (e.g. com.example.app)", i, uri.Scheme)
-				}
-			}
-			// For confidential clients, custom schemes are less common but allowed
 		}
+		// Custom schemes need no further check here: validateScheme already
+		// blocked the ones that are dangerous in a redirect context, and RFC
+		// 8252 §7.1 only recommends reverse-domain notation rather than
+		// requiring it. Rejecting bare schemes such as vscode:// or
+		// jetbrains:// would penalize the native and CLI apps this client
+		// type exists for; PKCE, not the scheme's spelling, is what secures
+		// the redirect.
 
 		// Prevent URI fragments (RFC 6749 section 3.1.2)
 		if uri.Fragment != "" || strings.Contains(uriStr, "#") {
@@ -298,23 +295,4 @@ func isLoopbackAddress(hostname string) bool {
 	return hostname == "localhost" ||
 		hostname == "127.0.0.1" ||
 		hostname == "::1"
-}
-
-// isValidCustomScheme validates custom schemes for public clients (RFC 8252)
-func isValidCustomScheme(scheme string) bool {
-	// For security and RFC compliance, require reverse domain notation
-	// Should contain at least one period and not be a well-known scheme
-	if !strings.Contains(scheme, ".") {
-		return false
-	}
-
-	// Block schemes that look like well-known protocols
-	wellKnownSchemes := []string{"http", "https", "ftp", "mailto", "tel", "sms"}
-	for _, wellKnown := range wellKnownSchemes {
-		if strings.EqualFold(scheme, wellKnown) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/codersdk/oauth2_validation.go
+++ b/codersdk/oauth2_validation.go
@@ -16,7 +16,9 @@ func (req *OAuth2ClientRegistrationRequest) Validate() error {
 		return xerrors.New("redirect_uris is required for authorization code flow")
 	}
 
-	if err := validateRedirectURIs(req.RedirectURIs, req.TokenEndpointAuthMethod); err != nil {
+	// The client type is derived once, by DetermineClientType, so which RFC 8252
+	// rules apply here cannot drift from what gets stored in client_type.
+	if err := validateRedirectURIs(req.RedirectURIs, req.DetermineClientType()); err != nil {
 		return xerrors.Errorf("invalid redirect_uris: %w", err)
 	}
 
@@ -118,8 +120,11 @@ func validateScheme(u *url.URL) error {
 	return nil
 }
 
-// validateRedirectURIs validates redirect URIs according to RFC 7591, 8252
-func validateRedirectURIs(uris []string, tokenEndpointAuthMethod OAuth2TokenEndpointAuthMethod) error {
+// validateRedirectURIs validates redirect URIs according to RFC 7591, 8252.
+// clientType selects which rules apply and is derived by DetermineClientType,
+// the single owner of that mapping, so this cannot disagree with the type the
+// app is stored as.
+func validateRedirectURIs(uris []string, clientType OAuth2ClientType) error {
 	if len(uris) == 0 {
 		return xerrors.New("at least one redirect URI is required")
 	}
@@ -144,8 +149,7 @@ func validateRedirectURIs(uris []string, tokenEndpointAuthMethod OAuth2TokenEndp
 			continue
 		}
 
-		// Determine if this is a public client based on token endpoint auth method
-		isPublicClient := tokenEndpointAuthMethod == OAuth2TokenEndpointAuthMethodNone
+		isPublicClient := clientType == OAuth2ClientTypePublic
 
 		// Handle different validation for public vs confidential clients
 		if uri.Scheme == "http" || uri.Scheme == "https" {

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -127,11 +127,10 @@ Public clients suit native, mobile, and CLI applications that cannot keep a secr
 If you use Dynamic Client Registration (RFC 7591) and omit `token_endpoint_auth_method`, clients default to `client_secret_basic`. To request `client_secret_post`, set `token_endpoint_auth_method` to `client_secret_post` in the registration request. To register a public client, set it to `none`: Coder issues no `client_secret`, and the registration response omits that field entirely.
 
 > [!IMPORTANT]
-> Public clients must use a loopback redirect (`http://127.0.0.1:{port}/...`), a
-> reverse-domain custom scheme (`com.example.app://callback`), or the
-> out-of-band URN. Single-word custom schemes such as `vscode://` or
-> `jetbrains://` are rejected for public clients and are usable only by
-> confidential ones.
+> Public clients must use a loopback redirect (`http://127.0.0.1:{port}/...`),
+> a custom scheme (`myapp://callback`, `vscode://callback`), or the
+> out-of-band URN. `http` redirects to any other host are rejected for
+> public clients and are usable only by confidential ones.
 
 A client's type is fixed when it registers. An RFC 7592 update that would move a client between public and confidential is rejected with `invalid_client_metadata`, since the client either holds a secret that would stop being required or has none and no way to be issued one. Switching between `client_secret_basic` and `client_secret_post` is allowed, because both are confidential. To change type, register a new client.
 

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -182,6 +182,13 @@ PKCE is **required** for all OAuth2 authorization code flows. Coder enforces
 PKCE in compliance with the OAuth 2.1 specification. Both public and
 confidential clients must include PKCE parameters:
 
+> [!NOTE]
+> `code_verifier` and `code_challenge` must each be 43-128 characters from
+> the unreserved character set `[A-Za-z0-9-._~]` (RFC 7636 §4.1). A value
+> outside these bounds is rejected with an `invalid_request` error, at the
+> token endpoint for `code_verifier` and at the authorization endpoint for
+> `code_challenge`.
+
 1. Generate a code verifier and challenge:
 
    ```sh

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -118,10 +118,26 @@ Coder supports the following OAuth2 client authentication methods at the token e
 
 - `client_secret_basic` (recommended): HTTP Basic authentication (RFC 6749 §2.3.1). The username is `client_id` and the password is `client_secret`.
 - `client_secret_post`: Form-based authentication where `client_id` and `client_secret` are sent in the request body.
+- `none`: No client secret. The client is a public client and authenticates with PKCE alone (RFC 7591 §2, OAuth 2.1 §2.1). Available only through [Dynamic Client Registration](#dynamic-client-registration), which is disabled by default, since a client's type is set when it registers and apps created through the admin UI or API are always confidential.
 
-Coder supports both methods for compatibility; existing integrations using `client_secret_post` do not need to change.
+Coder supports both secret-based methods for compatibility; existing integrations using `client_secret_post` do not need to change.
 
-If you use Dynamic Client Registration (RFC 7591) and omit `token_endpoint_auth_method`, clients default to `client_secret_basic`. To request `client_secret_post`, set `token_endpoint_auth_method` to `client_secret_post` in the registration request.
+Public clients suit native, mobile, and CLI applications that cannot keep a secret confidential. Note the redirect URI restriction below before choosing one.
+
+If you use Dynamic Client Registration (RFC 7591) and omit `token_endpoint_auth_method`, clients default to `client_secret_basic`. To request `client_secret_post`, set `token_endpoint_auth_method` to `client_secret_post` in the registration request. To register a public client, set it to `none`: Coder issues no `client_secret`, and the registration response omits that field entirely.
+
+> [!IMPORTANT]
+> Public clients must use a loopback redirect (`http://127.0.0.1:{port}/...`), a
+> reverse-domain custom scheme (`com.example.app://callback`), or the
+> out-of-band URN. Single-word custom schemes such as `vscode://` or
+> `jetbrains://` are rejected for public clients and are usable only by
+> confidential ones.
+
+A client's type is fixed when it registers. An RFC 7592 update that would move a client between public and confidential is rejected with `invalid_client_metadata`, since the client either holds a secret that would stop being required or has none and no way to be issued one. Switching between `client_secret_basic` and `client_secret_post` is allowed, because both are confidential. To change type, register a new client.
+
+Clients registered with `token_endpoint_auth_method: none` before Coder honored it are stored as confidential and still require their `client_secret`. Coder reports `client_secret_basic` for those clients so that what it reports matches what it enforces, and the mismatch clears itself the next time the client updates its registration.
+
+Redirect URIs are matched exactly, so register every URI the client will use, including any that differ only by port.
 
 If client authentication fails, the token endpoint returns **HTTP 401** with an OAuth2 `invalid_client` error and a `WWW-Authenticate: Basic realm="coder"` response header.
 
@@ -209,12 +225,31 @@ confidential clients must include PKCE parameters:
 
 3. Include the code verifier in the token exchange (see [Client Authentication Methods](#client-authentication-methods)):
 
+   **Confidential client**
+
    ```sh
    curl -X POST \
      -u "$CLIENT_ID:$CLIENT_SECRET" \
      -H "Content-Type: application/x-www-form-urlencoded" \
      -d "grant_type=authorization_code" \
      -d "code=$AUTH_CODE" \
+     -d "code_verifier=$CODE_VERIFIER" \
+     -d "redirect_uri=https://yourapp.example.com/callback" \
+     "$CODER_URL/oauth2/tokens"
+   ```
+
+   **Public client (`token_endpoint_auth_method: none`)**
+
+   Send `client_id` in the form body and omit `client_secret` entirely. The code
+   verifier is the only client authentication, so it must be 43-128 characters
+   as RFC 7636 §4.1 requires; shorter values are rejected.
+
+   ```sh
+   curl -X POST \
+     -H "Content-Type: application/x-www-form-urlencoded" \
+     -d "grant_type=authorization_code" \
+     -d "code=$AUTH_CODE" \
+     -d "client_id=$CLIENT_ID" \
      -d "code_verifier=$CODE_VERIFIER" \
      -d "redirect_uri=https://yourapp.example.com/callback" \
      "$CODER_URL/oauth2/tokens"
@@ -255,6 +290,17 @@ curl -X POST \
   -d "refresh_token=$REFRESH_TOKEN" \
   -d "client_id=$CLIENT_ID" \
   -d "client_secret=$CLIENT_SECRET" \
+  "$CODER_URL/oauth2/tokens"
+```
+
+**Option C: Public client (`none`)**
+
+```sh
+curl -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=$REFRESH_TOKEN" \
+  -d "client_id=$CLIENT_ID" \
   "$CODER_URL/oauth2/tokens"
 ```
 

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -185,8 +185,8 @@ confidential clients must include PKCE parameters:
 1. Generate a code verifier and challenge:
 
    ```sh
-   CODE_VERIFIER=$(openssl rand -base64 96 | tr -d "=+/" | cut -c1-128)
-   CODE_CHALLENGE=$(echo -n $CODE_VERIFIER | openssl dgst -sha256 -binary | base64 | tr -d "=+/" | cut -c1-43)
+   CODE_VERIFIER=$(openssl rand -base64 96 | tr -d '\n' | tr '+/' '-_' | tr -d '=')
+   CODE_CHALLENGE=$(echo -n $CODE_VERIFIER | openssl dgst -sha256 -binary | base64 | tr -d "=" | tr '+/' '-_')
    ```
 
 2. Include PKCE parameters in the authorization request:

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -5089,6 +5089,7 @@ curl -X POST http://coder-server:8080/oauth2/tokens \
 client_id: string
 client_secret: string
 code: string
+code_verifier: string
 refresh_token: string
 grant_type: authorization_code
 
@@ -5096,14 +5097,15 @@ grant_type: authorization_code
 
 ### Parameters
 
-| Name              | In   | Type   | Required | Description                                                   |
-|-------------------|------|--------|----------|---------------------------------------------------------------|
-| `body`            | body | object | false    |                                                               |
-| `» client_id`     | body | string | false    | Client ID, required if grant_type=authorization_code          |
-| `» client_secret` | body | string | false    | Client secret, required if grant_type=authorization_code      |
-| `» code`          | body | string | false    | Authorization code, required if grant_type=authorization_code |
-| `» refresh_token` | body | string | false    | Refresh token, required if grant_type=refresh_token           |
-| `» grant_type`    | body | string | true     | Grant type                                                    |
+| Name              | In   | Type   | Required | Description                                                                                                                                                |
+|-------------------|------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `body`            | body | object | false    |                                                                                                                                                            |
+| `» client_id`     | body | string | false    | Client ID, required if grant_type=authorization_code                                                                                                       |
+| `» client_secret` | body | string | false    | Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.  |
+| `» code`          | body | string | false    | Authorization code, required if grant_type=authorization_code                                                                                              |
+| `» code_verifier` | body | string | false    | PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636. This is the only client authentication a public client has. |
+| `» refresh_token` | body | string | false    | Refresh token, required if grant_type=refresh_token                                                                                                        |
+| `» grant_type`    | body | string | true     | Grant type                                                                                                                                                 |
 
 #### Enumerated Values
 

--- a/scripts/oauth2/generate-pkce.sh
+++ b/scripts/oauth2/generate-pkce.sh
@@ -4,7 +4,7 @@
 # Usage: ./generate-pkce.sh
 
 # Generate code verifier (43-128 characters, URL-safe)
-CODE_VERIFIER=$(openssl rand -base64 32 | tr -d "=+/" | cut -c -43)
+CODE_VERIFIER=$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')
 
 # Generate code challenge (S256 method)
 CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | base64 | tr -d "=" | tr '+/' '-_')

--- a/scripts/oauth2/test-manual-flow.sh
+++ b/scripts/oauth2/test-manual-flow.sh
@@ -39,7 +39,7 @@ if ! command -v go &>/dev/null; then
 fi
 
 # Generate PKCE parameters
-CODE_VERIFIER=$(openssl rand -base64 32 | tr -d "=+/" | cut -c -43)
+CODE_VERIFIER=$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')
 export CODE_VERIFIER
 CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | base64 | tr -d "=" | tr '+/' '-_')
 export CODE_CHALLENGE

--- a/scripts/oauth2/test-mcp-oauth2.sh
+++ b/scripts/oauth2/test-mcp-oauth2.sh
@@ -66,7 +66,7 @@ echo -e "${GREEN}✓ Created client secret${NC}\n"
 
 # Test 2: PKCE Flow
 echo -e "${YELLOW}Test 2: PKCE Flow${NC}"
-CODE_VERIFIER=$(openssl rand -base64 32 | tr -d "=+/" | cut -c -43)
+CODE_VERIFIER=$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')
 CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | base64 | tr -d "=" | tr '+/' '-_')
 STATE=$(openssl rand -hex 16)
 
@@ -132,7 +132,7 @@ fi
 echo -e "${YELLOW}Test 4: Resource Parameter Support${NC}"
 RESOURCE="https://api.example.com"
 STATE=$(openssl rand -hex 16)
-RESOURCE_CODE_VERIFIER=$(openssl rand -base64 32 | tr -d "=+/" | cut -c -43)
+RESOURCE_CODE_VERIFIER=$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')
 RESOURCE_CODE_CHALLENGE=$(echo -n "$RESOURCE_CODE_VERIFIER" | openssl dgst -sha256 -binary | base64 | tr -d "=" | tr '+/' '-_')
 RESOURCE_AUTH_URL="$BASE_URL/oauth2/authorize?client_id=$CLIENT_ID&response_type=code&redirect_uri=http://localhost:9876/callback&state=$STATE&resource=$RESOURCE&code_challenge=$RESOURCE_CODE_CHALLENGE&code_challenge_method=S256"
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6426,6 +6426,11 @@ export interface OAuth2ClientRegistrationResponse {
 	readonly registration_client_uri: string;
 }
 
+// From codersdk/oauth2.go
+export type OAuth2ClientType = "confidential" | "public";
+
+export const OAuth2ClientTypes: OAuth2ClientType[] = ["confidential", "public"];
+
 // From codersdk/deployment.go
 export interface OAuth2Config {
 	readonly github: OAuth2GithubConfig;


### PR DESCRIPTION
Layer 2 of the #27195 split. Depends on #27712, which made the schema able to store a secretless client's tokens and moved revocation ownership onto `app_id`, but deliberately added no new capability. This turns the capability on.

An RFC 7591 registration requesting `token_endpoint_auth_method: "none"` now produces a public client: no secret is minted, `client_type` is persisted as `public`, and the token endpoint accepts that client's `authorization_code` exchange with PKCE alone. Discovery advertises `"none"` as a supported auth method.

PKCE was already mandatory for every authorization_code flow, so public clients inherit it with no new code. That also makes the code ownership check (`dbCode.AppID != app.ID`, added in #27712) the *only* binding between the exchange and the app named by `client_id` for a public client, where it was defense in depth for confidential ones. It is retained and now covered with a public client on both sides.

Clients already registered with `token_endpoint_auth_method: "none"` are stored as confidential with a secret and are not reclassified, so their token exchange is unaffected. Only new registrations get a different client type.

Those clients need one extra accommodation, caught in review. Registration always persisted the requested auth method verbatim while hardcoding `client_type` to `confidential`, and `"none"` has always passed validation, so an app can be stored as confidential with an auth method of `"none"`. Comparing only the derived client type would reject such a client from RFC 7592 forever, including when it resends the exact metadata `GET` reports. The guard therefore rejects only an update that actually changes `token_endpoint_auth_method`, and the update carries the stored `client_type` through rather than re-deriving it, so a legacy client can never be converted to public while it still holds a secret.

## Two changes beyond the original PR

Both were found while implementing this layer, and both are in `registration.go` because that is the function public clients already restructure.

**Registration now writes the app and its secret in one transaction.** They were two independently committed inserts, so a failure of the second left a permanently committed app that can never authenticate while still holding a registration access token. Pre-existing, but `isPublic` makes "app with no secret row" a legitimate state, which removes the ability to spot the orphaned case by inspection later.

**An RFC 7592 update can no longer move a registered client between public and confidential.** `UpdateClientConfiguration` wrote `client_type` straight from the request body with no comparison to the existing app, which was inert only while `DetermineClientType()` was hardcoded. Public to confidential is the damaging direction: the client is marked confidential with no secret row, the token endpoint then demands a `client_secret` it was never issued, and `OAuth2ClientConfiguration` has no field to deliver a newly minted one. That client is permanently unable to obtain a token, recoverable only by re-registering. RFC 7592 §2.2 permits rejecting metadata the server will not accept, so this returns `400 invalid_client_metadata`. The guard compares the derived client type rather than the raw auth method, so `client_secret_basic` and `client_secret_post` stay interchangeable.

Refs https://linear.app/codercom/issue/ENG-3029/oauth2-support-public-client
