### PR TITLE
feat: add built-in Browser tab for agent-browser

### DIFF
--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -91,6 +91,10 @@ type ExecuteResult struct {
 type ExecuteOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
 	DefaultTimeout   time.Duration
+	// AgentBrowserSession, when non-empty, is exported as
+	// AGENT_BROWSER_SESSION so agent-browser CLI invocations land in a
+	// browser session scoped to this chat instead of a shared default.
+	AgentBrowserSession string
 }
 
 // ProcessToolOptions configures a process management tool
@@ -126,7 +130,7 @@ func Execute(options ExecuteOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeTool(ctx, conn, args, options.DefaultTimeout), nil
+			return executeTool(ctx, conn, args, options), nil
 		},
 	)
 }
@@ -135,15 +139,18 @@ func executeTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args ExecuteArgs,
-	optTimeout time.Duration,
+	options ExecuteOptions,
 ) fantasy.ToolResponse {
 	if args.Command == "" {
 		return fantasy.NewTextErrorResponse("command is required")
 	}
 
 	// Build the environment map for the process request.
-	env := make(map[string]string, len(nonInteractiveEnvVars)+1)
+	env := make(map[string]string, len(nonInteractiveEnvVars)+2)
 	env["CODER_CHAT_AGENT"] = "true"
+	if options.AgentBrowserSession != "" {
+		env["AGENT_BROWSER_SESSION"] = options.AgentBrowserSession
+	}
 	for k, v := range nonInteractiveEnvVars {
 		env[k] = v
 	}
@@ -168,7 +175,7 @@ func executeTool(
 	if background {
 		return executeBackground(ctx, conn, args.Command, workDir, env)
 	}
-	return executeForeground(ctx, conn, args, optTimeout, workDir, env)
+	return executeForeground(ctx, conn, args, options.DefaultTimeout, workDir, env)
 }
 
 // executeBackground starts a process in the background and

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -228,6 +228,44 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "hello world", result.Output)
 		assert.Empty(t, result.BackgroundProcessID)
 		assert.Equal(t, "true", capturedReq.Env["CODER_CHAT_AGENT"])
