### PR TITLE
feat: migrate AI Bridge `visible_users` to contain `email` in `MinimalUser`

### DIFF
--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -267,6 +267,7 @@ func MinimalUserFromVisibleUser(user database.VisibleUser) codersdk.MinimalUser 
 		ID:        user.ID,
 		Username:  user.Username,
 		Name:      user.Name,
+		Email:     user.Email,
 		AvatarURL: user.AvatarURL,
 	}
 }
@@ -1118,6 +1119,7 @@ func AIBridgeSession(row database.ListAIBridgeSessionsRow) codersdk.AIBridgeSess
 			Username:  row.UserUsername,
 			Name:      row.UserName,
 			AvatarURL: row.UserAvatarUrl,
+			Email:     row.UserEmail,
 		}),
 		Providers:    row.Providers,
 		Models:       row.Models,
@@ -1243,6 +1245,7 @@ func AIBridgeSessionThreads(p AIBridgeSessionThreadsParams) codersdk.AIBridgeSes
 			Username:  session.UserUsername,
 			Name:      session.UserName,
 			AvatarURL: session.UserAvatarUrl,
+			Email:     session.UserEmail,
 		}),
 		Providers:     session.Providers,
 		Models:        session.Models,

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -2179,7 +2179,8 @@ CREATE VIEW visible_users AS
  SELECT users.id,
     users.username,
     users.name,
-    users.avatar_url
+    users.avatar_url,
+    users.email
    FROM users;
 
 COMMENT ON VIEW visible_users IS 'Visible fields of users are allowed to be joined with other tables for including context of other resources.';
@@ -3426,7 +3427,8 @@ CREATE VIEW template_version_with_user AS
     template_versions.has_external_agent,
     COALESCE(visible_users.avatar_url, ''::text) AS created_by_avatar_url,
     COALESCE(visible_users.username, ''::text) AS created_by_username,
-    COALESCE(visible_users.name, ''::text) AS created_by_name
+    COALESCE(visible_users.name, ''::text) AS created_by_name,
+    COALESCE(visible_users.email, ''::text) AS created_by_email
    FROM (template_versions
      LEFT JOIN visible_users ON ((template_versions.created_by = visible_users.id)));
 

--- a/coderd/database/migrations/000565_visible_users_email.down.sql
+++ b/coderd/database/migrations/000565_visible_users_email.down.sql
@@ -1,0 +1,34 @@
+-- CREATE OR REPLACE cannot remove columns, so drop and recreate.
+DROP VIEW template_version_with_user;
+
+CREATE VIEW template_version_with_user AS
+SELECT
+	template_versions.id,
+	template_versions.template_id,
+	template_versions.organization_id,
+	template_versions.created_at,
+	template_versions.updated_at,
+	template_versions.name,
+	template_versions.readme,
+	template_versions.job_id,
+	template_versions.created_by,
+	template_versions.external_auth_providers,
+	template_versions.message,
+	template_versions.archived,
+	template_versions.source_example_id,
+	template_versions.has_ai_task,
+	template_versions.has_external_agent,
+	COALESCE(visible_users.avatar_url, ''::text) AS created_by_avatar_url,
+	COALESCE(visible_users.username, ''::text) AS created_by_username,
+	COALESCE(visible_users.name, ''::text) AS created_by_name
+FROM (
+	template_versions
+	LEFT JOIN visible_users ON (template_versions.created_by = visible_users.id)
+);
+
+COMMENT ON VIEW template_version_with_user IS 'Joins in the username + avatar url of the created by user.';
+
+-- visible_users.email is left in place. Removing it would require cascading
+-- drops of chats_expanded, tasks_with_status, template_with_names,
+-- workspace_build_with_user, and workspaces_expanded. The extra column is
+-- unused by those views and is harmless if this migration is rolled back.

