### PR TITLE
docs: regenerate configuration reference for backticked Bedrock URL

### DIFF
--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -355,7 +355,7 @@ Emit structured logs for AI Gateway interception records. Use this for exporting
 
 ### Bedrock region
 
-**Deprecated**: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of 'https://bedrock-runtime.<region>.amazonaws.com'.
+**Deprecated**: manage AI Providers from the Coder UI or HTTP API. If set, this option seeds provider configuration at startup only exactly once. It will not be used in service runtime. The AWS Bedrock API region to use. Constructs a base URL to use for the AWS Bedrock API in the form of `https://bedrock-runtime.<region>.amazonaws.com`.
 
 - Environment variable: `CODER_AI_GATEWAY_BEDROCK_REGION`
 - CLI flag: [`--ai-gateway-bedrock-region`](../../reference/cli/server.md#--ai-gateway-bedrock-region)


### PR DESCRIPTION
## Summary

Regenerates `docs/admin/setup/configuration-reference.md`, which drifted out of sync with its generator.

#27399 added the docs inline-HTML linter (`scripts/docshtmlcheck/`) and backticked generated placeholders in `codersdk/deployment.go`, and regenerated most affected docs — but `docs/admin/setup/configuration-reference.md` was not regenerated. As a result, `main` is currently red on two checks:

- **`gen`** — `make gen` produces a one-line change (the AWS Bedrock URL placeholder is now backticked).
- **`lint` (`lint/docs-html`)** — the unbackticked `<region>` is parsed as an unknown HTML element.

This regenerates the file via `make docs/admin/setup/configuration-reference.md`, wrapping the URL containing `<region>` in backticks. No source changes.

## Testing

- `make docs/admin/setup/configuration-reference.md` produces exactly this diff and leaves the tree clean.

---

*Opened by Coder Agents on behalf of @aqandrew.*
