### PR TITLE
ci: notify Slack when audit-docs-paths finds docs URL drift

### DIFF
--- a/.github/workflows/audit-docs-paths.yaml
+++ b/.github/workflows/audit-docs-paths.yaml
@@ -185,6 +185,22 @@ jobs:
             fi
           fi
 
+      - name: Send Slack notification on drift
+        # Mirrors weekly-docs.yaml's link-check Slack step and reuses the docs
+        # webhook. Fires only on drift (findings > 0); clean runs and audit
+        # errors stay silent. Turns on with the job's AUDIT_DOCS_PATHS_ENABLED gate.
+        if: steps.audit.outputs.count != '' && steps.audit.outputs.count != '0'
+        env:
+          COUNT: ${{ steps.audit.outputs.count }}
+          LOGS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl \
+            -X POST \
+            -H 'Content-type: application/json' \
+            -d '{"text":":warning: *Docs URL drift detected by audit-docs-paths.*\n'"${COUNT}"' stale docs path reference(s) resolve to a redirect source. See the tracked issue and logs: '"${LOGS_URL}"'"}' \
+            "${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}"
+          echo "Sent Slack notification"
+
       - name: Fail the run when findings exist
         if: steps.audit.outputs.count != '' && steps.audit.outputs.count != '0'
         env:

--- a/.github/workflows/audit-docs-paths.yaml
+++ b/.github/workflows/audit-docs-paths.yaml
@@ -121,6 +121,52 @@ jobs:
             cat "${WORKSPACE}/audit-report.md"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Send Slack notification on drift
+        # Reuses weekly-docs.yaml's docs Slack webhook (same channel, no new secret).
+        # Runs right after the audit so a later report- or issue-step failure can't
+        # suppress the ping.
+        if: steps.audit.outputs.count != '' && steps.audit.outputs.count != '0'
+        env:
+          COUNT: ${{ steps.audit.outputs.count }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          # -f: a revoked or misconfigured webhook must fail the step, not log success.
+          [ -n "${SLACK_WEBHOOK}" ] || { echo "::error::DOCS_LINK_SLACK_WEBHOOK is not set"; exit 1; }
+          curl \
+            -fsS \
+            --max-time 10 \
+            --retry 3 \
+            --retry-all-errors \
+            -X POST \
+            -H 'Content-type: application/json' \
+            -d '{"text":":warning: *Docs URL drift detected by audit-docs-paths.*\n'"${COUNT}"' stale docs path reference(s) resolve to a redirect source. See the run: '"${RUN_URL}"'"}' \
+            "${SLACK_WEBHOOK}"
+          echo "Sent Slack drift notification"
+
+      - name: Send Slack notification on audit failure
+        # If the audit errors out (expired token, coder.com layout change, script
+        # bug) it can't report drift; alert so a broken audit is visible, not just
+        # an unwatched red run.
+        if: failure() && steps.audit.outcome == 'failure'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          [ -n "${SLACK_WEBHOOK}" ] || { echo "::error::DOCS_LINK_SLACK_WEBHOOK is not set"; exit 1; }
+          curl \
+            -fsS \
+            --max-time 10 \
+            --retry 3 \
+            --retry-all-errors \
+            -X POST \
+            -H 'Content-type: application/json' \
+            -d '{"text":":rotating_light: *audit-docs-paths failed before it could check for docs URL drift.*\nDrift is not being monitored until this is fixed. See the run: '"${RUN_URL}"'"}' \
+            "${SLACK_WEBHOOK}"
+          echo "Sent Slack audit-failure notification"
+
       - name: Upload audit report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -184,28 +230,6 @@ jobs:
               echo "Audit clean and no tracked issue open; nothing to do."
             fi
           fi
-
-      - name: Send Slack notification on drift
-        # Mirrors weekly-docs.yaml's link-check Slack step and reuses the docs
-        # webhook. Fires only on drift (findings > 0); clean runs and audit
-        # errors stay silent. Turns on with the job's AUDIT_DOCS_PATHS_ENABLED gate.
-        if: steps.audit.outputs.count != '' && steps.audit.outputs.count != '0'
-        env:
-          COUNT: ${{ steps.audit.outputs.count }}
-          LOGS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          # -fsS makes curl exit non-zero on an HTTP error (e.g. a revoked or
-          # misconfigured webhook) so a failed post turns the step red instead
-          # of silently logging success; --max-time caps a hung request.
-          curl \
-            -fsS \
-            --max-time 10 \
-            -X POST \
-            -H 'Content-type: application/json' \
-            -d '{"text":":warning: *Docs URL drift detected by audit-docs-paths.*\n'"${COUNT}"' stale docs path reference(s) resolve to a redirect source. See the tracked issue and logs: '"${LOGS_URL}"'"}' \
-            "${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}"
-          echo "Sent Slack notification"
 
       - name: Fail the run when findings exist
         if: steps.audit.outputs.count != '' && steps.audit.outputs.count != '0'

--- a/.github/workflows/audit-docs-paths.yaml
+++ b/.github/workflows/audit-docs-paths.yaml
@@ -99,6 +99,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Fail on a missing scan root; the script only warns and exits 0 (false all-clear).
+          for root in "${WORKSPACE}/site/src" "${WORKSPACE}/coder.com/src"; do
+            [ -d "${root}" ] || { echo "::error::audit scan root not found: ${root}"; exit 1; }
+          done
+
           # Absolute --roots are required: the audit classifies findings by
           # matching the "/coder/site/" and "/coder.com/src/" segments in
           # each file's absolute path. Relative roots would leave every
@@ -109,7 +114,8 @@ jobs:
             --out="${WORKSPACE}/audit-report.md" \
             2>&1 | tee "${WORKSPACE}/audit-output.txt"
 
-          count=$(grep -oP 'Total findings: \K\d+' "${WORKSPACE}/audit-output.txt" || echo "0")
+          # No fallback: a missing "Total findings:" line must fail, not read as zero.
+          count=$(grep -oP 'Total findings: \K\d+' "${WORKSPACE}/audit-output.txt")
           echo "count=${count}" >> "$GITHUB_OUTPUT"
           echo "Total findings: ${count}"
 
@@ -122,9 +128,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Send Slack notification on drift
+        id: slack_drift
         # Reuses weekly-docs.yaml's docs Slack webhook (same channel, no new secret).
-        # Runs right after the audit so a later report- or issue-step failure can't
-        # suppress the ping.
+        # Runs before the report/issue/fail steps so their failure can't drop the ping.
         if: steps.audit.outputs.count != '' && steps.audit.outputs.count != '0'
         env:
           COUNT: ${{ steps.audit.outputs.count }}
@@ -132,8 +138,8 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}
         run: |
           set -euo pipefail
