### PR TITLE
fix: avoid scaletest prompts without interactive input

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -489,6 +489,7 @@ type prepWorkspaceBuildArgs struct {
 	RichParameterDefaults []codersdk.WorkspaceBuildParameter
 
 	UseParameterDefaults bool
+	NonInteractive       bool
 }
 
 // resolvePreset returns the preset matching the given presetName (if specified),
@@ -597,7 +598,8 @@ func prepWorkspaceBuild(inv *serpent.Invocation, client *codersdk.Client, args p
 		WithRichParameters(args.RichParameters).
 		WithRichParametersFile(parameterFile).
 		WithRichParametersDefaults(args.RichParameterDefaults).
-		WithUseParameterDefaults(args.UseParameterDefaults)
+		WithUseParameterDefaults(args.UseParameterDefaults).
+		WithNonInteractive(args.NonInteractive)
 
 	var templateVersionParameters []codersdk.TemplateVersionParameter
 	if !dynamicParameters {

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -883,10 +883,12 @@ func (r *RootCmd) scaletestCreateWorkspaces() *serpent.Command {
 			}
 
 			richParameters, err := prepWorkspaceBuild(inv, client, prepWorkspaceBuildArgs{
-				Action:            WorkspaceCreate,
-				TemplateVersionID: tpl.ActiveVersionID,
-				NewWorkspaceName:  "scaletest-N", // TODO: the scaletest runner will pass in a different name here. Does this matter?
-				Owner:             codersdk.Me,
+				Action:               WorkspaceCreate,
+				TemplateVersionID:    tpl.ActiveVersionID,
+				NewWorkspaceName:     "scaletest-N", // TODO: the scaletest runner will pass in a different name here. Does this matter?
+				Owner:                codersdk.Me,
+				NonInteractive:       !isTTYIn(inv),
+				UseParameterDefaults: parameterFlags.useParameterDefaults,
 
 				RichParameterFile: parameterFlags.richParameterFile,
 				RichParameters:    cliRichParameters,
@@ -1142,6 +1144,7 @@ func (r *RootCmd) scaletestCreateWorkspaces() *serpent.Command {
 	}
 
 	cmd.Options = append(cmd.Options, parameterFlags.cliParameters()...)
+	cmd.Options = append(cmd.Options, parameterFlags.useParameterDefaultsOption())
 	tracingFlags.attach(&cmd.Options)
 	strategy.attach(&cmd.Options)
 	cleanupStrategy.attach(&cmd.Options)
@@ -1231,9 +1234,11 @@ func (r *RootCmd) scaletestWorkspaceUpdates() *serpent.Command {
 			}
 
 			richParameters, err := prepWorkspaceBuild(inv, client, prepWorkspaceBuildArgs{
-				Action:            WorkspaceCreate,
-				TemplateVersionID: tpl.ActiveVersionID,
-				Owner:             codersdk.Me,
+				Action:               WorkspaceCreate,
+				TemplateVersionID:    tpl.ActiveVersionID,
+				Owner:                codersdk.Me,
+				NonInteractive:       !isTTYIn(inv),
+				UseParameterDefaults: parameterFlags.useParameterDefaults,
 
 				RichParameterFile: parameterFlags.richParameterFile,
 				RichParameters:    cliRichParameters,
@@ -1438,6 +1443,7 @@ func (r *RootCmd) scaletestWorkspaceUpdates() *serpent.Command {
 	}
 
 	cmd.Options = append(cmd.Options, parameterFlags.cliParameters()...)
+	cmd.Options = append(cmd.Options, parameterFlags.useParameterDefaultsOption())
 	tracingFlags.attach(&cmd.Options)
 	timeoutStrategy.attach(&cmd.Options)
 	cleanupStrategy.attach(&cmd.Options)
@@ -1955,9 +1961,11 @@ func (r *RootCmd) scaletestAutostart() *serpent.Command {
 			}
 
 			richParameters, err := prepWorkspaceBuild(inv, client, prepWorkspaceBuildArgs{
-				Action:            WorkspaceCreate,
-				TemplateVersionID: tpl.ActiveVersionID,
-				Owner:             codersdk.Me,
+				Action:               WorkspaceCreate,
+				TemplateVersionID:    tpl.ActiveVersionID,
+				Owner:                codersdk.Me,
+				NonInteractive:       !isTTYIn(inv),
+				UseParameterDefaults: parameterFlags.useParameterDefaults,
 
 				RichParameterFile: parameterFlags.richParameterFile,
 				RichParameters:    cliRichParameters,
@@ -2149,6 +2157,7 @@ func (r *RootCmd) scaletestAutostart() *serpent.Command {
 	}
 
 	cmd.Options = append(cmd.Options, parameterFlags.cliParameters()...)
+	cmd.Options = append(cmd.Options, parameterFlags.useParameterDefaultsOption())
 	tracingFlags.attach(&cmd.Options)
 	output.attach(&cmd.Options)
 	timeoutStrategy.attach(&cmd.Options)

--- a/cli/parameterresolver.go
+++ b/cli/parameterresolver.go
@@ -36,6 +36,7 @@ type ParameterResolver struct {
 	promptRichParameters      bool
 	promptEphemeralParameters bool
 	useParameterDefaults      bool
+	nonInteractive            bool
 }
 
 func (pr *ParameterResolver) WithLastBuildParameters(params []codersdk.WorkspaceBuildParameter) *ParameterResolver {
@@ -90,6 +91,11 @@ func (pr *ParameterResolver) WithPromptEphemeralParameters(promptEphemeralParame
 
 func (pr *ParameterResolver) WithUseParameterDefaults(useParameterDefaults bool) *ParameterResolver {
 	pr.useParameterDefaults = useParameterDefaults
+	return pr
+}
+
+func (pr *ParameterResolver) WithNonInteractive(nonInteractive bool) *ParameterResolver {
+	pr.nonInteractive = nonInteractive
 	return pr
 }
 
@@ -341,9 +347,14 @@ func (pr *ParameterResolver) resolveWithInput(resolved []codersdk.WorkspaceBuild
 			// a default was set in Terraform, even if it is
 			// an empty string).
 			hasDefault := cliDefaultProvided || !tvp.Required
-			if pr.useParameterDefaults && hasDefault {
+			switch {
+			case pr.useParameterDefaults && hasDefault:
 				_, _ = fmt.Fprintf(inv.Stdout, "Using default value for %s: '%s'\n", name, parameterValue)
-			} else {
+			case pr.nonInteractive && hasDefault:
+				return nil, xerrors.Errorf("parameter %q is unresolved and input is not interactive; pass --use-parameter-defaults to accept its default or set it with --parameter %s=<value>", tvp.Name, tvp.Name)
+			case pr.nonInteractive:
+				return nil, xerrors.Errorf("parameter %q is unresolved and input is not interactive; set it with --parameter %s=<value>", tvp.Name, tvp.Name)
+			default:
 				var err error
 				parameterValue, err = cliui.RichParameter(inv, tvp, name, parameterValue)
 				if err != nil {

--- a/scaletest/templates/scaletest-runner/scripts/run.sh
+++ b/scaletest/templates/scaletest-runner/scripts/run.sh
@@ -21,6 +21,7 @@ if [[ ${SCALETEST_PARAM_SKIP_CREATE_WORKSPACES} == 0 ]]; then
 		--retry 5 \
 		--count "${SCALETEST_PARAM_NUM_WORKSPACES}" \
 		--template "${SCALETEST_PARAM_TEMPLATE}" \
+		--use-parameter-defaults \
 		--concurrency "${SCALETEST_PARAM_CREATE_CONCURRENCY}" \
 		--timeout 5h \
 		--job-timeout 5h \
@@ -48,6 +49,7 @@ else
 	coder exp scaletest create-workspaces \
 		--count 1 \
 		--template "${SCALETEST_PARAM_GREEDY_AGENT_TEMPLATE}" \
+		--use-parameter-defaults \
 		--concurrency 1 \
 		--timeout 5h \
 		--job-timeout 5h \


### PR DESCRIPTION
Relates to PRODUCT-534

A user reported that the scaletest runner startup script failed when it invoked `coder exp scaletest create-workspaces`:

```text
error: prepare build: error creating cancelreader: add reader to epoll interest list
Scaletest failed!
```

The runner has no interactive stdin, but template parameter resolution tried to open a selector. Bubble Tea then failed whilst creating its Linux `cancelreader`, so the unresolved template parameter was hidden by this confusing epoll error.

This PR fixes that error message for non-interactive scaletest commands. Instead of trying to prompt, the CLI now identifies the unresolved parameter and tells the user to pass `--use-parameter-defaults` or set it with `--parameter`.

The scaletest commands now expose `--use-parameter-defaults`, and the scaletest runner passes it explicitly when creating workspaces. This lets the runner use declared defaults without attempting to open an interactive selector.
