### PR TITLE
fix(coderd): show correct deletion time in dormancy notification (backport #26488)

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -382,8 +382,11 @@ func (e *Executor) runOnce(t time.Time) Stats {
 							Old: wsOld.WorkspaceTable(),
 							New: wsNew,
 						}
-						// To keep the `ws` accurate without doing a sql fetch
+						// To keep the `ws` accurate without doing a sql fetch.
+						// deleting_at is computed by the UPDATE from the template's
+						// time_til_dormant_autodelete.
 						ws.DormantAt = wsNew.DormantAt
+						ws.DeletingAt = wsNew.DeletingAt
 
 						shouldNotifyDormancy = true
 
@@ -467,7 +470,14 @@ func (e *Executor) runOnce(t time.Time) Stats {
 					}
 				}
 				if shouldNotifyDormancy {
-					dormantTime := dbtime.Now().Add(time.Duration(tmpl.TimeTilDormant))
+					// The notification body renders this label inside the
+					// "will be automatically deleted in ..." sentence, so it
+					// must carry the auto-delete countdown. When auto-delete is
+					// disabled there is no deadline, so use generic wording.
+					timeTilDelete := "line with your template's auto-deletion policy"
+					if ws.DeletingAt.Valid {
+						timeTilDelete = humanize.Time(ws.DeletingAt.Time)
+					}
 					_, err = e.notificationsEnqueuer.Enqueue(
 						e.ctx,
 						ws.OwnerID,
@@ -475,7 +485,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 						map[string]string{
 							"name":           ws.Name,
 							"reason":         "inactivity exceeded the dormancy threshold",
-							"timeTilDormant": humanize.Time(dormantTime),
+							"timeTilDormant": timeTilDelete,
 						},
 						"lifecycle_executor",
 						ws.ID,

--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -382,9 +382,8 @@ func (e *Executor) runOnce(t time.Time) Stats {
 							Old: wsOld.WorkspaceTable(),
 							New: wsNew,
 						}
-						// To keep the `ws` accurate without doing a sql fetch.
-						// deleting_at is computed by the UPDATE from the template's
-						// time_til_dormant_autodelete.
+						// Keep `ws` accurate without a sql fetch. The UPDATE derives
+						// deleting_at from the template's time_til_dormant_autodelete.
 						ws.DormantAt = wsNew.DormantAt
 						ws.DeletingAt = wsNew.DeletingAt
 
@@ -470,10 +469,9 @@ func (e *Executor) runOnce(t time.Time) Stats {
 					}
 				}
 				if shouldNotifyDormancy {
-					// The notification body renders this label inside the
-					// "will be automatically deleted in ..." sentence, so it
-					// must carry the auto-delete countdown. When auto-delete is
-					// disabled there is no deadline, so use generic wording.
+					// The body renders this label in its "will be automatically
+					// deleted in ..." sentence, so it must carry the auto-delete
+					// countdown, or generic wording when there is no deadline.
 					timeTilDelete := "line with your template's auto-deletion policy"
 					if ws.DeletingAt.Valid {
 						timeTilDelete = humanize.Time(ws.DeletingAt.Time)

--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -469,13 +468,6 @@ func (e *Executor) runOnce(t time.Time) Stats {
 					}
 				}
 				if shouldNotifyDormancy {
-					// The body renders this label in its "will be automatically
-					// deleted in ..." sentence, so it must carry the auto-delete
-					// countdown, or generic wording when there is no deadline.
-					timeTilDelete := "line with your template's auto-deletion policy"
-					if ws.DeletingAt.Valid {
-						timeTilDelete = humanize.Time(ws.DeletingAt.Time)
-					}
 					_, err = e.notificationsEnqueuer.Enqueue(
 						e.ctx,
 						ws.OwnerID,
@@ -483,7 +475,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 						map[string]string{
 							"name":           ws.Name,
 							"reason":         "inactivity exceeded the dormancy threshold",
-							"timeTilDormant": timeTilDelete,
+							"timeTilDormant": notifications.DormantDeletionText(ws.DeletingAt),
 						},
 						"lifecycle_executor",
 						ws.ID,

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -1337,8 +1337,6 @@ func TestNotifications(t *testing.T) {
 		require.Contains(t, sent[0].Targets, workspace.OrganizationID)
 		require.Contains(t, sent[0].Targets, workspace.OwnerID)
 
-		// Auto-delete is not configured, so the label must fall back to
-		// generic wording instead of promising a deletion time.
 		require.Equal(t, "line with your template's auto-deletion policy", sent[0].Labels["timeTilDormant"])
 		require.Equal(t, workspace.Name, sent[0].Labels["name"])
 		require.Equal(t, "inactivity exceeded the dormancy threshold", sent[0].Labels["reason"])
@@ -1347,14 +1345,11 @@ func TestNotifications(t *testing.T) {
 	t.Run("DormancyAutoDelete", func(t *testing.T) {
 		t.Parallel()
 
-		// Setup template with dormancy and auto-delete and create a workspace
-		// with it. The two durations are intentionally far apart to reliably
-		// check what's rendered in the notification.
 		var (
 			ticker    = make(chan time.Time)
 			statCh    = make(chan autobuild.Stats)
 			notifyEnq = notificationstest.FakeEnqueuer{}
-			// 35 days is inside humanize.Time's "1 month" bucket (between 30 and 60 days).
+			// 35 days keeps humanize.Time deterministically in its "1 month" bucket.
 			timeTilDormant           = time.Minute
 			timeTilDormantAutoDelete = 35 * 24 * time.Hour
 			client, db               = coderdtest.NewWithDatabase(t, &coderdtest.Options{
@@ -1393,27 +1388,21 @@ func TestNotifications(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, userClient, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, workspace.LatestBuild.ID)
 
-		// Stop workspace
 		workspace = coderdtest.MustTransitionWorkspace(t, client, workspace.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
 		_ = coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, workspace.LatestBuild.ID)
 
 		p, err := coderdtest.GetProvisionerForTags(db, time.Now(), workspace.OrganizationID, nil)
 		require.NoError(t, err)
 
-		// Wait for workspace to become dormant
 		notifyEnq.Clear()
 		tickTime := workspace.LastUsedAt.Add(timeTilDormant * 3)
 		coderdtest.UpdateProvisionerLastSeenAt(t, db, p.ID, tickTime)
 		ticker <- tickTime
 		_ = testutil.TryReceive(testutil.Context(t, testutil.WaitShort), t, statCh)
 
-		// Check that the workspace is dormant
 		workspace = coderdtest.MustWorkspace(t, client, workspace.ID)
 		require.NotNil(t, workspace.DormantAt)
 
-		// The label must render the deletion countdown from the template's
-		// `time_til_dormant_autodelete` value. With auto-delete at 35 days and
-		// dormancy at 1 minute, humanize.Time renders it as "1 month from now".
 		sent := notifyEnq.Sent()
 		require.Len(t, sent, 1)
 		require.Equal(t, sent[0].TemplateID, notifications.TemplateWorkspaceDormant)

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -1336,6 +1336,94 @@ func TestNotifications(t *testing.T) {
 		require.Contains(t, sent[0].Targets, workspace.ID)
 		require.Contains(t, sent[0].Targets, workspace.OrganizationID)
 		require.Contains(t, sent[0].Targets, workspace.OwnerID)
+
+		// Auto-delete is not configured, so the label must fall back to
+		// generic wording instead of promising a deletion time.
+		require.Equal(t, "line with your template's auto-deletion policy", sent[0].Labels["timeTilDormant"])
+		require.Equal(t, workspace.Name, sent[0].Labels["name"])
+		require.Equal(t, "inactivity exceeded the dormancy threshold", sent[0].Labels["reason"])
+	})
+
+	t.Run("DormancyAutoDelete", func(t *testing.T) {
+		t.Parallel()
+
+		// Setup template with dormancy and auto-delete and create a workspace
+		// with it. The two durations are intentionally far apart to reliably
+		// check what's rendered in the notification.
+		var (
+			ticker    = make(chan time.Time)
+			statCh    = make(chan autobuild.Stats)
+			notifyEnq = notificationstest.FakeEnqueuer{}
+			// 35 days is inside humanize.Time's "1 month" bucket (between 30 and 60 days).
+			timeTilDormant           = time.Minute
+			timeTilDormantAutoDelete = 35 * 24 * time.Hour
+			client, db               = coderdtest.NewWithDatabase(t, &coderdtest.Options{
+				AutobuildTicker:          ticker,
+				AutobuildStats:           statCh,
+				IncludeProvisionerDaemon: true,
+				NotificationsEnqueuer:    &notifyEnq,
+				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
+					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
+						template.TimeTilDormant = int64(options.TimeTilDormant)
+						template.TimeTilDormantAutoDelete = int64(options.TimeTilDormantAutoDelete)
+						return schedule.NewAGPLTemplateScheduleStore().Set(ctx, db, template, options)
+					},
+					GetFn: func(_ context.Context, _ database.Store, _ uuid.UUID) (schedule.TemplateScheduleOptions, error) {
+						return schedule.TemplateScheduleOptions{
+							UserAutostartEnabled:     false,
+							UserAutostopEnabled:      true,
+							DefaultTTL:               0,
+							AutostopRequirement:      schedule.TemplateAutostopRequirement{},
+							TimeTilDormant:           timeTilDormant,
+							TimeTilDormantAutoDelete: timeTilDormantAutoDelete,
+						}, nil
+					},
+				},
+			})
+			admin   = coderdtest.CreateFirstUser(t, client)
+			version = coderdtest.CreateTemplateVersion(t, client, admin.OrganizationID, nil)
+		)
+
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, admin.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+			ctr.TimeTilDormantMillis = ptr.Ref(timeTilDormant.Milliseconds())
+			ctr.TimeTilDormantAutoDeleteMillis = ptr.Ref(timeTilDormantAutoDelete.Milliseconds())
+		})
+		userClient, _ := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
+		workspace := coderdtest.CreateWorkspace(t, userClient, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, workspace.LatestBuild.ID)
+
+		// Stop workspace
+		workspace = coderdtest.MustTransitionWorkspace(t, client, workspace.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
+		_ = coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, workspace.LatestBuild.ID)
+
+		p, err := coderdtest.GetProvisionerForTags(db, time.Now(), workspace.OrganizationID, nil)
+		require.NoError(t, err)
+
+		// Wait for workspace to become dormant
+		notifyEnq.Clear()
+		tickTime := workspace.LastUsedAt.Add(timeTilDormant * 3)
+		coderdtest.UpdateProvisionerLastSeenAt(t, db, p.ID, tickTime)
+		ticker <- tickTime
+		_ = testutil.TryReceive(testutil.Context(t, testutil.WaitShort), t, statCh)
+
+		// Check that the workspace is dormant
+		workspace = coderdtest.MustWorkspace(t, client, workspace.ID)
+		require.NotNil(t, workspace.DormantAt)
+
+		// The label must render the deletion countdown from the template's
+		// `time_til_dormant_autodelete` value. With auto-delete at 35 days and
+		// dormancy at 1 minute, humanize.Time renders it as "1 month from now".
+		sent := notifyEnq.Sent()
+		require.Len(t, sent, 1)
+		require.Equal(t, sent[0].TemplateID, notifications.TemplateWorkspaceDormant)
+		require.Contains(t, sent[0].Labels, "timeTilDormant")
+		require.Contains(t, sent[0].Labels["timeTilDormant"], "1 month",
+			"timeTilDormant must humanize TimeTilDormantAutoDelete, got %q",
+			sent[0].Labels["timeTilDormant"])
+		require.NotContains(t, sent[0].Labels["timeTilDormant"], "ago",
+			"timeTilDormant must be a future timestamp, got %q",
+			sent[0].Labels["timeTilDormant"])
 	})
 }
 

--- a/coderd/notifications/dormancy.go
+++ b/coderd/notifications/dormancy.go
@@ -1,0 +1,16 @@
+package notifications
+
+import (
+	"database/sql"
+
+	"github.com/dustin/go-humanize"
+)
+
+// DormantDeletionText supplies the timeTilDormant label embedded in the stored
+// TemplateWorkspaceDormant "will be automatically deleted in ..." sentence.
+func DormantDeletionText(deletingAt sql.NullTime) string {
+	if deletingAt.Valid {
+		return humanize.Time(deletingAt.Time)
+	}
+	return "line with your template's auto-deletion policy"
+}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1515,10 +1515,9 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		if initiatorErr == nil {
-			// The notification body renders this label inside the
-			// "will be automatically deleted in ..." sentence, so it must
-			// carry the auto-delete countdown. When auto-delete is disabled
-			// there is no deadline, so use generic wording.
+			// The body renders this label in its "will be automatically
+			// deleted in ..." sentence, so it must carry the auto-delete
+			// countdown, or generic wording when there is no deadline.
 			timeTilDelete := "line with your template's auto-deletion policy"
 			if newWorkspace.DeletingAt.Valid {
 				timeTilDelete = humanize.Time(newWorkspace.DeletingAt.Time)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -1515,13 +1514,6 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		if initiatorErr == nil {
-			// The body renders this label in its "will be automatically
-			// deleted in ..." sentence, so it must carry the auto-delete
-			// countdown, or generic wording when there is no deadline.
-			timeTilDelete := "line with your template's auto-deletion policy"
-			if newWorkspace.DeletingAt.Valid {
-				timeTilDelete = humanize.Time(newWorkspace.DeletingAt.Time)
-			}
 			_, err = api.NotificationsEnqueuer.Enqueue(
 				// nolint:gocritic // Need notifier actor to enqueue notifications
 				dbauthz.AsNotifier(ctx),
@@ -1530,7 +1522,7 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 				map[string]string{
 					"name":           newWorkspace.Name,
 					"reason":         "a " + initiator.Username + " request",
-					"timeTilDormant": timeTilDelete,
+					"timeTilDormant": notifications.DormantDeletionText(newWorkspace.DeletingAt),
 				},
 				"api",
 				newWorkspace.ID,

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1514,19 +1514,15 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 			)
 		}
 
-		tmpl, tmplErr := api.Database.GetTemplateByID(ctx, newWorkspace.TemplateID)
-		if tmplErr != nil {
-			api.Logger.Warn(
-				ctx,
-				"failed to fetch the template of the workspace marked as dormant",
-				slog.Error(err),
-				slog.F("workspace_id", newWorkspace.ID),
-				slog.F("template_id", newWorkspace.TemplateID),
-			)
-		}
-
-		if initiatorErr == nil && tmplErr == nil {
-			dormantTime := dbtime.Time(now).Add(time.Duration(tmpl.TimeTilDormant))
+		if initiatorErr == nil {
+			// The notification body renders this label inside the
+			// "will be automatically deleted in ..." sentence, so it must
+			// carry the auto-delete countdown. When auto-delete is disabled
+			// there is no deadline, so use generic wording.
+			timeTilDelete := "line with your template's auto-deletion policy"
+			if newWorkspace.DeletingAt.Valid {
+				timeTilDelete = humanize.Time(newWorkspace.DeletingAt.Time)
+			}
 			_, err = api.NotificationsEnqueuer.Enqueue(
 				// nolint:gocritic // Need notifier actor to enqueue notifications
 				dbauthz.AsNotifier(ctx),
@@ -1535,7 +1531,7 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 				map[string]string{
 					"name":           newWorkspace.Name,
 					"reason":         "a " + initiator.Username + " request",
-					"timeTilDormant": humanize.Time(dormantTime),
+					"timeTilDormant": timeTilDelete,
 				},
 				"api",
 				newWorkspace.ID,

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -5156,6 +5156,75 @@ func TestWorkspaceNotifications(t *testing.T) {
 			require.Contains(t, sent[0].Targets, workspace.ID)
 			require.Contains(t, sent[0].Targets, workspace.OrganizationID)
 			require.Contains(t, sent[0].Targets, workspace.OwnerID)
+			// Auto-delete is not configured, so the label must fall back to
+			// generic wording instead of promising a deletion time.
+			require.Equal(t, "line with your template's auto-deletion policy", sent[0].Labels["timeTilDormant"])
+		})
+
+		t.Run("InitiatorNotOwnerWithAutoDelete", func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			var (
+				notifyEnq = &notificationstest.FakeEnqueuer{}
+				// 35 days sits solidly inside humanize.Time's "1 month"
+				// bucket (between 30 and 60 days), so the rendered label is
+				// deterministic regardless of microsecond-level timing
+				// differences.
+				timeTilDormantAutoDelete = 35 * 24 * time.Hour
+				client                   = coderdtest.New(t, &coderdtest.Options{
+					IncludeProvisionerDaemon: true,
+					NotificationsEnqueuer:    notifyEnq,
+					// AGPL templateScheduleStore drops TimeTilDormantAutoDelete
+					// when Set runs. The mock propagates it into the template
+					// row so the UPDATE in UpdateWorkspaceDormantDeletingAt
+					// can compute deleting_at.
+					TemplateScheduleStore: schedule.MockTemplateScheduleStore{
+						SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
+							template.TimeTilDormantAutoDelete = int64(options.TimeTilDormantAutoDelete)
+							return schedule.NewAGPLTemplateScheduleStore().Set(ctx, db, template, options)
+						},
+						GetFn: func(_ context.Context, _ database.Store, _ uuid.UUID) (schedule.TemplateScheduleOptions, error) {
+							return schedule.TemplateScheduleOptions{
+								UserAutostartEnabled:     false,
+								UserAutostopEnabled:      true,
+								DefaultTTL:               0,
+								AutostopRequirement:      schedule.TemplateAutostopRequirement{},
+								TimeTilDormantAutoDelete: timeTilDormantAutoDelete,
+							}, nil
+						},
+					},
+				})
+				user            = coderdtest.CreateFirstUser(t, client)
+				memberClient, _ = coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleOwner())
+				version         = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+				_               = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+				template        = coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+					ctr.TimeTilDormantAutoDeleteMillis = ptr.Ref[int64](timeTilDormantAutoDelete.Milliseconds())
+				})
+				workspace = coderdtest.CreateWorkspace(t, client, template.ID)
+				_         = coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+			t.Cleanup(cancel)
+
+			// When
+			err := memberClient.UpdateWorkspaceDormancy(ctx, workspace.ID, codersdk.UpdateWorkspaceDormancy{
+				Dormant: true,
+			})
+
+			// Then
+			require.NoError(t, err, "mark workspace as dormant")
+			sent := notifyEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateWorkspaceDormant))
+			require.Len(t, sent, 1)
+			require.Contains(t, sent[0].Labels, "timeTilDormant")
+			require.Contains(t, sent[0].Labels["timeTilDormant"], "1 month",
+				"timeTilDormant must humanize the workspace's deleting_at, got %q",
+				sent[0].Labels["timeTilDormant"])
+			require.NotContains(t, sent[0].Labels["timeTilDormant"], "ago",
+				"timeTilDormant must be a future timestamp, got %q",
+				sent[0].Labels["timeTilDormant"])
 		})
 
 		t.Run("InitiatorIsOwner", func(t *testing.T) {

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -5156,8 +5156,6 @@ func TestWorkspaceNotifications(t *testing.T) {
 			require.Contains(t, sent[0].Targets, workspace.ID)
 			require.Contains(t, sent[0].Targets, workspace.OrganizationID)
 			require.Contains(t, sent[0].Targets, workspace.OwnerID)
-			// Auto-delete is not configured, so the label must fall back to
-			// generic wording instead of promising a deletion time.
 			require.Equal(t, "line with your template's auto-deletion policy", sent[0].Labels["timeTilDormant"])
 		})
 
@@ -5167,18 +5165,13 @@ func TestWorkspaceNotifications(t *testing.T) {
 			// Given
 			var (
 				notifyEnq = &notificationstest.FakeEnqueuer{}
-				// 35 days sits solidly inside humanize.Time's "1 month"
-				// bucket (between 30 and 60 days), so the rendered label is
-				// deterministic regardless of microsecond-level timing
-				// differences.
+				// 35 days keeps humanize.Time deterministically in its "1 month" bucket.
 				timeTilDormantAutoDelete = 35 * 24 * time.Hour
 				client                   = coderdtest.New(t, &coderdtest.Options{
 					IncludeProvisionerDaemon: true,
 					NotificationsEnqueuer:    notifyEnq,
-					// AGPL templateScheduleStore drops TimeTilDormantAutoDelete
-					// when Set runs. The mock propagates it into the template
-					// row so the UPDATE in UpdateWorkspaceDormantDeletingAt
-					// can compute deleting_at.
+					// The AGPL store ignores TimeTilDormantAutoDelete, so the mock
+					// writes it to the template row for deleting_at computation.
 					TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 						SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
 							template.TimeTilDormantAutoDelete = int64(options.TimeTilDormantAutoDelete)


### PR DESCRIPTION
Code-only backport of #26488 to `release/2.34`.

The dormancy notification's "will be automatically deleted in X" sentence rendered the dormancy threshold (`time_til_dormant`) instead of the auto-delete duration (`time_til_dormant_autodelete`). A 30-day threshold rendered as "4 weeks" even when auto-delete was configured to fire much sooner or later, so users were told the wrong deletion date.

Unlike #26488, this backport contains **no migration**. Adding migration 000527 to the 2.34 line would break the migration ordering for deployments that later upgrade. Instead, the stored notification body is left untouched and the existing `timeTilDormant` label is populated with the correct value:

- When the template has auto-delete configured, the label carries the countdown derived from the workspace's `deleting_at`, which `UpdateWorkspaceDormantDeletingAt` already computes atomically from `time_til_dormant_autodelete`.
- When auto-delete is disabled, `deleting_at` is unset and the sentence cannot be omitted without a body change, so the label falls back to generic wording: "...will be automatically deleted in line with your template's auto-deletion policy if it remains inactive."

Upgrading to >= 2.35.1 later applies migration 000527 and the `timeTilDelete` rename as usual; this patch is fully superseded at that point.

<details>
<summary>Implementation notes</summary>

- `coderd/autobuild/lifecycle_executor.go`: propagate `wsNew.DeletingAt` onto `ws` after the dormancy UPDATE and humanize it into the `timeTilDormant` label.
- `coderd/workspaces.go` (`putWorkspaceDormant`): use `newWorkspace.DeletingAt` for the label; the template fetch that fed the wrong duration is removed.
- The label key intentionally stays `timeTilDormant` because the 2.34 notification body (migration 000311) references it; renaming would require a data migration, which this backport deliberately avoids.
- No feature flag: the change is a pure correctness fix with no schema or API surface.
- Tests adapted from #26488: `TestNotifications/DormancyAutoDelete` (lifecycle executor) and `TestWorkspaceNotifications/Dormant/InitiatorNotOwnerWithAutoDelete` (API path), plus fallback-wording assertions in the existing no-auto-delete tests. Both use a 35-day auto-delete so `humanize.Time` deterministically renders "1 month from now".

</details>

---

*This PR was generated by Coder Agents on behalf of @ibetitsmike.*