-          # -f: a revoked or misconfigured webhook must fail the step, not log success.
           [ -n "${SLACK_WEBHOOK}" ] || { echo "::error::DOCS_LINK_SLACK_WEBHOOK is not set"; exit 1; }
+          # -f: a revoked or misconfigured webhook must fail the step, not log success.
           curl \
             -fsS \
             --max-time 10 \
@@ -144,28 +150,6 @@ jobs:
             -d '{"text":":warning: *Docs URL drift detected by audit-docs-paths.*\n'"${COUNT}"' stale docs path reference(s) resolve to a redirect source. See the run: '"${RUN_URL}"'"}' \
             "${SLACK_WEBHOOK}"
           echo "Sent Slack drift notification"
-
-      - name: Send Slack notification on audit failure
-        # If the audit errors out (expired token, coder.com layout change, script
-        # bug) it can't report drift; alert so a broken audit is visible, not just
-        # an unwatched red run.
-        if: failure() && steps.audit.outcome == 'failure'
-        env:
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SLACK_WEBHOOK: ${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}
-        run: |
-          set -euo pipefail
-          [ -n "${SLACK_WEBHOOK}" ] || { echo "::error::DOCS_LINK_SLACK_WEBHOOK is not set"; exit 1; }
-          curl \
-            -fsS \
-            --max-time 10 \
-            --retry 3 \
-            --retry-all-errors \
-            -X POST \
-            -H 'Content-type: application/json' \
-            -d '{"text":":rotating_light: *audit-docs-paths failed before it could check for docs URL drift.*\nDrift is not being monitored until this is fixed. See the run: '"${RUN_URL}"'"}' \
-            "${SLACK_WEBHOOK}"
-          echo "Sent Slack audit-failure notification"
 
       - name: Upload audit report
         if: always()
@@ -238,3 +222,24 @@ jobs:
         run: |
           echo "::error::audit-docs-paths found ${COUNT} stale docs path reference(s). See the tracked issue and the audit-docs-paths-report artifact."
           exit 1
+
+      - name: Send Slack notification on failure
+        # A failed scheduled run notifies nobody, so ping on any job failure the
+        # drift step above didn't already announce.
+        if: failure() && steps.slack_drift.outcome != 'success'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          [ -n "${SLACK_WEBHOOK}" ] || { echo "::error::DOCS_LINK_SLACK_WEBHOOK is not set"; exit 1; }
+          curl \
+            -fsS \
+            --max-time 10 \
+            --retry 3 \
+            --retry-all-errors \
+            -X POST \
+            -H 'Content-type: application/json' \
+            -d '{"text":":rotating_light: *audit-docs-paths failed; docs URL drift monitoring needs attention.* See the run: '"${RUN_URL}"'"}' \
+            "${SLACK_WEBHOOK}"
+          echo "Sent Slack failure notification"

