### PR TITLE
chore: send job logs via the Workspace Agent Connection Watch

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -29996,6 +29996,9 @@ const docTemplate = `{
                 },
                 "error": {
                     "$ref": "#/definitions/workspacesdk.WatchError"
+                },
+                "job_log": {
+                    "$ref": "#/definitions/codersdk.ProvisionerJobLog"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -27692,6 +27692,9 @@
 				},
 				"error": {
 					"$ref": "#/definitions/workspacesdk.WatchError"
+				},
+				"job_log": {
+					"$ref": "#/definitions/codersdk.ProvisionerJobLog"
 				}
 			}
 		},

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -2242,3 +2242,22 @@ func UserSkillMetadataList(rows []database.ListUserSkillMetadataByUserIDRow) []c
 	}
 	return metadata
 }
+
+func ConvertProvisionerJobLogs(provisionerJobLogs []database.ProvisionerJobLog) []codersdk.ProvisionerJobLog {
+	sdk := make([]codersdk.ProvisionerJobLog, 0, len(provisionerJobLogs))
+	for _, log := range provisionerJobLogs {
+		sdk = append(sdk, ConvertProvisionerJobLog(log))
+	}
+	return sdk
+}
+
+func ConvertProvisionerJobLog(provisionerJobLog database.ProvisionerJobLog) codersdk.ProvisionerJobLog {
+	return codersdk.ProvisionerJobLog{
+		ID:        provisionerJobLog.ID,
+		CreatedAt: provisionerJobLog.CreatedAt,
+		Source:    codersdk.LogSource(provisionerJobLog.Source),
+		Level:     codersdk.LogLevel(provisionerJobLog.Level),
+		Stage:     provisionerJobLog.Stage,
+		Output:    provisionerJobLog.Output,
+	}
+}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -36726,7 +36726,7 @@ func (q *sqlQuerier) GetLatestWorkspaceBuildByWorkspaceID(ctx context.Context, w
 
 const getLatestWorkspaceBuildWithStatusByWorkspaceID = `-- name: GetLatestWorkspaceBuildWithStatusByWorkspaceID :one
 SELECT
-	workspace_builds.transition, workspace_builds.build_number, provisioner_jobs.job_status,
+	workspace_builds.transition, workspace_builds.build_number, workspace_builds.job_id, provisioner_jobs.job_status,
 	workspaces.id, workspaces.created_at, workspaces.updated_at, workspaces.owner_id, workspaces.organization_id, workspaces.template_id, workspaces.deleted, workspaces.name, workspaces.autostart_schedule, workspaces.ttl, workspaces.last_used_at, workspaces.dormant_at, workspaces.deleting_at, workspaces.automatic_updates, workspaces.favorite, workspaces.next_start_at, workspaces.group_acl, workspaces.user_acl -- Used for dbauthz fetch() checks
 FROM
 	workspace_builds
@@ -36746,6 +36746,7 @@ ORDER BY
 type GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow struct {
 	Transition     WorkspaceTransition  `db:"transition" json:"transition"`
 	BuildNumber    int32                `db:"build_number" json:"build_number"`
+	JobID          uuid.UUID            `db:"job_id" json:"job_id"`
 	JobStatus      ProvisionerJobStatus `db:"job_status" json:"job_status"`
 	WorkspaceTable WorkspaceTable       `db:"workspace_table" json:"workspace_table"`
 }
