### PR TITLE
docs: note bulk stop confirmation

### DIFF
--- a/docs/user-guides/workspace-management.md
+++ b/docs/user-guides/workspace-management.md
@@ -110,8 +110,8 @@ operation.
 The start and stop operations can be applied even when the selected workspaces
 are not all in the same state. Bulk start will only apply to selected workspaces
 that are currently stopped, and bulk stop will only apply to selected workspaces
-that are currently running. For update and delete, the user will be prompted for
-confirmation before any action is taken.
+that are currently running. For update, delete, and stop, the user is prompted
+for confirmation before any action is taken.
 
 ![Bulk workspace actions](../images/user-guides/workspace-bulk-actions.png)
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

## What

Restores the docs change that was reverted out of #27631. The bulk **Stop** action now shows a confirmation dialog (shipped in #27631), so the workspace management docs should reflect that stop, alongside update and delete, prompts for confirmation.

## How

Updates the Bulk operations section of `docs/user-guides/workspace-management.md` to note that stop is now included in the actions that prompt for confirmation before running.

<details>
<summary>Reverted change being restored</summary>

Before:

> For update and delete, the user will be prompted for confirmation before any action is taken.

After:

> For update, delete, and stop, the user is prompted for confirmation before any action is taken.

This content was originally added in #27631 (commit `e6a0aff`) and reverted in commit `2378960` before merge.

</details>