### PR TITLE
perf(coderd/database): sort AI Bridge sessions by denormalized last_prompt_at

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1606,7 +1606,8 @@ CREATE TABLE aibridge_interceptions (
     agent_firewall_session_id uuid,
     agent_firewall_sequence_number integer,
     error_type aibridge_interception_error_type,
-    error_message character varying(1024)
+    error_message character varying(1024),
+    last_prompt_at timestamp with time zone
 );
 
 COMMENT ON TABLE aibridge_interceptions IS 'Audit log of requests intercepted by AI Bridge';
@@ -1634,6 +1635,8 @@ COMMENT ON COLUMN aibridge_interceptions.agent_firewall_sequence_number IS 'The 
 COMMENT ON COLUMN aibridge_interceptions.error_type IS 'Categorised terminal upstream error for a failed interception; NULL when the interception succeeded.';
 
 COMMENT ON COLUMN aibridge_interceptions.error_message IS 'Raw terminal upstream error message for a failed interception; NULL when the interception succeeded.';
+
+COMMENT ON COLUMN aibridge_interceptions.last_prompt_at IS 'Denormalized cache of the maximum aibridge_user_prompts.created_at recorded for this interception. NULL when the interception has no user prompts. Maintained monotonically on prompt insert and used to sort sessions by last activity without joining the prompts table.';
 
 CREATE TABLE aibridge_model_thoughts (
     interception_id uuid NOT NULL,

--- a/coderd/database/migrations/000563_aibridge_interception_last_prompt_at.down.sql
+++ b/coderd/database/migrations/000563_aibridge_interception_last_prompt_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aibridge_interceptions
+	DROP COLUMN last_prompt_at;

--- a/coderd/database/migrations/000563_aibridge_interception_last_prompt_at.up.sql
+++ b/coderd/database/migrations/000563_aibridge_interception_last_prompt_at.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE aibridge_interceptions
+	ADD COLUMN last_prompt_at timestamp with time zone;
+
+COMMENT ON COLUMN aibridge_interceptions.last_prompt_at IS 'Denormalized cache of the maximum aibridge_user_prompts.created_at recorded for this interception. NULL when the interception has no user prompts. Maintained monotonically on prompt insert and used to sort sessions by last activity without joining the prompts table.';
+
+-- Backfill existing rows from the prompts table.
+UPDATE aibridge_interceptions ai
+	SET last_prompt_at = up.max_created_at
+	FROM (
+		SELECT interception_id, MAX(created_at) AS max_created_at
+		FROM aibridge_user_prompts
+		GROUP BY interception_id
+	) up
+	WHERE up.interception_id = ai.id;

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -1165,6 +1165,7 @@ func (q *sqlQuerier) ListAuthorizedAIBridgeSessionThreads(ctx context.Context, a
 			&i.AIBridgeInterception.AgentFirewallSequenceNumber,
 			&i.AIBridgeInterception.ErrorType,
 			&i.AIBridgeInterception.ErrorMessage,
+			&i.AIBridgeInterception.LastPromptAt,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4717,6 +4717,8 @@ type AIBridgeInterception struct {
 	ErrorType NullAIBridgeInterceptionErrorType `db:"error_type" json:"error_type"`
 	// Raw terminal upstream error message for a failed interception; NULL when the interception succeeded.
 	ErrorMessage sql.NullString `db:"error_message" json:"error_message"`
+	// Denormalized cache of the maximum aibridge_user_prompts.created_at recorded for this interception. NULL when the interception has no user prompts. Maintained monotonically on prompt insert and used to sort sessions by last activity without joining the prompts table.
+	LastPromptAt sql.NullTime `db:"last_prompt_at" json:"last_prompt_at"`
 }
 
 // Audit log of model thinking in intercepted requests in AI Bridge

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1082,6 +1082,11 @@ type sqlcQuerier interface {
 	InsertAIBridgeModelThought(ctx context.Context, arg InsertAIBridgeModelThoughtParams) (AIBridgeModelThought, error)
 	InsertAIBridgeTokenUsage(ctx context.Context, arg InsertAIBridgeTokenUsageParams) (AIBridgeTokenUsage, error)
 	InsertAIBridgeToolUsage(ctx context.Context, arg InsertAIBridgeToolUsageParams) (AIBridgeToolUsage, error)
+	// Inserts a user prompt and monotonically bumps the owning interception's
+	// denormalized last_prompt_at cache in a single atomic statement. The bump is a
+	// data-modifying CTE, which Postgres always runs to completion regardless of
+	// whether the primary query reads its output. GREATEST is NULL-safe, so retries
+	// or out-of-order records never regress the cached value.
 	InsertAIBridgeUserPrompt(ctx context.Context, arg InsertAIBridgeUserPromptParams) (AIBridgeUserPrompt, error)
 	InsertAIGatewayKey(ctx context.Context, arg InsertAIGatewayKeyParams) (InsertAIGatewayKeyRow, error)
 	InsertAIProvider(ctx context.Context, arg InsertAIProviderParams) (AIProvider, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -11498,6 +11498,73 @@ func TestAIBridgeInterceptionAgentFirewallColumns(t *testing.T) {
 	})
 }
 
+func TestAIBridgeInterceptionLastPromptAt(t *testing.T) {
+	t.Parallel()
+	db, _ := dbtestutil.NewDB(t)
+
+	newInterception := func(t *testing.T, ctx context.Context) database.AIBridgeInterception {
+		t.Helper()
+		user := dbgen.User(t, db, database.User{})
+		intc, err := db.InsertAIBridgeInterception(ctx, database.InsertAIBridgeInterceptionParams{
+			ID:             uuid.New(),
+			InitiatorID:    user.ID,
+			Metadata:       json.RawMessage("{}"),
+			CredentialKind: database.CredentialKindCentralized,
+		})
+		require.NoError(t, err)
+		// A fresh interception has no prompts yet.
+		require.False(t, intc.LastPromptAt.Valid)
+		return intc
+	}
+
+	insertPrompt := func(t *testing.T, ctx context.Context, interceptionID uuid.UUID, at time.Time) {
+		t.Helper()
+		_, err := db.InsertAIBridgeUserPrompt(ctx, database.InsertAIBridgeUserPromptParams{
+			ID:                 uuid.New(),
+			InterceptionID:     interceptionID,
+			ProviderResponseID: "resp",
+			Prompt:             "prompt",
+			Metadata:           json.RawMessage("{}"),
+			CreatedAt:          at,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("InsertBumpsCache", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		intc := newInterception(t, ctx)
+		promptAt := dbtime.Now()
+		insertPrompt(t, ctx, intc.ID, promptAt)
+
+		got, err := db.GetAIBridgeInterceptionByID(ctx, intc.ID)
+		require.NoError(t, err)
+		require.True(t, got.LastPromptAt.Valid)
+		require.WithinDuration(t, promptAt, got.LastPromptAt.Time, time.Millisecond)
+	})
+
+	t.Run("MonotonicAcrossOutOfOrderPrompts", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		intc := newInterception(t, ctx)
+		latest := dbtime.Now()
+		earlier := latest.Add(-time.Hour)
+
+		// Record the latest prompt first, then an earlier one. GREATEST must keep
+		// the cache at the maximum, so an out-of-order (older) prompt never
+		// regresses last_prompt_at.
+		insertPrompt(t, ctx, intc.ID, latest)
+		insertPrompt(t, ctx, intc.ID, earlier)
+
+		got, err := db.GetAIBridgeInterceptionByID(ctx, intc.ID)
+		require.NoError(t, err)
+		require.True(t, got.LastPromptAt.Valid)
+		require.WithinDuration(t, latest, got.LastPromptAt.Time, time.Millisecond)
+	})
+}
+
 func TestDeleteExpiredAPIKeys(t *testing.T) {
 	t.Parallel()
 	db, _ := dbtestutil.NewDB(t)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1211,7 +1211,7 @@ func (q *sqlQuerier) GetAIBridgeChatCost(ctx context.Context, rootChatID uuid.UU
 
 const getAIBridgeInterceptionByID = `-- name: GetAIBridgeInterceptionByID :one
 SELECT
-	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, last_prompt_at
 FROM
 	aibridge_interceptions
 WHERE
@@ -1242,6 +1242,7 @@ func (q *sqlQuerier) GetAIBridgeInterceptionByID(ctx context.Context, id uuid.UU
 		&i.AgentFirewallSequenceNumber,
 		&i.ErrorType,
 		&i.ErrorMessage,
+		&i.LastPromptAt,
 	)
 	return i, err
 }
@@ -1276,7 +1277,7 @@ func (q *sqlQuerier) GetAIBridgeInterceptionLineageByToolCallID(ctx context.Cont
 
 const getAIBridgeInterceptions = `-- name: GetAIBridgeInterceptions :many
 SELECT
-	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, last_prompt_at
 FROM
 	aibridge_interceptions
 `
@@ -1311,6 +1312,7 @@ func (q *sqlQuerier) GetAIBridgeInterceptions(ctx context.Context) ([]AIBridgeIn
 			&i.AgentFirewallSequenceNumber,
 			&i.ErrorType,
 			&i.ErrorMessage,
+			&i.LastPromptAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1565,7 +1567,7 @@ INSERT INTO aibridge_interceptions (
 ) VALUES (
 	$1, $2, $3, $4, $5, $6, COALESCE($7::jsonb, '{}'::jsonb), $8, $9, $10, $11::uuid, $12::uuid, $13, $14, $15::uuid, $16
 )
-RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, last_prompt_at
 `
 
 type InsertAIBridgeInterceptionParams struct {
@@ -1628,6 +1630,7 @@ func (q *sqlQuerier) InsertAIBridgeInterception(ctx context.Context, arg InsertA
 		&i.AgentFirewallSequenceNumber,
 		&i.ErrorType,
 		&i.ErrorMessage,
+		&i.LastPromptAt,
 	)
 	return i, err
 }
@@ -1791,10 +1794,16 @@ func (q *sqlQuerier) InsertAIBridgeToolUsage(ctx context.Context, arg InsertAIBr
 }
 
 const insertAIBridgeUserPrompt = `-- name: InsertAIBridgeUserPrompt :one
+WITH bump AS (
+	UPDATE aibridge_interceptions
+	SET last_prompt_at = GREATEST(last_prompt_at, $6::timestamptz)
+	WHERE id = $2
+	RETURNING 1
+)
 INSERT INTO aibridge_user_prompts (
-  id, interception_id, provider_response_id, prompt, metadata, created_at
+	id, interception_id, provider_response_id, prompt, metadata, created_at
 ) VALUES (
-  $1, $2, $3, $4, COALESCE($5::jsonb, '{}'::jsonb), $6
+	$1, $2, $3, $4, COALESCE($5::jsonb, '{}'::jsonb), $6
 )
 RETURNING id, interception_id, provider_response_id, prompt, metadata, created_at
 `
@@ -1808,6 +1817,11 @@ type InsertAIBridgeUserPromptParams struct {
 	CreatedAt          time.Time       `db:"created_at" json:"created_at"`
 }
 
+// Inserts a user prompt and monotonically bumps the owning interception's
+// denormalized last_prompt_at cache in a single atomic statement. The bump is a
+// data-modifying CTE, which Postgres always runs to completion regardless of
+// whether the primary query reads its output. GREATEST is NULL-safe, so retries
+// or out-of-order records never regress the cached value.
 func (q *sqlQuerier) InsertAIBridgeUserPrompt(ctx context.Context, arg InsertAIBridgeUserPromptParams) (AIBridgeUserPrompt, error) {
 	row := q.db.QueryRowContext(ctx, insertAIBridgeUserPrompt,
 		arg.ID,
@@ -2137,7 +2151,7 @@ WITH paginated_threads AS (
 )
 SELECT
 	COALESCE(aibridge_interceptions.thread_root_id, aibridge_interceptions.id) AS thread_id,
-	aibridge_interceptions.id, aibridge_interceptions.initiator_id, aibridge_interceptions.provider, aibridge_interceptions.model, aibridge_interceptions.started_at, aibridge_interceptions.metadata, aibridge_interceptions.ended_at, aibridge_interceptions.api_key_id, aibridge_interceptions.client, aibridge_interceptions.thread_parent_id, aibridge_interceptions.thread_root_id, aibridge_interceptions.client_session_id, aibridge_interceptions.session_id, aibridge_interceptions.provider_name, aibridge_interceptions.credential_kind, aibridge_interceptions.credential_hint, aibridge_interceptions.agent_firewall_session_id, aibridge_interceptions.agent_firewall_sequence_number, aibridge_interceptions.error_type, aibridge_interceptions.error_message
+	aibridge_interceptions.id, aibridge_interceptions.initiator_id, aibridge_interceptions.provider, aibridge_interceptions.model, aibridge_interceptions.started_at, aibridge_interceptions.metadata, aibridge_interceptions.ended_at, aibridge_interceptions.api_key_id, aibridge_interceptions.client, aibridge_interceptions.thread_parent_id, aibridge_interceptions.thread_root_id, aibridge_interceptions.client_session_id, aibridge_interceptions.session_id, aibridge_interceptions.provider_name, aibridge_interceptions.credential_kind, aibridge_interceptions.credential_hint, aibridge_interceptions.agent_firewall_session_id, aibridge_interceptions.agent_firewall_sequence_number, aibridge_interceptions.error_type, aibridge_interceptions.error_message, aibridge_interceptions.last_prompt_at
 FROM
 	aibridge_interceptions
 JOIN
@@ -2205,6 +2219,7 @@ func (q *sqlQuerier) ListAIBridgeSessionThreads(ctx context.Context, arg ListAIB
 			&i.AIBridgeInterception.AgentFirewallSequenceNumber,
 			&i.AIBridgeInterception.ErrorType,
 			&i.AIBridgeInterception.ErrorMessage,
+			&i.AIBridgeInterception.LastPromptAt,
 		); err != nil {
 			return nil, err
 		}
@@ -2222,42 +2237,32 @@ func (q *sqlQuerier) ListAIBridgeSessionThreads(ctx context.Context, arg ListAIB
 const listAIBridgeSessions = `-- name: ListAIBridgeSessions :many
 WITH cursor_pos AS (
 	-- Resolve the cursor's last_active_at once, outside the HAVING clause,
-	-- so the planner cannot accidentally re-evaluate it per group. Direct
-	-- LEFT JOIN is safe here since we only use MAX/MIN aggregates (no COUNT
-	-- affected by fan-out from multiple prompts per interception).
-	-- COALESCE falls back to MIN(ai.started_at) so the cursor value is
+	-- so the planner cannot accidentally re-evaluate it per group.
+	-- last_active_at is the session's most recent prompt time, read from the
+	-- denormalized aibridge_interceptions.last_prompt_at cache (no prompts
+	-- join). COALESCE falls back to MIN(ai.started_at) so the cursor value is
 	-- never NULL, which would silently drop rows from the HAVING comparison.
-	SELECT COALESCE(MAX(up.created_at), MIN(ai.started_at)) AS last_active_at
+	SELECT COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at)) AS last_active_at
 	FROM aibridge_interceptions ai
-	LEFT JOIN aibridge_user_prompts up ON up.interception_id = ai.id
 	WHERE ai.session_id = $1 AND ai.ended_at IS NOT NULL
 ),
 session_page AS (
 	-- Paginate at the session level first; only cheap aggregates here.
-	-- A lateral correlated subquery for prompts keeps the join one-to-one
-	-- with aibridge_interceptions so COUNT(*) for thread tallies is not
-	-- inflated. LIMIT 1 combined with the (interception_id, created_at DESC)
-	-- index makes this an index-only lookup per interception row rather than
-	-- a full-table-scan GROUP BY over all prompts.
-	-- last_active_at is the latest prompt timestamp, falling back to
-	-- MIN(started_at) for sessions with no prompts. The COALESCE ensures
+	-- last_active_at is the latest prompt timestamp read from the
+	-- denormalized aibridge_interceptions.last_prompt_at cache, falling back
+	-- to MIN(started_at) for sessions with no prompts. The COALESCE ensures
 	-- it is never NULL so the HAVING row-value cursor comparison is safe.
+	-- Sorting on stored columns avoids the per-interception prompts lateral
+	-- that previously ran across the whole filtered set.
 	SELECT
 		ai.session_id,
 		ai.initiator_id,
 		MIN(ai.started_at) AS started_at,
 		MAX(ai.ended_at) AS ended_at,
 		COUNT(*) FILTER (WHERE ai.thread_root_id IS NULL) AS threads,
-		COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at))::timestamptz AS last_active_at
+		COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at))::timestamptz AS last_active_at
 	FROM
 		aibridge_interceptions ai
-	LEFT JOIN LATERAL (
-		SELECT created_at AS latest_prompt_at
-		FROM aibridge_user_prompts
-		WHERE interception_id = ai.id
-		ORDER BY created_at DESC
-		LIMIT 1
-	) latest_prompt ON true
 	WHERE
 		-- Remove inflight interceptions (ones which lack an ended_at value).
 		ai.ended_at IS NOT NULL
@@ -2311,7 +2316,7 @@ session_page AS (
 		-- value comes from cursor_pos to guarantee single evaluation.
 		CASE
 			WHEN $1::text != '' THEN (
-				(COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at)), ai.session_id) < (
+				(COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at)), ai.session_id) < (
 					(SELECT last_active_at FROM cursor_pos),
 					$1::text
 				)
@@ -2681,7 +2686,7 @@ UPDATE aibridge_interceptions
 WHERE
 	id = $5::uuid
 	AND ended_at IS NULL
-RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, last_prompt_at
 `
 
 type UpdateAIBridgeInterceptionEndedParams struct {
@@ -2722,6 +2727,7 @@ func (q *sqlQuerier) UpdateAIBridgeInterceptionEnded(ctx context.Context, arg Up
 		&i.AgentFirewallSequenceNumber,
 		&i.ErrorType,
 		&i.ErrorMessage,
+		&i.LastPromptAt,
 	)
 	return i, err
 }

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -51,10 +51,21 @@ INSERT INTO aibridge_token_usages (
 RETURNING *;
 
 -- name: InsertAIBridgeUserPrompt :one
+-- Inserts a user prompt and monotonically bumps the owning interception's
+-- denormalized last_prompt_at cache in a single atomic statement. The bump is a
+-- data-modifying CTE, which Postgres always runs to completion regardless of
+-- whether the primary query reads its output. GREATEST is NULL-safe, so retries
+-- or out-of-order records never regress the cached value.
+WITH bump AS (
+	UPDATE aibridge_interceptions
+	SET last_prompt_at = GREATEST(last_prompt_at, @created_at::timestamptz)
+	WHERE id = @interception_id
+	RETURNING 1
+)
 INSERT INTO aibridge_user_prompts (
-  id, interception_id, provider_response_id, prompt, metadata, created_at
+	id, interception_id, provider_response_id, prompt, metadata, created_at
 ) VALUES (
-  @id, @interception_id, @provider_response_id, @prompt, COALESCE(@metadata::jsonb, '{}'::jsonb), @created_at
+	@id, @interception_id, @provider_response_id, @prompt, COALESCE(@metadata::jsonb, '{}'::jsonb), @created_at
 )
 RETURNING *;
 
@@ -359,42 +370,32 @@ WHERE
 -- first-interception metadata) only for the ~page-size result set.
 WITH cursor_pos AS (
 	-- Resolve the cursor's last_active_at once, outside the HAVING clause,
-	-- so the planner cannot accidentally re-evaluate it per group. Direct
-	-- LEFT JOIN is safe here since we only use MAX/MIN aggregates (no COUNT
-	-- affected by fan-out from multiple prompts per interception).
-	-- COALESCE falls back to MIN(ai.started_at) so the cursor value is
+	-- so the planner cannot accidentally re-evaluate it per group.
+	-- last_active_at is the session's most recent prompt time, read from the
+	-- denormalized aibridge_interceptions.last_prompt_at cache (no prompts
+	-- join). COALESCE falls back to MIN(ai.started_at) so the cursor value is
 	-- never NULL, which would silently drop rows from the HAVING comparison.
-	SELECT COALESCE(MAX(up.created_at), MIN(ai.started_at)) AS last_active_at
+	SELECT COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at)) AS last_active_at
 	FROM aibridge_interceptions ai
-	LEFT JOIN aibridge_user_prompts up ON up.interception_id = ai.id
 	WHERE ai.session_id = @after_session_id AND ai.ended_at IS NOT NULL
 ),
 session_page AS (
 	-- Paginate at the session level first; only cheap aggregates here.
-	-- A lateral correlated subquery for prompts keeps the join one-to-one
-	-- with aibridge_interceptions so COUNT(*) for thread tallies is not
-	-- inflated. LIMIT 1 combined with the (interception_id, created_at DESC)
-	-- index makes this an index-only lookup per interception row rather than
-	-- a full-table-scan GROUP BY over all prompts.
-	-- last_active_at is the latest prompt timestamp, falling back to
-	-- MIN(started_at) for sessions with no prompts. The COALESCE ensures
+	-- last_active_at is the latest prompt timestamp read from the
+	-- denormalized aibridge_interceptions.last_prompt_at cache, falling back
+	-- to MIN(started_at) for sessions with no prompts. The COALESCE ensures
 	-- it is never NULL so the HAVING row-value cursor comparison is safe.
+	-- Sorting on stored columns avoids the per-interception prompts lateral
+	-- that previously ran across the whole filtered set.
 	SELECT
 		ai.session_id,
 		ai.initiator_id,
 		MIN(ai.started_at) AS started_at,
 		MAX(ai.ended_at) AS ended_at,
 		COUNT(*) FILTER (WHERE ai.thread_root_id IS NULL) AS threads,
-		COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at))::timestamptz AS last_active_at
+		COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at))::timestamptz AS last_active_at
 	FROM
 		aibridge_interceptions ai
-	LEFT JOIN LATERAL (
-		SELECT created_at AS latest_prompt_at
-		FROM aibridge_user_prompts
-		WHERE interception_id = ai.id
-		ORDER BY created_at DESC
-		LIMIT 1
-	) latest_prompt ON true
 	WHERE
 		-- Remove inflight interceptions (ones which lack an ended_at value).
 		ai.ended_at IS NOT NULL
@@ -448,7 +449,7 @@ session_page AS (
 		-- value comes from cursor_pos to guarantee single evaluation.
 		CASE
 			WHEN @after_session_id::text != '' THEN (
-				(COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at)), ai.session_id) < (
+				(COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at)), ai.session_id) < (
 					(SELECT last_active_at FROM cursor_pos),
 					@after_session_id::text
 				)


### PR DESCRIPTION
## Summary

The `/ai-gateway/sessions` page takes 5-10s to load (AIGOV-580). Root cause is a regression from #24440 (AIGOV-208): `ListAIBridgeSessions` sorts by the runtime aggregate `COALESCE(MAX(prompt.created_at), MIN(started_at))`, computed via a per-interception `LEFT JOIN LATERAL` into `aibridge_user_prompts`. That lateral runs for **every matched interception across the whole filtered set** before `LIMIT/OFFSET`, so the query scales O(N) with interception/prompt counts.

This denormalizes the sort key onto `aibridge_interceptions.last_prompt_at`, maintained monotonically at prompt-insert time, and reads it from the stored column instead of joining prompts. Ordering, offset pagination, total count, and `last_active_at` semantics are unchanged.

Fixes [AIGOV-580](https://linear.app/codercom/issue/AIGOV-580).

## Changes

- **Migration 000563**: add `aibridge_interceptions.last_prompt_at timestamptz NULL`, backfilled from `aibridge_user_prompts`.
- **`InsertAIBridgeUserPrompt`**: fold a NULL-safe `GREATEST(last_prompt_at, @created_at)` bump into the insert via a data-modifying CTE, so the write stays atomic in a single statement.
- **`ListAIBridgeSessions`**: drop the per-interception prompt lateral; `session_page`, `cursor_pos`, and the keyset `HAVING` comparison now read `last_prompt_at`.
- Fix the hand-written scan in `ListAuthorizedAIBridgeSessionThreads` for the new embedded column.
- Add `TestAIBridgeInterceptionLastPromptAt` (cache bump + monotonicity).

## Implementation note

The plan's 3.2 sketch put the `INSERT` in the CTE and the bump second. The final query flips that (bump `UPDATE` in the CTE, `INSERT ... RETURNING *` as the final statement) so sqlc keeps the return type as `AIBridgeUserPrompt` instead of generating a new row type that would churn the store interface. Postgres runs data-modifying CTEs to completion regardless of reference, so behavior is identical.

## Testing

- `TestAIBridge*` (enterprise/coderd), migration tests, and the new DB test pass against Postgres.
- `make gen`, `make fmt`, `golangci-lint ./coderd/database/...`, and the emdash lint are clean.

## Follow-up

Restores most of the regression by removing the whole-set prompt lateral. The sort key is still a per-session aggregate (not indexable), so true keyset early-termination is intentionally deferred (see plan 3.4). Recommend confirming with `EXPLAIN ANALYZE` on a large seed before deciding whether phase 2 is needed; this PR has not been benchmarked against a large dataset.

<details>
<summary>Implementation plan &amp; decision log</summary>

# Brainstorm: restore `ListAIBridgeSessions` performance without sacrificing pagination

Regression source: PR #24440 (AIGOV-208).
Goal: sort AI Bridge sessions by last activity (last prompt time) **and** keep the current numbered/offset pagination + total count, while making the query scale to large interception/prompt row counts.

Constraints chosen by the user:

- **Light denormalization only**: a single denormalized column + backfill is acceptable. No new session-summary table. Maintain the column from the application write path, not DB triggers.
- **Keep current pagination semantics**: numbered pages (offset) + total count, as rendered today by `PaginationContainer`. Not switching to pure keyset.

## 1. Root cause (verified in the tree)

`ListAIBridgeSessions` orders by a runtime aggregate `COALESCE(MAX(latest_prompt.latest_prompt_at), MIN(ai.started_at))` via a `LEFT JOIN LATERAL` over `aibridge_user_prompts`, per interception. Pre-#24440 it ordered by `MIN(ai.started_at)` (a stored column).

Why this hurts at scale:

1. **Prompt lateral runs over the whole filtered set, not the page.** The lateral sits inside the `session_page` CTE **before** `LIMIT/OFFSET`, so Postgres probes `aibridge_user_prompts` for every matched interception in the entire filter window, then aggregates, sorts, and slices the page. Dominant new cost.
2. **The sort key is not indexable.** `last_active_at` is computed per group, so the planner must build and sort every group before honoring `OFFSET/LIMIT`. The `after_session_id` keyset path does not help either: its `HAVING` compares the same aggregate, so all groups are still materialized.

Supporting facts: no index covers a per-session "last activity" value; `session_id` is a stored generated column so a session is not a first-class row; `CountAIBridgeSessions` is independent of the sort key; prompts are written from `Server.RecordPromptUsage`, the natural place to maintain a denormalized timestamp.

## 2. Reframing the tradeoff

"keyset vs numbered pagination" is a false dichotomy. The real blocker is that the sort key is not materialized. Once it derives from stored columns: offset pagination gets cheaper, total count is already independent, and a future keyset path becomes possible.

## 3. Recommended direction

Denormalize a per-interception activity timestamp and drop the prompt lateral.

### 3.1 Schema
Add `last_prompt_at timestamptz NULL` to `aibridge_interceptions` = max `created_at` of that interception's prompts (NULL when none). Backfill in the migration. Follow DATABASE.md (migration pair, `make gen`, audit table if needed).

### 3.2 Write-path maintenance (app write, no triggers)
Fold the bump into the prompt insert as a single CTE (`GREATEST` is NULL-safe and monotonic; retries/out-of-order records never regress the value). Rejected: two store calls wrapped in `InTx` (extra transaction + round trip for a cache write inseparable from the insert).

### 3.3 Query rewrite
Session sort key becomes `COALESCE(MAX(ai.last_prompt_at), MIN(ai.started_at))`. `session_page` is a single `GROUP BY` over interceptions on stored columns; `cursor_pos` and the keyset `HAVING` use the same expression. Page-only lateral joins and `ORDER BY` unchanged.

### 3.4 Optional follow-up (deferred): true early termination
**Decision (7.2): tabled.** If deep pages remain slow, add an `activity_at` column + index and a recursive-CTE skip scan that emits the max-activity row per session in global order and stops after `offset+limit`. Phase 2, gated on measurement.

## 4. Correctness considerations
Fallback: prompt-less sessions fall back to `MIN(started_at)` (only when every interception has `last_prompt_at IS NULL`). Multiple prompts per interception handled by the max. Monotonic via `GREATEST`. `ended_at IS NOT NULL` filter stays. Backfill must match the query aggregate. Audit table entry not required (not audited).

## 5. Alternatives considered
- **Session-summary table + triggers**: best read perf and native keyset, but violates the no-new-table/no-triggers constraint. Long-term option.
- **Prompt-driven loose index scan**: denormalizes onto the higher-volume prompts table and needs filter columns there; awkward for prompt-less sessions.
- **Query-only / index-only**: cannot remove the whole-set lateral nor make the aggregate indexable.

## 6. Validation plan
Large synthetic seed; `EXPLAIN (ANALYZE, BUFFERS)` before/after for first page, deep offset, filtered, time-window, and keyset paths; golden comparison of ordering and count; Go tests for ordering/fallback/multi-prompt/prompt-less/pagination; `make gen/fmt/lint/test`.

## 7. Decisions
1. **7.1:** maintain `last_prompt_at` only; compute `activity_at` inline later if needed.
2. **7.2:** defer 3.4 (skip scan); ship 3.3 and measure.
3. **7.3:** fold the bump into the prompt insert CTE.

</details>

---
This pull request was generated by Coder Agents.
