### PR TITLE
feat!: paginate and standardize provisioner job filters

### DIFF
--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -44,8 +44,10 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 			cliui.JSONFormat(),
 		)
 		status    []string
+		jobTypes  []string
 		limit     int64
 		initiator string
+		template  string
 	)
 
 	cmd := &serpent.Command{
@@ -79,7 +81,9 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 					Limit: int(limit),
 				},
 				Status:    slice.StringEnums[codersdk.ProvisionerJobStatus](status),
+				Types:     slice.StringEnums[codersdk.ProvisionerJobType](jobTypes),
 				Initiator: initiator,
+				Template:  template,
 			})
 			if err != nil {
 				return xerrors.Errorf("list provisioner jobs: %w", err)
@@ -132,6 +136,12 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 			Value:         serpent.EnumArrayOf(&status, slice.ToStrings(codersdk.ProvisionerJobStatusEnums())...),
 		},
 		{
+			Flag:        "type",
+			Env:         "CODER_PROVISIONER_JOB_LIST_TYPE",
+			Description: "Filter by job type.",
+			Value:       serpent.EnumArrayOf(&jobTypes, slice.ToStrings(codersdk.ProvisionerJobTypeEnums())...),
+		},
+		{
 			Flag:          "limit",
 			FlagShorthand: "l",
 			Env:           "CODER_PROVISIONER_JOB_LIST_LIMIT",
@@ -145,6 +155,12 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 			Env:           "CODER_PROVISIONER_JOB_LIST_INITIATOR",
 			Description:   "Filter by initiator (user ID or username).",
 			Value:         serpent.StringOf(&initiator),
+		},
+		{
+			Flag:        "template",
+			Env:         "CODER_PROVISIONER_JOB_LIST_TEMPLATE",
+			Description: "Filter by template ID.",
+			Value:       serpent.StringOf(&template),
 		},
 	}...)
 

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -74,22 +74,24 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 				initiator = user.ID.String()
 			}
 
-			jobs, err := client.OrganizationProvisionerJobs(ctx, org.ID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := client.OrganizationProvisionerJobs(ctx, org.ID, &codersdk.OrganizationProvisionerJobsOptions{
+				Pagination: codersdk.Pagination{
+					Limit: int(limit),
+				},
 				Status:    slice.StringEnums[codersdk.ProvisionerJobStatus](status),
-				Limit:     int(limit),
 				Initiator: initiator,
 			})
 			if err != nil {
 				return xerrors.Errorf("list provisioner jobs: %w", err)
 			}
 
-			if len(jobs) == 0 {
+			if len(jobsRes.Jobs) == 0 {
 				_, _ = fmt.Fprintln(inv.Stdout, "No provisioner jobs found")
 				return nil
 			}
 
 			var rows []provisionerJobRow
-			for _, job := range jobs {
+			for _, job := range jobsRes.Jobs {
 				row := provisionerJobRow{
 					ProvisionerJob:   job,
 					OrganizationName: org.HumanName(),

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -69,23 +69,15 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 				return xerrors.Errorf("current organization: %w", err)
 			}
 
-			if initiator != "" {
-				user, err := client.User(ctx, initiator)
-				if err != nil {
-					return xerrors.Errorf("initiator not found: %s", initiator)
-				}
-				initiator = user.ID.String()
-			}
-
 			jobsRes, err := client.OrganizationProvisionerJobs(ctx, org.ID, &codersdk.OrganizationProvisionerJobsOptions{
 				Pagination: codersdk.Pagination{
 					Limit: int(limit),
 				},
-				Status:    slice.StringEnums[codersdk.ProvisionerJobStatus](status),
-				Types:     slice.StringEnums[codersdk.ProvisionerJobType](jobTypes),
-				Initiator: initiator,
-				Template:  template,
-				Search:    search,
+				Status:      slice.StringEnums[codersdk.ProvisionerJobStatus](status),
+				Types:       slice.StringEnums[codersdk.ProvisionerJobType](jobTypes),
+				Initiator:   initiator,
+				Template:    template,
+				FilterQuery: search,
 			})
 			if err != nil {
 				return xerrors.Errorf("list provisioner jobs: %w", err)
@@ -161,14 +153,14 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 		{
 			Flag:        "template",
 			Env:         "CODER_PROVISIONER_JOB_LIST_TEMPLATE",
-			Description: "Filter by template ID.",
+			Description: "Filter by template name or ID.",
 			Value:       serpent.StringOf(&template),
 		},
 		{
 			Flag:          "search",
 			FlagShorthand: "q",
 			Env:           "CODER_PROVISIONER_JOB_LIST_SEARCH",
-			Description:   "Free-text search against workspace name, template name, template display name, or job ID.",
+			Description:   "Search query in the format key:value. Available keys are: status, type, template, id, initiator, tag. Bare text searches workspace name, template name, template display name, or job ID.",
 			Value:         serpent.StringOf(&search),
 		},
 	}...)

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -48,6 +48,7 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 		limit     int64
 		initiator string
 		template  string
+		search    string
 	)
 
 	cmd := &serpent.Command{
@@ -84,6 +85,7 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 				Types:     slice.StringEnums[codersdk.ProvisionerJobType](jobTypes),
 				Initiator: initiator,
 				Template:  template,
+				Search:    search,
 			})
 			if err != nil {
 				return xerrors.Errorf("list provisioner jobs: %w", err)
@@ -161,6 +163,13 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 			Env:         "CODER_PROVISIONER_JOB_LIST_TEMPLATE",
 			Description: "Filter by template ID.",
 			Value:       serpent.StringOf(&template),
+		},
+		{
+			Flag:          "search",
+			FlagShorthand: "q",
+			Env:           "CODER_PROVISIONER_JOB_LIST_SEARCH",
+			Description:   "Free-text search against workspace name, template name, template display name, or job ID.",
+			Value:         serpent.StringOf(&search),
 		},
 	}...)
 

--- a/cli/provisionerjobs_test.go
+++ b/cli/provisionerjobs_test.go
@@ -319,7 +319,8 @@ func TestProvisionerJobs(t *testing.T) {
 			inv.Stdout = &buf
 			err := inv.Run()
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "initiator not found: nonexistent-user")
+			assert.Contains(t, err.Error(), "list provisioner jobs")
+			assert.Contains(t, err.Error(), "nonexistent-user")
 		})
 	})
 }

--- a/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -23,6 +23,10 @@ OPTIONS:
   -o, --output table|json (default: table)
           Output format.
 
+  -q, --search string, $CODER_PROVISIONER_JOB_LIST_SEARCH
+          Free-text search against workspace name, template name, template
+          display name, or job ID.
+
   -s, --status [pending|running|succeeded|canceling|canceled|failed|unknown], $CODER_PROVISIONER_JOB_LIST_STATUS
           Filter by job status.
 

--- a/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -24,14 +24,15 @@ OPTIONS:
           Output format.
 
   -q, --search string, $CODER_PROVISIONER_JOB_LIST_SEARCH
-          Free-text search against workspace name, template name, template
-          display name, or job ID.
+          Search query in the format key:value. Available keys are: status,
+          type, template, id, initiator, tag. Bare text searches workspace name,
+          template name, template display name, or job ID.
 
   -s, --status [pending|running|succeeded|canceling|canceled|failed|unknown], $CODER_PROVISIONER_JOB_LIST_STATUS
           Filter by job status.
 
       --template string, $CODER_PROVISIONER_JOB_LIST_TEMPLATE
-          Filter by template ID.
+          Filter by template name or ID.
 
       --type [template_version_import|workspace_build|template_version_dry_run], $CODER_PROVISIONER_JOB_LIST_TYPE
           Filter by job type.

--- a/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -26,5 +26,11 @@ OPTIONS:
   -s, --status [pending|running|succeeded|canceling|canceled|failed|unknown], $CODER_PROVISIONER_JOB_LIST_STATUS
           Filter by job status.
 
+      --template string, $CODER_PROVISIONER_JOB_LIST_TEMPLATE
+          Filter by template ID.
+
+      --type [template_version_import|workspace_build|template_version_dry_run], $CODER_PROVISIONER_JOB_LIST_TYPE
+          Filter by job type.
+
 ———
 Run `coder --help` for a list of global options.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6030,6 +6030,12 @@ const docTemplate = `{
                         "description": "Filter results by template ID",
                         "name": "template",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Free-text search against workspace name, template name, template display name, or job ID",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5998,6 +5998,20 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "template_version_import",
+                            "workspace_build",
+                            "template_version_dry_run",
+                            "template_version_import",
+                            "workspace_build",
+                            "template_version_dry_run"
+                        ],
+                        "type": "string",
+                        "description": "Filter results by job type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
                         "type": "object",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
@@ -6008,6 +6022,13 @@ const docTemplate = `{
                         "format": "uuid",
                         "description": "Filter results by initiator",
                         "name": "initiator",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Filter results by template ID",
+                        "name": "template",
                         "in": "query"
                     }
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5960,6 +5960,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "integer",
+                        "description": "Page offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
                         "type": "array",
                         "format": "uuid",
                         "items": {
@@ -6009,10 +6015,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.ProvisionerJob"
-                            }
+                            "$ref": "#/definitions/codersdk.ProvisionerJobsResponse"
                         }
                     }
                 },
