### PR TITLE
feat(site/src/pages/AgentsPage): agent chat prompt timeline rail (prototype)

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -33,6 +33,7 @@ import {
 	ChatConversationSkeleton,
 	RightPanelSkeleton,
 } from "./components/AgentsSkeletons";
+import { ChatTimelineRailContainer } from "./components/ChatConversation/ChatTimelineRail";
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
@@ -909,6 +910,12 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							hasMoreMessages={hasMoreMessages}
 							onFetchMoreMessages={onFetchMoreMessages}
 							messageCount={messageCount}
+							overlay={
+								<ChatTimelineRailContainer
+									scrollContainerRef={scrollContainerRef}
+									store={store}
+								/>
+							}
 						>
 							<div className="px-4" data-chat-scroll-content>
 								<ChatPageTimeline

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
@@ -115,9 +115,12 @@ const buildTimelineItems = (
 
 type Position = {
 	item: TimelineItem;
-	// 0..1 fraction along the rail height
-	ratio: number;
 };
+
+// Vertical spacing (px) between consecutive ticks. Chosen to match the
+// mocked dashes: tight enough to read as a group, loose enough to hit
+// individual ticks with a pointer.
+const TICK_SPACING_PX = 12;
 
 interface ChatTimelineRailProps {
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
@@ -145,8 +148,13 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 		return map;
 	}, [items]);
 
-	// Recomputes tick ratios from DOM anchor positions. Called on scroll,
+	// Recomputes tick positions from DOM anchor order. Called on scroll,
 	// resize, and DOM mutation. Uses rAF batching to avoid layout thrash.
