### PR TITLE
fix(site/src/pages/AgentsPage): show error state with retry when chat fetch fails

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -3062,20 +3062,14 @@ export const SendResponseAfterChatSwitch: Story = {
 	},
 };
 
-const queryErrorChat: TypesGen.Chat = {
+const mockErrorChat: TypesGen.Chat = {
 	...MockChat,
 	id: CHAT_ID,
 	...baseChatFields,
 	title: "Failing chat",
 };
 
-const queryErrorMessages: TypesGen.ChatMessagesResponse = {
-	messages: [],
-	queued_messages: [],
-	has_more: false,
-};
-
-const serverError = {
+const mockServerError = {
 	...mockApiError({ message: "Internal server error." }),
 	status: 500,
 };
@@ -3088,12 +3082,16 @@ const withoutQuery = (
 export const DetailQueryError: Story = {
 	parameters: {
 		queries: withoutQuery(
-			buildQueries(queryErrorChat, queryErrorMessages),
+			buildQueries(mockErrorChat, {
+				messages: [],
+				queued_messages: [],
+				has_more: false,
+			}),
 			chatKey(CHAT_ID),
 		),
 	},
 	beforeEach: () => {
-		spyOn(API.experimental, "getChat").mockRejectedValue(serverError);
+		spyOn(API.experimental, "getChat").mockRejectedValue(mockServerError);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -3108,12 +3106,18 @@ export const DetailQueryError: Story = {
 export const InitialMessagesError: Story = {
 	parameters: {
 		queries: withoutQuery(
-			buildQueries(queryErrorChat, queryErrorMessages),
+			buildQueries(mockErrorChat, {
+				messages: [],
+				queued_messages: [],
+				has_more: false,
+			}),
 			chatMessagesKey(CHAT_ID),
 		),
 	},
 	beforeEach: () => {
-		spyOn(API.experimental, "getChatMessages").mockRejectedValue(serverError);
+		spyOn(API.experimental, "getChatMessages").mockRejectedValue(
+			mockServerError,
+		);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -3125,14 +3129,18 @@ export const InitialMessagesError: Story = {
 export const ErrorRetryRecovers: Story = {
 	parameters: {
 		queries: withoutQuery(
-			buildQueries(queryErrorChat, queryErrorMessages),
+			buildQueries(mockErrorChat, {
+				messages: [],
+				queued_messages: [],
+				has_more: false,
+			}),
 			chatKey(CHAT_ID),
 		),
 	},
 	beforeEach: ({ parameters }) => {
 		const getChatSpy = spyOn(API.experimental, "getChat")
-			.mockRejectedValueOnce(serverError)
-			.mockResolvedValue(queryErrorChat);
+			.mockRejectedValueOnce(mockServerError)
+			.mockResolvedValue(mockErrorChat);
 		parameters.getChatCallsForChat = () =>
 			getChatSpy.mock.calls.filter(([chatId]) => chatId === CHAT_ID).length;
 	},
@@ -3151,7 +3159,11 @@ export const ErrorRetryRecovers: Story = {
 export const ChatNotFound: Story = {
 	parameters: {
 		queries: withoutQuery(
-			buildQueries(queryErrorChat, queryErrorMessages),
+			buildQueries(mockErrorChat, {
+				messages: [],
+				queued_messages: [],
+				has_more: false,
+			}),
 			chatKey(CHAT_ID),
 		),
 	},

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -3059,6 +3059,144 @@ export const SendResponseAfterChatSwitch: Story = {
 	},
 };
 
+// ---------------------------------------------------------------------------
+// Query failure states: a transport failure must render an error view with
+// retry, never "Chat not found". Only a 404 from the detail endpoint means
+// the chat is genuinely absent.
+// ---------------------------------------------------------------------------
+
+const minimalChat: TypesGen.Chat = {
+	id: CHAT_ID,
+	...baseChatFields,
+	title: "Failing chat",
+	status: "waiting",
+};
+
+const minimalMessages: TypesGen.ChatMessagesResponse = {
+	messages: [],
+	queued_messages: [],
+	has_more: false,
+};
+
+const serverError = {
+	isAxiosError: true,
+	response: {
+		status: 500,
+		data: { message: "Internal server error." },
+	},
+};
+
+// Spy cleanup matters here: an invalidated query from an earlier story's
+// play function can refetch after that story unmounted, through whatever
+// spy is still registered. Returning restore functions from beforeEach
+// keeps each story's mocks scoped to that story.
+const mockChatFetchError = (error: unknown) => {
+	const getChatSpy = spyOn(API.experimental, "getChat").mockImplementation(
+		(chatId) =>
+			chatId === CHAT_ID ? Promise.reject(error) : Promise.resolve(minimalChat),
+	);
+	const getChatMessagesSpy = spyOn(
+		API.experimental,
+		"getChatMessages",
+	).mockResolvedValue(minimalMessages);
+	return () => {
+		getChatSpy.mockRestore();
+		getChatMessagesSpy.mockRestore();
+	};
+};
+
+/** The detail query fails with a 500: error view, not "Chat not found". */
+export const DetailQueryError: Story = {
+	beforeEach: () => mockChatFetchError(serverError),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("Failed to load chat")).toBeVisible();
+		expect(canvas.queryByText("Chat not found")).not.toBeInTheDocument();
+		expect(
+			canvas.getByRole("button", { name: "Try again" }),
+		).toBeInTheDocument();
+	},
+};
+
+/** The initial messages query fails: error view, not "Chat not found". */
+export const InitialMessagesError: Story = {
+	beforeEach: () => {
+		const getChatSpy = spyOn(API.experimental, "getChat").mockResolvedValue(
+			minimalChat,
+		);
+		const getChatMessagesSpy = spyOn(
+			API.experimental,
+			"getChatMessages",
+		).mockImplementation((chatId) =>
+			chatId === CHAT_ID
+				? Promise.reject(serverError)
+				: Promise.resolve(minimalMessages),
+		);
+		return () => {
+			getChatSpy.mockRestore();
+			getChatMessagesSpy.mockRestore();
+		};
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("Failed to load chat")).toBeVisible();
+		expect(canvas.queryByText("Chat not found")).not.toBeInTheDocument();
+	},
+};
+
+/** Clicking retry refetches both queries and recovers the chat. */
+export const ErrorRetryRecovers: Story = {
+	beforeEach: ({ parameters }) => {
+		let shouldFail = true;
+		const getChatSpy = spyOn(API.experimental, "getChat").mockImplementation(
+			(chatId) => {
+				if (chatId === CHAT_ID && shouldFail) {
+					shouldFail = false;
+					return Promise.reject(serverError);
+				}
+				return Promise.resolve(minimalChat);
+			},
+		);
+		parameters.getChatCallsForChat = () =>
+			getChatSpy.mock.calls.filter(([chatId]) => chatId === CHAT_ID).length;
+		const getChatMessagesSpy = spyOn(
+			API.experimental,
+			"getChatMessages",
+		).mockResolvedValue(minimalMessages);
+		return () => {
+			getChatSpy.mockRestore();
+			getChatMessagesSpy.mockRestore();
+		};
+	},
+	play: async ({ canvasElement, parameters }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("Failed to load chat")).toBeVisible();
+		await userEvent.click(canvas.getByRole("button", { name: "Try again" }));
+		await waitFor(() => {
+			expect(canvas.queryByText("Failed to load chat")).not.toBeInTheDocument();
+		});
+		expect(canvas.queryByText("Chat not found")).not.toBeInTheDocument();
+		expect(parameters.getChatCallsForChat()).toBeGreaterThanOrEqual(2);
+	},
+};
+
+/** A genuine 404 from the detail endpoint still renders "Chat not found". */
+export const ChatNotFound: Story = {
+	beforeEach: () =>
+		mockChatFetchError({
+			isAxiosError: true,
+			response: {
+				status: 404,
+				data: { message: "Chat not found." },
+			},
+		}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("Chat not found")).toBeVisible();
+		expect(canvas.queryByText("Failed to load chat")).not.toBeInTheDocument();
+	},
+};
+
 export const SendRejectedByHookDispatchFailure: Story = {
 	parameters: {
 		queries: buildQueries(

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useRef } from "react";
+import { hashKey } from "react-query";
 import { Outlet, useNavigate } from "react-router";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import {
@@ -22,6 +23,7 @@ import {
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
+	MockChat,
 	MockChatMessage,
 	MockChatQueuedMessage,
 } from "#/testHelpers/chatEntities";
@@ -32,6 +34,7 @@ import {
 	MockOrganizationMember2,
 	MockUserOwner,
 	MockWorkspace,
+	mockApiError,
 } from "#/testHelpers/entities";
 import {
 	withAuthProvider,
@@ -3059,55 +3062,39 @@ export const SendResponseAfterChatSwitch: Story = {
 	},
 };
 
-// ---------------------------------------------------------------------------
-// Query failure states: a transport failure must render an error view with
-// retry, never "Chat not found". Only a 404 from the detail endpoint means
-// the chat is genuinely absent.
-// ---------------------------------------------------------------------------
-
-const minimalChat: TypesGen.Chat = {
+const queryErrorChat: TypesGen.Chat = {
+	...MockChat,
 	id: CHAT_ID,
 	...baseChatFields,
 	title: "Failing chat",
-	status: "waiting",
 };
 
-const minimalMessages: TypesGen.ChatMessagesResponse = {
+const queryErrorMessages: TypesGen.ChatMessagesResponse = {
 	messages: [],
 	queued_messages: [],
 	has_more: false,
 };
 
 const serverError = {
-	isAxiosError: true,
-	response: {
-		status: 500,
-		data: { message: "Internal server error." },
-	},
+	...mockApiError({ message: "Internal server error." }),
+	status: 500,
 };
 
-// Spy cleanup matters here: an invalidated query from an earlier story's
-// play function can refetch after that story unmounted, through whatever
-// spy is still registered. Returning restore functions from beforeEach
-// keeps each story's mocks scoped to that story.
-const mockChatFetchError = (error: unknown) => {
-	const getChatSpy = spyOn(API.experimental, "getChat").mockImplementation(
-		(chatId) =>
-			chatId === CHAT_ID ? Promise.reject(error) : Promise.resolve(minimalChat),
-	);
-	const getChatMessagesSpy = spyOn(
-		API.experimental,
-		"getChatMessages",
-	).mockResolvedValue(minimalMessages);
-	return () => {
-		getChatSpy.mockRestore();
-		getChatMessagesSpy.mockRestore();
-	};
-};
+const withoutQuery = (
+	queries: ReturnType<typeof buildQueries>,
+	queryKey: readonly unknown[],
+) => queries.filter(({ key }) => hashKey(key) !== hashKey(queryKey));
 
-/** The detail query fails with a 500: error view, not "Chat not found". */
 export const DetailQueryError: Story = {
-	beforeEach: () => mockChatFetchError(serverError),
+	parameters: {
+		queries: withoutQuery(
+			buildQueries(queryErrorChat, queryErrorMessages),
+			chatKey(CHAT_ID),
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChat").mockRejectedValue(serverError);
+	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(await canvas.findByText("Failed to load chat")).toBeVisible();
@@ -3118,24 +3105,15 @@ export const DetailQueryError: Story = {
 	},
 };
 
-/** The initial messages query fails: error view, not "Chat not found". */
 export const InitialMessagesError: Story = {
+	parameters: {
+		queries: withoutQuery(
+			buildQueries(queryErrorChat, queryErrorMessages),
+			chatMessagesKey(CHAT_ID),
+		),
+	},
 	beforeEach: () => {
-		const getChatSpy = spyOn(API.experimental, "getChat").mockResolvedValue(
-			minimalChat,
-		);
-		const getChatMessagesSpy = spyOn(
-			API.experimental,
-			"getChatMessages",
-		).mockImplementation((chatId) =>
-			chatId === CHAT_ID
-				? Promise.reject(serverError)
-				: Promise.resolve(minimalMessages),
-		);
-		return () => {
-			getChatSpy.mockRestore();
-			getChatMessagesSpy.mockRestore();
-		};
+		spyOn(API.experimental, "getChatMessages").mockRejectedValue(serverError);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -3144,29 +3122,19 @@ export const InitialMessagesError: Story = {
 	},
 };
 
-/** Clicking retry refetches both queries and recovers the chat. */
 export const ErrorRetryRecovers: Story = {
+	parameters: {
+		queries: withoutQuery(
+			buildQueries(queryErrorChat, queryErrorMessages),
+			chatKey(CHAT_ID),
+		),
+	},
 	beforeEach: ({ parameters }) => {
-		let shouldFail = true;
-		const getChatSpy = spyOn(API.experimental, "getChat").mockImplementation(
-			(chatId) => {
-				if (chatId === CHAT_ID && shouldFail) {
-					shouldFail = false;
-					return Promise.reject(serverError);
-				}
-				return Promise.resolve(minimalChat);
-			},
-		);
+		const getChatSpy = spyOn(API.experimental, "getChat")
+			.mockRejectedValueOnce(serverError)
+			.mockResolvedValue(queryErrorChat);
 		parameters.getChatCallsForChat = () =>
 			getChatSpy.mock.calls.filter(([chatId]) => chatId === CHAT_ID).length;
-		const getChatMessagesSpy = spyOn(
-			API.experimental,
-			"getChatMessages",
-		).mockResolvedValue(minimalMessages);
-		return () => {
-			getChatSpy.mockRestore();
-			getChatMessagesSpy.mockRestore();
-		};
 	},
 	play: async ({ canvasElement, parameters }) => {
 		const canvas = within(canvasElement);
@@ -3180,16 +3148,19 @@ export const ErrorRetryRecovers: Story = {
 	},
 };
 
-/** A genuine 404 from the detail endpoint still renders "Chat not found". */
 export const ChatNotFound: Story = {
-	beforeEach: () =>
-		mockChatFetchError({
-			isAxiosError: true,
-			response: {
-				status: 404,
-				data: { message: "Chat not found." },
-			},
-		}),
+	parameters: {
+		queries: withoutQuery(
+			buildQueries(queryErrorChat, queryErrorMessages),
+			chatKey(CHAT_ID),
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChat").mockRejectedValue({
+			...mockApiError({ message: "Chat not found." }),
+			status: 404,
+		});
+	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(await canvas.findByText("Chat not found")).toBeVisible();

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1,3 +1,5 @@
+import { isAxiosError } from "axios";
+
 import {
 	type FC,
 	useEffect,
@@ -69,6 +71,7 @@ import { pageTitle } from "#/utils/page";
 import { rewriteLocalhostURL } from "#/utils/portForward";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import {
+	AgentChatPageErrorView,
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
@@ -1877,6 +1880,40 @@ const AgentChatPage: FC = () => {
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 				showRightPanel={showSidebarPanel}
+			/>
+		);
+	}
+
+	// The detail endpoint throws on 404, so only treat a query failure as
+	// "not found" when the server actually said the chat is gone. Anything
+	// else (network, 5xx, timeout) is a retriable transport failure. This
+	// only applies when the query has no data to show; a background refetch
+	// that fails after content already rendered must not blank the page.
+	if (
+		(chatQuery.isError && chatQuery.data === undefined) ||
+		(chatMessagesQuery.isError && chatMessagesQuery.data === undefined)
+	) {
+		const chatNotFoundError =
+			isAxiosError(chatQuery.error) && chatQuery.error.response?.status === 404;
+		if (chatNotFoundError) {
+			return (
+				<AgentChatPageNotFoundView
+					titleElement={titleElement}
+					isSidebarCollapsed={isSidebarCollapsed}
+					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+				/>
+			);
+		}
+		return (
+			<AgentChatPageErrorView
+				titleElement={titleElement}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+				error={chatQuery.error ?? chatMessagesQuery.error}
+				onRetry={() => {
+					void chatQuery.refetch();
+					void chatMessagesQuery.refetch();
+				}}
 			/>
 		);
 	}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1,5 +1,3 @@
-import { isAxiosError } from "axios";
-
 import {
 	type FC,
 	useEffect,
@@ -24,7 +22,7 @@ import {
 	type CreateChatMessageRequestWithClearablePlanMode,
 	watchWorkspace,
 } from "#/api/api";
-import { getErrorMessage, isApiError } from "#/api/errors";
+import { getErrorMessage, getErrorStatus, isApiError } from "#/api/errors";
 import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
@@ -70,8 +68,8 @@ import { isMobileViewport } from "#/utils/mobile";
 import { pageTitle } from "#/utils/page";
 import { rewriteLocalhostURL } from "#/utils/portForward";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
+import { AgentChatPageErrorView } from "./AgentChatPageErrorView";
 import {
-	AgentChatPageErrorView,
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
@@ -1884,18 +1882,8 @@ const AgentChatPage: FC = () => {
 		);
 	}
 
-	// The detail endpoint throws on 404, so only treat a query failure as
-	// "not found" when the server actually said the chat is gone. Anything
-	// else (network, 5xx, timeout) is a retriable transport failure. This
-	// only applies when the query has no data to show; a background refetch
-	// that fails after content already rendered must not blank the page.
-	if (
-		(chatQuery.isError && chatQuery.data === undefined) ||
-		(chatMessagesQuery.isError && chatMessagesQuery.data === undefined)
-	) {
-		const chatNotFoundError =
-			isAxiosError(chatQuery.error) && chatQuery.error.response?.status === 404;
-		if (chatNotFoundError) {
+	if (chatQuery.isLoadingError || chatMessagesQuery.isLoadingError) {
+		if (getErrorStatus(chatQuery.error) === 404) {
 			return (
 				<AgentChatPageNotFoundView
 					titleElement={titleElement}
@@ -1904,15 +1892,22 @@ const AgentChatPage: FC = () => {
 				/>
 			);
 		}
+
 		return (
 			<AgentChatPageErrorView
 				titleElement={titleElement}
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-				error={chatQuery.error ?? chatMessagesQuery.error}
+				error={
+					chatQuery.isLoadingError ? chatQuery.error : chatMessagesQuery.error
+				}
 				onRetry={() => {
-					void chatQuery.refetch();
-					void chatMessagesQuery.refetch();
+					if (chatQuery.isLoadingError) {
+						void chatQuery.refetch();
+					}
+					if (chatMessagesQuery.isLoadingError) {
+						void chatMessagesQuery.refetch();
+					}
 				}}
 			/>
 		);

--- a/site/src/pages/AgentsPage/AgentChatPageErrorView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageErrorView.tsx
@@ -1,0 +1,60 @@
+import { RotateCcwIcon } from "lucide-react";
+import type { FC, ReactNode } from "react";
+import { getErrorDetail, getErrorMessage } from "#/api/errors";
+import { Button } from "#/components/Button/Button";
+import { ChatTopBar } from "./components/ChatTopBar";
+
+interface AgentChatPageErrorViewProps {
+	titleElement: ReactNode;
+	isSidebarCollapsed: boolean;
+	onToggleSidebarCollapsed: () => void;
+	error: unknown;
+	onRetry: () => void;
+}
+
+export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
+	titleElement,
+	isSidebarCollapsed,
+	onToggleSidebarCollapsed,
+	error,
+	onRetry,
+}) => {
+	const detail = getErrorDetail(error);
+
+	return (
+		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+			{titleElement}
+			<ChatTopBar
+				panel={{
+					showSidebarPanel: false,
+					onToggleSidebar: () => {},
+				}}
+				onArchiveAgent={() => {}}
+				onUnarchiveAgent={() => {}}
+				onArchiveAndDeleteWorkspace={() => {}}
+				hasWorkspace={false}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+			/>
+			<div className="flex flex-1 items-center justify-center px-6 text-center">
+				<div className="flex flex-col items-center">
+					<h3 className="m-0 font-medium text-base text-content-primary">
+						Failed to load chat
+					</h3>
+					<p className="m-0 mt-1 max-w-md text-sm text-content-secondary">
+						{getErrorMessage(error, "The chat could not be loaded.")}
+					</p>
+					{detail && (
+						<p className="m-0 mt-1 max-w-md text-sm text-content-secondary">
+							{detail}
+						</p>
+					)}
+					<Button size="sm" onClick={onRetry} className="mt-4">
+						<RotateCcwIcon />
+						Try again
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -18,7 +18,6 @@ import type {
 	ChatDiffStatus,
 	ChatMessagePart,
 } from "#/api/typesGenerated";
-import { Button } from "#/components/Button/Button";
 import { useProxy } from "#/contexts/ProxyContext";
 import { isWorkspaceAppEmbeddable } from "#/modules/apps/apps";
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
@@ -1154,18 +1153,16 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	);
 };
 
-interface AgentChatPageStatusViewProps {
+interface AgentChatPageNotFoundViewProps {
 	titleElement: React.ReactNode;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
-	children: React.ReactNode;
 }
 
-const AgentChatPageStatusView: FC<AgentChatPageStatusViewProps> = ({
+export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
 	titleElement,
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
-	children,
 }) => {
 	return (
 		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
@@ -1183,54 +1180,8 @@ const AgentChatPageStatusView: FC<AgentChatPageStatusViewProps> = ({
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>
 			<div className="flex flex-1 items-center justify-center text-content-secondary">
-				{children}
+				Chat not found
 			</div>
 		</div>
-	);
-};
-
-interface AgentChatPageNotFoundViewProps {
-	titleElement: React.ReactNode;
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
-}
-
-export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = (
-	props,
-) => {
-	return (
-		<AgentChatPageStatusView {...props}>Chat not found</AgentChatPageStatusView>
-	);
-};
-
-interface AgentChatPageErrorViewProps {
-	titleElement: React.ReactNode;
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
-	error: unknown;
-	onRetry: () => void;
-}
-
-export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
-	error,
-	onRetry,
-	...statusViewProps
-}) => {
-	const message =
-		error instanceof Error ? error.message : "The chat could not be loaded.";
-	return (
-		<AgentChatPageStatusView {...statusViewProps}>
-			<div className="flex flex-col items-center gap-4 px-6 text-center">
-				<div className="space-y-2">
-					<p className="font-semibold text-content-primary">
-						Failed to load chat
-					</p>
-					<p className="max-w-md text-sm">{message}</p>
-				</div>
-				<Button variant="outline" onClick={onRetry}>
-					Try again
-				</Button>
-			</div>
-		</AgentChatPageStatusView>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -18,6 +18,7 @@ import type {
 	ChatDiffStatus,
 	ChatMessagePart,
 } from "#/api/typesGenerated";
+import { Button } from "#/components/Button/Button";
 import { useProxy } from "#/contexts/ProxyContext";
 import { isWorkspaceAppEmbeddable } from "#/modules/apps/apps";
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
@@ -1153,16 +1154,18 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	);
 };
 
-interface AgentChatPageNotFoundViewProps {
+interface AgentChatPageStatusViewProps {
 	titleElement: React.ReactNode;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
+	children: React.ReactNode;
 }
 
-export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
+const AgentChatPageStatusView: FC<AgentChatPageStatusViewProps> = ({
 	titleElement,
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
+	children,
 }) => {
 	return (
 		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
@@ -1180,8 +1183,54 @@ export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>
 			<div className="flex flex-1 items-center justify-center text-content-secondary">
-				Chat not found
+				{children}
 			</div>
 		</div>
+	);
+};
+
+interface AgentChatPageNotFoundViewProps {
+	titleElement: React.ReactNode;
+	isSidebarCollapsed: boolean;
+	onToggleSidebarCollapsed: () => void;
+}
+
+export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = (
+	props,
+) => {
+	return (
+		<AgentChatPageStatusView {...props}>Chat not found</AgentChatPageStatusView>
+	);
+};
+
+interface AgentChatPageErrorViewProps {
+	titleElement: React.ReactNode;
+	isSidebarCollapsed: boolean;
+	onToggleSidebarCollapsed: () => void;
+	error: unknown;
+	onRetry: () => void;
+}
+
+export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
+	error,
+	onRetry,
+	...statusViewProps
+}) => {
+	const message =
+		error instanceof Error ? error.message : "The chat could not be loaded.";
+	return (
+		<AgentChatPageStatusView {...statusViewProps}>
+			<div className="flex flex-col items-center gap-4 px-6 text-center">
+				<div className="space-y-2">
+					<p className="font-semibold text-content-primary">
+						Failed to load chat
+					</p>
+					<p className="max-w-md text-sm">{message}</p>
+				</div>
+				<Button variant="outline" onClick={onRetry}>
+					Try again
+				</Button>
+			</div>
+		</AgentChatPageStatusView>
 	);
 };


### PR DESCRIPTION
The Coder Agents chat page rendered "Chat not found" whenever the chat detail or initial messages query failed. A network error, 500, or timeout was indistinguishable from a genuine 404, leaving users with no way to recover short of a manual reload.

Add an error branch before the not-found branch: when either query fails with no data, the page renders a "Failed to load chat" view with a retry button that refetches both queries. The API layer (axios) throws on 404, so the not-found view is now reserved for a genuine 404 from the detail endpoint or a successful response with absent data. A background refetch that fails after content already rendered keeps showing the conversation instead of blanking the page.

Stories added to AgentChatPage: detail query error, initial messages error, retry recovery via play function, and genuine 404 still rendering "Chat not found".

PR generated by Coder Agents.