### PR TITLE
fix(coderd/database): match group name case-insensitively in search

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -14976,7 +14976,9 @@ FROM
 WHERE
 	organization_id = $1
 AND
-	name = $2
+	-- Match group name case-insensitively, consistent with organization and
+	-- workspace name lookups.
+	LOWER("name") = LOWER($2)
 LIMIT
 	1
 `

--- a/coderd/database/queries/groups.sql
+++ b/coderd/database/queries/groups.sql
@@ -32,9 +32,11 @@ SELECT
 FROM
 	groups
 WHERE
-	organization_id = $1
+	organization_id = @organization_id
 AND
-	name = $2
+	-- Match group name case-insensitively, consistent with organization and
+	-- workspace name lookups.
+	LOWER("name") = LOWER(@name)
 LIMIT
 	1;
 

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -417,6 +417,27 @@ func TestSearchWorkspace(t *testing.T) {
 			},
 		},
 		{
+			Name: "SharedWithGroupInOrgMixedCase",
+			// The parser lowercases the whole query, so a group whose stored
+			// name contains uppercase letters must still resolve. See
+			// GetGroupByOrgAndName, which matches the name case-insensitively.
+			Query: "shared_with_group:wibble/SupportShare",
+			Setup: func(t *testing.T, db database.Store) {
+				org := dbgen.Organization(t, db, database.Organization{
+					ID:   uuid.MustParse("b5f9d1f4-6d0e-4f6a-9a4a-7b2c3d4e5f60"),
+					Name: "wibble",
+				})
+				dbgen.Group(t, db, database.Group{
+					ID:             uuid.MustParse("1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d"),
+					Name:           "SupportShare",
+					OrganizationID: org.ID,
+				})
+			},
+			Expected: database.GetWorkspacesParams{
+				SharedWithGroupID: uuid.MustParse("1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d"),
+			},
+		},
+		{
 			Name:  "SharedWithGroupID",
 			Query: "shared_with_group:a7d1ba00-53c7-4aa6-92ea-83157dd57480",
 			Setup: func(t *testing.T, db database.Store) {

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -199,11 +199,14 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Name != "" && req.Name != group.Name {
-		_, err := api.Database.GetGroupByOrgAndName(ctx, database.GetGroupByOrgAndNameParams{
+		existing, err := api.Database.GetGroupByOrgAndName(ctx, database.GetGroupByOrgAndNameParams{
 			OrganizationID: group.OrganizationID,
 			Name:           req.Name,
 		})
-		if err == nil {
+		// GetGroupByOrgAndName matches names case-insensitively, so exclude the
+		// group being renamed. This allows changing only the casing of a name
+		// while still rejecting a name already taken by a different group.
+		if err == nil && existing.ID != group.ID {
 			httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
 				Message: fmt.Sprintf("A group with name %q already exists.", req.Name),
 			})

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -242,6 +242,31 @@ func TestPatchGroup(t *testing.T) {
 		require.Equal(t, "hi", group.Name)
 	})
 
+	t.Run("RenameCasingOnlyOK", func(t *testing.T) {
+		t.Parallel()
+
+		client, user := coderdenttest.New(t, &coderdenttest.Options{LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureTemplateRBAC: 1,
+			},
+		}})
+		userAdminClient, _ := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleUserAdmin())
+		ctx := testutil.Context(t, testutil.WaitLong)
+		group, err := userAdminClient.CreateGroup(ctx, user.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "supportshare",
+		})
+		require.NoError(t, err)
+
+		// GetGroupByOrgAndName now matches names case-insensitively, so the
+		// conflict check must exclude the group being renamed. Otherwise it
+		// would find itself and reject a rename that only changes casing.
+		group, err = userAdminClient.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
+			Name: "SupportShare",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "SupportShare", group.Name)
+	})
+
 	t.Run("AddUsers", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Problem

`coder list --search shared_with_group:<org>/<name>` fails whenever the group's name contains uppercase letters.

The workspace search parser lowercases the entire query string before the value is resolved, but `GetGroupByOrgAndName` matched the name with an exact-case comparison (`name = $2`). The lowercased value therefore never matched a mixed-case group, and the API returned a misleading error implying the group does not exist or the caller is unauthorized. The sibling `GetOrganizationByName` already uses `LOWER("name") = LOWER(@name)`, so the org half of the reference worked case-insensitively while the group half did not. Looking up a group by UUID was unaffected.

Fixes [PRODUCT-518](https://linear.app/codercom/issue/PRODUCT-518/bug-searching-for-shared-with-group-using-cli-fails).

## Changes

- `coderd/database/queries/groups.sql`: `GetGroupByOrgAndName` now matches the name case-insensitively (`LOWER("name") = LOWER(@name)`), consistent with organization and workspace name lookups. Regenerated `queries.sql.go` via sqlc.
- `enterprise/coderd/groups.go`: guard the group-rename conflict check so it excludes the group being renamed. Because the lookup is now case-insensitive, a case-only rename (e.g. `supportshare` -> `SupportShare`) would otherwise match itself and be falsely rejected.
- Tests: added `TestSearchWorkspace/SharedWithGroupInOrgMixedCase` and `TestPatchGroup/RenameCasingOnlyOK`.

This is a backend/CLI behavior fix with no UI changes. Test output is included below as evidence.

```
$ go test ./coderd/searchquery/ -run 'TestSearchWorkspace/SharedWithGroup' -count=1
ok  github.com/coder/coder/v2/coderd/searchquery 2.631s

$ go test ./enterprise/coderd/ -run 'TestPatchGroup/RenameCasingOnlyOK|TestPatchGroup/NameConflict|TestPatchGroup/SameNameOK' -count=1
ok  github.com/coder/coder/v2/enterprise/coderd 0.242s
```

<details>
<summary>Scope notes / decision log</summary>

- The Linear issue also suggested improving the error message to distinguish "not found" from "unauthorized" from "org not found", and mentioned `--shared-with-me` / `--shared-with-group` CLI ergonomics. Those are separate concerns and are intentionally left out of this bug fix to keep it minimal and reviewable.
- The `groups` table has a case-sensitive unique constraint `UNIQUE (name, organization_id)`, so two groups differing only by case can technically coexist; in that rare case the case-insensitive lookup returns one arbitrarily (`LIMIT 1`). This matches existing organization lookup behavior. Enforcing case-insensitive uniqueness on group creation would require a schema/migration change and is out of scope.
- The change also makes `ExtractGroupByNameParam` (group-by-name URL resolution) case-insensitive, which is consistent with organization URL resolution.

</details>

---
_This PR was generated by Coder Agents on behalf of @david-fraley._