### PR TITLE
fix(coderd): document HTTP 201 for workspace and build creation

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5684,8 +5684,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/codersdk.Workspace"
                         }
@@ -11752,8 +11752,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/codersdk.Workspace"
                         }
@@ -13979,8 +13979,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/codersdk.WorkspaceBuild"
                         }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5029,8 +5029,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.Workspace"
 						}
@@ -10429,8 +10429,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.Workspace"
 						}
@@ -12407,8 +12407,8 @@
 					}
 				],
 				"responses": {
-					"200": {
-						"description": "OK",
+					"201": {
+						"description": "Created",
 						"schema": {
 							"$ref": "#/definitions/codersdk.WorkspaceBuild"
 						}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -323,7 +323,7 @@ func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Requ
 // @Tags Builds
 // @Param workspace path string true "Workspace ID" format(uuid)
 // @Param request body codersdk.CreateWorkspaceBuildRequest true "Create workspace build request"
-// @Success 200 {object} codersdk.WorkspaceBuild
+// @Success 201 {object} codersdk.WorkspaceBuild
 // @Router /api/v2/workspaces/{workspace}/builds [post]
 func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -364,7 +364,7 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param user path string true "Username, UUID, or me"
 // @Param request body codersdk.CreateWorkspaceRequest true "Create workspace request"
-// @Success 200 {object} codersdk.Workspace
+// @Success 201 {object} codersdk.Workspace
 // @Router /api/v2/organizations/{organization}/members/{user}/workspaces [post]
 func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -425,7 +425,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 // @Tags Workspaces
 // @Param user path string true "Username, UUID, or me"
 // @Param request body codersdk.CreateWorkspaceRequest true "Create workspace request"
-// @Success 200 {object} codersdk.Workspace
+// @Success 201 {object} codersdk.Workspace
 // @Router /api/v2/users/{user}/workspaces [post]
 func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 	var (

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -1804,7 +1804,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 
 ### Example responses
 
-> 200 Response
+> 201 Response
 
 ```json
 {
@@ -2020,8 +2020,8 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                       |
-|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
+| Status | Meaning                                                      | Description | Schema                                                       |
+|--------|--------------------------------------------------------------|-------------|--------------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -49,7 +49,7 @@ of the template will be used.
 
 ### Example responses
 
-> 200 Response
+> 201 Response
 
 ```json
 {
@@ -328,9 +328,9 @@ of the template will be used.
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                             |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Workspace](schemas.md#codersdkworkspace) |
+| Status | Meaning                                                      | Description | Schema                                             |
+|--------|--------------------------------------------------------------|-------------|----------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.Workspace](schemas.md#codersdkworkspace) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -748,7 +748,7 @@ of the template will be used.
 
 ### Example responses
 
-> 200 Response
+> 201 Response
 
 ```json
 {
@@ -1027,9 +1027,9 @@ of the template will be used.
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                             |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Workspace](schemas.md#codersdkworkspace) |
+| Status | Meaning                                                      | Description | Schema                                             |
+|--------|--------------------------------------------------------------|-------------|----------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.Workspace](schemas.md#codersdkworkspace) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 


### PR DESCRIPTION
## Summary

The generated Swagger document declared HTTP 200 for three workspace/build creation operations whose handlers actually return HTTP 201. Clients generated from the contract (e.g. go-swagger v0.31.0) treat the real 201 response as an error even though the resource is created successfully.

This corrects the `@Success` annotations to 201 so the contract matches runtime behavior, and regenerates the API docs.

Fixes [PLAT-434](https://linear.app/codercom/issue/PLAT-434) / #27304.

## Changes

- `coderd/workspaces.go`: `create-user-workspace-by-organization` (deprecated) and `create-user-workspace` now declare `@Success 201`.
- `coderd/workspacebuilds.go`: `create-workspace-build` now declares `@Success 201`.
- Regenerated `coderd/apidoc/swagger.json`, `coderd/apidoc/docs.go`, and `docs/reference/api/{workspaces,builds}.md` via `make coderd/apidoc/.gen`.

## Notes

This is a contract/documentation fix only; no runtime behavior changes. The handlers already write `http.StatusCreated`, and the Go `codersdk` client already expects 201 (e.g. `CreateWorkspaceBuild` checks `http.StatusCreated`), so this only aligns the published OpenAPI contract with existing behavior.

<details>
<summary>Verification</summary>

- Confirmed all three handlers end with `httpapi.Write(ctx, rw, http.StatusCreated, ...)`.
- `go build ./coderd/apidoc/...` passes with the regenerated `docs.go`.
- Generated `swagger.json` diff shows the three operations changing from `200 OK` to `201 Created`.

</details>

---

*This PR was generated by Coder Agents on behalf of @david-fraley.*