### PR TITLE
fix(site/src/pages/WorkspacesPage): make workspace name a real link

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -255,6 +255,22 @@ export const AllStates: Story = {
 	},
 };
 
+export const WorkspaceNameIsALink: Story = {
+	args: {
+		workspaces: allWorkspaces,
+		count: allWorkspaces.length,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const workspace = allWorkspaces[0];
+		const link = await canvas.findByRole("link", { name: workspace.name });
+		expect(link).toHaveAttribute(
+			"href",
+			`/@${workspace.owner_name}/${workspace.name}`,
+		);
+	},
+};
+
 export const Loading: Story = {
 	args: {
 		workspaces: undefined,

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -17,7 +17,7 @@ import {
 	useState,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 import { API } from "#/api/api";
 import { templateVersion } from "#/api/queries/templates";
 import {
@@ -63,7 +63,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
-import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import {
 	getTerminalHref,
 	getVSCodeHref,
@@ -185,13 +184,13 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 					return (
 						<WorkspacesRow
 							workspace={workspace}
-							workspacePageLink={workspacePageLink}
 							key={workspace.id}
 							checked={checked}
 						>
 							<TableCell>
 								<div className="flex items-center gap-5">
 									<Checkbox
+										className="relative z-10"
 										data-testid={`checkbox-${workspace.id}`}
 										disabled={cantBeChecked(workspace)}
 										checked={checked}
@@ -216,8 +215,15 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 											<div className="flex items-center gap-1">
 												<Link
 													to={workspacePageLink}
-													onClick={(e) => e.stopPropagation()}
-													className="whitespace-nowrap text-inherit no-underline hover:underline"
+													className={cn(
+														"whitespace-nowrap text-inherit no-underline hover:underline",
+														// Stretch the anchor across the whole row so the
+														// entire row supports real link interactions such
+														// as right-click "Open in new tab" and Cmd/Ctrl
+														// click. The row is positioned relative so the
+														// overlay resolves to the row bounds.
+														"after:content-[''] after:absolute after:inset-0",
+													)}
 												>
 													{workspace.name}
 												</Link>
@@ -225,7 +231,9 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													<StarIcon className="size-icon-xs" />
 												)}
 												{workspace.outdated && (
-													<WorkspaceOutdatedTooltip workspace={workspace} />
+													<span className="relative z-10 inline-flex">
+														<WorkspaceOutdatedTooltip workspace={workspace} />
+													</span>
 												)}
 												{workspace.task_id && (
 													<Badge size="xs" variant="default">
@@ -233,10 +241,15 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													</Badge>
 												)}
 												{chatsByWorkspace?.[workspace.id] && (
-													<Badge size="xs" variant="info" hover asChild>
+													<Badge
+														size="xs"
+														variant="info"
+														hover
+														asChild
+														className="relative z-10"
+													>
 														<Link
 															to={`/agents/${chatsByWorkspace[workspace.id]}`}
-															onClick={(e) => e.stopPropagation()}
 															aria-label={`View agent conversation for ${workspace.name}`}
 														>
 															Agent
@@ -252,10 +265,12 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													{workspace.owner_name}
 													{workspace.shared_with &&
 														workspace.shared_with.length > 0 && (
-															<WorkspaceSharingIndicator
-																sharedWith={workspace.shared_with}
-																settingsPath={`/@${workspace.owner_name}/${workspace.name}/settings/sharing`}
-															/>
+															<span className="relative z-10 inline-flex">
+																<WorkspaceSharingIndicator
+																	sharedWith={workspace.shared_with}
+																	settingsPath={`/@${workspace.owner_name}/${workspace.name}/settings/sharing`}
+																/>
+															</span>
 														)}
 												</div>
 											</div>
@@ -316,44 +331,25 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 
 interface WorkspacesRowProps {
 	workspace: Workspace;
-	workspacePageLink: string;
 	children?: ReactNode;
 	checked: boolean;
 }
 
 const WorkspacesRow: FC<WorkspacesRowProps> = ({
 	workspace,
-	workspacePageLink,
 	children,
 	checked,
 }) => {
-	const navigate = useNavigate();
-
-	const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
-	const { role, hover, ...clickableProps } = useClickableTableRow({
-		onMiddleClick: openLinkInNewTab,
-		onClick: (event) => {
-			// Order of booleans actually matters here for Windows-Mac compatibility;
-			// meta key is Cmd on Macs, but on Windows, it's either the Windows key,
-			// or the key does nothing at all (depends on the browser)
-			const shouldOpenInNewTab =
-				event.shiftKey || event.metaKey || event.ctrlKey;
-
-			if (shouldOpenInNewTab) {
-				openLinkInNewTab();
-			} else {
-				navigate(workspacePageLink);
-			}
-		},
-	});
-
 	return (
 		<TableRow
-			{...clickableProps}
 			data-testid={`workspace-${workspace.id}`}
 			className={cn([
+				// The row is the positioning context for the stretched anchor
+				// rendered on the workspace name. `focus-within` keeps the row
+				// outline in sync with keyboard focus on that anchor.
+				"relative cursor-pointer hover:outline focus-within:outline outline-1 -outline-offset-1 outline-border-secondary",
+				"first:rounded-t-md last:rounded-b-md",
 				checked ? "bg-surface-secondary hover:bg-surface-secondary" : undefined,
-				clickableProps.className,
 			])}
 		>
 			{children}
@@ -488,6 +484,7 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 
 	return (
 		<TableCell
+			className="relative z-10"
 			onClick={(e) => {
 				// Prevent the click in the actions to trigger the row click
 				e.stopPropagation();

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -17,7 +17,7 @@ import {
 	useState,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 import { API } from "#/api/api";
 import { templateVersion } from "#/api/queries/templates";
 import {
@@ -63,7 +63,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
-import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import {
 	getTerminalHref,
 	getVSCodeHref,
@@ -185,13 +184,13 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 					return (
 						<WorkspacesRow
 							workspace={workspace}
-							workspacePageLink={workspacePageLink}
 							key={workspace.id}
 							checked={checked}
 						>
 							<TableCell>
 								<div className="flex items-center gap-5">
 									<Checkbox
+										className="relative z-10"
 										data-testid={`checkbox-${workspace.id}`}
 										disabled={cantBeChecked(workspace)}
 										checked={checked}
@@ -216,8 +215,19 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 											<div className="flex items-center gap-1">
 												<Link
 													to={workspacePageLink}
-													onClick={(e) => e.stopPropagation()}
-													className="whitespace-nowrap text-inherit no-underline"
+													className={cn(
+														"whitespace-nowrap text-inherit no-underline",
+														// Stretch the anchor across the whole row so the
+														// entire row is a real link (right-click "Open in
+														// new tab", middle-click, Cmd/Ctrl click). The row
+														// is positioned relative and interactive controls
+														// are raised above this overlay with z-10.
+														"after:content-[''] after:absolute after:inset-0",
+														// Show the keyboard focus outline on the whole row
+														// (via the stretched pseudo-element) rather than
+														// only around the name text.
+														"outline-none focus-visible:after:rounded-md focus-visible:after:outline focus-visible:after:outline-1 focus-visible:after:-outline-offset-1 focus-visible:after:outline-border-secondary",
+													)}
 												>
 													{workspace.name}
 												</Link>
@@ -225,7 +235,9 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													<StarIcon className="size-icon-xs" />
 												)}
 												{workspace.outdated && (
-													<WorkspaceOutdatedTooltip workspace={workspace} />
+													<span className="relative z-10 inline-flex">
+														<WorkspaceOutdatedTooltip workspace={workspace} />
+													</span>
 												)}
 												{workspace.task_id && (
 													<Badge size="xs" variant="default">
@@ -233,10 +245,15 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													</Badge>
 												)}
 												{chatsByWorkspace?.[workspace.id] && (
-													<Badge size="xs" variant="info" hover asChild>
+													<Badge
+														size="xs"
+														variant="info"
+														hover
+														asChild
+														className="relative z-10"
+													>
 														<Link
 															to={`/agents/${chatsByWorkspace[workspace.id]}`}
-															onClick={(e) => e.stopPropagation()}
 															aria-label={`View agent conversation for ${workspace.name}`}
 														>
 															Agent
@@ -252,10 +269,12 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													{workspace.owner_name}
 													{workspace.shared_with &&
 														workspace.shared_with.length > 0 && (
-															<WorkspaceSharingIndicator
-																sharedWith={workspace.shared_with}
-																settingsPath={`/@${workspace.owner_name}/${workspace.name}/settings/sharing`}
-															/>
+															<span className="relative z-10 inline-flex">
+																<WorkspaceSharingIndicator
+																	sharedWith={workspace.shared_with}
+																	settingsPath={`/@${workspace.owner_name}/${workspace.name}/settings/sharing`}
+																/>
+															</span>
 														)}
 												</div>
 											</div>
@@ -316,44 +335,24 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 
 interface WorkspacesRowProps {
 	workspace: Workspace;
-	workspacePageLink: string;
 	children?: ReactNode;
 	checked: boolean;
 }
 
 const WorkspacesRow: FC<WorkspacesRowProps> = ({
 	workspace,
-	workspacePageLink,
 	children,
 	checked,
 }) => {
-	const navigate = useNavigate();
-
-	const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
-	const { role, hover, ...clickableProps } = useClickableTableRow({
-		onMiddleClick: openLinkInNewTab,
-		onClick: (event) => {
-			// Order of booleans actually matters here for Windows-Mac compatibility;
-			// meta key is Cmd on Macs, but on Windows, it's either the Windows key,
-			// or the key does nothing at all (depends on the browser)
-			const shouldOpenInNewTab =
-				event.shiftKey || event.metaKey || event.ctrlKey;
-
-			if (shouldOpenInNewTab) {
-				openLinkInNewTab();
-			} else {
-				navigate(workspacePageLink);
-			}
-		},
-	});
-
 	return (
 		<TableRow
-			{...clickableProps}
+			hover
 			data-testid={`workspace-${workspace.id}`}
 			className={cn([
+				// Positioning context for the stretched workspace-name anchor that
+				// turns the whole row into a real link.
+				"relative",
 				checked ? "bg-surface-secondary hover:bg-surface-secondary" : undefined,
-				clickableProps.className,
 			])}
 		>
 			{children}
@@ -488,6 +487,7 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 
 	return (
 		<TableCell
+			className="relative z-10"
 			onClick={(e) => {
 				// Prevent the click in the actions to trigger the row click
 				e.stopPropagation();

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -180,10 +180,12 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 					const activeOrg = dashboard.organizations.find(
 						(o) => o.id === workspace.organization_id,
 					);
+					const workspacePageLink = `/@${workspace.owner_name}/${workspace.name}`;
 
 					return (
 						<WorkspacesRow
 							workspace={workspace}
+							workspacePageLink={workspacePageLink}
 							key={workspace.id}
 							checked={checked}
 						>
@@ -212,9 +214,13 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 									<AvatarData
 										title={
 											<div className="flex items-center gap-1">
-												<span className="whitespace-nowrap">
+												<Link
+													to={workspacePageLink}
+													onClick={(e) => e.stopPropagation()}
+													className="whitespace-nowrap text-inherit no-underline hover:underline"
+												>
 													{workspace.name}
-												</span>
+												</Link>
 												{workspace.favorite && (
 													<StarIcon className="size-icon-xs" />
 												)}
@@ -310,18 +316,19 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 
 interface WorkspacesRowProps {
 	workspace: Workspace;
+	workspacePageLink: string;
 	children?: ReactNode;
 	checked: boolean;
 }
 
 const WorkspacesRow: FC<WorkspacesRowProps> = ({
 	workspace,
+	workspacePageLink,
 	children,
 	checked,
 }) => {
 	const navigate = useNavigate();
 
-	const workspacePageLink = `/@${workspace.owner_name}/${workspace.name}`;
 	const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
 	const { role, hover, ...clickableProps } = useClickableTableRow({
 		onMiddleClick: openLinkInNewTab,

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -17,7 +17,7 @@ import {
 	useState,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { API } from "#/api/api";
 import { templateVersion } from "#/api/queries/templates";
 import {
@@ -63,6 +63,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import {
 	getTerminalHref,
 	getVSCodeHref,
@@ -184,13 +185,13 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 					return (
 						<WorkspacesRow
 							workspace={workspace}
+							workspacePageLink={workspacePageLink}
 							key={workspace.id}
 							checked={checked}
 						>
 							<TableCell>
 								<div className="flex items-center gap-5">
 									<Checkbox
-										className="relative z-10"
 										data-testid={`checkbox-${workspace.id}`}
 										disabled={cantBeChecked(workspace)}
 										checked={checked}
@@ -215,15 +216,8 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 											<div className="flex items-center gap-1">
 												<Link
 													to={workspacePageLink}
-													className={cn(
-														"whitespace-nowrap text-inherit no-underline hover:underline",
-														// Stretch the anchor across the whole row so the
-														// entire row supports real link interactions such
-														// as right-click "Open in new tab" and Cmd/Ctrl
-														// click. The row is positioned relative so the
-														// overlay resolves to the row bounds.
-														"after:content-[''] after:absolute after:inset-0",
-													)}
+													onClick={(e) => e.stopPropagation()}
+													className="whitespace-nowrap text-inherit no-underline"
 												>
 													{workspace.name}
 												</Link>
@@ -231,9 +225,7 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													<StarIcon className="size-icon-xs" />
 												)}
 												{workspace.outdated && (
-													<span className="relative z-10 inline-flex">
-														<WorkspaceOutdatedTooltip workspace={workspace} />
-													</span>
+													<WorkspaceOutdatedTooltip workspace={workspace} />
 												)}
 												{workspace.task_id && (
 													<Badge size="xs" variant="default">
@@ -241,15 +233,10 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													</Badge>
 												)}
 												{chatsByWorkspace?.[workspace.id] && (
-													<Badge
-														size="xs"
-														variant="info"
-														hover
-														asChild
-														className="relative z-10"
-													>
+													<Badge size="xs" variant="info" hover asChild>
 														<Link
 															to={`/agents/${chatsByWorkspace[workspace.id]}`}
+															onClick={(e) => e.stopPropagation()}
 															aria-label={`View agent conversation for ${workspace.name}`}
 														>
 															Agent
@@ -265,12 +252,10 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													{workspace.owner_name}
 													{workspace.shared_with &&
 														workspace.shared_with.length > 0 && (
-															<span className="relative z-10 inline-flex">
-																<WorkspaceSharingIndicator
-																	sharedWith={workspace.shared_with}
-																	settingsPath={`/@${workspace.owner_name}/${workspace.name}/settings/sharing`}
-																/>
-															</span>
+															<WorkspaceSharingIndicator
+																sharedWith={workspace.shared_with}
+																settingsPath={`/@${workspace.owner_name}/${workspace.name}/settings/sharing`}
+															/>
 														)}
 												</div>
 											</div>
@@ -331,25 +316,44 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 
 interface WorkspacesRowProps {
 	workspace: Workspace;
+	workspacePageLink: string;
 	children?: ReactNode;
 	checked: boolean;
 }
 
 const WorkspacesRow: FC<WorkspacesRowProps> = ({
 	workspace,
+	workspacePageLink,
 	children,
 	checked,
 }) => {
+	const navigate = useNavigate();
+
+	const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
+	const { role, hover, ...clickableProps } = useClickableTableRow({
+		onMiddleClick: openLinkInNewTab,
+		onClick: (event) => {
+			// Order of booleans actually matters here for Windows-Mac compatibility;
+			// meta key is Cmd on Macs, but on Windows, it's either the Windows key,
+			// or the key does nothing at all (depends on the browser)
+			const shouldOpenInNewTab =
+				event.shiftKey || event.metaKey || event.ctrlKey;
+
+			if (shouldOpenInNewTab) {
+				openLinkInNewTab();
+			} else {
+				navigate(workspacePageLink);
+			}
+		},
+	});
+
 	return (
 		<TableRow
+			{...clickableProps}
 			data-testid={`workspace-${workspace.id}`}
 			className={cn([
-				// The row is the positioning context for the stretched anchor
-				// rendered on the workspace name. `focus-within` keeps the row
-				// outline in sync with keyboard focus on that anchor.
-				"relative cursor-pointer hover:outline focus-within:outline outline-1 -outline-offset-1 outline-border-secondary",
-				"first:rounded-t-md last:rounded-b-md",
 				checked ? "bg-surface-secondary hover:bg-surface-secondary" : undefined,
+				clickableProps.className,
 			])}
 		>
 			{children}
@@ -484,7 +488,6 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 
 	return (
 		<TableCell
-			className="relative z-10"
 			onClick={(e) => {
 				// Prevent the click in the actions to trigger the row click
 				e.stopPropagation();


### PR DESCRIPTION
## Problem

On the workspaces list (`/workspaces`), rows looked and behaved like links (pointer cursor, navigate on click) but were only clickable via JavaScript, so you could not right-click → "Open in new tab" (or middle/Cmd/Ctrl-click) to open a workspace.

Fixes coder/coder#25354.

## Change

The **entire row** is now a real link, with no visual change to the row:

* The workspace name is a real `<Link>` (anchor with `href`) whose `::after` pseudo-element is stretched across the whole row (`after:content-[''] after:absolute after:inset-0`, with the row positioned `relative`) using the same pattern already used elsewhere in the codebase (`AgentRow`, `WorkspaceTimings`). Right-click "Open in new tab", middle-click, and Cmd/Ctrl-click now work anywhere on the row.
* The row keeps its original appearance (hover outline, cursor, rounded corners via the `hover` variant). Keyboard focus draws the outline over the whole row via the stretched pseudo-element.
* Interactive controls (checkbox, the "Agent" badge link, outdated/sharing indicators, and the action buttons cell) are raised above the overlay with `relative z-10`, so they remain independently clickable and keep their own targets.
* Workspace app buttons (VS Code apps, terminal, and user apps such as "claude"/"file browser") already render as real anchors via `BaseIconLink`, so they support right-click "Open in new tab" to their own targets.

The row-spanning overlay was verified in a headless Chromium check to cover every point of the row while the raised controls stay on top.

## Testing

* Added a Storybook story (`WorkspaceNameIsALink`) whose `play` function asserts the workspace name is a semantic `link` with the correct `href`.
* `pnpm test:storybook src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx` — 23 passed.
* Typecheck and Biome lint pass on the changed files.

---

*This PR was generated by Coder Agents on behalf of* @chrifro\*.\*