+	//
+	// Ticks are laid out with fixed pixel spacing, centered vertically on
+	// the rail. This keeps the column feeling like a compact indicator
+	// stack rather than a justified min-to-max scale, which felt clunky
+	// for chats with only a few prompts.
 	const measure = useCallback(() => {
 		const scroller = scrollContainerRef.current;
 		if (!scroller) {
@@ -160,37 +168,20 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 			setPositions([]);
 			return;
 		}
-		// Establish a stable content coordinate space by taking the min and
-		// max top of all anchors in viewport coordinates. Using this range
-		// (rather than scrollHeight) is robust against the flex-col-reverse
-		// scroller layout in ChatScrollContainer.
-		let minTop = Number.POSITIVE_INFINITY;
-		let maxTop = Number.NEGATIVE_INFINITY;
-		const raw: Array<{ id: number; top: number }> = [];
+		const ordered: TimelineItem[] = [];
 		for (const anchor of anchors) {
 			const rawId = anchor.getAttribute("data-timeline-anchor-id");
 			if (!rawId) continue;
 			const id = Number(rawId);
-			if (!itemsById.has(id)) continue;
-			const rect = anchor.getBoundingClientRect();
-			// Skip zero-sized wrappers that never mounted content.
-			if (rect.width === 0 && rect.height === 0 && rect.top === 0) {
-				continue;
-			}
-			raw.push({ id, top: rect.top });
-			if (rect.top < minTop) minTop = rect.top;
-			if (rect.top > maxTop) maxTop = rect.top;
+			const item = itemsById.get(id);
+			if (!item) continue;
+			ordered.push(item);
 		}
-		if (raw.length === 0) {
+		if (ordered.length === 0) {
 			setPositions([]);
 			return;
 		}
-		const span = Math.max(1, maxTop - minTop);
-		const next: Position[] = raw.map(({ id, top }) => ({
-			item: itemsById.get(id) as TimelineItem,
-			ratio: (top - minTop) / span,
-		}));
-		setPositions(next);
+		setPositions(ordered.map((item) => ({ item })));
 	}, [scrollContainerRef, itemsById]);
 
 	useLayoutEffect(() => {
@@ -329,6 +320,10 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 		>
 			{positions.map((pos, idx) => {
 				const isHovered = hoveredIndex === idx;
+				// Center the whole stack vertically on the rail, then offset
+				// each tick by its index. calc(50% + Npx) keeps the group
+				// centered regardless of the rail's actual height.
+				const offsetPx = (idx - (positions.length - 1) / 2) * TICK_SPACING_PX;
 				return (
 					<button
 						type="button"
@@ -351,7 +346,7 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 								: "bg-content-secondary/50 hover:bg-content-primary",
 							isHovered && "h-[3px] w-4",
 						)}
-						style={{ top: `${pos.ratio * 100}%` }}
+						style={{ top: `calc(50% + ${offsetPx}px)` }}
 						aria-label={pos.item.preview}
 					>
 						{isHovered && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
@@ -25,7 +25,7 @@ import type { ParsedMessageEntry } from "./types";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
-// PROTOTYPE — Agent conversation timeline rail.
+// PROTOTYPE. Agent conversation timeline rail.
 //
 // This component renders a minimap-style column of ticks along the right edge
 // of the chat scroll container, just to the left of the native scrollbar.
@@ -79,7 +79,7 @@ const truncate = (text: string, max: number): string => {
 	return `${text.slice(0, max - 1).trimEnd()}…`;
 };
 
-export const buildTimelineItems = (
+const buildTimelineItems = (
 	parsedMessages: readonly ParsedMessageEntry[],
 ): TimelineItem[] => {
 	const items: TimelineItem[] = [];
@@ -124,7 +124,7 @@ interface ChatTimelineRailProps {
 	items: readonly TimelineItem[];
 }
 
-export const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
+const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 	scrollContainerRef,
 	items,
 }) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
@@ -117,6 +117,11 @@ type Position = {
 	item: TimelineItem;
 };
 
+type MeasureState = {
+	positions: Position[];
+	activeIndex: number;
+};
+
 // Vertical spacing (px) between consecutive ticks. Chosen to match the
 // mocked dashes: tight enough to read as a group, loose enough to hit
 // individual ticks with a pointer.
@@ -132,7 +137,11 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 	items,
 }) => {
 	const railRef = useRef<HTMLDivElement>(null);
-	const [positions, setPositions] = useState<Position[]>([]);
+	const [state, setState] = useState<MeasureState>({
+		positions: [],
+		activeIndex: -1,
+	});
+	const { positions, activeIndex } = state;
 	const [visible, setVisible] = useState(false);
 	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 	const hoverRef = useRef(false);
@@ -158,30 +167,47 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 	const measure = useCallback(() => {
 		const scroller = scrollContainerRef.current;
 		if (!scroller) {
-			setPositions([]);
+			setState({ positions: [], activeIndex: -1 });
 			return;
 		}
 		const anchors = scroller.querySelectorAll<HTMLElement>(
 			"[data-timeline-anchor-id]",
 		);
 		if (anchors.length === 0) {
-			setPositions([]);
+			setState({ positions: [], activeIndex: -1 });
 			return;
 		}
-		const ordered: TimelineItem[] = [];
+		const scrollerTop = scroller.getBoundingClientRect().top;
+		// The active tick is the last anchor whose top has scrolled to or
+		// above the top edge of the viewport, with a small offset so it
+		// flips as the message crosses that threshold rather than only
+		// once it fully leaves.
+		const ACTIVE_OFFSET = 24;
+		const ordered: Position[] = [];
+		let activeIdx = -1;
 		for (const anchor of anchors) {
 			const rawId = anchor.getAttribute("data-timeline-anchor-id");
 			if (!rawId) continue;
 			const id = Number(rawId);
 			const item = itemsById.get(id);
 			if (!item) continue;
-			ordered.push(item);
+			const rect = anchor.getBoundingClientRect();
+			const pastTop = rect.top - scrollerTop <= ACTIVE_OFFSET;
+			if (pastTop) {
+				activeIdx = ordered.length;
+			}
+			ordered.push({ item });
 		}
 		if (ordered.length === 0) {
-			setPositions([]);
+			setState({ positions: [], activeIndex: -1 });
 			return;
 		}
-		setPositions(ordered.map((item) => ({ item })));
+		// If nothing has scrolled past the threshold yet, treat the first
+		// prompt as active so the indicator is always shown.
+		if (activeIdx === -1) {
+			activeIdx = 0;
+		}
+		setState({ positions: ordered, activeIndex: activeIdx });
 	}, [scrollContainerRef, itemsById]);
 
 	useLayoutEffect(() => {
@@ -320,6 +346,7 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 		>
 			{positions.map((pos, idx) => {
 				const isHovered = hoveredIndex === idx;
+				const isActive = activeIndex === idx;
 				// Center the whole stack vertically on the rail, then offset
 				// each tick by its index. calc(50% + Npx) keeps the group
 				// centered regardless of the rail's actual height.
@@ -358,7 +385,14 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 												? "bg-content-destructive"
 												: "bg-content-primary",
 										)
-									: "h-[2px] w-3",
+									: isActive
+										? cn(
+												"h-[3px] w-4",
+												pos.item.isError
+													? "bg-content-destructive"
+													: "bg-content-primary",
+											)
+										: "h-[2px] w-3",
 							)}
 						/>
 						{isHovered && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
@@ -309,7 +309,7 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 			data-testid="chat-timeline-rail"
 			aria-hidden
 			className={cn(
-				"pointer-events-auto absolute inset-y-2 right-3 z-20 w-4",
+				"pointer-events-auto absolute inset-y-2 right-1 z-20 w-6",
 				"transition-opacity duration-200",
 				visible ? "opacity-100" : "opacity-0",
 			)}
@@ -338,17 +338,29 @@ const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
 						}
 						onClick={() => handleJump(pos.item.id)}
 						className={cn(
-							"absolute left-1/2 -translate-x-1/2 -translate-y-1/2",
-							"h-[2px] w-3 rounded-full border-0 p-0",
-							"transition-[width,height,background-color] duration-150",
-							pos.item.isError
-								? "bg-content-destructive/70 hover:bg-content-destructive"
-								: "bg-content-secondary/50 hover:bg-content-primary",
-							isHovered && "h-[3px] w-4",
+							"absolute inset-x-0 -translate-y-1/2",
+							"flex h-3 items-center justify-center border-0 bg-transparent p-0",
 						)}
 						style={{ top: `calc(50% + ${offsetPx}px)` }}
 						aria-label={pos.item.preview}
 					>
+						<span
+							aria-hidden
+							className={cn(
+								"block rounded-full transition-[width,height,background-color] duration-150",
+								pos.item.isError
+									? "bg-content-destructive/70"
+									: "bg-content-secondary/50",
+								isHovered
+									? cn(
+											"h-[3px] w-5",
+											pos.item.isError
+												? "bg-content-destructive"
+												: "bg-content-primary",
+										)
+									: "h-[2px] w-3",
+							)}
+						/>
 						{isHovered && (
 							<span
 								className={cn(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatTimelineRail.tsx
@@ -1,0 +1,408 @@
+import {
+	type FC,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import type * as TypesGen from "#/api/typesGenerated";
+import { cn } from "#/utils/cn";
+import {
+	selectChatStatus,
+	selectMessagesByID,
+	selectOrderedMessageIDs,
+	useChatSelector,
+	type useChatStore,
+} from "./chatStore";
+import {
+	getPendingToolCallIDs,
+	parseMessagesWithMergedTools,
+} from "./messageParsing";
+import type { ParsedMessageEntry } from "./types";
+
+type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
+
+// PROTOTYPE — Agent conversation timeline rail.
+//
+// This component renders a minimap-style column of ticks along the right edge
+// of the chat scroll container, just to the left of the native scrollbar.
+//
+// Behaviour, per prototype spec:
+// - Rail is hidden by default. It reveals on pointer hover over its column
+//   and while the chat is actively scrolling. It fades out ~1.2s after both
+//   the pointer leaves and scrolling settles.
+// - Each user prompt renders as a grey tick. Assistant messages that contain
+//   a failed tool call render as an additional red tick.
+// - Hovering a tick shows a floating preview label (first line of the
+//   prompt, or a short error label).
+// - Clicking a tick smoothly scrolls the anchor into view.
+//
+// Positions are computed from the DOM: every anchored element carries a
+// `data-timeline-anchor-id` attribute placed by `ConversationTimeline`. The
+// rail queries them each frame that a re-measure is needed, so it does not
+// need to track message layout state directly.
+
+type TimelineItem = {
+	id: number;
+	role: "user" | "assistant";
+	preview: string;
+	isError: boolean;
+	errorLabel?: string;
+};
+
+const HIDE_DELAY_MS = 1200;
+const SCROLL_QUIET_MS = 400;
+const PREVIEW_MAX_CHARS = 80;
+
+const getTextFromContent = (
+	content: readonly TypesGen.ChatMessagePart[] | undefined,
+): string => {
+	if (!content) {
+		return "";
+	}
+	let text = "";
+	for (const part of content) {
+		if (part.type === "text") {
+			text += part.text;
+		}
+	}
+	return text.replace(/\s+/g, " ").trim();
+};
+
+const truncate = (text: string, max: number): string => {
+	if (text.length <= max) {
+		return text;
+	}
+	return `${text.slice(0, max - 1).trimEnd()}…`;
+};
+
+export const buildTimelineItems = (
+	parsedMessages: readonly ParsedMessageEntry[],
+): TimelineItem[] => {
+	const items: TimelineItem[] = [];
+	for (const { message, parsed } of parsedMessages) {
+		if (message.role === "user") {
+			const preview = truncate(
+				getTextFromContent(message.content) || "(empty prompt)",
+				PREVIEW_MAX_CHARS,
+			);
+			items.push({
+				id: message.id,
+				role: "user",
+				preview,
+				isError: false,
+			});
+			continue;
+		}
+		if (message.role === "assistant") {
+			const erroredTool = parsed.tools.find((t) => t.isError);
+			if (erroredTool) {
+				items.push({
+					id: message.id,
+					role: "assistant",
+					preview: `Error in ${erroredTool.name}`,
+					isError: true,
+					errorLabel: `Error in ${erroredTool.name}`,
+				});
+			}
+		}
+	}
+	return items;
+};
+
+type Position = {
+	item: TimelineItem;
+	// 0..1 fraction along the rail height
+	ratio: number;
+};
+
+interface ChatTimelineRailProps {
+	scrollContainerRef: RefObject<HTMLDivElement | null>;
+	items: readonly TimelineItem[];
+}
+
+export const ChatTimelineRail: FC<ChatTimelineRailProps> = ({
+	scrollContainerRef,
+	items,
+}) => {
+	const railRef = useRef<HTMLDivElement>(null);
+	const [positions, setPositions] = useState<Position[]>([]);
+	const [visible, setVisible] = useState(false);
+	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+	const hoverRef = useRef(false);
+	const scrollingRef = useRef(false);
+	const hideTimerRef = useRef<number | null>(null);
+	const scrollQuietTimerRef = useRef<number | null>(null);
+
+	const itemsById = useMemo(() => {
+		const map = new Map<number, TimelineItem>();
+		for (const item of items) {
+			map.set(item.id, item);
+		}
+		return map;
+	}, [items]);
+
+	// Recomputes tick ratios from DOM anchor positions. Called on scroll,
+	// resize, and DOM mutation. Uses rAF batching to avoid layout thrash.
+	const measure = useCallback(() => {
+		const scroller = scrollContainerRef.current;
+		if (!scroller) {
+			setPositions([]);
+			return;
+		}
+		const anchors = scroller.querySelectorAll<HTMLElement>(
+			"[data-timeline-anchor-id]",
+		);
+		if (anchors.length === 0) {
+			setPositions([]);
+			return;
+		}
+		// Establish a stable content coordinate space by taking the min and
+		// max top of all anchors in viewport coordinates. Using this range
+		// (rather than scrollHeight) is robust against the flex-col-reverse
+		// scroller layout in ChatScrollContainer.
+		let minTop = Number.POSITIVE_INFINITY;
+		let maxTop = Number.NEGATIVE_INFINITY;
+		const raw: Array<{ id: number; top: number }> = [];
+		for (const anchor of anchors) {
+			const rawId = anchor.getAttribute("data-timeline-anchor-id");
+			if (!rawId) continue;
+			const id = Number(rawId);
+			if (!itemsById.has(id)) continue;
+			const rect = anchor.getBoundingClientRect();
+			// Skip zero-sized wrappers that never mounted content.
+			if (rect.width === 0 && rect.height === 0 && rect.top === 0) {
+				continue;
+			}
+			raw.push({ id, top: rect.top });
+			if (rect.top < minTop) minTop = rect.top;
+			if (rect.top > maxTop) maxTop = rect.top;
+		}
+		if (raw.length === 0) {
+			setPositions([]);
+			return;
+		}
+		const span = Math.max(1, maxTop - minTop);
+		const next: Position[] = raw.map(({ id, top }) => ({
+			item: itemsById.get(id) as TimelineItem,
+			ratio: (top - minTop) / span,
+		}));
+		setPositions(next);
+	}, [scrollContainerRef, itemsById]);
+
+	useLayoutEffect(() => {
+		measure();
+	}, [measure]);
+
+	useEffect(() => {
+		const scroller = scrollContainerRef.current;
+		if (!scroller) return;
+		let raf = 0;
+		const schedule = () => {
+			if (raf) return;
+			raf = requestAnimationFrame(() => {
+				raf = 0;
+				measure();
+			});
+		};
+		const observer = new ResizeObserver(schedule);
+		observer.observe(scroller);
+		const mo = new MutationObserver(schedule);
+		mo.observe(scroller, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: [
+				"data-timeline-anchor-id",
+				"data-timeline-anchor-error",
+			],
+		});
+		return () => {
+			observer.disconnect();
+			mo.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	}, [scrollContainerRef, measure]);
+
+	// Compute visibility from pointer hover + scroll activity. Kept in a
+	// dedicated helper so both signals can flip the visible state through
+	// the same debounce.
+	const updateVisibility = useCallback(() => {
+		const shouldShow = hoverRef.current || scrollingRef.current;
+		if (shouldShow) {
+			if (hideTimerRef.current) {
+				window.clearTimeout(hideTimerRef.current);
+				hideTimerRef.current = null;
+			}
+			setVisible(true);
+			return;
+		}
+		if (hideTimerRef.current) return;
+		hideTimerRef.current = window.setTimeout(() => {
+			hideTimerRef.current = null;
+			setVisible(false);
+			setHoveredIndex(null);
+		}, HIDE_DELAY_MS);
+	}, []);
+
+	useEffect(() => {
+		const scroller = scrollContainerRef.current;
+		if (!scroller) return;
+		let raf = 0;
+		const onScroll = () => {
+			scrollingRef.current = true;
+			updateVisibility();
+			if (scrollQuietTimerRef.current) {
+				window.clearTimeout(scrollQuietTimerRef.current);
+			}
+			scrollQuietTimerRef.current = window.setTimeout(() => {
+				scrollingRef.current = false;
+				updateVisibility();
+			}, SCROLL_QUIET_MS);
+			if (raf) return;
+			raf = requestAnimationFrame(() => {
+				raf = 0;
+				measure();
+			});
+		};
+		scroller.addEventListener("scroll", onScroll, { passive: true });
+		return () => {
+			scroller.removeEventListener("scroll", onScroll);
+			if (raf) cancelAnimationFrame(raf);
+			if (scrollQuietTimerRef.current) {
+				window.clearTimeout(scrollQuietTimerRef.current);
+			}
+		};
+	}, [scrollContainerRef, measure, updateVisibility]);
+
+	useEffect(() => {
+		return () => {
+			if (hideTimerRef.current) window.clearTimeout(hideTimerRef.current);
+			if (scrollQuietTimerRef.current)
+				window.clearTimeout(scrollQuietTimerRef.current);
+		};
+	}, []);
+
+	const handleJump = useCallback(
+		(id: number) => {
+			const scroller = scrollContainerRef.current;
+			if (!scroller) return;
+			const anchor = scroller.querySelector<HTMLElement>(
+				`[data-timeline-anchor-id="${CSS.escape(String(id))}"]`,
+			);
+			if (!anchor) return;
+			anchor.scrollIntoView({ behavior: "smooth", block: "start" });
+		},
+		[scrollContainerRef],
+	);
+
+	const handleEnter = () => {
+		hoverRef.current = true;
+		updateVisibility();
+	};
+	const handleLeave = () => {
+		hoverRef.current = false;
+		updateVisibility();
+	};
+
+	if (items.length === 0) {
+		return null;
+	}
+
+	return (
+		<div
+			ref={railRef}
+			data-testid="chat-timeline-rail"
+			aria-hidden
+			className={cn(
+				"pointer-events-auto absolute inset-y-2 right-3 z-20 w-4",
+				"transition-opacity duration-200",
+				visible ? "opacity-100" : "opacity-0",
+			)}
+			onMouseEnter={handleEnter}
+			onMouseLeave={handleLeave}
+			onFocus={handleEnter}
+			onBlur={handleLeave}
+		>
+			{positions.map((pos, idx) => {
+				const isHovered = hoveredIndex === idx;
+				return (
+					<button
+						type="button"
+						key={pos.item.id}
+						onMouseEnter={() => setHoveredIndex(idx)}
+						onMouseLeave={() =>
+							setHoveredIndex((current) => (current === idx ? null : current))
+						}
+						onFocus={() => setHoveredIndex(idx)}
+						onBlur={() =>
+							setHoveredIndex((current) => (current === idx ? null : current))
+						}
+						onClick={() => handleJump(pos.item.id)}
+						className={cn(
+							"absolute left-1/2 -translate-x-1/2 -translate-y-1/2",
+							"h-[2px] w-3 rounded-full border-0 p-0",
+							"transition-[width,height,background-color] duration-150",
+							pos.item.isError
+								? "bg-content-destructive/70 hover:bg-content-destructive"
+								: "bg-content-secondary/50 hover:bg-content-primary",
+							isHovered && "h-[3px] w-4",
+						)}
+						style={{ top: `${pos.ratio * 100}%` }}
+						aria-label={pos.item.preview}
+					>
+						{isHovered && (
+							<span
+								className={cn(
+									"pointer-events-none absolute right-full top-1/2 mr-2 -translate-y-1/2",
+									"whitespace-nowrap rounded-md border px-2 py-1 text-xs shadow-md",
+									"bg-surface-primary text-content-primary border-border-default",
+									pos.item.isError &&
+										"text-content-destructive border-border-destructive",
+								)}
+							>
+								{pos.item.preview}
+							</span>
+						)}
+					</button>
+				);
+			})}
+		</div>
+	);
+};
+
+// Store-connected wrapper. Kept in the same module so consumers only need
+// to thread the scroll container ref and the chat store handle.
+interface ChatTimelineRailContainerProps {
+	scrollContainerRef: RefObject<HTMLDivElement | null>;
+	store: ChatStoreHandle;
+}
+
+const isChatMessage = (
+	m: TypesGen.ChatMessage | undefined,
+): m is TypesGen.ChatMessage => Boolean(m);
+
+export const ChatTimelineRailContainer: FC<ChatTimelineRailContainerProps> = ({
+	scrollContainerRef,
+	store,
+}) => {
+	const messagesByID = useChatSelector(store, selectMessagesByID);
+	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
+	const chatStatus = useChatSelector(store, selectChatStatus);
+	const items = useMemo(() => {
+		const messages = orderedMessageIDs
+			.map((id) => messagesByID.get(id))
+			.filter(isChatMessage);
+		const pendingToolCallIDs = getPendingToolCallIDs(messages, chatStatus);
+		const parsed = parseMessagesWithMergedTools(messages, {
+			pendingToolCallIDs,
+		});
+		return buildTimelineItems(parsed);
+	}, [orderedMessageIDs, messagesByID, chatStatus]);
+	return (
+		<ChatTimelineRail scrollContainerRef={scrollContainerRef} items={items} />
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1067,7 +1067,13 @@ const StickyUserMessage = memo<{
 
 		return (
 			<>
-				<div ref={setSentinelRef} className="h-0" data-user-sentinel />
+				<div
+					ref={setSentinelRef}
+					className="h-0"
+					data-user-sentinel
+					data-timeline-anchor-id={messageId}
+					data-timeline-anchor-role="user"
+				/>
 				<div
 					ref={containerRef}
 					className={cn(
@@ -1357,32 +1363,42 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 						// last in a consecutive assistant chain. Flags are
 						// precomputed in a single reverse pass above.
 						const isLastInChain = lastInChainFlags[msgIdx];
+						const hasErrorTool = parsed.tools.some((t) => t.isError);
 						return (
-							<ChatMessageItem
+							<div
 								key={message.id}
-								message={message}
-								parsed={parsed}
-								onImplementPlan={onImplementPlan}
-								onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
-								isChatCompleted={isChatCompleted}
-								latestAskUserQuestionToolId={latestAskUserQuestionToolId}
-								askUserQuestionResponseTextByToolId={
-									historicalAskUserQuestionResponseTextByToolId
-								}
-								hasUserResponseAfterAskQuestion={
-									hasUserResponseAfterAskQuestion
-								}
-								urlTransform={urlTransform}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-								hideActions={!isLastInChain}
-								hasActiveStream={Boolean(hasActiveStream)}
-								isAwaitingFirstStreamChunk={Boolean(isAwaitingFirstStreamChunk)}
-								isLastMessage={msgIdx === displayMessages.length - 1}
-								mcpServers={mcpServers}
-								subagentTitles={subagentTitles}
-								subagentVariants={subagentVariants}
-								showDesktopPreviews={showDesktopPreviews}
-							/>
+								data-timeline-anchor-id={message.id}
+								data-timeline-anchor-role="assistant"
+								data-timeline-anchor-error={hasErrorTool ? "true" : undefined}
+							>
+								<ChatMessageItem
+									key={message.id}
+									message={message}
+									parsed={parsed}
+									onImplementPlan={onImplementPlan}
+									onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
+									isChatCompleted={isChatCompleted}
+									latestAskUserQuestionToolId={latestAskUserQuestionToolId}
+									askUserQuestionResponseTextByToolId={
+										historicalAskUserQuestionResponseTextByToolId
+									}
+									hasUserResponseAfterAskQuestion={
+										hasUserResponseAfterAskQuestion
+									}
+									urlTransform={urlTransform}
+									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									hideActions={!isLastInChain}
+									hasActiveStream={Boolean(hasActiveStream)}
+									isAwaitingFirstStreamChunk={Boolean(
+										isAwaitingFirstStreamChunk,
+									)}
+									isLastMessage={msgIdx === displayMessages.length - 1}
+									mcpServers={mcpServers}
+									subagentTitles={subagentTitles}
+									subagentVariants={subagentVariants}
+									showDesktopPreviews={showDesktopPreviews}
+								/>
+							</div>
 						);
 					})}
 				</div>

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -105,6 +105,10 @@ const ChatScrollContainer: FC<{
 	onFetchMoreMessages: () => void;
 	messageCount: number;
 	children: ReactNode;
+	// Rendered as an absolutely-positioned sibling of the scroller inside the
+	// relative wrapper. Used to hang overlays such as the timeline rail
+	// alongside the scrollbar without scrolling with the content.
+	overlay?: ReactNode;
 }> = ({
 	scrollContainerRef,
 	scrollToBottomRef,
@@ -113,6 +117,7 @@ const ChatScrollContainer: FC<{
 	onFetchMoreMessages,
 	messageCount,
 	children,
+	overlay,
 }) => {
 	const [scrollContainerElement, setScrollContainerElement] =
 		useState<HTMLDivElement | null>(null);
@@ -172,6 +177,7 @@ const ChatScrollContainer: FC<{
 					{children}
 				</InfiniteScroll>
 			</div>
+			{overlay}
 			<ScrollToBottomButton
 				scrollContainerElement={scrollContainerElement}
 				messageCount={messageCount}


### PR DESCRIPTION
Prototype for the design spec: a minimap-style timeline column that lives at the right edge of the agent chat, just left of the native scrollbar.

> [!NOTE]
> **8080 preview** — this is a frontend-only prototype for design review, not a production PR. Backend was intentionally not touched. See the "Cheats and caveats" section below.

_Coder Agents generated on behalf of @tracyjohnsonux._

## Behaviour

- Hidden by default. Reveals on pointer hover over the rail column **and** while the chat is actively scrolling.
- Fades out ~1.2s after the pointer leaves and scrolling settles.
- Every user prompt renders as a grey tick.
- Assistant messages with a failed tool call render as a red tick.
- Hovering a tick surfaces a small preview label to the left (first line of the prompt, or a short error label).
- Clicking a tick smooth-scrolls the message into view.

## Implementation sketch

- New `ChatTimelineRail.tsx` component under `site/src/pages/AgentsPage/components/ChatConversation/`.
- `ConversationTimeline.tsx` now stamps `data-timeline-anchor-id` on the sticky user-message sentinel and on a thin wrapper around each assistant `ChatMessageItem`. Assistant wrappers also carry `data-timeline-anchor-error` when any tool in that message ended in error.
- `ChatScrollContainer` grew an `overlay` slot that renders inside its existing `relative` wrapper so the rail can be absolutely positioned next to the scrollbar without scrolling with the content.
- `AgentChatPageView` passes a store-connected `ChatTimelineRailContainer` into the new `overlay` slot.

The rail queries anchor positions from the DOM each frame it needs to remeasure (via `ResizeObserver` + a scoped `MutationObserver` + the scroll listener), so it does not track message layout state itself. Positions are computed from `getBoundingClientRect().top` deltas, which is robust against the `flex-col-reverse` scroller layout.

## Cheats and caveats

<details>
<summary>Full list</summary>

1. **Error detection is coarse.** Any assistant message containing at least one tool with `isError` becomes a red tick; label is `Error in <tool.name>`. The design shows a labelled "Test suite failure" tick, which would need real error classification / summarisation to reproduce faithfully.
2. **Preview text is the raw first ~80 chars** of the user prompt, whitespace-collapsed. No markdown stripping beyond that.
3. **Rail position** is `absolute right-3 inset-y-2 w-4`. That lands roughly next to the thin scrollbar but does not measure the actual scrollbar gutter width, so it may look ~1-2px off on platforms with fatter scrollbars.
4. **Reveal signal for "scrolling" is a debounced timer** (400ms quiet window) rather than real momentum / user-intent detection.
5. **Position math uses first/last anchor top-delta** as the coordinate span, not `scroller.scrollHeight`. This works well for the reverse layout but means the topmost and bottommost anchors always sit at 0 % / 100 % of the rail, so ticks are relative to the range of prompts rather than the full scrollable extent. Feels close enough to the mock for review; can be revisited.
6. **New assistant wrapper `<div>`** around `ChatMessageItem` breaks the previous "assistant message is a direct flex child of the gap-2 column" invariant. Layout looks fine locally but is worth eyeballing.
7. **No Storybook story or tests** for the new component. Manual review only.
8. **No a11y story yet** — the rail is `aria-hidden` and its buttons carry `aria-label`s, but there is no keyboard navigation or roving focus.
9. **Backend untouched**, as requested. Error classification and prompt summaries are both computed client-side from data already in the chat store.

</details>

## Testing

- `pnpm run lint:types` — clean
- `pnpm run check` (biome) — clean
- `pnpm run lint:circular-deps` — clean
- `pnpm test -- --run ChatConversation` — 3104 passed, 2 skipped