--- a/coderd/database/migrations/000565_visible_users_email.up.sql
+++ b/coderd/database/migrations/000565_visible_users_email.up.sql
@@ -1,0 +1,42 @@
+-- Add email to visible_users so identity joins can disambiguate users.
+-- CREATE OR REPLACE may append columns; dependent views keep working.
+
+CREATE OR REPLACE VIEW visible_users AS
+SELECT
+	users.id,
+	users.username,
+	users.name,
+	users.avatar_url,
+	users.email
+FROM users;
+
+COMMENT ON VIEW visible_users IS 'Visible fields of users are allowed to be joined with other tables for including context of other resources.';
+
+-- Expose created_by_email on template versions (MinimalUser.created_by).
+CREATE OR REPLACE VIEW template_version_with_user AS
+SELECT
+	template_versions.id,
+	template_versions.template_id,
+	template_versions.organization_id,
+	template_versions.created_at,
+	template_versions.updated_at,
+	template_versions.name,
+	template_versions.readme,
+	template_versions.job_id,
+	template_versions.created_by,
+	template_versions.external_auth_providers,
+	template_versions.message,
+	template_versions.archived,
+	template_versions.source_example_id,
+	template_versions.has_ai_task,
+	template_versions.has_external_agent,
+	COALESCE(visible_users.avatar_url, ''::text) AS created_by_avatar_url,
+	COALESCE(visible_users.username, ''::text) AS created_by_username,
+	COALESCE(visible_users.name, ''::text) AS created_by_name,
+	COALESCE(visible_users.email, ''::text) AS created_by_email
+FROM (
+	template_versions
+	LEFT JOIN visible_users ON (template_versions.created_by = visible_users.id)
+);
+
+COMMENT ON VIEW template_version_with_user IS 'Joins in the username + avatar url of the created by user.';

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -1052,6 +1052,7 @@ func (q *sqlQuerier) ListAuthorizedAIBridgeSessions(ctx context.Context, arg Lis
 			&i.UserUsername,
 			&i.UserName,
 			&i.UserAvatarUrl,
+			&i.UserEmail,
 			pq.Array(&i.Providers),
 			pq.Array(&i.Models),
 			&i.Client,

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -6019,6 +6019,7 @@ type TemplateVersion struct {
 	CreatedByAvatarURL    string          `db:"created_by_avatar_url" json:"created_by_avatar_url"`
 	CreatedByUsername     string          `db:"created_by_username" json:"created_by_username"`
 	CreatedByName         string          `db:"created_by_name" json:"created_by_name"`
+	CreatedByEmail        string          `db:"created_by_email" json:"created_by_email"`
 }
 
 type TemplateVersionParameter struct {
@@ -6287,6 +6288,7 @@ type VisibleUser struct {
 	Username  string    `db:"username" json:"username"`
 	Name      string    `db:"name" json:"name"`
 	AvatarURL string    `db:"avatar_url" json:"avatar_url"`
+	Email     string    `db:"email" json:"email"`
 }
 
 type WebpushSubscription struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2330,6 +2330,7 @@ SELECT
 	visible_users.username AS user_username,
 	visible_users.name AS user_name,
 	visible_users.avatar_url AS user_avatar_url,
+	visible_users.email AS user_email,
 	sr.providers::text[] AS providers,
 	sr.models::text[] AS models,
 	COALESCE(sr.client, '')::varchar(64) AS client,
@@ -2435,6 +2436,7 @@ type ListAIBridgeSessionsRow struct {
 	UserUsername          string          `db:"user_username" json:"user_username"`
 	UserName              string          `db:"user_name" json:"user_name"`
 	UserAvatarUrl         string          `db:"user_avatar_url" json:"user_avatar_url"`
+	UserEmail             string          `db:"user_email" json:"user_email"`
 	Providers             []string        `db:"providers" json:"providers"`
 	Models                []string        `db:"models" json:"models"`
 	Client                string          `db:"client" json:"client"`
@@ -2493,6 +2495,7 @@ func (q *sqlQuerier) ListAIBridgeSessions(ctx context.Context, arg ListAIBridgeS
 			&i.UserUsername,
 			&i.UserName,
 			&i.UserAvatarUrl,
+			&i.UserEmail,
 			pq.Array(&i.Providers),
 			pq.Array(&i.Models),
 			&i.Client,
@@ -27860,7 +27863,7 @@ func (q *sqlQuerier) ArchiveUnusedTemplateVersions(ctx context.Context, arg Arch
 
 const getPreviousTemplateVersion = `-- name: GetPreviousTemplateVersion :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email
 FROM
 	template_version_with_user AS template_versions
 WHERE
@@ -27903,13 +27906,14 @@ func (q *sqlQuerier) GetPreviousTemplateVersion(ctx context.Context, arg GetPrev
 		&i.CreatedByAvatarURL,
 		&i.CreatedByUsername,
 		&i.CreatedByName,
+		&i.CreatedByEmail,
 	)
 	return i, err
 }
 
 const getTemplateVersionByID = `-- name: GetTemplateVersionByID :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email
 FROM
 	template_version_with_user AS template_versions
 WHERE
@@ -27938,13 +27942,14 @@ func (q *sqlQuerier) GetTemplateVersionByID(ctx context.Context, id uuid.UUID) (
 		&i.CreatedByAvatarURL,
 		&i.CreatedByUsername,
 		&i.CreatedByName,
+		&i.CreatedByEmail,
 	)
 	return i, err
 }
 
 const getTemplateVersionByJobID = `-- name: GetTemplateVersionByJobID :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email
 FROM
 	template_version_with_user AS template_versions
 WHERE
@@ -27973,13 +27978,14 @@ func (q *sqlQuerier) GetTemplateVersionByJobID(ctx context.Context, jobID uuid.U
 		&i.CreatedByAvatarURL,
 		&i.CreatedByUsername,
 		&i.CreatedByName,
+		&i.CreatedByEmail,
 	)
 	return i, err
 }
 
 const getTemplateVersionByTemplateIDAndName = `-- name: GetTemplateVersionByTemplateIDAndName :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email
 FROM
 	template_version_with_user AS template_versions
 WHERE
@@ -28014,13 +28020,14 @@ func (q *sqlQuerier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, 
 		&i.CreatedByAvatarURL,
 		&i.CreatedByUsername,
 		&i.CreatedByName,
+		&i.CreatedByEmail,
 	)
 	return i, err
 }
 
 const getTemplateVersionsByIDs = `-- name: GetTemplateVersionsByIDs :many
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email
 FROM
 	template_version_with_user AS template_versions
 WHERE
@@ -28055,6 +28062,7 @@ func (q *sqlQuerier) GetTemplateVersionsByIDs(ctx context.Context, ids []uuid.UU
 			&i.CreatedByAvatarURL,
 			&i.CreatedByUsername,
 			&i.CreatedByName,
+			&i.CreatedByEmail,
 		); err != nil {
 			return nil, err
 		}
@@ -28071,7 +28079,7 @@ func (q *sqlQuerier) GetTemplateVersionsByIDs(ctx context.Context, ids []uuid.UU
 
 const getTemplateVersionsByTemplateID = `-- name: GetTemplateVersionsByTemplateID :many
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email
 FROM
 	template_version_with_user AS template_versions
 WHERE
@@ -28153,6 +28161,7 @@ func (q *sqlQuerier) GetTemplateVersionsByTemplateID(ctx context.Context, arg Ge
 			&i.CreatedByAvatarURL,
 			&i.CreatedByUsername,
 			&i.CreatedByName,
+			&i.CreatedByEmail,
 		); err != nil {
 			return nil, err
 		}
@@ -28168,7 +28177,7 @@ func (q *sqlQuerier) GetTemplateVersionsByTemplateID(ctx context.Context, arg Ge
 }
 
 const getTemplateVersionsCreatedAfter = `-- name: GetTemplateVersionsCreatedAfter :many
-SELECT id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name FROM template_version_with_user AS template_versions WHERE created_at > $1
+SELECT id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, has_external_agent, created_by_avatar_url, created_by_username, created_by_name, created_by_email FROM template_version_with_user AS template_versions WHERE created_at > $1
 `
 
 func (q *sqlQuerier) GetTemplateVersionsCreatedAfter(ctx context.Context, createdAt time.Time) ([]TemplateVersion, error) {
@@ -28199,6 +28208,7 @@ func (q *sqlQuerier) GetTemplateVersionsCreatedAfter(ctx context.Context, create
 			&i.CreatedByAvatarURL,
 			&i.CreatedByUsername,
 			&i.CreatedByName,
+			&i.CreatedByEmail,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -467,6 +467,7 @@ SELECT
 	visible_users.username AS user_username,
 	visible_users.name AS user_name,
 	visible_users.avatar_url AS user_avatar_url,
+	visible_users.email AS user_email,
 	sr.providers::text[] AS providers,
 	sr.models::text[] AS models,
 	COALESCE(sr.client, '')::varchar(64) AS client,

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -2010,6 +2010,7 @@ func convertTemplateVersion(version database.TemplateVersion, job codersdk.Provi
 			ID:        version.CreatedBy,
 			Username:  version.CreatedByUsername,
 			Name:      version.CreatedByName,
+			Email:     version.CreatedByEmail,
 			AvatarURL: version.CreatedByAvatarURL,
 		},
 		Archived:            version.Archived,


### PR DESCRIPTION
[DEVEX-448](https://linear.app/codercom/issue/DEVEX-448/normalize-user-identity-display-across-coder)

MinimalUser now has email, but VisibleUser-backed joins still could not populate it. AI Bridge initiators and template version created_by stayed empty.

Add email to the `visible_users` view, project created_by_email on template_version_with_user, and thread it through ListAIBridgeSessions and template version conversion so those MinimalUsers get real emails.