### PR TITLE
perf(coderd/database): speed up AI Gateway sessions list and count queries

### DIFF
--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1244,10 +1244,6 @@ type sqlcQuerier interface {
 	// Returns paginated sessions with aggregated metadata, token counts, and
 	// the most recent user prompt. A "session" is a logical grouping of
 	// interceptions that share the same session_id (set by the client).
-	//
-	// Pagination-first strategy: identify the page of sessions cheaply via a
-	// single GROUP BY scan, then do expensive lateral joins (tokens, prompts,
-	// first-interception metadata) only for the ~page-size result set.
 	// The last interception in a session has no next row, so next_seq uses
 	// the largest sequence_number instead of NULL. The lookup stays a plain
 	// range, so the (session_id, sequence_number) index answers it alone.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1029,8 +1029,9 @@ func (q *sqlQuerier) CalculateAIBridgeInterceptionsTelemetrySummary(ctx context.
 }
 
 const countAIBridgeSessions = `-- name: CountAIBridgeSessions :one
+SELECT COUNT(*) FROM (
 SELECT
-	COUNT(DISTINCT (aibridge_interceptions.session_id, aibridge_interceptions.initiator_id))
+	1
 FROM
 	aibridge_interceptions
 WHERE
@@ -1077,6 +1078,9 @@ WHERE
 	END
 	-- Authorize Filter clause will be injected below in CountAuthorizedAIBridgeSessions
 	-- @authorize_filter
+GROUP BY
+	aibridge_interceptions.session_id, aibridge_interceptions.initiator_id
+) grouped_sessions
 `
 
 type CountAIBridgeSessionsParams struct {
@@ -2233,12 +2237,8 @@ WITH cursor_pos AS (
 	WHERE ai.session_id = $1 AND ai.ended_at IS NOT NULL
 ),
 session_page AS (
-	-- Paginate at the session level first; only cheap aggregates here.
-	-- A lateral correlated subquery for prompts keeps the join one-to-one
-	-- with aibridge_interceptions so COUNT(*) for thread tallies is not
-	-- inflated. LIMIT 1 combined with the (interception_id, created_at DESC)
-	-- index makes this an index-only lookup per interception row rather than
-	-- a full-table-scan GROUP BY over all prompts.
+	-- Aggregate prompts to one row per interception so prompt fan-out does not
+	-- inflate thread counts.
 	-- last_active_at is the latest prompt timestamp, falling back to
 	-- MIN(started_at) for sessions with no prompts. The COALESCE ensures
 	-- it is never NULL so the HAVING row-value cursor comparison is safe.
@@ -2251,13 +2251,11 @@ session_page AS (
 		COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at))::timestamptz AS last_active_at
 	FROM
 		aibridge_interceptions ai
-	LEFT JOIN LATERAL (
-		SELECT created_at AS latest_prompt_at
+	LEFT JOIN (
+		SELECT interception_id, MAX(created_at) AS latest_prompt_at
 		FROM aibridge_user_prompts
-		WHERE interception_id = ai.id
-		ORDER BY created_at DESC
-		LIMIT 1
-	) latest_prompt ON true
+		GROUP BY interception_id
+	) latest_prompt ON latest_prompt.interception_id = ai.id
 	WHERE
 		-- Remove inflight interceptions (ones which lack an ended_at value).
 		ai.ended_at IS NOT NULL
@@ -2456,10 +2454,6 @@ type ListAIBridgeSessionsRow struct {
 // Returns paginated sessions with aggregated metadata, token counts, and
 // the most recent user prompt. A "session" is a logical grouping of
 // interceptions that share the same session_id (set by the client).
-//
-// Pagination-first strategy: identify the page of sessions cheaply via a
-// single GROUP BY scan, then do expensive lateral joins (tokens, prompts,
-// first-interception metadata) only for the ~page-size result set.
 // The last interception in a session has no next row, so next_seq uses
 // the largest sequence_number instead of NULL. The lookup stays a plain
 // range, so the (session_id, sequence_number) index answers it alone.

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -299,8 +299,9 @@ SELECT (
 )::bigint as total_deleted;
 
 -- name: CountAIBridgeSessions :one
+SELECT COUNT(*) FROM (
 SELECT
-	COUNT(DISTINCT (aibridge_interceptions.session_id, aibridge_interceptions.initiator_id))
+	1
 FROM
 	aibridge_interceptions
 WHERE
@@ -347,16 +348,14 @@ WHERE
 	END
 	-- Authorize Filter clause will be injected below in CountAuthorizedAIBridgeSessions
 	-- @authorize_filter
-;
+GROUP BY
+	aibridge_interceptions.session_id, aibridge_interceptions.initiator_id
+) grouped_sessions;
 
 -- name: ListAIBridgeSessions :many
 -- Returns paginated sessions with aggregated metadata, token counts, and
 -- the most recent user prompt. A "session" is a logical grouping of
 -- interceptions that share the same session_id (set by the client).
---
--- Pagination-first strategy: identify the page of sessions cheaply via a
--- single GROUP BY scan, then do expensive lateral joins (tokens, prompts,
--- first-interception metadata) only for the ~page-size result set.
 WITH cursor_pos AS (
 	-- Resolve the cursor's last_active_at once, outside the HAVING clause,
 	-- so the planner cannot accidentally re-evaluate it per group. Direct
@@ -370,12 +369,8 @@ WITH cursor_pos AS (
 	WHERE ai.session_id = @after_session_id AND ai.ended_at IS NOT NULL
 ),
 session_page AS (
-	-- Paginate at the session level first; only cheap aggregates here.
-	-- A lateral correlated subquery for prompts keeps the join one-to-one
-	-- with aibridge_interceptions so COUNT(*) for thread tallies is not
-	-- inflated. LIMIT 1 combined with the (interception_id, created_at DESC)
-	-- index makes this an index-only lookup per interception row rather than
-	-- a full-table-scan GROUP BY over all prompts.
+	-- Aggregate prompts to one row per interception so prompt fan-out does not
+	-- inflate thread counts.
 	-- last_active_at is the latest prompt timestamp, falling back to
 	-- MIN(started_at) for sessions with no prompts. The COALESCE ensures
 	-- it is never NULL so the HAVING row-value cursor comparison is safe.
@@ -388,13 +383,11 @@ session_page AS (
 		COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at))::timestamptz AS last_active_at
 	FROM
 		aibridge_interceptions ai
-	LEFT JOIN LATERAL (
-		SELECT created_at AS latest_prompt_at
+	LEFT JOIN (
+		SELECT interception_id, MAX(created_at) AS latest_prompt_at
 		FROM aibridge_user_prompts
-		WHERE interception_id = ai.id
-		ORDER BY created_at DESC
-		LIMIT 1
-	) latest_prompt ON true
+		GROUP BY interception_id
+	) latest_prompt ON latest_prompt.interception_id = ai.id
 	WHERE
 		-- Remove inflight interceptions (ones which lack an ended_at value).
 		ai.ended_at IS NOT NULL


### PR DESCRIPTION
Opening https://dev.coder.com/ai-gateway/sessions takes 10-15s on dogfood. The page fires 3 concurrent `GET /api/v2/ai-gateway/sessions` requests (current page plus next/previous prefetch), and each one runs two queries that do O(all interceptions) work (954k rows on dogfood today). This PR rewrites both queries; a simulated page load (3 concurrent count+list pairs against the dogfood database) drops from 13.8s to 6.7s, and single filtered requests improve proportionally.

## Problem

`CountAIBridgeSessions` used `COUNT(DISTINCT (session_id, initiator_id))`, which Postgres executes as a full sort of every interception row, spilling ~125MB to disk. `ListAIBridgeSessions` resolved each session's latest prompt with a correlated `LIMIT 1` lateral, costing one index search per interception row (950k index searches, 2.9M buffer hits) before grouping.

## Fix

- Count over a `GROUP BY session_id, initiator_id` subquery instead of `COUNT(DISTINCT (row))`, letting the planner hash-aggregate: 4.6s -> 0.38s.
- Pre-aggregate prompts to one `MAX(created_at)` row per interception and hash-join, which also unlocks parallel workers: page-1 list 4.2s -> 1.7s.

Both rewrites preserve the one-row-per-interception join shape, so thread counts and cursor pagination semantics are unchanged.

## Validation

A 21-scenario harness ran the exact old (`origin/main`) and new (this PR) SQL against the dogfood database, comparing full result sets and median-of-3 `EXPLAIN ANALYZE` timings per scenario: all filter combinations (initiator, provider+model, client, session_id, time windows), offset/cursor/deep pagination, an injected RBAC member filter, and empty results. All 21 scenarios returned identical results. Two initial mismatches were proven to be live-data churn: re-running the unmodified old query against itself minutes apart showed the same drift (`ended_at`/token sums of an in-flight session), while adjacent-in-time old-vs-new runs matched exactly.

Timing highlights (median of 3, dogfood):

| Scenario | Old | New |
|---|---|---|
| Count, no filters | 4634ms | 384ms |
| List page 1 (limit 25) | 4197ms | 1724ms |
| List page 2 (offset 25) | 4495ms | 2212ms |
| List cursor pagination | 3010ms | 1475ms |
| Count by initiator | 512ms | 115ms |
| List by provider+model | 802ms | 657ms |
| Simulated page load (3 concurrent requests) | 13.8s | 6.7s |

Measured tradeoff: highly selective filters (single session, low-activity initiator) go from ~2-3ms to ~75ms because the prompt pre-aggregation scans all prompts regardless of filter selectivity. Absolute latency stays imperceptible, and those paths are not the ones users wait on.

Existing coverage: `TestAIBridgeListSessions` (pagination, filters, RBAC) and dbauthz suites pass against Postgres.

> Mux acted on Mike's behalf to investigate, implement, and validate this change.
