### PR TITLE
feat: use organization-scoped chat models

### DIFF
--- a/docs/ai-coder/agents/models.md
+++ b/docs/ai-coder/agents/models.md
@@ -125,6 +125,44 @@ For each provider request, Coder selects credentials in this order:
 Each model belongs to a provider and has its own configuration for context limits,
 generation parameters, and provider-specific options.
 
+### Select an organization
+
+Model settings use the stable path `/ai/settings/models` and the `org` query parameter to select an organization.
+For example, `/ai/settings/models?org=engineering` opens the models that you can read in the `engineering` organization.
+
+If the requested organization isn't accessible, Coder selects your accessible default organization or your first accessible organization.
+Coder shows the organization picker when you can access more than 1 organization.
+
+Members with model read access can open the model list and model details.
+Coder shows model fields as read-only unless the member also has update permission.
+Create, update, delete, and share permissions control their corresponding actions independently.
+
+### Share a model
+
+Members with model share permission can grant model read access to members and groups in the selected organization.
+
+1. Navigate to **Admin settings** > **AI** > **Models**.
+2. Select the organization that owns the model.
+3. Select the model.
+4. Open **Model actions** and select **Share model**.
+5. Add or remove organization members and groups.
+6. Select **Save**.
+
+Coder applies the complete member and group list when you save.
+Removing all entries clears the model's access list, so members without another read grant lose access on their next request.
+
+### Model visibility and runtime availability
+
+Management visibility and runtime availability are separate.
+A member can see a model in settings through its access list even when the model isn't available for chat.
+
+The Agents model selector includes the model only when its exact provider configuration has usable credentials for that member.
+Coder evaluates providers by provider UUID, so 2 providers of the same type can have different availability.
+An unavailable provider can remain visible with a redacted reason while its models are omitted from the selector.
+
+Model APIs identify each configured model with a UUID.
+The provider's model identifier, such as `gpt-5.3-codex`, doesn't replace this model UUID.
+
 ### Add a model
 
 1. Navigate to **Admin settings** > **AI** > **Models**.

--- a/site/permissions.json
+++ b/site/permissions.json
@@ -154,5 +154,25 @@
 	"createChat": {
 		"object": { "resource_type": "chat", "any_org": true, "owner_id": "me" },
 		"action": "create"
+	},
+	"viewAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "read"
+	},
+	"createAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "create"
+	},
+	"editAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "update"
+	},
+	"deleteAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "delete"
+	},
+	"shareAnyChatModelConfig": {
+		"object": { "resource_type": "chat_model_config", "any_org": true },
+		"action": "share"
 	}
 }

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -432,18 +432,21 @@ describe("api.ts", () => {
 	});
 
 	describe("chat configuration endpoints", () => {
+		const organizationId = "organization/id";
+
 		it.each<[string, () => Promise<unknown>, unknown]>([
 			[
-				"/api/experimental/chats/models",
-				() => API.experimental.getChatModelAvailability(),
+				"/api/experimental/organizations/organization%2Fid/chats/models/available",
+				() => API.experimental.getChatModelAvailability(organizationId),
 				{
 					providers: [],
+					unsupported_providers: [],
 				},
 			],
 			[
-				"/api/experimental/chats/model-configs",
-				() => API.experimental.getChatModels(),
-				[],
+				"/api/experimental/organizations/organization%2Fid/chats/models",
+				() => API.experimental.getChatModels(organizationId),
+				{ models: [], providers: [] },
 			],
 		])("returns response data for %s", async (path, request, responseData) => {
 			vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({
@@ -458,12 +461,12 @@ describe("api.ts", () => {
 
 		it.each<[string, () => Promise<unknown>]>([
 			[
-				"/api/experimental/chats/models",
-				() => API.experimental.getChatModelAvailability(),
+				"/api/experimental/organizations/organization%2Fid/chats/models/available",
+				() => API.experimental.getChatModelAvailability(organizationId),
 			],
 			[
-				"/api/experimental/chats/model-configs",
-				() => API.experimental.getChatModels(),
+				"/api/experimental/organizations/organization%2Fid/chats/models",
+				() => API.experimental.getChatModels(organizationId),
 			],
 		])("rethrows axios errors for %s", async (path, request) => {
 			const expectedError = new Error("request failed");
@@ -471,6 +474,57 @@ describe("api.ts", () => {
 
 			await expect(request()).rejects.toBe(expectedError);
 			expect(axiosInstance.get).toHaveBeenCalledWith(path);
+		});
+
+		it("uses organization-nested chat model item paths", async () => {
+			const modelId = "model/id";
+			const responseData = { id: modelId };
+			vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({
+				data: responseData,
+			});
+			vi.spyOn(axiosInstance, "patch").mockResolvedValueOnce({
+				data: responseData,
+			});
+			vi.spyOn(axiosInstance, "delete").mockResolvedValueOnce({});
+
+			await expect(
+				API.experimental.getChatModel(organizationId, modelId),
+			).resolves.toStrictEqual(responseData);
+			await expect(
+				API.experimental.updateChatModel(organizationId, modelId, {
+					enabled: true,
+				}),
+			).resolves.toStrictEqual(responseData);
+			await expect(
+				API.experimental.deleteChatModel(organizationId, modelId),
+			).resolves.toBeUndefined();
+
+			const itemPath =
+				"/api/experimental/organizations/organization%2Fid/chats/models/model%2Fid";
+			expect(axiosInstance.get).toHaveBeenCalledWith(itemPath);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(itemPath, {
+				enabled: true,
+			});
+			expect(axiosInstance.delete).toHaveBeenCalledWith(itemPath);
+		});
+
+		it("uses organization-nested chat model ACL paths", async () => {
+			const modelId = "model/id";
+			const acl = { user_roles: {}, group_roles: {} };
+			vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({ data: acl });
+			vi.spyOn(axiosInstance, "patch").mockResolvedValueOnce({});
+
+			await expect(
+				API.experimental.getChatModelACL(organizationId, modelId),
+			).resolves.toStrictEqual(acl);
+			await expect(
+				API.experimental.updateChatModelACL(organizationId, modelId, acl),
+			).resolves.toBeUndefined();
+
+			const aclPath =
+				"/api/experimental/organizations/organization%2Fid/chats/models/model%2Fid/acl";
+			expect(axiosInstance.get).toHaveBeenCalledWith(aclPath);
+			expect(axiosInstance.patch).toHaveBeenCalledWith(aclPath, acl);
 		});
 	});
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -352,7 +352,14 @@ const aiSpendBatchSize = 100;
 
 const aiProviderConfigsPath = "/api/v2/ai/providers";
 const aiGatewayPath = "/api/v2/ai-gateway";
-const chatModelsPath = "/api/experimental/chats/model-configs";
+const chatModelsPath = (organizationId: string) =>
+	`/api/experimental/organizations/${encodeURIComponent(organizationId)}/chats/models`;
+const chatModelPath = (organizationId: string, modelId: string) =>
+	`${chatModelsPath(organizationId)}/${encodeURIComponent(modelId)}`;
+const chatModelACLPath = (organizationId: string, modelId: string) =>
+	`${chatModelPath(organizationId, modelId)}/acl`;
+const chatModelAvailabilityPath = (organizationId: string) =>
+	`${chatModelsPath(organizationId)}/available`;
 const userSkillsPath = (user: string) =>
 	`/api/experimental/users/${encodeURIComponent(user)}/skills`;
 const userSkillPath = (user: string, name: string) =>
@@ -3490,14 +3497,15 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
-	getChatModelAvailability =
-		async (): Promise<TypesGen.ChatModelAvailabilityResponse> => {
-			const response =
-				await this.axios.get<TypesGen.ChatModelAvailabilityResponse>(
-					"/api/experimental/chats/models",
-				);
-			return response.data;
-		};
+	getChatModelAvailability = async (
+		organizationId: string,
+	): Promise<TypesGen.ChatModelAvailabilityResponse> => {
+		const response =
+			await this.axios.get<TypesGen.ChatModelAvailabilityResponse>(
+				chatModelAvailabilityPath(organizationId),
+			);
+		return response.data;
+	};
 
 	getAIModelPrices = async (filter: {
 		provider?: string;
@@ -3894,34 +3902,72 @@ class ExperimentalApiMethods {
 		);
 	};
 
-	getChatModels = async (): Promise<TypesGen.ChatModel[]> => {
-		const response = await this.axios.get<TypesGen.ChatModel[]>(chatModelsPath);
+	getChatModels = async (
+		organizationId: string,
+	): Promise<TypesGen.OrganizationChatModelsResponse> => {
+		const response =
+			await this.axios.get<TypesGen.OrganizationChatModelsResponse>(
+				chatModelsPath(organizationId),
+			);
+		return response.data;
+	};
+
+	getChatModel = async (
+		organizationId: string,
+		modelId: string,
+	): Promise<TypesGen.ChatModel> => {
+		const response = await this.axios.get<TypesGen.ChatModel>(
+			chatModelPath(organizationId, modelId),
+		);
 		return response.data;
 	};
 
 	createChatModel = async (
+		organizationId: string,
 		req: TypesGen.CreateChatModelRequest,
 	): Promise<TypesGen.ChatModel> => {
 		const response = await this.axios.post<TypesGen.ChatModel>(
-			chatModelsPath,
+			chatModelsPath(organizationId),
 			req,
 		);
 		return response.data;
 	};
 
 	updateChatModel = async (
+		organizationId: string,
 		modelId: string,
 		req: TypesGen.UpdateChatModelRequest,
 	): Promise<TypesGen.ChatModel> => {
 		const response = await this.axios.patch<TypesGen.ChatModel>(
-			`${chatModelsPath}/${encodeURIComponent(modelId)}`,
+			chatModelPath(organizationId, modelId),
 			req,
 		);
 		return response.data;
 	};
 
-	deleteChatModel = async (modelId: string): Promise<void> => {
-		await this.axios.delete(`${chatModelsPath}/${encodeURIComponent(modelId)}`);
+	getChatModelACL = async (
+		organizationId: string,
+		modelId: string,
+	): Promise<TypesGen.ChatModelACL> => {
+		const response = await this.axios.get<TypesGen.ChatModelACL>(
+			chatModelACLPath(organizationId, modelId),
+		);
+		return response.data;
+	};
+
+	updateChatModelACL = async (
+		organizationId: string,
+		modelId: string,
+		req: TypesGen.UpdateChatModelACLRequest,
+	): Promise<void> => {
+		await this.axios.patch(chatModelACLPath(organizationId, modelId), req);
+	};
+
+	deleteChatModel = async (
+		organizationId: string,
+		modelId: string,
+	): Promise<void> => {
+		await this.axios.delete(chatModelPath(organizationId, modelId));
 	};
 
 	getMCPServerConfigs = async (

--- a/site/src/api/queries/aiProviders.ts
+++ b/site/src/api/queries/aiProviders.ts
@@ -8,7 +8,7 @@ import type {
 	UpdateAIProviderRequest,
 } from "#/api/typesGenerated";
 
-const aiProvidersListKey = ["ai", "providers"] as const;
+export const aiProvidersListKey = ["ai", "providers"] as const;
 
 const aiModelPricesKey = ["ai", "model-prices"] as const;
 

--- a/site/src/api/queries/authCheck.ts
+++ b/site/src/api/queries/authCheck.ts
@@ -8,8 +8,10 @@ import { disabledRefetchOptions } from "./util";
 
 const AUTHORIZATION_KEY = "authorization";
 
+export const authorizationKey = [AUTHORIZATION_KEY] as const;
+
 export const getAuthorizationKey = (req: AuthorizationRequest) =>
-	[AUTHORIZATION_KEY, req] as const;
+	[...authorizationKey, req] as const;
 
 export function checkAuthorization<TResponse extends AuthorizationResponse>(
 	req: AuthorizationRequest,

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -8,6 +8,7 @@ import {
 	SUCCESS_STATUSES,
 } from "#/pages/AgentsPage/components/RightPanel/DebugPanel/debugPanelUtils";
 import { MockChatMessage } from "#/testHelpers/chatEntities";
+import { MockChatModel } from "#/testHelpers/chatModels";
 import { createDeferred } from "#/testHelpers/deferred";
 import { buildOptimisticEditedMessage } from "./chatMessageEdits";
 import {
@@ -36,11 +37,17 @@ import {
 	chatListFamilyKey,
 	chatListKey,
 	chatMessagesKey,
+	chatModel,
+	chatModelACL,
+	chatModelACLKey,
+	chatModelAvailabilityKey,
+	chatModelKey,
 	chatPromptsKey,
 	chatSearch,
 	chatsByWorkspace,
 	createChat,
 	createChatMessage,
+	deleteChatModel,
 	deleteChatQueuedMessage,
 	editChatMessage,
 	getChatListQueryString,
@@ -60,6 +67,7 @@ import {
 	mergeWatchedChatIntoCaches,
 	mergeWatchedChatSummary,
 	openChat,
+	organizationChatModelsKey,
 	patchChatEntity,
 	patchChatMessages,
 	pinChat,
@@ -81,6 +89,8 @@ import {
 	unarchiveChat,
 	unpinChat,
 	updateChatAdvisorConfig,
+	updateChatModel,
+	updateChatModelACL,
 	updateChatPlanMode,
 	updateChatTitle,
 	updateChatWorkspace,
@@ -107,6 +117,11 @@ vi.mock("#/api/api", () => ({
 			updateChatAdvisorConfig: vi.fn(),
 			getChatACL: vi.fn(),
 			updateChatACL: vi.fn(),
+			getChatModel: vi.fn(),
+			getChatModelACL: vi.fn(),
+			updateChatModelACL: vi.fn(),
+			updateChatModel: vi.fn(),
+			deleteChatModel: vi.fn(),
 		},
 	},
 }));
@@ -208,6 +223,122 @@ const observeChatWithDeferredFirstFetch = (
 		unsubscribe,
 	};
 };
+
+describe("chat model query factories", () => {
+	const organizationId = "organization-1";
+	const otherOrganizationId = "organization-2";
+	const modelId = MockChatModel.id;
+
+	it("includes the organization in the item key and request", async () => {
+		vi.mocked(API.experimental.getChatModel).mockResolvedValue(MockChatModel);
+
+		const query = chatModel(organizationId, modelId);
+
+		expect(query.queryKey).toEqual(chatModelKey(organizationId, modelId));
+		await expect(query.queryFn()).resolves.toEqual(MockChatModel);
+		expect(API.experimental.getChatModel).toHaveBeenCalledWith(
+			organizationId,
+			modelId,
+		);
+	});
+
+	it("gets and sparsely updates an organization-scoped model ACL", async () => {
+		const acl = { user_roles: {}, group_roles: {} };
+		const req = { user_roles: { "user-1": "read" as const } };
+		vi.mocked(API.experimental.getChatModelACL).mockResolvedValue(acl);
+		vi.mocked(API.experimental.updateChatModelACL).mockResolvedValue();
+
+		const query = chatModelACL(organizationId, modelId);
+		expect(query.queryKey).toEqual(chatModelACLKey(organizationId, modelId));
+		await expect(query.queryFn()).resolves.toEqual(acl);
+		expect(API.experimental.getChatModelACL).toHaveBeenCalledWith(
+			organizationId,
+			modelId,
+		);
+
+		const queryClient = createTestQueryClient();
+		const keys = [
+			chatModelACLKey(organizationId, modelId),
+			chatModelKey(organizationId, modelId),
+			organizationChatModelsKey(organizationId),
+			chatModelAvailabilityKey(organizationId),
+			["authorization", "models"],
+			["organizations", [organizationId], "permissions"],
+		] as const;
+		const unaffectedKeys = [
+			["organizations"],
+			["organizations", [otherOrganizationId], "permissions"],
+		] as const;
+		for (const key of [...keys, ...unaffectedKeys]) {
+			queryClient.setQueryData(key, {});
+		}
+		const variables = { organizationId, modelId, req };
+		const mutation = updateChatModelACL(queryClient);
+
+		await expect(mutation.mutationFn(variables)).resolves.toBeUndefined();
+		expect(API.experimental.updateChatModelACL).toHaveBeenCalledWith(
+			organizationId,
+			modelId,
+			req,
+		);
+		await mutation.onSuccess(undefined, variables);
+		for (const key of keys) {
+			expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true);
+		}
+		for (const key of unaffectedKeys) {
+			expect(queryClient.getQueryState(key)?.isInvalidated).toBe(false);
+		}
+	});
+
+	it("scopes update variables and invalidation to the organization", async () => {
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(organizationChatModelsKey(organizationId), {});
+		queryClient.setQueryData(
+			organizationChatModelsKey(otherOrganizationId),
+			{},
+		);
+		vi.mocked(API.experimental.updateChatModel).mockResolvedValue(
+			MockChatModel,
+		);
+		const variables = {
+			organizationId,
+			modelId,
+			req: { enabled: true },
+		};
+		const mutation = updateChatModel(queryClient);
+
+		await expect(mutation.mutationFn(variables)).resolves.toEqual(
+			MockChatModel,
+		);
+		expect(API.experimental.updateChatModel).toHaveBeenCalledWith(
+			organizationId,
+			modelId,
+			variables.req,
+		);
+		await mutation.onSuccess(MockChatModel, variables);
+		expect(
+			queryClient.getQueryState(organizationChatModelsKey(organizationId))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(organizationChatModelsKey(otherOrganizationId))
+				?.isInvalidated,
+		).toBe(false);
+	});
+
+	it("passes organization and model IDs to delete", async () => {
+		const queryClient = createTestQueryClient();
+		vi.mocked(API.experimental.deleteChatModel).mockResolvedValue();
+		const mutation = deleteChatModel(queryClient);
+
+		await mutation.mutationFn({ organizationId, modelId });
+
+		expect(API.experimental.deleteChatModel).toHaveBeenCalledWith(
+			organizationId,
+			modelId,
+		);
+	});
+});
 
 describe("advisor config query factories", () => {
 	it("builds the advisor config query and delegates to the API", async () => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -12,6 +12,7 @@ import {
 } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ChatListSources } from "#/api/typesGenerated";
+import { authorizationKey } from "./authCheck";
 import {
 	projectEditedConversationIntoCache,
 	reconcileEditedMessageInCache,
@@ -2163,28 +2164,39 @@ export const deleteUserCompactionThreshold = (queryClient: QueryClient) => ({
 	},
 });
 
-export const chatModelAvailabilityKey = [
-	...chatConfigKey,
-	"models",
-	"catalog",
-] as const;
+const chatModelsKey = [...chatConfigKey, "models"] as const;
 
-export const chatModelAvailability = () => ({
-	queryKey: chatModelAvailabilityKey,
-	queryFn: (): Promise<TypesGen.ChatModelAvailabilityResponse> =>
-		API.experimental.getChatModelAvailability(),
+export const organizationChatModelsKey = (organizationId: string) =>
+	[...chatModelsKey, organizationId] as const;
+
+export const chatModelKey = (organizationId: string, modelId: string) =>
+	[...organizationChatModelsKey(organizationId), "model", modelId] as const;
+
+export const chatModel = (organizationId: string, modelId: string) => ({
+	queryKey: chatModelKey(organizationId, modelId),
+	queryFn: (): Promise<TypesGen.ChatModel> =>
+		API.experimental.getChatModel(organizationId, modelId),
+	enabled: organizationId !== "" && modelId !== "",
 });
 
-export const chatModelsKey = [
-	...chatConfigKey,
-	"models",
-	"definitions",
-] as const;
+const CHAT_MODELS_STALE_MS = 30_000;
 
-export const chatModels = () => ({
-	queryKey: chatModelsKey,
-	queryFn: (): Promise<TypesGen.ChatModel[]> =>
-		API.experimental.getChatModels(),
+export const chatModels = (organizationId: string) => ({
+	queryKey: organizationChatModelsKey(organizationId),
+	queryFn: (): Promise<TypesGen.OrganizationChatModelsResponse> =>
+		API.experimental.getChatModels(organizationId),
+	enabled: organizationId !== "",
+	staleTime: CHAT_MODELS_STALE_MS,
+});
+
+export const chatModelAvailabilityKey = (organizationId: string) =>
+	[...organizationChatModelsKey(organizationId), "available"] as const;
+
+export const chatModelAvailability = (organizationId: string) => ({
+	queryKey: chatModelAvailabilityKey(organizationId),
+	queryFn: (): Promise<TypesGen.ChatModelAvailabilityResponse> =>
+		API.experimental.getChatModelAvailability(organizationId),
+	enabled: organizationId !== "",
 });
 
 export const userChatProviderConfigsKey = [
@@ -2223,7 +2235,7 @@ export const upsertUserChatProviderKey = (queryClient: QueryClient) => ({
 			queryClient.invalidateQueries({
 				queryKey: userChatProviderConfigsKey,
 			}),
-			queryClient.invalidateQueries({ queryKey: chatModelAvailabilityKey }),
+			queryClient.invalidateQueries({ queryKey: chatModelsKey }),
 		]);
 	},
 });
@@ -2236,16 +2248,20 @@ export const deleteUserChatProviderKey = (queryClient: QueryClient) => ({
 			queryClient.invalidateQueries({
 				queryKey: userChatProviderConfigsKey,
 			}),
-			queryClient.invalidateQueries({ queryKey: chatModelAvailabilityKey }),
+			queryClient.invalidateQueries({ queryKey: chatModelsKey }),
 		]);
 	},
 });
 
-const invalidateChatConfigurationQueries = async (queryClient: QueryClient) => {
-	await Promise.all([
-		queryClient.invalidateQueries({ queryKey: chatModelsKey }),
-		queryClient.invalidateQueries({ queryKey: chatModelAvailabilityKey }),
-	]);
+const invalidateChatConfigurationQueries = async (
+	queryClient: QueryClient,
+	organizationId?: string,
+) => {
+	await queryClient.invalidateQueries({
+		queryKey: organizationId
+			? organizationChatModelsKey(organizationId)
+			: chatModelsKey,
+	});
 };
 
 // Called after AI provider mutations so open model pickers refresh.
@@ -2258,31 +2274,114 @@ export const invalidateChatProviderDependentQueries = async (
 	]);
 };
 
+type CreateChatModelMutationArgs = {
+	organizationId: string;
+	req: TypesGen.CreateChatModelRequest;
+};
+
 export const createChatModel = (queryClient: QueryClient) => ({
-	mutationFn: (req: TypesGen.CreateChatModelRequest) =>
-		API.experimental.createChatModel(req),
-	onSuccess: async () => {
-		await invalidateChatConfigurationQueries(queryClient);
+	mutationFn: ({ organizationId, req }: CreateChatModelMutationArgs) =>
+		API.experimental.createChatModel(organizationId, req),
+	onSuccess: async (
+		_model: TypesGen.ChatModel,
+		variables: CreateChatModelMutationArgs,
+	) => {
+		await invalidateChatConfigurationQueries(
+			queryClient,
+			variables.organizationId,
+		);
 	},
 });
 
 type UpdateChatModelMutationArgs = {
+	organizationId: string;
 	modelId: string;
 	req: TypesGen.UpdateChatModelRequest;
 };
 
 export const updateChatModel = (queryClient: QueryClient) => ({
-	mutationFn: ({ modelId, req }: UpdateChatModelMutationArgs) =>
-		API.experimental.updateChatModel(modelId, req),
-	onSuccess: async () => {
-		await invalidateChatConfigurationQueries(queryClient);
+	mutationFn: ({ organizationId, modelId, req }: UpdateChatModelMutationArgs) =>
+		API.experimental.updateChatModel(organizationId, modelId, req),
+	onSuccess: async (
+		_model: TypesGen.ChatModel,
+		variables: UpdateChatModelMutationArgs,
+	) => {
+		await invalidateChatConfigurationQueries(
+			queryClient,
+			variables.organizationId,
+		);
 	},
 });
 
+export const chatModelACLKey = (organizationId: string, modelId: string) =>
+	[...chatModelKey(organizationId, modelId), "acl"] as const;
+
+export const chatModelACL = (organizationId: string, modelId: string) => ({
+	queryKey: chatModelACLKey(organizationId, modelId),
+	queryFn: (): Promise<TypesGen.ChatModelACL> =>
+		API.experimental.getChatModelACL(organizationId, modelId),
+	enabled: organizationId !== "" && modelId !== "",
+});
+
+type UpdateChatModelACLMutationArgs = {
+	organizationId: string;
+	modelId: string;
+	req: TypesGen.UpdateChatModelACLRequest;
+};
+
+export const updateChatModelACL = (queryClient: QueryClient) => ({
+	mutationFn: ({
+		organizationId,
+		modelId,
+		req,
+	}: UpdateChatModelACLMutationArgs) =>
+		API.experimental.updateChatModelACL(organizationId, modelId, req),
+	onSuccess: async (
+		_data: unknown,
+		variables: UpdateChatModelACLMutationArgs,
+	) => {
+		const { organizationId, modelId } = variables;
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: chatModelACLKey(organizationId, modelId),
+				exact: true,
+			}),
+			queryClient.invalidateQueries({
+				queryKey: chatModelKey(organizationId, modelId),
+				exact: true,
+			}),
+			queryClient.invalidateQueries({
+				queryKey: organizationChatModelsKey(organizationId),
+				exact: true,
+			}),
+			queryClient.invalidateQueries({
+				queryKey: chatModelAvailabilityKey(organizationId),
+				exact: true,
+			}),
+			queryClient.invalidateQueries({ queryKey: authorizationKey }),
+			queryClient.invalidateQueries({
+				predicate: ({ queryKey }) =>
+					queryKey[0] === "organizations" &&
+					queryKey[2] === "permissions" &&
+					(queryKey[1] as readonly string[]).includes(organizationId),
+			}),
+		]);
+	},
+});
+
+type DeleteChatModelMutationArgs = {
+	organizationId: string;
+	modelId: string;
+};
+
 export const deleteChatModel = (queryClient: QueryClient) => ({
-	mutationFn: (modelId: string) => API.experimental.deleteChatModel(modelId),
-	onSuccess: async () => {
-		await invalidateChatConfigurationQueries(queryClient);
+	mutationFn: ({ organizationId, modelId }: DeleteChatModelMutationArgs) =>
+		API.experimental.deleteChatModel(organizationId, modelId),
+	onSuccess: async (_data: unknown, variables: DeleteChatModelMutationArgs) => {
+		await invalidateChatConfigurationQueries(
+			queryClient,
+			variables.organizationId,
+		);
 	},
 });
 

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -330,13 +330,15 @@ export const permittedOrganizations = (check: AuthorizationCheck) => {
  *
  * If organizations are undefined, return a disabled query.
  */
+const organizationsPermissionsKey = ["organizations"] as const;
+
 export const organizationsPermissions = (
 	organizationIds: string[] | undefined,
 ) => {
 	return {
 		enabled: Boolean(organizationIds),
 		queryKey: [
-			"organizations",
+			...organizationsPermissionsKey,
 			[...(organizationIds ?? []).sort()],
 			"permissions",
 		],

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
@@ -34,89 +34,31 @@ export const ManyOrgs: Story = {
 	},
 };
 
-const collidingDisplayNameOrganizations = [
-	{ ...MockOrganization, name: "org-a", display_name: "Dev" },
-	{ ...MockOrganization2, name: "org-b", display_name: "Dev" },
-	{ ...MockOrganization, id: "org-c", name: "org-c", display_name: "Ops" },
-];
-
-export const CollidingDisplayNames: Story = {
+export const ActiveSortsFirstThenAlphabetical: Story = {
 	args: {
-		value: collidingDisplayNameOrganizations[0],
-		options: collidingDisplayNameOrganizations,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("button", { name: /Dev \(org-a\)/ }),
-		).toBeInTheDocument();
-		await userEvent.click(canvas.getByRole("button"));
-		await waitFor(() => {
-			expect(
-				screen.getByRole("option", { name: "Dev (org-a)" }),
-			).toBeInTheDocument();
-			expect(
-				screen.getByRole("option", { name: "Dev (org-b)" }),
-			).toBeInTheDocument();
-			expect(screen.getByRole("option", { name: "Ops" })).toBeInTheDocument();
-		});
-	},
-};
-
-// Collides with an option but is not itself selectable, mirroring a
-// deep link to a list-only organization.
-const listOnlyOrganization = {
-	...MockOrganization,
-	id: "org-t",
-	name: "org-t",
-	display_name: "Dev",
-};
-
-export const NonOptionValueDisambiguatesOptions: Story = {
-	args: {
-		value: listOnlyOrganization,
-		options: collidingDisplayNameOrganizations.slice(0, 1),
-		labelOrganizations: [
-			...collidingDisplayNameOrganizations.slice(0, 1),
-			listOnlyOrganization,
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("button", { name: /Dev \(org-t\)/ }),
-		).toBeInTheDocument();
-		await userEvent.click(canvas.getByRole("button"));
-		await waitFor(() => {
-			expect(
-				screen.getByRole("option", { name: "Dev (org-a)" }),
-			).toBeInTheDocument();
-			expect(
-				screen.queryByRole("option", { name: /org-t/ }),
-			).not.toBeInTheDocument();
-		});
-	},
-};
-
-export const FallbackNameCollision: Story = {
-	args: {
-		value: null,
-		options: [
-			{ ...MockOrganization, name: "dev", display_name: "" },
-			{ ...MockOrganization2, name: "org-b", display_name: "dev" },
-			{ ...MockOrganization, id: "org-c", name: "org-c", display_name: "Ops" },
-		],
+		value: MockOrganization2,
+		options: [MockOrganization, MockOrganization2],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button"));
-		await waitFor(() => {
-			expect(screen.getByRole("option", { name: /^dev$/ })).toBeInTheDocument();
-			expect(
-				screen.getByRole("option", { name: "dev (org-b)" }),
-			).toBeInTheDocument();
-			expect(screen.getByRole("option", { name: "Ops" })).toBeInTheDocument();
-		});
+		const options = await screen.findAllByRole("option");
+		expect(options[0]).toHaveTextContent(MockOrganization2.display_name);
+		expect(options[1]).toHaveTextContent(MockOrganization.display_name);
+	},
+};
+
+export const TabbableOptions: Story = {
+	args: {
+		value: MockOrganization,
+		optionsTabbable: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button"));
+		const options = await screen.findAllByRole("option");
+		await userEvent.tab();
+		expect(options[0]).toHaveFocus();
 	},
 };
 

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -17,6 +17,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
+import { cn } from "#/utils/cn";
 
 type OrganizationAutocompleteProps = {
 	value: Organization | null;
@@ -30,6 +31,12 @@ type OrganizationAutocompleteProps = {
 	ariaLabel?: string;
 	required?: boolean;
 	disabled?: boolean;
+	/**
+	 * Overrides the trigger button's width/layout classes when the default
+	 * full-width treatment does not fit (e.g. a fixed-width switcher).
+	 */
+	triggerClassName?: string;
+	optionsTabbable?: boolean;
 };
 
 export const getOrganizationLabel = (
@@ -58,9 +65,20 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	ariaLabel,
 	required,
 	disabled,
+	triggerClassName,
+	optionsTabbable = false,
 }) => {
 	const [open, setOpen] = useState(false);
 	const labelContext = labelOrganizations ?? options;
+
+	// GetOrganizations has no ORDER BY, so the caller needs a stable order.
+	const sortedOptions = options.toSorted((a, b) => {
+		if (a.id === value?.id) return -1;
+		if (b.id === value?.id) return 1;
+		return a.display_name
+			.toLowerCase()
+			.localeCompare(b.display_name.toLowerCase());
+	});
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
@@ -73,7 +91,10 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					aria-expanded={open}
 					aria-required={required}
 					data-testid="organization-autocomplete"
-					className="w-full justify-start gap-2 font-normal"
+					className={cn(
+						"w-full justify-start gap-2 font-normal",
+						triggerClassName,
+					)}
 				>
 					{value ? (
 						<>
@@ -103,7 +124,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					<CommandList>
 						<CommandEmpty>No organizations found.</CommandEmpty>
 						<CommandGroup>
-							{options.map((org) => (
+							{sortedOptions.map((org) => (
 								<CommandItem
 									key={org.id}
 									value={`${org.display_name} ${org.name}`}
@@ -111,6 +132,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 										onChange(org);
 										setOpen(false);
 									}}
+									tabIndex={optionsTabbable ? 0 : undefined}
 								>
 									<Avatar
 										size="sm"

--- a/site/src/modules/aiModels/helpers.ts
+++ b/site/src/modules/aiModels/helpers.ts
@@ -1,15 +1,3 @@
 export function normalizeProvider(provider: string): string {
 	return provider.trim().toLowerCase();
 }
-
-const canonicalProviderBaseURLs: Record<string, string> = {
-	anthropic: "https://api.anthropic.com",
-	google: "https://generativelanguage.googleapis.com/v1beta",
-	openai: "https://api.openai.com/v1",
-	openrouter: "https://openrouter.ai/api/v1",
-	vercel: "https://ai-gateway.vercel.sh/v1",
-};
-
-export function getDefaultProviderBaseURL(provider: string): string {
-	return canonicalProviderBaseURLs[normalizeProvider(provider)] ?? "";
-}

--- a/site/src/modules/aiModels/providerStates.test.ts
+++ b/site/src/modules/aiModels/providerStates.test.ts
@@ -3,7 +3,7 @@ import type * as TypesGen from "#/api/typesGenerated";
 import {
 	MockChatModel,
 	MockChatModelProvider,
-	MockChatProviderConfig,
+	MockChatModelProviderDescriptor,
 } from "#/testHelpers/chatModels";
 import {
 	canManageProviderModels,
@@ -12,171 +12,64 @@ import {
 } from "./providerStates";
 
 const baseProviderState: ProviderState = {
-	key: "prov-openai",
-	provider: "openai",
-	label: "OpenAI",
-	providerConfig: MockChatProviderConfig,
+	key: MockChatModelProviderDescriptor.id,
+	provider: MockChatModelProviderDescriptor.type,
+	label: MockChatModelProviderDescriptor.display_name,
+	providerDescriptor: MockChatModelProviderDescriptor,
 	models: [],
 	catalogModelCount: 0,
-	hasManagedAPIKey: true,
-	hasCatalogAPIKey: false,
 	hasEffectiveAPIKey: true,
 	allowUserAPIKey: false,
-	isEnvPreset: false,
-	baseURL: "",
 };
 
 describe("deriveProviderStates", () => {
-	it("orders providers alphabetically by display label", () => {
-		const providerConfigs = [
+	it("orders descriptors by display label", () => {
+		const descriptors: TypesGen.ChatModelProviderDescriptor[] = [
 			{
-				...MockChatProviderConfig,
-				id: "prov-openai",
-				provider: "openai",
-				display_name: "OpenAI",
+				...MockChatModelProviderDescriptor,
+				id: "google-id",
+				type: "google",
+				display_name: "Google",
+			},
+			{
+				...MockChatModelProviderDescriptor,
+				id: "anthropic-id",
+				type: "anthropic",
+				display_name: "Anthropic",
 			},
 		];
-		const catalog: TypesGen.ChatModelAvailabilityResponse = {
-			providers: [
-				{ ...MockChatModelProvider, provider: "google" },
-				{ ...MockChatModelProvider, provider: "anthropic" },
-			],
-			unsupported_providers: [],
-		};
 
-		const states = deriveProviderStates([], providerConfigs, catalog);
+		const states = deriveProviderStates([], descriptors, undefined);
 
-		expect(states.map((s) => s.provider)).toEqual([
+		expect(states.map((state) => state.provider)).toEqual([
 			"anthropic",
 			"google",
-			"openai",
 		]);
-		expect(states.map((s) => s.label)).toEqual([
-			"Anthropic",
-			"Google",
-			"OpenAI",
-		]);
-		expect(states[0].hasEffectiveAPIKey).toBe(true);
-		expect(states[1].hasEffectiveAPIKey).toBe(true);
-		expect(states[2].hasEffectiveAPIKey).toBe(true);
 	});
 
-	it("matches model configs to provider configs by ai_provider_id", () => {
-		const providerConfigs = [
-			{ ...MockChatProviderConfig, id: "prov-openai", provider: "openai" },
-		];
-		const models = [
-			{
-				...MockChatModel,
-				id: "m1",
-				ai_provider_id: "prov-openai",
-			},
-			{ ...MockChatModel, id: "m2", ai_provider_id: "prov-openai" },
+	it("matches model configs to descriptors by ai_provider_id", () => {
+		const modelConfigs = [
+			{ ...MockChatModel, id: "m1" },
+			{ ...MockChatModel, id: "m2" },
 		];
 
-		const states = deriveProviderStates(models, providerConfigs, null);
+		const states = deriveProviderStates(
+			modelConfigs,
+			[MockChatModelProviderDescriptor],
+			undefined,
+		);
 
-		expect(states).toHaveLength(1);
-		expect(states[0].key).toBe("prov-openai");
-		expect(states[0].models.map((m) => m.id)).toEqual(["m1", "m2"]);
+		expect(states[0].models.map((model) => model.id)).toEqual(["m1", "m2"]);
 	});
 
-	it("treats bedrock with central_api_key_enabled as having an effective key", () => {
-		const providerConfigs = [
-			{
-				...MockChatProviderConfig,
-				id: "prov-bedrock",
-				provider: "bedrock",
-				has_api_key: false,
-				central_api_key_enabled: true,
-			},
-		];
-
-		const states = deriveProviderStates([], providerConfigs, null);
-
-		expect(states[0].hasEffectiveAPIKey).toBe(true);
-	});
-
-	it("drops models without ai_provider_id", () => {
-		const providerConfigs = [
-			{ ...MockChatProviderConfig, id: "prov-a", provider: "openai" },
-			{ ...MockChatProviderConfig, id: "prov-b", provider: "openai" },
-		];
-		const models = [{ ...MockChatModel, id: "m1", ai_provider_id: "" }];
-
-		const states = deriveProviderStates(models, providerConfigs, null);
-
-		expect(states.flatMap((s) => s.models)).toHaveLength(0);
-	});
-
-	it("detects env-preset providers from the catalog when no config exists", () => {
-		const catalog: TypesGen.ChatModelAvailabilityResponse = {
-			providers: [
-				{ ...MockChatModelProvider, provider: "openai", available: true },
-			],
-			unsupported_providers: [],
-		};
-
-		const states = deriveProviderStates([], null, catalog);
-
-		expect(states).toHaveLength(1);
-		expect(states[0].provider).toBe("openai");
-		expect(states[0].isEnvPreset).toBe(true);
-		expect(states[0].hasCatalogAPIKey).toBe(true);
-	});
-
-	it("flags env-preset providers via the provider config source", () => {
-		const providerConfigs = [
-			{
-				...MockChatProviderConfig,
-				id: "prov-openai",
-				provider: "openai",
-				source: "env_preset" as const,
-			},
-		];
-
-		const states = deriveProviderStates([], providerConfigs, null);
-
-		expect(states[0].isEnvPreset).toBe(true);
-		expect(states[0].providerConfig).toBeUndefined();
-	});
-
-	it("treats an unavailable catalog provider as having a key unless the api key is missing", () => {
-		const catalog: TypesGen.ChatModelAvailabilityResponse = {
+	it("uses availability only for catalog model counts", () => {
+		const availability: TypesGen.ChatModelAvailabilityResponse = {
 			providers: [
 				{
 					...MockChatModelProvider,
-					provider: "openai",
-					available: false,
-					unavailable_reason: "fetch_failed",
-				},
-			],
-			unsupported_providers: [],
-		};
-
-		const states = deriveProviderStates([], null, catalog);
-
-		expect(states[0].hasCatalogAPIKey).toBe(true);
-	});
-
-	it("derives label, catalogModelCount, and baseURL from the inputs", () => {
-		const providerConfigs = [
-			{
-				...MockChatProviderConfig,
-				id: "prov-openai",
-				provider: "openai",
-				display_name: "Custom OpenAI",
-				base_url: "https://custom.example.com/v1",
-			},
-		];
-		const catalog: TypesGen.ChatModelAvailabilityResponse = {
-			providers: [
-				{
-					...MockChatModelProvider,
-					provider: "openai",
 					models: [
 						{
-							id: "gpt-x",
+							id: "openai:gpt-x",
 							provider: "openai",
 							model: "gpt-x",
 							display_name: "GPT-X",
@@ -187,33 +80,62 @@ describe("deriveProviderStates", () => {
 			unsupported_providers: [],
 		};
 
-		const states = deriveProviderStates([], providerConfigs, catalog);
+		const states = deriveProviderStates(
+			[],
+			[MockChatModelProviderDescriptor],
+			availability,
+		);
 
-		expect(states[0].label).toBe("Custom OpenAI");
 		expect(states[0].catalogModelCount).toBe(1);
-		expect(states[0].baseURL).toBe("https://custom.example.com/v1");
+	});
+
+	it("treats null provider models as an empty catalog", () => {
+		const states = deriveProviderStates([], [MockChatModelProviderDescriptor], {
+			providers: [{ ...MockChatModelProvider, models: null }],
+			unsupported_providers: [],
+		});
+
+		expect(states[0].catalogModelCount).toBe(0);
+	});
+
+	it.each([
+		{
+			name: "uses ambient credentials",
+			hasAPIKey: false,
+			hasUserAPIKey: false,
+			hasEffectiveAPIKey: true,
+		},
+		{
+			name: "ignores an ineffective user key",
+			hasAPIKey: false,
+			hasUserAPIKey: true,
+			hasEffectiveAPIKey: false,
+		},
+	])("$name", ({ hasAPIKey, hasUserAPIKey, hasEffectiveAPIKey }) => {
+		const descriptor: TypesGen.ChatModelProviderDescriptor = {
+			...MockChatModelProviderDescriptor,
+			has_api_key: hasAPIKey,
+			has_user_api_key: hasUserAPIKey,
+			has_effective_api_key: hasEffectiveAPIKey,
+		};
+
+		const states = deriveProviderStates([], [descriptor], undefined);
+
+		expect(states[0].hasEffectiveAPIKey).toBe(hasEffectiveAPIKey);
 	});
 });
 
 describe("canManageProviderModels", () => {
-	const baseState = baseProviderState;
-
-	it("returns false without a managed provider config", () => {
-		expect(
-			canManageProviderModels({ ...baseState, providerConfig: undefined }),
-		).toBe(false);
-	});
-
 	it("returns true when the provider has an effective API key", () => {
-		expect(canManageProviderModels(baseState)).toBe(true);
+		expect(canManageProviderModels(baseProviderState)).toBe(true);
 	});
 
 	it("returns true when user-supplied API keys are allowed", () => {
 		expect(
 			canManageProviderModels({
-				...baseState,
+				...baseProviderState,
 				hasEffectiveAPIKey: false,
-				providerConfig: { ...MockChatProviderConfig, allow_user_api_key: true },
+				allowUserAPIKey: true,
 			}),
 		).toBe(true);
 	});
@@ -221,12 +143,9 @@ describe("canManageProviderModels", () => {
 	it("returns false with no key and user keys disallowed", () => {
 		expect(
 			canManageProviderModels({
-				...baseState,
+				...baseProviderState,
 				hasEffectiveAPIKey: false,
-				providerConfig: {
-					...MockChatProviderConfig,
-					allow_user_api_key: false,
-				},
+				allowUserAPIKey: false,
 			}),
 		).toBe(false);
 	});
@@ -234,8 +153,11 @@ describe("canManageProviderModels", () => {
 	it("returns false when the provider is disabled", () => {
 		expect(
 			canManageProviderModels({
-				...baseState,
-				providerConfig: { ...MockChatProviderConfig, enabled: false },
+				...baseProviderState,
+				providerDescriptor: {
+					...MockChatModelProviderDescriptor,
+					enabled: false,
+				},
 			}),
 		).toBe(false);
 	});

--- a/site/src/modules/aiModels/providerStates.ts
+++ b/site/src/modules/aiModels/providerStates.ts
@@ -1,206 +1,77 @@
 import type * as TypesGen from "#/api/typesGenerated";
-import {
-	getDefaultProviderBaseURL,
-	normalizeProvider,
-} from "#/modules/aiModels/helpers";
+import { normalizeProvider } from "#/modules/aiModels/helpers";
 import { formatProviderLabel } from "#/utils/aiProviders";
 
 export type ProviderState = {
 	key: string;
 	provider: string;
 	label: string;
-	providerConfig: TypesGen.ChatProviderConfig | undefined;
+	providerDescriptor: TypesGen.ChatModelProviderDescriptor;
 	models: readonly TypesGen.ChatModel[];
 	catalogModelCount: number;
-	hasManagedAPIKey: boolean;
-	hasCatalogAPIKey: boolean;
 	hasEffectiveAPIKey: boolean;
 	allowUserAPIKey: boolean;
-	isEnvPreset: boolean;
-	baseURL: string;
 };
 
-type CatalogProvider =
+type GeneratedAvailableProvider =
 	TypesGen.ChatModelAvailabilityResponse["providers"][number];
-
-const envPresetProviders = new Set(["openai", "anthropic"]);
-
-const readOptionalString = (value: unknown): string | undefined => {
-	if (typeof value !== "string") return undefined;
-	const trimmed = value.trim();
-	return trimmed || undefined;
+type AvailableProvider = Omit<GeneratedAvailableProvider, "models"> & {
+	models: GeneratedAvailableProvider["models"] | null;
+};
+type ChatModelAvailability = Omit<
+	TypesGen.ChatModelAvailabilityResponse,
+	"providers"
+> & {
+	providers: readonly AvailableProvider[];
 };
 
-const isDatabaseProviderConfig = (
-	providerConfig: TypesGen.ChatProviderConfig | undefined,
-	source: TypesGen.ChatProviderConfigSource | undefined,
-): providerConfig is TypesGen.ChatProviderConfig => {
-	if (!providerConfig) return false;
-	if (providerConfig.id === "00000000-0000-0000-0000-000000000000") {
-		return false;
-	}
-	return source === undefined || source === "database";
-};
-
-const getCatalogProviders = (
-	catalog: TypesGen.ChatModelAvailabilityResponse | null | undefined,
-): readonly CatalogProvider[] => {
-	const providers = catalog?.providers;
-	return Array.isArray(providers) ? providers : [];
-};
-
-const providerHasCatalogAPIKey = (provider: CatalogProvider): boolean =>
-	provider.available ||
-	(Boolean(provider.unavailable_reason) &&
-		provider.unavailable_reason !== "missing_api_key");
-
-const getProviderModels = (
-	provider: CatalogProvider | undefined,
-): readonly CatalogProvider["models"][number][] => {
-	const models = provider?.models;
-	return Array.isArray(models) ? models : [];
-};
-
-const getProviderBaseURL = (
-	providerConfig: TypesGen.ChatProviderConfig | undefined,
-): string => {
-	return (
-		readOptionalString(providerConfig?.base_url) ??
-		getDefaultProviderBaseURL(providerConfig?.provider ?? "")
-	);
-};
-
-const providerConfigStateKey = (
-	providerConfig: TypesGen.ChatProviderConfig,
-): string => {
-	const providerID = readOptionalString(providerConfig.id);
-	if (providerID && providerID !== "00000000-0000-0000-0000-000000000000") {
-		return providerID;
-	}
-	return normalizeProvider(providerConfig.provider);
-};
-
-type ProviderEntry = {
-	key: string;
-	provider: string;
-};
-
-// Returns provider states ordered alphabetically by display label.
 export const deriveProviderStates = (
-	models: readonly TypesGen.ChatModel[],
-	providerConfigs: TypesGen.ChatProviderConfig[] | null | undefined,
-	catalog: TypesGen.ChatModelAvailabilityResponse | null | undefined,
+	modelConfigs: readonly TypesGen.ChatModel[],
+	providerDescriptors: readonly TypesGen.ChatModelProviderDescriptor[],
+	availability: ChatModelAvailability | null | undefined,
 ): readonly ProviderState[] => {
-	const orderedEntries: ProviderEntry[] = [];
-	const seenEntries = new Set<string>();
-	const includeEntry = (keyValue: string, providerValue: string) => {
-		const key = readOptionalString(keyValue);
-		const provider = normalizeProvider(providerValue);
-		if (!key || !provider || seenEntries.has(key)) return;
-		seenEntries.add(key);
-		orderedEntries.push({ key, provider });
-	};
-
-	const catalogProviders = getCatalogProviders(catalog);
-	const catalogProvidersByProvider = new Map<string, CatalogProvider>();
-	for (const cp of catalogProviders) {
-		const provider = normalizeProvider(cp.provider);
-		if (!provider) continue;
-		catalogProvidersByProvider.set(provider, cp);
+	const availableProvidersByType = new Map<string, AvailableProvider>();
+	for (const availableProvider of availability?.providers ?? []) {
+		availableProvidersByType.set(
+			normalizeProvider(availableProvider.provider),
+			availableProvider,
+		);
 	}
 
-	const providerTypesWithConfigs = new Set<string>();
-	const providerConfigsByKey = new Map<string, TypesGen.ChatProviderConfig>();
-	for (const pc of providerConfigs ?? []) {
-		const provider = normalizeProvider(pc.provider);
-		if (!provider) continue;
-		const key = providerConfigStateKey(pc);
-		providerTypesWithConfigs.add(provider);
-		if (key) {
-			providerConfigsByKey.set(key, pc);
-		}
-		includeEntry(key, provider);
-	}
-	const modelStateKey = (modelConfig: TypesGen.ChatModel): string =>
-		readOptionalString(modelConfig.ai_provider_id) ?? "";
-
-	for (const cp of catalogProviders) {
-		const provider = normalizeProvider(cp.provider);
-		if (!provider || providerTypesWithConfigs.has(provider)) continue;
-		includeEntry(provider, provider);
-	}
-	for (const mc of models) {
-		const key = modelStateKey(mc);
-		includeEntry(key, providerConfigsByKey.get(key)?.provider ?? "");
-	}
-
-	const modelsByKey = new Map<string, TypesGen.ChatModel[]>();
-	for (const mc of models) {
-		const key = modelStateKey(mc);
-		if (!key) continue;
-		const existing = modelsByKey.get(key);
+	const modelConfigsByProviderID = new Map<string, TypesGen.ChatModel[]>();
+	for (const modelConfig of modelConfigs) {
+		const existing = modelConfigsByProviderID.get(modelConfig.ai_provider_id);
 		if (existing) {
-			existing.push(mc);
+			existing.push(modelConfig);
 		} else {
-			modelsByKey.set(key, [mc]);
+			modelConfigsByProviderID.set(modelConfig.ai_provider_id, [modelConfig]);
 		}
 	}
 
-	const states = orderedEntries.map(({ key, provider }) => {
-		const providerConfigEntry = providerConfigsByKey.get(key);
-		const providerConfigSource = providerConfigEntry?.source;
-		const providerConfig = isDatabaseProviderConfig(
-			providerConfigEntry,
-			providerConfigSource,
-		)
-			? providerConfigEntry
-			: undefined;
-		const catalogProvider = catalogProvidersByProvider.get(provider);
-		const hasManagedAPIKey = providerConfig?.has_api_key ?? false;
-		const hasProviderEntryAPIKey = providerConfigEntry?.has_api_key ?? false;
-		const hasCatalogAPIKey = catalogProvider
-			? providerHasCatalogAPIKey(catalogProvider)
-			: false;
-		const label =
-			readOptionalString(providerConfigEntry?.display_name) ??
-			formatProviderLabel(provider);
-		const hasBedrockAmbientCredentials =
-			provider === "bedrock" &&
-			providerConfig?.central_api_key_enabled === true;
-		const modelsForProvider = modelsByKey.get(key) ?? [];
-		const isCatalogEnvPreset =
-			!providerConfig && envPresetProviders.has(provider) && hasCatalogAPIKey;
-		const isEnvPreset =
-			providerConfigSource === "env_preset" || isCatalogEnvPreset;
-
-		return {
-			key,
-			provider,
-			label,
-			providerConfig,
-			models: modelsForProvider,
-			catalogModelCount: getProviderModels(catalogProvider).length,
-			hasManagedAPIKey,
-			hasCatalogAPIKey,
-			hasEffectiveAPIKey: providerConfigEntry
-				? hasProviderEntryAPIKey || hasBedrockAmbientCredentials
-				: hasManagedAPIKey || hasCatalogAPIKey,
-			allowUserAPIKey: providerConfigEntry?.allow_user_api_key ?? true,
-			isEnvPreset,
-			baseURL: getProviderBaseURL(providerConfigEntry),
-		};
-	});
-
-	return states.toSorted((a, b) => a.label.localeCompare(b.label));
+	return providerDescriptors
+		.map((providerDescriptor) => {
+			const provider = normalizeProvider(providerDescriptor.type);
+			const availableProvider = availableProvidersByType.get(provider);
+			return {
+				key: providerDescriptor.id,
+				provider,
+				label:
+					providerDescriptor.display_name.trim() ||
+					formatProviderLabel(provider),
+				providerDescriptor,
+				models: modelConfigsByProviderID.get(providerDescriptor.id) ?? [],
+				catalogModelCount: availableProvider?.models?.length ?? 0,
+				hasEffectiveAPIKey: providerDescriptor.has_effective_api_key,
+				allowUserAPIKey: providerDescriptor.allow_user_api_key,
+			};
+		})
+		.toSorted((a, b) => a.label.localeCompare(b.label));
 };
 
 export const canManageProviderModels = (
 	providerState: ProviderState | undefined,
-): boolean => {
-	return Boolean(
-		providerState?.providerConfig &&
-			providerState.providerConfig.enabled !== false &&
-			(providerState.hasEffectiveAPIKey ||
-				providerState.providerConfig.allow_user_api_key),
+): boolean =>
+	Boolean(
+		providerState?.providerDescriptor.enabled &&
+			(providerState.hasEffectiveAPIKey || providerState.allowUserAPIKey),
 	);
-};

--- a/site/src/modules/aiModels/providerStates.ts
+++ b/site/src/modules/aiModels/providerStates.ts
@@ -28,7 +28,7 @@ type ChatModelAvailability = Omit<
 export const deriveProviderStates = (
 	modelConfigs: readonly TypesGen.ChatModel[],
 	providerDescriptors: readonly TypesGen.ChatModelProviderDescriptor[],
-	availability: ChatModelAvailability | null | undefined,
+	availability?: ChatModelAvailability | null,
 ): readonly ProviderState[] => {
 	const availableProvidersByType = new Map<string, AvailableProvider>();
 	for (const availableProvider of availability?.providers ?? []) {

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -6,12 +6,15 @@ import {
 } from "storybook-addon-remix-react-router";
 import { buildInfoKey } from "#/api/queries/buildInfo";
 import { deploymentStatsQueryKey } from "#/api/queries/deployment";
+import { organizationsPermissions } from "#/api/queries/organizations";
 import { updateCheckQueryKey } from "#/api/queries/updateCheck";
 import type { UpdateCheckResponse } from "#/api/typesGenerated";
 import {
 	MockBuildInfo,
+	MockDefaultOrganization,
 	MockDeploymentStats,
 	MockNoPermissions,
+	MockOrganizationPermissions,
 	MockPermissions,
 	MockUpdateCheck,
 	MockUserMember,
@@ -88,6 +91,39 @@ export const ForMember: Story = {
 		await expect(
 			screen.queryByTestId("update-check-notice"),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const CustomOrganizationRoleCanOpenAISettings: Story = {
+	parameters: {
+		user: MockUserMember,
+		permissions: MockNoPermissions,
+		queries: [
+			{ key: buildInfoKey, data: MockBuildInfo },
+			{ key: updateCheckQueryKey, data: MockUpdateCheck },
+			{ key: deploymentStatsQueryKey, data: MockDeploymentStats },
+			{
+				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
+				data: {
+					[MockDefaultOrganization.id]: {
+						...MockOrganizationPermissions,
+						createChatModelConfigs: false,
+						editChatModelConfigs: false,
+						deleteChatModelConfigs: false,
+					},
+				},
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Admin settings" }),
+		);
+		await expect(screen.getByRole("menuitem", { name: "AI" })).toHaveAttribute(
+			"href",
+			"/ai/settings",
+		);
 	},
 };
 

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -5,16 +5,21 @@ import {
 	reactRouterParameters,
 } from "storybook-addon-remix-react-router";
 import { buildInfoKey } from "#/api/queries/buildInfo";
+import { chatModels } from "#/api/queries/chats";
 import { deploymentStatsQueryKey } from "#/api/queries/deployment";
 import { organizationsPermissions } from "#/api/queries/organizations";
 import { updateCheckQueryKey } from "#/api/queries/updateCheck";
 import type { UpdateCheckResponse } from "#/api/typesGenerated";
 import {
+	MockChatModel,
+	MockChatModelProviderDescriptor,
+} from "#/testHelpers/chatModels";
+import {
 	MockBuildInfo,
 	MockDefaultOrganization,
 	MockDeploymentStats,
+	MockNoOrganizationPermissions,
 	MockNoPermissions,
-	MockOrganizationPermissions,
 	MockPermissions,
 	MockUpdateCheck,
 	MockUserMember,
@@ -41,6 +46,17 @@ const pageContent = (
 		<p>Page content rendered in the dashboard outlet.</p>
 	</DashboardFullPage>
 );
+
+const modelSettingsRouter = reactRouterParameters({
+	location: { path: "/" },
+	routing: [
+		{ path: "/", useStoryElement: true },
+		{
+			path: "/ai/settings/models",
+			element: <h1>Organization models</h1>,
+		},
+	],
+});
 
 const meta: Meta<typeof DashboardLayout> = {
 	title: "modules/dashboard/DashboardLayout",
@@ -91,13 +107,20 @@ export const ForMember: Story = {
 		await expect(
 			screen.queryByTestId("update-check-notice"),
 		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("button", { name: "Admin settings" }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: "Models" }),
+		).not.toBeInTheDocument();
 	},
 };
 
-export const CustomOrganizationRoleCanOpenAISettings: Story = {
+export const CustomOrganizationRoleCanOpenModels: Story = {
 	parameters: {
 		user: MockUserMember,
 		permissions: MockNoPermissions,
+		reactRouter: modelSettingsRouter,
 		queries: [
 			{ key: buildInfoKey, data: MockBuildInfo },
 			{ key: updateCheckQueryKey, data: MockUpdateCheck },
@@ -106,25 +129,40 @@ export const CustomOrganizationRoleCanOpenAISettings: Story = {
 				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
 				data: {
 					[MockDefaultOrganization.id]: {
-						...MockOrganizationPermissions,
-						createChatModelConfigs: false,
-						editChatModelConfigs: false,
-						deleteChatModelConfigs: false,
+						...MockNoOrganizationPermissions,
+						viewChatModelConfigs: true,
 					},
 				},
 			},
 		],
 	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.click(
-			canvas.getByRole("button", { name: "Admin settings" }),
-		);
-		await expect(screen.getByRole("menuitem", { name: "AI" })).toHaveAttribute(
-			"href",
-			"/ai/settings",
-		);
+	play: openModels,
+};
+
+export const ACLReadableMemberCanOpenModels: Story = {
+	parameters: {
+		user: MockUserMember,
+		permissions: MockNoPermissions,
+		reactRouter: modelSettingsRouter,
+		queries: [
+			{ key: buildInfoKey, data: MockBuildInfo },
+			{ key: updateCheckQueryKey, data: MockUpdateCheck },
+			{ key: deploymentStatsQueryKey, data: MockDeploymentStats },
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: {
+					models: [
+						{
+							...MockChatModel,
+							organization_id: MockDefaultOrganization.id,
+						},
+					],
+					providers: [MockChatModelProviderDescriptor],
+				},
+			},
+		],
 	},
+	play: openModels,
 };
 
 export const UpdateAvailable: Story = {
@@ -159,3 +197,15 @@ export const SkipToMainContent: Story = {
 		await expect(main).toHaveFocus();
 	},
 };
+
+async function openModels({ canvasElement }: { canvasElement: HTMLElement }) {
+	const user = userEvent.setup();
+	const canvas = within(canvasElement);
+	await expect(
+		canvas.queryByRole("button", { name: "Admin settings" }),
+	).not.toBeInTheDocument();
+	await user.click(canvas.getByRole("link", { name: "Models" }));
+	await expect(
+		await canvas.findByRole("heading", { name: "Organization models" }),
+	).toBeInTheDocument();
+}

--- a/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import {
 	MockPrimaryWorkspaceProxy,
 	MockProxyLatencies,
@@ -42,6 +43,7 @@ const meta: Meta<typeof MobileMenu> = {
 		supportLinks: MockSupportLinks,
 		onSignOut: fn(),
 		isDefaultOpen: true,
+		canViewModels: false,
 		adminPermissions: {
 			canViewDeployment: true,
 			canViewOrganizations: true,
@@ -93,6 +95,38 @@ export const Member: Story = {
 	args: {
 		user: MockUserMember,
 		adminPermissions: {},
+	},
+};
+
+export const MemberWithModelAccess: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/" },
+			routing: [
+				{ path: "/", useStoryElement: true },
+				{
+					path: "/ai/settings/models",
+					element: <h1>Organization models</h1>,
+				},
+			],
+		}),
+	},
+	args: {
+		user: MockUserMember,
+		adminPermissions: {},
+		canViewModels: true,
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await expect(
+			body.queryByRole("menuitem", { name: /admin settings/i }),
+		).not.toBeInTheDocument();
+		await user.click(body.getByRole("menuitem", { name: "Models" }));
+		await expect(
+			await canvas.findByRole("heading", { name: "Organization models" }),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -43,6 +43,7 @@ const itemStyles = {
 
 type MobileMenuProps = {
 	proxyContextValue?: ProxyContextValue;
+	canViewModels: boolean;
 	adminPermissions: AdminSettingsPermissions;
 	user?: TypesGen.User;
 	supportLinks?: readonly TypesGen.LinkConfig[];
@@ -52,6 +53,7 @@ type MobileMenuProps = {
 
 export const MobileMenu: FC<MobileMenuProps> = ({
 	adminPermissions,
+	canViewModels,
 	proxyContextValue,
 	user,
 	supportLinks,
@@ -87,6 +89,11 @@ export const MobileMenu: FC<MobileMenuProps> = ({
 				<DropdownMenuItem asChild className={itemStyles.default}>
 					<Link to="/agents">Agents</Link>
 				</DropdownMenuItem>
+				{canViewModels && (
+					<DropdownMenuItem asChild className={itemStyles.default}>
+						<Link to="/ai/settings/models">Models</Link>
+					</DropdownMenuItem>
+				)}
 				<DropdownMenuSeparator />
 				<ProxySettingsSub proxyContextValue={proxyContextValue} />
 

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -23,6 +23,7 @@ export const Navbar: React.FC = () => {
 	const proxyContextValue = useProxy();
 	const accessibleModelOrgsQuery =
 		useAccessibleModelOrganizations(organizations);
+	const canAccessAnyModel = canAccessAnyChatModelConfig(permissions);
 
 	const canViewDeployment = canViewDeploymentSettings(permissions);
 	const canViewOrganizations = canViewOrganizationSettings;
@@ -41,8 +42,9 @@ export const Navbar: React.FC = () => {
 		permissions.createAnyMCPServerConfig ||
 		permissions.updateAnyMCPServerConfig ||
 		permissions.deleteAnyMCPServerConfig ||
-		canAccessAnyChatModelConfig(permissions) ||
-		(accessibleModelOrgsQuery.organizations.length ?? 0) > 0;
+		canAccessAnyModel;
+	const canViewModels =
+		!canViewAISettings && accessibleModelOrgsQuery.organizations.length > 0;
 	const canCreateChat = permissions.createChat;
 
 	const uniqueLinks = new Map<string, LinkConfig>();
@@ -66,6 +68,7 @@ export const Navbar: React.FC = () => {
 				canViewAIBridge,
 				canViewHealth,
 			}}
+			canViewModels={canViewModels}
 			canCreateChat={canCreateChat}
 			proxyContextValue={proxyContextValue}
 		/>

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -5,17 +5,24 @@ import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
-import { canViewDeploymentSettings } from "#/modules/permissions";
+import {
+	canAccessAnyChatModelConfig,
+	canViewDeploymentSettings,
+} from "#/modules/permissions";
+import { useAccessibleModelOrganizations } from "#/pages/AISettingsPage/ModelsPage/organizationModels";
 import { useFeatureVisibility } from "../useFeatureVisibility";
 import { NavbarView } from "./NavbarView";
 
 export const Navbar: React.FC = () => {
 	const { metadata } = useEmbeddedMetadata();
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
-	const { appearance, canViewOrganizationSettings } = useDashboard();
+	const { appearance, canViewOrganizationSettings, organizations } =
+		useDashboard();
 	const { user: me, permissions, signOut } = useAuthenticated();
 	const featureVisibility = useFeatureVisibility();
 	const proxyContextValue = useProxy();
+	const accessibleModelOrgsQuery =
+		useAccessibleModelOrganizations(organizations);
 
 	const canViewDeployment = canViewDeploymentSettings(permissions);
 	const canViewOrganizations = canViewOrganizationSettings;
@@ -33,7 +40,9 @@ export const Navbar: React.FC = () => {
 		permissions.viewAnyMCPServerConfigs ||
 		permissions.createAnyMCPServerConfig ||
 		permissions.updateAnyMCPServerConfig ||
-		permissions.deleteAnyMCPServerConfig;
+		permissions.deleteAnyMCPServerConfig ||
+		canAccessAnyChatModelConfig(permissions) ||
+		(accessibleModelOrgsQuery.organizations.length ?? 0) > 0;
 	const canCreateChat = permissions.createChat;
 
 	const uniqueLinks = new Map<string, LinkConfig>();

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -3,7 +3,7 @@ import { expect, userEvent, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { TasksFilter } from "#/api/typesGenerated";
 import { AuthProvider } from "#/contexts/auth/AuthProvider";
-import { AISettingsIndexRedirect } from "#/router";
+import { AISettingsIndexRedirect } from "#/pages/AISettingsPage/AISettingsIndexRedirect";
 import {
 	MockBuildInfo,
 	MockNoPermissions,

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -3,9 +3,13 @@ import { expect, userEvent, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { TasksFilter } from "#/api/typesGenerated";
 import { AuthProvider } from "#/contexts/auth/AuthProvider";
+import { DashboardContext } from "#/modules/dashboard/DashboardProvider";
 import { AISettingsIndexRedirect } from "#/pages/AISettingsPage/AISettingsIndexRedirect";
 import {
+	MockAppearanceConfig,
 	MockBuildInfo,
+	MockDefaultOrganization,
+	MockEntitlements,
 	MockNoPermissions,
 	MockTasks,
 	MockUserMember,
@@ -25,6 +29,24 @@ const tasksFilter: TasksFilter = {
 const memberTasksFilter: TasksFilter = {
 	owner: MockUserMember.username,
 };
+
+const AISettingsIndexRedirectWithProviders = () => (
+	<AuthProvider>
+		<DashboardContext.Provider
+			value={{
+				entitlements: MockEntitlements,
+				experiments: [],
+				appearance: MockAppearanceConfig,
+				buildInfo: MockBuildInfo,
+				organizations: [MockDefaultOrganization],
+				showOrganizations: false,
+				canViewOrganizationSettings: false,
+			}}
+		>
+			<AISettingsIndexRedirect />
+		</DashboardContext.Provider>
+	</AuthProvider>
+);
 
 const meta: Meta<typeof NavbarView> = {
 	title: "modules/dashboard/NavbarView",
@@ -50,6 +72,7 @@ const meta: Meta<typeof NavbarView> = {
 			canViewAIBridge: true,
 			canViewHealth: true,
 		},
+		canViewModels: false,
 		canCreateChat: true,
 		supportLinks: [],
 	},
@@ -118,14 +141,7 @@ export const ForMCPUpdateOnlyAdmin: Story = {
 				{ path: "/", useStoryElement: true },
 				{
 					path: "/ai/settings",
-					// Route elements render outside story decorators, so the
-					// redirect needs its own AuthProvider; it reads the query
-					// data seeded by withAuthProvider.
-					element: (
-						<AuthProvider>
-							<AISettingsIndexRedirect />
-						</AuthProvider>
-					),
+					element: <AISettingsIndexRedirectWithProviders />,
 				},
 				{
 					path: "/ai/settings/mcp-servers",
@@ -171,11 +187,7 @@ export const ForMCPDeleteOnlyAdmin: Story = {
 				{ path: "/", useStoryElement: true },
 				{
 					path: "/ai/settings",
-					element: (
-						<AuthProvider>
-							<AISettingsIndexRedirect />
-						</AuthProvider>
-					),
+					element: <AISettingsIndexRedirectWithProviders />,
 				},
 				{
 					path: "/ai/settings/mcp-servers",
@@ -219,14 +231,7 @@ export const ForMCPCreateOnlyAdmin: Story = {
 				{ path: "/", useStoryElement: true },
 				{
 					path: "/ai/settings",
-					// Route elements render outside story decorators, so the
-					// redirect needs its own AuthProvider; it reads the query
-					// data seeded by withAuthProvider.
-					element: (
-						<AuthProvider>
-							<AISettingsIndexRedirect />
-						</AuthProvider>
-					),
+					element: <AISettingsIndexRedirectWithProviders />,
 				},
 				{
 					path: "/ai/settings/mcp-servers/add",
@@ -274,6 +279,38 @@ export const ForMember: Story = {
 		user: MockUserMember,
 		adminPermissions: {},
 		canCreateChat: false,
+	},
+};
+
+export const ForMemberWithModelAccess: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/" },
+			routing: [
+				{ path: "/", useStoryElement: true },
+				{
+					path: "/ai/settings/models",
+					element: <h1>Organization models</h1>,
+				},
+			],
+		}),
+	},
+	args: {
+		user: MockUserMember,
+		adminPermissions: {},
+		canViewModels: true,
+		canCreateChat: false,
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("button", { name: "Admin settings" }),
+		).not.toBeInTheDocument();
+		await user.click(canvas.getByRole("link", { name: "Models" }));
+		await expect(
+			await canvas.findByRole("heading", { name: "Organization models" }),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -33,6 +33,7 @@ interface NavbarViewProps {
 	onSignOut: () => void;
 	adminPermissions: AdminSettingsPermissions;
 	canCreateChat: boolean;
+	canViewModels: boolean;
 	proxyContextValue?: ProxyContextValue;
 }
 
@@ -49,6 +50,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 	onSignOut,
 	adminPermissions,
 	canCreateChat,
+	canViewModels,
 	proxyContextValue,
 }) => {
 	const prerelease = getPrereleaseFlag(buildInfo);
@@ -80,6 +82,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 			<NavItems
 				className="ml-4 hidden md:flex"
 				user={user}
+				canViewModels={canViewModels}
 				canCreateChat={canCreateChat}
 			/>
 
@@ -145,6 +148,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 				<div className="md:hidden">
 					<MobileMenu
 						proxyContextValue={proxyContextValue}
+						canViewModels={canViewModels}
 						adminPermissions={adminPermissions}
 						user={user}
 						supportLinks={supportLinks}
@@ -159,10 +163,16 @@ export const NavbarView: FC<NavbarViewProps> = ({
 interface NavItemsProps {
 	className?: string;
 	user: TypesGen.User;
+	canViewModels: boolean;
 	canCreateChat: boolean;
 }
 
-const NavItems: FC<NavItemsProps> = ({ className, user, canCreateChat }) => {
+const NavItems: FC<NavItemsProps> = ({
+	className,
+	user,
+	canCreateChat,
+	canViewModels,
+}) => {
 	const location = useLocation();
 
 	return (
@@ -187,6 +197,16 @@ const NavItems: FC<NavItemsProps> = ({ className, user, canCreateChat }) => {
 				Templates
 			</NavLink>
 			<TasksNavItem user={user} />
+			{canViewModels && (
+				<NavLink
+					className={({ isActive }) =>
+						cn(linkStyles.default, { [linkStyles.active]: isActive })
+					}
+					to="/ai/settings/models"
+				>
+					Models
+				</NavLink>
+			)}
 			{canCreateChat && (
 				<NavLink
 					className={({ isActive }) => {

--- a/site/src/modules/dashboard/useDashboard.ts
+++ b/site/src/modules/dashboard/useDashboard.ts
@@ -5,9 +5,7 @@ export const useDashboard = (): DashboardValue => {
 	const context = useContext(DashboardContext);
 
 	if (!context) {
-		throw new Error(
-			"useDashboard only can be used inside of DashboardProvider",
-		);
+		throw new Error("useDashboard must be used within DashboardProvider");
 	}
 
 	return context;
@@ -16,3 +14,7 @@ export const useDashboard = (): DashboardValue => {
 export const getDefaultOrganizationName = (
 	organizations: DashboardValue["organizations"],
 ): string => organizations.find((org) => org.is_default)?.name ?? "";
+
+export const getDefaultOrganizationId = (
+	organizations: DashboardValue["organizations"],
+): string => organizations.find((org) => org.is_default)?.id ?? "";

--- a/site/src/modules/management/AISettingsSidebar.tsx
+++ b/site/src/modules/management/AISettingsSidebar.tsx
@@ -1,11 +1,23 @@
 import type { FC } from "react";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import AISettingsSidebarView from "#/modules/management/AISettingsSidebarView";
+import { useAccessibleModelOrganizations } from "#/pages/AISettingsPage/ModelsPage/organizationModels";
 
 /**
  * A sidebar for AI settings.
  */
 export const AISettingsSidebar: FC = () => {
 	const { permissions } = useAuthenticated();
-	return <AISettingsSidebarView permissions={permissions} />;
+	const { organizations } = useDashboard();
+	const accessibleOrgsQuery = useAccessibleModelOrganizations(organizations);
+
+	return (
+		<AISettingsSidebarView
+			permissions={permissions}
+			canAccessOrganizationModels={
+				(accessibleOrgsQuery.organizations.length ?? 0) > 0
+			}
+		/>
+	);
 };

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -1,7 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
-import { MockNoPermissions, MockPermissions } from "#/testHelpers/entities";
+import { organizationsPermissions } from "#/api/queries/organizations";
+import {
+	MockDefaultOrganization,
+	MockNoPermissions,
+	MockOrganizationPermissions,
+	MockPermissions,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+} from "#/testHelpers/storybook";
+import { AISettingsSidebar } from "./AISettingsSidebar";
 import AISettingsSidebarView from "./AISettingsSidebarView";
 
 const meta: Meta<typeof AISettingsSidebarView> = {
@@ -48,6 +60,36 @@ export const ModelsActive: Story = {
 			routing: [{ path: "/ai/settings/models", useStoryElement: true }],
 		}),
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	},
+};
+
+export const ModelsActiveOnOrganizationRoute: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/organizations/my-organization/models",
+			},
+			routing: [
+				{
+					path: "/ai/settings/organizations/:organization/models",
+					useStoryElement: true,
+				},
+			],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	},
 };
 
 export const LifecycleActive: Story = {
@@ -65,6 +107,81 @@ export const ProvidersActive: Story = {
 			location: { path: "/ai/settings/providers" },
 			routing: [{ path: "/ai/settings/providers", useStoryElement: true }],
 		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: "Models" }),
+		).not.toHaveAttribute("aria-current", "page");
+	},
+};
+
+export const ModelsWithoutDeploymentConfig: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			editAnyChatModelConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: "Models" }),
+		).toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: "Coder Agents" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const ModelsWithDeletePermissionOnly: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			deleteAnyChatModelConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toBeVisible();
+	},
+};
+
+export const ModelsWithReadPermissionOnly: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			viewAnyChatModelConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toBeVisible();
+	},
+};
+
+export const OrganizationOnlyRoleCanAccessModels: Story = {
+	render: () => <AISettingsSidebar />,
+	decorators: [withAuthProvider, withDashboardProvider],
+	parameters: {
+		user: MockUserOwner,
+		permissions: MockNoPermissions,
+		organizations: [MockDefaultOrganization],
+		queries: [
+			{
+				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+				},
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toBeVisible();
+		await expect(
+			canvas.queryByRole("link", { name: "Coder Agents" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,15 +1,19 @@
 import type { FC, ReactNode } from "react";
-import { NavLink } from "react-router";
+import { Link, NavLink, useMatch } from "react-router";
 import {
 	Sidebar as BaseSidebar,
 	SettingsSidebarNavItem as SidebarNavItem,
 } from "#/components/Sidebar/Sidebar";
-import type { Permissions } from "#/modules/permissions";
+import {
+	canAccessAnyChatModelConfig,
+	type Permissions,
+} from "#/modules/permissions";
 import { cn } from "#/utils/cn";
 
 interface AISettingsSidebarViewProps {
 	/** Site-wide permissions. */
 	permissions: Permissions;
+	canAccessOrganizationModels?: boolean;
 }
 
 const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
@@ -31,8 +35,30 @@ const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
 	</NavLink>
 );
 
+const ModelsSidebarNavItem: FC = () => {
+	const legacyMatch = useMatch("/ai/settings/models/*");
+	const organizationMatch = useMatch(
+		"/ai/settings/organizations/:organization/models/*",
+	);
+	const isActive = legacyMatch !== null || organizationMatch !== null;
+
+	return (
+		<Link
+			to="/ai/settings/models"
+			aria-current={isActive ? "page" : undefined}
+			className={cn(
+				"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
+				isActive && "font-semibold text-content-primary",
+			)}
+		>
+			Models
+		</Link>
+	);
+};
+
 const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 	permissions,
+	canAccessOrganizationModels = false,
 }) => {
 	return (
 		<BaseSidebar>
@@ -52,13 +78,14 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 						Providers
 					</SidebarNavItem>
 				)}
+				{(canAccessAnyChatModelConfig(permissions) ||
+					canAccessOrganizationModels) && <ModelsSidebarNavItem />}
 				{permissions.editDeploymentConfig && (
 					<>
 						<SidebarNavItem href="/ai/settings/coder-agents">
 							Coder Agents
 						</SidebarNavItem>
 						<div className="flex flex-col gap-1 ml-3 border-0 border-solid border-l border-l-border">
-							<SubNavItem href="/ai/settings/models">Models</SubNavItem>
 							<SubNavItem href="/ai/settings/mcp-servers">
 								MCP servers
 							</SubNavItem>

--- a/site/src/modules/permissions/index.ts
+++ b/site/src/modules/permissions/index.ts
@@ -15,6 +15,19 @@ export const permissionChecks =
 	permissionChecksData as typeof permissionChecksData &
 		Record<string, AuthorizationCheck>;
 
+export const canAccessAnyChatModelConfig = (
+	permissions: Permissions | undefined,
+): boolean => {
+	return (
+		permissions !== undefined &&
+		(permissions.viewAnyChatModelConfig ||
+			permissions.createAnyChatModelConfig ||
+			permissions.editAnyChatModelConfig ||
+			permissions.deleteAnyChatModelConfig ||
+			permissions.shareAnyChatModelConfig)
+	);
+};
+
 export const canViewDeploymentSettings = (
 	permissions: Permissions | undefined,
 ): permissions is Permissions => {
@@ -27,7 +40,8 @@ export const canViewDeploymentSettings = (
 			permissions.viewNotificationTemplate ||
 			permissions.viewOrganizationIDPSyncSettings ||
 			permissions.viewAnyAIProvider ||
-			permissions.viewAIGatewayKeys)
+			permissions.viewAIGatewayKeys ||
+			canAccessAnyChatModelConfig(permissions))
 	);
 };
 

--- a/site/src/modules/permissions/organizations.ts
+++ b/site/src/modules/permissions/organizations.ts
@@ -143,6 +143,41 @@ export const organizationPermissionChecks = (organizationId: string) =>
 			},
 			action: "delete",
 		},
+		viewChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "read",
+		},
+		createChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "create",
+		},
+		editChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "update",
+		},
+		deleteChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "delete",
+		},
+		shareChatModelConfigs: {
+			object: {
+				resource_type: "chat_model_config",
+				organization_id: organizationId,
+			},
+			action: "share",
+		},
 	}) as const satisfies Record<string, AuthorizationCheck>;
 
 /**

--- a/site/src/modules/permissions/organizations.ts
+++ b/site/src/modules/permissions/organizations.ts
@@ -181,6 +181,20 @@ export const organizationPermissionChecks = (organizationId: string) =>
 	}) as const satisfies Record<string, AuthorizationCheck>;
 
 /**
+ * Checks if the user can access chat model settings for the organization that
+ * produced the given OrganizationPermissions.
+ */
+export const canAccessOrganizationChatModelConfig = (
+	permissions: OrganizationPermissions | undefined,
+): permissions is OrganizationPermissions =>
+	permissions !== undefined &&
+	(permissions.viewChatModelConfigs ||
+		permissions.createChatModelConfigs ||
+		permissions.editChatModelConfigs ||
+		permissions.deleteChatModelConfigs ||
+		permissions.shareChatModelConfigs);
+
+/**
  * Checks if the user can view or edit members or groups for the organization
  * that produced the given OrganizationPermissions.
  */

--- a/site/src/pages/AISettingsPage/AISettingsIndexRedirect.test.tsx
+++ b/site/src/pages/AISettingsPage/AISettingsIndexRedirect.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { beforeEach, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import type { Permissions } from "#/modules/permissions";
+import {
+	MockDefaultOrganization,
+	MockNoPermissions,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import { AISettingsIndexRedirect } from "./AISettingsIndexRedirect";
+
+let permissions: Permissions = MockNoPermissions;
+
+vi.mock("#/hooks/useAuthenticated", () => ({
+	useAuthenticated: () => ({
+		user: MockUserOwner,
+		permissions,
+	}),
+}));
+
+vi.mock("#/modules/dashboard/useDashboard", () => ({
+	useDashboard: () => ({ organizations: [MockDefaultOrganization] }),
+}));
+
+beforeEach(() => {
+	permissions = MockNoPermissions;
+});
+
+it("redirects a deployment administrator to Coder Agents", async () => {
+	permissions = { ...MockNoPermissions, editDeploymentConfig: true };
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	vi.spyOn(API.experimental, "getChatModels").mockRejectedValue({
+		isAxiosError: true,
+		response: { status: 403 },
+	});
+	const router = createMemoryRouter(
+		[
+			{ path: "/ai/settings", element: <AISettingsIndexRedirect /> },
+			{
+				path: "/ai/settings/coder-agents",
+				element: <div>Coder Agents</div>,
+			},
+		],
+		{ initialEntries: ["/ai/settings"] },
+	);
+
+	render(
+		<QueryClientProvider client={queryClient}>
+			<RouterProvider router={router} />
+		</QueryClientProvider>,
+	);
+
+	await screen.findByText("Coder Agents");
+	expect(router.state.location.pathname).toBe("/ai/settings/coder-agents");
+});

--- a/site/src/pages/AISettingsPage/AISettingsIndexRedirect.tsx
+++ b/site/src/pages/AISettingsPage/AISettingsIndexRedirect.tsx
@@ -1,0 +1,55 @@
+import { Navigate } from "react-router";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Loader } from "#/components/Loader/Loader";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { canAccessAnyChatModelConfig } from "#/modules/permissions";
+import { useAccessibleModelOrganizations } from "./ModelsPage/organizationModels";
+
+export const AISettingsIndexRedirect = () => {
+	const { permissions } = useAuthenticated();
+	const { organizations } = useDashboard();
+	const accessibleOrgsQuery = useAccessibleModelOrganizations(organizations);
+
+	if (permissions.viewAnyAIProvider) {
+		return <Navigate to="/ai/settings/providers" replace />;
+	}
+
+	if (permissions.viewAIGatewayKeys) {
+		return <Navigate to="/ai/settings/gateway-keys" replace />;
+	}
+
+	if (canAccessAnyChatModelConfig({ ...permissions })) {
+		return <Navigate to="/ai/settings/models" replace />;
+	}
+
+	if (
+		permissions.viewAnyMCPServerConfigs ||
+		permissions.updateAnyMCPServerConfig ||
+		permissions.deleteAnyMCPServerConfig
+	) {
+		return <Navigate to="/ai/settings/mcp-servers" replace />;
+	}
+
+	if (permissions.createAnyMCPServerConfig) {
+		return <Navigate to="/ai/settings/mcp-servers/add" replace />;
+	}
+
+	if (accessibleOrgsQuery.isLoading) {
+		return <Loader fullscreen />;
+	}
+
+	if (accessibleOrgsQuery.error !== null) {
+		return <ErrorAlert error={accessibleOrgsQuery.error} />;
+	}
+
+	if (accessibleOrgsQuery.organizations.length > 0) {
+		return <Navigate to="/ai/settings/models" replace />;
+	}
+
+	if (permissions.editDeploymentConfig) {
+		return <Navigate to="/ai/settings/coder-agents" replace />;
+	}
+
+	return <Navigate to="/ai/settings/providers" replace />;
+};

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import {
 	chatAdvisorConfig,
 	chatComputerUseProvider,
@@ -14,9 +13,12 @@ import {
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
-import { useDashboard } from "#/modules/dashboard/useDashboard";
+import {
+	getDefaultOrganizationId,
+	useDashboard,
+} from "#/modules/dashboard/useDashboard";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
-import { providerInfoByIDFromConfigs } from "#/pages/AgentsPage/utils/modelOptions";
+import { providerInfoByIDFromDescriptors } from "#/pages/AgentsPage/utils/modelOptions";
 import { pageTitle } from "#/utils/page";
 import { CoderAgentsPageView } from "./CoderAgentsPageView";
 
@@ -29,13 +31,14 @@ const compactionOverrideContext: TypesGen.ChatModelOverrideContext =
 
 const CoderAgentsPage: FC = () => {
 	const { permissions } = useAuthenticated();
-	const { experiments } = useDashboard();
+	const { experiments, organizations } = useDashboard();
 	const queryClient = useQueryClient();
 	const canEditDeploymentConfig = permissions.editDeploymentConfig;
 	const showAdvisorSettings = experiments.includes("chat-advisor");
 	const showVirtualDesktopSettings = experiments.includes(
 		"chat-virtual-desktop",
 	);
+	const defaultOrganizationId = getDefaultOrganizationId(organizations);
 
 	const personalModelOverridesAdminSettingsQuery = useQuery({
 		...chatPersonalModelOverridesAdminSettings(),
@@ -57,7 +60,7 @@ const CoderAgentsPage: FC = () => {
 		...chatModelOverride(compactionOverrideContext),
 		enabled: canEditDeploymentConfig,
 	});
-	const modelsQuery = useQuery(chatModels());
+	const modelsQuery = useQuery(chatModels(defaultOrganizationId));
 	const advisorConfigQuery = useQuery({
 		...chatAdvisorConfig(),
 		enabled: canEditDeploymentConfig && showAdvisorSettings,
@@ -65,10 +68,6 @@ const CoderAgentsPage: FC = () => {
 	const computerUseProviderQuery = useQuery({
 		...chatComputerUseProvider(),
 		enabled: canEditDeploymentConfig && showVirtualDesktopSettings,
-	});
-	const providerConfigsQuery = useQuery({
-		...chatProviderConfigs(),
-		enabled: canEditDeploymentConfig,
 	});
 	const savePersonalModelOverridesAdminSettingsMutation = useMutation(
 		updateChatPersonalModelOverridesAdminSettings(queryClient),
@@ -92,9 +91,10 @@ const CoderAgentsPage: FC = () => {
 		updateChatComputerUseProvider(queryClient),
 	);
 
-	const providerInfoByID = providerInfoByIDFromConfigs(
-		providerConfigsQuery.data,
+	const providerInfoByID = providerInfoByIDFromDescriptors(
+		modelsQuery.data?.providers,
 	);
+	const defaultOrganizationModels = modelsQuery.data?.models ?? [];
 
 	return (
 		<RequirePermission isFeatureVisible={canEditDeploymentConfig}>
@@ -121,15 +121,11 @@ const CoderAgentsPage: FC = () => {
 				titleGenerationModelOverrideData={titleGenerationModelQuery.data}
 				compactionModelOverrideData={compactionModelQuery.data}
 				exploreModelOverrideData={exploreModelOverrideQuery.data}
-				models={modelsQuery.data}
+				models={defaultOrganizationModels}
 				providerInfoByID={providerInfoByID}
-				modelsError={modelsQuery.error ?? providerConfigsQuery.error}
-				isLoadingModels={
-					modelsQuery.isLoading || providerConfigsQuery.isLoading
-				}
-				isFetchingModels={
-					modelsQuery.isFetching || providerConfigsQuery.isFetching
-				}
+				modelsError={modelsQuery.error}
+				isLoadingModels={modelsQuery.isLoading}
+				isFetchingModels={modelsQuery.isFetching}
 				onSaveGeneralModelOverride={saveGeneralModelOverrideMutation.mutate}
 				isSavingGeneralModelOverride={
 					saveGeneralModelOverrideMutation.isPending

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
@@ -38,7 +38,7 @@ export interface CoderAgentsPageViewProps {
 	titleGenerationModelOverrideData?: TypesGen.ChatModelOverrideResponse;
 	compactionModelOverrideData?: TypesGen.ChatModelOverrideResponse;
 	exploreModelOverrideData?: TypesGen.ChatModelOverrideResponse;
-	models: TypesGen.ChatModel[] | undefined;
+	models: readonly TypesGen.ChatModel[] | undefined;
 	providerInfoByID: ReadonlyMap<string, ProviderInfo>;
 	modelsError: unknown;
 	isLoadingModels: boolean;

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
@@ -1,91 +1,109 @@
-import { type FC, useMemo } from "react";
+import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
-import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import {
 	chatModelAvailability,
 	chatModels,
 	createChatModel,
 } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
 import {
 	canManageProviderModels,
 	deriveProviderStates,
 } from "#/modules/aiModels/providerStates";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
+import {
+	organizationAddModelPath,
+	organizationModelPath,
+	splitModelQueryErrors,
+	useOrganizationModels,
+} from "../organizationModels";
 import AddModelPageView from "./AddModelPageView";
 
 const AddModelPage: FC = () => {
-	const { permissions } = useAuthenticated();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [searchParams] = useSearchParams();
 	const providerKey = searchParams.get("provider") ?? "";
 	const duplicateId = searchParams.get("duplicate");
+	const { organization, permissions, requestedOrganizationDenied } =
+		useOrganizationModels();
 
-	const providerConfigsQuery = useQuery(chatProviderConfigs());
-	const modelsQuery = useQuery(chatModels());
-	const modelCatalogQuery = useQuery(chatModelAvailability());
-
+	const organizationModelsQuery = useQuery(chatModels(organization.id));
+	const availableModelsQuery = useQuery(chatModelAvailability(organization.id));
 	const createMutation = useMutation(createChatModel(queryClient));
-
-	const providerStates = useMemo(
-		() =>
-			deriveProviderStates(
-				modelsQuery.data ?? [],
-				providerConfigsQuery.data,
-				modelCatalogQuery.data,
-			),
-		[modelsQuery.data, providerConfigsQuery.data, modelCatalogQuery.data],
+	const models = organizationModelsQuery.data?.models ?? [];
+	const providerStates = deriveProviderStates(
+		models,
+		organizationModelsQuery.data?.providers ?? [],
+		availableModelsQuery.data,
+	);
+	const isLoading =
+		organizationModelsQuery.isLoading || availableModelsQuery.isLoading;
+	const { loadError, refetchError } = splitModelQueryErrors(
+		organizationModelsQuery,
+		availableModelsQuery,
 	);
 
-	const isLoading =
-		providerConfigsQuery.isLoading ||
-		modelsQuery.isLoading ||
-		modelCatalogQuery.isLoading;
+	if (requestedOrganizationDenied) {
+		return (
+			<>
+				<title>{pageTitle("Add model", "AI Settings")}</title>
+				<RequirePermission isFeatureVisible={false} />
+			</>
+		);
+	}
 
 	const selectedProviderState = providerKey
 		? (providerStates.find((ps) => ps.key === providerKey) ?? null)
 		: (providerStates.find(canManageProviderModels) ?? null);
 	const duplicateSourceModel = duplicateId
-		? modelsQuery.data?.find((m) => m.id === duplicateId)
+		? models.find((m) => m.id === duplicateId)
 		: undefined;
-	const currentDefaultModel = modelsQuery.data?.find((m) => m.is_default);
+	const currentDefaultModel = models.find((m) => m.is_default);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<>
 			<title>{pageTitle("Add model", "AI Settings")}</title>
 
-			<AddModelPageView
-				isLoading={isLoading}
-				providerStates={providerStates}
-				selectedProviderState={selectedProviderState}
-				duplicateSourceModel={duplicateSourceModel}
-				currentDefaultModel={currentDefaultModel}
-				isSaving={createMutation.isPending}
-				onProviderChange={(key) => {
-					const next = new URLSearchParams(searchParams);
-					next.set("provider", key);
-					void navigate(`/ai/settings/models/add?${next.toString()}`, {
-						replace: true,
-					});
-				}}
-				onCreateModel={async (req) => {
-					try {
-						const created = await createMutation.mutateAsync(req);
-						toast.success(
-							`Model "${created.display_name || created.model}" added.`,
-						);
-						await navigate(`/ai/settings/models/${created.id}`);
-					} catch (error) {
-						toast.error(getErrorMessage(error, "Failed to add model."));
-					}
-				}}
-			/>
-		</RequirePermission>
+			<RequirePermission
+				isFeatureVisible={permissions?.createChatModelConfigs ?? false}
+			>
+				<AddModelPageView
+					isLoading={isLoading}
+					loadError={loadError}
+					refetchError={refetchError}
+					providerStates={providerStates}
+					selectedProviderState={selectedProviderState}
+					duplicateSourceModel={duplicateSourceModel}
+					currentDefaultModel={currentDefaultModel}
+					isSaving={createMutation.isPending}
+					onProviderChange={(key) => {
+						const next = new URLSearchParams(searchParams);
+						next.set("provider", key);
+						void navigate(organizationAddModelPath(organization, next), {
+							replace: true,
+						});
+					}}
+					onCreateModel={async (req) => {
+						try {
+							const created = await createMutation.mutateAsync({
+								organizationId: organization.id,
+								req,
+							});
+							toast.success(
+								`Model "${created.display_name || created.model}" added.`,
+							);
+							await navigate(organizationModelPath(organization, created.id));
+						} catch (error) {
+							toast.error(getErrorMessage(error, "Failed to add model."));
+						}
+					}}
+				/>
+			</RequirePermission>
+		</>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPage.tsx
@@ -3,11 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
-import {
-	chatModelAvailability,
-	chatModels,
-	createChatModel,
-} from "#/api/queries/chats";
+import { chatModels, createChatModel } from "#/api/queries/chats";
 import {
 	canManageProviderModels,
 	deriveProviderStates,
@@ -32,19 +28,14 @@ const AddModelPage: FC = () => {
 		useOrganizationModels();
 
 	const organizationModelsQuery = useQuery(chatModels(organization.id));
-	const availableModelsQuery = useQuery(chatModelAvailability(organization.id));
 	const createMutation = useMutation(createChatModel(queryClient));
 	const models = organizationModelsQuery.data?.models ?? [];
 	const providerStates = deriveProviderStates(
 		models,
 		organizationModelsQuery.data?.providers ?? [],
-		availableModelsQuery.data,
 	);
-	const isLoading =
-		organizationModelsQuery.isLoading || availableModelsQuery.isLoading;
 	const { loadError, refetchError } = splitModelQueryErrors(
 		organizationModelsQuery,
-		availableModelsQuery,
 	);
 
 	if (requestedOrganizationDenied) {
@@ -72,7 +63,7 @@ const AddModelPage: FC = () => {
 				isFeatureVisible={permissions?.createChatModelConfigs ?? false}
 			>
 				<AddModelPageView
-					isLoading={isLoading}
+					isLoading={organizationModelsQuery.isLoading}
 					loadError={loadError}
 					refetchError={refetchError}
 					providerStates={providerStates}

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.stories.tsx
@@ -1,6 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
+import { deriveProviderStates } from "#/modules/aiModels/providerStates";
+import {
+	MockChatModelProvider,
+	MockChatModelProviderDescriptor,
+} from "#/testHelpers/chatModels";
+import {
+	MockDefaultOrganization,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
 import { withToaster } from "#/testHelpers/storybook";
+import { OrganizationModelsContext } from "../organizationModels";
 import {
 	MockAnthropicProviderState,
 	MockCopilotProviderState,
@@ -11,9 +21,25 @@ import AddModelPageView from "./AddModelPageView";
 const meta: Meta<typeof AddModelPageView> = {
 	title: "pages/AISettingsPage/ModelsPage/AddModelPageView",
 	component: AddModelPageView,
-	decorators: [withToaster],
+	decorators: [
+		(Story) => (
+			<OrganizationModelsContext.Provider
+				value={{
+					organization: MockDefaultOrganization,
+					organizations: [MockDefaultOrganization],
+					permissions: MockOrganizationPermissions,
+					requestedOrganizationDenied: false,
+				}}
+			>
+				<Story />
+			</OrganizationModelsContext.Provider>
+		),
+		withToaster,
+	],
 	args: {
 		isLoading: false,
+		loadError: null,
+		refetchError: null,
 		providerStates: [MockOpenAIProviderState, MockAnthropicProviderState],
 		selectedProviderState: MockOpenAIProviderState,
 		isSaving: false,
@@ -68,11 +94,54 @@ export const NoProviderConfigurationFields: Story = {
 	},
 };
 
+export const NullAvailabilityModelsUsesEmptyCatalog: Story = {
+	args: {
+		providerStates: deriveProviderStates(
+			[],
+			[MockChatModelProviderDescriptor],
+			{
+				providers: [{ ...MockChatModelProvider, models: null }],
+				unsupported_providers: [],
+			},
+		),
+		selectedProviderState:
+			deriveProviderStates([], [MockChatModelProviderDescriptor], {
+				providers: [{ ...MockChatModelProvider, models: null }],
+				unsupported_providers: [],
+			})[0] ?? null,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByRole("heading", { name: /add an? OpenAI model/i }),
+		).toBeVisible();
+	},
+};
+
 export const ProviderNotFound: Story = {
 	args: { selectedProviderState: null },
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Provider not found")).toBeInTheDocument();
+	},
+};
+
+export const LoadError: Story = {
+	args: { loadError: new Error("Failed to load models") },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Failed to load models")).toBeVisible();
+	},
+};
+
+export const RefetchError: Story = {
+	args: { refetchError: new Error("Failed to refresh models") },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Failed to refresh models")).toBeVisible();
+		expect(
+			canvas.getByRole("heading", { name: /add an? OpenAI model/i }),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.tsx
@@ -1,15 +1,16 @@
-import { ArrowLeftIcon } from "lucide-react";
 import type { FC } from "react";
-import { Link } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
-import { Button } from "#/components/Button/Button";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Loader } from "#/components/Loader/Loader";
 import type { ProviderState } from "#/modules/aiModels/providerStates";
 import { ModelForm } from "../components/ModelForm";
+import { ModelFormBackLink } from "../components/ModelFormHeader";
 
 interface AddModelPageViewProps {
 	isLoading: boolean;
+	loadError: unknown;
+	refetchError: unknown;
 	providerStates: readonly ProviderState[];
 	selectedProviderState: ProviderState | null;
 	duplicateSourceModel?: TypesGen.ChatModel;
@@ -21,6 +22,8 @@ interface AddModelPageViewProps {
 
 const AddModelPageView: FC<AddModelPageViewProps> = ({
 	isLoading,
+	loadError,
+	refetchError,
 	providerStates,
 	selectedProviderState,
 	duplicateSourceModel,
@@ -33,15 +36,19 @@ const AddModelPageView: FC<AddModelPageViewProps> = ({
 		return <Loader fullscreen />;
 	}
 
+	if (loadError) {
+		return (
+			<div className="flex flex-col items-start gap-4">
+				<ModelFormBackLink />
+				<ErrorAlert error={loadError} />
+			</div>
+		);
+	}
+
 	if (!selectedProviderState) {
 		return (
 			<div className="flex flex-col items-start gap-4">
-				<Link to="/ai/settings/models" className="-ml-3">
-					<Button variant="subtle">
-						<ArrowLeftIcon />
-						<span>Back to models</span>
-					</Button>
-				</Link>
+				<ModelFormBackLink />
 				<Alert severity="warning">
 					<AlertTitle>Provider not found</AlertTitle>
 					<AlertDescription>
@@ -54,17 +61,20 @@ const AddModelPageView: FC<AddModelPageViewProps> = ({
 	}
 
 	return (
-		<ModelForm
-			duplicateSourceModel={duplicateSourceModel}
-			currentDefaultModel={currentDefaultModel}
-			providerStates={providerStates}
-			selectedProviderState={selectedProviderState}
-			onProviderChange={onProviderChange}
-			isSaving={isSaving}
-			isDeleting={false}
-			onCreateModel={onCreateModel}
-			onUpdateModel={async () => {}}
-		/>
+		<div className="flex flex-col gap-4">
+			{refetchError != null && <ErrorAlert error={refetchError} />}
+			<ModelForm
+				duplicateSourceModel={duplicateSourceModel}
+				currentDefaultModel={currentDefaultModel}
+				providerStates={providerStates}
+				selectedProviderState={selectedProviderState}
+				onProviderChange={onProviderChange}
+				isSaving={isSaving}
+				isDeleting={false}
+				onCreateModel={onCreateModel}
+				onUpdateModel={async () => {}}
+			/>
+		</div>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPage.tsx
@@ -1,60 +1,57 @@
 import type { FC } from "react";
 import { useQuery } from "react-query";
-import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import { chatModelAvailability, chatModels } from "#/api/queries/chats";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { deriveProviderStates } from "#/modules/aiModels/providerStates";
-import { RequirePermission } from "#/modules/permissions/RequirePermission";
-import { providerTypeByIDFromConfigs } from "#/pages/AgentsPage/utils/modelOptions";
 import { pageTitle } from "#/utils/page";
 import ModelsPageView from "./ModelsPageView";
+import {
+	splitModelQueryErrors,
+	useOrganizationModels,
+} from "./organizationModels";
 
 const ModelsPage: FC = () => {
-	const { permissions } = useAuthenticated();
-
-	const providerConfigsQuery = useQuery({
-		...chatProviderConfigs(),
-		enabled: permissions.editDeploymentConfig,
-	});
-	const modelsQuery = useQuery(chatModels());
-	const modelCatalogQuery = useQuery(chatModelAvailability());
-
-	const providerTypeByID = providerTypeByIDFromConfigs(
-		providerConfigsQuery.data,
+	const { organization, permissions } = useOrganizationModels();
+	const organizationModelsQuery = useQuery(chatModels(organization.id));
+	const availableModelsQuery = useQuery(chatModelAvailability(organization.id));
+	const providers = organizationModelsQuery.data?.providers ?? [];
+	const providerTypeByID = new Map(
+		providers.map((provider) => [provider.id, provider.type]),
 	);
-
-	const models = (modelsQuery.data ?? []).slice().sort((a, b) => {
-		const aProvider = providerTypeByID.get(a.ai_provider_id) ?? "";
-		const bProvider = providerTypeByID.get(b.ai_provider_id) ?? "";
-		const cmp = aProvider.localeCompare(bProvider);
-		return cmp !== 0 ? cmp : a.model.localeCompare(b.model);
-	});
+	const models = (organizationModelsQuery.data?.models ?? []).toSorted(
+		(a, b) => {
+			const aProvider = providerTypeByID.get(a.ai_provider_id) ?? "";
+			const bProvider = providerTypeByID.get(b.ai_provider_id) ?? "";
+			const cmp = aProvider.localeCompare(bProvider);
+			return cmp !== 0 ? cmp : a.model.localeCompare(b.model);
+		},
+	);
 	const providerStates = deriveProviderStates(
 		models,
-		providerConfigsQuery.data,
-		modelCatalogQuery.data,
+		providers,
+		availableModelsQuery.data,
+	);
+	const { loadError, refetchError } = splitModelQueryErrors(
+		organizationModelsQuery,
+		availableModelsQuery,
 	);
 
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+		<>
 			<title>{pageTitle("Models", "AI Settings")}</title>
 
 			<ModelsPageView
+				key={organization.id}
 				isLoading={
-					providerConfigsQuery.isLoading ||
-					modelsQuery.isLoading ||
-					modelCatalogQuery.isLoading
+					organizationModelsQuery.isLoading || availableModelsQuery.isLoading
 				}
-				error={
-					providerConfigsQuery.error ??
-					modelsQuery.error ??
-					modelCatalogQuery.error
-				}
+				loadError={loadError}
+				refetchError={refetchError}
 				models={models}
 				providerStates={providerStates}
 				providerTypeByID={providerTypeByID}
+				canCreateModel={permissions?.createChatModelConfigs ?? false}
 			/>
-		</RequirePermission>
+		</>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -2,7 +2,12 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { ChatModel } from "#/api/typesGenerated";
+import {
+	MockDefaultOrganization,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
 import ModelsPageView from "./ModelsPageView";
+import { OrganizationModelsContext } from "./organizationModels";
 import {
 	MockAnthropicProviderState,
 	MockBedrockProviderState,
@@ -19,9 +24,24 @@ import {
 const meta: Meta<typeof ModelsPageView> = {
 	title: "pages/AISettingsPage/ModelsPage/ModelsPageView",
 	component: ModelsPageView,
+	decorators: [
+		(Story) => (
+			<OrganizationModelsContext.Provider
+				value={{
+					organization: MockDefaultOrganization,
+					organizations: [MockDefaultOrganization],
+					permissions: MockOrganizationPermissions,
+					requestedOrganizationDenied: false,
+				}}
+			>
+				<Story />
+			</OrganizationModelsContext.Provider>
+		),
+	],
 	args: {
 		isLoading: false,
-		error: null,
+		loadError: null,
+		refetchError: null,
 		models: [mockGPT5, mockClaude, mockDisabledModel, mockBedrockClaude],
 		providerStates: [
 			MockOpenAIProviderState,
@@ -33,6 +53,7 @@ const meta: Meta<typeof ModelsPageView> = {
 			["prov-anthropic", "anthropic"],
 			["prov-bedrock", "bedrock"],
 		]),
+		canCreateModel: true,
 	},
 	parameters: {
 		// TODO: Stories in this file fail when pixel runs their play functions. Fix them and remove the exclude.
@@ -83,6 +104,28 @@ export const Default: Story = {
 		const menu = await within(document.body).findByRole("menu");
 		await within(menu).findByRole("menuitem", { name: "Anthropic" });
 		await userEvent.keyboard("{Escape}");
+	},
+};
+
+export const CreateOnlyUserCanAdd: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: /add model/i }));
+		const menu = await within(document.body).findByRole("menu");
+		await expect(
+			within(menu).getByRole("menuitem", { name: "OpenAI" }),
+		).toBeInTheDocument();
+	},
+};
+
+export const ReadOnlyUserCannotAdd: Story = {
+	args: { canCreateModel: false },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("GPT-5")).toBeVisible();
+		await expect(
+			canvas.queryByRole("button", { name: /add model/i }),
+		).not.toBeInTheDocument();
 	},
 };
 
@@ -192,8 +235,28 @@ export const Empty: Story = {
 
 export const LoadError: Story = {
 	args: {
-		error: new Error("Failed to load models"),
+		loadError: new Error("Failed to load models"),
 		models: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Failed to load models")).toBeVisible();
+		await expect(
+			canvas.queryByText("No models configured"),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const RefetchError: Story = {
+	args: {
+		refetchError: new Error("Failed to refresh models"),
+		models: [mockGPT5, mockClaude],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Failed to refresh models")).toBeVisible();
+		await expect(canvas.getByText("GPT-5")).toBeVisible();
+		await expect(canvas.getByText("Claude Sonnet 4.5")).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon, PlusIcon, SearchIcon } from "lucide-react";
 import { type FC, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import type { ChatModel } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
@@ -44,6 +44,11 @@ import {
 import { ProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
 import { paginateItems } from "#/utils/paginateItems";
 import { ModelRow } from "./components/ModelRow";
+import {
+	organizationAddModelPath,
+	organizationModelPath,
+	useOrganizationModels,
+} from "./organizationModels";
 
 const MODELS_PAGE_SIZE = 10;
 const ALL_PROVIDERS_VALUE = "all";
@@ -53,6 +58,8 @@ const AddModelDropdown: FC<{
 	align?: "start" | "end";
 }> = ({ providerStates, align = "end" }) => {
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const { organization } = useOrganizationModels();
 	const manageableProviderStates = providerStates.filter(
 		canManageProviderModels,
 	);
@@ -76,13 +83,11 @@ const AddModelDropdown: FC<{
 					manageableProviderStates.map((providerState) => (
 						<DropdownMenuItem
 							key={providerState.key}
-							onSelect={() =>
-								void navigate(
-									`/ai/settings/models/add?provider=${encodeURIComponent(
-										providerState.key,
-									)}`,
-								)
-							}
+							onSelect={() => {
+								const next = new URLSearchParams(searchParams);
+								next.set("provider", providerState.key);
+								void navigate(organizationAddModelPath(organization, next));
+							}}
 						>
 							<ProviderIcon provider={providerState.provider} />
 							<span>{providerState.label}</span>
@@ -96,20 +101,26 @@ const AddModelDropdown: FC<{
 
 interface ModelsPageViewProps {
 	isLoading: boolean;
-	error: unknown;
+	loadError: unknown;
+	refetchError: unknown;
 	models: readonly ChatModel[];
 	providerStates: readonly ProviderState[];
 	providerTypeByID: ReadonlyMap<string, string>;
+	canCreateModel: boolean;
 }
 
 const ModelsPageView: FC<ModelsPageViewProps> = ({
 	isLoading,
-	error,
+	loadError,
+	refetchError,
 	models,
 	providerStates,
 	providerTypeByID,
+	canCreateModel,
 }) => {
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const { organization } = useOrganizationModels();
 	const [page, setPage] = useState(1);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [providerFilter, setProviderFilter] =
@@ -139,7 +150,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 		const map = new Map<string, boolean>();
 		for (const providerState of providerStates) {
 			for (const providerModel of providerState.models) {
-				map.set(providerModel.id, Boolean(providerState.providerConfig));
+				map.set(providerModel.id, true);
 			}
 		}
 		return map;
@@ -149,10 +160,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 		const map = new Map<string, boolean>();
 		for (const providerState of providerStates) {
 			for (const providerModel of providerState.models) {
-				map.set(
-					providerModel.id,
-					providerState.providerConfig?.enabled === true,
-				);
+				map.set(providerModel.id, providerState.providerDescriptor.enabled);
 			}
 		}
 		return map;
@@ -207,7 +215,11 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	return (
 		<div>
 			<SettingsHeader
-				actions={<AddModelDropdown providerStates={providerStates} />}
+				actions={
+					canCreateModel ? (
+						<AddModelDropdown providerStates={providerStates} />
+					) : undefined
+				}
 			>
 				<SettingsHeaderTitle>Models</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
@@ -215,9 +227,9 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 					users to select. You can set a default and adjust context limits.
 				</SettingsHeaderDescription>
 			</SettingsHeader>
-			{Boolean(error) && (
+			{(loadError ?? refetchError) != null && (
 				<div className="mb-4">
-					<ErrorAlert error={error} />
+					<ErrorAlert error={loadError ?? refetchError} />
 				</div>
 			)}
 			<div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -270,15 +282,17 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 				<TableBody size="lg">
 					{isLoading ? (
 						<TableLoader />
-					) : !hasModels ? (
+					) : loadError != null ? null : !hasModels ? (
 						<TableEmpty
 							message="No models configured"
 							description="Configured models will appear here."
 							cta={
-								<AddModelDropdown
-									providerStates={providerStates}
-									align="start"
-								/>
+								canCreateModel ? (
+									<AddModelDropdown
+										providerStates={providerStates}
+										align="start"
+									/>
+								) : undefined
 							}
 						/>
 					) : filteredModels.length === 0 ? (
@@ -297,7 +311,11 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 								providerEnabled={
 									providerEnabledByModelId.get(model.id) ?? false
 								}
-								onClick={() => void navigate(`/ai/settings/models/${model.id}`)}
+								onClick={() =>
+									void navigate(
+										organizationModelPath(organization, model.id, searchParams),
+									)
+								}
 							/>
 						))
 					)}

--- a/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.stories.tsx
@@ -1,0 +1,333 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLocation } from "react-router";
+import {
+	expect,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import { chatModelAvailability, chatModels } from "#/api/queries/chats";
+import { organizationsPermissions } from "#/api/queries/organizations";
+import {
+	MockDefaultOrganization,
+	MockOrganization2,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import AddModelPage from "./AddModelPage/AddModelPage";
+import OrganizationModelsLayout from "./OrganizationModelsLayout";
+
+const LocationProbe = () => {
+	const location = useLocation();
+	return (
+		<div data-testid="location-probe">
+			{location.pathname}
+			{location.search}
+		</div>
+	);
+};
+
+const meta: Meta<typeof OrganizationModelsLayout> = {
+	title: "pages/AISettingsPage/OrganizationModelsLayout",
+	component: OrganizationModelsLayout,
+	decorators: [withDashboardProvider],
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/models",
+				searchParams: { org: MockDefaultOrganization.name },
+			},
+			routing: [{ path: "*", useStoryElement: true }],
+		}),
+		queries: [
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: chatModels(MockOrganization2.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+				},
+			},
+			{
+				key: organizationsPermissions([MockOrganization2.id]).queryKey,
+				data: { [MockOrganization2.id]: MockOrganizationPermissions },
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OrganizationModelsLayout>;
+
+export const SwitchOrganizationPreservesAuxiliaryParameters: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/models/add",
+				searchParams: {
+					org: MockDefaultOrganization.name,
+					provider: "openai",
+					duplicate: "model-id",
+				},
+			},
+			routing: [{ path: "*", useStoryElement: true }],
+		}),
+	},
+	render: () => (
+		<>
+			<OrganizationModelsLayout />
+			<LocationProbe />
+		</>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByRole("button", {
+				name: new RegExp(MockDefaultOrganization.display_name, "i"),
+			}),
+		);
+		await userEvent.click(
+			await screen.findByRole("option", {
+				name: new RegExp(MockOrganization2.display_name),
+			}),
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe")).toHaveTextContent(
+				`/ai/settings/models/add?org=${MockOrganization2.name}&provider=openai&duplicate=model-id`,
+			);
+		});
+	},
+};
+
+export const InvalidRequestedOrganizationFallsBackToDefault: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/models",
+				searchParams: { org: "missing" },
+			},
+			routing: [{ path: "*", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByRole("button", {
+				name: new RegExp(MockDefaultOrganization.display_name, "i"),
+			}),
+		).toBeVisible();
+	},
+};
+
+export const InvalidRequestedOrganizationDeniesAdd: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "createChatModel");
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/models/add",
+				searchParams: { org: "missing" },
+			},
+			routing: [
+				{
+					path: "/ai/settings/models",
+					useStoryElement: true,
+					children: [{ path: "add", element: <AddModelPage /> }],
+				},
+			],
+		}),
+		queries: [
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: chatModels(MockOrganization2.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: chatModelAvailability(MockDefaultOrganization.id).queryKey,
+				data: { providers: [], unsupported_providers: [] },
+			},
+			{
+				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+				},
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await waitFor(() =>
+			expect(
+				body.getByRole("heading", {
+					name: "You don't have permission to view this page",
+				}),
+			).toBeVisible(),
+		);
+		expect(
+			body.queryByRole("heading", { name: /add an? .* model/i }),
+		).not.toBeInTheDocument();
+		expect(API.experimental.createChatModel).not.toHaveBeenCalled();
+	},
+};
+
+export const SingleAccessibleOrganizationHidesPicker: Story = {
+	parameters: {
+		organizations: [MockDefaultOrganization],
+		queries: [
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+				},
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() =>
+			expect(canvas.queryByTestId("organization-autocomplete")).toBeNull(),
+		);
+	},
+};
+
+const duplicateNameOrganization = {
+	...MockOrganization2,
+	display_name: MockDefaultOrganization.display_name,
+};
+
+export const DuplicateDisplayNamesAreDisambiguated: Story = {
+	parameters: {
+		organizations: [MockDefaultOrganization, duplicateNameOrganization],
+		queries: [
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: chatModels(duplicateNameOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
+				data: {
+					[MockDefaultOrganization.id]: MockOrganizationPermissions,
+				},
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByRole("button", {
+				name: new RegExp(MockDefaultOrganization.name),
+			}),
+		);
+		expect(
+			await screen.findByRole("option", {
+				name: new RegExp(duplicateNameOrganization.name),
+			}),
+		).toHaveTextContent(duplicateNameOrganization.name);
+	},
+};
+
+export const PermissionLoadingShowsLoader: Story = {
+	beforeEach: () => {
+		spyOn(API, "checkAuthorization").mockReturnValue(
+			new Promise(() => undefined),
+		);
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: chatModels(MockOrganization2.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByRole("status")).toBeVisible();
+		expect(
+			canvas.queryByText("You don't have permission to view this page"),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const PermissionLoadErrorShowsAlert: Story = {
+	beforeEach: () => {
+		spyOn(API, "checkAuthorization").mockRejectedValue(
+			new Error("Failed to load organization permissions"),
+		);
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+			{
+				key: chatModels(MockOrganization2.id).queryKey,
+				data: { models: [], providers: [] },
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("Failed to load organization permissions"),
+		).toBeVisible();
+	},
+};
+
+export const Loading: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatModels").mockImplementation(
+			() => new Promise(() => undefined),
+		);
+	},
+	parameters: { queries: [] },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByRole("status")).toBeVisible();
+	},
+};
+
+export const NoReadableOrganizationIsNotFound: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatModels").mockRejectedValue({
+			isAxiosError: true,
+			response: { status: 403 },
+		});
+	},
+	parameters: { queries: [] },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("This page could not be found."),
+		).toBeVisible();
+	},
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/OrganizationModelsLayout.tsx
@@ -1,0 +1,123 @@
+import type { FC } from "react";
+import { useQuery } from "react-query";
+import {
+	Outlet,
+	useLocation,
+	useNavigate,
+	useSearchParams,
+} from "react-router";
+import { organizationsPermissions } from "#/api/queries/organizations";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Loader } from "#/components/Loader/Loader";
+import {
+	getOrganizationLabel,
+	OrganizationAutocomplete,
+} from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import NotFoundPage from "#/pages/NotFoundPage/NotFoundPage";
+import {
+	modelOrganizationSearchParam,
+	OrganizationModelsContext,
+	selectModelOrganization,
+	useAccessibleModelOrganizations,
+} from "./organizationModels";
+
+const OrganizationModelsLayout: FC = () => {
+	const { organizations } = useDashboard();
+	const location = useLocation();
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const accessibleOrganizationsQuery =
+		useAccessibleModelOrganizations(organizations);
+	const accessibleOrganizations = accessibleOrganizationsQuery.organizations;
+	const organizationSelection = selectModelOrganization(
+		accessibleOrganizations,
+		searchParams.get(modelOrganizationSearchParam),
+	);
+	const activeOrganization = organizationSelection.organization;
+	const permissionsQuery = useQuery({
+		...organizationsPermissions(
+			activeOrganization ? [activeOrganization.id] : undefined,
+		),
+		enabled: activeOrganization !== undefined,
+	});
+	const activePermissions = activeOrganization
+		? permissionsQuery.data?.[activeOrganization.id]
+		: undefined;
+
+	if (accessibleOrganizationsQuery.error) {
+		return <ErrorAlert error={accessibleOrganizationsQuery.error} />;
+	}
+
+	if (accessibleOrganizationsQuery.isLoading) {
+		return <Loader />;
+	}
+
+	if (!activeOrganization) {
+		return <NotFoundPage />;
+	}
+
+	if (permissionsQuery.data === undefined && permissionsQuery.error) {
+		return <ErrorAlert error={permissionsQuery.error} />;
+	}
+
+	if (permissionsQuery.data === undefined) {
+		return <Loader />;
+	}
+
+	if (!activePermissions) {
+		return <NotFoundPage />;
+	}
+
+	return (
+		<OrganizationModelsContext.Provider
+			value={{
+				organization: activeOrganization,
+				organizations: accessibleOrganizations,
+				permissions: activePermissions,
+				requestedOrganizationDenied:
+					organizationSelection.requestedOrganizationDenied,
+			}}
+		>
+			<div className="flex flex-col gap-6">
+				{(accessibleOrganizationsQuery.partialError ??
+					permissionsQuery.error) != null && (
+					<div>
+						<ErrorAlert
+							error={
+								accessibleOrganizationsQuery.partialError ??
+								permissionsQuery.error
+							}
+						/>
+					</div>
+				)}
+				{accessibleOrganizations.length > 1 && (
+					<div>
+						<OrganizationAutocomplete
+							value={activeOrganization}
+							ariaLabel={`Organization ${getOrganizationLabel(
+								activeOrganization,
+								accessibleOrganizations,
+							)}`}
+							options={accessibleOrganizations}
+							triggerClassName="w-60"
+							optionsTabbable
+							onChange={(organization) => {
+								if (!organization) {
+									return;
+								}
+								const next = new URLSearchParams(searchParams);
+								next.set(modelOrganizationSearchParam, organization.name);
+								const pathname = location.pathname.split("?", 1)[0];
+								void navigate(`${pathname}?${next.toString()}`);
+							}}
+						/>
+					</div>
+				)}
+				<Outlet />
+			</div>
+		</OrganizationModelsContext.Provider>
+	);
+};
+
+export default OrganizationModelsLayout;

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
@@ -1,52 +1,57 @@
-import { type FC, useMemo, useState } from "react";
+import { isAxiosError } from "axios";
+import { type FC, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
-import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import {
+	chatModel,
 	chatModelAvailability,
 	chatModels,
 	deleteChatModel,
 	updateChatModel,
 } from "#/api/queries/chats";
 import { Loader } from "#/components/Loader/Loader";
-import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { deriveProviderStates } from "#/modules/aiModels/providerStates";
-import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
+import {
+	organizationAddModelPath,
+	splitModelQueryErrors,
+	useOrganizationModels,
+	useOrganizationModelsPath,
+} from "../organizationModels";
 import UpdateModelPageView from "./UpdateModelPageView";
 
 const UpdateModelPage: FC = () => {
-	const { permissions } = useAuthenticated();
 	const { modelId } = useParams<{ modelId: string }>();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const { organization, permissions } = useOrganizationModels();
+	const modelsPath = useOrganizationModelsPath();
 
-	const providerConfigsQuery = useQuery(chatProviderConfigs());
-	const modelsQuery = useQuery(chatModels());
-	const modelCatalogQuery = useQuery(chatModelAvailability());
-
+	const modelQuery = useQuery(chatModel(organization.id, modelId ?? ""));
+	const organizationModelsQuery = useQuery(chatModels(organization.id));
+	const availableModelsQuery = useQuery(chatModelAvailability(organization.id));
 	const updateMutation = useMutation(updateChatModel(queryClient));
 	const deleteMutation = useMutation(deleteChatModel(queryClient));
-
-	const providerStates = useMemo(
-		() =>
-			deriveProviderStates(
-				modelsQuery.data ?? [],
-				providerConfigsQuery.data,
-				modelCatalogQuery.data,
-			),
-		[modelsQuery.data, providerConfigsQuery.data, modelCatalogQuery.data],
+	const models = organizationModelsQuery.data?.models ?? [];
+	const providerStates = deriveProviderStates(
+		models,
+		organizationModelsQuery.data?.providers ?? [],
+		availableModelsQuery.data,
 	);
-
 	const isLoading =
-		providerConfigsQuery.isLoading ||
-		modelsQuery.isLoading ||
-		modelCatalogQuery.isLoading;
+		modelQuery.isLoading ||
+		organizationModelsQuery.isLoading ||
+		availableModelsQuery.isLoading;
+	const { loadError, refetchError } = splitModelQueryErrors(
+		modelQuery,
+		organizationModelsQuery,
+		availableModelsQuery,
+	);
+	const model = modelQuery.data;
+	const currentDefaultModel = models.find((model) => model.is_default);
 
-	const model = modelsQuery.data?.find((m) => m.id === modelId);
-	const currentDefaultModel = modelsQuery.data?.find((m) => m.is_default);
 	const [providerKeyOverride, setProviderKeyOverride] = useState<string | null>(
 		null,
 	);
@@ -57,81 +62,114 @@ const UpdateModelPage: FC = () => {
 		providerStates.find((ps) => ps.models.some((m) => m.id === modelId)) ??
 		null;
 
+	if (!modelId) {
+		return <Navigate to={modelsPath} replace />;
+	}
+
+	if (isLoading) {
+		return (
+			<>
+				<title>{pageTitle("Loading...", "AI Settings")}</title>
+				<Loader fullscreen />
+			</>
+		);
+	}
+
+	if (
+		modelQuery.error &&
+		isAxiosError(modelQuery.error) &&
+		(modelQuery.error.response?.status === 403 ||
+			modelQuery.error.response?.status === 404)
+	) {
+		return <UpdateModelPageView state="notFound" />;
+	}
+
+	if (loadError) {
+		return <UpdateModelPageView state="error" error={loadError} />;
+	}
+
+	if (!model) {
+		return <UpdateModelPageView state="notFound" />;
+	}
+
 	return (
-		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
-			{!modelId ? (
-				<Navigate to="/ai/settings/models" replace />
-			) : isLoading ? (
-				<>
-					<title>{pageTitle("Loading...", "AI Settings")}</title>
-					<Loader fullscreen />
-				</>
-			) : !model ? (
-				<Navigate to="/ai/settings/models" replace />
-			) : (
-				<UpdateModelPageView
-					model={model}
-					currentDefaultModel={currentDefaultModel}
-					providerStates={providerStates}
-					selectedProviderState={selectedProviderState}
-					onProviderChange={setProviderKeyOverride}
-					isSaving={updateMutation.isPending}
-					isDeleting={deleteMutation.isPending}
-					onUpdateModel={async (id, req) => {
-						try {
-							const updated = await updateMutation.mutateAsync({
-								modelId: id,
-								req,
-							});
+		<UpdateModelPageView
+			state="loaded"
+			model={model}
+			refetchError={refetchError}
+			currentDefaultModel={currentDefaultModel}
+			providerStates={providerStates}
+			selectedProviderState={selectedProviderState}
+			onProviderChange={setProviderKeyOverride}
+			isSaving={updateMutation.isPending}
+			isDeleting={deleteMutation.isPending}
+			canCreateModel={permissions?.createChatModelConfigs ?? false}
+			canUpdateModel={permissions?.editChatModelConfigs ?? false}
+			canShareModel={permissions?.shareChatModelConfigs ?? false}
+			canDeleteModel={permissions?.deleteChatModelConfigs ?? false}
+			onUpdateModel={async (id, req) => {
+				try {
+					const updated = await updateMutation.mutateAsync({
+						organizationId: organization.id,
+						modelId: id,
+						req,
+					});
+					toast.success(
+						`Model "${updated.display_name || updated.model}" updated.`,
+					);
+					await navigate(modelsPath);
+				} catch (error) {
+					toast.error(getErrorMessage(error, "Failed to update model."));
+				}
+			}}
+			onDeleteModel={async (id) => {
+				try {
+					await deleteMutation.mutateAsync({
+						organizationId: organization.id,
+						modelId: id,
+					});
+					toast.success(
+						`Model "${model.display_name || model.model}" deleted.`,
+					);
+					await navigate(modelsPath, { replace: true });
+				} catch (error) {
+					toast.error(getErrorMessage(error, "Failed to delete model."));
+				}
+			}}
+			onDuplicate={() => {
+				if (!selectedProviderState) return;
+				void navigate(
+					organizationAddModelPath(
+						organization,
+						new URLSearchParams({
+							provider: selectedProviderState.key,
+							duplicate: model.id,
+						}),
+					),
+				);
+			}}
+			onToggleEnabled={(enabled) => {
+				updateMutation.mutate(
+					{
+						organizationId: organization.id,
+						modelId: model.id,
+						req: { enabled },
+					},
+					{
+						onSuccess: () => {
 							toast.success(
-								`Model "${updated.display_name || updated.model}" updated.`,
+								`Model "${model.display_name || model.model}" ${
+									enabled ? "enabled" : "disabled"
+								}.`,
 							);
-							await navigate("/ai/settings/models");
-						} catch (error) {
+						},
+						onError: (error) => {
 							toast.error(getErrorMessage(error, "Failed to update model."));
-						}
-					}}
-					onDeleteModel={async (id) => {
-						try {
-							await deleteMutation.mutateAsync(id);
-							toast.success(
-								`Model "${model.display_name || model.model}" deleted.`,
-							);
-							await navigate("/ai/settings/models", { replace: true });
-						} catch (error) {
-							toast.error(getErrorMessage(error, "Failed to delete model."));
-						}
-					}}
-					onDuplicate={() => {
-						if (!selectedProviderState) return;
-						void navigate(
-							`/ai/settings/models/add?provider=${encodeURIComponent(
-								selectedProviderState.key,
-							)}&duplicate=${encodeURIComponent(model.id)}`,
-						);
-					}}
-					onToggleEnabled={(enabled) => {
-						updateMutation.mutate(
-							{ modelId: model.id, req: { enabled } },
-							{
-								onSuccess: () => {
-									toast.success(
-										`Model "${model.display_name || model.model}" ${
-											enabled ? "enabled" : "disabled"
-										}.`,
-									);
-								},
-								onError: (error) => {
-									toast.error(
-										getErrorMessage(error, "Failed to update model."),
-									);
-								},
-							},
-						);
-					}}
-				/>
-			)}
-		</RequirePermission>
+						},
+					},
+				);
+			}}
+		/>
 	);
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPage.tsx
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import {
 	chatModel,
-	chatModelAvailability,
 	chatModels,
 	deleteChatModel,
 	updateChatModel,
@@ -31,23 +30,16 @@ const UpdateModelPage: FC = () => {
 
 	const modelQuery = useQuery(chatModel(organization.id, modelId ?? ""));
 	const organizationModelsQuery = useQuery(chatModels(organization.id));
-	const availableModelsQuery = useQuery(chatModelAvailability(organization.id));
 	const updateMutation = useMutation(updateChatModel(queryClient));
 	const deleteMutation = useMutation(deleteChatModel(queryClient));
 	const models = organizationModelsQuery.data?.models ?? [];
 	const providerStates = deriveProviderStates(
 		models,
 		organizationModelsQuery.data?.providers ?? [],
-		availableModelsQuery.data,
 	);
-	const isLoading =
-		modelQuery.isLoading ||
-		organizationModelsQuery.isLoading ||
-		availableModelsQuery.isLoading;
 	const { loadError, refetchError } = splitModelQueryErrors(
 		modelQuery,
 		organizationModelsQuery,
-		availableModelsQuery,
 	);
 	const model = modelQuery.data;
 	const currentDefaultModel = models.find((model) => model.is_default);
@@ -66,7 +58,7 @@ const UpdateModelPage: FC = () => {
 		return <Navigate to={modelsPath} replace />;
 	}
 
-	if (isLoading) {
+	if (modelQuery.isLoading || organizationModelsQuery.isLoading) {
 		return (
 			<>
 				<title>{pageTitle("Loading...", "AI Settings")}</title>

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.stories.tsx
@@ -1,24 +1,65 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { useLocation } from "react-router";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import {
+	chatModel,
+	chatModelAvailability,
+	chatModels,
+} from "#/api/queries/chats";
+import {
+	MockDefaultOrganization,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
 import { withToaster } from "#/testHelpers/storybook";
+import { OrganizationModelsContext } from "../organizationModels";
 import {
 	MockAnthropicProviderState,
 	MockOpenAIProviderState,
 	mockGPT5,
 } from "../testFixtures";
+import UpdateModelPage from "./UpdateModelPage";
 import UpdateModelPageView from "./UpdateModelPageView";
+
+const LocationProbe = () => {
+	const location = useLocation();
+	return (
+		<span role="status" aria-label="Current location">
+			{location.pathname}
+			{location.search}
+		</span>
+	);
+};
 
 const meta: Meta<typeof UpdateModelPageView> = {
 	title: "pages/AISettingsPage/ModelsPage/UpdateModelPageView",
 	component: UpdateModelPageView,
-	decorators: [withToaster],
+	decorators: [
+		(Story) => (
+			<OrganizationModelsContext.Provider
+				value={{
+					organization: MockDefaultOrganization,
+					organizations: [MockDefaultOrganization],
+					permissions: MockOrganizationPermissions,
+					requestedOrganizationDenied: false,
+				}}
+			>
+				<Story />
+			</OrganizationModelsContext.Provider>
+		),
+		withToaster,
+	],
 	args: {
+		state: "loaded",
 		model: mockGPT5,
 		providerStates: [MockOpenAIProviderState, MockAnthropicProviderState],
 		selectedProviderState: MockOpenAIProviderState,
 		onProviderChange: fn(),
 		isSaving: false,
 		isDeleting: false,
+		canCreateModel: true,
+		canUpdateModel: true,
+		canDeleteModel: true,
 		onUpdateModel: fn(async () => undefined),
 		onDeleteModel: fn(async () => undefined),
 		onDuplicate: fn(),
@@ -36,5 +77,207 @@ export const Default: Story = {
 			canvas.getByRole("button", { name: /^update model$/i }),
 		).toBeVisible();
 		await expect(canvas.getByLabelText(/model identifier/i)).toBeEnabled();
+	},
+};
+
+export const CreateOnlyUser: Story = {
+	args: {
+		canCreateModel: true,
+		canUpdateModel: false,
+		canDeleteModel: false,
+	},
+	play: async ({ canvasElement, args }) => {
+		if (args.state !== "loaded") {
+			throw new Error("Expected the loaded model state.");
+		}
+		const canvas = within(canvasElement);
+		await expect(canvas.getByLabelText(/model identifier/i)).toBeDisabled();
+		await expect(
+			canvas.queryByRole("button", { name: /^update model$/i }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("switch", { name: /model enabled/i }),
+		).not.toBeInTheDocument();
+		await userEvent.click(
+			canvas.getByRole("button", { name: /model actions/i }),
+		);
+		const menu = await screen.findByRole("menu");
+		await expect(
+			within(menu).queryByRole("menuitem", { name: /delete/i }),
+		).not.toBeInTheDocument();
+		await userEvent.click(
+			within(menu).getByRole("menuitem", { name: /duplicate model/i }),
+		);
+		await expect(args.onDuplicate).toHaveBeenCalledTimes(1);
+	},
+};
+
+export const UpdateOnlyUser: Story = {
+	args: {
+		model: { ...mockGPT5, is_default: false },
+		canCreateModel: false,
+		canUpdateModel: true,
+		canDeleteModel: false,
+	},
+	play: async ({ canvasElement, args }) => {
+		if (args.state !== "loaded") {
+			throw new Error("Expected the loaded model state.");
+		}
+		const canvas = within(canvasElement);
+		await expect(canvas.getByLabelText(/model identifier/i)).toBeEnabled();
+		await userEvent.click(
+			canvas.getByRole("switch", { name: /model enabled/i }),
+		);
+		await expect(args.onToggleEnabled).toHaveBeenCalledTimes(1);
+		await userEvent.clear(canvas.getByLabelText(/display name/i));
+		await userEvent.type(
+			canvas.getByLabelText(/display name/i),
+			"Updated model",
+		);
+		await userEvent.click(
+			canvas.getByRole("button", { name: /^update model$/i }),
+		);
+		await expect(args.onUpdateModel).toHaveBeenCalledTimes(1);
+		await expect(
+			canvas.queryByRole("button", { name: /model actions/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const DeleteOnlyUser: Story = {
+	args: {
+		canCreateModel: false,
+		canUpdateModel: false,
+		canDeleteModel: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByLabelText(/model identifier/i)).toBeDisabled();
+		await userEvent.click(
+			canvas.getByRole("button", { name: /model actions/i }),
+		);
+		const menu = await screen.findByRole("menu");
+		await expect(
+			within(menu).queryByRole("menuitem", { name: /duplicate model/i }),
+		).not.toBeInTheDocument();
+		await userEvent.click(
+			within(menu).getByRole("menuitem", { name: /delete/i }),
+		);
+		await expect(await screen.findByRole("dialog")).toHaveAttribute(
+			"data-state",
+			"open",
+		);
+	},
+};
+
+export const ReadOnlyUser: Story = {
+	args: {
+		canCreateModel: false,
+		canUpdateModel: false,
+		canDeleteModel: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByLabelText(/model identifier/i)).toBeDisabled();
+		await expect(
+			canvas.queryByRole("button", { name: /^update model$/i }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("switch", { name: /model enabled/i }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("button", { name: /model actions/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const DuplicateNavigatesToStructuralAddPath: Story = {
+	render: () => (
+		<>
+			<UpdateModelPage />
+			<LocationProbe />
+		</>
+	),
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/models/:modelId",
+				pathParams: { modelId: mockGPT5.id },
+				searchParams: { org: MockDefaultOrganization.name },
+			},
+			routing: [
+				{
+					path: "/ai/settings/models/:modelId",
+					useStoryElement: true,
+				},
+				{ path: "/ai/settings/models/add", element: <LocationProbe /> },
+			],
+		}),
+		queries: [
+			{
+				key: chatModel(MockDefaultOrganization.id, mockGPT5.id).queryKey,
+				data: mockGPT5,
+			},
+			{
+				key: chatModels(MockDefaultOrganization.id).queryKey,
+				data: {
+					models: [mockGPT5],
+					providers: [MockOpenAIProviderState.providerDescriptor],
+				},
+			},
+			{
+				key: chatModelAvailability(MockDefaultOrganization.id).queryKey,
+				data: { providers: [], unsupported_providers: [] },
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByRole("button", { name: /model actions/i }),
+		);
+		await userEvent.click(
+			await screen.findByRole("menuitem", { name: /duplicate model/i }),
+		);
+
+		await waitFor(() =>
+			expect(
+				canvas.getByRole("status", { name: "Current location" }),
+			).toHaveTextContent(
+				`/ai/settings/models/add?provider=${MockOpenAIProviderState.key}&duplicate=${mockGPT5.id}&org=${MockDefaultOrganization.name}`,
+			),
+		);
+	},
+};
+
+export const RefetchError: Story = {
+	args: { refetchError: new Error("Failed to refresh model") },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Failed to refresh model")).toBeVisible();
+		expect(canvas.getByLabelText(/model identifier/i)).toBeEnabled();
+	},
+};
+
+export const LoadError: Story = {
+	render: () => (
+		<UpdateModelPageView
+			state="error"
+			error={new Error("Failed to load model")}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Failed to load model")).toBeVisible();
+	},
+};
+
+export const ModelNotFound: Story = {
+	render: () => <UpdateModelPageView state="notFound" />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("This page could not be found."),
+		).toBeVisible();
 	},
 };

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.tsx
@@ -1,44 +1,76 @@
 import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import type { ProviderState } from "#/modules/aiModels/providerStates";
+import NotFoundPage from "#/pages/NotFoundPage/NotFoundPage";
 import { pageTitle } from "#/utils/page";
 import { ModelForm } from "../components/ModelForm";
+import { ModelFormBackLink } from "../components/ModelFormHeader";
 
-interface UpdateModelPageViewProps {
-	model: TypesGen.ChatModel;
-	currentDefaultModel?: TypesGen.ChatModel;
-	providerStates: readonly ProviderState[];
-	selectedProviderState: ProviderState | null;
-	onProviderChange: (providerKey: string) => void;
-	isSaving: boolean;
-	isDeleting: boolean;
-	onUpdateModel: (
-		modelId: string,
-		req: TypesGen.UpdateChatModelRequest,
-	) => Promise<unknown>;
-	onDeleteModel: (modelId: string) => Promise<void>;
-	onDuplicate: () => void;
-	onToggleEnabled: (enabled: boolean) => void;
-}
+type UpdateModelPageViewProps =
+	| { state: "error"; error: unknown }
+	| { state: "notFound" }
+	| {
+			state: "loaded";
+			model: TypesGen.ChatModel;
+			refetchError?: unknown;
+			currentDefaultModel?: TypesGen.ChatModel;
+			providerStates: readonly ProviderState[];
+			selectedProviderState: ProviderState | null;
+			onProviderChange: (providerKey: string) => void;
+			isSaving: boolean;
+			isDeleting: boolean;
+			canCreateModel: boolean;
+			canUpdateModel: boolean;
+			canDeleteModel: boolean;
+			canShareModel: boolean;
+			onUpdateModel: (
+				modelId: string,
+				req: TypesGen.UpdateChatModelRequest,
+			) => Promise<unknown>;
+			onDeleteModel: (modelId: string) => Promise<void>;
+			onDuplicate: () => void;
+			onToggleEnabled: (enabled: boolean) => void;
+	  };
 
-const UpdateModelPageView: FC<UpdateModelPageViewProps> = ({
-	model,
-	currentDefaultModel,
-	providerStates,
-	selectedProviderState,
-	onProviderChange,
-	isSaving,
-	isDeleting,
-	onUpdateModel,
-	onDeleteModel,
-	onDuplicate,
-	onToggleEnabled,
-}) => {
+const UpdateModelPageView: FC<UpdateModelPageViewProps> = (props) => {
+	if (props.state === "error") {
+		return (
+			<div className="flex flex-col items-start gap-4">
+				<ModelFormBackLink />
+				<ErrorAlert error={props.error} />
+			</div>
+		);
+	}
+
+	if (props.state === "notFound") {
+		return <NotFoundPage />;
+	}
+
+	const {
+		model,
+		refetchError,
+		currentDefaultModel,
+		providerStates,
+		selectedProviderState,
+		onProviderChange,
+		isSaving,
+		isDeleting,
+		canCreateModel,
+		canUpdateModel,
+		canDeleteModel,
+		canShareModel,
+		onUpdateModel,
+		onDeleteModel,
+		onDuplicate,
+		onToggleEnabled,
+	} = props;
 	return (
 		<>
 			<title>
 				{pageTitle(model.display_name || model.model, "AI Settings")}
 			</title>
+			{refetchError != null && <ErrorAlert error={refetchError} />}
 			<ModelForm
 				key={model.id}
 				editingModel={model}
@@ -48,11 +80,13 @@ const UpdateModelPageView: FC<UpdateModelPageViewProps> = ({
 				onProviderChange={onProviderChange}
 				isSaving={isSaving}
 				isDeleting={isDeleting}
+				canUpdateModel={canUpdateModel}
+				canShareModel={canShareModel}
 				onCreateModel={async () => {}}
 				onUpdateModel={onUpdateModel}
-				onDeleteModel={onDeleteModel}
-				onDuplicate={onDuplicate}
-				onToggleEnabled={onToggleEnabled}
+				onDeleteModel={canDeleteModel ? onDeleteModel : undefined}
+				onDuplicate={canCreateModel ? onDuplicate : undefined}
+				onToggleEnabled={canUpdateModel ? onToggleEnabled : undefined}
 			/>
 		</>
 	);

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ChatModelSharingDialog.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ChatModelSharingDialog.stories.tsx
@@ -1,0 +1,366 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { API } from "#/api/api";
+import {
+	MockDefaultOrganization,
+	MockGroup,
+	MockGroup2,
+	MockOrganizationMember,
+	MockOrganizationMember2,
+} from "#/testHelpers/entities";
+import { withDashboardProvider, withToaster } from "#/testHelpers/storybook";
+import { mockGPT5 } from "../testFixtures";
+import { ChatModelSharingDialog } from "./ChatModelSharingDialog";
+
+type MockACL = {
+	user_roles: Record<string, "read">;
+	group_roles: Record<string, "read">;
+};
+
+const emptyACL: MockACL = { user_roles: {}, group_roles: {} };
+const populatedACL: MockACL = {
+	user_roles: { [MockOrganizationMember2.user_id]: "read" as const },
+	group_roles: { [MockGroup.id]: "read" as const },
+};
+
+const mockPrincipalRequests = () => {
+	spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+		members: [MockOrganizationMember, MockOrganizationMember2],
+		count: 2,
+	});
+	spyOn(API, "getGroupsByOrganization").mockResolvedValue([
+		MockGroup,
+		MockGroup2,
+	]);
+};
+
+const mockRequests = ({
+	acl = emptyACL,
+	aclError,
+	aclPending = false,
+	updateError,
+}: {
+	acl?: MockACL;
+	aclError?: Error;
+	aclPending?: boolean;
+	updateError?: Error;
+} = {}) => {
+	mockPrincipalRequests();
+	if (aclPending) {
+		spyOn(API.experimental, "getChatModelACL").mockReturnValue(
+			new Promise(() => undefined),
+		);
+	} else if (aclError) {
+		spyOn(API.experimental, "getChatModelACL").mockRejectedValue(aclError);
+	} else {
+		spyOn(API.experimental, "getChatModelACL").mockResolvedValue(acl);
+	}
+	if (updateError) {
+		spyOn(API.experimental, "updateChatModelACL").mockRejectedValue(
+			updateError,
+		);
+	} else {
+		spyOn(API.experimental, "updateChatModelACL").mockResolvedValue();
+	}
+};
+
+const addAutocompleteOption = async (
+	body: ReturnType<typeof within>,
+	query: string,
+	option: string | RegExp,
+) => {
+	await userEvent.click(
+		await body.findByRole("button", { name: "Search for user or group" }),
+	);
+	await userEvent.type(
+		body.getByPlaceholderText("Search for user or group"),
+		query,
+	);
+	await userEvent.click(await body.findByRole("option", { name: option }));
+	await userEvent.click(body.getByRole("button", { name: "Add member" }));
+};
+
+const refreshedACL: MockACL = {
+	user_roles: { [MockOrganizationMember.user_id]: "read" },
+	group_roles: { [MockGroup2.id]: "read" },
+};
+let currentServerACL = populatedACL;
+
+const ReopenableSharingDialog = () => {
+	const [open, setOpen] = useState(true);
+	return (
+		<>
+			<button type="button" onClick={() => setOpen(true)}>
+				Open sharing
+			</button>
+			<ChatModelSharingDialog
+				open={open}
+				onOpenChange={setOpen}
+				organizationId={MockDefaultOrganization.id}
+				modelId={mockGPT5.id}
+				modelName={mockGPT5.display_name}
+			/>
+		</>
+	);
+};
+
+const meta: Meta<typeof ChatModelSharingDialog> = {
+	title: "pages/AISettingsPage/ModelsPage/ChatModelSharingDialog",
+	component: ChatModelSharingDialog,
+	decorators: [withDashboardProvider, withToaster],
+	args: {
+		open: true,
+		onOpenChange: fn(),
+		organizationId: MockDefaultOrganization.id,
+		modelId: mockGPT5.id,
+		modelName: mockGPT5.display_name,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatModelSharingDialog>;
+
+export const EmptyACL: Story = {
+	beforeEach: () => mockRequests(),
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		expect(
+			await body.findByText("No shared members or groups yet"),
+		).toBeInTheDocument();
+		expect(body.getByRole("button", { name: "Save sharing" })).toBeDisabled();
+	},
+};
+
+export const Loading: Story = {
+	beforeEach: () => mockRequests({ aclPending: true }),
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		expect(await body.findByRole("status")).toHaveTextContent(
+			"Loading model sharing",
+		);
+	},
+};
+
+export const LoadError: Story = {
+	beforeEach: () => mockRequests({ aclError: new Error("Unable to load ACL") }),
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		expect(await body.findByText("Unable to load ACL")).toBeInTheDocument();
+		expect(body.getByRole("button", { name: "Save sharing" })).toBeDisabled();
+	},
+};
+
+export const AddUser: Story = {
+	beforeEach: () => mockRequests(),
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await addAutocompleteOption(
+			body,
+			MockOrganizationMember2.email,
+			new RegExp(MockOrganizationMember2.email, "i"),
+		);
+
+		expect(
+			body.getByRole("row", {
+				name: new RegExp(MockOrganizationMember2.username, "i"),
+			}),
+		).toBeVisible();
+		const saveButton = body.getByRole("button", { name: "Save sharing" });
+		expect(saveButton).toBeEnabled();
+		await userEvent.click(saveButton);
+
+		await waitFor(() =>
+			expect(API.experimental.updateChatModelACL).toHaveBeenCalledTimes(1),
+		);
+		expect(API.experimental.updateChatModelACL).toHaveBeenCalledWith(
+			MockDefaultOrganization.id,
+			mockGPT5.id,
+			{ user_roles: { [MockOrganizationMember2.user_id]: "read" } },
+		);
+		expect(args.onOpenChange).toHaveBeenCalledWith(false);
+	},
+};
+
+export const AddGroup: Story = {
+	beforeEach: () => mockRequests(),
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await addAutocompleteOption(
+			body,
+			MockGroup2.name,
+			new RegExp(MockGroup2.display_name || MockGroup2.name, "i"),
+		);
+
+		expect(
+			body.getByRole("row", {
+				name: new RegExp(MockGroup2.display_name || MockGroup2.name, "i"),
+			}),
+		).toBeVisible();
+		const saveButton = body.getByRole("button", { name: "Save sharing" });
+		expect(saveButton).toBeEnabled();
+		await userEvent.click(saveButton);
+
+		await waitFor(() =>
+			expect(API.experimental.updateChatModelACL).toHaveBeenCalledTimes(1),
+		);
+		expect(API.experimental.updateChatModelACL).toHaveBeenCalledWith(
+			MockDefaultOrganization.id,
+			mockGPT5.id,
+			{ group_roles: { [MockGroup2.id]: "read" } },
+		);
+		expect(args.onOpenChange).toHaveBeenCalledWith(false);
+	},
+};
+
+export const SelectedPrincipalsExcludedFromAutocomplete: Story = {
+	beforeEach: () => mockRequests({ acl: populatedACL }),
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("button", {
+				name: "Search for user or group",
+			}),
+		);
+
+		expect(
+			body.queryByRole("option", {
+				name: new RegExp(MockOrganizationMember2.email, "i"),
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			body.queryByRole("option", {
+				name: new RegExp(MockGroup.display_name || MockGroup.name, "i"),
+			}),
+		).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(
+				body.getByRole("option", {
+					name: new RegExp(MockOrganizationMember.email, "i"),
+				}),
+			).toBeVisible();
+			expect(
+				body.getByRole("option", {
+					name: new RegExp(MockGroup2.display_name || MockGroup2.name, "i"),
+				}),
+			).toBeVisible();
+		});
+	},
+};
+
+export const SaveRemovalsAsSparseDelta: Story = {
+	beforeEach: () => mockRequests({ acl: populatedACL }),
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("button", {
+				name: `Remove ${MockGroup.display_name}`,
+			}),
+		);
+		await userEvent.click(
+			body.getByRole("button", {
+				name: `Remove ${MockOrganizationMember2.username}`,
+			}),
+		);
+		await userEvent.click(body.getByRole("button", { name: "Save sharing" }));
+
+		await waitFor(() =>
+			expect(API.experimental.updateChatModelACL).toHaveBeenCalledWith(
+				MockDefaultOrganization.id,
+				mockGPT5.id,
+				{
+					user_roles: { [MockOrganizationMember2.user_id]: "" },
+					group_roles: { [MockGroup.id]: "" },
+				},
+			),
+		);
+		expect(args.onOpenChange).toHaveBeenCalledWith(false);
+	},
+};
+
+export const ReopenUsesFreshACL: Story = {
+	render: () => <ReopenableSharingDialog />,
+	beforeEach: () => {
+		mockPrincipalRequests();
+		currentServerACL = populatedACL;
+		spyOn(API.experimental, "getChatModelACL").mockImplementation(
+			async () => currentServerACL,
+		);
+		spyOn(API.experimental, "updateChatModelACL").mockResolvedValue();
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		expect(
+			await body.findByRole("row", {
+				name: new RegExp(MockOrganizationMember2.username, "i"),
+			}),
+		).toBeInTheDocument();
+		await userEvent.click(body.getByRole("button", { name: "Cancel" }));
+		await waitFor(() =>
+			expect(
+				body.queryByRole("dialog", { name: "Share model" }),
+			).not.toBeInTheDocument(),
+		);
+
+		currentServerACL = refreshedACL;
+		await userEvent.click(body.getByRole("button", { name: "Open sharing" }));
+
+		expect(
+			await body.findByRole("row", {
+				name: new RegExp(MockOrganizationMember.username, "i"),
+			}),
+		).toBeInTheDocument();
+		expect(
+			body.getByRole("row", {
+				name: new RegExp(MockGroup2.display_name || MockGroup2.name, "i"),
+			}),
+		).toBeInTheDocument();
+		expect(
+			body.queryByRole("row", {
+				name: new RegExp(MockOrganizationMember2.username, "i"),
+			}),
+		).not.toBeInTheDocument();
+		expect(API.experimental.getChatModelACL).toHaveBeenCalled();
+	},
+};
+
+export const SaveErrorKeepsEditorOpen: Story = {
+	beforeEach: () =>
+		mockRequests({
+			acl: populatedACL,
+			updateError: new Error("Unable to save ACL"),
+		}),
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("button", {
+				name: `Remove ${MockGroup.display_name}`,
+			}),
+		);
+		await userEvent.click(body.getByRole("button", { name: "Save sharing" }));
+
+		const alert = await body.findByRole("alert");
+		expect(alert).toHaveTextContent("Unable to save ACL");
+		expect(body.getByRole("dialog", { name: "Share model" })).toHaveAttribute(
+			"data-state",
+			"open",
+		);
+		expect(args.onOpenChange).not.toHaveBeenCalledWith(false);
+	},
+};
+
+export const CancelDiscardsDraft: Story = {
+	beforeEach: () => mockRequests({ acl: populatedACL }),
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("button", {
+				name: `Remove ${MockGroup.display_name}`,
+			}),
+		);
+		await userEvent.click(body.getByRole("button", { name: "Cancel" }));
+
+		expect(API.experimental.updateChatModelACL).not.toHaveBeenCalled();
+		expect(args.onOpenChange).toHaveBeenCalledWith(false);
+	},
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ChatModelSharingDialog.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ChatModelSharingDialog.tsx
@@ -1,0 +1,368 @@
+import isEqual from "lodash/isEqual";
+import { Trash2Icon, UserPlusIcon } from "lucide-react";
+import { type FC, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import { toast } from "sonner";
+import { chatModelACL, updateChatModelACL } from "#/api/queries/chats";
+import { groupsByOrganization } from "#/api/queries/groups";
+import { organizationMembers } from "#/api/queries/organizations";
+import type * as TypesGen from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { getGroupSubtitle, isGroup } from "#/modules/groups";
+import {
+	UserOrGroupAutocomplete,
+	type UserOrGroupAutocompleteValue,
+} from "#/modules/workspaces/WorkspaceSharingForm/UserOrGroupAutocomplete";
+
+type ChatModelSharingDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	organizationId: string;
+	modelId: string;
+	modelName: string;
+};
+
+type DraftACL = {
+	user_roles: Record<string, TypesGen.ChatRole>;
+	group_roles: Record<string, TypesGen.ChatRole>;
+};
+
+const emptyDraft = (): DraftACL => ({ user_roles: {}, group_roles: {} });
+
+const buildRoleDelta = (
+	initial: Record<string, TypesGen.ChatRole>,
+	current: Record<string, TypesGen.ChatRole>,
+): Record<string, TypesGen.ChatRole> => {
+	const delta: Record<string, TypesGen.ChatRole> = {};
+	for (const [principalId, role] of Object.entries(current)) {
+		if (initial[principalId] !== role) {
+			delta[principalId] = role;
+		}
+	}
+	for (const principalId of Object.keys(initial)) {
+		if (current[principalId] === undefined) {
+			delta[principalId] = "";
+		}
+	}
+	return delta;
+};
+
+const buildACLDelta = (
+	initial: DraftACL,
+	current: DraftACL,
+): TypesGen.UpdateChatModelACLRequest => {
+	const userRoles = buildRoleDelta(initial.user_roles, current.user_roles);
+	const groupRoles = buildRoleDelta(initial.group_roles, current.group_roles);
+	return {
+		...(Object.keys(userRoles).length > 0 ? { user_roles: userRoles } : {}),
+		...(Object.keys(groupRoles).length > 0 ? { group_roles: groupRoles } : {}),
+	};
+};
+
+export const ChatModelSharingDialog: FC<ChatModelSharingDialogProps> = ({
+	open,
+	onOpenChange,
+	organizationId,
+	modelId,
+	modelName,
+}) => {
+	const queryClient = useQueryClient();
+	const [draft, setDraft] = useState<DraftACL>(emptyDraft);
+	const [initialACL, setInitialACL] = useState<DraftACL | null>(null);
+	const [initialized, setInitialized] = useState(false);
+	const [selectedOption, setSelectedOption] =
+		useState<UserOrGroupAutocompleteValue>(null);
+
+	const aclQuery = useQuery({
+		...chatModelACL(organizationId, modelId),
+		enabled: open && initialized,
+	});
+	const membersQuery = useQuery({
+		...organizationMembers(organizationId, { limit: 0 }),
+		enabled: open,
+	});
+	const groupsQuery = useQuery({
+		...groupsByOrganization(organizationId),
+		enabled: open,
+	});
+	const updateMutation = useMutation(updateChatModelACL(queryClient));
+
+	useEffect(() => {
+		if (!open || initialized) {
+			return;
+		}
+		let cancelled = false;
+		void aclQuery.refetch().then(({ data }) => {
+			if (cancelled || !data) {
+				return;
+			}
+			const snapshot = {
+				user_roles: { ...data.user_roles },
+				group_roles: { ...data.group_roles },
+			};
+			setInitialACL(snapshot);
+			setDraft(snapshot);
+			setInitialized(true);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [aclQuery.refetch, initialized, open]);
+
+	const reset = () => {
+		setDraft(emptyDraft());
+		setInitialACL(null);
+		setInitialized(false);
+		setSelectedOption(null);
+		updateMutation.reset();
+	};
+	const close = () => {
+		reset();
+		onOpenChange(false);
+	};
+
+	const members = membersQuery.data?.members ?? [];
+	const groups = groupsQuery.data ?? [];
+	const userIds = Object.keys(draft.user_roles);
+	const groupIds = Object.keys(draft.group_roles);
+	const excludedPrincipals = [
+		...members
+			.filter((member) => userIds.includes(member.user_id))
+			.map((member) => ({ id: member.user_id })),
+		...groups.filter((group) => groupIds.includes(group.id)),
+	];
+	const loadError =
+		(!initialized ? aclQuery.error : null) ??
+		(membersQuery.data === undefined ? membersQuery.error : null) ??
+		(groupsQuery.data === undefined ? groupsQuery.error : null);
+	const refetchError = loadError
+		? null
+		: (aclQuery.error ?? membersQuery.error ?? groupsQuery.error);
+	const isLoading =
+		!loadError &&
+		((open && !initialized) || membersQuery.isLoading || groupsQuery.isLoading);
+	const isEmpty = userIds.length === 0 && groupIds.length === 0;
+	const isDirty =
+		initialized && initialACL !== null && !isEqual(draft, initialACL);
+
+	const addSelectedPrincipal = () => {
+		if (!selectedOption) {
+			return;
+		}
+		if (isGroup(selectedOption)) {
+			setDraft((current) => ({
+				...current,
+				group_roles: { ...current.group_roles, [selectedOption.id]: "read" },
+			}));
+		} else {
+			setDraft((current) => ({
+				...current,
+				user_roles: { ...current.user_roles, [selectedOption.id]: "read" },
+			}));
+		}
+		setSelectedOption(null);
+	};
+
+	const removeUser = (userId: string) => {
+		setDraft((current) => {
+			const userRoles = { ...current.user_roles };
+			delete userRoles[userId];
+			return { ...current, user_roles: userRoles };
+		});
+	};
+	const removeGroup = (groupId: string) => {
+		setDraft((current) => {
+			const groupRoles = { ...current.group_roles };
+			delete groupRoles[groupId];
+			return { ...current, group_roles: groupRoles };
+		});
+	};
+
+	const save = () => {
+		if (!initialACL) {
+			return;
+		}
+		updateMutation.mutate(
+			{
+				organizationId,
+				modelId,
+				req: buildACLDelta(initialACL, draft),
+			},
+			{
+				onSuccess: () => {
+					toast.success(`Sharing for "${modelName}" updated.`);
+					close();
+				},
+			},
+		);
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen && !updateMutation.isPending) {
+					close();
+				}
+			}}
+		>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>Share model</DialogTitle>
+					<DialogDescription>
+						Choose which organization members and groups can use {modelName}.
+					</DialogDescription>
+				</DialogHeader>
+
+				{updateMutation.error && <ErrorAlert error={updateMutation.error} />}
+				{refetchError && <ErrorAlert error={refetchError} />}
+				{loadError && <ErrorAlert error={loadError} />}
+
+				{loadError ? null : isLoading ? (
+					<div
+						role="status"
+						className="flex items-center justify-center gap-3 py-10"
+					>
+						<Spinner loading />
+						<span>Loading model sharing</span>
+					</div>
+				) : !initialized ? null : (
+					<div className="flex flex-col gap-4">
+						<form
+							action={addSelectedPrincipal}
+							className="flex flex-col gap-2 sm:flex-row sm:items-center"
+						>
+							<div className="min-w-0 flex-1">
+								<UserOrGroupAutocomplete
+									organizationId={organizationId}
+									value={selectedOption}
+									onChange={setSelectedOption}
+									exclude={excludedPrincipals}
+									className="w-full"
+								/>
+							</div>
+							<Button
+								type="submit"
+								disabled={!selectedOption || updateMutation.isPending}
+							>
+								<UserPlusIcon className="size-icon-sm" />
+								Add member
+							</Button>
+						</form>
+
+						{isEmpty ? (
+							<div className="rounded-md border border-solid border-border px-6 py-10 text-center">
+								<p className="m-0 text-sm font-medium">
+									No shared members or groups yet
+								</p>
+								<p className="m-0 mt-2 text-sm text-content-secondary">
+									Add a member or group using the controls above.
+								</p>
+							</div>
+						) : (
+							<Table aria-label="Shared model members and groups">
+								<TableHeader>
+									<TableRow>
+										<TableHead>Member</TableHead>
+										<TableHead className="w-24">Role</TableHead>
+										<TableHead className="w-16" />
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{groupIds.map((groupId) => {
+										const group = groups.find((item) => item.id === groupId);
+										const name = group?.display_name || group?.name || groupId;
+										return (
+											<TableRow key={groupId}>
+												<TableCell>
+													<AvatarData
+														title={name}
+														subtitle={group ? getGroupSubtitle(group) : "Group"}
+														src={group?.avatar_url}
+													/>
+												</TableCell>
+												<TableCell>Read</TableCell>
+												<TableCell>
+													<Button
+														variant="subtle"
+														size="icon"
+														type="button"
+														disabled={updateMutation.isPending}
+														aria-label={`Remove ${name}`}
+														onClick={() => removeGroup(groupId)}
+													>
+														<Trash2Icon />
+													</Button>
+												</TableCell>
+											</TableRow>
+										);
+									})}
+									{userIds.map((userId) => {
+										const member = members.find(
+											(item) => item.user_id === userId,
+										);
+										const name = member?.username || userId;
+										return (
+											<TableRow key={userId}>
+												<TableCell>
+													<AvatarData
+														title={name}
+														subtitle={member?.name || member?.email || "User"}
+														src={member?.avatar_url}
+													/>
+												</TableCell>
+												<TableCell>Read</TableCell>
+												<TableCell>
+													<Button
+														variant="subtle"
+														size="icon"
+														type="button"
+														disabled={updateMutation.isPending}
+														aria-label={`Remove ${name}`}
+														onClick={() => removeUser(userId)}
+													>
+														<Trash2Icon />
+													</Button>
+												</TableCell>
+											</TableRow>
+										);
+									})}
+								</TableBody>
+							</Table>
+						)}
+					</div>
+				)}
+
+				<DialogFooter>
+					<DialogActions
+						confirmText="Save sharing"
+						confirmLoading={updateMutation.isPending}
+						confirmDisabled={isLoading || Boolean(loadError) || !isDirty}
+						onConfirm={save}
+						onCancel={close}
+					/>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -17,7 +17,15 @@ import {
 	MockGPT5BelowThresholdModelPrice,
 	MockGPT5ModelPrice,
 } from "#/testHelpers/chatModels";
+import {
+	MockDefaultOrganization,
+	MockOrganizationPermissions,
+} from "#/testHelpers/entities";
 import { withDashboardProvider, withToaster } from "#/testHelpers/storybook";
+import {
+	modelOrganizationSearchParam,
+	OrganizationModelsContext,
+} from "../organizationModels";
 import {
 	MockAnthropicProviderState,
 	MockAzureProviderState,
@@ -46,10 +54,23 @@ const waitForPriceLoading = async (canvas: ReturnType<typeof within>) => {
 	);
 };
 
+const withOrganizationModels = (Story: React.FC) => (
+	<OrganizationModelsContext.Provider
+		value={{
+			organization: MockDefaultOrganization,
+			organizations: [MockDefaultOrganization],
+			permissions: MockOrganizationPermissions,
+			requestedOrganizationDenied: false,
+		}}
+	>
+		<Story />
+	</OrganizationModelsContext.Provider>
+);
+
 const meta: Meta<typeof ModelForm> = {
 	title: "pages/AISettingsPage/ModelsPage/ModelForm",
 	component: ModelForm,
-	decorators: [withToaster, withDashboardProvider],
+	decorators: [withToaster, withDashboardProvider, withOrganizationModels],
 	args: {
 		providerStates: [MockOpenAIProviderState, MockAnthropicProviderState],
 		selectedProviderState: MockOpenAIProviderState,
@@ -62,10 +83,21 @@ const meta: Meta<typeof ModelForm> = {
 	parameters: {
 		features: ["aibridge"],
 		reactRouter: reactRouterParameters({
-			location: { path: "/ai/settings/models/add" },
+			location: {
+				path: "/ai/settings/models/add",
+				searchParams: {
+					[modelOrganizationSearchParam]: MockDefaultOrganization.name,
+				},
+			},
 			routing: [
-				{ path: "/ai/settings/models/add", useStoryElement: true },
-				{ path: "/ai/settings/models", element: <div>Models</div> },
+				{
+					path: "/ai/settings/models/add",
+					useStoryElement: true,
+				},
+				{
+					path: "/ai/settings/models",
+					element: <div>Models</div>,
+				},
 			],
 		}),
 	},
@@ -256,6 +288,83 @@ export const Edit: Story = {
 		await expect(
 			screen.getByRole("menuitem", { name: /delete/i }),
 		).toBeInTheDocument();
+	},
+};
+
+export const ShareOnlyAccess: Story = {
+	args: {
+		editingModel: mockGPT5,
+		canUpdateModel: false,
+		canShareModel: true,
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatModelACL").mockResolvedValue({
+			user_roles: {},
+			group_roles: {},
+		});
+		spyOn(API.experimental, "updateChatModelACL").mockResolvedValue();
+		spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+			members: [],
+			count: 0,
+		});
+		spyOn(API, "getGroupsByOrganization").mockResolvedValue([]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByRole("button", { name: /^update model$/i }),
+		).toBeNull();
+		await userEvent.click(
+			canvas.getByRole("button", { name: /model actions/i }),
+		);
+		expect(
+			screen.getByRole("menuitem", { name: /share model/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("menuitem", { name: /duplicate model/i }),
+		).toBeNull();
+		expect(screen.queryByRole("menuitem", { name: /delete/i })).toBeNull();
+	},
+};
+
+export const FullAccessActions: Story = {
+	args: {
+		editingModel: mockGPT5,
+		canShareModel: true,
+		onDeleteModel: fn(async () => undefined),
+		onDuplicate: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: /model actions/i }),
+		);
+		expect(
+			screen.getByRole("menuitem", { name: /share model/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: /duplicate model/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: /delete/i }),
+		).toBeInTheDocument();
+	},
+};
+
+export const NoShareReadOnlyAccess: Story = {
+	args: {
+		editingModel: mockGPT5,
+		canUpdateModel: false,
+		canShareModel: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByRole("button", { name: /model actions/i })).toBeNull();
+		expect(
+			canvas.queryByRole("button", { name: /^update model$/i }),
+		).toBeNull();
+		expect(canvas.getByLabelText(/model identifier/i)).toBeDisabled();
+		expect(canvas.getByRole("combobox", { name: /provider/i })).toBeDisabled();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.tsx
@@ -16,6 +16,8 @@ import {
 	parseThresholdInteger,
 } from "#/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic";
 import { getFormHelpers } from "#/utils/formUtils";
+import { useOrganizationModels } from "../organizationModels";
+import { ChatModelSharingDialog } from "./ChatModelSharingDialog";
 import { ModelFormDialogs } from "./ModelFormDialogs";
 import { ModelFormFields } from "./ModelFormFields";
 import { ModelFormBackLink, ModelFormHeader } from "./ModelFormHeader";
@@ -51,6 +53,8 @@ interface ModelFormProps {
 	onProviderChange: (providerKey: string) => void;
 	isSaving: boolean;
 	isDeleting: boolean;
+	canUpdateModel?: boolean;
+	canShareModel?: boolean;
 	onCreateModel: (req: TypesGen.CreateChatModelRequest) => Promise<unknown>;
 	onUpdateModel: (
 		modelId: string,
@@ -71,6 +75,8 @@ export const ModelForm: FC<ModelFormProps> = ({
 	onProviderChange,
 	isSaving,
 	isDeleting,
+	canUpdateModel = true,
+	canShareModel = false,
 	onCreateModel,
 	onUpdateModel,
 	onDeleteModel,
@@ -78,6 +84,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 	currentDefaultModel,
 	onToggleEnabled,
 }) => {
+	const { organization } = useOrganizationModels();
 	const initialModel = editingModel ?? duplicateSourceModel;
 	const isEditing = Boolean(editingModel);
 	const isDuplicating = Boolean(duplicateSourceModel) && !isEditing;
@@ -88,6 +95,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const [showAdvanced, setShowAdvanced] = useState(false);
 	const [showCostEstimate, setShowCostEstimate] = useState(false);
 	const [showProviderConfig, setShowProviderConfig] = useState(false);
+	const [sharingOpen, setSharingOpen] = useState(false);
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 	const [confirmingReplaceDefault, setConfirmingReplaceDefault] =
 		useState(false);
@@ -142,7 +150,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 			const builtModelConfig = buildResult.modelConfig;
 
 			const selectedProviderConfigID =
-				selectedProviderState?.providerConfig?.id;
+				selectedProviderState?.providerDescriptor.id;
 			const editingProviderConfigID = editingModel?.ai_provider_id.trim() ?? "";
 
 			if (isEditing && editingModel) {
@@ -177,10 +185,10 @@ export const ModelForm: FC<ModelFormProps> = ({
 
 				await onUpdateModel(editingModel.id, req);
 			} else {
-				if (!selectedProviderState?.providerConfig) return;
+				if (!selectedProviderState) return;
 
 				const req: TypesGen.CreateChatModelRequest = {
-					ai_provider_id: selectedProviderState.providerConfig.id,
+					ai_provider_id: selectedProviderState.providerDescriptor.id,
 					model: trimmedModel,
 					enabled: values.enabled,
 					is_default: values.isDefault,
@@ -216,9 +224,11 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const hasFieldErrors =
 		Object.keys(modelConfigFormBuildResult.fieldErrors).length > 0;
 	const enabledToggleDisabled =
+		!canUpdateModel ||
 		isSaving ||
 		(editingModel?.is_default === true && editingModel.enabled === true);
 	const setDefaultDisabled =
+		!canUpdateModel ||
 		isSaving ||
 		(isEditing &&
 			(editingModel?.is_default === true || editingModel?.enabled === false));
@@ -231,9 +241,10 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const hasProviderChange =
 		isEditing &&
 		!!editingModel &&
-		!!selectedProviderState?.providerConfig &&
-		selectedProviderState.providerConfig.id !== editingModel.ai_provider_id;
+		!!selectedProviderState &&
+		selectedProviderState.providerDescriptor.id !== editingModel.ai_provider_id;
 	const canSubmit =
+		(!isEditing || canUpdateModel) &&
 		!isSaving &&
 		!hasFieldErrors &&
 		form.values.model.trim().length > 0 &&
@@ -267,11 +278,9 @@ export const ModelForm: FC<ModelFormProps> = ({
 							/>
 							{selectedProviderState && (
 								<p className="text-sm text-content-secondary m-0">
-									{!selectedProviderState.providerConfig
-										? "Create a managed provider before adding models."
-										: selectedProviderState.providerConfig.enabled === false
-											? `${selectedProviderState.label} is disabled. Enable it before adding models.`
-											: "Set an API key for this provider before adding models."}
+									{selectedProviderState.providerDescriptor.enabled === false
+										? `${selectedProviderState.label} is disabled. Enable it before adding models.`
+										: "Set an API key for this provider before adding models."}
 								</p>
 							)}
 						</div>
@@ -304,6 +313,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 				editingModel={editingModel}
 				onDeleteModel={onDeleteModel}
 				onDuplicate={onDuplicate}
+				onShareModel={canShareModel ? () => setSharingOpen(true) : undefined}
 				onToggleEnabled={onToggleEnabled}
 				isSaving={isSaving}
 				enabledToggleDisabled={enabledToggleDisabled}
@@ -321,6 +331,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 					isDuplicating={isDuplicating}
 					isEditing={isEditing}
 					isSaving={isSaving}
+					isReadOnly={isEditing && !canUpdateModel}
 					canSubmit={canSubmit}
 					initialModel={initialModel}
 					modelField={modelField}
@@ -337,6 +348,15 @@ export const ModelForm: FC<ModelFormProps> = ({
 					setShowAdvanced={setShowAdvanced}
 				/>
 			</div>
+			{editingModel && canShareModel && (
+				<ChatModelSharingDialog
+					open={sharingOpen}
+					onOpenChange={setSharingOpen}
+					organizationId={organization.id}
+					modelId={editingModel.id}
+					modelName={editingModel.display_name || editingModel.model}
+				/>
+			)}
 			<ModelFormDialogs
 				editingModel={editingModel}
 				onDeleteModel={onDeleteModel}

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -40,6 +40,7 @@ import type {
 import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import type { FormHelpers } from "#/utils/formUtils";
+import { useOrganizationModelsPath } from "../organizationModels";
 import { ModelFormProviderSelect } from "./ModelFormProviderSelect";
 
 const CollapsibleSection: FC<{
@@ -96,6 +97,7 @@ export const ModelFormFields: FC<{
 	isDuplicating: boolean;
 	isEditing: boolean;
 	isSaving: boolean;
+	isReadOnly: boolean;
 	canSubmit: boolean;
 	initialModel?: TypesGen.ChatModel;
 	modelField: FormHelpers;
@@ -121,6 +123,7 @@ export const ModelFormFields: FC<{
 	isDuplicating,
 	isEditing,
 	isSaving,
+	isReadOnly,
 	canSubmit,
 	initialModel,
 	modelField,
@@ -136,6 +139,7 @@ export const ModelFormFields: FC<{
 	showAdvanced,
 	setShowAdvanced,
 }) => {
+	const modelsPath = useOrganizationModelsPath();
 	const hasProviderConfigFields =
 		getVisibleProviderFields(selectedProviderState.provider).length > 0;
 
@@ -153,7 +157,9 @@ export const ModelFormFields: FC<{
 						selectedProviderKey={selectedProviderKey}
 						isEditing={mode === "edit"}
 						onProviderChange={onProviderChange}
-						disabled={isDuplicating || providerStates.length === 0}
+						disabled={
+							isDuplicating || isReadOnly || providerStates.length === 0
+						}
 					/>
 					<div className="flex flex-col gap-1">
 						<ModelIdentifierField
@@ -161,7 +167,7 @@ export const ModelFormFields: FC<{
 							modelField={modelField}
 							mode={mode}
 							selectedProvider={selectedProviderType}
-							disabled={isSaving}
+							disabled={isSaving || isReadOnly}
 							controlClassName="shadow-none"
 						/>
 						<label
@@ -174,7 +180,7 @@ export const ModelFormFields: FC<{
 								onCheckedChange={(checked) =>
 									form.setFieldValue("isDefault", checked === true)
 								}
-								disabled={setDefaultDisabled}
+								disabled={setDefaultDisabled || isReadOnly}
 							/>
 							Set as Coder Agents default model
 						</label>
@@ -200,7 +206,7 @@ export const ModelFormFields: FC<{
 							value={displayNameField.value}
 							onChange={displayNameField.onChange}
 							onBlur={displayNameField.onBlur}
-							disabled={isSaving}
+							disabled={isSaving || isReadOnly}
 						/>
 					</div>
 					<div className="grid gap-1.5">
@@ -235,7 +241,7 @@ export const ModelFormFields: FC<{
 								value={contextLimitField.value}
 								onChange={contextLimitField.onChange}
 								onBlur={contextLimitField.onBlur}
-								disabled={isSaving}
+								disabled={isSaving || isReadOnly}
 								aria-invalid={contextLimitField.error}
 							/>
 							<InputGroupAddon align="inline-end">
@@ -285,13 +291,13 @@ export const ModelFormFields: FC<{
 								provider={selectedProviderState.provider}
 								form={form}
 								fieldErrors={modelConfigFormBuildResult.fieldErrors}
-								disabled={isSaving}
+								disabled={isSaving || isReadOnly}
 							>
 								<ReasoningEffortConfigFields
 									provider={selectedProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
-									disabled={isSaving}
+									disabled={isSaving || isReadOnly}
 								/>
 							</ModelConfigFields>
 						</CollapsibleSection>
@@ -309,7 +315,7 @@ export const ModelFormFields: FC<{
 							provider={selectedProviderState.provider}
 							form={form}
 							fieldErrors={modelConfigFormBuildResult.fieldErrors}
-							disabled={isSaving}
+							disabled={isSaving || isReadOnly}
 						/>
 						<div className="flex min-w-0 flex-col gap-1.5">
 							<Label
@@ -340,7 +346,7 @@ export const ModelFormFields: FC<{
 									value={compressionThresholdField.value}
 									onChange={compressionThresholdField.onChange}
 									onBlur={compressionThresholdField.onBlur}
-									disabled={isSaving}
+									disabled={isSaving || isReadOnly}
 									aria-invalid={compressionThresholdField.error}
 								/>
 								<InputGroupAddon align="inline-end">
@@ -357,19 +363,21 @@ export const ModelFormFields: FC<{
 				</div>
 
 				<div className="flex items-center justify-end gap-3">
-					<RouterLink to="/ai/settings/models">
+					<RouterLink to={modelsPath}>
 						<Button variant="outline" type="button">
 							Cancel
 						</Button>
 					</RouterLink>
-					<Button type="submit" disabled={!canSubmit}>
-						{isSaving && <Spinner loading />}
-						{isEditing
-							? "Update model"
-							: isDuplicating
-								? "Create duplicate"
-								: "Add Model"}
-					</Button>
+					{!isReadOnly && (
+						<Button type="submit" disabled={!canSubmit}>
+							{isSaving && <Spinner loading />}
+							{isEditing
+								? "Update model"
+								: isDuplicating
+									? "Create duplicate"
+									: "Add Model"}
+						</Button>
+					)}
 				</div>
 			</form>
 		</div>

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
@@ -2,6 +2,7 @@ import {
 	ArrowLeftIcon,
 	CopyIcon,
 	EllipsisVerticalIcon,
+	Share2Icon,
 	TrashIcon,
 } from "lucide-react";
 import type { FC } from "react";
@@ -27,10 +28,12 @@ import {
 import type { ProviderState } from "#/modules/aiModels/providerStates";
 import { getProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
 import { cn } from "#/utils/cn";
+import { useOrganizationModelsPath } from "../organizationModels";
 
 export const ModelFormBackLink: FC = () => {
+	const modelsPath = useOrganizationModelsPath();
 	return (
-		<Link to="/ai/settings/models" className="-ml-3">
+		<Link to={modelsPath} className="-ml-3">
 			<Button variant="subtle" type="button">
 				<ArrowLeftIcon />
 				<span>Back to models</span>
@@ -46,6 +49,7 @@ export const ModelFormHeader: FC<{
 	editingModel?: TypesGen.ChatModel;
 	onDeleteModel?: (modelId: string) => Promise<void>;
 	onDuplicate?: () => void;
+	onShareModel?: () => void;
 	onToggleEnabled?: (enabled: boolean) => void;
 	isSaving: boolean;
 	enabledToggleDisabled: boolean;
@@ -57,6 +61,7 @@ export const ModelFormHeader: FC<{
 	editingModel,
 	onDeleteModel,
 	onDuplicate,
+	onShareModel,
 	onToggleEnabled,
 	isSaving,
 	enabledToggleDisabled,
@@ -66,37 +71,49 @@ export const ModelFormHeader: FC<{
 		<>
 			<div className="flex items-center justify-between">
 				<ModelFormBackLink />
-				{isEditing && editingModel && onDeleteModel && (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								variant="subtle"
-								size="icon"
-								type="button"
-								disabled={isSaving}
-								aria-label="Model actions"
-							>
-								<EllipsisVerticalIcon />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							{onDuplicate && (
-								<DropdownMenuItem onClick={onDuplicate}>
-									<CopyIcon className="size-icon-sm" />
-									Duplicate model
-								</DropdownMenuItem>
-							)}
-							<DropdownMenuSeparator />
-							<DropdownMenuItem
-								className="text-content-destructive focus:text-content-destructive"
-								onClick={onRequestDelete}
-							>
-								<TrashIcon />
-								Delete…
-							</DropdownMenuItem>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				)}
+				{isEditing &&
+					editingModel &&
+					(onDeleteModel || onDuplicate || onShareModel) && (
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="subtle"
+									size="icon"
+									type="button"
+									disabled={isSaving}
+									aria-label="Model actions"
+								>
+									<EllipsisVerticalIcon />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								{onShareModel && (
+									<DropdownMenuItem onClick={onShareModel}>
+										<Share2Icon className="size-icon-sm" />
+										Share model
+									</DropdownMenuItem>
+								)}
+								{onDuplicate && (
+									<DropdownMenuItem onClick={onDuplicate}>
+										<CopyIcon className="size-icon-sm" />
+										Duplicate model
+									</DropdownMenuItem>
+								)}
+								{onDeleteModel && (onShareModel || onDuplicate) && (
+									<DropdownMenuSeparator />
+								)}
+								{onDeleteModel && (
+									<DropdownMenuItem
+										className="text-content-destructive focus:text-content-destructive"
+										onClick={onRequestDelete}
+									>
+										<TrashIcon />
+										Delete…
+									</DropdownMenuItem>
+								)}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					)}
 			</div>
 			<div className="flex items-center justify-between gap-4">
 				<div className="flex items-center gap-4 min-w-0">
@@ -123,14 +140,14 @@ export const ModelFormHeader: FC<{
 						!editingModel.is_default &&
 						!editingModel.enabled && <Badge variant="default">Disabled</Badge>}
 				</div>
-				{isEditing && editingModel && (
+				{isEditing && editingModel && onToggleEnabled && (
 					<div className="flex shrink-0 items-center gap-2">
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<span className="inline-flex">
 									<Switch
 										checked={editingModel.enabled}
-										onCheckedChange={(checked) => onToggleEnabled?.(checked)}
+										onCheckedChange={onToggleEnabled}
 										disabled={enabledToggleDisabled}
 										aria-label="Model enabled"
 									/>

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormProviderSelect.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormProviderSelect.tsx
@@ -28,7 +28,7 @@ export const ModelFormProviderSelect: FC<{
 	// whose provider was disabled afterwards still renders.
 	const selectableProviderStates = providerStates.filter(
 		(ps) =>
-			ps.providerConfig?.enabled !== false ||
+			ps.providerDescriptor.enabled ||
 			(isEditing && ps.key === selectedProviderKey),
 	);
 	return (

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.test.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.test.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
+import { MockChatModel } from "#/testHelpers/chatModels";
 import {
 	MockDefaultOrganization,
 	MockOrganization2,
@@ -79,7 +80,8 @@ describe("selectModelOrganization", () => {
 });
 
 describe("useAccessibleModelOrganizations", () => {
-	it("uses successful ACL-filtered collection reads without permission prechecks", async () => {
+	it("excludes successful empty collection reads without model permissions", async () => {
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue({});
 		const getChatModels = vi
 			.spyOn(API.experimental, "getChatModels")
 			.mockImplementation(async (_organizationId) => ({
@@ -97,17 +99,75 @@ describe("useAccessibleModelOrganizations", () => {
 		);
 
 		await waitFor(() => expect(result.current.isLoading).toBe(false));
-		expect(result.current.organizations).toEqual([
-			MockDefaultOrganization,
-			MockOrganization2,
-		]);
+		expect(result.current.organizations).toEqual([]);
 		expect(getChatModels).toHaveBeenCalledTimes(2);
 
 		unmount();
 		queryClient.clear();
 	});
 
-	it("keeps successful organization data when another request fails", async () => {
+	it("includes organization-level model access without readable rows", async () => {
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue({
+			[`${MockDefaultOrganization.id}.viewChatModelConfigs`]: true,
+		});
+		vi.spyOn(API.experimental, "getChatModels").mockResolvedValue({
+			models: [],
+			providers: [],
+		});
+		const { queryClient, wrapper } = createQueryWrapper();
+		const { result, unmount } = renderHook(
+			() =>
+				useAccessibleModelOrganizations([
+					MockDefaultOrganization,
+					MockOrganization2,
+				]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.organizations).toEqual([MockDefaultOrganization]);
+
+		unmount();
+		queryClient.clear();
+	});
+
+	it("includes ACL-filtered readable model rows without collection access", async () => {
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue({});
+		vi.spyOn(API.experimental, "getChatModels").mockImplementation(
+			async (organizationId) => ({
+				models:
+					organizationId === MockDefaultOrganization.id
+						? [
+								{
+									...MockChatModel,
+									organization_id: organizationId,
+								},
+							]
+						: [],
+				providers: [],
+			}),
+		);
+		const { queryClient, wrapper } = createQueryWrapper();
+		const { result, unmount } = renderHook(
+			() =>
+				useAccessibleModelOrganizations([
+					MockDefaultOrganization,
+					MockOrganization2,
+				]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.organizations).toEqual([MockDefaultOrganization]);
+
+		unmount();
+		queryClient.clear();
+	});
+
+	it("keeps accessible organization data when another request fails", async () => {
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue({
+			[`${MockDefaultOrganization.id}.viewChatModelConfigs`]: true,
+		});
 		vi.spyOn(API.experimental, "getChatModels").mockImplementation(
 			async (organizationId) => {
 				if (organizationId === MockOrganization2.id) {

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.test.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.test.tsx
@@ -1,0 +1,139 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import {
+	MockDefaultOrganization,
+	MockOrganization2,
+} from "#/testHelpers/entities";
+import {
+	organizationAddModelPath,
+	selectModelOrganization,
+	useAccessibleModelOrganizations,
+} from "./organizationModels";
+
+const createQueryWrapper = () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	const wrapper = ({ children }: PropsWithChildren) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	return { queryClient, wrapper };
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("selectModelOrganization", () => {
+	const organizations = [MockDefaultOrganization, MockOrganization2];
+
+	it("falls back only when no organization is requested", () => {
+		expect(selectModelOrganization(organizations, null)).toEqual({
+			organization: MockDefaultOrganization,
+			requestedOrganizationDenied: false,
+		});
+		expect(
+			selectModelOrganization(
+				organizations.map((organization) => ({
+					...organization,
+					is_default: false,
+				})),
+				null,
+			).organization?.id,
+		).toBe(MockDefaultOrganization.id);
+		expect(selectModelOrganization([], null)).toEqual({
+			organization: undefined,
+			requestedOrganizationDenied: false,
+		});
+	});
+
+	it("uses exactly the requested accessible organization", () => {
+		expect(
+			selectModelOrganization(organizations, MockOrganization2.name),
+		).toEqual({
+			organization: MockOrganization2,
+			requestedOrganizationDenied: false,
+		});
+	});
+
+	it("marks a requested missing organization as denied", () => {
+		expect(selectModelOrganization(organizations, "missing")).toEqual({
+			organization: MockDefaultOrganization,
+			requestedOrganizationDenied: true,
+		});
+	});
+
+	it("preserves auxiliary parameters in organization model paths", () => {
+		const params = new URLSearchParams({
+			provider: "openai",
+			duplicate: "model-id",
+		});
+
+		expect(organizationAddModelPath(MockOrganization2, params)).toBe(
+			`/ai/settings/models/add?provider=openai&duplicate=model-id&org=${MockOrganization2.name}`,
+		);
+	});
+});
+
+describe("useAccessibleModelOrganizations", () => {
+	it("uses successful ACL-filtered collection reads without permission prechecks", async () => {
+		const getChatModels = vi
+			.spyOn(API.experimental, "getChatModels")
+			.mockImplementation(async (_organizationId) => ({
+				models: [],
+				providers: [],
+			}));
+		const { queryClient, wrapper } = createQueryWrapper();
+		const { result, unmount } = renderHook(
+			() =>
+				useAccessibleModelOrganizations([
+					MockDefaultOrganization,
+					MockOrganization2,
+				]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.organizations).toEqual([
+			MockDefaultOrganization,
+			MockOrganization2,
+		]);
+		expect(getChatModels).toHaveBeenCalledTimes(2);
+
+		unmount();
+		queryClient.clear();
+	});
+
+	it("keeps successful organization data when another request fails", async () => {
+		vi.spyOn(API.experimental, "getChatModels").mockImplementation(
+			async (organizationId) => {
+				if (organizationId === MockOrganization2.id) {
+					throw new Error("Failed to load organization");
+				}
+				return { models: [], providers: [] };
+			},
+		);
+		const { queryClient, wrapper } = createQueryWrapper();
+		const { result, unmount } = renderHook(
+			() =>
+				useAccessibleModelOrganizations([
+					MockDefaultOrganization,
+					MockOrganization2,
+				]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.organizations).toEqual([MockDefaultOrganization]);
+		expect(result.current.error).toBeNull();
+		expect(result.current.partialError).toEqual(
+			new Error("Failed to load organization"),
+		);
+
+		unmount();
+		queryClient.clear();
+	});
+});

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
@@ -1,0 +1,137 @@
+import { isAxiosError } from "axios";
+import { createContext, useContext } from "react";
+import { useQueries } from "react-query";
+import { useSearchParams } from "react-router";
+import { chatModels } from "#/api/queries/chats";
+import type { Organization } from "#/api/typesGenerated";
+import type { OrganizationPermissions } from "#/modules/permissions/organizations";
+
+export const modelOrganizationSearchParam = "org";
+
+const isInaccessibleOrganizationError = (error: unknown): boolean =>
+	isAxiosError(error) &&
+	(error.response?.status === 403 || error.response?.status === 404);
+
+export const useAccessibleModelOrganizations = (
+	organizations: readonly Organization[],
+) => {
+	const queries = useQueries({
+		queries: organizations.map((organization) => chatModels(organization.id)),
+	});
+	const accessibleOrganizations = organizations.filter(
+		(_, index) => queries[index]?.data !== undefined,
+	);
+	const requestError = queries.find(
+		(query) => query.error && !isInaccessibleOrganizationError(query.error),
+	)?.error;
+	const hasData = accessibleOrganizations.length > 0;
+
+	return {
+		organizations: accessibleOrganizations,
+		isLoading: queries.some((query) => query.isLoading),
+		error: hasData ? null : (requestError ?? null),
+		partialError: hasData ? (requestError ?? null) : null,
+	};
+};
+
+type ModelOrganizationSelection = {
+	organization: Organization | undefined;
+	requestedOrganizationDenied: boolean;
+};
+
+export const selectModelOrganization = (
+	organizations: readonly Organization[],
+	requestedName: string | null,
+): ModelOrganizationSelection => {
+	const requestedOrganization =
+		requestedName === null
+			? undefined
+			: organizations.find(
+					(organization) => organization.name === requestedName,
+				);
+
+	return {
+		organization:
+			requestedOrganization ??
+			organizations.find((organization) => organization.is_default) ??
+			organizations[0],
+		requestedOrganizationDenied:
+			requestedName !== null && requestedOrganization === undefined,
+	};
+};
+
+type ModelQueryState = {
+	data: unknown;
+	error: unknown;
+};
+
+export const splitModelQueryErrors = (
+	...queries: readonly ModelQueryState[]
+): { loadError: unknown; refetchError: unknown } => {
+	const loadError =
+		queries.find((query) => query.data === undefined && query.error)?.error ??
+		null;
+	return {
+		loadError,
+		refetchError: loadError
+			? null
+			: (queries.find((query) => query.error)?.error ?? null),
+	};
+};
+
+type OrganizationModelsContextValue = {
+	organization: Organization;
+	organizations: readonly Organization[];
+	permissions: OrganizationPermissions | undefined;
+	requestedOrganizationDenied: boolean;
+};
+
+export const OrganizationModelsContext =
+	createContext<OrganizationModelsContextValue | null>(null);
+
+export const useOrganizationModels = (): OrganizationModelsContextValue => {
+	const context = useContext(OrganizationModelsContext);
+	if (!context) {
+		throw new Error(
+			"useOrganizationModels must be used within OrganizationModelsLayout",
+		);
+	}
+	return context;
+};
+
+const organizationModelSettingsPath = (
+	organization: Organization,
+	suffix: string,
+	searchParams?: URLSearchParams,
+): string => {
+	const next = new URLSearchParams(searchParams);
+	next.set(modelOrganizationSearchParam, organization.name);
+	return `/ai/settings/models${suffix}?${next.toString()}`;
+};
+
+const organizationModelsPath = (
+	organization: Organization,
+	searchParams?: URLSearchParams,
+): string => organizationModelSettingsPath(organization, "", searchParams);
+
+export const organizationAddModelPath = (
+	organization: Organization,
+	searchParams?: URLSearchParams,
+): string => organizationModelSettingsPath(organization, "/add", searchParams);
+
+export const organizationModelPath = (
+	organization: Organization,
+	modelId: string,
+	searchParams?: URLSearchParams,
+): string =>
+	organizationModelSettingsPath(
+		organization,
+		`/${encodeURIComponent(modelId)}`,
+		searchParams,
+	);
+
+export const useOrganizationModelsPath = (): string => {
+	const { organization } = useOrganizationModels();
+	const [searchParams] = useSearchParams();
+	return organizationModelsPath(organization, searchParams);
+};

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
@@ -1,10 +1,14 @@
 import { isAxiosError } from "axios";
 import { createContext, useContext } from "react";
-import { useQueries } from "react-query";
+import { useQueries, useQuery } from "react-query";
 import { useSearchParams } from "react-router";
 import { chatModels } from "#/api/queries/chats";
+import { organizationsPermissions } from "#/api/queries/organizations";
 import type { Organization } from "#/api/typesGenerated";
-import type { OrganizationPermissions } from "#/modules/permissions/organizations";
+import {
+	canAccessOrganizationChatModelConfig,
+	type OrganizationPermissions,
+} from "#/modules/permissions/organizations";
 
 export const modelOrganizationSearchParam = "org";
 
@@ -18,17 +22,28 @@ export const useAccessibleModelOrganizations = (
 	const queries = useQueries({
 		queries: organizations.map((organization) => chatModels(organization.id)),
 	});
-	const accessibleOrganizations = organizations.filter(
-		(_, index) => queries[index]?.data !== undefined,
+	const permissionsQuery = useQuery(
+		organizationsPermissions(
+			organizations.map((organization) => organization.id),
+		),
 	);
-	const requestError = queries.find(
-		(query) => query.error && !isInaccessibleOrganizationError(query.error),
-	)?.error;
+	const accessibleOrganizations = organizations.filter(
+		(organization, index) =>
+			(queries[index]?.data?.models.length ?? 0) > 0 ||
+			canAccessOrganizationChatModelConfig(
+				permissionsQuery.data?.[organization.id],
+			),
+	);
+	const requestError =
+		queries.find(
+			(query) => query.error && !isInaccessibleOrganizationError(query.error),
+		)?.error ?? permissionsQuery.error;
 	const hasData = accessibleOrganizations.length > 0;
 
 	return {
 		organizations: accessibleOrganizations,
-		isLoading: queries.some((query) => query.isLoading),
+		isLoading:
+			queries.some((query) => query.isLoading) || permissionsQuery.isLoading,
 		error: hasData ? null : (requestError ?? null),
 		partialError: hasData ? (requestError ?? null) : null,
 	};

--- a/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
+++ b/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
@@ -1,34 +1,27 @@
-import type { ChatModel, ChatProviderConfig } from "#/api/typesGenerated";
+import type {
+	ChatModel,
+	ChatModelProviderDescriptor,
+} from "#/api/typesGenerated";
 import type { ProviderState } from "#/modules/aiModels/providerStates";
+import { MockChatModelProviderDescriptor } from "#/testHelpers/chatModels";
 
 const now = "2026-02-18T12:00:00.000Z";
 
-const MockOpenAIProviderConfig: ChatProviderConfig = {
+const MockOpenAIProviderDescriptor: ChatModelProviderDescriptor = {
+	...MockChatModelProviderDescriptor,
 	id: "prov-openai",
-	provider: "openai",
-	display_name: "OpenAI",
-	icon: "",
-	enabled: true,
-	has_api_key: true,
-	central_api_key_enabled: true,
-	allow_user_api_key: false,
-	allow_central_api_key_fallback: true,
-	base_url: "",
-	source: "database",
-	created_at: now,
-	updated_at: now,
 };
 
-const MockAnthropicProviderConfig: ChatProviderConfig = {
-	...MockOpenAIProviderConfig,
+const MockAnthropicProviderDescriptor: ChatModelProviderDescriptor = {
+	...MockOpenAIProviderDescriptor,
 	id: "prov-anthropic",
-	provider: "anthropic",
+	type: "anthropic",
 	display_name: "Anthropic",
 };
 
 export const mockGPT5: ChatModel = {
-	organization_id: "00000000-0000-0000-0000-000000000000",
 	id: "model-gpt5",
+	organization_id: "org-1",
 	ai_provider_id: "prov-openai",
 	model: "gpt-5",
 	display_name: "GPT-5",
@@ -63,15 +56,11 @@ export const MockOpenAIProviderState: ProviderState = {
 	key: "prov-openai",
 	provider: "openai",
 	label: "OpenAI",
-	providerConfig: MockOpenAIProviderConfig,
+	providerDescriptor: MockOpenAIProviderDescriptor,
 	models: [mockGPT5, mockDisabledModel],
 	catalogModelCount: 0,
-	hasManagedAPIKey: true,
-	hasCatalogAPIKey: true,
 	hasEffectiveAPIKey: true,
 	allowUserAPIKey: false,
-	isEnvPreset: false,
-	baseURL: "",
 };
 
 export const MockAnthropicProviderState: ProviderState = {
@@ -79,14 +68,14 @@ export const MockAnthropicProviderState: ProviderState = {
 	key: "prov-anthropic",
 	provider: "anthropic",
 	label: "Anthropic",
-	providerConfig: MockAnthropicProviderConfig,
+	providerDescriptor: MockAnthropicProviderDescriptor,
 	models: [mockClaude],
 };
 
-const MockGoogleProviderConfig: ChatProviderConfig = {
-	...MockOpenAIProviderConfig,
+const MockGoogleProviderDescriptor: ChatModelProviderDescriptor = {
+	...MockOpenAIProviderDescriptor,
 	id: "prov-google",
-	provider: "google",
+	type: "google",
 	display_name: "Google",
 };
 
@@ -95,14 +84,14 @@ export const MockGoogleProviderState: ProviderState = {
 	key: "prov-google",
 	provider: "google",
 	label: "Google",
-	providerConfig: MockGoogleProviderConfig,
+	providerDescriptor: MockGoogleProviderDescriptor,
 	models: [],
 };
 
-const MockBedrockProviderConfig: ChatProviderConfig = {
-	...MockOpenAIProviderConfig,
+const MockBedrockProviderDescriptor: ChatModelProviderDescriptor = {
+	...MockOpenAIProviderDescriptor,
 	id: "prov-bedrock",
-	provider: "bedrock",
+	type: "bedrock",
 	display_name: "AWS Bedrock",
 };
 
@@ -119,7 +108,7 @@ export const MockBedrockProviderState: ProviderState = {
 	key: "prov-bedrock",
 	provider: "bedrock",
 	label: "AWS Bedrock",
-	providerConfig: MockBedrockProviderConfig,
+	providerDescriptor: MockBedrockProviderDescriptor,
 	models: [mockBedrockClaude],
 };
 
@@ -128,17 +117,17 @@ export const MockAzureProviderState: ProviderState = {
 	key: "prov-azure",
 	provider: "azure",
 	label: "Azure OpenAI",
-	providerConfig: {
-		...MockOpenAIProviderConfig,
+	providerDescriptor: {
+		...MockOpenAIProviderDescriptor,
 		id: "prov-azure",
-		provider: "azure",
+		type: "azure",
 		display_name: "Azure OpenAI",
 	},
 	models: [],
 };
 
-const MockDisabledProviderConfig: ChatProviderConfig = {
-	...MockOpenAIProviderConfig,
+const MockDisabledProviderDescriptor: ChatModelProviderDescriptor = {
+	...MockOpenAIProviderDescriptor,
 	id: "prov-openai-disabled",
 	display_name: "OpenAI Secondary",
 	enabled: false,
@@ -158,7 +147,7 @@ export const MockDisabledProviderState: ProviderState = {
 	key: "prov-openai-disabled",
 	provider: "openai",
 	label: "OpenAI Secondary",
-	providerConfig: MockDisabledProviderConfig,
+	providerDescriptor: MockDisabledProviderDescriptor,
 	models: [mockProviderDisabledModel],
 };
 
@@ -167,19 +156,15 @@ export const MockCopilotProviderState: ProviderState = {
 	key: "prov-copilot",
 	provider: "copilot",
 	label: "GitHub Copilot",
-	providerConfig: {
-		...MockOpenAIProviderConfig,
+	providerDescriptor: {
+		...MockOpenAIProviderDescriptor,
 		id: "prov-copilot",
-		provider: "copilot",
+		type: "copilot",
 		display_name: "GitHub Copilot",
 	},
 	models: [],
 };
 
-// A model whose provider row has been deleted. In production such models
-// still appear in the top-level model list, but `deriveProviderStates`
-// drops them from every providerState.models. Stories should feed
-// this fixture through `models` alone; do not add it to a provider state.
 export const mockOrphanedModel: ChatModel = {
 	...mockGPT5,
 	id: "model-orphaned",

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -15,10 +15,10 @@ import {
 	chatListKey,
 	chatMessagesKey,
 	chatModelAvailabilityKey,
-	chatModels,
 	chatPromptsKey,
 	mcpServerConfigsKey,
 	toChatListParams,
+	userChatProviderConfigsKey,
 } from "#/api/queries/chats";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -92,6 +92,9 @@ const AgentChatPageLayout: FC = () => {
 const CHAT_ID = "chat-1";
 const SWITCHED_CHAT_ID = "chat-2";
 const MODEL_CONFIG_ID = "model-config-1";
+const STALE_MODEL_CONFIG_ID = "stale-model-config";
+const DISABLED_DEFAULT_MODEL_CONFIG_ID = "disabled-default-model-config";
+const RECOVERY_MODEL_CONFIG_ID = "recovery-model-config";
 
 const AgentChatSwitchHarness: FC = () => {
 	const navigate = useNavigate();
@@ -126,6 +129,22 @@ const mockWorkspace: TypesGen.Workspace = {
 };
 
 const mockModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	models: [
+		{
+			...MockChatModel,
+			id: MODEL_CONFIG_ID,
+			organization_id: "test-org-id",
+			model: "gpt-4o",
+			display_name: "GPT-4o",
+			is_default: true,
+			model_config: {
+				reasoning_effort: { default: "medium", max: "high" },
+			},
+			reasoning_efforts: ["low", "medium", "high"],
+			created_at: "2026-02-18T00:00:00.000Z",
+			updated_at: "2026-02-18T00:00:00.000Z",
+		},
+	],
 	providers: [
 		{
 			provider: "openai",
@@ -143,21 +162,28 @@ const mockModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
 	unsupported_providers: [],
 };
 
-const mockModels: TypesGen.ChatModel[] = [
-	{
-		...MockChatModel,
-		id: MODEL_CONFIG_ID,
-		model: "gpt-4o",
-		display_name: "GPT-4o",
-		is_default: true,
-		model_config: {
-			reasoning_effort: { default: "medium", max: "high" },
+const foreignOnlyModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...mockModelCatalog,
+	models: [
+		{
+			...MockChatModel,
+			id: "foreign-model-config",
+			organization_id: "foreign-org-id",
+			model: "gpt-4o",
+			display_name: "GPT-4o",
+			is_default: true,
 		},
-		reasoning_efforts: ["low", "medium", "high"],
-		created_at: "2026-02-18T00:00:00.000Z",
-		updated_at: "2026-02-18T00:00:00.000Z",
-	},
-];
+	],
+};
+
+const userApiKeyRequiredModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...mockModelCatalog,
+	providers: mockModelCatalog.providers.map((provider) => ({
+		...provider,
+		available: false,
+		unavailable_reason: "user_api_key_required",
+	})),
+};
 
 const baseChatFields = {
 	organization_id: "test-org-id",
@@ -179,6 +205,30 @@ const baseChatFields = {
 	summary: null,
 	children: [],
 } as const;
+
+const recoveryModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...mockModelCatalog,
+	models: [
+		{
+			...MockChatModel,
+			id: DISABLED_DEFAULT_MODEL_CONFIG_ID,
+			organization_id: baseChatFields.organization_id,
+			model: "gpt-4o",
+			display_name: "Disabled local default",
+			enabled: false,
+			is_default: true,
+		},
+		{
+			...MockChatModel,
+			id: RECOVERY_MODEL_CONFIG_ID,
+			organization_id: baseChatFields.organization_id,
+			model: "gpt-4.1",
+			display_name: "Usable local model",
+			enabled: true,
+			is_default: false,
+		},
+	],
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -307,8 +357,25 @@ const buildQueries = (
 			key: workspaceByIdKey(mockWorkspace.id),
 			data: mockWorkspace,
 		},
-		{ key: chatModelAvailabilityKey, data: mockModelCatalog },
-		{ key: chatModels().queryKey, data: mockModels },
+		{
+			key: chatModelAvailabilityKey(chat.organization_id),
+			data: mockModelCatalog,
+		},
+		{
+			key: userChatProviderConfigsKey,
+			data: [
+				{
+					provider_id: "provider-1",
+					provider: "openai",
+					display_name: "OpenAI",
+					icon: "",
+					enabled: true,
+					has_user_api_key: false,
+					has_central_api_key_fallback: true,
+					byok_enabled: true,
+				},
+			],
+		},
 		{
 			key: mcpServerConfigsKey(chat.organization_id),
 			data: opts?.mcpServers ?? [],
@@ -1307,6 +1374,179 @@ export const WithMessageHistory: Story = {
 			5,
 			expect.objectContaining({ reasoning_effort: "medium" }),
 		);
+	},
+};
+
+export const StaleEditedModelUsesUsableLocalModel: Story = {
+	parameters: {
+		queries: [
+			...withoutQuery(
+				buildQueries(
+					{
+						id: CHAT_ID,
+						...baseChatFields,
+						title: "Recovered edit model chat",
+						status: "waiting",
+						last_model_config_id: STALE_MODEL_CONFIG_ID,
+					},
+					{
+						messages: [
+							{
+								...MockChatMessage,
+								id: 5,
+								chat_id: CHAT_ID,
+								model_config_id: STALE_MODEL_CONFIG_ID,
+								content: [{ type: "text", text: "Edit this request" }],
+							},
+						],
+						queued_messages: [],
+						has_more: false,
+					},
+				),
+				chatModelAvailabilityKey(baseChatFields.organization_id),
+			),
+			{
+				key: chatModelAvailabilityKey(baseChatFields.organization_id),
+				data: recoveryModelCatalog,
+			},
+		],
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChat").mockResolvedValue({
+			id: CHAT_ID,
+			...baseChatFields,
+			title: "Recovered edit model chat",
+			status: "waiting",
+			last_model_config_id: STALE_MODEL_CONFIG_ID,
+		});
+		spyOn(API.experimental, "editChatMessage").mockResolvedValue({
+			message: {
+				...MockChatMessage,
+				id: 5,
+				chat_id: CHAT_ID,
+				model_config_id: RECOVERY_MODEL_CONFIG_ID,
+				content: [{ type: "text", text: "Edit this request" }],
+			},
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const modelSelector = canvas.getByRole("combobox", {
+			name: "Usable local model",
+		});
+		expect(modelSelector).toBeVisible();
+		await userEvent.click(modelSelector);
+		const modelListbox = await body.findByRole("listbox");
+		expect(
+			within(modelListbox).getByRole("option", {
+				name: /Usable local model/,
+			}),
+		).toBeInTheDocument();
+		expect(
+			within(modelListbox).queryByRole("option", {
+				name: /Disabled local default/,
+			}),
+		).not.toBeInTheDocument();
+		await userEvent.click(modelSelector);
+		await userEvent.click(canvas.getByRole("button", { name: "Edit message" }));
+		await userEvent.click(canvas.getByRole("button", { name: "Save Edit" }));
+		await waitFor(() => {
+			expect(API.experimental.editChatMessage).toHaveBeenCalledTimes(1);
+		});
+		expect(API.experimental.editChatMessage).toHaveBeenCalledWith(
+			CHAT_ID,
+			5,
+			expect.objectContaining({
+				model_config_id: RECOVERY_MODEL_CONFIG_ID,
+			}),
+		);
+		expect(API.experimental.editChatMessage).not.toHaveBeenCalledWith(
+			CHAT_ID,
+			5,
+			expect.not.objectContaining({ model_config_id: expect.anything() }),
+		);
+	},
+};
+
+export const StaleHistoricalModelUsesLocalDefault: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Recovered model chat",
+				status: "waiting",
+				last_model_config_id: "foreign-model-config",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const sendSpy = spyOn(
+			API.experimental,
+			"createChatMessage",
+		).mockResolvedValue({ queued: false, messages: [] });
+		expect(
+			canvas.getByRole("status", {
+				name: "The model used by this chat is not available. A usable model is selected for new messages.",
+			}),
+		).toBeVisible();
+		expect(canvas.getByRole("combobox", { name: "GPT-4o" })).toBeVisible();
+		const editor = canvas.getByTestId("chat-message-input");
+		await userEvent.click(editor);
+		await userEvent.keyboard("Use a local model");
+		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
+		await waitFor(() => {
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+		});
+		expect(sendSpy).toHaveBeenCalledWith(
+			CHAT_ID,
+			expect.objectContaining({ model_config_id: MODEL_CONFIG_ID }),
+		);
+		expect(sendSpy).not.toHaveBeenCalledWith(
+			CHAT_ID,
+			expect.objectContaining({ model_config_id: "foreign-model-config" }),
+		);
+	},
+};
+
+export const NoLocalModelDisablesGeneration: Story = {
+	parameters: {
+		queries: [
+			...withoutQuery(
+				buildQueries(
+					{
+						id: CHAT_ID,
+						...baseChatFields,
+						title: "Unavailable model chat",
+						status: "waiting",
+						last_model_config_id: "foreign-model-config",
+					},
+					{ messages: [], queued_messages: [], has_more: false },
+				),
+				chatModelAvailabilityKey(baseChatFields.organization_id),
+			),
+			{
+				key: chatModelAvailabilityKey(baseChatFields.organization_id),
+				data: foreignOnlyModelCatalog,
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const sendSpy = spyOn(API.experimental, "createChatMessage");
+		expect(
+			canvas.getByRole("status", {
+				name: "The model used by this chat is not available. Generation is disabled because no usable model is available.",
+			}),
+		).toBeVisible();
+		expect(
+			canvas.getByRole("textbox", { name: "Chat message" }),
+		).toHaveAttribute("aria-disabled", "true");
+		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+		expect(sendSpy).not.toHaveBeenCalled();
 	},
 };
 
@@ -3656,6 +3896,88 @@ export const ErrorRetryRecovers: Story = {
 		});
 		expect(canvas.queryByText("Chat not found")).not.toBeInTheDocument();
 		expect(parameters.getChatCallsForChat()).toBeGreaterThanOrEqual(2);
+	},
+};
+
+export const ModelEndpointFailureKeepsHistoryReadable: Story = {
+	parameters: {
+		queries: withoutQuery(
+			buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Model endpoint failure",
+					status: "waiting",
+				},
+				{
+					messages: [
+						{
+							id: 1,
+							chat_id: CHAT_ID,
+							created_at: "2026-02-18T00:01:00.000Z",
+							role: "user",
+							content: [{ type: "text", text: "Readable history line" }],
+						},
+					],
+					queued_messages: [],
+					has_more: false,
+				},
+			),
+			chatModelAvailabilityKey(baseChatFields.organization_id),
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatModelAvailability").mockRejectedValue(
+			mockServerError,
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("Readable history line")).toBeVisible();
+		expect(await canvas.findByText("Internal server error.")).toBeVisible();
+		expect(canvas.queryByText("Failed to load chat")).not.toBeInTheDocument();
+		expect(
+			canvas.getByRole("textbox", { name: "Chat message" }),
+		).toHaveAttribute("aria-disabled", "true");
+	},
+};
+
+export const ProviderRequiresUserApiKey: Story = {
+	parameters: {
+		queries: [
+			...withoutQuery(
+				buildQueries(
+					{
+						id: CHAT_ID,
+						...baseChatFields,
+						title: "Provider requires user API key",
+						status: "waiting",
+					},
+					{
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+				),
+				chatModelAvailabilityKey(baseChatFields.organization_id),
+			),
+			{
+				key: chatModelAvailabilityKey(baseChatFields.organization_id),
+				data: userApiKeyRequiredModelCatalog,
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("status", {
+				name: "The model used by this chat is not available. Add your API key in provider settings to enable models.",
+			}),
+		).toBeVisible();
+		expect(canvas.getByRole("link", { name: "Settings" })).toHaveAttribute(
+			"href",
+			"/agents/settings/api-keys",
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -34,7 +34,6 @@ import {
 	chat,
 	chatMessagesForInfiniteScroll,
 	chatModelAvailability,
-	chatModels,
 	chatQueueConvergence,
 	compactChat,
 	createChatMessage,
@@ -119,7 +118,9 @@ import {
 	countConfiguredProviderConfigs,
 	getModelSelectorPlaceholder,
 	getUnsupportedProviderNames,
+	getUsableDefaultModelIDForOrganization,
 	hasUserFixableProviders,
+	isUnavailableHistoricalModelID,
 	resolveModelOptionId,
 	resolveModelSelector,
 } from "./utils/modelOptions";
@@ -942,8 +943,10 @@ const AgentChatPage: FC = () => {
 	});
 	const workspace = workspaceQuery.data;
 
-	const chatModelAvailabilityQuery = useQuery(chatModelAvailability());
-	const chatModelsQuery = useQuery(chatModels());
+	const availableModelsQuery = useQuery(
+		chatModelAvailability(chatOrganizationId),
+	);
+	const models = availableModelsQuery.data?.models ?? [];
 	const chatProviderConfigsQuery = useQuery({
 		...chatProviderConfigs(),
 		enabled: permissions.editDeploymentConfig,
@@ -993,26 +996,25 @@ const AgentChatPage: FC = () => {
 		modelCatalog,
 		hasConfiguredModels,
 	} = resolveModelSelector(
-		chatModelsQuery,
-		chatModelAvailabilityQuery,
+		chatOrganizationId,
+		availableModelsQuery,
 		userProviderConfigsQuery,
 	);
-	const models = chatModelsQuery.data ?? [];
+	const isModelDataPending = chatOrganizationId === "" || isModelCatalogLoading;
 	const providerCount =
 		permissions.editDeploymentConfig &&
-		chatProviderConfigsQuery.isSuccess &&
-		chatModelAvailabilityQuery.isSuccess
+		chatProviderConfigsQuery.data &&
+		availableModelsQuery.data
 			? countConfiguredProviderConfigs(
 					chatProviderConfigsQuery.data,
-					chatModelAvailabilityQuery.data,
+					availableModelsQuery.data,
 				)
 			: undefined;
-	const modelCount =
-		chatModelsQuery.isSuccess && chatModelAvailabilityQuery.isSuccess
-			? modelOptions.length
-			: undefined;
+	const modelCount = availableModelsQuery.data
+		? modelOptions.length
+		: undefined;
 	const unsupportedProviderNames = getUnsupportedProviderNames(
-		chatModelAvailabilityQuery.data,
+		availableModelsQuery.data,
 	);
 
 	const agentBindingRefetchKeyRef = useRef<string | undefined>(undefined);
@@ -1335,9 +1337,8 @@ const AgentChatPage: FC = () => {
 	);
 	const prNumber =
 		chatQuery.data?.diff_status?.pr_number ?? (parsedPrNumber || undefined);
-	// Compute an effective selected model by validating the user's
-	// explicit choice against the current model options, falling
-	// back to the chat's last model or the first available option.
+	// Validate explicit and historical choices against organization options.
+	// Prefer the usable organization default before another organization model.
 	const effectiveSelectedModel = (() => {
 		const resolvedSelectedModel = resolveModelOptionId(
 			selectedModel,
@@ -1355,8 +1356,38 @@ const AgentChatPage: FC = () => {
 			return resolvedChatModel;
 		}
 
-		return modelOptions[0]?.id ?? "";
+		return (
+			getUsableDefaultModelIDForOrganization(
+				models,
+				modelOptions,
+				chatOrganizationId,
+			) ||
+			modelOptions[0]?.id ||
+			""
+		);
 	})();
+	const hasModelOptions = modelOptions.length > 0;
+	const hasResolvedModelData =
+		!isModelDataPending &&
+		availableModelsQuery.data !== undefined &&
+		availableModelsQuery.error == null &&
+		userProviderConfigsQuery.data !== undefined &&
+		userProviderConfigsQuery.error == null;
+	const hasUnavailableHistoricalModel =
+		hasResolvedModelData &&
+		isUnavailableHistoricalModelID(chatLastModelConfigID, modelOptions);
+	const hasUserFixableModelProviders = hasUserFixableProviders(modelCatalog);
+	const unavailableModelNotice = hasUnavailableHistoricalModel
+		? hasModelOptions
+			? "The model used by this chat is not available. A usable model is selected for new messages."
+			: hasUserFixableModelProviders
+				? "The model used by this chat is not available. Add your API key in provider settings to enable models."
+				: "The model used by this chat is not available. Generation is disabled because no usable model is available."
+		: hasResolvedModelData && !hasModelOptions
+			? hasUserFixableModelProviders
+				? "No usable chat model is available. Add your API key in provider settings to enable models."
+				: "No usable chat model is currently available. Generation is disabled."
+			: undefined;
 
 	const effectiveModelOption = modelOptions.find(
 		(option) => option.id === effectiveSelectedModel,
@@ -1374,16 +1405,14 @@ const AgentChatPage: FC = () => {
 		userThresholdsQuery.data?.thresholds,
 		models,
 	);
-	const hasModelOptions = modelOptions.length > 0;
-	const hasUserFixableModelProviders = hasUserFixableProviders(modelCatalog);
 	const modelSelectorPlaceholder = getModelSelectorPlaceholder(
 		modelOptions,
-		isModelCatalogLoading,
+		isModelDataPending,
 		hasConfiguredModels,
 		modelCatalog,
 	);
 	const modelSelectorHelp = getModelSelectorHelp({
-		isModelCatalogLoading,
+		isModelCatalogLoading: isModelDataPending,
 		hasModelOptions,
 		hasConfiguredModels,
 		hasUserFixableModelProviders,
@@ -1713,15 +1742,19 @@ const AgentChatPage: FC = () => {
 			const pickerModelConfigID = effectiveSelectedModel || undefined;
 			const originalIsSelectable =
 				originalModelConfigID !== undefined &&
-				modelOptions.some((opt) => opt.id === originalModelConfigID);
-			// Only override the original model when the user has switched to
-			// a different selectable option. If the original is no longer
-			// selectable, the picker is showing a fallback we should not
-			// silently use; let the backend preserve the original.
+				modelOptions.some((option) => option.id === originalModelConfigID);
+			const originalIsUnavailable = isUnavailableHistoricalModelID(
+				originalModelConfigID,
+				modelOptions,
+			);
+			// Use the picker fallback for an unavailable historical model.
+			// Override a selectable model only after the user changes it.
+			// Omit blank and nil references so the backend preserves the original.
 			const editSelectedModelConfigID =
 				pickerModelConfigID &&
-				originalIsSelectable &&
-				pickerModelConfigID !== originalModelConfigID
+				(originalIsUnavailable ||
+					(originalIsSelectable &&
+						pickerModelConfigID !== originalModelConfigID))
 					? pickerModelConfigID
 					: undefined;
 			// Omit so the backend preserves the original effort.
@@ -1930,7 +1963,7 @@ const AgentChatPage: FC = () => {
 				modelOptions={modelOptions}
 				modelSelectorPlaceholder={modelSelectorPlaceholder}
 				hasModelOptions={hasModelOptions}
-				isModelCatalogLoading={isModelCatalogLoading}
+				isModelCatalogLoading={isModelDataPending}
 				planModeEnabled={planModeEnabled}
 				onPlanModeToggle={handlePlanModeToggle}
 				isSidebarCollapsed={isSidebarCollapsed}
@@ -2009,6 +2042,10 @@ const AgentChatPage: FC = () => {
 			modelOptions={modelOptions}
 			modelSelectorPlaceholder={modelSelectorPlaceholder}
 			modelSelectorHelp={modelSelectorHelp}
+			modelCatalogError={
+				availableModelsQuery.error ?? userProviderConfigsQuery.error
+			}
+			unavailableModelNotice={unavailableModelNotice}
 			reasoningEffort={effectiveReasoningEffort}
 			onReasoningEffortChange={(value) => {
 				setSelectedReasoningEffort(value);
@@ -2022,7 +2059,7 @@ const AgentChatPage: FC = () => {
 			unsupportedProviderNames={unsupportedProviderNames}
 			aiGatewayDisabled={aiGatewayDisabled}
 			hasModelOptions={hasModelOptions}
-			isModelCatalogLoading={isModelCatalogLoading}
+			isModelCatalogLoading={isModelDataPending}
 			planModeEnabled={planModeEnabled}
 			onPlanModeToggle={handlePlanModeToggle}
 			compressionThreshold={compressionThreshold}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -245,6 +245,25 @@ export const Default: Story = {
 	},
 };
 
+export const CachedModelsWithRefetchError: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			modelCatalogError={new Error("Failed to refresh available models.")}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText("Failed to refresh available models."),
+		).toBeVisible();
+		expect(
+			canvas.getByRole("combobox", {
+				name: defaultModelOptions[0].displayName,
+			}),
+		).toBeVisible();
+	},
+};
+
 /** Archived agent displays the read-only banner below the top bar. */
 export const Archived: Story = {
 	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -16,6 +16,7 @@ import type {
 	ChatDiffStatus,
 	ChatMessagePart,
 } from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import {
@@ -140,6 +141,8 @@ interface AgentChatPageViewProps {
 	modelOptions: readonly ModelSelectorOption[];
 	modelSelectorPlaceholder: string;
 	modelSelectorHelp?: ReactNode;
+	modelCatalogError?: unknown;
+	unavailableModelNotice?: string;
 	reasoningEffort?: string;
 	onReasoningEffortChange?: (value: string) => void;
 	canConfigureAgentSetup: boolean;
@@ -336,6 +339,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	modelOptions,
 	modelSelectorPlaceholder,
 	modelSelectorHelp,
+	modelCatalogError,
+	unavailableModelNotice,
 	reasoningEffort,
 	onReasoningEffortChange,
 	canConfigureAgentSetup,
@@ -911,6 +916,20 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										: undefined
 								}
 							/>
+							{modelCatalogError != null && (
+								<ErrorAlert error={modelCatalogError} />
+							)}
+							{unavailableModelNotice && (
+								<div
+									role="status"
+									aria-label={unavailableModelNotice}
+									aria-live="polite"
+									className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
+								>
+									<TriangleAlertIcon className="size-4 shrink-0 text-content-warning" />
+									{unavailableModelNotice}
+								</div>
+							)}
 							{chatOwnerWarning && (
 								<div
 									role="status"
@@ -940,6 +959,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						</div>
 						<ChatPageTimeline
 							key={agentId}
+							organizationId={organizationId}
 							store={store}
 							initialActiveTurnMaxMessageId={initialActiveTurnMaxMessageId}
 							persistedError={persistedError}

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -3,13 +3,9 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
-import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import {
-	chatModelAvailability,
-	chatModels,
 	createChat,
 	userChatPersonalModelOverrides,
-	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import { preferenceSettings } from "#/api/queries/users";
 import { workspaces } from "#/api/queries/workspaces";
@@ -26,11 +22,6 @@ import { ChimeButton } from "./components/ChimeButton";
 import { WebPushButton } from "./components/WebPushButton";
 import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
 import { getChimeEnabled, setChimeEnabled } from "./utils/chime";
-import {
-	countConfiguredProviderConfigs,
-	getUnsupportedProviderNames,
-	resolveModelSelector,
-} from "./utils/modelOptions";
 import { buildAgentChatPath } from "./utils/navigation";
 
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
@@ -42,13 +33,6 @@ const AgentCreatePage: FC = () => {
 	const { permissions } = useAuthenticated();
 	const aiGatewayDisabled = !useAIGatewayEnabled();
 
-	const chatModelAvailabilityQuery = useQuery(chatModelAvailability());
-	const chatModelsQuery = useQuery(chatModels());
-	const chatProviderConfigsQuery = useQuery({
-		...chatProviderConfigs(),
-		enabled: permissions.editDeploymentConfig,
-	});
-	const userProviderConfigsQuery = useQuery(userChatProviderConfigs());
 	const personalModelOverridesQuery = useQuery(
 		userChatPersonalModelOverrides(),
 	);
@@ -57,29 +41,6 @@ const AgentCreatePage: FC = () => {
 	const createMutation = useMutation(createChat(queryClient));
 	const webPush = useWebpushNotifications();
 	const [chimeEnabled, setChimeEnabledState] = useState(getChimeEnabled);
-
-	const { options: catalogModelOptions, isModelCatalogLoading } =
-		resolveModelSelector(
-			chatModelsQuery,
-			chatModelAvailabilityQuery,
-			userProviderConfigsQuery,
-		);
-	const providerCount =
-		permissions.editDeploymentConfig &&
-		chatProviderConfigsQuery.isSuccess &&
-		chatModelAvailabilityQuery.isSuccess
-			? countConfiguredProviderConfigs(
-					chatProviderConfigsQuery.data,
-					chatModelAvailabilityQuery.data,
-				)
-			: undefined;
-	const modelCount =
-		chatModelsQuery.isSuccess && chatModelAvailabilityQuery.isSuccess
-			? catalogModelOptions.length
-			: undefined;
-	const unsupportedProviderNames = getUnsupportedProviderNames(
-		chatModelAvailabilityQuery.data,
-	);
 
 	const handleCreateChat = async ({
 		message,
@@ -165,16 +126,8 @@ const AgentCreatePage: FC = () => {
 				isCreating={createMutation.isPending}
 				createError={createMutation.error}
 				canCreateChat={permissions.createChat}
-				modelCatalog={chatModelAvailabilityQuery.data}
-				modelOptions={catalogModelOptions}
 				canConfigureAgentSetup={permissions.editDeploymentConfig}
-				providerCount={providerCount}
-				modelCount={modelCount}
-				unsupportedProviderNames={unsupportedProviderNames}
 				aiGatewayDisabled={aiGatewayDisabled}
-				models={chatModelsQuery.data ?? []}
-				isModelCatalogLoading={isModelCatalogLoading}
-				isModelsLoading={chatModelsQuery.isLoading}
 				rootPersonalModelOverride={rootPersonalModelOverride}
 				isPersonalModelOverridesLoading={personalModelOverridesQuery.isLoading}
 				workspaceCount={workspacesQuery.data?.count}

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.stories.tsx
@@ -201,6 +201,21 @@ export const ModelsUnavailable: Story = {
 	},
 };
 
+export const SomeModelsUnavailable: Story = {
+	args: {
+		areModelsUnavailable: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(
+				"Some enabled model badges are temporarily unavailable.",
+			),
+		).toBeVisible();
+		expect(canvas.getByText(baseModel.display_name)).toBeVisible();
+	},
+};
+
 export const SavingSingleProvider: Story = {
 	args: {
 		providerItems: [

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.tsx
@@ -4,12 +4,13 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
 import {
-	chatModels,
 	deleteUserChatProviderKey,
 	upsertUserChatProviderKey,
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsAPIKeysPageView } from "./AgentSettingsAPIKeysPageView";
+import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
 
 const incrementResetToken = (
 	current: Record<string, number>,
@@ -21,12 +22,15 @@ const incrementResetToken = (
 
 const AgentSettingsAPIKeysPage: FC = () => {
 	const queryClient = useQueryClient();
+	const { organizations } = useDashboard();
+	const organizationModels = useOrganizationChatModels(
+		organizations.map((organization) => organization.id),
+	);
 	const [providerPanelResetTokens, setProviderPanelResetTokens] = useState<
 		Record<string, number>
 	>({});
 
 	const providersQuery = useQuery(userChatProviderConfigs());
-	const modelsQuery = useQuery(chatModels());
 
 	const upsertMutationOptions = upsertUserChatProviderKey(queryClient);
 	const upsertMutation = useMutation({
@@ -78,9 +82,11 @@ const AgentSettingsAPIKeysPage: FC = () => {
 			error={providersQuery.error}
 			isLoading={providersQuery.isLoading}
 			providerItems={providerItems}
-			models={modelsQuery.data ?? []}
-			isModelsLoading={modelsQuery.isLoading}
-			areModelsUnavailable={Boolean(modelsQuery.error)}
+			models={organizationModels.models}
+			isModelsLoading={organizationModels.isLoading}
+			areModelsUnavailable={Boolean(
+				organizationModels.error ?? organizationModels.partialError,
+			)}
 			onSave={(providerConfigId, apiKey) => {
 				upsertMutation.mutate({
 					providerConfigId,

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.tsx
@@ -195,11 +195,12 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 				<p className="m-0 text-sm font-medium text-content-primary">
 					Enabled models
 				</p>
-				{areModelsUnavailable ? (
+				{areModelsUnavailable && enabledModels.length > 0 && (
 					<p className="m-0 text-sm text-content-secondary">
-						Enabled model badges are temporarily unavailable.
+						Some enabled model badges are temporarily unavailable.
 					</p>
-				) : isModelsLoading ? (
+				)}
+				{isModelsLoading ? (
 					<p className="m-0 text-sm text-content-secondary">
 						Loading models...
 					</p>
@@ -211,6 +212,10 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 							</Badge>
 						))}
 					</div>
+				) : areModelsUnavailable ? (
+					<p className="m-0 text-sm text-content-secondary">
+						Enabled model badges are temporarily unavailable.
+					</p>
 				) : (
 					<p className="m-0 text-sm text-content-secondary">
 						No enabled models configured.

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx
@@ -47,7 +47,7 @@ const AgentSettingsCompactionPage: FC = () => {
 				new Map(
 					organizations.map((organization) => [
 						organization.id,
-						organization.display_name,
+						organization.display_name || organization.name,
 					]),
 				)
 			}

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPage.tsx
@@ -1,18 +1,22 @@
 import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
-	chatModels,
 	deleteUserCompactionThreshold,
 	updateUserCompactionThreshold,
 	userChatProviderConfigs,
 	userCompactionThresholds,
 } from "#/api/queries/chats";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsCompactionPageView } from "./AgentSettingsCompactionPageView";
+import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
 import { providerTypeByIDFromUserConfigs } from "./utils/modelOptions";
 
 const AgentSettingsCompactionPage: FC = () => {
 	const queryClient = useQueryClient();
-	const modelsQuery = useQuery(chatModels());
+	const { organizations } = useDashboard();
+	const organizationModels = useOrganizationChatModels(
+		organizations.map((organization) => organization.id),
+	);
 	const providerConfigsQuery = useQuery(userChatProviderConfigs());
 	const thresholdsQuery = useQuery(userCompactionThresholds());
 	const saveThresholdMutation = useMutation(
@@ -37,10 +41,18 @@ const AgentSettingsCompactionPage: FC = () => {
 
 	return (
 		<AgentSettingsCompactionPageView
-			models={modelsQuery.data}
+			models={organizationModels.models}
 			providerTypeByID={providerTypeByID}
-			modelsError={modelsQuery.error}
-			isLoadingModels={modelsQuery.isLoading}
+			organizationNameByID={
+				new Map(
+					organizations.map((organization) => [
+						organization.id,
+						organization.display_name,
+					]),
+				)
+			}
+			modelsError={organizationModels.error ?? organizationModels.partialError}
+			isLoadingModels={organizationModels.isLoading}
 			thresholds={thresholdsQuery.data?.thresholds}
 			isThresholdsLoading={thresholdsQuery.isLoading}
 			thresholdsError={thresholdsQuery.error}

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
-import type * as TypesGen from "#/api/typesGenerated";
+import { MockChatModel } from "#/testHelpers/chatModels";
+import { MockDefaultOrganization } from "#/testHelpers/entities";
 import {
 	AgentSettingsCompactionPageView,
 	type AgentSettingsCompactionPageViewProps,
@@ -9,19 +10,20 @@ import {
 const baseArgs: AgentSettingsCompactionPageViewProps = {
 	models: [
 		{
+			...MockChatModel,
 			id: "model-config-1",
+			organization_id: MockDefaultOrganization.id,
 			ai_provider_id: "prov-openai",
 			model: "gpt-4.1-mini",
 			display_name: "GPT 4.1 Mini",
-			enabled: true,
 			is_default: false,
 			context_limit: 1_000_000,
-			compression_threshold: 70,
-			created_at: "2026-03-12T12:00:00.000Z",
-			updated_at: "2026-03-12T12:00:00.000Z",
 		},
-	] as TypesGen.ChatModel[],
+	],
 	providerTypeByID: new Map<string, string>([["prov-openai", "openai"]]),
+	organizationNameByID: new Map<string, string>([
+		[MockDefaultOrganization.id, MockDefaultOrganization.display_name],
+	]),
 	modelsError: undefined,
 	isLoadingModels: false,
 	thresholds: [
@@ -51,7 +53,7 @@ export const SavesThreshold: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		const thresholdInput = await canvas.findByLabelText(
-			"GPT 4.1 Mini compaction threshold",
+			`GPT 4.1 Mini compaction threshold for ${MockDefaultOrganization.display_name}`,
 		);
 
 		await userEvent.clear(thresholdInput);
@@ -75,7 +77,7 @@ export const ResetsThreshold: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		const resetButton = await canvas.findByLabelText(
-			"Reset GPT 4.1 Mini to default",
+			`Reset GPT 4.1 Mini for ${MockDefaultOrganization.display_name} to default`,
 		);
 
 		await waitFor(() => {
@@ -93,7 +95,7 @@ export const InvalidThresholdIsRejected: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const thresholdInput = await canvas.findByLabelText(
-			"GPT 4.1 Mini compaction threshold",
+			`GPT 4.1 Mini compaction threshold for ${MockDefaultOrganization.display_name}`,
 		);
 
 		await userEvent.clear(thresholdInput);

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.tsx
@@ -4,8 +4,9 @@ import { SectionHeader } from "./components/SectionHeader";
 import { UserCompactionThresholdSettings } from "./components/UserCompactionThresholdSettings";
 
 export interface AgentSettingsCompactionPageViewProps {
-	models: TypesGen.ChatModel[] | undefined;
+	models: readonly TypesGen.ChatModel[] | undefined;
 	providerTypeByID: ReadonlyMap<string, string>;
+	organizationNameByID: ReadonlyMap<string, string>;
 	modelsError: unknown;
 	isLoadingModels: boolean;
 	thresholds: readonly TypesGen.UserChatCompactionThreshold[] | undefined;
@@ -23,6 +24,7 @@ export const AgentSettingsCompactionPageView: FC<
 > = ({
 	models,
 	providerTypeByID,
+	organizationNameByID,
 	modelsError,
 	isLoadingModels,
 	thresholds,
@@ -40,6 +42,7 @@ export const AgentSettingsCompactionPageView: FC<
 			<UserCompactionThresholdSettings
 				models={models ?? []}
 				providerTypeByID={providerTypeByID}
+				organizationNameByID={organizationNameByID}
 				modelsError={modelsError}
 				isLoadingModels={isLoadingModels}
 				thresholds={thresholds}

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPage.tsx
@@ -2,20 +2,26 @@ import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
 	chatModelAvailability,
-	chatModels,
 	updateUserChatPersonalModelOverride,
 	userChatPersonalModelOverrides,
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
+import {
+	getDefaultOrganizationId,
+	useDashboard,
+} from "#/modules/dashboard/useDashboard";
 import { AgentSettingsUserAgentsPageView } from "./AgentSettingsUserAgentsPageView";
 import { resolveModelSelector } from "./utils/modelOptions";
 
 const AgentSettingsUserAgentsPage: FC = () => {
 	const queryClient = useQueryClient();
+	const { organizations } = useDashboard();
 	const overridesQuery = useQuery(userChatPersonalModelOverrides());
-	const chatModelAvailabilityQuery = useQuery(chatModelAvailability());
-	const modelsQuery = useQuery(chatModels());
+	const defaultOrganizationId = getDefaultOrganizationId(organizations);
+	const availableModelsQuery = useQuery(
+		chatModelAvailability(defaultOrganizationId),
+	);
 	const providerConfigsQuery = useQuery(userChatProviderConfigs());
 	const saveRootModelOverrideMutation = useMutation(
 		updateUserChatPersonalModelOverride(queryClient),
@@ -26,12 +32,15 @@ const AgentSettingsUserAgentsPage: FC = () => {
 	const saveExploreModelOverrideMutation = useMutation(
 		updateUserChatPersonalModelOverride(queryClient),
 	);
+
+	const defaultOrgModelConfigs = availableModelsQuery.data?.models ?? [];
+	const hasDefaultOrgModels = defaultOrgModelConfigs.length > 0;
+
 	const { options: modelOptions, isModelCatalogLoading } = resolveModelSelector(
-		modelsQuery,
-		chatModelAvailabilityQuery,
+		defaultOrganizationId,
+		availableModelsQuery,
 		providerConfigsQuery,
 	);
-	const modelsError = modelsQuery.error ?? chatModelAvailabilityQuery.error;
 
 	const saveModelOverride = (
 		context: TypesGen.ChatPersonalModelOverrideContext,
@@ -55,9 +64,17 @@ const AgentSettingsUserAgentsPage: FC = () => {
 			isRetryingOverrides={overridesQuery.isFetching}
 			isLoadingOverrides={overridesQuery.isLoading}
 			modelOptions={modelOptions}
-			models={modelsQuery.data ?? []}
-			modelsError={modelsError}
+			models={defaultOrgModelConfigs}
+			modelsError={availableModelsQuery.error}
 			isLoadingModels={isModelCatalogLoading}
+			isDefaultOrganizationUnresolved={defaultOrganizationId === ""}
+			hasNoDefaultOrgModels={
+				defaultOrganizationId !== "" &&
+				!availableModelsQuery.isLoading &&
+				availableModelsQuery.error === null &&
+				availableModelsQuery.data !== undefined &&
+				!hasDefaultOrgModels
+			}
 			onSaveRootModelOverride={saveModelOverride(
 				"root",
 				saveRootModelOverrideMutation,

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -160,6 +160,8 @@ const buildArgs = (
 	models,
 	modelsError: undefined,
 	isLoadingModels: false,
+	isDefaultOrganizationUnresolved: false,
+	hasNoDefaultOrgModels: false,
 	onSaveRootModelOverride: fn(),
 	isSavingRootModelOverride: false,
 	isSaveRootModelOverrideError: false,
@@ -695,6 +697,42 @@ export const SaveErrorState: Story = {
 				"Failed to save general subagent model override.",
 			),
 		).toBeInTheDocument();
+	},
+};
+
+export const NoDefaultOrgModels: Story = {
+	args: buildArgs({
+		hasNoDefaultOrgModels: true,
+		modelOptions: [],
+		models: [],
+	}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(/default organization has no available chat models/i),
+		).toBeInTheDocument();
+		const rootSection = await getSection(canvasElement, "Root agent model");
+		expect(
+			within(rootSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
+	},
+};
+
+export const DefaultOrganizationUnresolved: Story = {
+	args: buildArgs({
+		isDefaultOrganizationUnresolved: true,
+		modelOptions: [],
+		models: [],
+	}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(/default organization is not available/i),
+		).toBeInTheDocument();
+		const rootSection = await getSection(canvasElement, "Root agent model");
+		expect(
+			within(rootSection).getByRole("button", { name: "Save" }),
+		).toBeDisabled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
@@ -20,6 +20,8 @@ export interface AgentSettingsUserAgentsPageViewProps {
 	models: readonly TypesGen.ChatModel[];
 	modelsError: unknown;
 	isLoadingModels: boolean;
+	isDefaultOrganizationUnresolved: boolean;
+	hasNoDefaultOrgModels: boolean;
 	onSaveRootModelOverride: SavePersonalOverride;
 	isSavingRootModelOverride: boolean;
 	isSaveRootModelOverrideError: boolean;
@@ -43,6 +45,8 @@ export const AgentSettingsUserAgentsPageView: FC<
 	models,
 	modelsError,
 	isLoadingModels,
+	isDefaultOrganizationUnresolved,
+	hasNoDefaultOrgModels,
 	onSaveRootModelOverride,
 	isSavingRootModelOverride,
 	isSaveRootModelOverrideError,
@@ -55,7 +59,11 @@ export const AgentSettingsUserAgentsPageView: FC<
 }) => {
 	const personalOverridesEnabled = overridesData?.enabled ?? true;
 	const isLoading = isLoadingOverrides || isLoadingModels;
-	const isDisabled = isLoading || !personalOverridesEnabled;
+	const isDisabled =
+		isLoading ||
+		!personalOverridesEnabled ||
+		isDefaultOrganizationUnresolved ||
+		hasNoDefaultOrgModels;
 
 	return (
 		<div className="flex flex-col gap-8">
@@ -84,6 +92,23 @@ export const AgentSettingsUserAgentsPageView: FC<
 					<AlertDescription>
 						Personal model overrides are disabled by an administrator. Saved
 						values are shown for reference, but changes cannot be saved.
+					</AlertDescription>
+				</Alert>
+			)}
+			{isDefaultOrganizationUnresolved && (
+				<Alert severity="info">
+					<AlertDescription>
+						Your default organization is not available. Personal model overrides
+						cannot be changed.
+					</AlertDescription>
+				</Alert>
+			)}
+			{hasNoDefaultOrgModels && (
+				<Alert severity="info">
+					<AlertDescription>
+						Your default organization has no available chat models. Ask an
+						organization administrator to add and enable a model before you set
+						personal overrides.
 					</AlertDescription>
 				</Alert>
 			)}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -61,8 +61,8 @@ const defaultModelID = "model-config-1";
 
 const defaultModels: TypesGen.ChatModel[] = [
 	{
-		organization_id: "00000000-0000-0000-0000-000000000000",
 		id: defaultModelID,
+		organization_id: "my-organization-id",
 		ai_provider_id: "provider-openai",
 		model: "gpt-4o",
 		display_name: "GPT-4o",
@@ -349,6 +349,7 @@ const meta: Meta<typeof AgentsPageLayout> = {
 		});
 		// Mocks for child route pages that fetch their own data.
 		spyOn(API.experimental, "getChatModelAvailability").mockResolvedValue({
+			models: defaultModels,
 			providers: [
 				{
 					provider: "openai",
@@ -365,21 +366,21 @@ const meta: Meta<typeof AgentsPageLayout> = {
 			],
 			unsupported_providers: [],
 		});
-		spyOn(API.experimental, "getChatModels").mockResolvedValue([
-			{
-				organization_id: "00000000-0000-0000-0000-000000000000",
-				id: defaultModelID,
-				ai_provider_id: "provider-openai",
-				model: "gpt-4o",
-				display_name: "GPT-4o",
-				enabled: true,
-				is_default: false,
-				context_limit: 200000,
-				compression_threshold: 70,
-				created_at: "2026-02-18T00:00:00.000Z",
-				updated_at: "2026-02-18T00:00:00.000Z",
-			},
-		]);
+		spyOn(API.experimental, "getChatModels").mockImplementation(
+			async (organizationId) => ({
+				models: [
+					{
+						...defaultModels[0],
+						id:
+							organizationId === MockDefaultOrganization.id
+								? defaultModelID
+								: `${defaultModelID}-${organizationId}`,
+						organization_id: organizationId,
+					},
+				],
+				providers: [],
+			}),
+		);
 		spyOn(API.experimental, "getUserAIProviderKeyConfigs").mockResolvedValue([
 			{
 				provider: {

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -754,6 +754,7 @@ const AgentsPageLayout: FC = () => {
 						currentUserId={user.id}
 						chatErrorReasons={sidebarChatErrorReasons}
 						modelConfigs={organizationModels.models}
+						isLoadingModelConfigs={organizationModels.isLoading}
 						onArchiveAgent={requestArchiveAgent}
 						onUnarchiveAgent={requestUnarchiveAgent}
 						onArchiveAndDeleteWorkspace={requestArchiveAndDeleteWorkspace}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -24,8 +24,6 @@ import {
 	cancelChatListRefetches,
 	cancelLoadedChatEntityRefetch,
 	chatEntityKey,
-	chatModelAvailability,
-	chatModels,
 	infiniteChats,
 	invalidateChatCostTree,
 	invalidateChatDiffContents,
@@ -47,7 +45,6 @@ import {
 	updateChatTitle,
 	updateInfiniteChatsCache,
 	userChatPersonalModelOverrides,
-	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import {
 	invalidateWorkspaceMutationQueries,
@@ -79,6 +76,7 @@ import {
 import { ResizableChatsSidebarFrame } from "./components/ChatsSidebar/ResizableChatsSidebarFrame";
 import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
+import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
 import { getAgentSidebarFilters } from "./utils/agentSidebarFilters";
 import {
 	archiveChatAndDeleteWorkspace,
@@ -88,10 +86,6 @@ import {
 	shouldNavigateAfterArchive,
 } from "./utils/agentWorkspaceUtils";
 import { maybePlayChime } from "./utils/chime";
-import {
-	getModelOptionsFromModels,
-	providerInfoByIDFromUserConfigs,
-} from "./utils/modelOptions";
 import { clearPersistedRightPanelState } from "./utils/rightPanelTabStorage";
 import { clearPersistedSidebarTabId } from "./utils/sidebarTabStorage";
 
@@ -232,13 +226,9 @@ const AgentsPageLayout: FC = () => {
 			sources: sidebarFilters.sources,
 		}),
 	);
-	// Model queries are kept here for the sidebar, which displays
-	// model info alongside each chat. Child routes that need models
-	// subscribe to the same queries independently, and react-query
-	// deduplicates the requests.
-	const chatModelAvailabilityQuery = useQuery(chatModelAvailability());
-	const chatModelsQuery = useQuery(chatModels());
-	const chatProviderConfigsQuery = useQuery(userChatProviderConfigs());
+	const organizationModels = useOrganizationChatModels(
+		organizations.map((organization) => organization.id),
+	);
 	const personalModelOverridesQuery = useQuery(
 		userChatPersonalModelOverrides(),
 	);
@@ -388,11 +378,6 @@ const AgentsPageLayout: FC = () => {
 		},
 	});
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-	const catalogModelOptions = getModelOptionsFromModels(
-		chatModelsQuery.data,
-		chatModelAvailabilityQuery.data,
-		providerInfoByIDFromUserConfigs(chatProviderConfigsQuery.data),
-	);
 	const chatList = chatsQuery.data?.pages.flat() ?? [];
 	const isArchiving =
 		archiveAgentMutation.isPending || archiveAndDeleteMutation.isPending;
@@ -768,8 +753,7 @@ const AgentsPageLayout: FC = () => {
 						chats={chatList}
 						currentUserId={user.id}
 						chatErrorReasons={sidebarChatErrorReasons}
-						modelOptions={catalogModelOptions}
-						models={chatModelsQuery.data ?? []}
+						modelConfigs={organizationModels.models}
 						onArchiveAgent={requestArchiveAgent}
 						onUnarchiveAgent={requestUnarchiveAgent}
 						onArchiveAndDeleteWorkspace={requestArchiveAndDeleteWorkspace}

--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -9,12 +9,14 @@ import type {
 import { Button } from "#/components/Button/Button";
 import { useTemporarySavedState } from "#/components/TemporarySavedState/TemporarySavedState";
 import { ModelSelector } from "#/pages/AgentsPage/components/ChatElements/ModelSelector";
-import type { ProviderInfo } from "#/pages/AgentsPage/utils/modelOptions";
+import {
+	isUnsetModelRef,
+	NIL_UUID,
+	type ProviderInfo,
+} from "#/pages/AgentsPage/utils/modelOptions";
 import { pickReasoningEffort } from "#/pages/AgentsPage/utils/reasoningEffort";
 import { AgentSettingLayout } from "#/pages/AISettingsPage/CoderAgentsPage/components/AgentSettingLayout";
 import { cn } from "#/utils/cn";
-
-const nilUUID = "00000000-0000-0000-0000-000000000000";
 
 interface MutationCallbacks {
 	onSuccess?: () => void;
@@ -47,9 +49,6 @@ type AdvisorSettingsFormValues = {
 	reasoning_effort: string;
 };
 
-const isUnsetModelConfigId = (id: string): boolean =>
-	id === "" || id === nilUUID;
-
 const normalizeNonNegativeInteger = (
 	value: number | string | undefined,
 ): number => {
@@ -71,7 +70,7 @@ const normalizeAdvisorConfig = (
 	),
 	model_config_id:
 		typeof config?.model_config_id === "string" &&
-		!isUnsetModelConfigId(config.model_config_id)
+		!isUnsetModelRef(config.model_config_id)
 			? config.model_config_id
 			: "",
 	reasoning_effort: config?.reasoning_effort ?? "",
@@ -83,10 +82,10 @@ const toAdvisorConfigRequest = (
 	enabled: true,
 	max_uses_per_run: normalizeNonNegativeInteger(values.max_uses_per_run),
 	max_output_tokens: normalizeNonNegativeInteger(values.max_output_tokens),
-	model_config_id: isUnsetModelConfigId(values.model_config_id)
-		? nilUUID
+	model_config_id: isUnsetModelRef(values.model_config_id)
+		? NIL_UUID
 		: values.model_config_id,
-	...(!isUnsetModelConfigId(values.model_config_id) && values.reasoning_effort
+	...(!isUnsetModelRef(values.model_config_id) && values.reasoning_effort
 		? { reasoning_effort: values.reasoning_effort }
 		: {}),
 });
@@ -167,11 +166,11 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 			// successfully and no refetch is in flight.
 			let source = values;
 			if (
-				!isUnsetModelConfigId(source.model_config_id) &&
+				!isUnsetModelRef(source.model_config_id) &&
 				!isLoadingModels &&
 				!isFetchingModels &&
 				!modelsError &&
-				!enabledModels.some((config) => config.id === source.model_config_id)
+				!enabledModels.some((model) => model.id === source.model_config_id)
 			) {
 				source = { ...source, model_config_id: "", reasoning_effort: "" };
 			}
@@ -231,7 +230,7 @@ export const AdvisorSettings: FC<AdvisorSettingsProps> = ({
 		: undefined;
 	const hasUnavailableSelectedModel =
 		!isLoadingModels &&
-		!isUnsetModelConfigId(form.values.model_config_id) &&
+		!isUnsetModelRef(form.values.model_config_id) &&
 		selectedModelOption === undefined;
 	const canSave = hasLoadedAdvisorConfig && form.dirty && form.isValid;
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1,6 +1,6 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { delay } from "msw";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider, useQueryClient } from "react-query";
 import {
 	expect,
@@ -12,6 +12,11 @@ import {
 	within,
 } from "storybook/test";
 import { API } from "#/api/api";
+import { aiProvidersListKey } from "#/api/queries/aiProviders";
+import {
+	chatModelAvailabilityKey,
+	userChatProviderConfigsKey,
+} from "#/api/queries/chats";
 import { permittedOrganizationsKey } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
@@ -39,26 +44,12 @@ const permittedOrgsKey = permittedOrganizationsKey({
 const modelID = "model-config-1";
 const claudeModelConfigID = "model-config-claude";
 
-const modelOptions = [
-	{
-		id: modelID,
-		provider: "openai",
-		model: "gpt-4o",
-		displayName: "GPT-4o",
-	},
-	{
-		id: claudeModelConfigID,
-		provider: "anthropic",
-		model: "claude-sonnet-4",
-		displayName: "Claude Sonnet 4",
-	},
-] as const;
-
 const buildModelConfig = (
 	overrides: Partial<TypesGen.ChatModel> = {},
 ): TypesGen.ChatModel => ({
 	...MockChatModel,
 	id: modelID,
+	organization_id: MockDefaultOrganization.id,
 	model: "gpt-4o",
 	display_name: "GPT-4o",
 	created_at: "2026-02-18T00:00:00.000Z",
@@ -66,7 +57,7 @@ const buildModelConfig = (
 	...overrides,
 });
 
-const defaultModels: TypesGen.ChatModel[] = [
+const defaultModelConfigs: TypesGen.ChatModel[] = [
 	buildModelConfig({ is_default: true }),
 	buildModelConfig({
 		id: claudeModelConfigID,
@@ -75,6 +66,72 @@ const defaultModels: TypesGen.ChatModel[] = [
 		display_name: "Claude Sonnet 4",
 		context_limit: 200_000,
 	}),
+];
+
+// Model catalog with both providers available, matching defaultModelConfigs.
+const organization2ModelConfig = buildModelConfig({
+	id: "model-config-org-2",
+	organization_id: MockOrganization2.id,
+	model: "gpt-4.1-mini",
+	display_name: "GPT 4.1 Mini",
+	is_default: true,
+});
+
+const defaultModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	models: defaultModelConfigs,
+	providers: [
+		{ provider: "openai", available: true, models: [] },
+		{ provider: "anthropic", available: true, models: [] },
+	],
+	unsupported_providers: [],
+};
+
+const organization2RuntimeCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...defaultModelCatalog,
+	models: [organization2ModelConfig, ...defaultModelConfigs],
+};
+
+const organization2LocalCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...defaultModelCatalog,
+	models: [organization2ModelConfig],
+};
+
+const organization2ForeignOnlyCatalog: TypesGen.ChatModelAvailabilityResponse =
+	{
+		...defaultModelCatalog,
+		models: defaultModelConfigs,
+	};
+
+const userApiKeyRequiredCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...defaultModelCatalog,
+	providers: defaultModelCatalog.providers.map((provider) => ({
+		...provider,
+		available: false,
+		unavailable_reason: "user_api_key_required",
+	})),
+};
+
+const defaultUserProviderConfigs: TypesGen.UserChatProviderConfig[] = [
+	{
+		provider_id: "provider-1",
+		provider: "openai",
+		display_name: "OpenAI",
+		icon: "",
+		enabled: true,
+		has_user_api_key: false,
+		has_central_api_key_fallback: true,
+		byok_enabled: false,
+	},
+	{
+		provider_id: "provider-anthropic",
+		provider: "anthropic",
+		display_name: "Anthropic",
+		icon: "",
+		enabled: true,
+		has_user_api_key: false,
+		has_central_api_key_fallback: true,
+		byok_enabled: false,
+	},
 ];
 
 const buildRootPersonalModelOverride = (
@@ -117,15 +174,22 @@ const meta: Meta<typeof AgentCreateForm> = {
 		isCreating: false,
 		createError: undefined,
 		canCreateChat: true,
-		modelCatalog: null,
-		modelOptions: [...modelOptions],
-		isModelCatalogLoading: false,
-		models: [],
-		isModelsLoading: false,
 		workspaceCount: 0,
 		workspaceOptions: [],
 		workspacesError: undefined,
 		isWorkspacesLoading: false,
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: defaultModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -161,7 +225,9 @@ const submitMessage = async (canvasElement: HTMLElement, message: string) => {
 	const input = canvas.getByRole("textbox", { name: "Chat message" });
 	await userEvent.click(input);
 	await userEvent.keyboard(message);
-	await userEvent.click(canvas.getByRole("button", { name: "Send" }));
+	const sendButton = canvas.getByRole("button", { name: "Send" });
+	await waitFor(() => expect(sendButton).toBeEnabled());
+	await userEvent.click(sendButton);
 };
 
 const getCreateOptions = (onCreateChat: unknown): CreateChatSubmission => {
@@ -182,7 +248,6 @@ export const RootPersonalModelOverrideModelSelected: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: claudeModelConfigID,
@@ -205,7 +270,6 @@ export const RootChatDefaultSubmitsDisplayedModel: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "chat_default",
 			model_config_id: "",
@@ -228,7 +292,6 @@ export const RootOverrideMissingFromCatalog: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: "model-does-not-exist",
@@ -253,7 +316,6 @@ export const MalformedRootOverrideUsesDefaultModel: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: claudeModelConfigID,
@@ -280,7 +342,6 @@ export const LastUsedModelFallbackWithoutRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		models: defaultModels,
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -303,7 +364,6 @@ export const ManualSelectionOverridesRootChatDefault: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "chat_default",
 			model_config_id: "",
@@ -324,13 +384,13 @@ export const ManualSelectionOverridesRootChatDefault: Story = {
 	},
 };
 
-// Model options with reasoning effort bounds configured. GPT-4o uses the
+// Model configs with reasoning effort bounds configured. GPT-4o uses the
 // full global scale; Claude is capped at medium.
-const effortModelOptions = [
-	{
-		...modelOptions[0],
-		reasoningEffortDefault: "medium",
-		reasoningEfforts: [
+const effortModelConfigs: TypesGen.ChatModel[] = [
+	buildModelConfig({
+		is_default: true,
+		model_config: { reasoning_effort: { default: "medium" } },
+		reasoning_efforts: [
 			"none",
 			"minimal",
 			"low",
@@ -339,18 +399,49 @@ const effortModelOptions = [
 			"xhigh",
 			"max",
 		],
-	},
-	{
-		...modelOptions[1],
-		reasoningEffortDefault: "low",
-		reasoningEfforts: ["low", "medium"],
-	},
-] as const;
+	}),
+	buildModelConfig({
+		id: claudeModelConfigID,
+		ai_provider_id: "provider-anthropic",
+		model: "claude-sonnet-4",
+		display_name: "Claude Sonnet 4",
+		context_limit: 200_000,
+		model_config: { reasoning_effort: { default: "low" } },
+		reasoning_efforts: ["low", "medium"],
+	}),
+];
+
+const effortModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...defaultModelCatalog,
+	models: effortModelConfigs,
+};
+
+const limitedEffortModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	...defaultModelCatalog,
+	models: [
+		buildModelConfig({
+			is_default: true,
+			model_config: { reasoning_effort: { default: "low" } },
+			reasoning_efforts: ["low", "medium"],
+		}),
+	],
+};
 
 export const RemembersReasoningEffortByModel: Story = {
 	args: {
 		...defaultArgs,
-		modelOptions: [...effortModelOptions],
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: effortModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -396,13 +487,23 @@ export const PersistedReasoningEffortOutranksRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelOptions: [...effortModelOptions],
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: modelID,
 			reasoning_effort: "high",
 		}),
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: effortModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -431,13 +532,23 @@ export const PersistedReasoningEffortOutranksRootOverride: Story = {
 export const ManualReselectKeepsRootOverrideEffort: Story = {
 	args: {
 		...defaultArgs,
-		modelOptions: [...effortModelOptions],
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: modelID,
 			reasoning_effort: "high",
 		}),
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: effortModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -459,19 +570,23 @@ export const StalePersistedEffortFallsThroughToRootOverride: Story = {
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelOptions: [
-			{
-				...modelOptions[0],
-				reasoningEffortDefault: "low",
-				reasoningEfforts: ["low", "medium"],
-			},
-		],
-		models: defaultModels,
 		rootPersonalModelOverride: buildRootPersonalModelOverride({
 			mode: "model",
 			model_config_id: modelID,
 			reasoning_effort: "medium",
 		}),
+	},
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: limitedEffortModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	beforeEach: () => {
 		localStorage.clear();
@@ -500,11 +615,22 @@ export const StalePersistedEffortFallsThroughToRootOverride: Story = {
 
 export const SubmitsReasoningEffort: Story = {
 	// TODO: This story fails when pixel runs its play function. Fix it and remove the exclude.
-	parameters: { pixel: { exclude: true } },
+	parameters: {
+		pixel: { exclude: true },
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: effortModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
+	},
 	args: {
 		...defaultArgs,
 		onCreateChat: fn().mockResolvedValue(undefined),
-		modelOptions: [...effortModelOptions],
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
@@ -668,12 +794,37 @@ export const SelectWorkspaceViaSearch: Story = {
 };
 
 export const LoadingModelCatalog: Story = {
+	// Leave the model queries unseeded so they stay pending.
+	parameters: { queries: [] },
 	args: {
 		...defaultArgs,
-		modelCatalog: null,
-		modelOptions: [],
-		isModelCatalogLoading: true,
-		isModelsLoading: true,
+	},
+};
+
+export const CachedModelsWithRefetchError: Story = {
+	decorators: [
+		(Story) => {
+			const queryClient = useQueryClient();
+			useEffect(() => {
+				void queryClient.invalidateQueries({
+					queryKey: chatModelAvailabilityKey(MockDefaultOrganization.id),
+					exact: true,
+				});
+			}, [queryClient]);
+			return <Story />;
+		},
+	],
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatModelAvailability").mockRejectedValue(
+			new Error("Failed to refresh available models."),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("Failed to refresh available models."),
+		).toBeVisible();
+		expect(canvas.getByRole("combobox", { name: "GPT-4o" })).toBeVisible();
 	},
 };
 
@@ -691,26 +842,73 @@ export const LoadingPersonalModelOverrides: Story = {
 	},
 };
 
+const emptyModelCatalog: TypesGen.ChatModelAvailabilityResponse = {
+	providers: [],
+	unsupported_providers: [],
+};
+
 export const NoModelsConfigured: Story = {
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: emptyModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
+	},
 	args: {
 		...defaultArgs,
-		modelCatalog: { providers: [], unsupported_providers: [] },
-		modelOptions: [],
-		isModelCatalogLoading: false,
-		isModelsLoading: false,
+	},
+};
+
+export const ProviderRequiresUserApiKey: Story = {
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: userApiKeyRequiredCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(
+				"A provider requires your API key. Add it in provider settings to enable models.",
+			),
+		).toBeVisible();
+		expect(canvas.getByRole("link", { name: "Settings" })).toHaveAttribute(
+			"href",
+			"/agents/settings/api-keys",
+		);
 	},
 };
 
 export const MissingProviderAndModelSetup: Story = {
+	parameters: {
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: emptyModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+			{ key: aiProvidersListKey, data: [] },
+		],
+	},
 	args: {
 		...defaultArgs,
 		canConfigureAgentSetup: true,
-		providerCount: 0,
-		modelCount: 0,
-		modelCatalog: { providers: [], unsupported_providers: [] },
-		modelOptions: [],
-		isModelCatalogLoading: false,
-		isModelsLoading: false,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -914,35 +1112,111 @@ export const WithOrganizationPicker: Story = {
 				key: permittedOrgsKey,
 				data: [MockOrganization2, MockDefaultOrganization],
 			},
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: defaultModelCatalog,
+			},
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2RuntimeCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
 		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const body = within(canvasElement.ownerDocument.body);
-		await waitFor(() => {
-			expect(API.experimental.getMCPServerConfigs).toHaveBeenCalledWith(
-				MockDefaultOrganization.id,
-			);
-		});
-		const organizationSelector = await canvas.findByRole("button", {
+		const organizationTrigger = await canvas.findByRole("button", {
 			name: `Organization: ${MockDefaultOrganization.display_name}`,
 		});
-		await userEvent.click(organizationSelector);
-		await userEvent.click(
-			await body.findByRole("option", { name: MockOrganization2.display_name }),
-		);
-		await waitFor(() => {
-			expect(API.experimental.getMCPServerConfigs).toHaveBeenCalledWith(
-				MockOrganization2.id,
-			);
-		});
+		expect(canvas.getByRole("combobox", { name: "GPT-4o" })).toBeVisible();
+
 		const input = canvas.getByRole("textbox", { name: "Chat message" });
 		await userEvent.click(input);
 		await userEvent.keyboard("hello world");
-		await expect(
-			canvas.getByRole("button", {
-				name: `Organization: ${MockOrganization2.display_name}`,
+		await expect(organizationTrigger).toBeVisible();
+
+		await userEvent.click(organizationTrigger);
+		await userEvent.click(
+			await body.findByRole("option", {
+				name: new RegExp(MockOrganization2.display_name),
 			}),
+		);
+
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", {
+					name: `Organization: ${MockOrganization2.display_name}`,
+				}),
+			).toBeVisible();
+			expect(
+				canvas.getByRole("combobox", { name: "GPT 4.1 Mini" }),
+			).toBeVisible();
+		});
+
+		await userEvent.keyboard("{Escape}");
+		await userEvent.click(
+			canvas.getByRole("combobox", { name: "GPT 4.1 Mini" }),
+		);
+		await waitFor(() => {
+			const visibleOptions = body
+				.getAllByRole("option")
+				.filter((option) => option.checkVisibility());
+			expect(
+				visibleOptions.some((option) =>
+					option.textContent?.includes("GPT 4.1 Mini"),
+				),
+			).toBe(true);
+			expect(
+				visibleOptions.some((option) => option.textContent?.includes("GPT-4o")),
+			).toBe(false);
+		});
+		expect(
+			canvas.queryByRole("combobox", { name: "GPT-4o" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const DelayedAuthorizationPreservesForeignPersistedModel: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: defaultModelCatalog,
+			},
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2LocalCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem(
+			"agents.last-model-config-id",
+			organization2ModelConfig.id,
+		);
+		mockPermittedOrganizations(
+			{
+				[MockDefaultOrganization.id]: false,
+				[MockOrganization2.id]: true,
+			},
+			100,
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByRole("combobox", { name: "GPT 4.1 Mini" }),
 		).toBeVisible();
 	},
 };
@@ -951,6 +1225,16 @@ export const RestrictedMultiOrganizationUser: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2LocalCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	beforeEach: () => {
 		spyOn(API, "getOrganizations").mockResolvedValue([
@@ -988,6 +1272,16 @@ export const RestrictedUserKeepsPersistedWorkspace: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2LocalCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
 	},
 	args: {
 		...defaultArgs,
@@ -1351,6 +1645,14 @@ export const SingleOrgIgnoresStalePermittedCache: Story = {
 				key: permittedOrgsKey,
 				data: [MockOrganization2],
 			},
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: defaultModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
 		],
 	},
 	args: {
@@ -1415,6 +1717,75 @@ export const RevokedPendingOrgClosesConfirmDialog: Story = {
 			).not.toBeInTheDocument(),
 		);
 		expect(canvas.getByLabelText("Remove notes.txt")).toBeInTheDocument();
+	},
+};
+
+export const LocalOrganizationModels: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockOrganization2],
+			},
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2LocalCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByRole("button", {
+				name: `Organization: ${MockOrganization2.display_name}`,
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			canvas.getByRole("combobox", { name: "GPT 4.1 Mini" }),
+		).toBeVisible();
+	},
+};
+
+export const ForeignOnlyModelsDisableGeneration: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockOrganization2],
+			},
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2ForeignOnlyCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("heading", { name: "No model is available" }),
+		).toBeVisible();
+		expect(
+			canvas.getByText(
+				"No chat model is currently available for this organization.",
+			),
+		).toBeVisible();
+		expect(
+			canvas.getByRole("textbox", { name: "Chat message" }),
+		).toHaveAttribute("aria-disabled", "true");
+		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+		expect(args.onCreateChat).not.toHaveBeenCalled();
 	},
 };
 
@@ -1556,6 +1927,20 @@ export const PermittedOrgsResolvesToSubset: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: chatModelAvailabilityKey(MockDefaultOrganization.id),
+				data: defaultModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+			{
+				key: chatModelAvailabilityKey(MockOrganization2.id),
+				data: organization2LocalCatalog,
+			},
+		],
 	},
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -2083,10 +2083,9 @@ export const MCPServersRefetchErrorKeepsSendEnabled: Story = {
 			throw new Error("query client was not captured by the story decorator");
 		}
 		await capturedQueryClient.refetchQueries();
-		const matches = await canvas.findAllByText(
-			/failed to refresh mcp servers/i,
-		);
-		expect(matches.length).toBeGreaterThan(0);
+		expect(
+			canvas.queryByText(/failed to refresh mcp servers/i),
+		).not.toBeInTheDocument();
 		expect(send).toBeEnabled();
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -581,6 +581,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						)
 					) : null}
 					{workspacesError != null && <ErrorAlert error={workspacesError} />}
+					{mcpServersQuery.data === undefined &&
+						mcpServersQuery.error != null && (
+							<ErrorAlert error={mcpServersQuery.error} />
+						)}
 					{permittedOrgsQuery.error != null && (
 						<ErrorAlert error={permittedOrgsQuery.error} />
 					)}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -2,7 +2,12 @@ import { type FC, useEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
-import { mcpServerConfigs } from "#/api/queries/chats";
+import { chatProviderConfigs } from "#/api/queries/aiProviders";
+import {
+	chatModelAvailability,
+	mcpServerConfigs,
+	userChatProviderConfigs,
+} from "#/api/queries/chats";
 import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
@@ -13,10 +18,13 @@ import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { useFileAttachments } from "../hooks/useFileAttachments";
 import { parseStoredDraft } from "../utils/draftStorage";
 import {
+	countConfiguredProviderConfigs,
 	getModelSelectorPlaceholder,
 	getProviderForModelOption,
-	hasConfiguredModelsInCatalog,
+	getUnsupportedProviderNames,
+	getUsableDefaultModelIDForOrganization,
 	hasUserFixableProviders,
+	resolveModelSelector,
 } from "../utils/modelOptions";
 import {
 	getReasoningEffortForModel,
@@ -30,7 +38,6 @@ import {
 	isChatHookDispatchFailedResponse,
 } from "./ChatConversation/chatError";
 import { getErrorTitle } from "./ChatConversation/chatStatusHelpers";
-import type { ModelSelectorOption } from "./ChatElements";
 import { CompactOrgSelector } from "./ChatElements";
 import {
 	getDefaultMCPSelection,
@@ -43,8 +50,6 @@ import { getModelSelectorHelp } from "./ModelSelectorHelp";
 export const emptyInputStorageKey = "agents.empty-input";
 const selectedWorkspaceIdStorageKey = "agents.selected-workspace-id";
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
-
-type ChatModelOption = ModelSelectorOption;
 
 export type CreateChatOptions = {
 	message: string;
@@ -128,16 +133,8 @@ interface AgentCreateFormProps {
 	isCreating: boolean;
 	createError: unknown;
 	canCreateChat: boolean;
-	modelCatalog: TypesGen.ChatModelAvailabilityResponse | null | undefined;
-	modelOptions: readonly ChatModelOption[];
 	canConfigureAgentSetup: boolean;
-	providerCount?: number;
-	modelCount?: number;
-	unsupportedProviderNames?: readonly string[];
 	aiGatewayDisabled?: boolean;
-	isModelCatalogLoading: boolean;
-	models: readonly TypesGen.ChatModel[];
-	isModelsLoading: boolean;
 	rootPersonalModelOverride?: TypesGen.ChatPersonalModelOverride;
 	isPersonalModelOverridesLoading?: boolean;
 	workspaceCount: number | undefined;
@@ -152,16 +149,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	isCreating,
 	createError,
 	canCreateChat,
-	modelCatalog,
-	modelOptions,
 	canConfigureAgentSetup,
-	providerCount,
-	modelCount,
-	unsupportedProviderNames,
 	aiGatewayDisabled,
-	models,
-	isModelCatalogLoading,
-	isModelsLoading,
 	rootPersonalModelOverride,
 	isPersonalModelOverridesLoading = false,
 	workspaceCount: _workspaceCount,
@@ -180,92 +169,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const [initialLastModelConfigID] = useState(() => {
 		return localStorage.getItem(lastModelConfigIDStorageKey) ?? "";
 	});
-	/*
-	 * Model precedence: user click > root override (specific model) > root
-	 * override (chat_default, resolved) > last-used > default > first available.
-	 */
-	const lastUsedModelID =
-		initialLastModelConfigID &&
-		modelOptions.some((option) => option.id === initialLastModelConfigID)
-			? initialLastModelConfigID
-			: "";
-	const defaultModelID = (() => {
-		const defaultModelConfig = Array.isArray(models)
-			? models.find((config) => config.is_default)
-			: undefined;
-		if (!defaultModelConfig) {
-			return "";
-		}
-		return modelOptions.some((option) => option.id === defaultModelConfig.id)
-			? defaultModelConfig.id
-			: "";
-	})();
-	const isUsableRootPersonalOverride =
-		rootPersonalModelOverride?.is_set === true &&
-		!rootPersonalModelOverride.is_malformed;
-	const rootOverrideModelID =
-		isUsableRootPersonalOverride &&
-		rootPersonalModelOverride.mode === "model" &&
-		modelOptions.some(
-			(option) => option.id === rootPersonalModelOverride.model_config_id,
-		)
-			? rootPersonalModelOverride.model_config_id
-			: "";
-	const isRootOverrideChatDefault =
-		isUsableRootPersonalOverride &&
-		rootPersonalModelOverride.mode === "chat_default";
-	const rootOverrideDisplayModelID = isRootOverrideChatDefault
-		? defaultModelID || (modelOptions[0]?.id ?? "")
-		: rootOverrideModelID;
-	const fallbackModelID =
-		lastUsedModelID || defaultModelID || (modelOptions[0]?.id ?? "");
-	const preferredModelID = rootOverrideDisplayModelID || fallbackModelID;
-	const [userSelectedModel, setUserSelectedModel] = useState("");
-	const [hasUserSelectedModel, setHasUserSelectedModel] = useState(false);
-	const hasValidUserSelectedModel =
-		hasUserSelectedModel &&
-		modelOptions.some((modelOption) => modelOption.id === userSelectedModel);
-	// Derive the effective model every render so we never reference
-	// a stale model id and can honor fallback precedence.
-	const selectedModel = hasValidUserSelectedModel
-		? userSelectedModel
-		: preferredModelID;
-	const submittedModel = (() => {
-		if (hasValidUserSelectedModel) {
-			return userSelectedModel;
-		}
-		if (rootOverrideModelID) {
-			return rootOverrideModelID;
-		}
-		return selectedModel || undefined;
-	})();
-	const [selectedReasoningEfforts, setSelectedReasoningEfforts] = useState<
-		Record<string, string>
-	>({});
-	const selectedModelOption = modelOptions.find(
-		(option) => option.id === selectedModel,
-	);
-	// Persisted per-model choice wins over a root override; a stale
-	// stored value is ignored so the override still applies. The
-	// override applies to its own model even after a manual re-select.
-	const rootOverrideReasoningEffort =
-		selectedModel === rootOverrideModelID
-			? rootPersonalModelOverride?.reasoning_effort
-			: undefined;
-	const persistedReasoningEffort = (() => {
-		const stored = getReasoningEffortForModel(selectedModel);
-		const efforts = selectedModelOption?.reasoningEfforts;
-		return stored && efforts?.includes(stored) ? stored : undefined;
-	})();
-	const effectiveReasoningEffort = selectedModelOption
-		? pickReasoningEffort(
-				selectedReasoningEfforts[selectedModel] ??
-					persistedReasoningEffort ??
-					rootOverrideReasoningEffort,
-				selectedModelOption.reasoningEfforts ?? [],
-				selectedModelOption.reasoningEffortDefault,
-			)
-		: undefined;
 	const initialOrg =
 		organizations.find((o) => o.is_default) ?? organizations[0];
 	// effectiveWorkspaceId nulls a stored selection outside the effective org's
@@ -372,39 +275,138 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			localStorage.removeItem(selectedWorkspaceIdStorageKey);
 		}
 	}, [selectedWorkspaceId]);
+	const availableModelsQuery = useQuery(chatModelAvailability(organizationId));
+	const availableModelConfigs = availableModelsQuery.data?.models ?? [];
+	const chatProviderConfigsQuery = useQuery({
+		...chatProviderConfigs(),
+		enabled: canConfigureAgentSetup,
+	});
+	const userProviderConfigsQuery = useQuery(userChatProviderConfigs());
+	const {
+		options: modelOptions,
+		isModelCatalogLoading,
+		modelCatalog,
+		hasConfiguredModels,
+	} = resolveModelSelector(
+		organizationId,
+		availableModelsQuery,
+		userProviderConfigsQuery,
+	);
+	const modelConfigs = availableModelConfigs;
+	/*
+	 * Model precedence: user click > root override (specific model) > root
+	 * override (chat_default, resolved) > last-used > default > first available.
+	 */
+	const lastUsedModelID =
+		initialLastModelConfigID &&
+		modelOptions.some((option) => option.id === initialLastModelConfigID)
+			? initialLastModelConfigID
+			: "";
+	const defaultModelID = getUsableDefaultModelIDForOrganization(
+		modelConfigs,
+		modelOptions,
+		organizationId,
+	);
+	const isUsableRootPersonalOverride =
+		rootPersonalModelOverride?.is_set === true &&
+		!rootPersonalModelOverride.is_malformed;
+	const rootOverrideModelID =
+		isUsableRootPersonalOverride &&
+		rootPersonalModelOverride.mode === "model" &&
+		modelOptions.some(
+			(option) => option.id === rootPersonalModelOverride.model_config_id,
+		)
+			? rootPersonalModelOverride.model_config_id
+			: "";
+	const isRootOverrideChatDefault =
+		isUsableRootPersonalOverride &&
+		rootPersonalModelOverride.mode === "chat_default";
+	const rootOverrideDisplayModelID = isRootOverrideChatDefault
+		? defaultModelID || (modelOptions[0]?.id ?? "")
+		: rootOverrideModelID;
+	const fallbackModelID =
+		lastUsedModelID || defaultModelID || (modelOptions[0]?.id ?? "");
+	const preferredModelID = rootOverrideDisplayModelID || fallbackModelID;
+	const [userSelectedModel, setUserSelectedModel] = useState("");
+	const [hasUserSelectedModel, setHasUserSelectedModel] = useState(false);
+	const hasValidUserSelectedModel =
+		hasUserSelectedModel &&
+		modelOptions.some((modelOption) => modelOption.id === userSelectedModel);
+	// Derive the effective model every render so we never reference
+	// a stale model id and can honor fallback precedence.
+	const selectedModel = hasValidUserSelectedModel
+		? userSelectedModel
+		: preferredModelID;
+	const submittedModel = (() => {
+		if (hasValidUserSelectedModel) {
+			return userSelectedModel;
+		}
+		if (rootOverrideModelID) {
+			return rootOverrideModelID;
+		}
+		return selectedModel || undefined;
+	})();
+	const [selectedReasoningEfforts, setSelectedReasoningEfforts] = useState<
+		Record<string, string>
+	>({});
+	const selectedModelOption = modelOptions.find(
+		(option) => option.id === selectedModel,
+	);
+	// Persisted per-model choice wins over a root override; a stale
+	// stored value is ignored so the override still applies. The
+	// override applies to its own model even after a manual re-select.
+	const rootOverrideReasoningEffort =
+		selectedModel === rootOverrideModelID
+			? rootPersonalModelOverride?.reasoning_effort
+			: undefined;
+	const persistedReasoningEffort = (() => {
+		const stored = getReasoningEffortForModel(selectedModel);
+		const efforts = selectedModelOption?.reasoningEfforts;
+		return stored && efforts?.includes(stored) ? stored : undefined;
+	})();
+	const effectiveReasoningEffort = selectedModelOption
+		? pickReasoningEffort(
+				selectedReasoningEfforts[selectedModel] ??
+					persistedReasoningEffort ??
+					rootOverrideReasoningEffort,
+				selectedModelOption.reasoningEfforts ?? [],
+				selectedModelOption.reasoningEffortDefault,
+			)
+		: undefined;
 	const [planModeEnabled, setPlanModeEnabled] = useState(false);
 	const hasModelOptions = modelOptions.length > 0;
-	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
 	const hasUserFixableModelProviders = hasUserFixableProviders(modelCatalog);
+	// Treat the unsettled-organization window as pending so the model selector
+	// keeps its loading state instead of flashing the provisional organization's
+	// catalog before permissions resolve.
+	const isModelDataPending = !orgSelectionSettled || isModelCatalogLoading;
 	const modelSelectorPlaceholder = getModelSelectorPlaceholder(
 		modelOptions,
-		isModelCatalogLoading,
+		isModelDataPending,
 		hasConfiguredModels,
 		modelCatalog,
 	);
 	const modelSelectorHelp = getModelSelectorHelp({
-		isModelCatalogLoading,
+		isModelCatalogLoading: isModelDataPending,
 		hasModelOptions,
 		hasConfiguredModels,
 		hasUserFixableModelProviders,
 	});
-	useEffect(() => {
-		if (!initialLastModelConfigID) {
-			return;
-		}
-		if (isModelCatalogLoading || isModelsLoading) {
-			return;
-		}
-		if (lastUsedModelID) {
-			return;
-		}
-		localStorage.removeItem(lastModelConfigIDStorageKey);
-	}, [
-		initialLastModelConfigID,
-		isModelCatalogLoading,
-		isModelsLoading,
-		lastUsedModelID,
-	]);
+	const providerCount =
+		canConfigureAgentSetup &&
+		chatProviderConfigsQuery.data &&
+		availableModelsQuery.data
+			? countConfiguredProviderConfigs(
+					chatProviderConfigsQuery.data,
+					availableModelsQuery.data,
+				)
+			: undefined;
+	const modelCount = availableModelsQuery.data
+		? modelOptions.length
+		: undefined;
+	const unsupportedProviderNames = getUnsupportedProviderNames(
+		availableModelsQuery.data,
+	);
 
 	const effectiveMCPServerIds = (() => {
 		if (userMCPServerIds !== null) {
@@ -440,14 +442,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		setUserSelectedModel(value);
 	};
 
-	const handleReasoningEffortChange = (value: string) => {
-		setSelectedReasoningEfforts((current) => ({
-			...current,
-			[selectedModel]: value,
-		}));
-		saveReasoningEffortForModel(selectedModel, value);
-	};
-
 	const isForbidden = !canCreateChat || noPermittedOrgs;
 
 	// Filter workspaces by the selected organization. We use
@@ -475,26 +469,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const workspaceValidationPending =
 		selectedWorkspaceId !== null && isWorkspacesLoading;
 
-	const handleSend = async (message: string, fileIDs?: string[]) => {
-		submitDraft();
-		await onCreateChat({
-			message,
-			fileIDs,
-			workspaceId: effectiveWorkspaceId ?? undefined,
-			model: submittedModel,
-			reasoningEffort: effectiveReasoningEffort,
-			organizationId,
-			mcpServerIds:
-				effectiveMCPServerIds.length > 0
-					? [...effectiveMCPServerIds]
-					: undefined,
-			planMode: planModeEnabled ? "plan" : undefined,
-		}).catch((err) => {
-			resetDraft();
-			throw err;
-		});
-	};
-
 	const {
 		organizationAdopted,
 		attachments,
@@ -515,6 +489,34 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			provider: getProviderForModelOption(modelOptions, selectedModel),
 		},
 	);
+
+	const handleReasoningEffortChange = (value: string) => {
+		setSelectedReasoningEfforts((current) => ({
+			...current,
+			[selectedModel]: value,
+		}));
+		saveReasoningEffortForModel(selectedModel, value);
+	};
+
+	const handleSend = async (message: string, fileIDs?: string[]) => {
+		submitDraft();
+		await onCreateChat({
+			message,
+			fileIDs,
+			workspaceId: effectiveWorkspaceId ?? undefined,
+			model: submittedModel,
+			reasoningEffort: effectiveReasoningEffort,
+			organizationId,
+			mcpServerIds:
+				effectiveMCPServerIds.length > 0
+					? [...effectiveMCPServerIds]
+					: undefined,
+			planMode: planModeEnabled ? "plan" : undefined,
+		}).catch((err) => {
+			resetDraft();
+			throw err;
+		});
+	};
 
 	const handleSendWithAttachments = async (message: string) => {
 		const fileIds: string[] = [];
@@ -582,9 +584,27 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					{permittedOrgsQuery.error != null && (
 						<ErrorAlert error={permittedOrgsQuery.error} />
 					)}
-					{mcpServersQuery.error != null && (
-						<ErrorAlert error={mcpServersQuery.error} />
+					{availableModelsQuery.error != null && (
+						<ErrorAlert error={availableModelsQuery.error} />
 					)}
+					{userProviderConfigsQuery.error != null && (
+						<ErrorAlert error={userProviderConfigsQuery.error} />
+					)}
+					{organizationId !== "" &&
+						availableModelsQuery.data !== undefined &&
+						availableModelsQuery.error == null &&
+						userProviderConfigsQuery.error == null &&
+						!isModelCatalogLoading &&
+						!hasModelOptions && (
+							<Alert severity="warning">
+								<AlertTitle>No model is available</AlertTitle>
+								<AlertDescription>
+									{hasUserFixableModelProviders
+										? "A provider requires your API key. Add it in provider settings to enable models."
+										: "No chat model is currently available for this organization."}
+								</AlertDescription>
+							</Alert>
+						)}
 					{/* The pre-settlement list is the unfiltered dashboard fallback;
 					    selecting from it could destroy existing workspace state. */}
 					{showOrganizations &&
@@ -634,7 +654,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						modelSelectorPlaceholder={modelSelectorPlaceholder}
 						reasoningEffort={effectiveReasoningEffort}
 						onReasoningEffortChange={handleReasoningEffortChange}
-						isModelCatalogLoading={isModelCatalogLoading}
+						isModelCatalogLoading={isModelDataPending}
 						hasModelOptions={hasModelOptions}
 						planModeEnabled={planModeEnabled}
 						onPlanModeToggle={setPlanModeEnabled}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -430,6 +430,7 @@ const defaultArgs: Omit<
 	React.ComponentProps<typeof ConversationTimeline>,
 	"parsedMessages"
 > = {
+	organizationId: "organization-id",
 	subagentTitles: new Map(),
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -97,6 +97,7 @@ const LifecycleHookNotice: FC<{
 );
 
 const ChatMessageItem = memo<{
+	organizationId: string | undefined;
 	renderKey: string;
 	// Durable messages and live assistant output share one rendering path.
 	message?: TypesGen.ChatMessage;
@@ -139,6 +140,7 @@ const ChatMessageItem = memo<{
 	onJumpToUserMessage?: (messageKey: string) => void;
 }>(
 	({
+		organizationId,
 		renderKey,
 		message,
 		parsed,
@@ -243,6 +245,7 @@ const ChatMessageItem = memo<{
 						<Message className="w-full">
 							<MessageContent className="whitespace-normal">
 								<AssistantOutput
+									organizationId={organizationId}
 									keyPrefix={renderKey}
 									blocks={parsed?.blocks ?? liveBlocks}
 									tools={parsed?.tools ?? liveTools}
@@ -399,6 +402,7 @@ const ChatMessageItem = memo<{
 );
 
 interface ConversationTimelineProps {
+	organizationId: string | undefined;
 	parsedMessages: readonly ParsedMessageEntry[];
 	initialActiveTurnMaxMessageId?: number;
 	streamState?: StreamState | null;
@@ -425,6 +429,7 @@ interface ConversationTimelineProps {
 
 export const ConversationTimeline = memo<ConversationTimelineProps>(
 	({
+		organizationId,
 		parsedMessages,
 		initialActiveTurnMaxMessageId,
 		streamState,
@@ -558,6 +563,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 						return (
 							<MessageScroller.Item key={row.key} messageId={row.key}>
 								<ChatMessageItem
+									organizationId={organizationId}
 									renderKey={row.key}
 									liveStatus={liveStatus}
 									liveBlocks={liveBlocks}
@@ -589,6 +595,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 							}
 						>
 							<ChatMessageItem
+								organizationId={organizationId}
 								renderKey={row.key}
 								message={message}
 								parsed={parsed}

--- a/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
@@ -187,6 +187,7 @@ const ReadFileTimelineBlock = memo<{
 });
 
 export type BlockListProps = {
+	organizationId?: string;
 	blocks: readonly RenderBlock[];
 	tools: readonly MergedTool[];
 	keyPrefix: string;
@@ -212,6 +213,7 @@ export type BlockListProps = {
 // consumers stay in sync. PascalCase so the React Compiler auto-memoizes every
 // element inside.
 export const BlockList: FC<BlockListProps> = ({
+	organizationId,
 	blocks,
 	tools,
 	keyPrefix,
@@ -331,6 +333,7 @@ export const BlockList: FC<BlockListProps> = ({
 							// Streaming placeholder for not-yet-resolved tool.
 							return (
 								<Tool
+									organizationId={organizationId}
 									key={block.id}
 									name="Tool"
 									status="running"
@@ -349,6 +352,7 @@ export const BlockList: FC<BlockListProps> = ({
 						}
 						return (
 							<Tool
+								organizationId={organizationId}
 								key={tool.id}
 								name={tool.name}
 								args={tool.args}
@@ -410,6 +414,7 @@ export const BlockList: FC<BlockListProps> = ({
 			})}
 			{remainingTools.map((tool) => (
 				<Tool
+					organizationId={organizationId}
 					key={tool.id}
 					name={tool.name}
 					args={tool.args}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -10,7 +10,7 @@ import type React from "react";
 import { useState } from "react";
 import { useQuery } from "react-query";
 import { Link, useLocation } from "react-router";
-import { chatModels } from "#/api/queries/chats";
+import { chatModel } from "#/api/queries/chats";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { safeBuildAgentChatPath } from "../../../utils/navigation";
 import { Response } from "../Response";
@@ -158,6 +158,7 @@ const SubagentStatusIcon: React.FC<{
  * "View Agent" link navigates to the sub-agent chat.
  */
 export const SubagentTool: React.FC<{
+	organizationId: string;
 	descriptor: SubagentDescriptor;
 	title: string;
 	chatId: string;
@@ -175,6 +176,7 @@ export const SubagentTool: React.FC<{
 	/** File ID for the JPEG thumbnail of a completed recording. */
 	thumbnailFileId?: string;
 }> = ({
+	organizationId,
 	descriptor,
 	title,
 	chatId,
@@ -194,13 +196,13 @@ export const SubagentTool: React.FC<{
 	const { desktopChatId, onOpenDesktop } = useDesktopPanel();
 	const wantsModelDisplay =
 		descriptor.action === "spawn" && Boolean(descriptor.modelId);
-	const modelsQuery = useQuery({
-		...chatModels(),
-		enabled: wantsModelDisplay,
+	const modelQuery = useQuery({
+		...chatModel(organizationId, descriptor.modelId ?? ""),
+		enabled: wantsModelDisplay && organizationId !== "",
 	});
 	const modelDisplay: SpawnModelDisplay = wantsModelDisplay
 		? resolveSpawnModelDisplay({
-				models: modelsQuery.data,
+				models: modelQuery.data ? [modelQuery.data] : undefined,
 				modelId: descriptor.modelId,
 				reasoningEffort: descriptor.reasoningEffort,
 			})

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
-import { chatModelsKey } from "#/api/queries/chats";
+import { chatModelKey } from "#/api/queries/chats";
 import { workspaceBuildLogs } from "#/api/queries/workspaceBuilds";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -35,6 +35,7 @@ const meta: Meta<typeof Tool> = {
 	title: "pages/AgentsPage/ChatElements/tools/Tool",
 	component: Tool,
 	args: {
+		organizationId: MockChatModel.organization_id,
 		name: "execute",
 		args: { command: executeCommand },
 		status: "completed",
@@ -885,7 +886,12 @@ export const SubagentSpawnWithModelAndEffort: Story = {
 		},
 	},
 	parameters: {
-		queries: [{ key: chatModelsKey, data: [mockChatModel] }],
+		queries: [
+			{
+				key: chatModelKey(mockChatModel.organization_id, mockChatModel.id),
+				data: mockChatModel,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -915,7 +921,12 @@ export const SubagentSpawnWithModelDefaultEffort: Story = {
 		},
 	},
 	parameters: {
-		queries: [{ key: chatModelsKey, data: [mockChatModel] }],
+		queries: [
+			{
+				key: chatModelKey(mockChatModel.organization_id, mockChatModel.id),
+				data: mockChatModel,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -947,7 +958,12 @@ export const SubagentSpawnWithEffortOnly: Story = {
 		},
 	},
 	parameters: {
-		queries: [{ key: chatModelsKey, data: [mockChatModel] }],
+		queries: [
+			{
+				key: chatModelKey(mockChatModel.organization_id, mockChatModel.id),
+				data: mockChatModel,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -975,7 +991,15 @@ export const SubagentSpawnWithUnknownModelConfig: Story = {
 		},
 	},
 	parameters: {
-		queries: [{ key: chatModelsKey, data: [mockChatModel] }],
+		queries: [
+			{
+				key: chatModelKey(
+					MockChatModel.organization_id,
+					"00000000-0000-0000-0000-000000000000",
+				),
+				data: null,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -62,6 +62,7 @@ import {
 import { WriteFileTool } from "./WriteFileTool";
 
 interface ToolProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
+	organizationId?: string;
 	name: string;
 	status?: ToolStatus;
 	args?: unknown;
@@ -98,6 +99,7 @@ interface ToolProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 // Props passed to each tool-specific renderer function. Each renderer
 // only computes the expensive values it needs from the raw args/result.
 type ToolRendererProps = {
+	organizationId?: string;
 	name: string;
 	status: ToolStatus;
 	args: unknown;
@@ -427,6 +429,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 };
 
 const SubagentRenderer: FC<ToolRendererProps> = ({
+	organizationId,
 	name,
 	status,
 	args,
@@ -514,6 +517,7 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 
 	return (
 		<SubagentTool
+			organizationId={organizationId ?? ""}
 			descriptor={descriptor}
 			title={title}
 			chatId={chatId}
@@ -1170,6 +1174,7 @@ export const toolRendererNames: readonly string[] = Object.keys(toolRenderers);
 export const Tool = memo(
 	({
 		className,
+		organizationId,
 		name,
 		status = "completed",
 		args,
@@ -1217,6 +1222,7 @@ export const Tool = memo(
 			>
 				<ToolCall.PolicyProvider hookRewritten={hookRewritten}>
 					<Renderer
+						organizationId={organizationId}
 						name={name}
 						status={status}
 						args={args}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -15,6 +15,7 @@ const StoryChatPageTimeline: FC<{
 }> = ({ store }) => (
 	<MessageScroller.Provider autoScroll defaultScrollPosition="end">
 		<ChatPageTimeline
+			organizationId="organization-id"
 			store={store}
 			persistedError={undefined}
 			hasMoreMessages={false}
@@ -285,6 +286,7 @@ export const InterruptingShowsBusyComposer: Story = {
 			<MessageScroller.Provider autoScroll defaultScrollPosition="end">
 				<div className="flex h-full flex-col">
 					<ChatPageTimeline
+						organizationId="organization-id"
 						store={store}
 						persistedError={undefined}
 						hasMoreMessages={false}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -87,6 +87,7 @@ export const workspaceSkillsFromChat = (
 };
 
 interface ChatPageTimelineProps {
+	organizationId: string | undefined;
 	store: ChatStoreHandle;
 	persistedError: ChatDetailError | undefined;
 	initialActiveTurnMaxMessageId?: number;
@@ -109,6 +110,7 @@ interface ChatPageTimelineProps {
 }
 
 export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
+	organizationId,
 	store,
 	persistedError,
 	initialActiveTurnMaxMessageId,
@@ -195,6 +197,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					   "disconnected" state. The MonitorIcon variant still
 					   renders correctly. */}
 				<ConversationTimeline
+					organizationId={organizationId}
 					parsedMessages={parsedMessages}
 					initialActiveTurnMaxMessageId={initialActiveTurnMaxMessageId}
 					streamState={streamState}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -22,7 +22,6 @@ import {
 } from "#/testHelpers/storybook";
 import { useAgentsPageKeybindings } from "../../hooks/useAgentsPageKeybindings";
 import { DEFAULT_AGENT_SIDEBAR_FILTERS as defaultSidebarFilters } from "../../utils/agentSidebarFilters";
-import type { ModelSelectorOption } from "../ChatElements";
 import { ChatsSidebar } from "./ChatsSidebar";
 
 // Probe element used by the archived-filter preservation story to surface the
@@ -40,19 +39,10 @@ const SettingsStateProbe = () => {
 	return <div data-testid="settings-state-from">{from}</div>;
 };
 
-const defaultModelOptions: ModelSelectorOption[] = [
+const defaultModelConfigs: TypesGen.ChatModel[] = [
 	{
-		id: "openai:gpt-4o",
-		provider: "openai",
-		model: "gpt-4o",
-		displayName: "GPT-4o",
-	},
-];
-
-const defaultModels: TypesGen.ChatModel[] = [
-	{
-		organization_id: "00000000-0000-0000-0000-000000000000",
 		id: "config-openai-gpt-4o",
+		organization_id: "my-organization-id",
 		ai_provider_id: "prov-1",
 		model: "gpt-4o",
 		display_name: "GPT-4o",
@@ -70,7 +60,7 @@ const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 const buildChat = (overrides: Partial<Chat> = {}): Chat => ({
 	...MockChat,
 	id: "chat-default",
-	last_model_config_id: defaultModels[0].id,
+	last_model_config_id: defaultModelConfigs[0].id,
 	created_at: oneWeekAgo,
 	updated_at: oneWeekAgo,
 	...overrides,
@@ -100,8 +90,7 @@ const meta: Meta<typeof ChatsSidebar> = {
 	decorators: [withAuthProvider, withDashboardProvider],
 	args: {
 		chatErrorReasons: {},
-		modelOptions: defaultModelOptions,
-		models: defaultModels,
+		modelConfigs: defaultModelConfigs,
 		onArchiveAgent: fn(),
 		onUnarchiveAgent: fn(),
 		onArchiveAndDeleteWorkspace: fn(),
@@ -153,6 +142,24 @@ const ChatsSidebarWithKeybindings = (
 			onSearchDialogOpenChange={handleSearchDialogOpenChange}
 		/>
 	);
+};
+
+export const UnavailableHistoricalModel: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "chat-unavailable-model",
+				title: "Historical chat",
+				last_model_config_id: "foreign-model-config",
+			}),
+		],
+		modelConfigs: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Historical chat")).toBeVisible();
+		expect(canvas.getByText("Unavailable model")).toBeVisible();
+	},
 };
 
 export const ChatWithTurnSummary: Story = {

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -144,6 +144,48 @@ const ChatsSidebarWithKeybindings = (
 	);
 };
 
+const ChatsSidebarWithDeferredModels = (
+	args: ComponentProps<typeof ChatsSidebar>,
+) => {
+	const [modelsResolved, setModelsResolved] = useState(false);
+
+	useEffect(() => {
+		const timeoutID = window.setTimeout(() => setModelsResolved(true), 500);
+		return () => window.clearTimeout(timeoutID);
+	}, []);
+
+	return (
+		<ChatsSidebar
+			{...args}
+			modelConfigs={modelsResolved ? defaultModelConfigs : []}
+			isLoadingModelConfigs={!modelsResolved}
+		/>
+	);
+};
+
+export const ModelNameWaitsForModelsToLoad: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "chat-models-loading",
+				title: "Chat loaded before models",
+			}),
+		],
+	},
+	render: (args) => <ChatsSidebarWithDeferredModels {...args} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Chat loaded before models")).toBeVisible();
+		expect(canvas.queryByText("Unavailable model")).not.toBeInTheDocument();
+		expect(canvas.queryByText("GPT-4o")).not.toBeInTheDocument();
+
+		await waitFor(() => expect(canvas.getByText("GPT-4o")).toBeVisible(), {
+			timeout: 3000,
+		});
+		expect(canvas.queryByText("Unavailable model")).not.toBeInTheDocument();
+	},
+};
+
 export const UnavailableHistoricalModel: Story = {
 	args: {
 		chats: [

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
@@ -10,6 +10,7 @@ import { TooltipProvider } from "#/components/Tooltip/Tooltip";
 import { ThemeOverride } from "#/contexts/ThemeProvider";
 import { DashboardContext } from "#/modules/dashboard/DashboardProvider";
 import { MockChat } from "#/testHelpers/chatEntities";
+import { MockChatModel } from "#/testHelpers/chatModels";
 import {
 	MockAppearanceConfig,
 	MockBuildInfo,
@@ -103,8 +104,7 @@ const defaultSidebarFilters: AgentSidebarFilters = {
 const defaultProps: React.ComponentProps<typeof ChatsSidebar> = {
 	chats: [buildChat({ id: "chat-1", title: "Chat One" })],
 	chatErrorReasons: {},
-	modelOptions: [],
-	models: [],
+	modelConfigs: [],
 	onArchiveAgent: vi.fn(),
 	onUnarchiveAgent: vi.fn(),
 	onArchiveAndDeleteWorkspace: vi.fn(),
@@ -564,139 +564,15 @@ describe("ChatsSidebar load-more behavior", () => {
 	});
 });
 
-describe("ChatsSidebar model display names", () => {
-	it("uses the chat model config ID to pick the correct duplicate model label", () => {
-		const modelOptions = [
-			{
-				id: "config-fast",
-				provider: "openai",
-				model: "gpt-4o",
-				displayName: "GPT-4o (Fast)",
-			},
-			{
-				id: "config-quality",
-				provider: "openai",
-				model: "gpt-4o",
-				displayName: "GPT-4o (Quality)",
-			},
-		];
-		const models: TypesGen.ChatModel[] = [
-			{
-				organization_id: "00000000-0000-0000-0000-000000000000",
-				id: "config-fast",
-				ai_provider_id: "prov-openai",
-				model: "gpt-4o",
-				display_name: "GPT-4o (Fast)",
-				enabled: true,
-				is_default: false,
-				context_limit: 128_000,
-				compression_threshold: 70,
-				created_at: oneWeekAgo,
-				updated_at: oneWeekAgo,
-			},
-			{
-				organization_id: "00000000-0000-0000-0000-000000000000",
-				id: "config-quality",
-				ai_provider_id: "prov-openai",
-				model: "gpt-4o",
-				display_name: "GPT-4o (Quality)",
-				enabled: true,
-				is_default: false,
-				context_limit: 128_000,
-				compression_threshold: 70,
-				created_at: oneWeekAgo,
-				updated_at: oneWeekAgo,
-			},
-		];
-
-		const { getByText, queryByText } = render(
-			<Wrapper>
-				<ChatsSidebar
-					{...defaultProps}
-					chats={[
-						buildChat({
-							id: "chat-quality",
-							title: "Quality chat",
-							last_model_config_id: "config-quality",
-						}),
-					]}
-					modelOptions={modelOptions}
-					models={models}
-				/>
-			</Wrapper>,
-		);
-
-		expect(getByText("GPT-4o (Quality)")).toBeInTheDocument();
-		expect(queryByText("GPT-4o (Fast)")).not.toBeInTheDocument();
-	});
-
-	it("shows Default model when last_model_config_id is a nil UUID", () => {
-		const { getByText } = render(
-			<Wrapper>
-				<ChatsSidebar
-					{...defaultProps}
-					chats={[
-						buildChat({
-							id: "nil-uuid-chat",
-							title: "Chat from pubsub",
-							last_model_config_id: "00000000-0000-0000-0000-000000000000",
-						}),
-					]}
-					modelOptions={[
-						{
-							id: "config-real",
-							provider: "openai",
-							model: "gpt-4o",
-							displayName: "GPT-4o",
-						},
-					]}
-				/>
-			</Wrapper>,
-		);
-
-		// A nil UUID means LastModelConfigID was left at its zero value,
-		// so the sidebar cannot resolve the model and falls back.
-		expect(getByText("Default model")).toBeInTheDocument();
-	});
-
-	it("shows model name when last_model_config_id matches a config", () => {
-		const { getByText, queryByText } = render(
-			<Wrapper>
-				<ChatsSidebar
-					{...defaultProps}
-					chats={[
-						buildChat({
-							id: "matched-chat",
-							title: "Chat with valid model",
-							last_model_config_id: "config-real",
-						}),
-					]}
-					modelOptions={[
-						{
-							id: "config-real",
-							provider: "openai",
-							model: "gpt-4o",
-							displayName: "GPT-4o",
-						},
-					]}
-				/>
-			</Wrapper>,
-		);
-
-		// Regression guard: a valid last_model_config_id must resolve
-		// to the actual model display name, not "Default model".
-		expect(getByText("GPT-4o")).toBeInTheDocument();
-		expect(queryByText("Default model")).not.toBeInTheDocument();
-	});
-});
-
 describe("ChatsSidebar subtitles", () => {
-	const modelOptions = [
+	const modelConfigs: TypesGen.ChatModel[] = [
 		{
+			...MockChatModel,
 			id: "model-1",
-			provider: "openai",
 			model: "gpt-4o",
-			displayName: "GPT-4o",
+			display_name: "GPT-4o",
+			created_at: oneWeekAgo,
+			updated_at: oneWeekAgo,
 		},
 	];
 
@@ -712,7 +588,7 @@ describe("ChatsSidebar subtitles", () => {
 							last_turn_summary: "Updated the Terraform template",
 						}),
 					]}
-					modelOptions={modelOptions}
+					modelConfigs={modelConfigs}
 				/>
 			</Wrapper>,
 		);
@@ -740,7 +616,7 @@ describe("ChatsSidebar subtitles", () => {
 							last_turn_summary: "Provisioned a workspace",
 						}),
 					]}
-					modelOptions={modelOptions}
+					modelConfigs={modelConfigs}
 				/>
 			</Wrapper>,
 		);
@@ -762,7 +638,7 @@ describe("ChatsSidebar subtitles", () => {
 							title: "Model fallback chat",
 						}),
 					]}
-					modelOptions={modelOptions}
+					modelConfigs={modelConfigs}
 				/>
 			</Wrapper>,
 		);
@@ -782,7 +658,7 @@ describe("ChatsSidebar subtitles", () => {
 							last_turn_summary: "   ",
 						}),
 					]}
-					modelOptions={modelOptions}
+					modelConfigs={modelConfigs}
 				/>
 			</Wrapper>,
 		);

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
@@ -4,7 +4,6 @@ import { useLocation, useParams } from "react-router";
 import { userChatProviderConfigs } from "#/api/queries/chats";
 import type { Chat, ChatModel } from "#/api/typesGenerated";
 import type { AgentSidebarFilters } from "../../utils/agentSidebarFilters";
-import type { ModelSelectorOption } from "../ChatElements";
 import { ChatsPanel } from "./chats/ChatsPanel";
 import { ChatSearchDialog, RenameChatDialog } from "./dialogs";
 import { SettingsPanel } from "./settings/SettingsPanel";
@@ -15,8 +14,7 @@ export { isSettingsView, sidebarViewFromPath } from "./sidebarView";
 interface ChatsSidebarProps {
 	chats: readonly Chat[];
 	chatErrorReasons: Record<string, string>;
-	modelOptions: readonly ModelSelectorOption[];
-	models: readonly ChatModel[];
+	modelConfigs: readonly ChatModel[];
 	onArchiveAgent: (chatId: string) => void;
 	onUnarchiveAgent: (chatId: string) => void;
 	onArchiveAndDeleteWorkspace: (chatId: string, workspaceId: string) => void;
@@ -57,8 +55,7 @@ export const ChatsSidebar: FC<ChatsSidebarProps> = (props) => {
 	const {
 		chats,
 		chatErrorReasons,
-		modelOptions,
-		models,
+		modelConfigs,
 		onArchiveAgent,
 		onUnarchiveAgent,
 		onArchiveAndDeleteWorkspace,
@@ -123,8 +120,7 @@ export const ChatsSidebar: FC<ChatsSidebarProps> = (props) => {
 			<ChatsPanel
 				chats={chats}
 				chatErrorReasons={chatErrorReasons}
-				modelOptions={modelOptions}
-				models={models}
+				modelConfigs={modelConfigs}
 				onArchiveAgent={onArchiveAgent}
 				onUnarchiveAgent={onUnarchiveAgent}
 				onArchiveAndDeleteWorkspace={onArchiveAndDeleteWorkspace}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
@@ -15,6 +15,7 @@ interface ChatsSidebarProps {
 	chats: readonly Chat[];
 	chatErrorReasons: Record<string, string>;
 	modelConfigs: readonly ChatModel[];
+	isLoadingModelConfigs?: boolean;
 	onArchiveAgent: (chatId: string) => void;
 	onUnarchiveAgent: (chatId: string) => void;
 	onArchiveAndDeleteWorkspace: (chatId: string, workspaceId: string) => void;
@@ -56,6 +57,7 @@ export const ChatsSidebar: FC<ChatsSidebarProps> = (props) => {
 		chats,
 		chatErrorReasons,
 		modelConfigs,
+		isLoadingModelConfigs = false,
 		onArchiveAgent,
 		onUnarchiveAgent,
 		onArchiveAndDeleteWorkspace,
@@ -121,6 +123,7 @@ export const ChatsSidebar: FC<ChatsSidebarProps> = (props) => {
 				chats={chats}
 				chatErrorReasons={chatErrorReasons}
 				modelConfigs={modelConfigs}
+				isLoadingModelConfigs={isLoadingModelConfigs}
 				onArchiveAgent={onArchiveAgent}
 				onUnarchiveAgent={onUnarchiveAgent}
 				onArchiveAndDeleteWorkspace={onArchiveAndDeleteWorkspace}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -37,7 +37,6 @@ import {
 	DEFAULT_AGENT_SIDEBAR_FILTERS,
 } from "../../../utils/agentSidebarFilters";
 import { getTimeGroup, TIME_GROUPS } from "../../../utils/timeGroups";
-import type { ModelSelectorOption } from "../../ChatElements";
 import { FilterPopover } from "../filters/FilterPopover";
 import { normalizeLocationSearch } from "../locationSearch";
 import { SettingsNavItem } from "../settings/SettingsNavItem";
@@ -67,8 +66,7 @@ const SHARED_WITH_YOU_SECTION_KEY = "Shared with you";
 interface ChatsPanelProps {
 	readonly chats: readonly Chat[];
 	readonly chatErrorReasons: Record<string, string>;
-	readonly modelOptions: readonly ModelSelectorOption[];
-	readonly models: readonly ChatModel[];
+	readonly modelConfigs: readonly ChatModel[];
 	readonly onArchiveAgent: (chatId: string) => void;
 	readonly onUnarchiveAgent: (chatId: string) => void;
 	readonly onArchiveAndDeleteWorkspace: (
@@ -103,8 +101,7 @@ interface ChatsPanelProps {
 export const ChatsPanel: FC<ChatsPanelProps> = ({
 	chats,
 	chatErrorReasons,
-	modelOptions,
-	models,
+	modelConfigs,
 	onArchiveAgent,
 	onUnarchiveAgent,
 	onArchiveAndDeleteWorkspace,
@@ -296,8 +293,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 		visibleChatIDs,
 		normalizedSearch: "",
 		expandedById,
-		modelOptions,
-		models,
+		modelConfigs,
 		chatErrorReasons,
 		activeChatId,
 		isArchiving,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -67,6 +67,7 @@ interface ChatsPanelProps {
 	readonly chats: readonly Chat[];
 	readonly chatErrorReasons: Record<string, string>;
 	readonly modelConfigs: readonly ChatModel[];
+	readonly isLoadingModelConfigs: boolean;
 	readonly onArchiveAgent: (chatId: string) => void;
 	readonly onUnarchiveAgent: (chatId: string) => void;
 	readonly onArchiveAndDeleteWorkspace: (
@@ -102,6 +103,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 	chats,
 	chatErrorReasons,
 	modelConfigs,
+	isLoadingModelConfigs,
 	onArchiveAgent,
 	onUnarchiveAgent,
 	onArchiveAndDeleteWorkspace,
@@ -294,6 +296,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 		normalizedSearch: "",
 		expandedById,
 		modelConfigs,
+		isLoadingModelConfigs,
 		chatErrorReasons,
 		activeChatId,
 		isArchiving,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext } from "react";
 import type { Chat, ChatModel } from "#/api/typesGenerated";
-import type { ModelSelectorOption } from "../../ChatElements";
 import type { ChatTree } from "./chatTree";
 
 export interface ChatTreeContextValue {
@@ -9,8 +8,7 @@ export interface ChatTreeContextValue {
 	readonly visibleChatIDs: ReadonlySet<string>;
 	readonly normalizedSearch: string;
 	readonly expandedById: Record<string, boolean>;
-	readonly modelOptions: readonly ModelSelectorOption[];
-	readonly models: readonly ChatModel[];
+	readonly modelConfigs: readonly ChatModel[];
 	readonly chatErrorReasons: Record<string, string>;
 	readonly activeChatId: string | undefined;
 	readonly isArchiving: boolean;

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeContext.tsx
@@ -9,6 +9,7 @@ export interface ChatTreeContextValue {
 	readonly normalizedSearch: string;
 	readonly expandedById: Record<string, boolean>;
 	readonly modelConfigs: readonly ChatModel[];
+	readonly isLoadingModelConfigs: boolean;
 	readonly chatErrorReasons: Record<string, string>;
 	readonly activeChatId: string | undefined;
 	readonly isArchiving: boolean;

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -59,6 +59,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 		normalizedSearch,
 		expandedById,
 		modelConfigs,
+		isLoadingModelConfigs,
 		chatErrorReasons,
 		activeChatId,
 		isArchiving,
@@ -82,6 +83,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 	const modelName = getModelDisplayName(
 		chat.last_model_config_id,
 		modelConfigs,
+		isLoadingModelConfigs,
 	);
 	const errorReason =
 		chat.status === "error"
@@ -89,7 +91,8 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 			: undefined;
 	const lastTurnSummary = asNonEmptyString(chat.last_turn_summary);
 	const isStreaming = chat.status === "running";
-	const streamingSubtitle = isStreaming ? `${modelName} streaming…` : undefined;
+	const streamingSubtitle =
+		isStreaming && modelName ? `${modelName} streaming…` : undefined;
 	const staleTurnSummaryReleaseMs = 10_000;
 	const [streamingSummary, setStreamingSummary] = useState<string | undefined>(
 		isStreaming ? lastTurnSummary : undefined,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -58,8 +58,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 		visibleChatIDs,
 		normalizedSearch,
 		expandedById,
-		modelOptions,
-		models,
+		modelConfigs,
 		chatErrorReasons,
 		activeChatId,
 		isArchiving,
@@ -82,8 +81,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 	const isDelegatedExecuting = isDelegated && chat.status === "running";
 	const modelName = getModelDisplayName(
 		chat.last_model_config_id,
-		models,
-		modelOptions,
+		modelConfigs,
 	);
 	const errorReason =
 		chat.status === "error"

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.test.ts
@@ -18,6 +18,10 @@ describe("getModelDisplayName", () => {
 		).toBe("Default model");
 	});
 
+	it("defers the unavailable fallback while models are loading", () => {
+		expect(getModelDisplayName("foreign-model", [], true)).toBeUndefined();
+	});
+
 	it("shows Unavailable model for an unknown non-empty historical ID", () => {
 		expect(getModelDisplayName("foreign-model", [])).toBe("Unavailable model");
 	});

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { MockChatModel } from "#/testHelpers/chatModels";
+import { getModelDisplayName } from "./modelDisplayName";
+
+describe("getModelDisplayName", () => {
+	it("shows the matching model display name", () => {
+		expect(
+			getModelDisplayName("model-1", [
+				{ ...MockChatModel, display_name: "GPT-5" },
+			]),
+		).toBe("GPT-5");
+	});
+
+	it("shows Default model for an unset historical ID", () => {
+		expect(getModelDisplayName("", [])).toBe("Default model");
+		expect(
+			getModelDisplayName("00000000-0000-0000-0000-000000000000", []),
+		).toBe("Default model");
+	});
+
+	it("shows Unavailable model for an unknown non-empty historical ID", () => {
+		expect(getModelDisplayName("foreign-model", [])).toBe("Unavailable model");
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.ts
@@ -5,6 +5,7 @@ import { asString } from "../../ChatElements/runtimeTypeUtils";
 export const getModelDisplayName = (
 	lastModelConfigID: Chat["last_model_config_id"] | undefined,
 	modelConfigs: readonly ChatModel[],
+	isLoadingModelConfigs = false,
 ) => {
 	if (isUnsetModelRef(lastModelConfigID)) {
 		return "Default model";
@@ -15,7 +16,7 @@ export const getModelDisplayName = (
 		(config) => config.id === normalizedModelConfigID,
 	);
 	if (!modelConfig) {
-		return "Unavailable model";
+		return isLoadingModelConfigs ? undefined : "Unavailable model";
 	}
 
 	const displayName = asString(modelConfig.display_name).trim();

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/modelDisplayName.ts
@@ -1,29 +1,21 @@
 import type { Chat, ChatModel } from "#/api/typesGenerated";
-import type { ModelSelectorOption } from "../../ChatElements";
+import { isUnsetModelRef } from "../../../utils/modelOptions";
 import { asString } from "../../ChatElements/runtimeTypeUtils";
 
 export const getModelDisplayName = (
 	lastModelConfigID: Chat["last_model_config_id"] | undefined,
-	models: readonly ChatModel[],
-	modelOptions: readonly ModelSelectorOption[],
+	modelConfigs: readonly ChatModel[],
 ) => {
-	const normalizedModelConfigID = asString(lastModelConfigID).trim();
-	if (!normalizedModelConfigID) {
+	if (isUnsetModelRef(lastModelConfigID)) {
 		return "Default model";
 	}
 
-	const modelOption = modelOptions.find(
-		(option) => option.id === normalizedModelConfigID,
-	);
-	if (modelOption?.displayName) {
-		return modelOption.displayName;
-	}
-
-	const modelConfig = models.find(
+	const normalizedModelConfigID = asString(lastModelConfigID).trim();
+	const modelConfig = modelConfigs.find(
 		(config) => config.id === normalizedModelConfigID,
 	);
 	if (!modelConfig) {
-		return "Default model";
+		return "Unavailable model";
 	}
 
 	const displayName = asString(modelConfig.display_name).trim();

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
@@ -9,6 +9,12 @@ import {
 } from "#/testHelpers/storybook";
 import { UserCompactionThresholdSettings } from "./UserCompactionThresholdSettings";
 
+const organizationWithEmptyDisplayName = {
+	...MockDefaultOrganization,
+	id: MockChatModel.organization_id,
+	display_name: "",
+};
+
 const mockModels: TypesGen.ChatModel[] = [
 	{
 		...MockChatModel,
@@ -82,9 +88,15 @@ export const Default: Story = {
 		expect(canvas.queryByText("GPT-3.5 (Disabled)")).not.toBeInTheDocument();
 
 		// Each badge announces provider + model (the icon itself is decorative).
-		expect(canvas.getByLabelText("OpenAI GPT-4o")).toBeInTheDocument();
 		expect(
-			canvas.getByLabelText("Anthropic Claude Sonnet"),
+			canvas.getByLabelText(
+				`OpenAI GPT-4o in ${MockDefaultOrganization.display_name}`,
+			),
+		).toBeInTheDocument();
+		expect(
+			canvas.getByLabelText(
+				`Anthropic Claude Sonnet in ${MockDefaultOrganization.display_name}`,
+			),
 		).toBeInTheDocument();
 
 		// No footer visible when nothing is dirty
@@ -99,6 +111,35 @@ export const Default: Story = {
 				canvas.getByRole("button", { name: /Save 1 change/i }),
 			).toBeInTheDocument();
 		});
+	},
+};
+
+export const EmptyOrganizationDisplayNameFallsBackToName: Story = {
+	args: {
+		organizationNameByID: new Map<string, string>([
+			[
+				organizationWithEmptyDisplayName.id,
+				organizationWithEmptyDisplayName.display_name ||
+					organizationWithEmptyDisplayName.name,
+			],
+		]),
+		thresholds: [{ model_config_id: "model-1", threshold_percent: 90 }],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getAllByText(organizationWithEmptyDisplayName.name).length,
+		).toBeGreaterThan(0);
+		expect(
+			canvas.getByRole("textbox", {
+				name: `GPT-4o compaction threshold for ${organizationWithEmptyDisplayName.name}`,
+			}),
+		).toBeVisible();
+		expect(
+			canvas.getByRole("button", {
+				name: `Reset GPT-4o for ${organizationWithEmptyDisplayName.name} to default`,
+			}),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChatModel } from "#/testHelpers/chatModels";
-import { MockUserOwner } from "#/testHelpers/entities";
+import { MockDefaultOrganization, MockUserOwner } from "#/testHelpers/entities";
 import {
 	withAuthProvider,
 	withDashboardProvider,
@@ -52,6 +52,9 @@ const meta = {
 		providerTypeByID: new Map<string, string>([
 			["provider-1", "openai"],
 			["provider-anthropic", "anthropic"],
+		]),
+		organizationNameByID: new Map<string, string>([
+			[MockChatModel.organization_id, MockDefaultOrganization.display_name],
 		]),
 		thresholds: [],
 		isThresholdsLoading: false,
@@ -280,5 +283,27 @@ export const ErrorState: Story = {
 	name: "Error",
 	args: {
 		thresholdsError: new globalThis.Error("Failed to load thresholds"),
+	},
+};
+
+export const PartialModelLoadError: Story = {
+	args: {
+		modelsError: new globalThis.Error(
+			"Failed to load models from one organization",
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("Failed to load models from one organization"),
+		).toBeVisible();
+		expect(
+			canvas.getAllByText(MockDefaultOrganization.display_name).length,
+		).toBeGreaterThan(0);
+		expect(
+			canvas.getByRole("textbox", {
+				name: `GPT-4o compaction threshold for ${MockDefaultOrganization.display_name}`,
+			}),
+		).toBeEnabled();
 	},
 };

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -31,6 +31,7 @@ import { ProviderIcon } from "./ChatModelAdminPanel/ProviderIcon";
 interface UserCompactionThresholdSettingsProps {
 	models: readonly TypesGen.ChatModel[];
 	providerTypeByID: ReadonlyMap<string, string>;
+	organizationNameByID: ReadonlyMap<string, string>;
 	modelsError?: unknown;
 	isLoadingModels?: boolean;
 	thresholds: readonly TypesGen.UserChatCompactionThreshold[] | undefined;
@@ -74,6 +75,7 @@ export const UserCompactionThresholdSettings: FC<
 > = ({
 	models,
 	providerTypeByID,
+	organizationNameByID,
 	modelsError,
 	isLoadingModels,
 	thresholds,
@@ -239,7 +241,7 @@ export const UserCompactionThresholdSettings: FC<
 					<Spinner loading className="size-4" />
 					Loading models...
 				</div>
-			) : modelsError ? (
+			) : modelsError && enabledModels.length === 0 ? (
 				<p className="m-0 text-xs text-content-destructive">
 					{getErrorMessage(modelsError, "Failed to load model configurations.")}
 				</p>
@@ -249,193 +251,213 @@ export const UserCompactionThresholdSettings: FC<
 					models before compaction thresholds can be set.
 				</p>
 			) : (
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead className="text-content-secondary">Model</TableHead>
-							<TableHead className="w-0 whitespace-nowrap">Default</TableHead>
-							<TableHead className="w-0 whitespace-nowrap">Threshold</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{enabledModels.map((modelConfig) => {
-							const existingOverride = overridesByModelID.get(modelConfig.id);
-							const hasOverride = overridesByModelID.has(modelConfig.id);
-							const draftValue =
-								drafts[modelConfig.id] ??
-								(existingOverride !== undefined
-									? String(existingOverride)
-									: "");
-							const parsedDraftValue = parseThresholdDraft(draftValue);
-							const isThisModelMutating = pendingModels.has(modelConfig.id);
-							const isInvalid =
-								draftValue.length > 0 && parsedDraftValue === null;
-							// Only warn when user-typed, not when loaded from
-							// the server.
-							const isDraftDisablingCompaction =
-								draftValue === "100" && drafts[modelConfig.id] !== undefined;
-							const rowError = rowErrors[modelConfig.id];
-							const modelName = modelConfig.display_name || modelConfig.model;
-							const provider =
-								providerTypeByID.get(modelConfig.ai_provider_id) ?? "";
-							const providerLabel = formatProviderLabel(provider);
+				<>
+					{modelsError && (
+						<p className="m-0 text-xs text-content-destructive">
+							{getErrorMessage(
+								modelsError,
+								"Some organization models could not be loaded.",
+							)}
+						</p>
+					)}
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead className="text-content-secondary">Model</TableHead>
+								<TableHead className="w-0 whitespace-nowrap">Default</TableHead>
+								<TableHead className="w-0 whitespace-nowrap">
+									Threshold
+								</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{enabledModels.map((modelConfig) => {
+								const existingOverride = overridesByModelID.get(modelConfig.id);
+								const hasOverride = overridesByModelID.has(modelConfig.id);
+								const draftValue =
+									drafts[modelConfig.id] ??
+									(existingOverride !== undefined
+										? String(existingOverride)
+										: "");
+								const parsedDraftValue = parseThresholdDraft(draftValue);
+								const isThisModelMutating = pendingModels.has(modelConfig.id);
+								const isInvalid =
+									draftValue.length > 0 && parsedDraftValue === null;
+								// Only warn when user-typed, not when loaded from
+								// the server.
+								const isDraftDisablingCompaction =
+									draftValue === "100" && drafts[modelConfig.id] !== undefined;
+								const rowError = rowErrors[modelConfig.id];
+								const modelName = modelConfig.display_name || modelConfig.model;
+								const provider =
+									providerTypeByID.get(modelConfig.ai_provider_id) ?? "";
+								const providerLabel = formatProviderLabel(provider);
+								const organizationName =
+									organizationNameByID.get(modelConfig.organization_id) ??
+									modelConfig.organization_id;
 
-							return (
-								<TableRow key={modelConfig.id}>
-									<TableCell className="text-sm font-medium text-content-primary">
-										<Badge
-											size="sm"
-											variant="default"
-											className="w-fit"
-											aria-label={`${providerLabel} ${modelName}`}
-										>
-											<ProviderIcon provider={provider} className="size-4" />
-											{modelName}
-										</Badge>
-										{rowError && (
-											<p
-												aria-live="polite"
-												className="m-0 mt-0.5 text-2xs font-normal text-content-destructive"
+								return (
+									<TableRow key={modelConfig.id}>
+										<TableCell className="text-sm font-medium text-content-primary">
+											<Badge
+												size="sm"
+												variant="default"
+												className="w-fit"
+												aria-label={`${providerLabel} ${modelName} in ${organizationName}`}
 											>
-												{rowError}
-											</p>
-										)}
-									</TableCell>
-									<TableCell className="w-0 whitespace-nowrap tabular-nums">
-										{modelConfig.compression_threshold}%
-									</TableCell>
-									<TableCell className="w-0 whitespace-nowrap">
-										<div className="flex items-center gap-1.5">
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<div className="relative">
-														<Input
-															aria-label={`${modelName} compaction threshold`}
-															aria-invalid={isInvalid || undefined}
-															type="text"
-															min={0}
-															max={100}
-															maxLength={3}
-															inputMode="numeric"
-															className={cn(
-																"h-7 w-16 px-2 pr-5 text-xs tabular-nums",
-																isInvalid &&
-																	"border-content-destructive focus:ring-content-destructive/30",
-															)}
-															value={draftValue}
-															placeholder={String(
-																modelConfig.compression_threshold,
-															)}
-															onChange={(event) => {
-																setDrafts((currentDrafts) => ({
-																	...currentDrafts,
-																	[modelConfig.id]: event.target.value,
-																}));
-																clearRowError(modelConfig.id);
-															}}
-															disabled={isThisModelMutating}
-														/>
-														<span
-															aria-hidden="true"
-															className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-content-secondary"
-														>
-															%
-														</span>
-													</div>
-												</TooltipTrigger>
-												{(isInvalid || isDraftDisablingCompaction) && (
-													<TooltipContent>
-														{isInvalid
-															? "Enter a whole number between 0 and 100."
-															: "Setting 100% will disable auto-compaction for this model."}
-													</TooltipContent>
-												)}
-											</Tooltip>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<Button
-														size="icon"
-														variant="subtle"
-														className={cn(
-															"size-7",
-															hasOverride
-																? "opacity-100"
-																: "pointer-events-none opacity-0",
-														)}
-														aria-label={`Reset ${modelName} to default`}
-														aria-hidden={!hasOverride}
-														tabIndex={hasOverride ? 0 : -1}
-														disabled={isThisModelMutating || !hasOverride}
-														onClick={() => handleReset(modelConfig.id)}
-													>
-														<RotateCcwIcon className="size-3.5" />
-													</Button>
-												</TooltipTrigger>
-												{hasOverride && (
-													<TooltipContent>
-														Reset to default (
-														{modelConfig.compression_threshold}%)
-													</TooltipContent>
-												)}
-											</Tooltip>
-										</div>
-										{isInvalid && (
-											<span className="sr-only" aria-live="polite">
-												Enter a whole number between 0 and 100.
-											</span>
-										)}
-										{isDraftDisablingCompaction && (
-											<span className="sr-only" aria-live="polite">
-												Setting 100% will disable auto-compaction for this
-												model.
-											</span>
-										)}
-									</TableCell>
-								</TableRow>
-							);
-						})}
-					</TableBody>
-					<TableFooter className="bg-transparent">
-						<TableRow className="border-0">
-							<TableCell colSpan={3} className="border-0 p-0">
-								<div className="mt-2 flex h-6 items-center justify-end gap-2 px-3">
-									{isSavedVisible ? (
-										<TemporarySavedState />
-									) : (
-										shouldShowActions && (
-											<>
-												<Button
-													size="xs"
-													variant="outline"
-													type="button"
-													onClick={handleCancelAll}
-													disabled={hasAnyPending}
+												<ProviderIcon provider={provider} className="size-4" />
+												{modelName}
+											</Badge>
+											{organizationName && (
+												<span className="mt-0.5 block text-2xs font-normal text-content-secondary">
+													{organizationName}
+												</span>
+											)}
+											{rowError && (
+												<p
+													aria-live="polite"
+													className="m-0 mt-0.5 text-2xs font-normal text-content-destructive"
 												>
-													Cancel
-												</Button>
-												{dirtyRows.length > 0 && (
+													{rowError}
+												</p>
+											)}
+										</TableCell>
+										<TableCell className="w-0 whitespace-nowrap tabular-nums">
+											{modelConfig.compression_threshold}%
+										</TableCell>
+										<TableCell className="w-0 whitespace-nowrap">
+											<div className="flex items-center gap-1.5">
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<div className="relative">
+															<Input
+																aria-label={`${modelName} compaction threshold for ${organizationName}`}
+																aria-invalid={isInvalid || undefined}
+																type="text"
+																min={0}
+																max={100}
+																maxLength={3}
+																inputMode="numeric"
+																className={cn(
+																	"h-7 w-16 px-2 pr-5 text-xs tabular-nums",
+																	isInvalid &&
+																		"border-content-destructive focus:ring-content-destructive/30",
+																)}
+																value={draftValue}
+																placeholder={String(
+																	modelConfig.compression_threshold,
+																)}
+																onChange={(event) => {
+																	setDrafts((currentDrafts) => ({
+																		...currentDrafts,
+																		[modelConfig.id]: event.target.value,
+																	}));
+																	clearRowError(modelConfig.id);
+																}}
+																disabled={isThisModelMutating}
+															/>
+															<span
+																aria-hidden="true"
+																className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-content-secondary"
+															>
+																%
+															</span>
+														</div>
+													</TooltipTrigger>
+													{(isInvalid || isDraftDisablingCompaction) && (
+														<TooltipContent>
+															{isInvalid
+																? "Enter a whole number between 0 and 100."
+																: "Setting 100% will disable auto-compaction for this model."}
+														</TooltipContent>
+													)}
+												</Tooltip>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Button
+															size="icon"
+															variant="subtle"
+															className={cn(
+																"size-7",
+																hasOverride
+																	? "opacity-100"
+																	: "pointer-events-none opacity-0",
+															)}
+															aria-label={`Reset ${modelName} for ${organizationName} to default`}
+															aria-hidden={!hasOverride}
+															tabIndex={hasOverride ? 0 : -1}
+															disabled={isThisModelMutating || !hasOverride}
+															onClick={() => handleReset(modelConfig.id)}
+														>
+															<RotateCcwIcon className="size-3.5" />
+														</Button>
+													</TooltipTrigger>
+													{hasOverride && (
+														<TooltipContent>
+															Reset to default (
+															{modelConfig.compression_threshold}%)
+														</TooltipContent>
+													)}
+												</Tooltip>
+											</div>
+											{isInvalid && (
+												<span className="sr-only" aria-live="polite">
+													Enter a whole number between 0 and 100.
+												</span>
+											)}
+											{isDraftDisablingCompaction && (
+												<span className="sr-only" aria-live="polite">
+													Setting 100% will disable auto-compaction for this
+													model.
+												</span>
+											)}
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+						<TableFooter className="bg-transparent">
+							<TableRow className="border-0">
+								<TableCell colSpan={3} className="border-0 p-0">
+									<div className="mt-2 flex h-6 items-center justify-end gap-2 px-3">
+										{isSavedVisible ? (
+											<TemporarySavedState />
+										) : (
+											shouldShowActions && (
+												<>
 													<Button
 														size="xs"
+														variant="outline"
 														type="button"
+														onClick={handleCancelAll}
 														disabled={hasAnyPending}
-														onClick={handleSaveAll}
 													>
-														{hasAnyPending && (
-															<Spinner loading className="size-4" />
-														)}
-														{hasAnyPending
-															? "Saving..."
-															: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
+														Cancel
 													</Button>
-												)}
-											</>
-										)
-									)}
-								</div>
-							</TableCell>
-						</TableRow>
-					</TableFooter>
-				</Table>
+													{dirtyRows.length > 0 && (
+														<Button
+															size="xs"
+															type="button"
+															disabled={hasAnyPending}
+															onClick={handleSaveAll}
+														>
+															{hasAnyPending && (
+																<Spinner loading className="size-4" />
+															)}
+															{hasAnyPending
+																? "Saving..."
+																: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
+														</Button>
+													)}
+												</>
+											)
+										)}
+									</div>
+								</TableCell>
+							</TableRow>
+						</TableFooter>
+					</Table>
+				</>
 			)}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/hooks/useOrganizationChatModels.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useOrganizationChatModels.test.tsx
@@ -1,0 +1,203 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
+import type { OrganizationChatModelsResponse } from "#/api/typesGenerated";
+import { MockChatModel } from "#/testHelpers/chatModels";
+import { useOrganizationChatModels } from "./useOrganizationChatModels";
+
+const createQueryWrapper = (staleTime = 0) => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime } },
+	});
+	const wrapper = ({ children }: PropsWithChildren) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	return { queryClient, wrapper };
+};
+
+const modelsResponse = (
+	organizationId: string,
+): OrganizationChatModelsResponse => ({
+	models: [
+		{
+			...MockChatModel,
+			id: `model-${organizationId}`,
+			organization_id: organizationId,
+		},
+	],
+	providers: [],
+});
+
+const apiError = (status: number, message: string) => ({
+	isAxiosError: true,
+	status,
+	response: { status, data: { message } },
+});
+
+beforeEach(() => {
+	vi.spyOn(API, "checkAuthorization").mockImplementation(async ({ checks }) =>
+		Object.fromEntries(Object.keys(checks).map((key) => [key, true])),
+	);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("useOrganizationChatModels", () => {
+	it("keeps each organization's models and reuses fresh cache", async () => {
+		const getChatModels = vi
+			.spyOn(API.experimental, "getChatModels")
+			.mockImplementation(async (organizationId) =>
+				modelsResponse(organizationId),
+			);
+		const { queryClient, wrapper } = createQueryWrapper(
+			Number.POSITIVE_INFINITY,
+		);
+
+		const first = renderHook(
+			() => useOrganizationChatModels(["organization-1", "organization-2"]),
+			{ wrapper },
+		);
+		await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+
+		expect(first.result.current.models).toEqual([
+			...modelsResponse("organization-1").models,
+			...modelsResponse("organization-2").models,
+		]);
+		expect(getChatModels).toHaveBeenCalledTimes(2);
+		expect(getChatModels).toHaveBeenCalledWith("organization-1");
+		expect(getChatModels).toHaveBeenCalledWith("organization-2");
+
+		first.rerender();
+		expect(getChatModels).toHaveBeenCalledTimes(2);
+		first.unmount();
+
+		const second = renderHook(
+			() => useOrganizationChatModels(["organization-1", "organization-2"]),
+			{ wrapper },
+		);
+
+		expect(second.result.current.isLoading).toBe(false);
+		expect(second.result.current.models).toHaveLength(2);
+		expect(getChatModels).toHaveBeenCalledTimes(2);
+
+		second.unmount();
+		queryClient.clear();
+	});
+
+	it("stays loading until every organization request settles", async () => {
+		let resolveSecond: (value: OrganizationChatModelsResponse) => void =
+			() => {};
+		const secondResponse = new Promise<OrganizationChatModelsResponse>(
+			(resolve) => {
+				resolveSecond = resolve;
+			},
+		);
+		vi.spyOn(API.experimental, "getChatModels").mockImplementation(
+			async (organizationId) =>
+				organizationId === "organization-1"
+					? modelsResponse("organization-1")
+					: secondResponse,
+		);
+		const { queryClient, wrapper } = createQueryWrapper();
+
+		const { result, unmount } = renderHook(
+			() => useOrganizationChatModels(["organization-1", "organization-2"]),
+			{ wrapper },
+		);
+
+		await waitFor(() =>
+			expect(result.current.models).toEqual(
+				modelsResponse("organization-1").models,
+			),
+		);
+		expect(result.current.isLoading).toBe(true);
+
+		resolveSecond(modelsResponse("organization-2"));
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.models).toHaveLength(2);
+
+		unmount();
+		queryClient.clear();
+	});
+
+	it("loads ACL-readable models without organization model permission", async () => {
+		vi.mocked(API.checkAuthorization).mockImplementation(async ({ checks }) =>
+			Object.fromEntries(Object.keys(checks).map((key) => [key, false])),
+		);
+		const getChatModels = vi
+			.spyOn(API.experimental, "getChatModels")
+			.mockImplementation(async (organizationId) =>
+				modelsResponse(organizationId),
+			);
+		const { queryClient, wrapper } = createQueryWrapper();
+
+		const { result, unmount } = renderHook(
+			() => useOrganizationChatModels(["organization-1"]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.models).toEqual(
+			modelsResponse("organization-1").models,
+		);
+		expect(result.current.error).toBeNull();
+		expect(result.current.partialError).toBeNull();
+		expect(getChatModels).toHaveBeenCalledOnce();
+		expect(getChatModels).toHaveBeenCalledWith("organization-1");
+		expect(API.checkAuthorization).not.toHaveBeenCalled();
+
+		unmount();
+		queryClient.clear();
+	});
+
+	it("reports a partial failure while keeping successful models", async () => {
+		vi.spyOn(API.experimental, "getChatModels").mockImplementation(
+			async (organizationId) => {
+				if (organizationId === "organization-2") {
+					throw apiError(500, "Server error");
+				}
+				return modelsResponse(organizationId);
+			},
+		);
+		const { queryClient, wrapper } = createQueryWrapper();
+
+		const { result, unmount } = renderHook(
+			() => useOrganizationChatModels(["organization-1", "organization-2"]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.models).toEqual(
+			modelsResponse("organization-1").models,
+		);
+		expect(result.current.error).toBeNull();
+		expect(result.current.partialError).not.toBeNull();
+
+		unmount();
+		queryClient.clear();
+	});
+
+	it("reports a blocking error when no organization returns data", async () => {
+		vi.spyOn(API.experimental, "getChatModels").mockImplementation(async () => {
+			throw apiError(500, "Server error");
+		});
+		const { queryClient, wrapper } = createQueryWrapper();
+
+		const { result, unmount } = renderHook(
+			() => useOrganizationChatModels(["organization-1", "organization-2"]),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.models).toEqual([]);
+		expect(result.current.error).not.toBeNull();
+		expect(result.current.partialError).toBeNull();
+
+		unmount();
+		queryClient.clear();
+	});
+});

--- a/site/src/pages/AgentsPage/hooks/useOrganizationChatModels.ts
+++ b/site/src/pages/AgentsPage/hooks/useOrganizationChatModels.ts
@@ -1,0 +1,31 @@
+import { useQueries } from "react-query";
+import { chatModels } from "#/api/queries/chats";
+
+/**
+ * Aggregates chat models across the given organizations.
+ *
+ * Each model endpoint applies its model ACL. Any request failure is reported
+ * through partialError while cached data is present, so callers keep showing
+ * cached models during a failed background refetch. isLoading stays true until
+ * every model request settles.
+ */
+export const useOrganizationChatModels = (
+	organizationIds: readonly string[],
+) => {
+	const queries = useQueries({
+		queries: organizationIds.map((organizationId) =>
+			chatModels(organizationId),
+		),
+	});
+
+	const modelError = queries.find((query) => query.error)?.error ?? null;
+	const hasData = queries.some((query) => query.data !== undefined);
+
+	return {
+		models: queries.flatMap((query) => query.data?.models ?? []),
+		isLoading: queries.some((query) => query.isLoading),
+		isFetching: queries.some((query) => query.isFetching),
+		error: hasData ? null : modelError,
+		partialError: hasData ? modelError : null,
+	};
+};

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -15,11 +15,13 @@ import {
 	getModelOptionsFromModels,
 	getModelSelectorPlaceholder,
 	getUnsupportedProviderNames,
+	getUsableDefaultModelIDForOrganization,
 	hasConfiguredProviderConfigs,
 	hasUserFixableProviders,
-	providerInfoByIDFromConfigs,
+	isUnavailableHistoricalModelID,
+	isUnsetModelRef,
+	NIL_UUID,
 	providerInfoByIDFromUserConfigs,
-	providerTypeByIDFromConfigs,
 	providerTypeByIDFromUserConfigs,
 	resolveModelOptionId,
 	resolveModelSelector,
@@ -36,6 +38,8 @@ const createConfig = (
 	updated_at: "",
 	...overrides,
 });
+
+const testOrganizationID = MockChatModel.organization_id;
 
 const providerInfoByID = new Map([
 	["prov-openai", { provider: "openai", displayName: "OpenAI", icon: "" }],
@@ -244,6 +248,20 @@ describe("getModelSelectorPlaceholder", () => {
 	});
 });
 
+describe("isUnsetModelRef", () => {
+	it.each([
+		[undefined, true],
+		[null, true],
+		["", true],
+		["   ", true],
+		[NIL_UUID, true],
+		[`  ${NIL_UUID}  `, true],
+		["config-1", false],
+	])("reports whether %j is unset", (modelRef, expected) => {
+		expect(isUnsetModelRef(modelRef)).toBe(expected);
+	});
+});
+
 describe("resolveModelOptionId", () => {
 	const modelOptions = [
 		{
@@ -276,12 +294,123 @@ describe("resolveModelOptionId", () => {
 		expect(resolveModelOptionId("config-2", modelOptions)).toBe("config-2");
 	});
 
+	it("treats a nil UUID as unset", () => {
+		expect(
+			resolveModelOptionId(
+				"00000000-0000-0000-0000-000000000000",
+				modelOptions,
+			),
+		).toBe("");
+	});
+
 	it("returns an empty string when no option matches", () => {
 		expect(resolveModelOptionId("openai:gpt-5", modelOptions)).toBe("");
+	});
+	it("detects only non-empty unavailable historical IDs", () => {
+		expect(isUnavailableHistoricalModelID("config-1", modelOptions)).toBe(
+			false,
+		);
+		expect(isUnavailableHistoricalModelID("foreign-config", modelOptions)).toBe(
+			true,
+		);
+		expect(isUnavailableHistoricalModelID("", modelOptions)).toBe(false);
+		expect(
+			isUnavailableHistoricalModelID(
+				"00000000-0000-0000-0000-000000000000",
+				modelOptions,
+			),
+		).toBe(false);
+	});
+});
+
+describe("getUsableDefaultModelIDForOrganization", () => {
+	const modelOptions = [
+		{
+			id: "local-default",
+			provider: "openai",
+			model: "gpt-4o",
+			displayName: "GPT-4o",
+		},
+	] as const;
+
+	it("selects only a usable default from the requested organization", () => {
+		const configs = [
+			createConfig({
+				id: "foreign-default",
+				organization_id: "foreign-org",
+				ai_provider_id: "prov-openai",
+				model: "gpt-4.1",
+				is_default: true,
+			}),
+			createConfig({
+				id: "local-default",
+				organization_id: testOrganizationID,
+				ai_provider_id: "prov-openai",
+				model: "gpt-4o",
+				is_default: true,
+			}),
+		];
+
+		expect(
+			getUsableDefaultModelIDForOrganization(
+				configs,
+				modelOptions,
+				testOrganizationID,
+			),
+		).toBe("local-default");
+	});
+
+	it("does not return a foreign or unusable default", () => {
+		const configs = [
+			createConfig({
+				id: "foreign-default",
+				organization_id: "foreign-org",
+				ai_provider_id: "prov-openai",
+				model: "gpt-4.1",
+				is_default: true,
+			}),
+		];
+
+		expect(
+			getUsableDefaultModelIDForOrganization(
+				configs,
+				modelOptions,
+				testOrganizationID,
+			),
+		).toBe("");
 	});
 });
 
 describe("getModelOptionsFromModels", () => {
+	it("excludes models from other organizations", () => {
+		const models = [
+			createConfig({
+				id: "foreign-config",
+				organization_id: "foreign-org",
+				ai_provider_id: "prov-openai",
+				model: "gpt-4.1",
+			}),
+			createConfig({
+				id: "local-config",
+				organization_id: testOrganizationID,
+				ai_provider_id: "prov-openai",
+				model: "gpt-4o",
+			}),
+		];
+		const catalog = createCatalog([
+			{ provider: "openai", available: true, models: [] },
+		]);
+
+		expect(
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			).map((option) => option.id),
+		).toEqual(["local-config"]);
+	});
+
 	it("returns distinct options for models with the same provider and model", () => {
 		const models = [
 			createConfig({
@@ -308,7 +437,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			),
 		).toEqual([
 			{
 				id: "config-1",
@@ -349,7 +483,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			),
 		).toEqual([
 			{
 				id: "config-no-effort",
@@ -395,7 +534,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			),
 		).toEqual([]);
 	});
 
@@ -426,9 +570,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual(["config-2"]);
 	});
 
@@ -451,7 +598,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			),
 		).toEqual([
 			expect.objectContaining({
 				id: "config-1",
@@ -462,9 +614,21 @@ describe("getModelOptionsFromModels", () => {
 	});
 
 	it("returns an empty array for null and undefined inputs", () => {
-		expect(getModelOptionsFromModels(null, null, providerInfoByID)).toEqual([]);
 		expect(
-			getModelOptionsFromModels(undefined, undefined, providerInfoByID),
+			getModelOptionsFromModels(
+				null,
+				null,
+				providerInfoByID,
+				testOrganizationID,
+			),
+		).toEqual([]);
+		expect(
+			getModelOptionsFromModels(
+				undefined,
+				undefined,
+				providerInfoByID,
+				testOrganizationID,
+			),
 		).toEqual([]);
 	});
 
@@ -506,9 +670,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual([
 			"config-anthropic",
 			"config-openai-alpha",
@@ -542,9 +709,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual(["config-2", "config-1"]);
 	});
 
@@ -562,7 +732,9 @@ describe("getModelOptionsFromModels", () => {
 			{ provider: "openai", available: true, models: [] },
 		]);
 
-		expect(getModelOptionsFromModels(models, catalog, new Map())).toEqual([]);
+		expect(
+			getModelOptionsFromModels(models, catalog, new Map(), testOrganizationID),
+		).toEqual([]);
 	});
 
 	it("keeps only models whose ai_provider_id resolves in the provider map", () => {
@@ -591,9 +763,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, partialMap).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				partialMap,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual(["config-openai"]);
 	});
 
@@ -629,7 +804,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, sameTypeProviders),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				sameTypeProviders,
+				testOrganizationID,
+			),
 		).toEqual([
 			expect.objectContaining({
 				id: "config-primary",
@@ -678,9 +858,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providers).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providers,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual(["config-enabled"]);
 	});
 
@@ -697,9 +880,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, providerInfoByID).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				providerInfoByID,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual(["config-openai"]);
 	});
 
@@ -743,9 +929,12 @@ describe("getModelOptionsFromModels", () => {
 		]);
 
 		expect(
-			getModelOptionsFromModels(models, catalog, sameTypeProviders).map(
-				(option) => option.id,
-			),
+			getModelOptionsFromModels(
+				models,
+				catalog,
+				sameTypeProviders,
+				testOrganizationID,
+			).map((option) => option.id),
 		).toEqual(["config-primary"]);
 	});
 });
@@ -805,28 +994,6 @@ describe("filterModelsWithEnabledProvider", () => {
 	});
 });
 
-describe("providerInfoByIDFromConfigs", () => {
-	it("maps ChatProviderConfig.id to provider metadata", () => {
-		const map = providerInfoByIDFromConfigs([
-			{
-				...MockChatProviderConfig,
-				id: "prov-openai",
-				provider: "openai",
-				display_name: "Primary OpenAI",
-				icon: "/icon/openai.svg",
-			},
-		]);
-
-		expect(map.get("prov-openai")).toEqual({
-			provider: "openai",
-			displayName: "Primary OpenAI",
-			icon: "/icon/openai.svg",
-			enabled: true,
-		});
-		expect(map.size).toBe(1);
-	});
-});
-
 describe("providerInfoByIDFromUserConfigs", () => {
 	it("maps UserChatProviderConfig.provider_id to provider metadata", () => {
 		const map = providerInfoByIDFromUserConfigs([
@@ -849,28 +1016,6 @@ describe("providerInfoByIDFromUserConfigs", () => {
 			enabled: true,
 		});
 		expect(map.size).toBe(1);
-	});
-});
-
-describe("providerTypeByIDFromConfigs", () => {
-	it("maps ChatProviderConfig.id to its provider type", () => {
-		const map = providerTypeByIDFromConfigs([
-			{ ...MockChatProviderConfig, id: "prov-openai", provider: "openai" },
-			{
-				...MockChatProviderConfig,
-				id: "prov-anthropic",
-				provider: "anthropic",
-			},
-		]);
-
-		expect(map.get("prov-openai")).toBe("openai");
-		expect(map.get("prov-anthropic")).toBe("anthropic");
-		expect(map.size).toBe(2);
-	});
-
-	it("returns an empty map for nullish input", () => {
-		expect(providerTypeByIDFromConfigs(undefined).size).toBe(0);
-		expect(providerTypeByIDFromConfigs(null).size).toBe(0);
 	});
 });
 
@@ -973,8 +1118,8 @@ describe("resolveModelSelector", () => {
 		// the provider map is empty. Options must be dropped and the flag must
 		// stay loading rather than flashing "No Models".
 		const state = resolveModelSelector(
-			{ data: [config], isLoading: false },
-			{ data: catalog, isLoading: false },
+			testOrganizationID,
+			{ data: { ...catalog, models: [config] }, isLoading: false },
 			{ data: undefined, isLoading: true },
 		);
 
@@ -983,14 +1128,15 @@ describe("resolveModelSelector", () => {
 	});
 
 	it("resolves options once every query settles", () => {
+		const runtimeCatalog = { ...catalog, models: [config] };
 		const state = resolveModelSelector(
-			{ data: [config], isLoading: false },
-			{ data: catalog, isLoading: false },
+			testOrganizationID,
+			{ data: runtimeCatalog, isLoading: false },
 			{ data: userProviderModels, isLoading: false },
 		);
 
 		expect(state.isModelCatalogLoading).toBe(false);
-		expect(state.modelCatalog).toBe(catalog);
+		expect(state.modelCatalog).toBe(runtimeCatalog);
 		expect(state.options).toEqual([
 			{
 				id: "config-openai",

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -1,4 +1,3 @@
-import type { UseQueryResult } from "react-query";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "../components/ChatElements";
 import {
@@ -7,7 +6,7 @@ import {
 } from "../components/ChatElements/runtimeTypeUtils";
 
 type CatalogModelLike =
-	| TypesGen.ChatModelCatalogEntry
+	| TypesGen.ChatModel
 	| {
 			readonly id?: unknown;
 			readonly display_name?: unknown;
@@ -74,7 +73,7 @@ const isProviderConfiguredInCatalog = (
 	return unavailableReason !== "" && unavailableReason !== "missing_api_key";
 };
 
-export const hasConfiguredModelsInCatalog = (
+const hasConfiguredModelsInCatalog = (
 	catalog: ModelCatalogLike | null | undefined,
 ): boolean => {
 	return getCatalogProviders(catalog).some(isProviderConfiguredInCatalog);
@@ -137,25 +136,70 @@ const getAvailableProviders = (
 };
 
 /**
+ * The nil UUID (all zeros) is the backend sentinel for an unset stored
+ * model reference. Exported so all model-selection surfaces share one value.
+ */
+export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Reports whether a stored model reference is unset. A blank string and the
+ * nil UUID both mean "no selection", so callers handle them identically.
+ */
+export const isUnsetModelRef = (ref: string | null | undefined): boolean => {
+	const normalized = asString(ref).trim();
+	return normalized === "" || normalized === NIL_UUID;
+};
+
+/**
  * Resolves a stored ChatModel ID to the ID of a matching model
  * option. Returns the matched option ID, or an empty string when the
- * stored ID is blank or no longer matches an available option.
+ * stored ID is unset or no longer matches an available option.
  */
 export const resolveModelOptionId = (
 	storedRef: string | null | undefined,
 	modelOptions: readonly ModelSelectorOption[],
 ): string => {
-	const normalized = asString(storedRef).trim();
-	if (!normalized) {
+	if (isUnsetModelRef(storedRef)) {
 		return "";
 	}
 
+	const normalized = asString(storedRef).trim();
 	const directMatch = modelOptions.find((option) => option.id === normalized);
 	if (directMatch) {
 		return directMatch.id;
 	}
 
 	return "";
+};
+
+/**
+ * Reports whether a stored model ID no longer matches an available option.
+ * Blank and nil UUID references mean no selection, so they are not unavailable.
+ */
+export const isUnavailableHistoricalModelID = (
+	storedRef: string | null | undefined,
+	modelOptions: readonly ModelSelectorOption[],
+): boolean =>
+	!isUnsetModelRef(storedRef) &&
+	resolveModelOptionId(storedRef, modelOptions) === "";
+
+/**
+ * Returns the usable default model ID for one organization.
+ * The function returns an empty string when the default is unavailable.
+ */
+export const getUsableDefaultModelIDForOrganization = (
+	configs: readonly TypesGen.ChatModel[] | null | undefined,
+	modelOptions: readonly ModelSelectorOption[],
+	organizationID: string,
+): string => {
+	if (!organizationID || !configs) {
+		return "";
+	}
+	const defaultConfig = configs.find(
+		(config) =>
+			config.organization_id === organizationID && config.is_default === true,
+	);
+	return resolveModelOptionId(defaultConfig?.id, modelOptions);
 };
 
 export type ProviderInfo = {
@@ -166,22 +210,21 @@ export type ProviderInfo = {
 	readonly enabled?: boolean;
 };
 
-// providerInfoByIDFromConfigs and providerInfoByIDFromUserConfigs build
-// the ai_provider_id -> provider metadata lookup that
-// getModelOptionsFromModels needs. The admin and user provider endpoints
-// expose the provider id under different field names (id vs provider_id), so
-// each source has its own helper to bake in the correct field.
-export const providerInfoByIDFromConfigs = (
-	providerConfigs: readonly TypesGen.ChatProviderConfig[] | null | undefined,
+// Provider descriptors use `id`; personal provider configs use `provider_id`.
+export const providerInfoByIDFromDescriptors = (
+	providerDescriptors:
+		| readonly TypesGen.ChatModelProviderDescriptor[]
+		| null
+		| undefined,
 ): ReadonlyMap<string, ProviderInfo> =>
 	new Map(
-		(providerConfigs ?? []).map((providerConfig) => [
-			providerConfig.id,
+		(providerDescriptors ?? []).map((providerDescriptor) => [
+			providerDescriptor.id,
 			{
-				provider: providerConfig.provider,
-				displayName: providerConfig.display_name,
-				icon: providerConfig.icon,
-				enabled: providerConfig.enabled,
+				provider: providerDescriptor.type,
+				displayName: providerDescriptor.display_name,
+				icon: providerDescriptor.icon,
+				enabled: providerDescriptor.enabled,
 			},
 		]),
 	);
@@ -201,16 +244,6 @@ export const providerInfoByIDFromUserConfigs = (
 				icon: providerConfig.icon,
 				enabled: providerConfig.enabled,
 			},
-		]),
-	);
-
-export const providerTypeByIDFromConfigs = (
-	providerConfigs: readonly TypesGen.ChatProviderConfig[] | null | undefined,
-): ReadonlyMap<string, string> =>
-	new Map(
-		Array.from(providerInfoByIDFromConfigs(providerConfigs), ([id, info]) => [
-			id,
-			info.provider,
 		]),
 	);
 
@@ -245,8 +278,9 @@ export const getModelOptionsFromModels = (
 	models: readonly TypesGen.ChatModel[] | null | undefined,
 	catalog: TypesGen.ChatModelAvailabilityResponse | null | undefined,
 	providerInfoByID: ReadonlyMap<string, ProviderInfo>,
+	organizationID: string,
 ): readonly ModelSelectorOption[] => {
-	if (!models || !catalog) {
+	if (!models || !catalog || !organizationID) {
 		return [];
 	}
 
@@ -256,7 +290,7 @@ export const getModelOptionsFromModels = (
 	// The catalog check below is keyed by provider type, so it cannot
 	// exclude a disabled provider when another of the same type is enabled.
 	for (const model of filterModelsWithEnabledProvider(
-		models,
+		models.filter((model) => model.organization_id === organizationID),
 		providerInfoByID,
 	)) {
 		if (!model.enabled) {
@@ -304,12 +338,9 @@ export const getModelOptionsFromModels = (
 	});
 };
 
-// Read slice of a react-query result. The field types come from UseQueryResult
-// by indexed access, not Pick (which would distribute over v5's status union),
-// so they track the library rather than being hand-maintained.
 type SelectorQuery<T> = {
-	readonly data: UseQueryResult<T>["data"];
-	readonly isLoading: UseQueryResult<T>["isLoading"];
+	readonly data: T | undefined;
+	readonly isLoading: boolean;
 };
 
 interface ModelSelectorState {
@@ -319,22 +350,22 @@ interface ModelSelectorState {
 	readonly hasConfiguredModels: boolean;
 }
 
-// Provider identity comes from a separate query (userChatProviderModels).
-// Folding all three loading states into one flag here spares every caller the
+// Provider identity comes from a separate query (userProviderModels).
+// Folding both loading states into one flag here spares every caller the
 // "models loaded but providers still pending" window that would otherwise
 // build an empty provider map, drop every option, and flash "No Models".
 export const resolveModelSelector = (
-	models: SelectorQuery<readonly TypesGen.ChatModel[]>,
+	organizationID: string,
 	catalog: SelectorQuery<TypesGen.ChatModelAvailabilityResponse>,
 	userProviderModels: SelectorQuery<readonly TypesGen.UserChatProviderConfig[]>,
 ): ModelSelectorState => ({
 	options: getModelOptionsFromModels(
-		models.data,
+		catalog.data?.models,
 		catalog.data,
 		providerInfoByIDFromUserConfigs(userProviderModels.data),
+		organizationID,
 	),
-	isModelCatalogLoading:
-		models.isLoading || catalog.isLoading || userProviderModels.isLoading,
+	isModelCatalogLoading: catalog.isLoading || userProviderModels.isLoading,
 	modelCatalog: catalog.data,
 	hasConfiguredModels: hasConfiguredModelsInCatalog(catalog.data),
 });

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -11,9 +11,9 @@ import {
 import { GlobalErrorBoundary } from "./components/ErrorBoundary/GlobalErrorBoundary";
 import { Loader } from "./components/Loader/Loader";
 import { RequireAuth } from "./contexts/auth/RequireAuth";
-import { useAuthenticated } from "./hooks/useAuthenticated";
 import { DashboardLayout } from "./modules/dashboard/DashboardLayout";
 import { aiTasksEnabled } from "./modules/tasks/useAITasksEnabled";
+import { AISettingsIndexRedirect } from "./pages/AISettingsPage/AISettingsIndexRedirect";
 import AuditPage from "./pages/AuditPage/AuditPage";
 import ConnectionLogPage from "./pages/ConnectionLogPage/ConnectionLogPage";
 import { HealthLayout } from "./pages/HealthPage/HealthLayout";
@@ -436,6 +436,9 @@ const AISettingsGatewayKeysPage = lazy(
 const AISettingsModelsPage = lazy(
 	() => import("./pages/AISettingsPage/ModelsPage/ModelsPage"),
 );
+const AISettingsOrganizationModelsLayout = lazy(
+	() => import("./pages/AISettingsPage/ModelsPage/OrganizationModelsLayout"),
+);
 const AISettingsInstructionsPage = lazy(
 	() => import("./pages/AISettingsPage/InstructionsPage/InstructionsPage"),
 );
@@ -464,36 +467,6 @@ const AISettingsUpdateMCPServerPage = lazy(
 			"./pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPage"
 		),
 );
-
-export const AISettingsIndexRedirect = () => {
-	const { permissions } = useAuthenticated();
-
-	if (permissions.viewAnyAIProvider) {
-		return <Navigate to="/ai/settings/providers" replace />;
-	}
-
-	if (permissions.viewAIGatewayKeys) {
-		return <Navigate to="/ai/settings/gateway-keys" replace />;
-	}
-
-	if (permissions.editDeploymentConfig) {
-		return <Navigate to="/ai/settings/models" replace />;
-	}
-
-	if (
-		permissions.viewAnyMCPServerConfigs ||
-		permissions.updateAnyMCPServerConfig ||
-		permissions.deleteAnyMCPServerConfig
-	) {
-		return <Navigate to="/ai/settings/mcp-servers" replace />;
-	}
-
-	if (permissions.createAnyMCPServerConfig) {
-		return <Navigate to="/ai/settings/mcp-servers/add" replace />;
-	}
-
-	return <Navigate to="/ai/settings/providers" replace />;
-};
 
 const GlobalLayout = () => {
 	return (
@@ -767,7 +740,14 @@ export const router = createBrowserRouter(
 							element={<AISettingsGatewayKeysPage />}
 						/>
 						<Route index element={<AISettingsIndexRedirect />} />
-						<Route path="models" element={<AISettingsModelsPage />} />
+						<Route
+							path="models"
+							element={<AISettingsOrganizationModelsLayout />}
+						>
+							<Route index element={<AISettingsModelsPage />} />
+							<Route path="add" element={<AISettingsAddModelPage />} />
+							<Route path=":modelId" element={<AISettingsUpdateModelPage />} />
+						</Route>
 						<Route
 							path="instructions"
 							element={<AISettingsInstructionsPage />}
@@ -775,11 +755,6 @@ export const router = createBrowserRouter(
 						<Route path="lifecycle" element={<AISettingsLifecyclePage />} />
 						<Route path="coder-agents" element={<CoderAgentsPage />} />
 						<Route path="templates" element={<AISettingsTemplatesPage />} />
-						<Route path="models/add" element={<AISettingsAddModelPage />} />
-						<Route
-							path="models/:modelId"
-							element={<AISettingsUpdateModelPage />}
-						/>
 						<Route path="mcp-servers" element={<AISettingsMCPServersPage />} />
 						<Route
 							path="mcp-servers/add"

--- a/site/src/testHelpers/chatModels.ts
+++ b/site/src/testHelpers/chatModels.ts
@@ -2,6 +2,7 @@ import type {
 	AIModelPrice,
 	ChatModel,
 	ChatModelProvider,
+	ChatModelProviderDescriptor,
 	ChatProviderConfig,
 } from "#/api/typesGenerated";
 import { MOCK_TIMESTAMP } from "./chatEntities";
@@ -40,6 +41,18 @@ export const MockChatModelProvider: ChatModelProvider = {
 	provider: "openai",
 	available: true,
 	models: [],
+};
+
+export const MockChatModelProviderDescriptor: ChatModelProviderDescriptor = {
+	id: "provider-1",
+	type: "openai",
+	display_name: "OpenAI",
+	icon: "",
+	enabled: true,
+	has_api_key: true,
+	has_user_api_key: false,
+	has_effective_api_key: true,
+	allow_user_api_key: false,
 };
 
 // Prices are micro-units per million tokens.

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3393,6 +3393,11 @@ export const MockPermissions: Permissions = {
 	deleteOAuth2App: true,
 	viewOAuth2AppSecrets: true,
 	createChat: true,
+	viewAnyChatModelConfig: true,
+	createAnyChatModelConfig: true,
+	editAnyChatModelConfig: true,
+	deleteAnyChatModelConfig: true,
+	shareAnyChatModelConfig: true,
 };
 
 export const MockNoPermissions: Permissions = {
@@ -3434,6 +3439,11 @@ export const MockNoPermissions: Permissions = {
 	deleteOAuth2App: false,
 	viewOAuth2AppSecrets: false,
 	createChat: false,
+	viewAnyChatModelConfig: false,
+	createAnyChatModelConfig: false,
+	editAnyChatModelConfig: false,
+	deleteAnyChatModelConfig: false,
+	shareAnyChatModelConfig: false,
 };
 
 export const MockOrganizationPermissions: OrganizationPermissions = {
@@ -3456,6 +3466,11 @@ export const MockOrganizationPermissions: OrganizationPermissions = {
 	createMCPServerConfig: true,
 	updateMCPServerConfig: true,
 	deleteMCPServerConfig: true,
+	viewChatModelConfigs: true,
+	createChatModelConfigs: true,
+	editChatModelConfigs: true,
+	deleteChatModelConfigs: true,
+	shareChatModelConfigs: true,
 };
 
 export const MockNoOrganizationPermissions: OrganizationPermissions = {
@@ -3478,6 +3493,11 @@ export const MockNoOrganizationPermissions: OrganizationPermissions = {
 	createMCPServerConfig: false,
 	updateMCPServerConfig: false,
 	deleteMCPServerConfig: false,
+	viewChatModelConfigs: false,
+	createChatModelConfigs: false,
+	editChatModelConfigs: false,
+	deleteChatModelConfigs: false,
+	shareChatModelConfigs: false,
 };
 
 export const MockDeploymentConfig: DeploymentConfig = {


### PR DESCRIPTION
Move chat model settings to `/ai/settings/organizations/:organization/models`, add an organization switcher, and redirect legacy settings paths. The pages use organization permissions for read, create, update, and delete controls. They use redacted provider descriptors.

Agent creation loads models for the selected organization. Existing chats load models for the chat organization. Chat views warn about unavailable historical models, select a usable local recovery model, and disable generation when none exists. Settings that aggregate organizations retain successful results when one request fails.

Depends on #27959

_This pull request description was generated by Coder Agents._