@@ -23402,6 +23405,25 @@ const docTemplate = `{
                 "ProvisionerJobTypeWorkspaceBuild",
                 "ProvisionerJobTypeTemplateVersionDryRun"
             ]
+        },
+        "codersdk.ProvisionerJobsResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "Count is the total number of jobs matching the filter, capped by CountCap.",
+                    "type": "integer"
+                },
+                "count_cap": {
+                    "description": "CountCap is the maximum number of jobs counted. When Count equals CountCap,\nthere may be additional matching jobs beyond the cap.",
+                    "type": "integer"
+                },
+                "jobs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ProvisionerJob"
+                    }
+                }
+            }
         },
         "codersdk.ProvisionerKey": {
             "type": "object",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5966,75 +5966,9 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "array",
-                        "format": "uuid",
-                        "items": {
-                            "type": "string"
-                        },
-                        "collectionFormat": "csv",
-                        "description": "Filter results by job IDs",
-                        "name": "ids",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "pending",
-                            "running",
-                            "succeeded",
-                            "canceling",
-                            "canceled",
-                            "failed",
-                            "unknown",
-                            "pending",
-                            "running",
-                            "succeeded",
-                            "canceling",
-                            "canceled",
-                            "failed"
-                        ],
                         "type": "string",
-                        "description": "Filter results by status",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "template_version_import",
-                            "workspace_build",
-                            "template_version_dry_run",
-                            "template_version_import",
-                            "workspace_build",
-                            "template_version_dry_run"
-                        ],
-                        "type": "string",
-                        "description": "Filter results by job type",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "object",
-                        "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
-                        "name": "tags",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Filter results by initiator",
-                        "name": "initiator",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Filter results by template ID",
-                        "name": "template",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Free-text search against workspace name, template name, template display name, or job ID",
-                        "name": "search",
+                        "description": "Search query in the format ` + "`" + `key:value` + "`" + `. Available keys are: status, type, template, id, initiator, tag. Bare text searches workspace name, template name, template display name, or job ID.",
+                        "name": "q",
                         "in": "query"
                     }
                 ],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5357,6 +5357,12 @@
 						"description": "Filter results by template ID",
 						"name": "template",
 						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "Free-text search against workspace name, template name, template display name, or job ID",
+						"name": "search",
+						"in": "query"
 					}
 				],
 				"responses": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5293,75 +5293,9 @@
 						"in": "query"
 					},
 					{
-						"type": "array",
-						"format": "uuid",
-						"items": {
-							"type": "string"
-						},
-						"collectionFormat": "csv",
-						"description": "Filter results by job IDs",
-						"name": "ids",
-						"in": "query"
-					},
-					{
-						"enum": [
-							"pending",
-							"running",
-							"succeeded",
-							"canceling",
-							"canceled",
-							"failed",
-							"unknown",
-							"pending",
-							"running",
-							"succeeded",
-							"canceling",
-							"canceled",
-							"failed"
-						],
 						"type": "string",
-						"description": "Filter results by status",
-						"name": "status",
-						"in": "query"
-					},
-					{
-						"enum": [
-							"template_version_import",
-							"workspace_build",
-							"template_version_dry_run",
-							"template_version_import",
-							"workspace_build",
-							"template_version_dry_run"
-						],
-						"type": "string",
-						"description": "Filter results by job type",
-						"name": "type",
-						"in": "query"
-					},
-					{
-						"type": "object",
-						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
-						"name": "tags",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Filter results by initiator",
-						"name": "initiator",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Filter results by template ID",
-						"name": "template",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"description": "Free-text search against workspace name, template name, template display name, or job ID",
-						"name": "search",
+						"description": "Search query in the format `key:value`. Available keys are: status, type, template, id, initiator, tag. Bare text searches workspace name, template name, template display name, or job ID.",
+						"name": "q",
 						"in": "query"
 					}
 				],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5325,6 +5325,20 @@
 						"in": "query"
 					},
 					{
+						"enum": [
+							"template_version_import",
+							"workspace_build",
+							"template_version_dry_run",
+							"template_version_import",
+							"workspace_build",
+							"template_version_dry_run"
+						],
+						"type": "string",
+						"description": "Filter results by job type",
+						"name": "type",
+						"in": "query"
+					},
+					{
 						"type": "object",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
@@ -5335,6 +5349,13 @@
 						"format": "uuid",
 						"description": "Filter results by initiator",
 						"name": "initiator",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Filter results by template ID",
+						"name": "template",
 						"in": "query"
 					}
 				],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5287,6 +5287,12 @@
 						"in": "query"
 					},
 					{
+						"type": "integer",
+						"description": "Page offset",
+						"name": "offset",
+						"in": "query"
+					},
+					{
 						"type": "array",
 						"format": "uuid",
 						"items": {
@@ -5336,10 +5342,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.ProvisionerJob"
-							}
+							"$ref": "#/definitions/codersdk.ProvisionerJobsResponse"
 						}
 					}
 				},
@@ -21430,6 +21433,25 @@
 				"ProvisionerJobTypeWorkspaceBuild",
 				"ProvisionerJobTypeTemplateVersionDryRun"
 			]
+		},
+		"codersdk.ProvisionerJobsResponse": {
+			"type": "object",
+			"properties": {
+				"count": {
+					"description": "Count is the total number of jobs matching the filter, capped by CountCap.",
+					"type": "integer"
+				},
+				"count_cap": {
+					"description": "CountCap is the maximum number of jobs counted. When Count equals CountCap,\nthere may be additional matching jobs beyond the cap.",
+					"type": "integer"
+				},
+				"jobs": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ProvisionerJob"
+					}
+				}
+			}
 		},
 		"codersdk.ProvisionerKey": {
 			"type": "object",

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2014,6 +2014,15 @@ func (q *querier) CountPendingNonActivePrebuilds(ctx context.Context) ([]databas
 	return q.db.CountPendingNonActivePrebuilds(ctx)
 }
 
+func (q *querier) CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg database.CountProvisionerJobsByOrganizationAndStatusParams) (int64, error) {
+	// Match the handler gate: org-scoped read on provisioner jobs.
+	// Details in https://github.com/coder/coder/issues/16160
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceProvisionerJobs.InOrg(arg.OrganizationID)); err != nil {
+		return 0, err
+	}
+	return q.db.CountProvisionerJobsByOrganizationAndStatus(ctx, arg)
+}
+
 func (q *querier) CountUnreadInboxNotificationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceInboxNotification.WithOwner(userID.String())); err != nil {
 		return 0, err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4619,6 +4619,16 @@ func (s *MethodTestSuite) TestExtraMethods() {
 			InitiatorID:    uuid.Nil,
 		}).Asserts(j1, policy.ActionRead, j2, policy.ActionRead).Returns(ds)
 	}))
+	s.Run("CountProvisionerJobsByOrganizationAndStatus", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		orgID := uuid.New()
+		arg := database.CountProvisionerJobsByOrganizationAndStatusParams{
+			OrganizationID: orgID,
+			InitiatorID:    uuid.Nil,
+			CountCap:       2000,
+		}
+		dbm.EXPECT().CountProvisionerJobsByOrganizationAndStatus(gomock.Any(), arg).Return(int64(0), nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceProvisionerJobs.InOrg(orgID), policy.ActionRead)
+	}))
 }
 
 func (s *MethodTestSuite) TestTailnetFunctions() {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -369,6 +369,14 @@ func (m queryMetricsStore) CountPendingNonActivePrebuilds(ctx context.Context) (
 	return r0, r1
 }
 
+func (m queryMetricsStore) CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg database.CountProvisionerJobsByOrganizationAndStatusParams) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.CountProvisionerJobsByOrganizationAndStatus(ctx, arg)
+	m.queryLatencies.WithLabelValues("CountProvisionerJobsByOrganizationAndStatus").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "CountProvisionerJobsByOrganizationAndStatus").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) CountUnreadInboxNotificationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
 	start := time.Now()
 	r0, r1 := m.s.CountUnreadInboxNotificationsByUserID(ctx, userID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -573,6 +573,21 @@ func (mr *MockStoreMockRecorder) CountPendingNonActivePrebuilds(ctx any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountPendingNonActivePrebuilds", reflect.TypeOf((*MockStore)(nil).CountPendingNonActivePrebuilds), ctx)
 }
 
+// CountProvisionerJobsByOrganizationAndStatus mocks base method.
+func (m *MockStore) CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg database.CountProvisionerJobsByOrganizationAndStatusParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountProvisionerJobsByOrganizationAndStatus", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountProvisionerJobsByOrganizationAndStatus indicates an expected call of CountProvisionerJobsByOrganizationAndStatus.
+func (mr *MockStoreMockRecorder) CountProvisionerJobsByOrganizationAndStatus(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountProvisionerJobsByOrganizationAndStatus", reflect.TypeOf((*MockStore)(nil).CountProvisionerJobsByOrganizationAndStatus), ctx, arg)
+}
+
 // CountUnreadInboxNotificationsByUserID mocks base method.
 func (m *MockStore) CountUnreadInboxNotificationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -110,6 +110,10 @@ type sqlcQuerier interface {
 	CountOIDCLinkedIDsByIssuer(ctx context.Context) ([]CountOIDCLinkedIDsByIssuerRow, error)
 	// CountPendingNonActivePrebuilds returns the number of pending prebuilds for non-active template versions
 	CountPendingNonActivePrebuilds(ctx context.Context) ([]CountPendingNonActivePrebuildsRow, error)
+	// Lean count for pagination. Uses the same filters as
+	// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner
+	// without the queue/metadata joins.
+	CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg CountProvisionerJobsByOrganizationAndStatusParams) (int64, error)
 	CountUnreadInboxNotificationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	CreateUserSecret(ctx context.Context, arg CreateUserSecretParams) (UserSecret, error)
 	CustomRoles(ctx context.Context, arg CustomRolesParams) ([]CustomRole, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -110,9 +110,9 @@ type sqlcQuerier interface {
 	CountOIDCLinkedIDsByIssuer(ctx context.Context) ([]CountOIDCLinkedIDsByIssuerRow, error)
 	// CountPendingNonActivePrebuilds returns the number of pending prebuilds for non-active template versions
 	CountPendingNonActivePrebuilds(ctx context.Context) ([]CountPendingNonActivePrebuildsRow, error)
-	// Lean count for pagination. Uses the same filters as
-	// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner
-	// without the queue/metadata joins.
+	// Count for pagination. Uses the same filters as
+	// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner.
+	// Joins template metadata only as needed for the template_id filter.
 	CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg CountProvisionerJobsByOrganizationAndStatusParams) (int64, error)
 	CountUnreadInboxNotificationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	CreateUserSecret(ctx context.Context, arg CreateUserSecretParams) (UserSecret, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -112,7 +112,8 @@ type sqlcQuerier interface {
 	CountPendingNonActivePrebuilds(ctx context.Context) ([]CountPendingNonActivePrebuildsRow, error)
 	// Count for pagination. Uses the same filters as
 	// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner.
-	// Joins template metadata only as needed for the template_id filter.
+	// Joins template and workspace metadata as needed for template_id and
+	// search filters.
 	CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg CountProvisionerJobsByOrganizationAndStatusParams) (int64, error)
 	CountUnreadInboxNotificationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	CreateUserSecret(ctx context.Context, arg CreateUserSecretParams) (UserSecret, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -22594,6 +22594,50 @@ func (q *sqlQuerier) AcquireProvisionerJob(ctx context.Context, arg AcquireProvi
 	return i, err
 }
 
+const countProvisionerJobsByOrganizationAndStatus = `-- name: CountProvisionerJobsByOrganizationAndStatus :one
+SELECT COUNT(*) FROM (
+	SELECT 1
+	FROM
+		provisioner_jobs pj
+	WHERE
+		pj.organization_id = $1::uuid
+		AND (COALESCE(array_length($2::uuid[], 1), 0) = 0 OR pj.id = ANY($2::uuid[]))
+		AND (COALESCE(array_length($3::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY($3::provisioner_job_status[]))
+		AND ($4::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $4::tagset))
+		AND ($5::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $5::uuid)
+	-- Avoid a slow scan on a large table. The caller passes the count
+	-- cap and we add 1 so the frontend can detect capping and show
+	-- "... of N+". A cap of 0 means no limit (NULLIF -> NULL + 1 = NULL).
+	LIMIT NULLIF($6::int, 0) + 1
+) AS limited_count
+`
+
+type CountProvisionerJobsByOrganizationAndStatusParams struct {
+	OrganizationID uuid.UUID              `db:"organization_id" json:"organization_id"`
+	IDs            []uuid.UUID            `db:"ids" json:"ids"`
+	Status         []ProvisionerJobStatus `db:"status" json:"status"`
+	Tags           StringMap              `db:"tags" json:"tags"`
+	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
+	CountCap       int32                  `db:"count_cap" json:"count_cap"`
+}
+
+// Lean count for pagination. Uses the same filters as
+// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner
+// without the queue/metadata joins.
+func (q *sqlQuerier) CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg CountProvisionerJobsByOrganizationAndStatusParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countProvisionerJobsByOrganizationAndStatus,
+		arg.OrganizationID,
+		pq.Array(arg.IDs),
+		pq.Array(arg.Status),
+		arg.Tags,
+		arg.InitiatorID,
+		arg.CountCap,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getProvisionerJobByID = `-- name: GetProvisionerJobByID :one
 SELECT
 	id, created_at, updated_at, started_at, canceled_at, completed_at, error, organization_id, initiator_id, provisioner, storage_method, type, input, worker_id, file_id, tags, error_code, trace_metadata, job_status, logs_length, logs_overflowed
@@ -22994,7 +23038,12 @@ GROUP BY
 ORDER BY
 	pj.created_at DESC
 LIMIT
-	$6::int
+	-- a limit of 0 means "no limit". The provisioner jobs table is
+	-- unbounded in size. Implement a default limit of 100 to prevent
+	-- accidental excessively large queries.
+	COALESCE(NULLIF($7::int, 0), 100)
+OFFSET
+	$6
 `
 
 type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams struct {
@@ -23003,7 +23052,8 @@ type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerPar
 	Status         []ProvisionerJobStatus `db:"status" json:"status"`
 	Tags           StringMap              `db:"tags" json:"tags"`
 	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
-	Limit          sql.NullInt32          `db:"limit" json:"limit"`
+	OffsetOpt      int32                  `db:"offset_opt" json:"offset_opt"`
+	LimitOpt       int32                  `db:"limit_opt" json:"limit_opt"`
 }
 
 type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow struct {
@@ -23029,7 +23079,8 @@ func (q *sqlQuerier) GetProvisionerJobsByOrganizationAndStatusWithQueuePositionA
 		pq.Array(arg.Status),
 		arg.Tags,
 		arg.InitiatorID,
-		arg.Limit,
+		arg.OffsetOpt,
+		arg.LimitOpt,
 	)
 	if err != nil {
 		return nil, err

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -22602,6 +22602,11 @@ SELECT COUNT(*) FROM (
 	LEFT JOIN
 		workspace_builds wb ON wb.id = CASE WHEN pj.input ? 'workspace_build_id' THEN (pj.input->>'workspace_build_id')::uuid END
 	LEFT JOIN
+		workspaces w ON (
+			w.id = wb.workspace_id
+			AND w.organization_id = pj.organization_id
+		)
+	LEFT JOIN
 		template_versions tv ON (
 			tv.id = CASE WHEN pj.input ? 'template_version_id' THEN (pj.input->>'template_version_id')::uuid ELSE wb.template_version_id END
 			AND tv.organization_id = pj.organization_id
@@ -22619,10 +22624,18 @@ SELECT COUNT(*) FROM (
 		AND ($5::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $5::tagset))
 		AND ($6::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $6::uuid)
 		AND ($7::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = $7::uuid)
+		AND CASE WHEN $8 :: text != '' THEN (
+				COALESCE(w.name, '') ILIKE concat('%', $8, '%')
+				OR COALESCE(t.name, '') ILIKE concat('%', $8, '%')
+				OR COALESCE(t.display_name, '') ILIKE concat('%', $8, '%')
+				OR pj.id::text ILIKE concat('%', $8, '%')
+			)
+			ELSE true
+		END
 	-- Avoid a slow scan on a large table. The caller passes the count
 	-- cap and we add 1 so the frontend can detect capping and show
 	-- "... of N+". A cap of 0 means no limit (NULLIF -> NULL + 1 = NULL).
-	LIMIT NULLIF($8::int, 0) + 1
+	LIMIT NULLIF($9::int, 0) + 1
 ) AS limited_count
 `
 
@@ -22634,12 +22647,14 @@ type CountProvisionerJobsByOrganizationAndStatusParams struct {
 	Tags           StringMap              `db:"tags" json:"tags"`
 	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
 	TemplateID     uuid.UUID              `db:"template_id" json:"template_id"`
+	Search         string                 `db:"search" json:"search"`
 	CountCap       int32                  `db:"count_cap" json:"count_cap"`
 }
 
 // Count for pagination. Uses the same filters as
 // GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner.
-// Joins template metadata only as needed for the template_id filter.
+// Joins template and workspace metadata as needed for template_id and
+// search filters.
 func (q *sqlQuerier) CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg CountProvisionerJobsByOrganizationAndStatusParams) (int64, error) {
 	row := q.db.QueryRowContext(ctx, countProvisionerJobsByOrganizationAndStatus,
 		arg.OrganizationID,
@@ -22649,6 +22664,7 @@ func (q *sqlQuerier) CountProvisionerJobsByOrganizationAndStatus(ctx context.Con
 		arg.Tags,
 		arg.InitiatorID,
 		arg.TemplateID,
+		arg.Search,
 		arg.CountCap,
 	)
 	var count int64
@@ -23042,6 +23058,16 @@ WHERE
 	AND ($5::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $5::tagset))
 	AND ($6::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $6::uuid)
 	AND ($7::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = $7::uuid)
+	-- Free-text search against workspace name, template name / display
+	-- name, or job ID (substring, case-insensitive).
+	AND CASE WHEN $8 :: text != '' THEN (
+			COALESCE(w.name, '') ILIKE concat('%', $8, '%')
+			OR COALESCE(t.name, '') ILIKE concat('%', $8, '%')
+			OR COALESCE(t.display_name, '') ILIKE concat('%', $8, '%')
+			OR pj.id::text ILIKE concat('%', $8, '%')
+		)
+		ELSE true
+	END
 GROUP BY
 	pj.id,
 	qp.queue_position,
@@ -23061,9 +23087,9 @@ LIMIT
 	-- a limit of 0 means "no limit". The provisioner jobs table is
 	-- unbounded in size. Implement a default limit of 100 to prevent
 	-- accidental excessively large queries.
-	COALESCE(NULLIF($9::int, 0), 100)
+	COALESCE(NULLIF($10::int, 0), 100)
 OFFSET
-	$8
+	$9
 `
 
 type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams struct {
@@ -23074,6 +23100,7 @@ type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerPar
 	Tags           StringMap              `db:"tags" json:"tags"`
 	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
 	TemplateID     uuid.UUID              `db:"template_id" json:"template_id"`
+	Search         string                 `db:"search" json:"search"`
 	OffsetOpt      int32                  `db:"offset_opt" json:"offset_opt"`
 	LimitOpt       int32                  `db:"limit_opt" json:"limit_opt"`
 }
@@ -23103,6 +23130,7 @@ func (q *sqlQuerier) GetProvisionerJobsByOrganizationAndStatusWithQueuePositionA
 		arg.Tags,
 		arg.InitiatorID,
 		arg.TemplateID,
+		arg.Search,
 		arg.OffsetOpt,
 		arg.LimitOpt,
 	)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -22599,16 +22599,30 @@ SELECT COUNT(*) FROM (
 	SELECT 1
 	FROM
 		provisioner_jobs pj
+	LEFT JOIN
+		workspace_builds wb ON wb.id = CASE WHEN pj.input ? 'workspace_build_id' THEN (pj.input->>'workspace_build_id')::uuid END
+	LEFT JOIN
+		template_versions tv ON (
+			tv.id = CASE WHEN pj.input ? 'template_version_id' THEN (pj.input->>'template_version_id')::uuid ELSE wb.template_version_id END
+			AND tv.organization_id = pj.organization_id
+		)
+	LEFT JOIN
+		templates t ON (
+			t.id = tv.template_id
+			AND t.organization_id = pj.organization_id
+		)
 	WHERE
 		pj.organization_id = $1::uuid
 		AND (COALESCE(array_length($2::uuid[], 1), 0) = 0 OR pj.id = ANY($2::uuid[]))
 		AND (COALESCE(array_length($3::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY($3::provisioner_job_status[]))
-		AND ($4::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $4::tagset))
-		AND ($5::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $5::uuid)
+		AND (COALESCE(array_length($4::provisioner_job_type[], 1), 0) = 0 OR pj.type = ANY($4::provisioner_job_type[]))
+		AND ($5::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $5::tagset))
+		AND ($6::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $6::uuid)
+		AND ($7::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = $7::uuid)
 	-- Avoid a slow scan on a large table. The caller passes the count
 	-- cap and we add 1 so the frontend can detect capping and show
 	-- "... of N+". A cap of 0 means no limit (NULLIF -> NULL + 1 = NULL).
-	LIMIT NULLIF($6::int, 0) + 1
+	LIMIT NULLIF($8::int, 0) + 1
 ) AS limited_count
 `
 
@@ -22616,21 +22630,25 @@ type CountProvisionerJobsByOrganizationAndStatusParams struct {
 	OrganizationID uuid.UUID              `db:"organization_id" json:"organization_id"`
 	IDs            []uuid.UUID            `db:"ids" json:"ids"`
 	Status         []ProvisionerJobStatus `db:"status" json:"status"`
+	Types          []ProvisionerJobType   `db:"types" json:"types"`
 	Tags           StringMap              `db:"tags" json:"tags"`
 	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
+	TemplateID     uuid.UUID              `db:"template_id" json:"template_id"`
 	CountCap       int32                  `db:"count_cap" json:"count_cap"`
 }
 
-// Lean count for pagination. Uses the same filters as
-// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner
-// without the queue/metadata joins.
+// Count for pagination. Uses the same filters as
+// GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner.
+// Joins template metadata only as needed for the template_id filter.
 func (q *sqlQuerier) CountProvisionerJobsByOrganizationAndStatus(ctx context.Context, arg CountProvisionerJobsByOrganizationAndStatusParams) (int64, error) {
 	row := q.db.QueryRowContext(ctx, countProvisionerJobsByOrganizationAndStatus,
 		arg.OrganizationID,
 		pq.Array(arg.IDs),
 		pq.Array(arg.Status),
+		pq.Array(arg.Types),
 		arg.Tags,
 		arg.InitiatorID,
+		arg.TemplateID,
 		arg.CountCap,
 	)
 	var count int64
@@ -23020,8 +23038,10 @@ WHERE
 	pj.organization_id = $1::uuid
 	AND (COALESCE(array_length($2::uuid[], 1), 0) = 0 OR pj.id = ANY($2::uuid[]))
 	AND (COALESCE(array_length($3::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY($3::provisioner_job_status[]))
-	AND ($4::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $4::tagset))
-	AND ($5::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $5::uuid)
+	AND (COALESCE(array_length($4::provisioner_job_type[], 1), 0) = 0 OR pj.type = ANY($4::provisioner_job_type[]))
+	AND ($5::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $5::tagset))
+	AND ($6::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $6::uuid)
+	AND ($7::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = $7::uuid)
 GROUP BY
 	pj.id,
 	qp.queue_position,
@@ -23041,17 +23061,19 @@ LIMIT
 	-- a limit of 0 means "no limit". The provisioner jobs table is
 	-- unbounded in size. Implement a default limit of 100 to prevent
 	-- accidental excessively large queries.
-	COALESCE(NULLIF($7::int, 0), 100)
+	COALESCE(NULLIF($9::int, 0), 100)
 OFFSET
-	$6
+	$8
 `
 
 type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams struct {
 	OrganizationID uuid.UUID              `db:"organization_id" json:"organization_id"`
 	IDs            []uuid.UUID            `db:"ids" json:"ids"`
 	Status         []ProvisionerJobStatus `db:"status" json:"status"`
+	Types          []ProvisionerJobType   `db:"types" json:"types"`
 	Tags           StringMap              `db:"tags" json:"tags"`
 	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
+	TemplateID     uuid.UUID              `db:"template_id" json:"template_id"`
 	OffsetOpt      int32                  `db:"offset_opt" json:"offset_opt"`
 	LimitOpt       int32                  `db:"limit_opt" json:"limit_opt"`
 }
@@ -23077,8 +23099,10 @@ func (q *sqlQuerier) GetProvisionerJobsByOrganizationAndStatusWithQueuePositionA
 		arg.OrganizationID,
 		pq.Array(arg.IDs),
 		pq.Array(arg.Status),
+		pq.Array(arg.Types),
 		arg.Tags,
 		arg.InitiatorID,
+		arg.TemplateID,
 		arg.OffsetOpt,
 		arg.LimitOpt,
 	)

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -228,8 +228,10 @@ WHERE
 	pj.organization_id = @organization_id::uuid
 	AND (COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR pj.id = ANY(@ids::uuid[]))
 	AND (COALESCE(array_length(@status::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY(@status::provisioner_job_status[]))
+	AND (COALESCE(array_length(@types::provisioner_job_type[], 1), 0) = 0 OR pj.type = ANY(@types::provisioner_job_type[]))
 	AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
 	AND (@initiator_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = @initiator_id::uuid)
+	AND (@template_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = @template_id::uuid)
 GROUP BY
 	pj.id,
 	qp.queue_position,
@@ -254,19 +256,33 @@ OFFSET
 	@offset_opt;
 
 -- name: CountProvisionerJobsByOrganizationAndStatus :one
--- Lean count for pagination. Uses the same filters as
--- GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner
--- without the queue/metadata joins.
+-- Count for pagination. Uses the same filters as
+-- GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner.
+-- Joins template metadata only as needed for the template_id filter.
 SELECT COUNT(*) FROM (
 	SELECT 1
 	FROM
 		provisioner_jobs pj
+	LEFT JOIN
+		workspace_builds wb ON wb.id = CASE WHEN pj.input ? 'workspace_build_id' THEN (pj.input->>'workspace_build_id')::uuid END
+	LEFT JOIN
+		template_versions tv ON (
+			tv.id = CASE WHEN pj.input ? 'template_version_id' THEN (pj.input->>'template_version_id')::uuid ELSE wb.template_version_id END
+			AND tv.organization_id = pj.organization_id
+		)
+	LEFT JOIN
+		templates t ON (
+			t.id = tv.template_id
+			AND t.organization_id = pj.organization_id
+		)
 	WHERE
 		pj.organization_id = @organization_id::uuid
 		AND (COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR pj.id = ANY(@ids::uuid[]))
 		AND (COALESCE(array_length(@status::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY(@status::provisioner_job_status[]))
+		AND (COALESCE(array_length(@types::provisioner_job_type[], 1), 0) = 0 OR pj.type = ANY(@types::provisioner_job_type[]))
 		AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
 		AND (@initiator_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = @initiator_id::uuid)
+		AND (@template_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = @template_id::uuid)
 	-- Avoid a slow scan on a large table. The caller passes the count
 	-- cap and we add 1 so the frontend can detect capping and show
 	-- "... of N+". A cap of 0 means no limit (NULLIF -> NULL + 1 = NULL).

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -246,7 +246,32 @@ GROUP BY
 ORDER BY
 	pj.created_at DESC
 LIMIT
-	sqlc.narg('limit')::int;
+	-- a limit of 0 means "no limit". The provisioner jobs table is
+	-- unbounded in size. Implement a default limit of 100 to prevent
+	-- accidental excessively large queries.
+	COALESCE(NULLIF(@limit_opt::int, 0), 100)
+OFFSET
+	@offset_opt;
+
+-- name: CountProvisionerJobsByOrganizationAndStatus :one
+-- Lean count for pagination. Uses the same filters as
+-- GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner
+-- without the queue/metadata joins.
+SELECT COUNT(*) FROM (
+	SELECT 1
+	FROM
+		provisioner_jobs pj
+	WHERE
+		pj.organization_id = @organization_id::uuid
+		AND (COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR pj.id = ANY(@ids::uuid[]))
+		AND (COALESCE(array_length(@status::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY(@status::provisioner_job_status[]))
+		AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
+		AND (@initiator_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = @initiator_id::uuid)
+	-- Avoid a slow scan on a large table. The caller passes the count
+	-- cap and we add 1 so the frontend can detect capping and show
+	-- "... of N+". A cap of 0 means no limit (NULLIF -> NULL + 1 = NULL).
+	LIMIT NULLIF(@count_cap::int, 0) + 1
+) AS limited_count;
 
 -- name: GetProvisionerJobsCreatedAfter :many
 SELECT * FROM provisioner_jobs WHERE created_at > $1;

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -232,6 +232,16 @@ WHERE
 	AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
 	AND (@initiator_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = @initiator_id::uuid)
 	AND (@template_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = @template_id::uuid)
+	-- Free-text search against workspace name, template name / display
+	-- name, or job ID (substring, case-insensitive).
+	AND CASE WHEN @search :: text != '' THEN (
+			COALESCE(w.name, '') ILIKE concat('%', @search, '%')
+			OR COALESCE(t.name, '') ILIKE concat('%', @search, '%')
+			OR COALESCE(t.display_name, '') ILIKE concat('%', @search, '%')
+			OR pj.id::text ILIKE concat('%', @search, '%')
+		)
+		ELSE true
+	END
 GROUP BY
 	pj.id,
 	qp.queue_position,
@@ -258,13 +268,19 @@ OFFSET
 -- name: CountProvisionerJobsByOrganizationAndStatus :one
 -- Count for pagination. Uses the same filters as
 -- GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner.
--- Joins template metadata only as needed for the template_id filter.
+-- Joins template and workspace metadata as needed for template_id and
+-- search filters.
 SELECT COUNT(*) FROM (
 	SELECT 1
 	FROM
 		provisioner_jobs pj
 	LEFT JOIN
 		workspace_builds wb ON wb.id = CASE WHEN pj.input ? 'workspace_build_id' THEN (pj.input->>'workspace_build_id')::uuid END
+	LEFT JOIN
+		workspaces w ON (
+			w.id = wb.workspace_id
+			AND w.organization_id = pj.organization_id
+		)
 	LEFT JOIN
 		template_versions tv ON (
 			tv.id = CASE WHEN pj.input ? 'template_version_id' THEN (pj.input->>'template_version_id')::uuid ELSE wb.template_version_id END
@@ -283,6 +299,14 @@ SELECT COUNT(*) FROM (
 		AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
 		AND (@initiator_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = @initiator_id::uuid)
 		AND (@template_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR t.id = @template_id::uuid)
+		AND CASE WHEN @search :: text != '' THEN (
+				COALESCE(w.name, '') ILIKE concat('%', @search, '%')
+				OR COALESCE(t.name, '') ILIKE concat('%', @search, '%')
+				OR COALESCE(t.display_name, '') ILIKE concat('%', @search, '%')
+				OR pj.id::text ILIKE concat('%', @search, '%')
+			)
+			ELSE true
+		END
 	-- Avoid a slow scan on a large table. The caller passes the count
 	-- cap and we add 1 so the frontend can detect capping and show
 	-- "... of N+". A cap of 0 means no limit (NULLIF -> NULL + 1 = NULL).

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -66,6 +66,11 @@ func (api *API) provisionerJob(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, convertProvisionerJobWithQueuePosition(jobs[0]))
 }
 
+// Limit the count query to avoid a slow sequential scan due to joins
+// on a large table. Set to 0 to disable capping (but also see the note
+// in the SQL query).
+const provisionerJobsCountCap = 2000
+
 // @Summary Get provisioner jobs
 // @ID get-provisioner-jobs
 // @Security CoderSessionToken
@@ -73,39 +78,108 @@ func (api *API) provisionerJob(rw http.ResponseWriter, r *http.Request) {
 // @Tags Organizations
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param limit query int false "Page limit"
+// @Param offset query int false "Page offset"
 // @Param ids query []string false "Filter results by job IDs" format(uuid)
 // @Param status query codersdk.ProvisionerJobStatus false "Filter results by status" enums(pending,running,succeeded,canceling,canceled,failed)
 // @Param tags query object false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
 // @Param initiator query string false "Filter results by initiator" format(uuid)
-// @Success 200 {array} codersdk.ProvisionerJob
+// @Success 200 {object} codersdk.ProvisionerJobsResponse
 // @Router /api/v2/organizations/{organization}/provisionerjobs [get]
 func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	jobs, ok := api.handleAuthAndFetchProvisionerJobs(rw, r, nil)
-	if !ok {
-		return
-	}
-
-	httpapi.Write(ctx, rw, http.StatusOK, slice.List(jobs, convertProvisionerJobWithQueuePosition))
-}
-
-// handleAuthAndFetchProvisionerJobs is an internal method shared by
-// provisionerJob and provisionerJobs. If ok is false the caller should
-// return immediately because the response has already been written.
-func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *http.Request, ids []uuid.UUID) (_ []database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow, ok bool) {
 	ctx := r.Context()
 	org := httpmw.OrganizationParam(r)
 
 	// For now, only owners and template admins can access provisioner jobs.
 	if !api.Authorize(r, policy.ActionRead, rbac.ResourceProvisionerJobs.InOrg(org.ID)) {
 		httpapi.ResourceNotFound(rw)
-		return nil, false
+		return
 	}
 
+	page, ok := ParsePagination(rw, r)
+	if !ok {
+		return
+	}
+
+	filters, ok := parseProvisionerJobFilters(rw, r, nil)
+	if !ok {
+		return
+	}
+
+	count, err := api.Database.CountProvisionerJobsByOrganizationAndStatus(ctx, database.CountProvisionerJobsByOrganizationAndStatusParams{
+		OrganizationID: org.ID,
+		Status:         filters.Status,
+		IDs:            filters.IDs,
+		Tags:           filters.Tags,
+		InitiatorID:    filters.InitiatorID,
+		CountCap:       provisionerJobsCountCap,
+	})
+	if err != nil {
+		if httpapi.Is404Error(err) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error counting provisioner jobs.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if count == 0 {
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ProvisionerJobsResponse{
+			Jobs:     []codersdk.ProvisionerJob{},
+			Count:    0,
+			CountCap: provisionerJobsCountCap,
+		})
+		return
+	}
+
+	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
+		OrganizationID: org.ID,
+		Status:         filters.Status,
+		IDs:            filters.IDs,
+		Tags:           filters.Tags,
+		InitiatorID:    filters.InitiatorID,
+		// #nosec G115 - Pagination offsets are small and fit in int32
+		OffsetOpt: int32(page.Offset),
+		// #nosec G115 - Pagination limits are small and fit in int32
+		LimitOpt: int32(page.Limit),
+	})
+	if err != nil {
+		if httpapi.Is404Error(err) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching provisioner jobs.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ProvisionerJobsResponse{
+		Jobs:     slice.List(jobs, convertProvisionerJobWithQueuePosition),
+		Count:    count,
+		CountCap: provisionerJobsCountCap,
+	})
+}
+
+type provisionerJobFilters struct {
+	IDs         []uuid.UUID
+	Status      []database.ProvisionerJobStatus
+	Tags        database.StringMap
+	InitiatorID uuid.UUID
+}
+
+// parseProvisionerJobFilters parses filter query params shared by the list and
+// single-job endpoints. Pagination params are marked parsed so they are not
+// rejected when callers also use ParsePagination.
+func parseProvisionerJobFilters(rw http.ResponseWriter, r *http.Request, ids []uuid.UUID) (provisionerJobFilters, bool) {
+	ctx := r.Context()
 	qp := r.URL.Query()
 	p := httpapi.NewQueryParamParser()
-	limit := p.PositiveInt32(qp, 50, "limit")
+	_ = p.PositiveInt32(qp, 0, "limit")
+	_ = p.PositiveInt32(qp, 0, "offset")
+	_ = p.UUID(qp, uuid.Nil, "after_id")
 	status := p.Strings(qp, nil, "status")
 	if ids == nil {
 		ids = p.UUIDs(qp, nil, "ids")
@@ -118,16 +192,44 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 			Message:     "Invalid query parameters.",
 			Validations: p.Errors,
 		})
+		return provisionerJobFilters{}, false
+	}
+
+	return provisionerJobFilters{
+		IDs:         ids,
+		Status:      slice.StringEnums[database.ProvisionerJobStatus](status),
+		Tags:        tags,
+		InitiatorID: initiatorID,
+	}, true
+}
+
+// handleAuthAndFetchProvisionerJobs is used by the singular provisioner job
+// endpoint. If ok is false the caller should return immediately because the
+// response has already been written.
+func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *http.Request, ids []uuid.UUID) (_ []database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow, ok bool) {
+	ctx := r.Context()
+	org := httpmw.OrganizationParam(r)
+
+	// For now, only owners and template admins can access provisioner jobs.
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceProvisionerJobs.InOrg(org.ID)) {
+		httpapi.ResourceNotFound(rw)
+		return nil, false
+	}
+
+	filters, ok := parseProvisionerJobFilters(rw, r, ids)
+	if !ok {
 		return nil, false
 	}
 
 	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
 		OrganizationID: org.ID,
-		Status:         slice.StringEnums[database.ProvisionerJobStatus](status),
-		Limit:          sql.NullInt32{Int32: limit, Valid: limit > 0},
-		IDs:            ids,
-		Tags:           tags,
-		InitiatorID:    initiatorID,
+		Status:         filters.Status,
+		IDs:            filters.IDs,
+		Tags:           filters.Tags,
+		InitiatorID:    filters.InitiatorID,
+		// Default page size is applied in SQL when LimitOpt is 0.
+		LimitOpt:  0,
+		OffsetOpt: 0,
 	})
 	if err != nil {
 		if httpapi.Is404Error(err) {

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -85,6 +85,7 @@ const provisionerJobsCountCap = 2000
 // @Param tags query object false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
 // @Param initiator query string false "Filter results by initiator" format(uuid)
 // @Param template query string false "Filter results by template ID" format(uuid)
+// @Param search query string false "Free-text search against workspace name, template name, template display name, or job ID"
 // @Success 200 {object} codersdk.ProvisionerJobsResponse
 // @Router /api/v2/organizations/{organization}/provisionerjobs [get]
 func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
@@ -115,6 +116,7 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 		Tags:           filters.Tags,
 		InitiatorID:    filters.InitiatorID,
 		TemplateID:     filters.TemplateID,
+		Search:         filters.Search,
 		CountCap:       provisionerJobsCountCap,
 	})
 	if err != nil {
@@ -145,6 +147,7 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 		Tags:           filters.Tags,
 		InitiatorID:    filters.InitiatorID,
 		TemplateID:     filters.TemplateID,
+		Search:         filters.Search,
 		// #nosec G115 - Pagination offsets are small and fit in int32
 		OffsetOpt: int32(page.Offset),
 		// #nosec G115 - Pagination limits are small and fit in int32
@@ -176,6 +179,7 @@ type provisionerJobFilters struct {
 	Tags        database.StringMap
 	InitiatorID uuid.UUID
 	TemplateID  uuid.UUID
+	Search      string
 }
 
 // parseProvisionerJobFilters parses filter query params shared by the list and
@@ -196,6 +200,7 @@ func parseProvisionerJobFilters(rw http.ResponseWriter, r *http.Request, ids []u
 	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
 	initiatorID := p.UUID(qp, uuid.Nil, "initiator")
 	templateID := p.UUID(qp, uuid.Nil, "template")
+	search := p.String(qp, "", "search")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -212,6 +217,7 @@ func parseProvisionerJobFilters(rw http.ResponseWriter, r *http.Request, ids []u
 		Tags:        tags,
 		InitiatorID: initiatorID,
 		TemplateID:  templateID,
+		Search:      search,
 	}, true
 }
 
@@ -241,6 +247,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 		Tags:           filters.Tags,
 		InitiatorID:    filters.InitiatorID,
 		TemplateID:     filters.TemplateID,
+		Search:         filters.Search,
 		// Default page size is applied in SQL when LimitOpt is 0.
 		LimitOpt:  0,
 		OffsetOpt: 0,

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpmw/loggermw"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/searchquery"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
@@ -41,14 +42,35 @@ import (
 // @Router /api/v2/organizations/{organization}/provisionerjobs/{job} [get]
 func (api *API) provisionerJob(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	org := httpmw.OrganizationParam(r)
 
 	jobID, ok := httpmw.ParseUUIDParam(rw, r, "job")
 	if !ok {
 		return
 	}
 
-	jobs, ok := api.handleAuthAndFetchProvisionerJobs(rw, r, []uuid.UUID{jobID})
-	if !ok {
+	// For now, only owners and template admins can access provisioner jobs.
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceProvisionerJobs.InOrg(org.ID)) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+
+	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
+		OrganizationID: org.ID,
+		IDs:            []uuid.UUID{jobID},
+		// Default page size is applied in SQL when LimitOpt is 0.
+		LimitOpt:  0,
+		OffsetOpt: 0,
+	})
+	if err != nil {
+		if httpapi.Is404Error(err) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching provisioner job.",
+			Detail:  err.Error(),
+		})
 		return
 	}
 	if len(jobs) == 0 {
@@ -79,13 +101,7 @@ const provisionerJobsCountCap = 2000
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param limit query int false "Page limit"
 // @Param offset query int false "Page offset"
-// @Param ids query []string false "Filter results by job IDs" format(uuid)
-// @Param status query codersdk.ProvisionerJobStatus false "Filter results by status" enums(pending,running,succeeded,canceling,canceled,failed)
-// @Param type query codersdk.ProvisionerJobType false "Filter results by job type" enums(template_version_import,workspace_build,template_version_dry_run)
-// @Param tags query object false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
-// @Param initiator query string false "Filter results by initiator" format(uuid)
-// @Param template query string false "Filter results by template ID" format(uuid)
-// @Param search query string false "Free-text search against workspace name, template name, template display name, or job ID"
+// @Param q query string false "Search query in the format `key:value`. Available keys are: status, type, template, id, initiator, tag. Bare text searches workspace name, template name, template display name, or job ID."
 // @Success 200 {object} codersdk.ProvisionerJobsResponse
 // @Router /api/v2/organizations/{organization}/provisionerjobs [get]
 func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
@@ -103,22 +119,17 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filters, ok := parseProvisionerJobFilters(rw, r, nil)
-	if !ok {
+	filter, countFilter, errs := searchquery.ProvisionerJobs(ctx, api.Database, org.ID, r.URL.Query().Get("q"))
+	if len(errs) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Invalid provisioner job search query.",
+			Validations: errs,
+		})
 		return
 	}
 
-	count, err := api.Database.CountProvisionerJobsByOrganizationAndStatus(ctx, database.CountProvisionerJobsByOrganizationAndStatusParams{
-		OrganizationID: org.ID,
-		Status:         filters.Status,
-		Types:          filters.Types,
-		IDs:            filters.IDs,
-		Tags:           filters.Tags,
-		InitiatorID:    filters.InitiatorID,
-		TemplateID:     filters.TemplateID,
-		Search:         filters.Search,
-		CountCap:       provisionerJobsCountCap,
-	})
+	countFilter.CountCap = provisionerJobsCountCap
+	count, err := api.Database.CountProvisionerJobsByOrganizationAndStatus(ctx, countFilter)
 	if err != nil {
 		if httpapi.Is404Error(err) {
 			httpapi.ResourceNotFound(rw)
@@ -139,20 +150,11 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
-		OrganizationID: org.ID,
-		Status:         filters.Status,
-		Types:          filters.Types,
-		IDs:            filters.IDs,
-		Tags:           filters.Tags,
-		InitiatorID:    filters.InitiatorID,
-		TemplateID:     filters.TemplateID,
-		Search:         filters.Search,
-		// #nosec G115 - Pagination offsets are small and fit in int32
-		OffsetOpt: int32(page.Offset),
-		// #nosec G115 - Pagination limits are small and fit in int32
-		LimitOpt: int32(page.Limit),
-	})
+	// #nosec G115 - Pagination offsets/limits are small and fit in int32
+	filter.OffsetOpt = int32(page.Offset)
+	// #nosec G115 - Pagination offsets/limits are small and fit in int32
+	filter.LimitOpt = int32(page.Limit)
+	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, filter)
 	if err != nil {
 		if httpapi.Is404Error(err) {
 			httpapi.ResourceNotFound(rw)
@@ -170,102 +172,6 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 		Count:    count,
 		CountCap: provisionerJobsCountCap,
 	})
-}
-
-type provisionerJobFilters struct {
-	IDs         []uuid.UUID
-	Status      []database.ProvisionerJobStatus
-	Types       []database.ProvisionerJobType
-	Tags        database.StringMap
-	InitiatorID uuid.UUID
-	TemplateID  uuid.UUID
-	Search      string
-}
-
-// parseProvisionerJobFilters parses filter query params shared by the list and
-// single-job endpoints. Pagination params are marked parsed so they are not
-// rejected when callers also use ParsePagination.
-func parseProvisionerJobFilters(rw http.ResponseWriter, r *http.Request, ids []uuid.UUID) (provisionerJobFilters, bool) {
-	ctx := r.Context()
-	qp := r.URL.Query()
-	p := httpapi.NewQueryParamParser()
-	_ = p.PositiveInt32(qp, 0, "limit")
-	_ = p.PositiveInt32(qp, 0, "offset")
-	_ = p.UUID(qp, uuid.Nil, "after_id")
-	status := p.Strings(qp, nil, "status")
-	jobTypes := p.Strings(qp, nil, "type")
-	if ids == nil {
-		ids = p.UUIDs(qp, nil, "ids")
-	}
-	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
-	initiatorID := p.UUID(qp, uuid.Nil, "initiator")
-	templateID := p.UUID(qp, uuid.Nil, "template")
-	search := p.String(qp, "", "search")
-	p.ErrorExcessParams(qp)
-	if len(p.Errors) > 0 {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message:     "Invalid query parameters.",
-			Validations: p.Errors,
-		})
-		return provisionerJobFilters{}, false
-	}
-
-	return provisionerJobFilters{
-		IDs:         ids,
-		Status:      slice.StringEnums[database.ProvisionerJobStatus](status),
-		Types:       slice.StringEnums[database.ProvisionerJobType](jobTypes),
-		Tags:        tags,
-		InitiatorID: initiatorID,
-		TemplateID:  templateID,
-		Search:      search,
-	}, true
-}
-
-// handleAuthAndFetchProvisionerJobs is used by the singular provisioner job
-// endpoint. If ok is false the caller should return immediately because the
-// response has already been written.
-func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *http.Request, ids []uuid.UUID) (_ []database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow, ok bool) {
-	ctx := r.Context()
-	org := httpmw.OrganizationParam(r)
-
-	// For now, only owners and template admins can access provisioner jobs.
-	if !api.Authorize(r, policy.ActionRead, rbac.ResourceProvisionerJobs.InOrg(org.ID)) {
-		httpapi.ResourceNotFound(rw)
-		return nil, false
-	}
-
-	filters, ok := parseProvisionerJobFilters(rw, r, ids)
-	if !ok {
-		return nil, false
-	}
-
-	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
-		OrganizationID: org.ID,
-		Status:         filters.Status,
-		Types:          filters.Types,
-		IDs:            filters.IDs,
-		Tags:           filters.Tags,
-		InitiatorID:    filters.InitiatorID,
-		TemplateID:     filters.TemplateID,
-		Search:         filters.Search,
-		// Default page size is applied in SQL when LimitOpt is 0.
-		LimitOpt:  0,
-		OffsetOpt: 0,
-	})
-	if err != nil {
-		if httpapi.Is404Error(err) {
-			httpapi.ResourceNotFound(rw)
-			return nil, false
-		}
-
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching provisioner jobs.",
-			Detail:  err.Error(),
-		})
-		return nil, false
-	}
-
-	return jobs, true
 }
 
 // Returns provisioner logs based on query parameters.

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -81,8 +81,10 @@ const provisionerJobsCountCap = 2000
 // @Param offset query int false "Page offset"
 // @Param ids query []string false "Filter results by job IDs" format(uuid)
 // @Param status query codersdk.ProvisionerJobStatus false "Filter results by status" enums(pending,running,succeeded,canceling,canceled,failed)
+// @Param type query codersdk.ProvisionerJobType false "Filter results by job type" enums(template_version_import,workspace_build,template_version_dry_run)
 // @Param tags query object false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
 // @Param initiator query string false "Filter results by initiator" format(uuid)
+// @Param template query string false "Filter results by template ID" format(uuid)
 // @Success 200 {object} codersdk.ProvisionerJobsResponse
 // @Router /api/v2/organizations/{organization}/provisionerjobs [get]
 func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
@@ -108,9 +110,11 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 	count, err := api.Database.CountProvisionerJobsByOrganizationAndStatus(ctx, database.CountProvisionerJobsByOrganizationAndStatusParams{
 		OrganizationID: org.ID,
 		Status:         filters.Status,
+		Types:          filters.Types,
 		IDs:            filters.IDs,
 		Tags:           filters.Tags,
 		InitiatorID:    filters.InitiatorID,
+		TemplateID:     filters.TemplateID,
 		CountCap:       provisionerJobsCountCap,
 	})
 	if err != nil {
@@ -136,9 +140,11 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
 		OrganizationID: org.ID,
 		Status:         filters.Status,
+		Types:          filters.Types,
 		IDs:            filters.IDs,
 		Tags:           filters.Tags,
 		InitiatorID:    filters.InitiatorID,
+		TemplateID:     filters.TemplateID,
 		// #nosec G115 - Pagination offsets are small and fit in int32
 		OffsetOpt: int32(page.Offset),
 		// #nosec G115 - Pagination limits are small and fit in int32
@@ -166,8 +172,10 @@ func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
 type provisionerJobFilters struct {
 	IDs         []uuid.UUID
 	Status      []database.ProvisionerJobStatus
+	Types       []database.ProvisionerJobType
 	Tags        database.StringMap
 	InitiatorID uuid.UUID
+	TemplateID  uuid.UUID
 }
 
 // parseProvisionerJobFilters parses filter query params shared by the list and
@@ -181,11 +189,13 @@ func parseProvisionerJobFilters(rw http.ResponseWriter, r *http.Request, ids []u
 	_ = p.PositiveInt32(qp, 0, "offset")
 	_ = p.UUID(qp, uuid.Nil, "after_id")
 	status := p.Strings(qp, nil, "status")
+	jobTypes := p.Strings(qp, nil, "type")
 	if ids == nil {
 		ids = p.UUIDs(qp, nil, "ids")
 	}
 	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
 	initiatorID := p.UUID(qp, uuid.Nil, "initiator")
+	templateID := p.UUID(qp, uuid.Nil, "template")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -198,8 +208,10 @@ func parseProvisionerJobFilters(rw http.ResponseWriter, r *http.Request, ids []u
 	return provisionerJobFilters{
 		IDs:         ids,
 		Status:      slice.StringEnums[database.ProvisionerJobStatus](status),
+		Types:       slice.StringEnums[database.ProvisionerJobType](jobTypes),
 		Tags:        tags,
 		InitiatorID: initiatorID,
+		TemplateID:  templateID,
 	}, true
 }
 
@@ -224,9 +236,11 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
 		OrganizationID: org.ID,
 		Status:         filters.Status,
+		Types:          filters.Types,
 		IDs:            filters.IDs,
 		Tags:           filters.Tags,
 		InitiatorID:    filters.InitiatorID,
+		TemplateID:     filters.TemplateID,
 		// Default page size is applied in SQL when LimitOpt is 0.
 		LimitOpt:  0,
 		OffsetOpt: 0,

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -195,6 +195,55 @@ func TestProvisionerJobs(t *testing.T) {
 			}
 		})
 
+		t.Run("SearchWorkspaceName", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Search: w.Name,
+			})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(jobsRes.Jobs), 1)
+			for _, found := range jobsRes.Jobs {
+				require.Equal(t, w.Name, found.Metadata.WorkspaceName)
+			}
+		})
+
+		t.Run("SearchTemplateName", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Search: template.Name,
+			})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(jobsRes.Jobs), 1)
+			for _, found := range jobsRes.Jobs {
+				require.Equal(t, template.Name, found.Metadata.TemplateName)
+			}
+		})
+
+		t.Run("SearchJobID", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Search: job.ID.String(),
+			})
+			require.NoError(t, err)
+			require.Len(t, jobsRes.Jobs, 1)
+			require.Equal(t, job.ID, jobsRes.Jobs[0].ID)
+			require.Equal(t, int64(1), jobsRes.Count)
+		})
+
+		t.Run("SearchNoMatch", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Search: "this-name-definitely-does-not-exist-" + uuid.NewString(),
+			})
+			require.NoError(t, err)
+			require.Empty(t, jobsRes.Jobs)
+			require.Equal(t, int64(0), jobsRes.Count)
+		})
+
 		t.Run("Tags", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -74,8 +74,8 @@ func TestProvisionerJobs(t *testing.T) {
 			TemplateVersionID: version.ID,
 		})
 
-		// Add more jobs than the default limit.
-		for i := range 60 {
+		// Add more jobs than the default limit (100).
+		for i := range 110 {
 			dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
 				OrganizationID: owner.OrganizationID,
 				Tags:           database.StringMap{"count": strconv.Itoa(i)},
@@ -140,51 +140,56 @@ func TestProvisionerJobs(t *testing.T) {
 		t.Run("Default limit", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
 			require.NoError(t, err)
-			require.Len(t, jobs, 50)
+			require.Len(t, jobsRes.Jobs, 100)
+			require.GreaterOrEqual(t, jobsRes.Count, int64(100))
+			require.Equal(t, int64(2000), jobsRes.CountCap)
 		})
 
 		t.Run("IDs", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				IDs: []uuid.UUID{workspace.LatestBuild.Job.ID, version.Job.ID},
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 2)
+			require.Len(t, jobsRes.Jobs, 2)
+			require.Equal(t, int64(2), jobsRes.Count)
 		})
 
 		t.Run("Status", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Status: []codersdk.ProvisionerJobStatus{codersdk.ProvisionerJobRunning},
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 1)
+			require.Len(t, jobsRes.Jobs, 1)
+			require.Equal(t, int64(1), jobsRes.Count)
 		})
 
 		t.Run("Tags", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Tags: map[string]string{"count": "1"},
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 1)
+			require.Len(t, jobsRes.Jobs, 1)
+			require.Equal(t, int64(1), jobsRes.Count)
 		})
 
 		t.Run("Initiator", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
 
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: member.ID.String(),
 			})
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, len(jobs), 1)
-			require.Equal(t, member.ID, jobs[0].InitiatorID)
+			require.GreaterOrEqual(t, len(jobsRes.Jobs), 1)
+			require.Equal(t, member.ID, jobsRes.Jobs[0].InitiatorID)
 		})
 
 		t.Run("InitiatorWithOtherFilters", func(t *testing.T) {
@@ -192,14 +197,14 @@ func TestProvisionerJobs(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitMedium)
 
 			// Test filtering by initiator ID combined with status filter
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: owner.UserID.String(),
 				Status:    []codersdk.ProvisionerJobStatus{codersdk.ProvisionerJobSucceeded},
 			})
 			require.NoError(t, err)
 
 			// Verify all returned jobs have the correct initiator and status
-			for _, job := range jobs {
+			for _, job := range jobsRes.Jobs {
 				require.Equal(t, owner.UserID, job.InitiatorID)
 				require.Equal(t, codersdk.ProvisionerJobSucceeded, job.Status)
 			}
@@ -210,15 +215,17 @@ func TestProvisionerJobs(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitMedium)
 
 			// Test filtering by initiator ID with limit
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: owner.UserID.String(),
-				Limit:     1,
+				Pagination: codersdk.Pagination{
+					Limit: 1,
+				},
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 1)
+			require.Len(t, jobsRes.Jobs, 1)
 
 			// Verify the returned job has the correct initiator
-			require.Equal(t, owner.UserID, jobs[0].InitiatorID)
+			require.Equal(t, owner.UserID, jobsRes.Jobs[0].InitiatorID)
 		})
 
 		t.Run("InitiatorWithTags", func(t *testing.T) {
@@ -226,16 +233,16 @@ func TestProvisionerJobs(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitMedium)
 
 			// Test filtering by initiator ID combined with tags
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: member.ID.String(),
 				Tags:      map[string]string{"initiatorTest": "true"},
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 1)
+			require.Len(t, jobsRes.Jobs, 1)
 
 			// Verify the returned job has the correct initiator and tags
-			require.Equal(t, member.ID, jobs[0].InitiatorID)
-			require.Equal(t, "true", jobs[0].Tags["initiatorTest"])
+			require.Equal(t, member.ID, jobsRes.Jobs[0].InitiatorID)
+			require.Equal(t, "true", jobsRes.Jobs[0].Tags["initiatorTest"])
 		})
 
 		t.Run("InitiatorNotFound", func(t *testing.T) {
@@ -244,11 +251,12 @@ func TestProvisionerJobs(t *testing.T) {
 
 			// Test with non-existent initiator ID
 			nonExistentID := uuid.New()
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: nonExistentID.String(),
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 0)
+			require.Len(t, jobsRes.Jobs, 0)
+			require.Equal(t, int64(0), jobsRes.Count)
 		})
 
 		t.Run("InitiatorNil", func(t *testing.T) {
@@ -256,21 +264,48 @@ func TestProvisionerJobs(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitMedium)
 
 			// Test with nil initiator ID (should return all jobs)
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: "",
 			})
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, len(jobs), 50) // Should return all jobs (up to default limit)
+			require.Len(t, jobsRes.Jobs, 100) // Default page limit
+			require.GreaterOrEqual(t, jobsRes.Count, int64(100))
 		})
 
 		t.Run("Limit", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				Limit: 1,
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Pagination: codersdk.Pagination{
+					Limit: 1,
+				},
 			})
 			require.NoError(t, err)
-			require.Len(t, jobs, 1)
+			require.Len(t, jobsRes.Jobs, 1)
+			require.GreaterOrEqual(t, jobsRes.Count, int64(1))
+		})
+
+		t.Run("Offset", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			page1, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Pagination: codersdk.Pagination{
+					Limit: 10,
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, page1.Jobs, 10)
+
+			page2, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Pagination: codersdk.Pagination{
+					Limit:  10,
+					Offset: 10,
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, page2.Jobs, 10)
+			require.Equal(t, page1.Count, page2.Count)
+			require.NotEqual(t, page1.Jobs[0].ID, page2.Jobs[0].ID)
 		})
 
 		// For now, this is not allowed even though the member has created a
@@ -279,20 +314,20 @@ func TestProvisionerJobs(t *testing.T) {
 		t.Run("MemberDenied", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			jobs, err := memberClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
+			jobsRes, err := memberClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
 			require.Error(t, err)
-			require.Len(t, jobs, 0)
+			require.Len(t, jobsRes.Jobs, 0)
 		})
 
 		t.Run("MemberDeniedWithInitiator", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
 			// Member should not be able to access jobs even with initiator filter
-			jobs, err := memberClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+			jobsRes, err := memberClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
 				Initiator: member.ID.String(),
 			})
 			require.Error(t, err)
-			require.Len(t, jobs, 0)
+			require.Len(t, jobsRes.Jobs, 0)
 		})
 	})
 
@@ -337,11 +372,12 @@ func TestProvisionerJobs(t *testing.T) {
 			}
 
 			// Get provisioner jobs
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
 			require.NoError(t, err)
-			require.Equal(t, 2, len(jobs))
+			require.Equal(t, 2, len(jobsRes.Jobs))
+			require.Equal(t, int64(2), jobsRes.Count)
 
-			for _, job := range jobs {
+			for _, job := range jobsRes.Jobs {
 				require.Equal(t, owner.OrganizationID, job.OrganizationID)
 				require.Equal(t, database.ProvisionerJobStatusSucceeded, database.ProvisionerJobStatus(job.Status))
 
@@ -367,13 +403,13 @@ func TestProvisionerJobs(t *testing.T) {
 			}
 
 			// Get all provisioner jobs
-			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
 			require.NoError(t, err)
-			require.Equal(t, 2, len(jobs))
+			require.Equal(t, 2, len(jobsRes.Jobs))
 
 			// Find workspace_build provisioner job ID
 			var workspaceProvisionerJobID uuid.UUID
-			for _, job := range jobs {
+			for _, job := range jobsRes.Jobs {
 				if job.Type == codersdk.ProvisionerJobTypeWorkspaceBuild {
 					workspaceProvisionerJobID = job.ID
 				}

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"net/http"
 	"strconv"
 	"testing"
 
@@ -193,6 +194,42 @@ func TestProvisionerJobs(t *testing.T) {
 			for _, job := range jobsRes.Jobs {
 				require.Equal(t, template.ID, job.Metadata.TemplateID)
 			}
+		})
+
+		t.Run("TemplateByName", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Template: template.Name,
+			})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(jobsRes.Jobs), 1)
+			for _, found := range jobsRes.Jobs {
+				require.Equal(t, template.ID, found.Metadata.TemplateID)
+			}
+		})
+
+		t.Run("FilterQuery", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				FilterQuery: "status:running",
+			})
+			require.NoError(t, err)
+			require.Len(t, jobsRes.Jobs, 1)
+			require.Equal(t, int64(1), jobsRes.Count)
+		})
+
+		t.Run("InvalidFilterQuery", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			_, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				FilterQuery: "nope:value",
+			})
+			require.Error(t, err)
+			var apiErr *codersdk.Error
+			require.ErrorAs(t, err, &apiErr)
+			require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 		})
 
 		t.Run("SearchWorkspaceName", func(t *testing.T) {

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -169,6 +169,32 @@ func TestProvisionerJobs(t *testing.T) {
 			require.Equal(t, int64(1), jobsRes.Count)
 		})
 
+		t.Run("Type", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Types: []codersdk.ProvisionerJobType{codersdk.ProvisionerJobTypeWorkspaceBuild},
+			})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(jobsRes.Jobs), 1)
+			for _, job := range jobsRes.Jobs {
+				require.Equal(t, codersdk.ProvisionerJobTypeWorkspaceBuild, job.Type)
+			}
+		})
+
+		t.Run("Template", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			jobsRes, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				Template: template.ID.String(),
+			})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(jobsRes.Jobs), 1)
+			for _, job := range jobsRes.Jobs {
+				require.Equal(t, template.ID, job.Metadata.TemplateID)
+			}
+		})
+
 		t.Run("Tags", func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -637,6 +637,121 @@ func Chats(query string) (database.GetChatsParams, []codersdk.ValidationError) {
 	return filter, parser.Errors
 }
 
+// ProvisionerJobs parses a provisioner job search query.
+//
+// Supported query parameters:
+//
+//   - bare text: free-text search (workspace name, template name/display name, job ID)
+//   - status: provisioner job status enum (csv or repeated)
+//   - type: provisioner job type enum (csv or repeated)
+//   - template: template name or UUID (resolved within the organization)
+//   - id: job UUID(s)
+//   - initiator: username or UUID
+//   - tag: key=value (repeated; accumulates into a tagset filter)
+func ProvisionerJobs(ctx context.Context, db database.Store, organizationID uuid.UUID, query string) (
+	database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams,
+	database.CountProvisionerJobsByOrganizationAndStatusParams,
+	[]codersdk.ValidationError,
+) {
+	// nolint:exhaustruct // OffsetOpt, LimitOpt, and CountCap are set by the handler.
+	filter := database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
+		OrganizationID: organizationID,
+	}
+	// nolint:exhaustruct // CountCap is set by the handler.
+	countFilter := database.CountProvisionerJobsByOrganizationAndStatusParams{
+		OrganizationID: organizationID,
+	}
+
+	if query == "" {
+		return filter, countFilter, nil
+	}
+
+	// Do not lowercase the entire query. Tag keys/values are case-sensitive
+	// in the provisioner tagset. Keys are lowercased by searchTerms; enum
+	// and name lookups normalize below as needed.
+	values, errors := searchTerms(query, func(term string, values url.Values) error {
+		values.Add("search", term)
+		return nil
+	})
+	if len(errors) > 0 {
+		return filter, countFilter, errors
+	}
+
+	parser := httpapi.NewQueryParamParser()
+	filter.Search = parser.String(values, "", "search")
+	filter.Status = httpapi.ParseCustomList(parser, values, []database.ProvisionerJobStatus{}, "status", func(v string) (database.ProvisionerJobStatus, error) {
+		return httpapi.ParseEnum[database.ProvisionerJobStatus](strings.ToLower(v))
+	})
+	filter.Types = httpapi.ParseCustomList(parser, values, []database.ProvisionerJobType{}, "type", func(v string) (database.ProvisionerJobType, error) {
+		return httpapi.ParseEnum[database.ProvisionerJobType](strings.ToLower(v))
+	})
+	filter.IDs = parser.UUIDs(values, nil, "id")
+	filter.InitiatorID = parseUser(ctx, db, parser, values, "initiator", uuid.Nil)
+	filter.TemplateID = parseTemplateInOrganization(ctx, db, parser, values, organizationID)
+	filter.Tags = parseProvisionerTags(parser, values)
+
+	countFilter.Search = filter.Search
+	countFilter.Status = filter.Status
+	countFilter.Types = filter.Types
+	countFilter.IDs = filter.IDs
+	countFilter.InitiatorID = filter.InitiatorID
+	countFilter.TemplateID = filter.TemplateID
+	countFilter.Tags = filter.Tags
+
+	parser.ErrorExcessParams(values)
+	return filter, countFilter, parser.Errors
+}
+
+// parseTemplateInOrganization resolves a "template" filter param as either a
+// UUID or a template name within the given organization.
+func parseTemplateInOrganization(
+	ctx context.Context,
+	db database.Store,
+	parser *httpapi.QueryParamParser,
+	vals url.Values,
+	organizationID uuid.UUID,
+) uuid.UUID {
+	return httpapi.ParseCustom(parser, vals, uuid.Nil, "template", func(v string) (uuid.UUID, error) {
+		if v == "" {
+			return uuid.Nil, nil
+		}
+		templateID, err := uuid.Parse(v)
+		if err == nil {
+			return templateID, nil
+		}
+		template, err := db.GetTemplateByOrganizationAndName(ctx, database.GetTemplateByOrganizationAndNameParams{
+			OrganizationID: organizationID,
+			Deleted:        false,
+			Name:           strings.ToLower(v),
+		})
+		if err != nil {
+			return uuid.Nil, xerrors.Errorf("template %q either does not exist, or you are unauthorized to view it", v)
+		}
+		return template.ID, nil
+	})
+}
+
+// parseProvisionerTags parses repeated tag:key=value terms into a StringMap.
+// When no tags are provided, the returned map is nil so the SQL filter treats
+// it as unrestricted (JSON null).
+func parseProvisionerTags(parser *httpapi.QueryParamParser, vals url.Values) database.StringMap {
+	pairs := httpapi.ParseCustomList(parser, vals, [][2]string{}, "tag", func(v string) ([2]string, error) {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return [2]string{}, xerrors.Errorf("tag must be in the form key=value, got %q", v)
+		}
+		return [2]string{parts[0], parts[1]}, nil
+	})
+	if len(pairs) == 0 {
+		return nil
+	}
+	tags := make(database.StringMap, len(pairs))
+	for _, pair := range pairs {
+		tags[pair[0]] = pair[1]
+	}
+	return tags
+}
+
 // validateDiffURL checks that the value is a syntactically valid HTTP(S)
 // URL. The check is intentionally forge-agnostic because the diff URL on
 // a chat may point to a pull request, merge request, branch page, etc.

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -1742,3 +1742,165 @@ func TestSearchChats(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchProvisionerJobs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		orgID := uuid.New()
+		filter, countFilter, errs := searchquery.ProvisionerJobs(context.Background(), nil, orgID, "")
+		require.Empty(t, errs)
+		require.Equal(t, orgID, filter.OrganizationID)
+		require.Equal(t, orgID, countFilter.OrganizationID)
+		require.Empty(t, filter.Search)
+		require.Nil(t, filter.Tags)
+	})
+
+	t.Run("BareText", func(t *testing.T) {
+		t.Parallel()
+		filter, countFilter, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "my-workspace")
+		require.Empty(t, errs)
+		require.Equal(t, "my-workspace", filter.Search)
+		require.Equal(t, "my-workspace", countFilter.Search)
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		t.Parallel()
+		filter, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "status:running")
+		require.Empty(t, errs)
+		require.Equal(t, []database.ProvisionerJobStatus{database.ProvisionerJobStatusRunning}, filter.Status)
+	})
+
+	t.Run("StatusCSV", func(t *testing.T) {
+		t.Parallel()
+		filter, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "status:running,pending")
+		require.Empty(t, errs)
+		require.Equal(t, []database.ProvisionerJobStatus{
+			database.ProvisionerJobStatusRunning,
+			database.ProvisionerJobStatusPending,
+		}, filter.Status)
+	})
+
+	t.Run("Type", func(t *testing.T) {
+		t.Parallel()
+		filter, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "type:workspace_build")
+		require.Empty(t, errs)
+		require.Equal(t, []database.ProvisionerJobType{database.ProvisionerJobTypeWorkspaceBuild}, filter.Types)
+	})
+
+	t.Run("ID", func(t *testing.T) {
+		t.Parallel()
+		jobID := uuid.New()
+		filter, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "id:"+jobID.String())
+		require.Empty(t, errs)
+		require.Equal(t, []uuid.UUID{jobID}, filter.IDs)
+	})
+
+	t.Run("InvalidID", func(t *testing.T) {
+		t.Parallel()
+		_, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "id:not-a-uuid")
+		require.NotEmpty(t, errs)
+		require.Equal(t, "id", errs[0].Field)
+	})
+
+	t.Run("UnknownKey", func(t *testing.T) {
+		t.Parallel()
+		_, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "nope:value")
+		require.NotEmpty(t, errs)
+		require.Equal(t, "nope", errs[0].Field)
+	})
+
+	t.Run("Tag", func(t *testing.T) {
+		t.Parallel()
+		filter, countFilter, errs := searchquery.ProvisionerJobs(
+			context.Background(), nil, uuid.New(), "tag:scope=organization tag:owner=me",
+		)
+		require.Empty(t, errs)
+		require.Equal(t, database.StringMap{
+			"scope": "organization",
+			"owner": "me",
+		}, filter.Tags)
+		require.Equal(t, filter.Tags, countFilter.Tags)
+	})
+
+	t.Run("InvalidTag", func(t *testing.T) {
+		t.Parallel()
+		_, _, errs := searchquery.ProvisionerJobs(context.Background(), nil, uuid.New(), "tag:missingequals")
+		require.NotEmpty(t, errs)
+		require.Equal(t, "tag", errs[0].Field)
+	})
+
+	t.Run("Mixed", func(t *testing.T) {
+		t.Parallel()
+		filter, _, errs := searchquery.ProvisionerJobs(
+			context.Background(), nil, uuid.New(), "status:failed type:workspace_build my-ws",
+		)
+		require.Empty(t, errs)
+		require.Equal(t, "my-ws", filter.Search)
+		require.Equal(t, []database.ProvisionerJobStatus{database.ProvisionerJobStatusFailed}, filter.Status)
+		require.Equal(t, []database.ProvisionerJobType{database.ProvisionerJobTypeWorkspaceBuild}, filter.Types)
+	})
+
+	t.Run("TemplateByName", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		user := dbgen.User(t, db, database.User{})
+		template := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "docker",
+		})
+
+		filter, countFilter, errs := searchquery.ProvisionerJobs(
+			context.Background(), db, org.ID, "template:docker",
+		)
+		require.Empty(t, errs)
+		require.Equal(t, template.ID, filter.TemplateID)
+		require.Equal(t, template.ID, countFilter.TemplateID)
+	})
+
+	t.Run("TemplateByID", func(t *testing.T) {
+		t.Parallel()
+		templateID := uuid.New()
+		filter, _, errs := searchquery.ProvisionerJobs(
+			context.Background(), nil, uuid.New(), "template:"+templateID.String(),
+		)
+		require.Empty(t, errs)
+		require.Equal(t, templateID, filter.TemplateID)
+	})
+
+	t.Run("TemplateNotFound", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		_, _, errs := searchquery.ProvisionerJobs(
+			context.Background(), db, org.ID, "template:missing",
+		)
+		require.NotEmpty(t, errs)
+		require.Equal(t, "template", errs[0].Field)
+	})
+
+	t.Run("InitiatorByUsername", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		user := dbgen.User(t, db, database.User{Username: "alice"})
+		filter, countFilter, errs := searchquery.ProvisionerJobs(
+			context.Background(), db, uuid.New(), "initiator:alice",
+		)
+		require.Empty(t, errs)
+		require.Equal(t, user.ID, filter.InitiatorID)
+		require.Equal(t, user.ID, countFilter.InitiatorID)
+	})
+
+	t.Run("InitiatorByID", func(t *testing.T) {
+		t.Parallel()
+		userID := uuid.New()
+		filter, _, errs := searchquery.ProvisionerJobs(
+			context.Background(), nil, uuid.New(), "initiator:"+userID.String(),
+		)
+		require.Empty(t, errs)
+		require.Equal(t, userID, filter.InitiatorID)
+	})
+}

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -424,17 +424,66 @@ type OrganizationProvisionerJobsOptions struct {
 	// Pagination controls page size and offset. A Limit of 0 uses the
 	// server default (100).
 	Pagination
-	IDs       []uuid.UUID
-	Status    []ProvisionerJobStatus
-	Types     []ProvisionerJobType
-	Tags      map[string]string
-	Initiator string
-	// Template is a template ID used to filter jobs associated with that
-	// template (via template version import, dry-run, or workspace build).
-	Template string
-	// Search is a free-text filter matched against workspace name, template
-	// name, template display name, or job ID.
-	Search string
+	// IDs filters by job ID. Typescript clients should use FilterQuery instead.
+	IDs []uuid.UUID `json:"ids,omitempty" typescript:"-"`
+	// Status filters by job status. Typescript clients should use FilterQuery instead.
+	Status []ProvisionerJobStatus `json:"status,omitempty" typescript:"-"`
+	// Types filters by job type. Typescript clients should use FilterQuery instead.
+	Types []ProvisionerJobType `json:"type,omitempty" typescript:"-"`
+	// Tags filters by provisioner tags (key=value). Typescript clients should use FilterQuery instead.
+	Tags map[string]string `json:"tags,omitempty" typescript:"-"`
+	// Initiator is a username or user ID. Typescript clients should use FilterQuery instead.
+	Initiator string `json:"initiator,omitempty" typescript:"-"`
+	// Template is a template name or ID. Typescript clients should use FilterQuery instead.
+	Template string `json:"template,omitempty" typescript:"-"`
+	// Search is free-text matched against workspace name, template name,
+	// template display name, or job ID. Typescript clients should use FilterQuery instead.
+	Search string `json:"search,omitempty" typescript:"-"`
+	// FilterQuery is a raw filter query string (same language as the API `q`
+	// parameter). Typed fields above are composed into `q` alongside this.
+	FilterQuery string `json:"q,omitempty"`
+}
+
+// asRequestOption composes typed filter fields and FilterQuery into a single
+// `q` query parameter, matching WorkspaceFilter.
+func (o OrganizationProvisionerJobsOptions) asRequestOption() RequestOption {
+	return func(r *http.Request) {
+		var params []string
+		if len(o.IDs) > 0 {
+			ids := make([]string, 0, len(o.IDs))
+			for _, id := range o.IDs {
+				ids = append(ids, id.String())
+			}
+			params = append(params, fmt.Sprintf("id:%s", strings.Join(ids, ",")))
+		}
+		for _, status := range o.Status {
+			params = append(params, fmt.Sprintf("status:%s", status))
+		}
+		for _, jobType := range o.Types {
+			params = append(params, fmt.Sprintf("type:%s", jobType))
+		}
+		for key, value := range o.Tags {
+			params = append(params, fmt.Sprintf("tag:%s=%s", key, value))
+		}
+		if o.Initiator != "" {
+			params = append(params, fmt.Sprintf("initiator:%q", o.Initiator))
+		}
+		if o.Template != "" {
+			params = append(params, fmt.Sprintf("template:%q", o.Template))
+		}
+		if o.Search != "" {
+			params = append(params, o.Search)
+		}
+		if o.FilterQuery != "" {
+			params = append(params, o.FilterQuery)
+		}
+
+		q := r.URL.Query()
+		if len(params) > 0 {
+			q.Set("q", strings.Join(params, " "))
+		}
+		r.URL.RawQuery = q.Encode()
+	}
 }
 
 // ProvisionerJobsResponse is the paginated response for listing provisioner jobs.
@@ -448,44 +497,15 @@ type ProvisionerJobsResponse struct {
 }
 
 func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID uuid.UUID, opts *OrganizationProvisionerJobsOptions) (ProvisionerJobsResponse, error) {
-	qp := url.Values{}
-	if opts != nil {
-		if opts.Limit > 0 {
-			qp.Add("limit", strconv.Itoa(opts.Limit))
-		}
-		if opts.Offset > 0 {
-			qp.Add("offset", strconv.Itoa(opts.Offset))
-		}
-		if len(opts.IDs) > 0 {
-			qp.Add("ids", joinSliceStringer(opts.IDs))
-		}
-		if len(opts.Status) > 0 {
-			qp.Add("status", joinSlice(opts.Status))
-		}
-		if len(opts.Types) > 0 {
-			qp.Add("type", joinSlice(opts.Types))
-		}
-		if len(opts.Tags) > 0 {
-			tagsRaw, err := json.Marshal(opts.Tags)
-			if err != nil {
-				return ProvisionerJobsResponse{}, xerrors.Errorf("marshal tags: %w", err)
-			}
-			qp.Add("tags", string(tagsRaw))
-		}
-		if opts.Initiator != "" {
-			qp.Add("initiator", opts.Initiator)
-		}
-		if opts.Template != "" {
-			qp.Add("template", opts.Template)
-		}
-		if opts.Search != "" {
-			qp.Add("search", opts.Search)
-		}
+	if opts == nil {
+		opts = &OrganizationProvisionerJobsOptions{}
 	}
 
 	res, err := c.Request(ctx, http.MethodGet,
-		fmt.Sprintf("/api/v2/organizations/%s/provisionerjobs?%s", organizationID.String(), qp.Encode()),
+		fmt.Sprintf("/api/v2/organizations/%s/provisionerjobs", organizationID.String()),
 		nil,
+		opts.Pagination.asRequestOption(),
+		opts.asRequestOption(),
 	)
 	if err != nil {
 		return ProvisionerJobsResponse{}, xerrors.Errorf("make request: %w", err)

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -432,6 +432,9 @@ type OrganizationProvisionerJobsOptions struct {
 	// Template is a template ID used to filter jobs associated with that
 	// template (via template version import, dry-run, or workspace build).
 	Template string
+	// Search is a free-text filter matched against workspace name, template
+	// name, template display name, or job ID.
+	Search string
 }
 
 // ProvisionerJobsResponse is the paginated response for listing provisioner jobs.
@@ -474,6 +477,9 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 		}
 		if opts.Template != "" {
 			qp.Add("template", opts.Template)
+		}
+		if opts.Search != "" {
+			qp.Add("search", opts.Search)
 		}
 	}
 

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -421,18 +421,33 @@ func (c *Client) OrganizationProvisionerDaemons(ctx context.Context, organizatio
 }
 
 type OrganizationProvisionerJobsOptions struct {
-	Limit     int
+	// Pagination controls page size and offset. A Limit of 0 uses the
+	// server default (100).
+	Pagination
 	IDs       []uuid.UUID
 	Status    []ProvisionerJobStatus
 	Tags      map[string]string
 	Initiator string
 }
 
-func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID uuid.UUID, opts *OrganizationProvisionerJobsOptions) ([]ProvisionerJob, error) {
+// ProvisionerJobsResponse is the paginated response for listing provisioner jobs.
+type ProvisionerJobsResponse struct {
+	Jobs []ProvisionerJob `json:"jobs"`
+	// Count is the total number of jobs matching the filter, capped by CountCap.
+	Count int64 `json:"count"`
+	// CountCap is the maximum number of jobs counted. When Count equals CountCap,
+	// there may be additional matching jobs beyond the cap.
+	CountCap int64 `json:"count_cap"`
+}
+
+func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID uuid.UUID, opts *OrganizationProvisionerJobsOptions) (ProvisionerJobsResponse, error) {
 	qp := url.Values{}
 	if opts != nil {
 		if opts.Limit > 0 {
 			qp.Add("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Offset > 0 {
+			qp.Add("offset", strconv.Itoa(opts.Offset))
 		}
 		if len(opts.IDs) > 0 {
 			qp.Add("ids", joinSliceStringer(opts.IDs))
@@ -443,7 +458,7 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 		if len(opts.Tags) > 0 {
 			tagsRaw, err := json.Marshal(opts.Tags)
 			if err != nil {
-				return nil, xerrors.Errorf("marshal tags: %w", err)
+				return ProvisionerJobsResponse{}, xerrors.Errorf("marshal tags: %w", err)
 			}
 			qp.Add("tags", string(tagsRaw))
 		}
@@ -457,16 +472,16 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 		nil,
 	)
 	if err != nil {
-		return nil, xerrors.Errorf("make request: %w", err)
+		return ProvisionerJobsResponse{}, xerrors.Errorf("make request: %w", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, ReadBodyAsError(res)
+		return ProvisionerJobsResponse{}, ReadBodyAsError(res)
 	}
 
-	var jobs []ProvisionerJob
-	return jobs, ReadBodyAsJSON(res, &jobs)
+	var jobsRes ProvisionerJobsResponse
+	return jobsRes, ReadBodyAsJSON(res, &jobsRes)
 }
 
 func (c *Client) OrganizationProvisionerJob(ctx context.Context, organizationID, jobID uuid.UUID) (job ProvisionerJob, err error) {

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -426,8 +426,12 @@ type OrganizationProvisionerJobsOptions struct {
 	Pagination
 	IDs       []uuid.UUID
 	Status    []ProvisionerJobStatus
+	Types     []ProvisionerJobType
 	Tags      map[string]string
 	Initiator string
+	// Template is a template ID used to filter jobs associated with that
+	// template (via template version import, dry-run, or workspace build).
+	Template string
 }
 
 // ProvisionerJobsResponse is the paginated response for listing provisioner jobs.
@@ -455,6 +459,9 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 		if len(opts.Status) > 0 {
 			qp.Add("status", joinSlice(opts.Status))
 		}
+		if len(opts.Types) > 0 {
+			qp.Add("type", joinSlice(opts.Types))
+		}
 		if len(opts.Tags) > 0 {
 			tagsRaw, err := json.Marshal(opts.Tags)
 			if err != nil {
@@ -464,6 +471,9 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 		}
 		if opts.Initiator != "" {
 			qp.Add("initiator", opts.Initiator)
+		}
+		if opts.Template != "" {
+			qp.Add("template", opts.Template)
 		}
 	}
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -161,6 +161,14 @@ const (
 	ProvisionerJobTypeTemplateVersionDryRun ProvisionerJobType = "template_version_dry_run"
 )
 
+func ProvisionerJobTypeEnums() []ProvisionerJobType {
+	return []ProvisionerJobType{
+		ProvisionerJobTypeTemplateVersionImport,
+		ProvisionerJobTypeWorkspaceBuild,
+		ProvisionerJobTypeTemplateVersionDryRun,
+	}
+}
+
 // JobErrorCode defines the error code returned by job runner.
 type JobErrorCode string
 

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -288,25 +288,12 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 
 ### Parameters
 
-| Name           | In    | Type         | Required | Description                                                                              |
-|----------------|-------|--------------|----------|------------------------------------------------------------------------------------------|
-| `organization` | path  | string(uuid) | true     | Organization ID                                                                          |
-| `limit`        | query | integer      | false    | Page limit                                                                               |
-| `offset`       | query | integer      | false    | Page offset                                                                              |
-| `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                                |
-| `status`       | query | string       | false    | Filter results by status                                                                 |
-| `type`         | query | string       | false    | Filter results by job type                                                               |
-| `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)     |
-| `initiator`    | query | string(uuid) | false    | Filter results by initiator                                                              |
-| `template`     | query | string(uuid) | false    | Filter results by template ID                                                            |
-| `search`       | query | string       | false    | Free-text search against workspace name, template name, template display name, or job ID |
-
-#### Enumerated Values
-
-| Parameter | Value(s)                                                                        |
-|-----------|---------------------------------------------------------------------------------|
-| `status`  | `canceled`, `canceling`, `failed`, `pending`, `running`, `succeeded`, `unknown` |
-| `type`    | `template_version_dry_run`, `template_version_import`, `workspace_build`        |
+| Name           | In    | Type         | Required | Description                                                                                                                                                                                 |
+|----------------|-------|--------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `organization` | path  | string(uuid) | true     | Organization ID                                                                                                                                                                             |
+| `limit`        | query | integer      | false    | Page limit                                                                                                                                                                                  |
+| `offset`       | query | integer      | false    | Page offset                                                                                                                                                                                 |
+| `q`            | query | string       | false    | Search query in the format `key:value`. Available keys are: status, type, template, id, initiator, tag. Bare text searches workspace name, template name, template display name, or job ID. |
 
 ### Example responses
 

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -295,14 +295,17 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 | `offset`       | query | integer      | false    | Page offset                                                                          |
 | `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                            |
 | `status`       | query | string       | false    | Filter results by status                                                             |
+| `type`         | query | string       | false    | Filter results by job type                                                           |
 | `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
 | `initiator`    | query | string(uuid) | false    | Filter results by initiator                                                          |
+| `template`     | query | string(uuid) | false    | Filter results by template ID                                                        |
 
 #### Enumerated Values
 
 | Parameter | Value(s)                                                                        |
 |-----------|---------------------------------------------------------------------------------|
 | `status`  | `canceled`, `canceling`, `failed`, `pending`, `running`, `succeeded`, `unknown` |
+| `type`    | `template_version_dry_run`, `template_version_import`, `workspace_build`        |
 
 ### Example responses
 

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -288,17 +288,18 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 
 ### Parameters
 
-| Name           | In    | Type         | Required | Description                                                                          |
-|----------------|-------|--------------|----------|--------------------------------------------------------------------------------------|
-| `organization` | path  | string(uuid) | true     | Organization ID                                                                      |
-| `limit`        | query | integer      | false    | Page limit                                                                           |
-| `offset`       | query | integer      | false    | Page offset                                                                          |
-| `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                            |
-| `status`       | query | string       | false    | Filter results by status                                                             |
-| `type`         | query | string       | false    | Filter results by job type                                                           |
-| `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
-| `initiator`    | query | string(uuid) | false    | Filter results by initiator                                                          |
-| `template`     | query | string(uuid) | false    | Filter results by template ID                                                        |
+| Name           | In    | Type         | Required | Description                                                                              |
+|----------------|-------|--------------|----------|------------------------------------------------------------------------------------------|
+| `organization` | path  | string(uuid) | true     | Organization ID                                                                          |
+| `limit`        | query | integer      | false    | Page limit                                                                               |
+| `offset`       | query | integer      | false    | Page offset                                                                              |
+| `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                                |
+| `status`       | query | string       | false    | Filter results by status                                                                 |
+| `type`         | query | string       | false    | Filter results by job type                                                               |
+| `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)     |
+| `initiator`    | query | string(uuid) | false    | Filter results by initiator                                                              |
+| `template`     | query | string(uuid) | false    | Filter results by template ID                                                            |
+| `search`       | query | string       | false    | Free-text search against workspace name, template name, template display name, or job ID |
 
 #### Enumerated Values
 

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -292,6 +292,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 |----------------|-------|--------------|----------|--------------------------------------------------------------------------------------|
 | `organization` | path  | string(uuid) | true     | Organization ID                                                                      |
 | `limit`        | query | integer      | false    | Page limit                                                                           |
+| `offset`       | query | integer      | false    | Page offset                                                                          |
 | `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                            |
 | `status`       | query | string       | false    | Filter results by status                                                             |
 | `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
@@ -308,106 +309,60 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 > 200 Response
 
 ```json
-[
-  {
-    "available_workers": [
-      "497f6eca-6276-4993-bfeb-53cbbbba6f08"
-    ],
-    "canceled_at": "2019-08-24T14:15:22Z",
-    "completed_at": "2019-08-24T14:15:22Z",
-    "created_at": "2019-08-24T14:15:22Z",
-    "error": "string",
-    "error_code": "REQUIRED_TEMPLATE_VARIABLES",
-    "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
-    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-    "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
-    "input": {
+{
+  "count": 0,
+  "count_cap": 0,
+  "jobs": [
+    {
+      "available_workers": [
+        "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+      ],
+      "canceled_at": "2019-08-24T14:15:22Z",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "created_at": "2019-08-24T14:15:22Z",
       "error": "string",
-      "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
-      "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
-    },
-    "logs_overflowed": true,
-    "metadata": {
-      "template_display_name": "string",
-      "template_icon": "string",
-      "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-      "template_name": "string",
-      "template_version_name": "string",
-      "workspace_build_transition": "start",
-      "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
-      "workspace_name": "string"
-    },
-    "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
-    "queue_position": 0,
-    "queue_size": 0,
-    "started_at": "2019-08-24T14:15:22Z",
-    "status": "pending",
-    "tags": {
-      "property1": "string",
-      "property2": "string"
-    },
-    "type": "template_version_import",
-    "worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b",
-    "worker_name": "string"
-  }
-]
+      "error_code": "REQUIRED_TEMPLATE_VARIABLES",
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+      "input": {
+        "error": "string",
+        "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+        "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+      },
+      "logs_overflowed": true,
+      "metadata": {
+        "template_display_name": "string",
+        "template_icon": "string",
+        "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
+        "template_name": "string",
+        "template_version_name": "string",
+        "workspace_build_transition": "start",
+        "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+        "workspace_name": "string"
+      },
+      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+      "queue_position": 0,
+      "queue_size": 0,
+      "started_at": "2019-08-24T14:15:22Z",
+      "status": "pending",
+      "tags": {
+        "property1": "string",
+        "property2": "string"
+      },
+      "type": "template_version_import",
+      "worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b",
+      "worker_name": "string"
+    }
+  ]
+}
 ```
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                                |
-|--------|---------------------------------------------------------|-------------|-----------------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob) |
-
-<h3 id="get-provisioner-jobs-responseschema">Response Schema</h3>
-
-Status Code **200**
-
-| Name                            | Type                                                                         | Required | Restrictions | Description |
-|---------------------------------|------------------------------------------------------------------------------|----------|--------------|-------------|
-| `[array item]`                  | array                                                                        | false    |              |             |
-| `» available_workers`           | array                                                                        | false    |              |             |
-| `» canceled_at`                 | string(date-time)                                                            | false    |              |             |
-| `» completed_at`                | string(date-time)                                                            | false    |              |             |
-| `» created_at`                  | string(date-time)                                                            | false    |              |             |
-| `» error`                       | string                                                                       | false    |              |             |
-| `» error_code`                  | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                     | false    |              |             |
-| `» file_id`                     | string(uuid)                                                                 | false    |              |             |
-| `» id`                          | string(uuid)                                                                 | false    |              |             |
-| `» initiator_id`                | string(uuid)                                                                 | false    |              |             |
-| `» input`                       | [codersdk.ProvisionerJobInput](schemas.md#codersdkprovisionerjobinput)       | false    |              |             |
-| `»» error`                      | string                                                                       | false    |              |             |
-| `»» template_version_id`        | string(uuid)                                                                 | false    |              |             |
-| `»» workspace_build_id`         | string(uuid)                                                                 | false    |              |             |
-| `» logs_overflowed`             | boolean                                                                      | false    |              |             |
-| `» metadata`                    | [codersdk.ProvisionerJobMetadata](schemas.md#codersdkprovisionerjobmetadata) | false    |              |             |
-| `»» template_display_name`      | string                                                                       | false    |              |             |
-| `»» template_icon`              | string                                                                       | false    |              |             |
-| `»» template_id`                | string(uuid)                                                                 | false    |              |             |
-| `»» template_name`              | string                                                                       | false    |              |             |
-| `»» template_version_name`      | string                                                                       | false    |              |             |
-| `»» workspace_build_transition` | [codersdk.WorkspaceTransition](schemas.md#codersdkworkspacetransition)       | false    |              |             |
-| `»» workspace_id`               | string(uuid)                                                                 | false    |              |             |
-| `»» workspace_name`             | string                                                                       | false    |              |             |
-| `» organization_id`             | string(uuid)                                                                 | false    |              |             |
-| `» queue_position`              | integer                                                                      | false    |              |             |
-| `» queue_size`                  | integer                                                                      | false    |              |             |
-| `» started_at`                  | string(date-time)                                                            | false    |              |             |
-| `» status`                      | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus)     | false    |              |             |
-| `» tags`                        | object                                                                       | false    |              |             |
-| `»» [any property]`             | string                                                                       | false    |              |             |
-| `» type`                        | [codersdk.ProvisionerJobType](schemas.md#codersdkprovisionerjobtype)         | false    |              |             |
-| `» worker_id`                   | string(uuid)                                                                 | false    |              |             |
-| `» worker_name`                 | string                                                                       | false    |              |             |
-
-#### Enumerated Values
-
-| Property                     | Value(s)                                                                 |
-|------------------------------|--------------------------------------------------------------------------|
-| `error_code`                 | `INSUFFICIENT_QUOTA`, `REQUIRED_TEMPLATE_VARIABLES`                      |
-| `workspace_build_transition` | `delete`, `start`, `stop`                                                |
-| `status`                     | `canceled`, `canceling`, `failed`, `pending`, `running`, `succeeded`     |
-| `type`                       | `template_version_dry_run`, `template_version_import`, `workspace_build` |
+| Status | Meaning                                                 | Description | Schema                                                                         |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ProvisionerJobsResponse](schemas.md#codersdkprovisionerjobsresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -10908,6 +10908,66 @@ Only certain features set these fields: - FeatureManagedAgentLimit - FeatureAgen
 |--------------------------------------------------------------------------|
 | `template_version_dry_run`, `template_version_import`, `workspace_build` |
 
+## codersdk.ProvisionerJobsResponse
+
+```json
+{
+  "count": 0,
+  "count_cap": 0,
+  "jobs": [
+    {
+      "available_workers": [
+        "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+      ],
+      "canceled_at": "2019-08-24T14:15:22Z",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "created_at": "2019-08-24T14:15:22Z",
+      "error": "string",
+      "error_code": "REQUIRED_TEMPLATE_VARIABLES",
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+      "input": {
+        "error": "string",
+        "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+        "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+      },
+      "logs_overflowed": true,
+      "metadata": {
+        "template_display_name": "string",
+        "template_icon": "string",
+        "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
+        "template_name": "string",
+        "template_version_name": "string",
+        "workspace_build_transition": "start",
+        "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+        "workspace_name": "string"
+      },
+      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+      "queue_position": 0,
+      "queue_size": 0,
+      "started_at": "2019-08-24T14:15:22Z",
+      "status": "pending",
+      "tags": {
+        "property1": "string",
+        "property2": "string"
+      },
+      "type": "template_version_import",
+      "worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b",
+      "worker_name": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name        | Type                                                        | Required | Restrictions | Description                                                                                                                        |
+|-------------|-------------------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `count`     | integer                                                     | false    |              | Count is the total number of jobs matching the filter, capped by CountCap.                                                         |
+| `count_cap` | integer                                                     | false    |              | Count cap is the maximum number of jobs counted. When Count equals CountCap, there may be additional matching jobs beyond the cap. |
+| `jobs`      | array of [codersdk.ProvisionerJob](#codersdkprovisionerjob) | false    |              |                                                                                                                                    |
+
 ## codersdk.ProvisionerKey
 
 ```json

--- a/docs/reference/cli/provisioner_jobs_list.md
+++ b/docs/reference/cli/provisioner_jobs_list.md
@@ -59,7 +59,7 @@ Filter by initiator (user ID or username).
 | Type        | <code>string</code>                               |
 | Environment | <code>$CODER_PROVISIONER_JOB_LIST_TEMPLATE</code> |
 
-Filter by template ID.
+Filter by template name or ID.
 
 ### -q, --search
 
@@ -68,7 +68,7 @@ Filter by template ID.
 | Type        | <code>string</code>                             |
 | Environment | <code>$CODER_PROVISIONER_JOB_LIST_SEARCH</code> |
 
-Free-text search against workspace name, template name, template display name, or job ID.
+Search query in the format key:value. Available keys are: status, type, template, id, initiator, tag. Bare text searches workspace name, template name, template display name, or job ID.
 
 ### -O, --org
 

--- a/docs/reference/cli/provisioner_jobs_list.md
+++ b/docs/reference/cli/provisioner_jobs_list.md
@@ -24,6 +24,15 @@ coder provisioner jobs list [flags]
 
 Filter by job status.
 
+### --type
+
+|             |                                                                                   |
+|-------------|-----------------------------------------------------------------------------------|
+| Type        | <code>[template_version_import\|workspace_build\|template_version_dry_run]</code> |
+| Environment | <code>$CODER_PROVISIONER_JOB_LIST_TYPE</code>                                     |
+
+Filter by job type.
+
 ### -l, --limit
 
 |             |                                                |
@@ -42,6 +51,15 @@ Limit the number of jobs returned.
 | Environment | <code>$CODER_PROVISIONER_JOB_LIST_INITIATOR</code> |
 
 Filter by initiator (user ID or username).
+
+### --template
+
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>string</code>                               |
+| Environment | <code>$CODER_PROVISIONER_JOB_LIST_TEMPLATE</code> |
+
+Filter by template ID.
 
 ### -O, --org
 

--- a/docs/reference/cli/provisioner_jobs_list.md
+++ b/docs/reference/cli/provisioner_jobs_list.md
@@ -61,6 +61,15 @@ Filter by initiator (user ID or username).
 
 Filter by template ID.
 
+### -q, --search
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>string</code>                             |
+| Environment | <code>$CODER_PROVISIONER_JOB_LIST_SEARCH</code> |
+
+Free-text search against workspace name, template name, template display name, or job ID.
+
 ### -O, --org
 
 |             |                                  |

--- a/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -23,6 +23,10 @@ OPTIONS:
   -o, --output table|json (default: table)
           Output format.
 
+  -q, --search string, $CODER_PROVISIONER_JOB_LIST_SEARCH
+          Free-text search against workspace name, template name, template
+          display name, or job ID.
+
   -s, --status [pending|running|succeeded|canceling|canceled|failed|unknown], $CODER_PROVISIONER_JOB_LIST_STATUS
           Filter by job status.
 

--- a/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -24,14 +24,15 @@ OPTIONS:
           Output format.
 
   -q, --search string, $CODER_PROVISIONER_JOB_LIST_SEARCH
-          Free-text search against workspace name, template name, template
-          display name, or job ID.
+          Search query in the format key:value. Available keys are: status,
+          type, template, id, initiator, tag. Bare text searches workspace name,
+          template name, template display name, or job ID.
 
   -s, --status [pending|running|succeeded|canceling|canceled|failed|unknown], $CODER_PROVISIONER_JOB_LIST_STATUS
           Filter by job status.
 
       --template string, $CODER_PROVISIONER_JOB_LIST_TEMPLATE
-          Filter by template ID.
+          Filter by template name or ID.
 
       --type [template_version_import|workspace_build|template_version_dry_run], $CODER_PROVISIONER_JOB_LIST_TYPE
           Filter by job type.

--- a/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -26,5 +26,11 @@ OPTIONS:
   -s, --status [pending|running|succeeded|canceling|canceled|failed|unknown], $CODER_PROVISIONER_JOB_LIST_STATUS
           Filter by job status.
 
+      --template string, $CODER_PROVISIONER_JOB_LIST_TEMPLATE
+          Filter by template ID.
+
+      --type [template_version_import|workspace_build|template_version_dry_run], $CODER_PROVISIONER_JOB_LIST_TYPE
+          Filter by job type.
+
 ———
 Run `coder --help` for a list of global options.

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -402,14 +402,9 @@ export class ParameterValidationError extends Error {
 }
 
 export type GetProvisionerJobsParams = {
-	status?: string;
-	type?: string;
-	template?: string;
-	search?: string;
+	q?: string;
 	limit?: number;
 	offset?: number;
-	// IDs separated by comma
-	ids?: string;
 };
 
 export type GetProvisionerDaemonsParams = {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -401,7 +401,7 @@ export class ParameterValidationError extends Error {
 	}
 }
 
-export type GetProvisionerJobsParams = {
+type GetProvisionerJobsParams = {
 	q?: string;
 	limit?: number;
 	offset?: number;

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -405,6 +405,7 @@ export type GetProvisionerJobsParams = {
 	status?: string;
 	type?: string;
 	template?: string;
+	search?: string;
 	limit?: number;
 	offset?: number;
 	// IDs separated by comma

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -403,6 +403,8 @@ export class ParameterValidationError extends Error {
 
 export type GetProvisionerJobsParams = {
 	status?: string;
+	type?: string;
+	template?: string;
 	limit?: number;
 	offset?: number;
 	// IDs separated by comma

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -404,6 +404,7 @@ export class ParameterValidationError extends Error {
 export type GetProvisionerJobsParams = {
 	status?: string;
 	limit?: number;
+	offset?: number;
 	// IDs separated by comma
 	ids?: string;
 };
@@ -2904,7 +2905,7 @@ class ApiMethods {
 		orgId: string,
 		params: GetProvisionerJobsParams = {},
 	) => {
-		const res = await this.axios.get<TypesGen.ProvisionerJob[]>(
+		const res = await this.axios.get<TypesGen.ProvisionerJobsResponse>(
 			`/api/v2/organizations/${orgId}/provisionerjobs`,
 			{ params },
 		);

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -12,10 +12,7 @@ import type {
 	UpdateWorkspaceSharingSettingsRequest,
 	UsersRequest,
 } from "#/api/typesGenerated";
-import {
-	parseFilterQuery,
-	useFilterParamsKey,
-} from "#/components/Filter/Filter";
+import { useFilterParamsKey } from "#/components/Filter/Filter";
 import type { MetadataState } from "#/hooks/useEmbeddedMetadata";
 import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
 import {
@@ -283,48 +280,18 @@ export const patchWorkspaceSharingSettings = (
 export const provisionerJobsQueryKey = (orgId: string) =>
 	["organization", orgId, "provisionerjobs"] as const;
 
-export type ProvisionerJobsFilterPayload = {
-	status: string;
-	type: string;
-	template: string;
-	ids: string;
-	search: string;
-};
-
 export const paginatedProvisionerJobs = (
 	orgId: string,
 	searchParams: URLSearchParams,
-): UsePaginatedQueryOptions<
-	ProvisionerJobsResponse,
-	ProvisionerJobsFilterPayload
-> => {
+): UsePaginatedQueryOptions<ProvisionerJobsResponse, string> => {
 	return {
 		searchParams,
-		queryPayload: () => {
-			const filterQuery = searchParams.get(useFilterParamsKey) ?? "";
-			const values = parseFilterQuery(filterQuery);
-			return {
-				status: values.status ?? "",
-				type: values.type ?? "",
-				template: values.template ?? "",
-				ids: values.ids ?? "",
-				// Bare text in the filter box (not key:value) maps to the
-				// API search param.
-				search: filterQuery
-					.replace(/(\w+):"[^"]+"|(\w+):\S+/g, " ")
-					.trim()
-					.replace(/\s+/g, " "),
-			};
-		},
+		queryPayload: () => searchParams.get(useFilterParamsKey) ?? "",
 		queryKey: ({ payload, pageNumber }) =>
 			[...provisionerJobsQueryKey(orgId), payload, pageNumber] as const,
 		queryFn: ({ payload, limit, offset }) =>
 			API.getProvisionerJobs(orgId, {
-				status: payload.status || undefined,
-				type: payload.type || undefined,
-				template: payload.template || undefined,
-				ids: payload.ids || undefined,
-				search: payload.search || undefined,
+				q: payload || undefined,
 				limit,
 				offset,
 			}),

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -12,6 +12,10 @@ import type {
 	UpdateWorkspaceSharingSettingsRequest,
 	UsersRequest,
 } from "#/api/typesGenerated";
+import {
+	parseFilterQuery,
+	useFilterParamsKey,
+} from "#/components/Filter/Filter";
 import type { MetadataState } from "#/hooks/useEmbeddedMetadata";
 import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
 import {
@@ -281,6 +285,8 @@ export const provisionerJobsQueryKey = (orgId: string) =>
 
 export type ProvisionerJobsFilterPayload = {
 	status: string;
+	type: string;
+	template: string;
 	ids: string;
 };
 
@@ -293,15 +299,24 @@ export const paginatedProvisionerJobs = (
 > => {
 	return {
 		searchParams,
-		queryPayload: () => ({
-			status: searchParams.get("status") ?? "",
-			ids: searchParams.get("ids") ?? "",
-		}),
+		queryPayload: () => {
+			const values = parseFilterQuery(
+				searchParams.get(useFilterParamsKey) ?? "",
+			);
+			return {
+				status: values.status ?? "",
+				type: values.type ?? "",
+				template: values.template ?? "",
+				ids: values.ids ?? "",
+			};
+		},
 		queryKey: ({ payload, pageNumber }) =>
 			[...provisionerJobsQueryKey(orgId), payload, pageNumber] as const,
 		queryFn: ({ payload, limit, offset }) =>
 			API.getProvisionerJobs(orgId, {
 				status: payload.status || undefined,
+				type: payload.type || undefined,
+				template: payload.template || undefined,
 				ids: payload.ids || undefined,
 				limit,
 				offset,

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -1,15 +1,12 @@
 import type { QueryClient, UseQueryOptions } from "react-query";
-import {
-	API,
-	type GetProvisionerDaemonsParams,
-	type GetProvisionerJobsParams,
-} from "#/api/api";
+import { API, type GetProvisionerDaemonsParams } from "#/api/api";
 import type {
 	AuthorizationCheck,
 	CreateOrganizationRequest,
 	GroupSyncSettings,
 	Organization,
 	PaginatedMembersResponse,
+	ProvisionerJobsResponse,
 	RoleSyncSettings,
 	UpdateOrganizationRequest,
 	UpdateWorkspaceSharingSettingsRequest,
@@ -279,21 +276,37 @@ export const patchWorkspaceSharingSettings = (
 	};
 };
 
-export const provisionerJobsQueryKey = (
-	orgId: string,
-	params: GetProvisionerJobsParams = {},
-) => ["organization", orgId, "provisionerjobs", params];
+export const provisionerJobsQueryKey = (orgId: string) =>
+	["organization", orgId, "provisionerjobs"] as const;
 
-export const provisionerJobs = (
+export type ProvisionerJobsFilterPayload = {
+	status: string;
+	ids: string;
+};
+
+export const paginatedProvisionerJobs = (
 	orgId: string,
-	params: GetProvisionerJobsParams = {},
-) => {
+	searchParams: URLSearchParams,
+): UsePaginatedQueryOptions<
+	ProvisionerJobsResponse,
+	ProvisionerJobsFilterPayload
+> => {
 	return {
-		queryKey: provisionerJobsQueryKey(orgId, params),
-		queryFn: async () => {
-			const res = await API.getProvisionerJobs(orgId, params);
-			return res.jobs;
-		},
+		searchParams,
+		queryPayload: () => ({
+			status: searchParams.get("status") ?? "",
+			ids: searchParams.get("ids") ?? "",
+		}),
+		queryKey: ({ payload, pageNumber }) =>
+			[...provisionerJobsQueryKey(orgId), payload, pageNumber] as const,
+		queryFn: ({ payload, limit, offset }) =>
+			API.getProvisionerJobs(orgId, {
+				status: payload.status || undefined,
+				ids: payload.ids || undefined,
+				limit,
+				offset,
+			}),
+		enabled: Boolean(orgId),
 	};
 };
 

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -288,6 +288,7 @@ export type ProvisionerJobsFilterPayload = {
 	type: string;
 	template: string;
 	ids: string;
+	search: string;
 };
 
 export const paginatedProvisionerJobs = (
@@ -300,14 +301,19 @@ export const paginatedProvisionerJobs = (
 	return {
 		searchParams,
 		queryPayload: () => {
-			const values = parseFilterQuery(
-				searchParams.get(useFilterParamsKey) ?? "",
-			);
+			const filterQuery = searchParams.get(useFilterParamsKey) ?? "";
+			const values = parseFilterQuery(filterQuery);
 			return {
 				status: values.status ?? "",
 				type: values.type ?? "",
 				template: values.template ?? "",
 				ids: values.ids ?? "",
+				// Bare text in the filter box (not key:value) maps to the
+				// API search param.
+				search: filterQuery
+					.replace(/(\w+):"[^"]+"|(\w+):\S+/g, " ")
+					.trim()
+					.replace(/\s+/g, " "),
 			};
 		},
 		queryKey: ({ payload, pageNumber }) =>
@@ -318,6 +324,7 @@ export const paginatedProvisionerJobs = (
 				type: payload.type || undefined,
 				template: payload.template || undefined,
 				ids: payload.ids || undefined,
+				search: payload.search || undefined,
 				limit,
 				offset,
 			}),

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -290,7 +290,10 @@ export const provisionerJobs = (
 ) => {
 	return {
 		queryKey: provisionerJobsQueryKey(orgId, params),
-		queryFn: () => API.getProvisionerJobs(orgId, params),
+		queryFn: async () => {
+			const res = await API.getProvisionerJobs(orgId, params);
+			return res.jobs;
+		},
 	};
 };
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6891,21 +6891,11 @@ export interface OrganizationProvisionerDaemonsOptions {
 
 // From codersdk/organizations.go
 export interface OrganizationProvisionerJobsOptions extends Pagination {
-	readonly IDs: readonly string[];
-	readonly Status: readonly ProvisionerJobStatus[];
-	readonly Types: readonly ProvisionerJobType[];
-	readonly Tags: Record<string, string>;
-	readonly Initiator: string;
 	/**
-	 * Template is a template ID used to filter jobs associated with that
-	 * template (via template version import, dry-run, or workspace build).
+	 * FilterQuery is a raw filter query string (same language as the API `q`
+	 * parameter). Typed fields above are composed into `q` alongside this.
 	 */
-	readonly Template: string;
-	/**
-	 * Search is a free-text filter matched against workspace name, template
-	 * name, template display name, or job ID.
-	 */
-	readonly Search: string;
+	readonly q?: string;
 }
 
 // From codersdk/idpsync.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6893,8 +6893,14 @@ export interface OrganizationProvisionerDaemonsOptions {
 export interface OrganizationProvisionerJobsOptions extends Pagination {
 	readonly IDs: readonly string[];
 	readonly Status: readonly ProvisionerJobStatus[];
+	readonly Types: readonly ProvisionerJobType[];
 	readonly Tags: Record<string, string>;
 	readonly Initiator: string;
+	/**
+	 * Template is a template ID used to filter jobs associated with that
+	 * template (via template version import, dry-run, or workspace build).
+	 */
+	readonly Template: string;
 }
 
 // From codersdk/idpsync.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6890,8 +6890,7 @@ export interface OrganizationProvisionerDaemonsOptions {
 }
 
 // From codersdk/organizations.go
-export interface OrganizationProvisionerJobsOptions {
-	readonly Limit: number;
+export interface OrganizationProvisionerJobsOptions extends Pagination {
 	readonly IDs: readonly string[];
 	readonly Status: readonly ProvisionerJobStatus[];
 	readonly Tags: Record<string, string>;
@@ -7419,6 +7418,23 @@ export const ProvisionerJobTypes: ProvisionerJobType[] = [
 	"template_version_import",
 	"workspace_build",
 ];
+
+// From codersdk/organizations.go
+/**
+ * ProvisionerJobsResponse is the paginated response for listing provisioner jobs.
+ */
+export interface ProvisionerJobsResponse {
+	readonly jobs: readonly ProvisionerJob[];
+	/**
+	 * Count is the total number of jobs matching the filter, capped by CountCap.
+	 */
+	readonly count: number;
+	/**
+	 * CountCap is the maximum number of jobs counted. When Count equals CountCap,
+	 * there may be additional matching jobs beyond the cap.
+	 */
+	readonly count_cap: number;
+}
 
 // From codersdk/provisionerdaemons.go
 export interface ProvisionerKey {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6901,6 +6901,11 @@ export interface OrganizationProvisionerJobsOptions extends Pagination {
 	 * template (via template version import, dry-run, or workspace build).
 	 */
 	readonly Template: string;
+	/**
+	 * Search is a free-text filter matched against workspace name, template
+	 * name, template display name, or job ID.
+	 */
+	readonly Search: string;
 }
 
 // From codersdk/idpsync.go

--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -102,7 +102,7 @@ export const useFilter = ({
 	};
 };
 
-const parseFilterQuery = (filterQuery: string): FilterValues => {
+export const parseFilterQuery = (filterQuery: string): FilterValues => {
 	if (filterQuery === "") {
 		return {};
 	}

--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -102,7 +102,7 @@ export const useFilter = ({
 	};
 };
 
-export const parseFilterQuery = (filterQuery: string): FilterValues => {
+const parseFilterQuery = (filterQuery: string): FilterValues => {
 	if (filterQuery === "") {
 		return {};
 	}

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
@@ -1,7 +1,8 @@
 import type { FC } from "react";
-import { useQuery } from "react-query";
 import { useSearchParams } from "react-router";
-import { provisionerJobs } from "#/api/queries/organizations";
+import { paginatedProvisionerJobs } from "#/api/queries/organizations";
+import { isNonInitialPage } from "#/components/PaginationWidget/utils";
+import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
 import { useOrganizationSettings } from "#/modules/management/OrganizationSettingsLayout";
 import OrganizationProvisionerJobsPageView from "./OrganizationProvisionerJobsPageView";
 
@@ -12,26 +13,22 @@ const OrganizationProvisionerJobsPage: FC = () => {
 		status: searchParams.get("status") ?? "",
 		ids: searchParams.get("ids") ?? "",
 	};
-	const {
-		data: jobs,
-		isLoadingError,
-		refetch,
-	} = useQuery({
-		...provisionerJobs(organization?.id ?? "", {
-			...filter,
-			limit: 100,
-		}),
-		enabled: organization !== undefined,
-	});
+	const jobsQuery = usePaginatedQuery(
+		paginatedProvisionerJobs(organization?.id ?? "", searchParams),
+	);
 
 	return (
 		<OrganizationProvisionerJobsPageView
-			jobs={jobs}
+			jobs={jobsQuery.data?.jobs}
+			jobsQuery={jobsQuery}
 			filter={filter}
 			organization={organization}
-			error={isLoadingError}
-			onRetry={refetch}
-			onFilterChange={setSearchParams}
+			error={jobsQuery.error}
+			isNonInitialPage={isNonInitialPage(searchParams)}
+			onRetry={jobsQuery.refetch}
+			onFilterChange={(nextFilter) => {
+				setSearchParams(nextFilter);
+			}}
 		/>
 	);
 };

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
@@ -1,33 +1,74 @@
 import type { FC } from "react";
 import { useSearchParams } from "react-router";
 import { paginatedProvisionerJobs } from "#/api/queries/organizations";
+import { useFilter } from "#/components/Filter/Filter";
 import { isNonInitialPage } from "#/components/PaginationWidget/utils";
 import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
 import { useOrganizationSettings } from "#/modules/management/OrganizationSettingsLayout";
 import OrganizationProvisionerJobsPageView from "./OrganizationProvisionerJobsPageView";
+import {
+	useProvisionerJobStatusFilterMenu,
+	useProvisionerJobTemplateFilterMenu,
+	useProvisionerJobTypeFilterMenu,
+} from "./ProvisionerJobsFilter";
 
 const OrganizationProvisionerJobsPage: FC = () => {
 	const { organization } = useOrganizationSettings();
 	const [searchParams, setSearchParams] = useSearchParams();
-	const filter = {
-		status: searchParams.get("status") ?? "",
-		ids: searchParams.get("ids") ?? "",
-	};
 	const jobsQuery = usePaginatedQuery(
 		paginatedProvisionerJobs(organization?.id ?? "", searchParams),
 	);
+
+	const filter = useFilter({
+		searchParams,
+		onSearchParamsChange: setSearchParams,
+		onUpdate: jobsQuery.goToFirstPage,
+	});
+
+	const statusMenu = useProvisionerJobStatusFilterMenu({
+		value: filter.values.status,
+		onChange: (option) =>
+			filter.update({
+				...filter.values,
+				status: option?.value,
+			}),
+	});
+
+	const typeMenu = useProvisionerJobTypeFilterMenu({
+		value: filter.values.type,
+		onChange: (option) =>
+			filter.update({
+				...filter.values,
+				type: option?.value,
+			}),
+	});
+
+	const templateMenu = useProvisionerJobTemplateFilterMenu({
+		organizationId: organization?.id,
+		value: filter.values.template,
+		onChange: (option) =>
+			filter.update({
+				...filter.values,
+				template: option?.value,
+			}),
+	});
 
 	return (
 		<OrganizationProvisionerJobsPageView
 			jobs={jobsQuery.data?.jobs}
 			jobsQuery={jobsQuery}
-			filter={filter}
 			organization={organization}
 			error={jobsQuery.error}
 			isNonInitialPage={isNonInitialPage(searchParams)}
 			onRetry={jobsQuery.refetch}
-			onFilterChange={(nextFilter) => {
-				setSearchParams(nextFilter);
+			filterProps={{
+				filter,
+				error: jobsQuery.error,
+				menus: {
+					status: statusMenu,
+					type: typeMenu,
+					template: templateMenu,
+				},
 			}}
 		/>
 	);

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
@@ -2,12 +2,17 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type { ProvisionerJob } from "#/api/typesGenerated";
+import type { PaginationResult } from "#/components/PaginationWidget/PaginationContainer";
+import {
+	mockInitialRenderResult,
+	mockSuccessResult,
+} from "#/components/PaginationWidget/PaginationContainer.mocks";
 import { MockOrganization, MockProvisionerJob } from "#/testHelpers/entities";
 import { daysAgo } from "#/utils/time";
 import OrganizationProvisionerJobsPageView from "./OrganizationProvisionerJobsPageView";
 
 const MockProvisionerJobs: ProvisionerJob[] = Array.from(
-	{ length: 50 },
+	{ length: 25 },
 	(_, i) => ({
 		...MockProvisionerJob,
 		id: i.toString(),
@@ -15,14 +20,28 @@ const MockProvisionerJobs: ProvisionerJob[] = Array.from(
 	}),
 );
 
+const mockMultiPageResult = {
+	...mockSuccessResult,
+	totalPages: 4,
+	totalRecords: 100,
+	hasNextPage: true,
+	hasPreviousPage: false,
+	onPageChange: fn(),
+	goToNextPage: fn(),
+	goToPreviousPage: fn(),
+} as const satisfies PaginationResult;
+
 const meta: Meta<typeof OrganizationProvisionerJobsPageView> = {
 	title: "pages/OrganizationProvisionerJobsPage",
 	component: OrganizationProvisionerJobsPageView,
 	args: {
 		organization: MockOrganization,
 		jobs: MockProvisionerJobs,
+		jobsQuery: mockMultiPageResult,
 		filter: { status: "", ids: "" },
+		isNonInitialPage: false,
 		onRetry: fn(),
+		onFilterChange: fn(),
 	},
 };
 
@@ -40,6 +59,7 @@ export const OrganizationNotFound: Story = {
 export const Loading: Story = {
 	args: {
 		jobs: undefined,
+		jobsQuery: mockInitialRenderResult,
 	},
 };
 
@@ -47,6 +67,7 @@ export const LoadingError: Story = {
 	args: {
 		jobs: undefined,
 		error: new Error("Failed to load jobs"),
+		jobsQuery: mockInitialRenderResult,
 	},
 };
 
@@ -55,6 +76,7 @@ export const RetryAfterError: Story = {
 		jobs: undefined,
 		error: new Error("Failed to load jobs"),
 		onRetry: fn(),
+		jobsQuery: mockInitialRenderResult,
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
@@ -73,6 +95,48 @@ export const RetryAfterError: Story = {
 export const Empty: Story = {
 	args: {
 		jobs: [],
+		jobsQuery: {
+			...mockSuccessResult,
+			totalRecords: 0,
+			totalPages: 0,
+		},
+	},
+};
+
+export const EmptyPage: Story = {
+	args: {
+		jobs: [],
+		isNonInitialPage: true,
+		jobsQuery: {
+			...mockSuccessResult,
+			currentPage: 2,
+			currentOffsetStart: 26,
+			totalRecords: 25,
+			totalPages: 1,
+			hasPreviousPage: true,
+			hasNextPage: false,
+		},
+	},
+};
+
+export const Pagination: Story = {
+	args: {
+		jobsQuery: {
+			...mockMultiPageResult,
+			onPageChange: fn(),
+		},
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const nextPage = await canvas.findByRole("button", { name: "Next page" });
+		await userEvent.click(nextPage);
+
+		await waitFor(() => {
+			expect(args.jobsQuery.onPageChange).toHaveBeenCalledWith(2);
+		});
+	},
+	parameters: {
+		pixel: { exclude: true },
 	},
 };
 
@@ -111,6 +175,11 @@ export const OnFilter: Story = {
 export const FilterByID: Story = {
 	args: {
 		jobs: [MockProvisionerJob],
+		jobsQuery: {
+			...mockSuccessResult,
+			totalRecords: 1,
+			totalPages: 1,
+		},
 		filter: {
 			ids: MockProvisionerJob.id,
 			status: "",

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import type { ComponentProps } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type { ProvisionerJob } from "#/api/typesGenerated";
+import {
+	getDefaultFilterProps,
+	MockMenu,
+} from "#/components/Filter/storyHelpers";
 import type { PaginationResult } from "#/components/PaginationWidget/PaginationContainer";
 import {
 	mockInitialRenderResult,
@@ -31,6 +35,25 @@ const mockMultiPageResult = {
 	goToPreviousPage: fn(),
 } as const satisfies PaginationResult;
 
+type FilterProps = ComponentProps<
+	typeof OrganizationProvisionerJobsPageView
+>["filterProps"];
+
+const defaultFilterProps = getDefaultFilterProps<FilterProps>({
+	query: "",
+	values: {
+		status: undefined,
+		type: undefined,
+		template: undefined,
+		ids: undefined,
+	},
+	menus: {
+		status: MockMenu,
+		type: MockMenu,
+		template: MockMenu,
+	},
+});
+
 const meta: Meta<typeof OrganizationProvisionerJobsPageView> = {
 	title: "pages/OrganizationProvisionerJobsPage",
 	component: OrganizationProvisionerJobsPageView,
@@ -38,10 +61,9 @@ const meta: Meta<typeof OrganizationProvisionerJobsPageView> = {
 		organization: MockOrganization,
 		jobs: MockProvisionerJobs,
 		jobsQuery: mockMultiPageResult,
-		filter: { status: "", ids: "" },
+		filterProps: defaultFilterProps,
 		isNonInitialPage: false,
 		onRetry: fn(),
-		onFilterChange: fn(),
 	},
 };
 
@@ -140,35 +162,35 @@ export const Pagination: Story = {
 	},
 };
 
-export const OnFilter: Story = {
-	render: function FilterWithState({ ...args }) {
-		const [jobs, setJobs] = useState<ProvisionerJob[]>([]);
-		const [filter, setFilter] = useState({ status: "pending", ids: "" });
-		const handleFilterChange = (newFilter: { status: string; ids: string }) => {
-			setFilter(newFilter);
-			const filteredJobs = MockProvisionerJobs.filter((job) =>
-				newFilter.status ? job.status === newFilter.status : true,
-			);
-			setJobs(filteredJobs);
-		};
-
-		return (
-			<OrganizationProvisionerJobsPageView
-				{...args}
-				filter={filter}
-				jobs={jobs}
-				onFilterChange={handleFilterChange}
-			/>
-		);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const statusFilter = canvas.getByTestId("status-filter");
-		await userEvent.click(statusFilter);
-
-		const body = within(canvasElement.ownerDocument.body);
-		const option = await body.findByRole("option", { name: "succeeded" });
-		await userEvent.click(option);
+export const WithFilters: Story = {
+	args: {
+		filterProps: getDefaultFilterProps<FilterProps>({
+			query: "status:running type:workspace_build",
+			used: true,
+			values: {
+				status: "running",
+				type: "workspace_build",
+				template: undefined,
+				ids: undefined,
+			},
+			menus: {
+				status: {
+					...MockMenu,
+					selectedOption: {
+						label: "Running",
+						value: "running",
+					},
+				},
+				type: {
+					...MockMenu,
+					selectedOption: {
+						label: "Workspace build",
+						value: "workspace_build",
+					},
+				},
+				template: MockMenu,
+			},
+		}),
 	},
 };
 
@@ -180,9 +202,20 @@ export const FilterByID: Story = {
 			totalRecords: 1,
 			totalPages: 1,
 		},
-		filter: {
-			ids: MockProvisionerJob.id,
-			status: "",
-		},
+		filterProps: getDefaultFilterProps<FilterProps>({
+			query: `ids:${MockProvisionerJob.id}`,
+			used: true,
+			values: {
+				status: undefined,
+				type: undefined,
+				template: undefined,
+				ids: MockProvisionerJob.id,
+			},
+			menus: {
+				status: MockMenu,
+				type: MockMenu,
+				template: MockMenu,
+			},
+		}),
 	},
 };

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
@@ -45,7 +45,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 		status: undefined,
 		type: undefined,
 		template: undefined,
-		ids: undefined,
+		id: undefined,
 	},
 	menus: {
 		status: MockMenu,
@@ -171,7 +171,7 @@ export const WithFilters: Story = {
 				status: "running",
 				type: "workspace_build",
 				template: undefined,
-				ids: undefined,
+				id: undefined,
 			},
 			menus: {
 				status: {
@@ -203,13 +203,13 @@ export const FilterByID: Story = {
 			totalPages: 1,
 		},
 		filterProps: getDefaultFilterProps<FilterProps>({
-			query: `ids:${MockProvisionerJob.id}`,
+			query: `id:${MockProvisionerJob.id}`,
 			used: true,
 			values: {
 				status: undefined,
 				type: undefined,
 				template: undefined,
-				ids: MockProvisionerJob.id,
+				id: MockProvisionerJob.id,
 			},
 			menus: {
 				status: MockMenu,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -1,11 +1,5 @@
-import { XIcon } from "lucide-react";
-import type { FC } from "react";
-import type {
-	Organization,
-	ProvisionerJob,
-	ProvisionerJobStatus,
-} from "#/api/typesGenerated";
-import { Badge } from "#/components/Badge/Badge";
+import type { ComponentProps, FC } from "react";
+import type { Organization, ProvisionerJob } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { Link } from "#/components/Link/Link";
@@ -14,23 +8,10 @@ import {
 	type PaginationResult,
 } from "#/components/PaginationWidget/PaginationContainer";
 import {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "#/components/Select/Select";
-import {
 	SettingsHeader,
 	SettingsHeaderDescription,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
-import {
-	StatusIndicator,
-	StatusIndicatorDot,
-	type StatusIndicatorProps,
-} from "#/components/StatusIndicator/StatusIndicator";
 import {
 	Table,
 	TableBody,
@@ -40,52 +21,19 @@ import {
 } from "#/components/Table/Table";
 import { TableEmpty } from "#/components/TableEmpty/TableEmpty";
 import { TableLoader } from "#/components/TableLoader/TableLoader";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 import { pageTitle } from "#/utils/page";
 import { JobRow } from "./JobRow";
-
-const variantByStatus: Record<
-	ProvisionerJobStatus,
-	StatusIndicatorProps["variant"]
-> = {
-	succeeded: "success",
-	failed: "failed",
-	pending: "pending",
-	running: "pending",
-	canceling: "pending",
-	canceled: "inactive",
-	unknown: "inactive",
-};
-
-const StatusFilters: ProvisionerJobStatus[] = [
-	"succeeded",
-	"pending",
-	"running",
-	"canceling",
-	"canceled",
-	"failed",
-	"unknown",
-];
-
-type JobProvisionersFilter = {
-	status: string;
-	ids: string;
-};
+import { ProvisionerJobsFilter } from "./ProvisionerJobsFilter";
 
 type OrganizationProvisionerJobsPageViewProps = {
 	jobs: readonly ProvisionerJob[] | undefined;
 	jobsQuery: PaginationResult;
 	organization: Organization | undefined;
 	error: unknown;
-	filter: JobProvisionersFilter;
 	isNonInitialPage: boolean;
 	onRetry: () => void;
-	onFilterChange: (filter: JobProvisionersFilter) => void;
+	filterProps: ComponentProps<typeof ProvisionerJobsFilter>;
 };
 
 const OrganizationProvisionerJobsPageView: FC<
@@ -95,10 +43,9 @@ const OrganizationProvisionerJobsPageView: FC<
 	jobsQuery,
 	organization,
 	error,
-	filter,
 	isNonInitialPage,
-	onFilterChange,
 	onRetry,
+	filterProps,
 }) => {
 	if (!organization) {
 		return (
@@ -113,6 +60,7 @@ const OrganizationProvisionerJobsPageView: FC<
 	const isLoading =
 		(jobs === undefined || jobsQuery.totalRecords === undefined) && !error;
 	const isEmpty = !isLoading && jobs?.length === 0;
+	const openJobIds = filterProps.filter.values.ids ?? "";
 
 	return (
 		<div className="w-full max-w-screen-2xl pb-10">
@@ -123,7 +71,7 @@ const OrganizationProvisionerJobsPageView: FC<
 				)}
 			</title>
 
-			<section>
+			<section className="flex flex-col gap-4">
 				<SettingsHeader>
 					<SettingsHeaderTitle>Provisioner Jobs</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
@@ -133,66 +81,9 @@ const OrganizationProvisionerJobsPageView: FC<
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<div className="flex items-center gap-2">
-					{filter.ids && (
-						<div className="relative">
-							<Badge className="h-10 text-sm pl-3 pr-10 font-mono">
-								{filter.ids}
-							</Badge>
-							<div className="size-10 flex items-center justify-center absolute top-0 right-0">
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											size="icon"
-											variant="subtle"
-											onClick={() => {
-												onFilterChange({ ...filter, ids: "" });
-											}}
-										>
-											<span className="sr-only">Clear ID</span>
-											<XIcon />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent>Clear ID</TooltipContent>
-								</Tooltip>
-							</div>
-						</div>
-					)}
+				<ProvisionerJobsFilter {...filterProps} />
 
-					<Select
-						value={filter.status}
-						onValueChange={(status) => {
-							onFilterChange({
-								...filter,
-								status,
-							});
-						}}
-					>
-						<SelectTrigger className="w-[180px]" data-testid="status-filter">
-							<SelectValue placeholder="All statuses" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectGroup>
-								{StatusFilters.map((status) => (
-									<SelectItem key={status} value={status}>
-										<StatusIndicator variant={variantByStatus[status]}>
-											<StatusIndicatorDot />
-											<span className="block first-letter:uppercase">
-												{status}
-											</span>
-										</StatusIndicator>
-									</SelectItem>
-								))}
-							</SelectGroup>
-						</SelectContent>
-					</Select>
-				</div>
-
-				<PaginationContainer
-					query={jobsQuery}
-					paginationUnitLabel="jobs"
-					className="mt-6"
-				>
+				<PaginationContainer query={jobsQuery} paginationUnitLabel="jobs">
 					<Table>
 						<TableHeader>
 							<TableRow>
@@ -227,7 +118,7 @@ const OrganizationProvisionerJobsPageView: FC<
 							) : (
 								jobs?.map((j) => (
 									<JobRow
-										defaultIsOpen={filter.ids.includes(j.id)}
+										defaultIsOpen={openJobIds.includes(j.id)}
 										key={j.id}
 										job={j}
 									/>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -60,7 +60,7 @@ const OrganizationProvisionerJobsPageView: FC<
 	const isLoading =
 		(jobs === undefined || jobsQuery.totalRecords === undefined) && !error;
 	const isEmpty = !isLoading && jobs?.length === 0;
-	const openJobIds = filterProps.filter.values.ids ?? "";
+	const openJobIds = filterProps.filter.values.id ?? "";
 
 	return (
 		<div className="w-full max-w-screen-2xl pb-10">

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -10,6 +10,10 @@ import { Button } from "#/components/Button/Button";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { Link } from "#/components/Link/Link";
 import {
+	PaginationContainer,
+	type PaginationResult,
+} from "#/components/PaginationWidget/PaginationContainer";
+import {
 	Select,
 	SelectContent,
 	SelectGroup,
@@ -75,16 +79,27 @@ type JobProvisionersFilter = {
 
 type OrganizationProvisionerJobsPageViewProps = {
 	jobs: readonly ProvisionerJob[] | undefined;
+	jobsQuery: PaginationResult;
 	organization: Organization | undefined;
 	error: unknown;
 	filter: JobProvisionersFilter;
+	isNonInitialPage: boolean;
 	onRetry: () => void;
 	onFilterChange: (filter: JobProvisionersFilter) => void;
 };
 
 const OrganizationProvisionerJobsPageView: FC<
 	OrganizationProvisionerJobsPageViewProps
-> = ({ jobs, organization, error, filter, onFilterChange, onRetry }) => {
+> = ({
+	jobs,
+	jobsQuery,
+	organization,
+	error,
+	filter,
+	isNonInitialPage,
+	onFilterChange,
+	onRetry,
+}) => {
 	if (!organization) {
 		return (
 			<>
@@ -94,6 +109,10 @@ const OrganizationProvisionerJobsPageView: FC<
 			</>
 		);
 	}
+
+	const isLoading =
+		(jobs === undefined || jobsQuery.totalRecords === undefined) && !error;
+	const isEmpty = !isLoading && jobs?.length === 0;
 
 	return (
 		<div className="w-full max-w-screen-2xl pb-10">
@@ -169,44 +188,54 @@ const OrganizationProvisionerJobsPageView: FC<
 					</Select>
 				</div>
 
-				<Table className="mt-6">
-					<TableHeader>
-						<TableRow>
-							<TableHead>Created</TableHead>
-							<TableHead>Type</TableHead>
-							<TableHead>Template</TableHead>
-							<TableHead>Tags</TableHead>
-							<TableHead>Status</TableHead>
-							<TableHead />
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{jobs ? (
-							jobs.length > 0 ? (
-								jobs.map((j) => (
+				<PaginationContainer
+					query={jobsQuery}
+					paginationUnitLabel="jobs"
+					className="mt-6"
+				>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Created</TableHead>
+								<TableHead>Type</TableHead>
+								<TableHead>Template</TableHead>
+								<TableHead>Tags</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead />
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{error ? (
+								<TableEmpty
+									message="Error loading the provisioner jobs"
+									cta={
+										<Button size="sm" onClick={onRetry}>
+											Retry
+										</Button>
+									}
+								/>
+							) : isLoading ? (
+								<TableLoader />
+							) : isEmpty ? (
+								<TableEmpty
+									message={
+										isNonInitialPage
+											? "No provisioner jobs available on this page"
+											: "No provisioner jobs found"
+									}
+								/>
+							) : (
+								jobs?.map((j) => (
 									<JobRow
 										defaultIsOpen={filter.ids.includes(j.id)}
 										key={j.id}
 										job={j}
 									/>
 								))
-							) : (
-								<TableEmpty message="No provisioner jobs found" />
-							)
-						) : error ? (
-							<TableEmpty
-								message="Error loading the provisioner jobs"
-								cta={
-									<Button size="sm" onClick={onRetry}>
-										Retry
-									</Button>
-								}
-							/>
-						) : (
-							<TableLoader />
-						)}
-					</TableBody>
-				</Table>
+							)}
+						</TableBody>
+					</Table>
+				</PaginationContainer>
 			</section>
 		</div>
 	);

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -74,7 +74,7 @@ type JobProvisionersFilter = {
 };
 
 type OrganizationProvisionerJobsPageViewProps = {
-	jobs: ProvisionerJob[] | undefined;
+	jobs: readonly ProvisionerJob[] | undefined;
 	organization: Organization | undefined;
 	error: unknown;
 	filter: JobProvisionersFilter;

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/ProvisionerJobsFilter.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/ProvisionerJobsFilter.tsx
@@ -84,7 +84,7 @@ export const useProvisionerJobStatusFilterMenu = ({
 	});
 };
 
-export type ProvisionerJobStatusFilterMenu = ReturnType<
+type ProvisionerJobStatusFilterMenu = ReturnType<
 	typeof useProvisionerJobStatusFilterMenu
 >;
 
@@ -102,7 +102,7 @@ export const useProvisionerJobTypeFilterMenu = ({
 	});
 };
 
-export type ProvisionerJobTypeFilterMenu = ReturnType<
+type ProvisionerJobTypeFilterMenu = ReturnType<
 	typeof useProvisionerJobTypeFilterMenu
 >;
 
@@ -141,7 +141,7 @@ export const useProvisionerJobTemplateFilterMenu = ({
 	});
 };
 
-export type ProvisionerJobTemplateFilterMenu = ReturnType<
+type ProvisionerJobTemplateFilterMenu = ReturnType<
 	typeof useProvisionerJobTemplateFilterMenu
 >;
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/ProvisionerJobsFilter.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/ProvisionerJobsFilter.tsx
@@ -1,0 +1,227 @@
+import type { FC } from "react";
+import { API } from "#/api/api";
+import type { ProvisionerJobStatus, Template } from "#/api/typesGenerated";
+import { Avatar } from "#/components/Avatar/Avatar";
+import { ComboboxInput } from "#/components/Combobox/Combobox";
+import {
+	Filter,
+	MenuSkeleton,
+	type useFilter,
+} from "#/components/Filter/Filter";
+import {
+	type UseFilterMenuOptions,
+	useFilterMenu,
+} from "#/components/Filter/menu";
+import {
+	SelectFilter,
+	type SelectFilterOption,
+} from "#/components/Filter/SelectFilter";
+import {
+	StatusIndicatorDot,
+	type StatusIndicatorProps,
+} from "#/components/StatusIndicator/StatusIndicator";
+import { docs } from "#/utils/docs";
+
+const variantByStatus: Record<
+	ProvisionerJobStatus,
+	StatusIndicatorProps["variant"]
+> = {
+	succeeded: "success",
+	failed: "failed",
+	pending: "pending",
+	running: "pending",
+	canceling: "pending",
+	canceled: "inactive",
+	unknown: "inactive",
+};
+
+const statusOptions: SelectFilterOption[] = (
+	[
+		"succeeded",
+		"pending",
+		"running",
+		"canceling",
+		"canceled",
+		"failed",
+		"unknown",
+	] as const
+).map((status) => ({
+	label: status.charAt(0).toUpperCase() + status.slice(1),
+	value: status,
+	startIcon: <StatusIndicatorDot variant={variantByStatus[status]} />,
+}));
+
+const typeOptions: SelectFilterOption[] = [
+	{ value: "workspace_build", label: "Workspace build" },
+	{ value: "template_version_import", label: "Template import" },
+	{ value: "template_version_dry_run", label: "Template dry-run" },
+];
+
+const templateOption = (template: Template): SelectFilterOption => ({
+	label: template.display_name || template.name,
+	value: template.id,
+	startIcon: (
+		<Avatar
+			size="sm"
+			variant="icon"
+			src={template.icon}
+			fallback={template.display_name || template.name}
+		/>
+	),
+});
+
+export const useProvisionerJobStatusFilterMenu = ({
+	value,
+	onChange,
+}: Pick<UseFilterMenuOptions, "value" | "onChange">) => {
+	return useFilterMenu({
+		id: "provisioner-job-status",
+		value,
+		onChange,
+		getSelectedOption: async () =>
+			statusOptions.find((option) => option.value === value) ?? null,
+		getOptions: async () => statusOptions,
+	});
+};
+
+export type ProvisionerJobStatusFilterMenu = ReturnType<
+	typeof useProvisionerJobStatusFilterMenu
+>;
+
+export const useProvisionerJobTypeFilterMenu = ({
+	value,
+	onChange,
+}: Pick<UseFilterMenuOptions, "value" | "onChange">) => {
+	return useFilterMenu({
+		id: "provisioner-job-type",
+		value,
+		onChange,
+		getSelectedOption: async () =>
+			typeOptions.find((option) => option.value === value) ?? null,
+		getOptions: async () => typeOptions,
+	});
+};
+
+export type ProvisionerJobTypeFilterMenu = ReturnType<
+	typeof useProvisionerJobTypeFilterMenu
+>;
+
+export const useProvisionerJobTemplateFilterMenu = ({
+	organizationId,
+	value,
+	onChange,
+}: Pick<UseFilterMenuOptions, "value" | "onChange"> & {
+	organizationId: string | undefined;
+}) => {
+	return useFilterMenu({
+		id: "provisioner-job-template",
+		value,
+		onChange,
+		enabled: Boolean(organizationId),
+		getSelectedOption: async () => {
+			if (!organizationId || !value) {
+				return null;
+			}
+			const templates = await API.getTemplatesByOrganization(organizationId);
+			const match = templates.find((template) => template.id === value);
+			return match ? templateOption(match) : null;
+		},
+		getOptions: async (query) => {
+			if (!organizationId) {
+				return [];
+			}
+			const templates = await API.getTemplatesByOrganization(organizationId);
+			const filtered = templates.filter(
+				(template) =>
+					template.name.toLowerCase().includes(query.toLowerCase()) ||
+					template.display_name.toLowerCase().includes(query.toLowerCase()),
+			);
+			return filtered.map(templateOption);
+		},
+	});
+};
+
+export type ProvisionerJobTemplateFilterMenu = ReturnType<
+	typeof useProvisionerJobTemplateFilterMenu
+>;
+
+type ProvisionerJobsFilterProps = {
+	filter: ReturnType<typeof useFilter>;
+	error?: unknown;
+	menus: {
+		status: ProvisionerJobStatusFilterMenu;
+		type: ProvisionerJobTypeFilterMenu;
+		template: ProvisionerJobTemplateFilterMenu;
+	};
+};
+
+export const ProvisionerJobsFilter: FC<ProvisionerJobsFilterProps> = ({
+	filter,
+	error,
+	menus,
+}) => {
+	return (
+		<Filter
+			filter={filter}
+			error={error}
+			isLoading={
+				menus.status.isInitializing ||
+				menus.type.isInitializing ||
+				menus.template.isInitializing
+			}
+			optionsSkeleton={
+				<>
+					<MenuSkeleton />
+					<MenuSkeleton />
+					<MenuSkeleton />
+				</>
+			}
+			learnMoreLink={docs("/admin/provisioners")}
+			presets={[
+				{ name: "All jobs", query: "" },
+				{ name: "Running", query: "status:running" },
+				{ name: "Failed", query: "status:failed" },
+				{ name: "Pending", query: "status:pending" },
+				{ name: "Workspace builds", query: "type:workspace_build" },
+				{
+					name: "Template imports",
+					query: "type:template_version_import",
+				},
+			]}
+			options={
+				<>
+					<SelectFilter
+						label="Select a status"
+						placeholder="All statuses"
+						options={menus.status.searchOptions}
+						selectedOption={menus.status.selectedOption ?? undefined}
+						onSelect={menus.status.selectOption}
+					/>
+					<SelectFilter
+						label="Select a type"
+						placeholder="All types"
+						options={menus.type.searchOptions}
+						selectedOption={menus.type.selectedOption ?? undefined}
+						onSelect={menus.type.selectOption}
+					/>
+					<SelectFilter
+						label="Select a template"
+						placeholder="All templates"
+						emptyText="No templates found"
+						options={menus.template.searchOptions}
+						selectedOption={menus.template.selectedOption ?? undefined}
+						onSelect={menus.template.selectOption}
+						selectFilterSearch={
+							<ComboboxInput
+								aria-label="Search template"
+								placeholder="Search template..."
+								value={menus.template.query}
+								onValueChange={menus.template.setQuery}
+							/>
+						}
+					/>
+				</>
+			}
+		/>
+	);
+};

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/ProvisionerJobsFilter.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/ProvisionerJobsFilter.tsx
@@ -59,7 +59,7 @@ const typeOptions: SelectFilterOption[] = [
 
 const templateOption = (template: Template): SelectFilterOption => ({
 	label: template.display_name || template.name,
-	value: template.id,
+	value: template.name,
 	startIcon: (
 		<Avatar
 			size="sm"
@@ -123,7 +123,7 @@ export const useProvisionerJobTemplateFilterMenu = ({
 				return null;
 			}
 			const templates = await API.getTemplatesByOrganization(organizationId);
-			const match = templates.find((template) => template.id === value);
+			const match = templates.find((template) => template.name === value);
 			return match ? templateOption(match) : null;
 		},
 		getOptions: async (query) => {

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -160,7 +160,7 @@ export const ProvisionerRow: FC<ProvisionerRowProps> = ({
 										<span>{provisioner.previous_job.id}</span>
 										<Button size="xs" variant="outline" asChild>
 											<RouterLink
-												to={`../provisioner-jobs?${new URLSearchParams({ ids: provisioner.previous_job.id })}`}
+												to={`../provisioner-jobs?${new URLSearchParams({ filter: `ids:${provisioner.previous_job.id}` })}`}
 											>
 												View job
 											</RouterLink>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -160,7 +160,7 @@ export const ProvisionerRow: FC<ProvisionerRowProps> = ({
 										<span>{provisioner.previous_job.id}</span>
 										<Button size="xs" variant="outline" asChild>
 											<RouterLink
-												to={`../provisioner-jobs?${new URLSearchParams({ filter: `ids:${provisioner.previous_job.id}` })}`}
+												to={`../provisioner-jobs?${new URLSearchParams({ filter: `id:${provisioner.previous_job.id}` })}`}
 											>
 												View job
 											</RouterLink>


### PR DESCRIPTION
> [!NOTE]
> The previous limit for `provisioner_jobs` was the INT32 limit `2,147,483,647`. This kinda snowballed from there 😅 

Add offset/limit pagination to organization provisioner jobs, and replace discrete list filter query params with the standard `q` + `searchquery` convention used by Audit / Workspaces / AI Bridge.

## Changes

- **API:** list response is now `{ jobs, count, count_cap }` with `limit`/`offset` pagination (default 100, count capped at 2000)
- **Filters:** `GET .../provisionerjobs` accepts `q` (`status`, `type`, `template`, `id`, `initiator`, `tag:key=value`, plus bare-text search). Discrete `status`/`type`/`template`/`ids`/`tags`/`initiator`/`search` query params are removed
- **SDK/CLI:** typed helpers compose into `q`; CLI `--search` is the raw query string
- **UI:** shared Filter + menus, `usePaginatedQuery`, filter string forwarded as `q`

## Breaking changes

- Response shape changes from a bare job array to `ProvisionerJobsResponse`
- List filters must use `q` instead of discrete query parameters