### PR TITLE
fix(enterprise/coderd): identify audit rows by content instead of order in diff tests

### DIFF
--- a/enterprise/coderd/aibridge_provider_audit_test.go
+++ b/enterprise/coderd/aibridge_provider_audit_test.go
@@ -82,15 +82,8 @@ func TestAIProviderAuditDiff(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected one create and one update audit row")
 
-	// Identify the update row by action instead of position. GetAuditLogsOffset
-	// orders by time only, so the create and update rows can come back in
-	// either order when their timestamps tie.
-	var updateLog database.AuditLog
-	for _, row := range rows {
-		if row.AuditLog.Action == database.AuditActionWrite {
-			updateLog = row.AuditLog
-		}
-	}
+	byAction := auditLogsByAction(t, rows)
+	updateLog := byAction[database.AuditActionWrite]
 	require.Equal(t, database.AuditActionWrite, updateLog.Action, "missing update audit log")
 
 	var updateDiff audit.Map

--- a/enterprise/coderd/aibridge_provider_audit_test.go
+++ b/enterprise/coderd/aibridge_provider_audit_test.go
@@ -82,9 +82,16 @@ func TestAIProviderAuditDiff(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected one create and one update audit row")
 
-	// GetAuditLogsOffset returns entries sorted by time in descending order.
-	updateLog := rows[0].AuditLog
-	require.Equal(t, database.AuditActionWrite, updateLog.Action)
+	// Identify the update row by action instead of position. GetAuditLogsOffset
+	// orders by time only, so the create and update rows can come back in
+	// either order when their timestamps tie.
+	var updateLog database.AuditLog
+	for _, row := range rows {
+		if row.AuditLog.Action == database.AuditActionWrite {
+			updateLog = row.AuditLog
+		}
+	}
+	require.Equal(t, database.AuditActionWrite, updateLog.Action, "missing update audit log")
 
 	var updateDiff audit.Map
 	require.NoError(t, json.Unmarshal(updateLog.Diff, &updateDiff))

--- a/enterprise/coderd/oauth2providersettings_audit_test.go
+++ b/enterprise/coderd/oauth2providersettings_audit_test.go
@@ -81,10 +81,7 @@ func TestOAuth2ProviderSettingsAuditDiff(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected exactly two rows")
-	// Both settings updates audit as "write" actions, so the rows cannot be
-	// distinguished by action. GetAuditLogsOffset orders by time only, and
-	// the rows can come back in either order when their timestamps tie, so
-	// identify them by the new value recorded in the diff.
+	// Both updates use the same action, so identify them by the new value.
 	var enableDiff, disableDiff audit.Map
 	for _, row := range rows {
 		var diff audit.Map

--- a/enterprise/coderd/oauth2providersettings_audit_test.go
+++ b/enterprise/coderd/oauth2providersettings_audit_test.go
@@ -80,22 +80,30 @@ func TestOAuth2ProviderSettingsAuditDiff(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(rows), "expected exactly two rows")
-	// GetAuditLogsOffset returns entries sorted by time in descending order.
-	enableLog := rows[1].AuditLog
-	disableLog := rows[0].AuditLog
-
-	var enableDiff audit.Map
-	require.NoError(t, json.Unmarshal(enableLog.Diff, &enableDiff))
-	if assert.Contains(t, enableDiff, "dynamic_client_registration_enabled", "tracked field missing from enableDiff") {
-		assert.Equal(t, false, enableDiff["dynamic_client_registration_enabled"].Old)
-		assert.Equal(t, true, enableDiff["dynamic_client_registration_enabled"].New)
+	require.Len(t, rows, 2, "expected exactly two rows")
+	// Both settings updates audit as "write" actions, so the rows cannot be
+	// distinguished by action. GetAuditLogsOffset orders by time only, and
+	// the rows can come back in either order when their timestamps tie, so
+	// identify them by the new value recorded in the diff.
+	var enableDiff, disableDiff audit.Map
+	for _, row := range rows {
+		var diff audit.Map
+		require.NoError(t, json.Unmarshal(row.AuditLog.Diff, &diff))
+		require.Contains(t, diff, "dynamic_client_registration_enabled", "tracked field missing from diff")
+		enabled, ok := diff["dynamic_client_registration_enabled"].New.(bool)
+		require.True(t, ok, "expected bool new value in diff")
+		if enabled {
+			enableDiff = diff
+		} else {
+			disableDiff = diff
+		}
 	}
+	require.NotNil(t, enableDiff, "missing audit log for enabling registration")
+	require.NotNil(t, disableDiff, "missing audit log for disabling registration")
 
-	var disableDiff audit.Map
-	require.NoError(t, json.Unmarshal(disableLog.Diff, &disableDiff))
-	if assert.Contains(t, disableDiff, "dynamic_client_registration_enabled", "tracked field missing from disableDiff") {
-		assert.Equal(t, true, disableDiff["dynamic_client_registration_enabled"].Old)
-		assert.Equal(t, false, disableDiff["dynamic_client_registration_enabled"].New)
-	}
+	assert.Equal(t, false, enableDiff["dynamic_client_registration_enabled"].Old)
+	assert.Equal(t, true, enableDiff["dynamic_client_registration_enabled"].New)
+
+	assert.Equal(t, true, disableDiff["dynamic_client_registration_enabled"].Old)
+	assert.Equal(t, false, disableDiff["dynamic_client_registration_enabled"].New)
 }

--- a/enterprise/coderd/usersecrets_audit_test.go
+++ b/enterprise/coderd/usersecrets_audit_test.go
@@ -81,20 +81,9 @@ func TestUserSecretAuditDiffRedaction(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected exactly two rows")
-	// Identify rows by action instead of position. GetAuditLogsOffset orders
-	// by time only, so the create and update rows can come back in either
-	// order when their timestamps tie.
-	var createLog, updateLog database.AuditLog
-	for _, row := range rows {
-		switch row.AuditLog.Action {
-		case database.AuditActionCreate:
-			createLog = row.AuditLog
-		case database.AuditActionWrite:
-			updateLog = row.AuditLog
-		default:
-			t.Fatalf("unexpected audit action %q", row.AuditLog.Action)
-		}
-	}
+	byAction := auditLogsByAction(t, rows)
+	createLog := byAction[database.AuditActionCreate]
+	updateLog := byAction[database.AuditActionWrite]
 	require.Equal(t, database.AuditActionCreate, createLog.Action, "missing create audit log")
 	require.Equal(t, database.AuditActionWrite, updateLog.Action, "missing update audit log")
 

--- a/enterprise/coderd/usersecrets_audit_test.go
+++ b/enterprise/coderd/usersecrets_audit_test.go
@@ -80,10 +80,23 @@ func TestUserSecretAuditDiffRedaction(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, len(rows), 2, "expected exactly two rows")
-	// GetAuditLogsOffset returns entries sorted by time in descending order.
-	createLog := rows[1].AuditLog
-	updateLog := rows[0].AuditLog
+	require.Len(t, rows, 2, "expected exactly two rows")
+	// Identify rows by action instead of position. GetAuditLogsOffset orders
+	// by time only, so the create and update rows can come back in either
+	// order when their timestamps tie.
+	var createLog, updateLog database.AuditLog
+	for _, row := range rows {
+		switch row.AuditLog.Action {
+		case database.AuditActionCreate:
+			createLog = row.AuditLog
+		case database.AuditActionWrite:
+			updateLog = row.AuditLog
+		default:
+			t.Fatalf("unexpected audit action %q", row.AuditLog.Action)
+		}
+	}
+	require.Equal(t, database.AuditActionCreate, createLog.Action, "missing create audit log")
+	require.Equal(t, database.AuditActionWrite, updateLog.Action, "missing update audit log")
 
 	var createDiff audit.Map
 	require.NoError(t, json.Unmarshal(createLog.Diff, &createDiff))

--- a/enterprise/coderd/userskills_audit_test.go
+++ b/enterprise/coderd/userskills_audit_test.go
@@ -3,7 +3,6 @@ package coderd_test
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,9 +71,22 @@ func TestUserSkillAuditDiffTracksContent(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected exactly two rows")
-	sort.Slice(rows, func(i, j int) bool { return rows[i].AuditLog.Action > rows[j].AuditLog.Action })
-	createLog := rows[1].AuditLog
-	updateLog := rows[0].AuditLog
+	// Identify rows by action instead of position. GetAuditLogsOffset orders
+	// by time only, so the create and update rows can come back in either
+	// order when their timestamps tie.
+	var createLog, updateLog database.AuditLog
+	for _, row := range rows {
+		switch row.AuditLog.Action {
+		case database.AuditActionCreate:
+			createLog = row.AuditLog
+		case database.AuditActionWrite:
+			updateLog = row.AuditLog
+		default:
+			t.Fatalf("unexpected audit action %q", row.AuditLog.Action)
+		}
+	}
+	require.Equal(t, database.AuditActionCreate, createLog.Action, "missing create audit log")
+	require.Equal(t, database.AuditActionWrite, updateLog.Action, "missing update audit log")
 
 	var createDiff audit.Map
 	require.NoError(t, json.Unmarshal(createLog.Diff, &createDiff))

--- a/enterprise/coderd/userskills_audit_test.go
+++ b/enterprise/coderd/userskills_audit_test.go
@@ -71,20 +71,9 @@ func TestUserSkillAuditDiffTracksContent(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "expected exactly two rows")
-	// Identify rows by action instead of position. GetAuditLogsOffset orders
-	// by time only, so the create and update rows can come back in either
-	// order when their timestamps tie.
-	var createLog, updateLog database.AuditLog
-	for _, row := range rows {
-		switch row.AuditLog.Action {
-		case database.AuditActionCreate:
-			createLog = row.AuditLog
-		case database.AuditActionWrite:
-			updateLog = row.AuditLog
-		default:
-			t.Fatalf("unexpected audit action %q", row.AuditLog.Action)
-		}
-	}
+	byAction := auditLogsByAction(t, rows)
+	createLog := byAction[database.AuditActionCreate]
+	updateLog := byAction[database.AuditActionWrite]
 	require.Equal(t, database.AuditActionCreate, createLog.Action, "missing create audit log")
 	require.Equal(t, database.AuditActionWrite, updateLog.Action, "missing update audit log")
 


### PR DESCRIPTION
`TestUserSecretAuditDiffRedaction` flakes when create and update audit rows receive equal timestamps and `GetAuditLogsOffset` returns the tied rows in either order.

Identify audit rows by action, or by diff content when both actions are writes, instead of relying on slice position. Fixes coder/internal#1625.

Reviewed and updated by Coder Agents on behalf of @dylanhuff-at-coder.