### PR TITLE
fix: redact env var values in agent debug manifest endpoint (#26904)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2148,8 +2148,26 @@ func (a *agent) HandleHTTPDebugManifest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Redact env values. This endpoint is unauthenticated on loopback,
+	// reachable by any process regardless of Unix user. Keys are preserved
+	// so operators can still see which variables are configured.
+	debugManifest := *sdkManifest
+	if len(sdkManifest.EnvironmentVariables) > 0 {
+		envs := make(map[string]string, len(sdkManifest.EnvironmentVariables))
+		for k, v := range sdkManifest.EnvironmentVariables {
+			// Preserve empty values, which carry no secret, matching
+			// sanitizeEnv in support/support.go.
+			if v == "" {
+				envs[k] = v
+				continue
+			}
+			envs[k] = redactedManifestEnvValue
+		}
+		debugManifest.EnvironmentVariables = envs
+	}
+
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(sdkManifest); err != nil {
+	if err := json.NewEncoder(w).Encode(debugManifest); err != nil {
 		a.logger.Error(a.hardCtx, "write debug manifest", slog.Error(err))
 	}
 }
@@ -2173,6 +2191,10 @@ func (a *agent) HandleHTTPDebugLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
+
+// redactedManifestEnvValue matches the marker used by sanitizeEnv in
+// support/support.go so a support bundle and this endpoint agree.
+const redactedManifestEnvValue = "***REDACTED***"
 
 func (a *agent) HTTPDebug() http.Handler {
 	r := chi.NewRouter()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3519,6 +3519,10 @@ func TestAgent_DebugServer(t *testing.T) {
 	//nolint:dogsled
 	conn, _, _, _, agnt := setupAgentWithSecrets(t, agentsdk.Manifest{
 		DERPMap: derpMap,
+		EnvironmentVariables: map[string]string{
+			"AWS_SECRET_ACCESS_KEY": "env-value-should-be-redacted-67890",
+			"EMPTY_VAR":             "",
+		},
 	}, []agentsdk.WorkspaceSecret{
 		{EnvName: "DEBUG_SECRET", Value: []byte("super-secret-value-12345")},
 	}, 0, func(c *agenttest.Client, o *agent.Options) {
@@ -3645,6 +3649,34 @@ func TestAgent_DebugServer(t *testing.T) {
 		// to leak through JSON encoding.
 		var v agentsdk.Manifest
 		require.NoError(t, json.Unmarshal(body, &v))
+	})
+
+	t.Run("ManifestEnvVarValuesRedacted", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/manifest", nil)
+		require.NoError(t, err)
+
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		require.NotContains(t, string(body), "env-value-should-be-redacted-67890")
+
+		var v agentsdk.Manifest
+		require.NoError(t, json.Unmarshal(body, &v))
+
+		require.Contains(t, v.EnvironmentVariables, "AWS_SECRET_ACCESS_KEY")
+		require.Equal(t, "***REDACTED***", v.EnvironmentVariables["AWS_SECRET_ACCESS_KEY"])
+
+		// Empty values carry no secret and are preserved as empty.
+		require.Contains(t, v.EnvironmentVariables, "EMPTY_VAR")
+		require.Equal(t, "", v.EnvironmentVariables["EMPTY_VAR"])
 	})
 
 	t.Run("Logs", func(t *testing.T) {


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/26904

Original PR: #26904 — fix: redact env var values in agent debug manifest endpoint
Merge commit: b33ff2d8514fd798a4e1610e1ca86a7aa448a266
Requested by: @jdomeracki-coder

<details>
<summary>Conflict resolution notes</summary>

The cherry-pick conflicted in `agent/agent.go` because the new
`redactedManifestEnvValue` constant landed where `release/2.34` has the
`HandleHTTPDebugLogs` handler. Resolved by keeping both: the existing handler
and the new constant. The manifest env-redaction block applied cleanly. The
`./agent/...` package builds successfully.
</details>

---
_Opened by Coder Agents on behalf of @jdomeracki-coder._