--- a/.github/workflows/audit-docs-paths.yaml
+++ b/.github/workflows/audit-docs-paths.yaml
@@ -99,7 +99,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fail on a missing scan root; the script only warns and exits 0 (false all-clear).
+          # audit-docs-paths.mjs treats a missing scan root as a warning, not an error, so fail the step here.
           for root in "${WORKSPACE}/site/src" "${WORKSPACE}/coder.com/src"; do
             [ -d "${root}" ] || { echo "::error::audit scan root not found: ${root}"; exit 1; }
           done

--- a/.github/workflows/audit-docs-paths.yaml
+++ b/.github/workflows/audit-docs-paths.yaml
@@ -194,7 +194,13 @@ jobs:
           COUNT: ${{ steps.audit.outputs.count }}
           LOGS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -euo pipefail
+          # -fsS makes curl exit non-zero on an HTTP error (e.g. a revoked or
+          # misconfigured webhook) so a failed post turns the step red instead
+          # of silently logging success; --max-time caps a hung request.
           curl \
+            -fsS \
+            --max-time 10 \
             -X POST \
             -H 'Content-type: application/json' \
             -d '{"text":":warning: *Docs URL drift detected by audit-docs-paths.*\n'"${COUNT}"' stale docs path reference(s) resolve to a redirect source. See the tracked issue and logs: '"${LOGS_URL}"'"}' \


### PR DESCRIPTION
## What

Adds Slack notifications to `.github/workflows/audit-docs-paths.yaml` so the scheduled audit actively pings the docs team both when it finds docs URL drift and when the run itself fails, on top of the existing tracked issue + red check + report artifact.

## Why

The dedicated `audit-docs-paths` workflow (#27245) surfaces drift only through a tracked GitHub issue, a failing check, and an uploaded report. None of those actively notify anyone, so drift can sit unseen unless someone is watching repo issues. The embedded `audit-docs-paths` job that #27245 removed from `weekly-docs.yaml` already posted to Slack, so this also restores that notification in the new workflow.

This also satisfies the condition on @bpmct's approval of #27245: "assuming you have a solid solution for getting notified/assigned when a link is old/stale."

## How

- Two notifications, both reusing the existing `secrets.DOCS_LINK_SLACK_WEBHOOK` (the same docs webhook `weekly-docs.yaml` uses), so no new secret or channel:
  - **Drift** (`findings > 0`, step id `slack_drift`): runs immediately after the audit, gated only on the audit outputs, so a later report- or issue-step failure can't suppress it.
  - **Failure** (`failure() && steps.slack_drift.outcome != 'success'`): the last step in the job, so it fires on any job failure the drift ping didn't already announce, whether pre-audit (e.g. an expired `CDRCI_GITHUB_TOKEN` failing the coder.com checkout), the audit itself, or a post-audit step (issue write, artifact upload). This restores and generalizes the `failure()` coverage the pre-#27245 embedded job had, and can't rot as steps are added. It stays silent on a drift run, where that ping already fired.
- The audit measurement now fails loud rather than open: it asserts both scan roots exist before running and drops the count fallback, so an incomplete scan (e.g. a coder.com `src/` restructure the script would only warn about) or an undetermined finding count fails the step and triggers the failure ping, instead of reporting a false all-clear and closing the tracked issue.
- Clean runs stay silent. The message links the run; the report artifact and tracked issue are reachable from there.
- The webhook is passed via `env` with a `[ -n ]` guard (named error if unset). `curl` uses `-fsS --max-time 10 --retry 3 --retry-all-errors` under `set -euo pipefail`, so a revoked or misconfigured webhook fails the step (red) instead of silently logging success, while a transient blip is retried.
- Everything stays gated behind the job-level `vars.AUDIT_DOCS_PATHS_ENABLED`.

## Follow-up (out of scope)

- `weekly-docs.yaml`'s `Send Slack notification` step has the same bare-`curl` pattern this step was copied from. It predates this PR and is tracked separately in [DOCS-705](https://linear.app/codercom/issue/DOCS-705/harden-weekly-docsyaml-slack-curl-with-fail).

## Rebase note

Originally stacked on #27245; since that merged, the branch is rebased onto `main`. The diff is scoped to `.github/workflows/audit-docs-paths.yaml`.

## Validation

- `make lint/actions` (actionlint + shellcheck + zizmor): clean.
- `make lint/emdash`, `make lint/typos`: clean.
- Verified empirically: both message payloads are valid JSON; the `[ -n ]` guard fails the step on an unset webhook; `curl -fsS` exits non-zero on an HTTP 4xx/5xx and `set -e` then fails the step, so a bad webhook can't log a false success.
- Traced the `failure() && steps.slack_drift.outcome != 'success'` gate across scenarios: clean run (silent), drift (drift ping only, no double-ping), and pre-audit / audit / post-audit failures (failure ping fires).

Linear: https://linear.app/codercom/issue/DOCS-617

> This PR was created with AI assistance (Coder Agents).