@@ -36756,6 +36757,7 @@ func (q *sqlQuerier) GetLatestWorkspaceBuildWithStatusByWorkspaceID(ctx context.
 	err := row.Scan(
 		&i.Transition,
 		&i.BuildNumber,
+		&i.JobID,
 		&i.JobStatus,
 		&i.WorkspaceTable.ID,
 		&i.WorkspaceTable.CreatedAt,

--- a/coderd/database/queries/workspacebuilds.sql
+++ b/coderd/database/queries/workspacebuilds.sql
@@ -307,7 +307,7 @@ WHERE
 
 -- name: GetLatestWorkspaceBuildWithStatusByWorkspaceID :one
 SELECT
-	workspace_builds.transition, workspace_builds.build_number, provisioner_jobs.job_status,
+	workspace_builds.transition, workspace_builds.build_number, workspace_builds.job_id, provisioner_jobs.job_status,
 	sqlc.embed(workspaces) -- Used for dbauthz fetch() checks
 FROM
 	workspace_builds

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -356,25 +356,6 @@ func (api *API) provisionerJobResources(rw http.ResponseWriter, r *http.Request,
 	httpapi.Write(ctx, rw, http.StatusOK, apiResources)
 }
 
-func convertProvisionerJobLogs(provisionerJobLogs []database.ProvisionerJobLog) []codersdk.ProvisionerJobLog {
-	sdk := make([]codersdk.ProvisionerJobLog, 0, len(provisionerJobLogs))
-	for _, log := range provisionerJobLogs {
-		sdk = append(sdk, convertProvisionerJobLog(log))
-	}
-	return sdk
-}
-
-func convertProvisionerJobLog(provisionerJobLog database.ProvisionerJobLog) codersdk.ProvisionerJobLog {
-	return codersdk.ProvisionerJobLog{
-		ID:        provisionerJobLog.ID,
-		CreatedAt: provisionerJobLog.CreatedAt,
-		Source:    codersdk.LogSource(provisionerJobLog.Source),
-		Level:     codersdk.LogLevel(provisionerJobLog.Level),
-		Stage:     provisionerJobLog.Stage,
-		Output:    provisionerJobLog.Output,
-	}
-}
-
 func convertProvisionerJob(pj database.GetProvisionerJobsByIDsWithQueuePositionRow) codersdk.ProvisionerJob {
 	provisionerJob := pj.ProvisionerJob
 	job := codersdk.ProvisionerJob{
@@ -466,7 +447,7 @@ func fetchAndWriteLogs(ctx context.Context, db database.Store, jobID uuid.UUID, 
 		}
 		return
 	}
-	httpapi.Write(ctx, rw, http.StatusOK, convertProvisionerJobLogs(logs))
+	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.ConvertProvisionerJobLogs(logs))
 }
 
 func jobIsComplete(logger slog.Logger, job database.ProvisionerJob) bool {
@@ -690,7 +671,7 @@ func (f *logFollower) query(watchCtx context.Context) error {
 		return xerrors.Errorf("error fetching logs: %w", err)
 	}
 	for _, log := range logs {
-		err := f.enc.Encode(convertProvisionerJobLog(log))
+		err := f.enc.Encode(db2sdk.ConvertProvisionerJobLog(log))
 		if err != nil {
 			return xerrors.Errorf("error writing to websocket: %w", err)
 		}

--- a/coderd/workspaceconnwatcher/watcher.go
+++ b/coderd/workspaceconnwatcher/watcher.go
@@ -3,7 +3,9 @@ package workspaceconnwatcher
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"sync"
 
@@ -11,6 +13,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -19,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
+	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/websocket"
 )
 
@@ -33,18 +37,21 @@ type Watcher struct {
 	wg     sync.WaitGroup
 	closed bool
 
-	connCtx     context.Context
-	conn        *websocket.Conn
-	enc         *wsjson.Encoder[workspacesdk.ConnectionWatchEvent]
-	workspaceID uuid.UUID
-	events      chan event
-	agentName   string
-	lastBuild   database.GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow
+	connCtx         context.Context
+	conn            *websocket.Conn
+	enc             *wsjson.Encoder[workspacesdk.ConnectionWatchEvent]
+	workspaceID     uuid.UUID
+	events          chan event
+	agentName       string
+	lastBuild       database.GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow
+	jobLogSubCancel context.CancelFunc
+	lastLogID       int64
 }
 
 type event struct {
-	sync    bool
-	wsEvent *wspubsub.WorkspaceEvent
+	sync         bool
+	wsEvent      *wspubsub.WorkspaceEvent
+	jobLogNotify *provisionersdk.ProvisionerJobLogsNotifyMessage
 }
 
 func New(ctx context.Context, logger slog.Logger, sub pubsub.Subscriber, db database.Store) *Watcher {
@@ -80,7 +87,7 @@ func (w *Watcher) WorkspaceAgentConnectionWatch(rw http.ResponseWriter, r *http.
 	w.events <- event{sync: true} // init sync
 	cancelWorkspaceSubscribe, err := w.sub.SubscribeWithErr(wspubsub.WorkspaceEventChannel(workspace.OwnerID),
 		wspubsub.HandleWorkspaceEvent(
-			func(ctx context.Context, payload wspubsub.WorkspaceEvent, err error) {
+			func(_ context.Context, payload wspubsub.WorkspaceEvent, err error) {
 				if err != nil {
 					// subscription error, resync
 					select {
@@ -160,6 +167,10 @@ func (w *Watcher) run() {
 	defer func() {
 		// this is a no-op if we have already closed for some other reason.
 		_ = w.enc.Close(websocket.StatusNormalClosure)
+		if w.jobLogSubCancel != nil {
+			w.jobLogSubCancel()
+			w.jobLogSubCancel = nil
+		}
 	}()
 
 	for {
@@ -193,6 +204,20 @@ func (w *Watcher) run() {
 					}
 				}
 			}
+			if e.jobLogNotify != nil {
+				if e.jobLogNotify.EndOfLogs {
+					// There aren't actually new logs, so we can ignore. Note that unlike a log stream, we should not
+					// be tearing things down here, since the end of build logs just means that the client of the stream
+					// will now be waiting additional build and agent updates.
+					continue
+				}
+				if e.jobLogNotify.CreatedAfter >= w.lastLogID {
+					// Newer logs are potentially available.
+					if !w.queryJobLogs() {
+						return
+					}
+				}
+			}
 		}
 	}
 }
@@ -218,11 +243,37 @@ func (w *Watcher) buildUpdate() bool {
 		})
 		return false
 	}
+	oldBuild := w.lastBuild
+	w.lastBuild = build
+	// We want to provide logs for builds we are waiting for. But, if the build job is already complete, don't bother
+	// sending logs.
+	if build.JobID != oldBuild.JobID && build.JobStatus != database.ProvisionerJobStatusSucceeded {
+		err = w.subscribeToJobLogs()
+		if err != nil {
+			w.errorThenClose(workspacesdk.WatchError{
+				Code:      workspacesdk.WatchErrorDatabase,
+				Retryable: false,
+				Message:   "failed to subscribe to build job logs",
+				Details:   err.Error(),
+			})
+			return false
+		}
+	}
 
-	if build.BuildNumber != w.lastBuild.BuildNumber ||
-		build.JobStatus != w.lastBuild.JobStatus ||
-		build.Transition != w.lastBuild.Transition {
-		w.lastBuild = build
+	if build.BuildNumber != oldBuild.BuildNumber ||
+		build.JobStatus != oldBuild.JobStatus ||
+		build.Transition != oldBuild.Transition {
+		if build.Transition == database.WorkspaceTransitionStart &&
+			build.JobStatus == database.ProvisionerJobStatusSucceeded &&
+			// Only if we have previously subscribed.
+			w.jobLogSubCancel != nil {
+			// Before we send the update about a successful build, do one last query of the job log to ensure we haven't
+			// missed any, since they logically precede the job completing.
+			if !w.queryJobLogs() {
+				return false
+			}
+		}
+
 		err = w.enc.Encode(workspacesdk.ConnectionWatchEvent{BuildUpdate: &workspacesdk.BuildUpdate{
 			Transition: codersdk.WorkspaceTransition(build.Transition),
 			JobStatus:  codersdk.ProvisionerJobStatus(build.JobStatus),
@@ -318,4 +369,79 @@ func (w *Watcher) errorThenClose(err workspacesdk.WatchError) {
 	_ = w.enc.Encode(workspacesdk.ConnectionWatchEvent{Error: &err})
 	// ignore encoding errors above because in any case, we are going to close the connection.
 	_ = w.conn.Close(websocket.StatusNormalClosure, "error")
+	if w.jobLogSubCancel != nil {
+		w.jobLogSubCancel()
+		w.jobLogSubCancel = nil
+	}
+}
+
+func (w *Watcher) subscribeToJobLogs() error {
+	// restart the logID, since we are subscribing to a new job ID, and log IDs are scoped to the job.
+	w.lastLogID = 0
+	if w.jobLogSubCancel != nil {
+		w.jobLogSubCancel()
+	}
+	var err error
+	w.jobLogSubCancel, err = w.sub.SubscribeWithErr(
+		provisionersdk.ProvisionerJobLogsNotifyChannel(w.lastBuild.JobID),
+		w.jobLogListener)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *Watcher) jobLogListener(_ context.Context, message []byte, err error) {
+	n := new(provisionersdk.ProvisionerJobLogsNotifyMessage)
+	if err == nil {
+		err = json.Unmarshal(message, &n)
+	}
+	if err != nil {
+		// This means there was a problem with the pubsub, like a disconnection, or with decoding. In either case we
+		// don't know if some new logs have arrived during the disconnection, so send a notify that will trigger a query
+		// of the latest.
+		n.CreatedAfter = math.MaxInt64
+		n.EndOfLogs = false
+	}
+	select {
+	case w.events <- event{jobLogNotify: n}:
+	case <-w.connCtx.Done():
+		return
+	}
+}
+
+func (w *Watcher) queryJobLogs() (ok bool) {
+	w.logger.Debug(w.connCtx, "querying logs", slog.F("after", w.lastLogID))
+	logs, err := w.db.GetProvisionerLogsAfterID(w.connCtx, database.GetProvisionerLogsAfterIDParams{
+		JobID:        w.lastBuild.JobID,
+		CreatedAfter: w.lastLogID,
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		details := err.Error()
+		retryable := true
+		if dbauthz.IsNotAuthorizedError(err) {
+			retryable = false
+			details = "unauthorized"
+		}
+		w.errorThenClose(workspacesdk.WatchError{
+			Code:      workspacesdk.WatchErrorDatabase,
+			Retryable: retryable,
+			Message:   "failed to fetch build logs",
+			Details:   details,
+		})
+		return false
+	}
+	for _, log := range logs {
+		sdkLog := db2sdk.ConvertProvisionerJobLog(log)
+		err = w.enc.Encode(workspacesdk.ConnectionWatchEvent{JobLog: &sdkLog})
+		if err != nil {
+			// probably this is just that the connection is closed, but in case there is some actual JSON serialization
+			// error, send a close frame.
+			_ = w.conn.Close(websocket.StatusInternalError, "failed to encode agent update")
+			return false
+		}
+		w.lastLogID = log.ID
+		w.logger.Debug(w.connCtx, "wrote log to websocket", slog.F("id", log.ID))
+	}
+	return true
 }

--- a/coderd/workspaceconnwatcher/watcher_test.go
+++ b/coderd/workspaceconnwatcher/watcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
+	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/websocket"
 )
@@ -35,6 +36,7 @@ var (
 	userID      = uuid.UUID{2}
 	orgID       = uuid.UUID{3}
 	agentID     = uuid.UUID{4}
+	jobID       = uuid.UUID{5}
 )
 
 type harness struct {
@@ -45,6 +47,7 @@ type harness struct {
 
 	// Initialized, but overridable before Dial()
 	workspace     database.Workspace
+	job           database.ProvisionerJob
 	userID, orgID uuid.UUID
 }
 
@@ -58,6 +61,10 @@ func newHarness(ctx context.Context, t *testing.T, logger slog.Logger) *harness 
 		orgID:  orgID,
 		userID: userID,
 		logger: logger,
+		job: database.ProvisionerJob{
+			ID:   jobID,
+			Type: database.ProvisionerJobTypeWorkspaceBuild,
+		},
 	}
 	ps := pubsub.NewInMemory()
 	h.pub = ps
@@ -93,6 +100,19 @@ func (h *harness) Dial(ctx context.Context, url string) (*wsjson.Decoder[workspa
 	dec := wsjson.NewDecoder[workspacesdk.ConnectionWatchEvent](
 		clientSock, websocket.MessageText, h.logger.Named("decoder"))
 	return dec, nil
+}
+
+// expectRBAC sets the database to expect RBAC queries for the workspace, agent, and provisioner logs
+func (h *harness) expectRBAC() {
+	h.db.EXPECT().GetProvisionerJobByID(gomock.Any(), jobID).
+		AnyTimes().
+		Return(h.job, nil)
+	h.db.EXPECT().GetWorkspaceBuildByJobID(gomock.Any(), h.job.ID).
+		AnyTimes().
+		Return(database.WorkspaceBuild{JobID: h.job.ID, WorkspaceID: h.workspace.ID}, nil)
+	h.db.EXPECT().GetWorkspaceByID(gomock.Any(), h.workspace.ID).
+		AnyTimes(). // these queries are identical between the initial and the update below
+		Return(h.workspace, nil)
 }
 
 func TestWatcher_Agents(t *testing.T) {
@@ -207,6 +227,7 @@ func TestWatcher_Agents(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			logger := testutil.Logger(t)
 			h := newHarness(ctx, t, logger)
+			h.expectRBAC()
 
 			h.db.EXPECT().GetLatestWorkspaceBuildWithStatusByWorkspaceID(gomock.Any(), h.workspace.ID).
 				Times(1).
@@ -214,16 +235,13 @@ func TestWatcher_Agents(t *testing.T) {
 					Transition:  database.WorkspaceTransitionStart,
 					BuildNumber: 1,
 					JobStatus:   database.ProvisionerJobStatusSucceeded,
+					JobID:       h.job.ID,
 					WorkspaceTable: database.WorkspaceTable{
 						ID:             h.workspace.ID,
 						OwnerID:        userID,
 						OrganizationID: orgID,
 					},
 				}, nil)
-			// RBAC check for agent query
-			h.db.EXPECT().GetWorkspaceByID(gomock.Any(), h.workspace.ID).
-				Times(1).
-				Return(h.workspace, nil)
 			h.db.EXPECT().GetWorkspaceAgentsByWorkspaceAndBuildNumber(
 				gomock.Any(),
 				database.GetWorkspaceAgentsByWorkspaceAndBuildNumberParams{
@@ -303,6 +321,7 @@ func TestWatcher_PublishChanges(t *testing.T) {
 			Transition:  database.WorkspaceTransitionStart,
 			BuildNumber: 1,
 			JobStatus:   database.ProvisionerJobStatusRunning,
+			JobID:       h.job.ID,
 			WorkspaceTable: database.WorkspaceTable{
 				ID:             h.workspace.ID,
 				OwnerID:        userID,
@@ -334,17 +353,24 @@ func TestWatcher_PublishChanges(t *testing.T) {
 			Transition:  database.WorkspaceTransitionStart,
 			BuildNumber: 1,
 			JobStatus:   database.ProvisionerJobStatusSucceeded,
+			JobID:       h.job.ID,
 			WorkspaceTable: database.WorkspaceTable{
 				ID:             h.workspace.ID,
 				OwnerID:        userID,
 				OrganizationID: orgID,
 			},
 		}, nil)
-	// RBAC check for agent query
-	h.db.EXPECT().GetWorkspaceByID(gomock.Any(), h.workspace.ID).
+
+	// Logs query
+	h.db.EXPECT().GetProvisionerLogsAfterID(gomock.Any(),
+		database.GetProvisionerLogsAfterIDParams{JobID: h.job.ID, CreatedAfter: 0}).
 		After(build1).
-		Times(2). // these queries are identical between the initial and the update below
-		Return(h.workspace, nil)
+		Times(1).
+		Return([]database.ProvisionerJobLog{
+			{Output: "foo"},
+			{Output: "bar"},
+		}, nil)
+	h.expectRBAC()
 	agent0 := h.db.EXPECT().GetWorkspaceAgentsByWorkspaceAndBuildNumber(
 		gomock.Any(),
 		database.GetWorkspaceAgentsByWorkspaceAndBuildNumberParams{
@@ -369,6 +395,17 @@ func TestWatcher_PublishChanges(t *testing.T) {
 	err = h.pub.Publish(wspubsub.WorkspaceEventChannel(h.workspace.OwnerID), changeBytes)
 	require.NoError(t, err)
 
+	// Logs
+	l0 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		JobLog: &codersdk.ProvisionerJobLog{Output: "foo"},
+	}, l0)
+	l1 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		JobLog: &codersdk.ProvisionerJobLog{Output: "bar"},
+	}, l1)
+
+	// Build update
 	e1 := testutil.RequireReceive(ctx, t, events)
 	require.Equal(t, workspacesdk.ConnectionWatchEvent{
 		BuildUpdate: &workspacesdk.BuildUpdate{
@@ -376,6 +413,8 @@ func TestWatcher_PublishChanges(t *testing.T) {
 			JobStatus:  codersdk.ProvisionerJobSucceeded,
 		},
 	}, e1)
+
+	// Agent update
 	e2 := testutil.RequireReceive(ctx, t, events)
 	require.Equal(t, workspacesdk.ConnectionWatchEvent{AgentUpdate: &workspacesdk.AgentUpdate{
 		ID:        agentID,
@@ -413,6 +452,168 @@ func TestWatcher_PublishChanges(t *testing.T) {
 		ID:        agentID,
 		Lifecycle: codersdk.WorkspaceAgentLifecycleReady,
 	}}, e3)
+}
+
+func TestWatcher_SubscribesToLogs(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := testutil.Logger(t)
+	h := newHarness(ctx, t, logger)
+	h.expectRBAC()
+
+	// Initial build update, job is running.
+	build0 := h.db.EXPECT().GetLatestWorkspaceBuildWithStatusByWorkspaceID(gomock.Any(), h.workspace.ID).
+		Times(1).
+		Return(database.GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow{
+			Transition:  database.WorkspaceTransitionStart,
+			BuildNumber: 1,
+			JobStatus:   database.ProvisionerJobStatusRunning,
+			JobID:       h.job.ID,
+			WorkspaceTable: database.WorkspaceTable{
+				ID:             h.workspace.ID,
+				OwnerID:        userID,
+				OrganizationID: orgID,
+			},
+		}, nil)
+
+	dec, err := h.Dial(ctx, "wss://local.test/")
+	require.NoError(t, err)
+	defer func() {
+		_ = dec.Close()
+	}()
+	events := dec.Chan()
+
+	e0 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		BuildUpdate: &workspacesdk.BuildUpdate{
+			Transition: codersdk.WorkspaceTransitionStart,
+			JobStatus:  codersdk.ProvisionerJobRunning,
+		},
+	}, e0)
+
+	// Logs query
+	h.db.EXPECT().GetProvisionerLogsAfterID(gomock.Any(),
+		database.GetProvisionerLogsAfterIDParams{JobID: h.job.ID, CreatedAfter: 0}).
+		After(build0).
+		Times(1).
+		Return([]database.ProvisionerJobLog{
+			{Output: "foo", ID: 1},
+			{Output: "bar", ID: 2},
+		}, nil)
+
+	logMsg := provisionersdk.ProvisionerJobLogsNotifyMessage{
+		CreatedAfter: 0,
+		EndOfLogs:    false,
+	}
+	logBytes, err := json.Marshal(logMsg)
+	require.NoError(t, err)
+	err = h.pub.Publish(provisionersdk.ProvisionerJobLogsNotifyChannel(h.job.ID), logBytes)
+	require.NoError(t, err)
+
+	l1 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		JobLog: &codersdk.ProvisionerJobLog{Output: "foo", ID: 1},
+	}, l1)
+	l2 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		JobLog: &codersdk.ProvisionerJobLog{Output: "bar", ID: 2},
+	}, l2)
+
+	h.db.EXPECT().GetProvisionerLogsAfterID(gomock.Any(),
+		database.GetProvisionerLogsAfterIDParams{JobID: h.job.ID, CreatedAfter: 2}).
+		After(build0).
+		Times(1).
+		Return([]database.ProvisionerJobLog{
+			{Output: "baz", ID: 3},
+		}, nil)
+
+	// Second log notification triggers new query
+	logMsg.CreatedAfter = 2
+	logBytes, err = json.Marshal(logMsg)
+	require.NoError(t, err)
+	err = h.pub.Publish(provisionersdk.ProvisionerJobLogsNotifyChannel(h.job.ID), logBytes)
+	require.NoError(t, err)
+
+	l3 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		JobLog: &codersdk.ProvisionerJobLog{Output: "baz", ID: 3},
+	}, l3)
+
+	// Repeating the notification won't trigger any new queries, since we already have logs up to ID = 3
+	err = h.pub.Publish(provisionersdk.ProvisionerJobLogsNotifyChannel(h.job.ID), logBytes)
+	require.NoError(t, err)
+
+	// Similarly, a notification of end of logs does not trigger a new query
+	logMsg.CreatedAfter = 0
+	logMsg.EndOfLogs = true
+	logBytes, err = json.Marshal(logMsg)
+	require.NoError(t, err)
+	err = h.pub.Publish(provisionersdk.ProvisionerJobLogsNotifyChannel(h.job.ID), logBytes)
+	require.NoError(t, err)
+
+	// However, the successful build will trigger a new query
+	h.db.EXPECT().GetLatestWorkspaceBuildWithStatusByWorkspaceID(gomock.Any(), h.workspace.ID).
+		Times(1).
+		Return(database.GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow{
+			Transition:  database.WorkspaceTransitionStart,
+			BuildNumber: 1,
+			JobStatus:   database.ProvisionerJobStatusSucceeded,
+			JobID:       h.job.ID,
+			WorkspaceTable: database.WorkspaceTable{
+				ID:             h.workspace.ID,
+				OwnerID:        userID,
+				OrganizationID: orgID,
+			},
+		}, nil)
+	h.db.EXPECT().GetProvisionerLogsAfterID(gomock.Any(),
+		database.GetProvisionerLogsAfterIDParams{JobID: h.job.ID, CreatedAfter: 3}).
+		Times(1).
+		Return([]database.ProvisionerJobLog{
+			{Output: "buzz", ID: 4},
+		}, nil)
+	// And will also query the agent
+	h.db.EXPECT().GetWorkspaceAgentsByWorkspaceAndBuildNumber(
+		gomock.Any(),
+		database.GetWorkspaceAgentsByWorkspaceAndBuildNumberParams{
+			WorkspaceID: h.workspace.ID,
+			BuildNumber: 1,
+		}).
+		Times(1).
+		Return([]database.WorkspaceAgent{
+			{
+				Name:           "test",
+				ID:             agentID,
+				LifecycleState: database.WorkspaceAgentLifecycleStateReady,
+			},
+		}, nil)
+
+	changeMsg := wspubsub.WorkspaceEvent{
+		Kind:        wspubsub.WorkspaceEventKindStateChange,
+		WorkspaceID: h.workspace.ID,
+	}
+	changeBytes, err := json.Marshal(changeMsg)
+	require.NoError(t, err)
+	err = h.pub.Publish(wspubsub.WorkspaceEventChannel(h.workspace.OwnerID), changeBytes)
+	require.NoError(t, err)
+
+	// Updates are final log, build, then agent
+	l4 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		JobLog: &codersdk.ProvisionerJobLog{Output: "buzz", ID: 4},
+	}, l4)
+	e1 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{
+		BuildUpdate: &workspacesdk.BuildUpdate{
+			Transition: codersdk.WorkspaceTransitionStart,
+			JobStatus:  codersdk.ProvisionerJobSucceeded,
+		},
+	}, e1)
+	e2 := testutil.RequireReceive(ctx, t, events)
+	require.Equal(t, workspacesdk.ConnectionWatchEvent{AgentUpdate: &workspacesdk.AgentUpdate{
+		ID:        agentID,
+		Lifecycle: codersdk.WorkspaceAgentLifecycleReady,
+	}}, e2)
 }
 
 func TestWatcher_ClosedBeforeDial(t *testing.T) {

--- a/codersdk/workspacesdk/workspaceagentconnwatch.go
+++ b/codersdk/workspacesdk/workspaceagentconnwatch.go
@@ -25,9 +25,10 @@ const (
 )
 
 type ConnectionWatchEvent struct {
-	Error       *WatchError  `json:"error"`
-	BuildUpdate *BuildUpdate `json:"build_update,omitempty"`
-	AgentUpdate *AgentUpdate `json:"agent_update,omitempty"`
+	Error       *WatchError                 `json:"error"`
+	BuildUpdate *BuildUpdate                `json:"build_update,omitempty"`
+	AgentUpdate *AgentUpdate                `json:"agent_update,omitempty"`
+	JobLog      *codersdk.ProvisionerJobLog `json:"job_log,omitempty"`
 }
 
 type WatchError struct {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -19795,17 +19795,26 @@ None
     "details": "string",
     "message": "string",
     "retryable": true
+  },
+  "job_log": {
+    "created_at": "2019-08-24T14:15:22Z",
+    "id": 0,
+    "log_level": "trace",
+    "log_source": "provisioner_daemon",
+    "output": "string",
+    "stage": "string"
   }
 }
 ```
 
 ### Properties
 
-| Name           | Type                                                 | Required | Restrictions | Description |
-|----------------|------------------------------------------------------|----------|--------------|-------------|
-| `agent_update` | [workspacesdk.AgentUpdate](#workspacesdkagentupdate) | false    |              |             |
-| `build_update` | [workspacesdk.BuildUpdate](#workspacesdkbuildupdate) | false    |              |             |
-| `error`        | [workspacesdk.WatchError](#workspacesdkwatcherror)   | false    |              |             |
+| Name           | Type                                                     | Required | Restrictions | Description |
+|----------------|----------------------------------------------------------|----------|--------------|-------------|
+| `agent_update` | [workspacesdk.AgentUpdate](#workspacesdkagentupdate)     | false    |              |             |
+| `build_update` | [workspacesdk.BuildUpdate](#workspacesdkbuildupdate)     | false    |              |             |
+| `error`        | [workspacesdk.WatchError](#workspacesdkwatcherror)       | false    |              |             |
+| `job_log`      | [codersdk.ProvisionerJobLog](#codersdkprovisionerjoblog) | false    |              |             |
 
 ## workspacesdk.WatchError
 

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -1929,6 +1929,14 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/agent-connect
     "details": "string",
     "message": "string",
     "retryable": true
+  },
+  "job_log": {
+    "created_at": "2019-08-24T14:15:22Z",
+    "id": 0,
+    "log_level": "trace",
+    "log_source": "provisioner_daemon",
+    "output": "string",
+    "stage": "string"
   }
 }
 ```


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

related to GRU-18

This PR adds provisioner job logs to the Workspace Agent Connection Watch, to replicate the current SSH behavior of showing these logs while waiting for a build to complete.

Further PRs will incorporate the logs into the FSM on the client side.