+		assert.NotContains(t, capturedReq.Env, "AGENT_BROWSER_SESSION")
+	})
+
+	t.Run("AgentBrowserSessionEnv", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		var capturedReq workspacesdk.StartProcessRequest
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				capturedReq = req
+				return workspacesdk.StartProcessResponse{ID: "proc-1"}, nil
+			})
+		exitCode := 0
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			Return(workspacesdk.ProcessOutputResponse{
+				Running:  false,
+				ExitCode: &exitCode,
+			}, nil)
+
+		tool := chattool.Execute(chattool.ExecuteOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			AgentBrowserSession: "chat-123",
+		})
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"echo hello"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Equal(t, "chat-123", capturedReq.Env["AGENT_BROWSER_SESSION"])
 	})
 
 	t.Run("ModelIntentIgnoredByExecution", func(t *testing.T) {

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -412,7 +412,10 @@ func (server *Server) prepareGeneration(
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
 			StoreFile:        storeChatAttachment,
 		}),
-		chattool.Execute(chattool.ExecuteOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
+		chattool.Execute(chattool.ExecuteOptions{
+			GetWorkspaceConn:    workspaceCtx.getWorkspaceConn,
+			AgentBrowserSession: chat.ID.String(),
+		}),
 		chattool.ProcessOutput(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
 		chattool.ProcessList(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
 		chattool.ProcessSignal(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -179,6 +179,29 @@ export const isWorkspaceAppEmbeddable = (app: WorkspaceApp): boolean => {
 	return !app.hidden && !isExternalApp(app) && !app.command;
 };
 
+export const AGENT_BROWSER_APP_SLUG = "agent-browser";
+
+/**
+ * The agent's agent-browser dashboard app when it can back the built-in
+ * Browser tab: embeddable and reporting "healthy", or "disabled" when the
+ * template declares no healthcheck.
+ */
+export const getAgentBrowserApp = (
+	agent: WorkspaceAgent | undefined,
+): WorkspaceApp | undefined => {
+	const app = agent?.apps.find(
+		(agentApp) => agentApp.slug === AGENT_BROWSER_APP_SLUG,
+	);
+	if (
+		app &&
+		isWorkspaceAppEmbeddable(app) &&
+		(app.health === "healthy" || app.health === "disabled")
+	) {
+		return app;
+	}
+	return undefined;
+};
+
 /**
  * True when an app requires subdomain access but the deployment has no wildcard
  * access URL configured, so the app cannot be launched or embedded.

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -181,17 +181,13 @@ export const isWorkspaceAppEmbeddable = (app: WorkspaceApp): boolean => {
 
 export const AGENT_BROWSER_APP_SLUG = "agent-browser";
 
-/**
- * The agent's agent-browser dashboard app when it can back the built-in
- * Browser tab: embeddable and reporting "healthy", or "disabled" when the
- * template declares no healthcheck.
- */
 export const getAgentBrowserApp = (
 	agent: WorkspaceAgent | undefined,
 ): WorkspaceApp | undefined => {
 	const app = agent?.apps.find(
 		(agentApp) => agentApp.slug === AGENT_BROWSER_APP_SLUG,
 	);
+	// "disabled" means the template does not configure a health check.
 	if (
 		app &&
 		isWorkspaceAppEmbeddable(app) &&

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -1,18 +1,29 @@
 import { act, renderHook } from "@testing-library/react";
 import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatMessage, ChatQueuedMessage } from "#/api/typesGenerated";
+import type {
+	ChatMessage,
+	ChatQueuedMessage,
+	Workspace,
+	WorkspaceApp,
+} from "#/api/typesGenerated";
 import {
 	MockChatMessage,
 	MockChatQueuedMessage,
 } from "#/testHelpers/chatEntities";
 import { createDeferred } from "#/testHelpers/deferred";
-import { MockUserOwner, MockWorkspace } from "#/testHelpers/entities";
+import {
+	MockUserOwner,
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+} from "#/testHelpers/entities";
 import {
 	buildInactiveChatQueueReconciliation,
 	draftInputStorageKeyPrefix,
 	getPersistedDraftInputValue,
 	getWorkspaceOptionsWithLinkedWorkspace,
+	isWatchedWorkspaceViewUnchanged,
 	reconcilePromotedQueueHead,
 	restoreOptimisticRequestSnapshot,
 	runPromoteQueuedMessage,
@@ -1391,5 +1402,62 @@ describe("sidebar tab persistence", () => {
 			expect(getPersistedSidebarTabId("chat-a")).toBeNull();
 			expect(getPersistedSidebarTabId("chat-b")).toBe("desktop");
 		});
+	});
+});
+
+describe("isWatchedWorkspaceViewUnchanged", () => {
+	const cloneWithApps = (apps: WorkspaceApp[]): Workspace => ({
+		...MockWorkspace,
+		latest_build: {
+			...MockWorkspace.latest_build,
+			resources: MockWorkspace.latest_build.resources.map((resource) => ({
+				...resource,
+				agents: resource.agents?.map((agent) =>
+					agent.id === MockWorkspaceAgent.id ? { ...agent, apps } : agent,
+				),
+			})),
+		},
+	});
+
+	it("is true for a fresh payload with only unwatched changes", () => {
+		const next: Workspace = {
+			...MockWorkspace,
+			last_used_at: "2024-01-01T00:00:00Z",
+		};
+
+		expect(
+			isWatchedWorkspaceViewUnchanged(
+				MockWorkspace,
+				next,
+				MockWorkspaceAgent.id,
+			),
+		).toBe(true);
+	});
+
+	it("is false when a bound-agent app changes health", () => {
+		const next = cloneWithApps([{ ...MockWorkspaceApp, health: "healthy" }]);
+
+		expect(
+			isWatchedWorkspaceViewUnchanged(
+				MockWorkspace,
+				next,
+				MockWorkspaceAgent.id,
+			),
+		).toBe(false);
+	});
+
+	it("is false when the bound agent gains an app", () => {
+		const next = cloneWithApps([
+			MockWorkspaceApp,
+			{ ...MockWorkspaceApp, id: "second-app", slug: "second-app" },
+		]);
+
+		expect(
+			isWatchedWorkspaceViewUnchanged(
+				MockWorkspace,
+				next,
+				MockWorkspaceAgent.id,
+			),
+		).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -426,7 +426,7 @@ export const getWorkspaceOptionsWithLinkedWorkspace = (
 
 // Keep this list in sync with app fields consumed by the chat UI, or live
 // updates to those fields can retain stale query data.
-const watchedAgentAppFields = [
+const watchedAgentAppFields: readonly (keyof TypesGen.WorkspaceApp)[] = [
 	"id",
 	"slug",
 	"health",
@@ -436,7 +436,7 @@ const watchedAgentAppFields = [
 	"subdomain",
 	"subdomain_name",
 	"display_name",
-] as const;
+];
 
 /** @internal Exported for testing. */
 export const isWatchedWorkspaceViewUnchanged = (

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -424,6 +424,57 @@ export const getWorkspaceOptionsWithLinkedWorkspace = (
 	return nextWorkspaceOptions;
 };
 
+// Fields of the bound agent's apps that the UI renders from: the right
+// panel derives tabs (including the built-in Browser tab) and their
+// iframe URLs from these.
+const watchedAgentAppFields = [
+	"id",
+	"slug",
+	"health",
+	"hidden",
+	"external",
+	"command",
+	"subdomain",
+	"subdomain_name",
+	"display_name",
+] as const;
+
+/**
+ * True when a watched workspace update changes nothing the chat UI reads,
+ * so the previous object reference can be kept to avoid re-renders on
+ * every heartbeat.
+ *
+ * @internal Exported for testing.
+ */
+export const isWatchedWorkspaceViewUnchanged = (
+	prev: TypesGen.Workspace,
+	next: TypesGen.Workspace,
+	chatAgentId: string | undefined,
+): boolean => {
+	const prevAgent = getWorkspaceAgent(prev, chatAgentId);
+	const nextAgent = getWorkspaceAgent(next, chatAgentId);
+	const prevApps = prevAgent?.apps ?? [];
+	const nextApps = nextAgent?.apps ?? [];
+	return (
+		prev.latest_build.status === next.latest_build.status &&
+		prev.health.healthy === next.health.healthy &&
+		prev.name === next.name &&
+		prev.owner_name === next.owner_name &&
+		prevAgent?.id === nextAgent?.id &&
+		prevAgent?.status === nextAgent?.status &&
+		prevAgent?.name === nextAgent?.name &&
+		prevAgent?.expanded_directory === nextAgent?.expanded_directory &&
+		prevAgent?.lifecycle_state === nextAgent?.lifecycle_state &&
+		prevApps.length === nextApps.length &&
+		prevApps.every((prevApp, index) => {
+			const nextApp = nextApps[index];
+			return watchedAgentAppFields.every(
+				(field) => prevApp[field] === nextApp[field],
+			);
+		})
+	);
+};
+
 const buildAttachmentMediaTypes = (
 	attachments?: readonly PendingAttachment[],
 ): ReadonlyMap<string, string> | undefined => {
@@ -967,19 +1018,9 @@ const AgentChatPage: FC = () => {
 					// reads has changed. This prevents react-query
 					// from notifying subscribers and avoids a full
 					// AgentChatPage re-render on every heartbeat.
-					const prevAgent = getWorkspaceAgent(prev, chatAgentId);
-					const nextAgent = getWorkspaceAgent(next, chatAgentId);
 					if (
 						prev &&
-						prev.latest_build.status === next.latest_build.status &&
-						prev.health.healthy === next.health.healthy &&
-						prev.name === next.name &&
-						prev.owner_name === next.owner_name &&
-						prevAgent?.id === nextAgent?.id &&
-						prevAgent?.status === nextAgent?.status &&
-						prevAgent?.name === nextAgent?.name &&
-						prevAgent?.expanded_directory === nextAgent?.expanded_directory &&
-						prevAgent?.lifecycle_state === nextAgent?.lifecycle_state
+						isWatchedWorkspaceViewUnchanged(prev, next, chatAgentId)
 					) {
 						return prev;
 					}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -424,9 +424,8 @@ export const getWorkspaceOptionsWithLinkedWorkspace = (
 	return nextWorkspaceOptions;
 };
 
-// Fields of the bound agent's apps that the UI renders from: the right
-// panel derives tabs (including the built-in Browser tab) and their
-// iframe URLs from these.
+// Keep this list in sync with app fields consumed by the chat UI, or live
+// updates to those fields can retain stale query data.
 const watchedAgentAppFields = [
 	"id",
 	"slug",
@@ -439,13 +438,7 @@ const watchedAgentAppFields = [
 	"display_name",
 ] as const;
 
-/**
- * True when a watched workspace update changes nothing the chat UI reads,
- * so the previous object reference can be kept to avoid re-renders on
- * every heartbeat.
- *
- * @internal Exported for testing.
- */
+/** @internal Exported for testing. */
 export const isWatchedWorkspaceViewUnchanged = (
 	prev: TypesGen.Workspace,
 	next: TypesGen.Workspace,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1680,7 +1680,7 @@ export const PreservesUnavailableSidebarTab: Story = {
 	},
 };
 
-const agentBrowserApp: TypesGen.WorkspaceApp = {
+const mockAgentBrowserApp: TypesGen.WorkspaceApp = {
 	...MockWorkspaceApp,
 	id: "agent-browser-app",
 	slug: AGENT_BROWSER_APP_SLUG,
@@ -1688,9 +1688,9 @@ const agentBrowserApp: TypesGen.WorkspaceApp = {
 	health: "healthy",
 };
 
-const agentWithBrowserApp: TypesGen.WorkspaceAgent = {
+const mockAgentWithBrowserApp: TypesGen.WorkspaceAgent = {
 	...MockWorkspaceAgent,
-	apps: [...MockWorkspaceAgent.apps, agentBrowserApp],
+	apps: [...MockWorkspaceAgent.apps, mockAgentBrowserApp],
 };
 
 export const BrowserTabForHealthyAgentBrowserApp: Story = {
@@ -1698,7 +1698,7 @@ export const BrowserTabForHealthyAgentBrowserApp: Story = {
 		<StoryAgentChatPageView
 			showSidebarPanel
 			workspace={MockWorkspace}
-			workspaceAgent={agentWithBrowserApp}
+			workspaceAgent={mockAgentWithBrowserApp}
 			sshCommand="ssh coder.workspace"
 		/>
 	),
@@ -1730,7 +1730,7 @@ export const BrowserTabForHealthDisabledAgentBrowserApp: Story = {
 			workspace={MockWorkspace}
 			workspaceAgent={{
 				...MockWorkspaceAgent,
-				apps: [{ ...agentBrowserApp, health: "disabled" }],
+				apps: [{ ...mockAgentBrowserApp, health: "disabled" }],
 			}}
 			sshCommand="ssh coder.workspace"
 		/>
@@ -1755,7 +1755,7 @@ export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
 			workspace={MockWorkspace}
 			workspaceAgent={{
 				...MockWorkspaceAgent,
-				apps: [{ ...agentBrowserApp, health: "unhealthy" }],
+				apps: [{ ...mockAgentBrowserApp, health: "unhealthy" }],
 			}}
 			sshCommand="ssh coder.workspace"
 		/>
@@ -1782,7 +1782,7 @@ export const NoBrowserTabForAppOnNonBoundAgent: Story = {
 							agents: [
 								MockWorkspaceAgent,
 								{
-									...agentWithBrowserApp,
+									...mockAgentWithBrowserApp,
 									id: "other-agent",
 									name: "other-agent",
 								},

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1723,6 +1723,35 @@ export const BrowserTabForHealthyAgentBrowserApp: Story = {
 	},
 };
 
+/**
+ * "disabled" health means the template declares no healthcheck, so the tab
+ * shows on template presence alone.
+ */
+export const BrowserTabForHealthDisabledAgentBrowserApp: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				apps: [{ ...agentBrowserApp, health: "disabled" }],
+			}}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const browserTab = await canvas.findByRole("tab", { name: "Browser" });
+		await userEvent.click(browserTab);
+
+		await waitFor(() => {
+			expect(browserTab).toHaveAttribute("aria-selected", "true");
+		});
+		expect(canvas.getByTitle("agent-browser").checkVisibility()).toBe(true);
+	},
+};
+
 export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
 	render: () => (
 		<StoryAgentChatPageView

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1723,10 +1723,6 @@ export const BrowserTabForHealthyAgentBrowserApp: Story = {
 	},
 };
 
-/**
- * "disabled" health means the template declares no healthcheck, so the tab
- * shows on template presence alone.
- */
 export const BrowserTabForHealthDisabledAgentBrowserApp: Story = {
 	render: () => (
 		<StoryAgentChatPageView

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -5,6 +5,7 @@ import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
+import { AGENT_BROWSER_APP_SLUG } from "#/modules/apps/apps";
 import { MockChat } from "#/testHelpers/chatEntities";
 import {
 	MockDefaultOrganization,
@@ -14,6 +15,8 @@ import {
 	MockUserOwner,
 	MockWorkspace,
 	MockWorkspaceAgent,
+	MockWorkspaceApp,
+	MockWorkspaceResource,
 } from "#/testHelpers/entities";
 import {
 	withAuthProvider,
@@ -1674,6 +1677,152 @@ export const PreservesUnavailableSidebarTab: Story = {
 		expect(canvas.queryByRole("tab", { name: "Terminal" })).toBeNull();
 
 		expect(localStorage.getItem(sidebarTabStorageKey)).toBe("terminal");
+	},
+};
+
+const agentBrowserApp: TypesGen.WorkspaceApp = {
+	...MockWorkspaceApp,
+	id: "agent-browser-app",
+	slug: AGENT_BROWSER_APP_SLUG,
+	display_name: "agent-browser",
+	health: "healthy",
+};
+
+const agentWithBrowserApp: TypesGen.WorkspaceAgent = {
+	...MockWorkspaceAgent,
+	apps: [...MockWorkspaceAgent.apps, agentBrowserApp],
+};
+
+/**
+ * A healthy agent-browser app on the bound agent surfaces as the built-in
+ * Browser tab, ordered with the other built-ins, and selecting it renders
+ * the embedded app frame.
+ */
+export const BrowserTabForHealthyAgentBrowserApp: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			workspace={MockWorkspace}
+			workspaceAgent={agentWithBrowserApp}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const browserTab = await canvas.findByRole("tab", { name: "Browser" });
+		const tabLabels = canvas.getAllByRole("tab").map((tab) => tab.textContent);
+		expect(tabLabels).toEqual(["Summary", "Git", "Browser", "Terminal"]);
+
+		// The frame stays mounted while inactive to preserve app state, so
+		// assert visibility rather than presence.
+		const frame = canvas.getByTitle("agent-browser");
+		expect(frame.checkVisibility()).toBe(false);
+
+		await userEvent.click(browserTab);
+
+		await waitFor(() => {
+			expect(browserTab).toHaveAttribute("aria-selected", "true");
+		});
+		expect(frame.checkVisibility()).toBe(true);
+	},
+};
+
+/**
+ * The Browser tab only appears while the agent-browser app reports
+ * "healthy" (or "disabled"); an unhealthy daemon must not surface a tab
+ * wrapping a troubleshooting screen.
+ */
+export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				apps: [{ ...agentBrowserApp, health: "unhealthy" }],
+			}}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByRole("tab", { name: "Summary" });
+		expect(canvas.queryByRole("tab", { name: "Browser" })).toBeNull();
+	},
+};
+
+/**
+ * The Browser tab is bound-agent-only: an agent-browser app on another
+ * agent in the same workspace does not surface a tab for this chat.
+ */
+export const NoBrowserTabForAppOnNonBoundAgent: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			workspace={{
+				...MockWorkspace,
+				latest_build: {
+					...MockWorkspace.latest_build,
+					resources: [
+						{
+							...MockWorkspaceResource,
+							agents: [
+								MockWorkspaceAgent,
+								{
+									...agentWithBrowserApp,
+									id: "other-agent",
+									name: "other-agent",
+								},
+							],
+						},
+					],
+				},
+			}}
+			workspaceAgent={MockWorkspaceAgent}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByRole("tab", { name: "Summary" });
+		expect(canvas.queryByRole("tab", { name: "Browser" })).toBeNull();
+	},
+};
+
+/**
+ * When localStorage holds "browser" but the agent-browser app is not
+ * available, the sidebar falls back to Summary while preserving the
+ * stored value so the tab restores when the app becomes healthy again.
+ */
+export const PreservesUnavailableBrowserTab: Story = {
+	beforeEach: () => {
+		localStorage.setItem(sidebarTabStorageKey, "browser");
+		return () => {
+			localStorage.removeItem(sidebarTabStorageKey);
+		};
+	},
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			workspace={MockWorkspace}
+			workspaceAgent={MockWorkspaceAgent}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await waitFor(() => {
+			const summaryTab = canvas.getByRole("tab", { name: "Summary" });
+			expect(summaryTab).toHaveAttribute("aria-selected", "true");
+		});
+
+		expect(canvas.queryByRole("tab", { name: "Browser" })).toBeNull();
+
+		expect(localStorage.getItem(sidebarTabStorageKey)).toBe("browser");
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1693,11 +1693,6 @@ const agentWithBrowserApp: TypesGen.WorkspaceAgent = {
 	apps: [...MockWorkspaceAgent.apps, agentBrowserApp],
 };
 
-/**
- * A healthy agent-browser app on the bound agent surfaces as the built-in
- * Browser tab, ordered with the other built-ins, and selecting it renders
- * the embedded app frame.
- */
 export const BrowserTabForHealthyAgentBrowserApp: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -1728,11 +1723,6 @@ export const BrowserTabForHealthyAgentBrowserApp: Story = {
 	},
 };
 
-/**
- * The Browser tab only appears while the agent-browser app reports
- * "healthy" (or "disabled"); an unhealthy daemon must not surface a tab
- * wrapping a troubleshooting screen.
- */
 export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -1753,10 +1743,6 @@ export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
 	},
 };
 
-/**
- * The Browser tab is bound-agent-only: an agent-browser app on another
- * agent in the same workspace does not surface a tab for this chat.
- */
 export const NoBrowserTabForAppOnNonBoundAgent: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -1792,11 +1778,6 @@ export const NoBrowserTabForAppOnNonBoundAgent: Story = {
 	},
 };
 
-/**
- * When localStorage holds "browser" but the agent-browser app is not
- * available, the sidebar falls back to Summary while preserving the
- * stored value so the tab restores when the app becomes healthy again.
- */
 export const PreservesUnavailableBrowserTab: Story = {
 	beforeEach: () => {
 		localStorage.setItem(sidebarTabStorageKey, "browser");

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -19,7 +19,10 @@ import type {
 	ChatMessagePart,
 } from "#/api/typesGenerated";
 import { useProxy } from "#/contexts/ProxyContext";
-import { isWorkspaceAppEmbeddable } from "#/modules/apps/apps";
+import {
+	getAgentBrowserApp,
+	isWorkspaceAppEmbeddable,
+} from "#/modules/apps/apps";
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
 import { findWorkspaceAppWithAgent } from "#/modules/apps/workspaceApps";
 import { cn } from "#/utils/cn";
@@ -500,6 +503,13 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const availableDesktopChatId =
 		workspace && workspaceAgent ? desktopChatId : undefined;
 
+	// Browser mirrors the Desktop availability semantics: when the
+	// agent-browser app stops being healthy the tab drops out, and the
+	// stored active-tab ID restores it when health returns.
+	const availableBrowserApp = workspace
+		? getAgentBrowserApp(workspaceAgent)
+		: undefined;
+
 	const validatedUserRightPanelTabs = validateUserRightPanelTabs(
 		userRightPanelTabs,
 		{ workspace, workspaceAgent, wildcardHostname },
@@ -516,6 +526,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		{ id: "summary", label: "Summary" },
 		{ id: "git", label: "Git" },
 		...(debugLoggingEnabled ? [{ id: "debug", label: "Debug" }] : []),
+		...(availableBrowserApp ? [{ id: "browser", label: "Browser" }] : []),
 		...(availableDesktopChatId ? [{ id: "desktop", label: "Desktop" }] : []),
 		...(hasBuiltInTerminal ? [{ id: "terminal", label: "Terminal" }] : []),
 	];
@@ -708,6 +719,14 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						chatInputRef={editing.chatInputRef}
 					/>
 				);
+			case "browser":
+				return workspace && workspaceAgent && availableBrowserApp ? (
+					<WorkspaceAppFrame
+						workspace={workspace}
+						app={{ ...availableBrowserApp, agent: workspaceAgent }}
+						active={effectiveSidebarTabId === "browser"}
+					/>
+				) : null;
 			case "desktop":
 				return availableDesktopChatId ? (
 					<DesktopPanel

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -503,9 +503,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const availableDesktopChatId =
 		workspace && workspaceAgent ? desktopChatId : undefined;
 
-	// Browser mirrors the Desktop availability semantics: when the
-	// agent-browser app stops being healthy the tab drops out, and the
-	// stored active-tab ID restores it when health returns.
 	const availableBrowserApp = workspace
 		? getAgentBrowserApp(workspaceAgent)
 		: undefined;

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
@@ -23,7 +23,7 @@ const embeddableApp: WorkspaceApp = {
 	command: undefined,
 };
 
-const agentBrowserApp: WorkspaceApp = {
+const mockAgentBrowserApp: WorkspaceApp = {
 	...MockWorkspaceApp,
 	id: "agent-browser-app",
 	slug: AGENT_BROWSER_APP_SLUG,
@@ -146,7 +146,7 @@ export const ExcludesAgentBrowserApp: Story = {
 	args: {
 		agent: {
 			...MockWorkspaceAgent,
-			apps: [embeddableApp, agentBrowserApp],
+			apps: [embeddableApp, mockAgentBrowserApp],
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
@@ -23,6 +23,14 @@ const embeddableApp: WorkspaceApp = {
 	command: undefined,
 };
 
+const agentBrowserApp: WorkspaceApp = {
+	...MockWorkspaceApp,
+	id: "agent-browser-app",
+	slug: AGENT_BROWSER_APP_SLUG,
+	display_name: "agent-browser",
+	health: "healthy",
+};
+
 const commandApp: WorkspaceApp = {
 	...MockWorkspaceApp,
 	id: "command-app",
@@ -138,16 +146,7 @@ export const ExcludesAgentBrowserApp: Story = {
 	args: {
 		agent: {
 			...MockWorkspaceAgent,
-			apps: [
-				embeddableApp,
-				{
-					...MockWorkspaceApp,
-					id: "agent-browser-app",
-					slug: AGENT_BROWSER_APP_SLUG,
-					display_name: "agent-browser",
-					health: "healthy",
-				},
-			],
+			apps: [embeddableApp, agentBrowserApp],
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
@@ -134,10 +134,6 @@ export const Default: Story = {
 	},
 };
 
-/**
- * The agent-browser app is surfaced as the built-in Browser tab, so the
- * add menu must not offer it while still listing the other apps.
- */
 export const ExcludesAgentBrowserApp: Story = {
 	args: {
 		agent: {

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type { WorkspaceApp } from "#/api/typesGenerated";
+import { AGENT_BROWSER_APP_SLUG } from "#/modules/apps/apps";
 import {
 	MockListeningPortsResponse,
 	MockSharedPortsResponse,
@@ -130,6 +131,38 @@ export const Default: Story = {
 		await expect(args.onOpenPort).toHaveBeenCalledWith(
 			expect.objectContaining({ port: 8080 }),
 		);
+	},
+};
+
+/**
+ * The agent-browser app is surfaced as the built-in Browser tab, so the
+ * add menu must not offer it while still listing the other apps.
+ */
+export const ExcludesAgentBrowserApp: Story = {
+	args: {
+		agent: {
+			...MockWorkspaceAgent,
+			apps: [
+				embeddableApp,
+				{
+					...MockWorkspaceApp,
+					id: "agent-browser-app",
+					slug: AGENT_BROWSER_APP_SLUG,
+					display_name: "agent-browser",
+					health: "healthy",
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByLabelText("Add panel"));
+
+		const body = within(document.body);
+		await waitFor(() => {
+			expect(body.getByText("Preview")).toBeInTheDocument();
+		});
+		expect(body.queryByText("agent-browser")).toBeNull();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
@@ -19,7 +19,10 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { isWorkspaceAppEmbeddable } from "#/modules/apps/apps";
+import {
+	AGENT_BROWSER_APP_SLUG,
+	isWorkspaceAppEmbeddable,
+} from "#/modules/apps/apps";
 import { AppLink } from "#/modules/resources/AppLink/AppLink";
 import {
 	canShowPortForwarding,
@@ -78,7 +81,12 @@ export const RightPanelAddTabControl: FC<{
 	onOpenPort,
 }) => {
 	const [open, setOpen] = useState(false);
-	const userApps = agent?.apps.filter((app) => !app.hidden) ?? [];
+	// agent-browser is surfaced as the built-in Browser tab, so the add
+	// menu never offers it as a duplicate workspace app tab.
+	const userApps =
+		agent?.apps.filter(
+			(app) => !app.hidden && app.slug !== AGENT_BROWSER_APP_SLUG,
+		) ?? [];
 	const canCreateTerminal =
 		workspace !== undefined && agent !== undefined && isRunning;
 

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
@@ -81,8 +81,7 @@ export const RightPanelAddTabControl: FC<{
 	onOpenPort,
 }) => {
 	const [open, setOpen] = useState(false);
-	// agent-browser is surfaced as the built-in Browser tab, so the add
-	// menu never offers it as a duplicate workspace app tab.
+	// agent-browser already has the built-in Browser tab.
 	const userApps =
 		agent?.apps.filter(
 			(app) => !app.hidden && app.slug !== AGENT_BROWSER_APP_SLUG,

--- a/site/src/pages/AgentsPage/utils/rightPanelTabs.test.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabs.test.ts
@@ -4,6 +4,7 @@ import type {
 	WorkspaceAgent,
 	WorkspaceApp,
 } from "#/api/typesGenerated";
+import { AGENT_BROWSER_APP_SLUG } from "#/modules/apps/apps";
 import {
 	MockWorkspace,
 	MockWorkspaceAgent,
@@ -130,6 +131,28 @@ describe("right-panel tab validation", () => {
 			label: "Command",
 			agentId: "agent-1",
 			appId: "command-app",
+		};
+
+		const validated = validateUserRightPanelTabs([appTab], {
+			workspace,
+			workspaceAgent: workspace.latest_build.resources[0].agents?.[0],
+			wildcardHostname: "*.apps.example.com",
+		});
+
+		expect(validated).toEqual([]);
+	});
+
+	it("drops agent-browser app tabs in favor of the built-in Browser tab", () => {
+		const browserApp = buildApp("browser-app", {
+			slug: AGENT_BROWSER_APP_SLUG,
+		});
+		const workspace = buildWorkspace([buildAgent("agent-1", [browserApp])]);
+		const appTab: UserRightPanelTab = {
+			id: "browser-app-tab",
+			kind: "workspace_app",
+			label: "agent-browser",
+			agentId: "agent-1",
+			appId: "browser-app",
 		};
 
 		const validated = validateUserRightPanelTabs([appTab], {

--- a/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
@@ -3,7 +3,10 @@ import type {
 	WorkspaceAgent,
 	WorkspaceAgentPortShareProtocol,
 } from "#/api/typesGenerated";
-import { isWorkspaceAppEmbeddable } from "#/modules/apps/apps";
+import {
+	AGENT_BROWSER_APP_SLUG,
+	isWorkspaceAppEmbeddable,
+} from "#/modules/apps/apps";
 import { findWorkspaceAppWithAgent } from "#/modules/apps/workspaceApps";
 import { canShowPortForwarding } from "#/modules/resources/usePortsData";
 import { findWorkspaceAgent } from "#/utils/workspace";
@@ -114,7 +117,13 @@ export function validateUserRightPanelTabs(
 
 		if (tab.kind === "workspace_app") {
 			const app = findWorkspaceAppWithAgent(workspace, tab.agentId, tab.appId);
-			return app !== undefined && isWorkspaceAppEmbeddable(app);
+			// Persisted agent-browser tabs collapse into the built-in
+			// Browser tab instead of duplicating it.
+			return (
+				app !== undefined &&
+				app.slug !== AGENT_BROWSER_APP_SLUG &&
+				isWorkspaceAppEmbeddable(app)
+			);
 		}
 
 		// Mirror the add-menu gate so a persisted port tab disappears when

--- a/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
@@ -117,8 +117,7 @@ export function validateUserRightPanelTabs(
 
 		if (tab.kind === "workspace_app") {
 			const app = findWorkspaceAppWithAgent(workspace, tab.agentId, tab.appId);
-			// Agent-browser uses the built-in Browser tab, so persisted workspace app
-			// tabs for it are omitted.
+			// agent-browser already has the built-in Browser tab.
 			return (
 				app !== undefined &&
 				app.slug !== AGENT_BROWSER_APP_SLUG &&

--- a/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
@@ -117,8 +117,8 @@ export function validateUserRightPanelTabs(
 
 		if (tab.kind === "workspace_app") {
 			const app = findWorkspaceAppWithAgent(workspace, tab.agentId, tab.appId);
-			// Persisted agent-browser tabs collapse into the built-in
-			// Browser tab instead of duplicating it.
+			// Agent-browser uses the built-in Browser tab, so persisted workspace app
+			// tabs for it are omitted.
 			return (
 				app !== undefined &&
 				app.slug !== AGENT_BROWSER_APP_SLUG &&


### PR DESCRIPTION
Adds a built-in Browser tab to the Agents page right panel, alongside the built-in Terminal and Desktop tabs, when the chat's bound agent has an app with the well-known slug `agent-browser`. The tab shows only while the app is embeddable and its health is `healthy` (or `disabled`, for templates without a healthcheck), so it appears and disappears live as the daemon comes up or goes down. The iframe stays mounted across tab switches to preserve session state.

To avoid duplicates, the generic Add Tab menu and persisted workspace-app tabs now exclude the `agent-browser` app. Detection uses the existing `coder_app` slug and healthcheck signals already present in the workspace data model. The workspace watch handler compares the agent app fields the chat UI consumes, so health transitions propagate without re-render churn on every heartbeat.

On the backend, the chat `execute` tool now exports `AGENT_BROWSER_SESSION=<chat id>` on every process it starts. agent-browser resolves its default session from that variable, so browser automation from each chat lands in its own isolated session (named by the chat id in the embedded dashboard) instead of a shared default browser.

> Mux created this PR on Mike's behalf.
