### PR TITLE
fix: update google.golang.org/grpc to v1.82.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -258,7 +258,7 @@ require (
 	golang.org/x/tools v0.47.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	google.golang.org/api v0.286.0
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -1549,8 +1549,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260610212136-7ab31c22f7ad h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:KdNqO+rCIWgFumrNBSEDlDNrkrQnpkax7Tv1WxNY8V4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad h1:45WmJvIV6C2+O/jjLkPUH+F3aOj/1miDoU2DD0+NWbg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=


### PR DESCRIPTION
## What

Updates `google.golang.org/grpc` from `v1.81.1` → `v1.82.1` on `release/2.35`.

## Why

IronBank's scan of Coder **v2.35.3** flagged `google.golang.org/grpc v1.81.1` as vulnerable to **GHSA-hrxh-6v49-42gf** (GO-2026-6061). The relevant exposure is the HTTP/2 Rapid Reset-style DoS; the xDS RBAC auth-bypass half of the advisory is not used by Coder. Fixed in **v1.82.1**.

`main` (v1.83.0) and `v2.36.0` (v1.82.1) already carry the fix — this is the backport to `release/2.35`. The matching `release/2.34` backport is tracked separately (ENT-144).

## Change

- `go.mod`: `google.golang.org/grpc v1.81.1` → `v1.82.1`
- `go.sum`: grpc hash lines only

No transitive fan-out — `release/2.35` already had the `x/net` / `protobuf` / `x/sys` / `x/text` versions grpc 1.82.1 requires.

## Validation (local; `golangci-lint` at the CI-pinned v1.64.8)

- `go build ./...` — clean
- `go vet ./tailnet/... ./codersdk/...` — clean
- `golangci-lint run` (full repo) — 0 issues
- `go run ./scripts/intxcheck ./...` — clean
- `go mod tidy` stable; `go mod verify` OK

DB-backed test suites (`make test-postgres`) will run in CI.

Linear: ENT-143