### PR TITLE
fix(site/src/modules/resources): show devcontainer actions menu for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { screen, spyOn, userEvent, within } from "storybook/test";
+import {
+	expect,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 import { API } from "#/api/api";
 import { getPreferredProxy } from "#/contexts/ProxyContext";
 import {
@@ -57,6 +64,37 @@ export const HasError: Story = {
 	},
 };
 
+export const FailedShowsDeleteAction: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			status: "error",
+			error: "exit status 1",
+			container: undefined,
+			agent: undefined,
+		},
+		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = canvasElement.ownerDocument.body;
+
+		await expect(canvas.getByRole("button", { name: "Start" })).toBeEnabled();
+
+		const moreActionsButton = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		await expect(moreActionsButton).toBeEnabled();
+		await user.click(moreActionsButton);
+
+		const deleteItem = await within(body).findByRole("menuitem", {
+			name: "Delete…",
+		});
+		await waitFor(() => expect(deleteItem).toBeVisible());
+	},
+};
+
 export const NoPorts: Story = {};
 
 export const WithPorts: Story = {
@@ -109,6 +147,12 @@ export const Deleting: Story = {
 			status: "deleting",
 		},
 		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("button", { name: "Dev Container actions" }),
+		).toBeDisabled();
 	},
 };
 

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -151,7 +151,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 		},
 	});
 
-	const showDevcontainerControls = subAgent && devcontainer.container;
+	const showSubAgentControls = subAgent && devcontainer.container;
 	const isTransitioning =
 		devcontainer.status === "starting" ||
 		devcontainer.status === "stopping" ||
@@ -255,14 +255,14 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 						{rebuildButtonLabel(devcontainer)}
 					</Button>
 
-					{showDevcontainerControls && displayApps.includes("ssh_helper") && (
+					{showSubAgentControls && displayApps.includes("ssh_helper") && (
 						<AgentSSHButton
 							workspaceName={workspace.name}
 							agentName={subAgent.name}
 							workspaceOwnerUsername={workspace.owner_name}
 						/>
 					)}
-					{showDevcontainerControls &&
+					{showSubAgentControls &&
 						displayApps.includes("port_forwarding_helper") &&
 						proxy.preferredWildcardHostname !== "" && (
 							<PortForwardButton
@@ -273,11 +273,10 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
-						<AgentDevcontainerMoreActions
-							deleteDevContainer={deleteDevcontainerMutation.mutate}
-						/>
-					)}
+					<AgentDevcontainerMoreActions
+						disabled={isTransitioning}
+						deleteDevContainer={deleteDevcontainerMutation.mutate}
+					/>
 
 					<DevcontainerDeleteErrorDialog
 						open={deleteDevcontainerMutation.isError}

--- a/site/src/modules/resources/AgentDevcontainerMoreActions.tsx
+++ b/site/src/modules/resources/AgentDevcontainerMoreActions.tsx
@@ -11,11 +11,12 @@ import {
 
 type AgentDevcontainerMoreActionsProps = {
 	deleteDevContainer: () => void;
+	disabled?: boolean;
 };
 
 export const AgentDevcontainerMoreActions: FC<
 	AgentDevcontainerMoreActionsProps
-> = ({ deleteDevContainer }) => {
+> = ({ deleteDevContainer, disabled }) => {
 	const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 	const [open, setOpen] = useState(false);
 	const menuContentId = useId();
@@ -23,7 +24,12 @@ export const AgentDevcontainerMoreActions: FC<
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger asChild>
-				<Button size="icon-lg" variant="subtle" aria-controls={menuContentId}>
+				<Button
+					size="icon-lg"
+					variant="subtle"
+					aria-controls={menuContentId}
+					disabled={disabled}
+				>
 					<EllipsisVerticalIcon aria-hidden="true" />
 					<span className="sr-only">Dev Container actions</span>
 				</Button>


### PR DESCRIPTION
Failed devcontainers (e.g. `exit status 1`) previously hid the three-dot actions menu because it was only rendered when both the sub agent and container reference were present, leaving no way to delete a failed devcontainer from the UI.

The actions menu is now always rendered on the devcontainer card, since deleting only requires the devcontainer ID. The menu trigger is disabled while the devcontainer is transitioning (starting, stopping, deleting). SSH and port-forward buttons remain gated on the sub agent and container being present.

Covered by Storybook stories: `FailedShowsDeleteAction` opens the menu on a failed devcontainer and asserts the Delete item, and `Deleting` asserts the menu is disabled mid-transition.

Fixes #23754

---

*This PR was generated by Coder Agents on behalf of @stirby.*
