### PR TITLE
refactor(site): normalize user identity display to username + email

### DIFF
--- a/site/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Autocomplete } from "./Autocomplete";
 
 const meta: Meta<typeof Autocomplete> = {
@@ -414,11 +415,7 @@ export const WithCustomRenderOption: Story = {
 					placeholder="Search for a user"
 					renderOption={(user, isSelected) => (
 						<div className="flex items-center justify-between w-full">
-							<AvatarData
-								title={user.username}
-								subtitle={user.email}
-								src={user.avatar_url}
-							/>
+							<AvatarData {...userIdentity(user)} />
 							{isSelected && <CheckIcon className="size-4 shrink-0" />}
 						</div>
 					)}
@@ -458,11 +455,7 @@ export const WithStartAdornment: Story = {
 					}
 					renderOption={(user, isSelected) => (
 						<div className="flex items-center justify-between w-full">
-							<AvatarData
-								title={user.username}
-								subtitle={user.email}
-								src={user.avatar_url}
-							/>
+							<AvatarData {...userIdentity(user)} />
 							{isSelected && <CheckIcon className="size-4 shrink-0" />}
 						</div>
 					)}

--- a/site/src/components/Avatar/userIdentity.test.ts
+++ b/site/src/components/Avatar/userIdentity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { userIdentity } from "./userIdentity";
+
+describe("userIdentity", () => {
+	it("uses username as title, email as subtitle, and avatar_url as src", () => {
+		expect(
+			userIdentity({
+				username: "aqandrew",
+				email: "andrew@coder.com",
+				avatar_url: "https://avatars.githubusercontent.com/u/9038965?v=4",
+			}),
+		).toEqual({
+			title: "aqandrew",
+			subtitle: "andrew@coder.com",
+			src: "https://avatars.githubusercontent.com/u/9038965?v=4",
+		});
+	});
+
+	it("uses Service Account subtitle for service accounts", () => {
+		expect(
+			userIdentity({
+				username: "bot",
+				email: "",
+				is_service_account: true,
+			}),
+		).toEqual({
+			title: "bot",
+			subtitle: "Service Account",
+			src: undefined,
+		});
+	});
+
+	it("omits subtitle and src when empty", () => {
+		expect(
+			userIdentity({ username: "bob", email: "", avatar_url: "" }),
+		).toEqual({
+			title: "bob",
+			subtitle: undefined,
+			src: undefined,
+		});
+	});
+});

--- a/site/src/components/Avatar/userIdentity.ts
+++ b/site/src/components/Avatar/userIdentity.ts
@@ -1,0 +1,24 @@
+type UserIdentityInput = {
+	username: string;
+	email?: string;
+	avatar_url?: string;
+	is_service_account?: boolean;
+};
+
+type UserIdentity = {
+	title: string;
+	subtitle: string | undefined;
+	src: string | undefined;
+};
+
+// Username is primary; email disambiguates. Service accounts have no login
+// email, so they get a fixed subtitle instead.
+export function userIdentity(user: UserIdentityInput): UserIdentity {
+	return {
+		title: user.username,
+		subtitle: user.is_service_account
+			? "Service Account"
+			: user.email || undefined,
+		src: user.avatar_url || undefined,
+	};
+}

--- a/site/src/components/MultiUserSelect/MultiUserSelect.tsx
+++ b/site/src/components/MultiUserSelect/MultiUserSelect.tsx
@@ -10,6 +10,7 @@ import type {
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { AvatarDataSkeleton } from "#/components/Avatar/AvatarDataSkeleton";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { SearchField } from "#/components/SearchField/SearchField";
@@ -204,11 +205,7 @@ const UsersTable = <T extends SelectedUser>({
 								}}
 								aria-label={`Select user ${user.username}`}
 							/>
-							<AvatarData
-								title={user.username}
-								subtitle={user.email}
-								src={user.avatar_url}
-							/>
+							<AvatarData {...userIdentity(user)} />
 						</div>
 					</UserRow>
 				);

--- a/site/src/components/UserAutocomplete/UserAutocomplete.tsx
+++ b/site/src/components/UserAutocomplete/UserAutocomplete.tsx
@@ -11,6 +11,7 @@ import type {
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Button } from "#/components/Button/Button";
 import {
 	Combobox,
@@ -241,11 +242,7 @@ const InnerAutocomplete = <T extends SelectedUser>({
 									]}
 									className="m-1"
 								>
-									<AvatarData
-										title={option.username}
-										subtitle={option.email}
-										src={option.avatar_url}
-									/>
+									<AvatarData {...userIdentity(option)} />
 								</ComboboxItem>
 							))}
 					</ComboboxList>

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -269,10 +269,7 @@ const UserSettingsSub: FC<UserSettingsSubProps> = ({
 						setOpen((prev) => !prev);
 					}}
 				>
-					<Avatar
-						src={user?.avatar_url}
-						fallback={user?.name || user?.username}
-					/>
+					<Avatar src={user?.avatar_url} fallback={user?.username} />
 					User settings
 					<ChevronRightIcon
 						className={cn("ml-auto", open ? "rotate-90" : "")}

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -9,6 +9,7 @@ import type { FC, ReactNode } from "react";
 import { Link } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { CheckIcon } from "#/components/AnimatedIcons/Check";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import {
 	DropdownMenuItem,
 	DropdownMenuSeparator,
@@ -39,14 +40,17 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 	onSignOut,
 }) => {
 	const { showCopiedSuccess, copyToClipboard } = useClipboard();
+	const { title, subtitle } = userIdentity(user);
 
 	return (
 		<>
 			<DropdownMenuItem className="flex items-center gap-3" asChild>
 				<Link to="/settings/account">
 					<div className="flex flex-col">
-						<span className="text-content-primary">{user.username}</span>
-						<span className="text-xs font-semibold">{user.email}</span>
+						<span className="text-content-primary">{title}</span>
+						{subtitle && (
+							<span className="text-xs font-semibold">{subtitle}</span>
+						)}
 					</div>
 				</Link>
 			</DropdownMenuItem>

--- a/site/src/modules/roles/RoleSelectorDialog.tsx
+++ b/site/src/modules/roles/RoleSelectorDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { AssignableRoles, SlimRole } from "#/api/typesGenerated";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import {
 	Dialog,
 	DialogActions,
@@ -93,11 +94,7 @@ const ActiveRoleSelectorDialog: React.FC<Required<RoleSelectorDialogProps>> = ({
 				<DialogHeader>
 					<div className="flex flex-row justify-between items-center">
 						<DialogTitle>Edit roles</DialogTitle>
-						<AvatarData
-							title={user.username}
-							subtitle={user.email}
-							src={user.avatar_url}
-						/>
+						<AvatarData {...userIdentity(user)} />
 					</div>
 				</DialogHeader>
 				<RoleSelector

--- a/site/src/modules/tasks/TasksSidebar/UserCombobox.tsx
+++ b/site/src/modules/tasks/TasksSidebar/UserCombobox.tsx
@@ -167,7 +167,7 @@ function mapUsersToOptions(
 	return includeAuthenticatedUser(users)
 		.toSorted(sortSelectedFirst)
 		.map((user) => ({
-			label: user.name || user.username,
+			label: user.username,
 			value: user.username,
 			avatarUrl: user.avatar_url,
 		}));

--- a/site/src/modules/workspaces/WorkspaceSharingForm/UserOrGroupAutocomplete.tsx
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/UserOrGroupAutocomplete.tsx
@@ -9,6 +9,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { getGroupSubtitle, isGroup } from "#/modules/groups";
 
 type OrganizationMember = OrganizationMemberWithUserData & { id: string };
@@ -115,15 +116,15 @@ export const UserOrGroupAutocomplete: FC<UserOrGroupAutocompleteProps> = ({
 			}
 			renderOption={(option, isSelected) => (
 				<div className="flex items-center justify-between w-full">
-					<AvatarData
-						title={
-							isGroup(option)
-								? option.display_name || option.name
-								: option.username
-						}
-						subtitle={isGroup(option) ? getGroupSubtitle(option) : option.email}
-						src={option.avatar_url}
-					/>
+					{isGroup(option) ? (
+						<AvatarData
+							title={option.display_name || option.name}
+							subtitle={getGroupSubtitle(option)}
+							src={option.avatar_url}
+						/>
+					) : (
+						<AvatarData {...userIdentity(option)} />
+					)}
 					{isSelected && <CheckIcon className="size-4 shrink-0" />}
 				</div>
 			)}

--- a/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
@@ -13,6 +13,7 @@ import { Alert } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,
@@ -292,11 +293,7 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 					{workspaceACL.users.map((user) => (
 						<TableRow key={user.id}>
 							<TableCell className="py-2 w-[50%]">
-								<AvatarData
-									title={user.username}
-									subtitle={user.name}
-									src={user.avatar_url}
-								/>
+								<AvatarData {...userIdentity(user)} />
 							</TableCell>
 							<TableCell className="py-2 w-[40%]">
 								{canUpdatePermissions ? (

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -57,7 +57,7 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 							className="flex-shrink-0"
 						/>
 						<div className="font-normal truncate min-w-0 flex-1 overflow-hidden">
-							{session.initiator.name ?? session.initiator.username}
+							{session.initiator.username}
 						</div>
 					</div>
 				</div>

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
@@ -121,10 +121,10 @@ export const SessionSummaryTable = ({
 					<Avatar
 						size="sm"
 						src={initiator.avatar_url}
-						fallback={initiator.name}
+						fallback={initiator.username}
 					/>
-					<span className="truncate min-w-0" title={initiator.name}>
-						{initiator.name}
+					<span className="truncate min-w-0" title={initiator.username}>
+						{initiator.username}
 					</span>
 				</dd>
 			</div>

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -291,7 +291,7 @@ const ThreadItem: FC<ThreadItemProps> = ({ thread, initiator }) => {
 				<div className="flex flex-row items-center gap-1">
 					<Avatar
 						src={initiator.avatar_url}
-						fallback={initiator.name ?? initiator.username}
+						fallback={initiator.username}
 						size="sm"
 						className="flex-shrink-0"
 					/>

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
@@ -11,6 +11,7 @@ import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,
@@ -137,13 +138,7 @@ const MemberIdentity: FC<MemberIdentityProps> = (props) => {
 	}
 
 	const { user } = props;
-	return (
-		<AvatarData
-			title={user.username}
-			subtitle={user.name}
-			src={user.avatar_url}
-		/>
-	);
+	return <AvatarData {...userIdentity(user)} />;
 };
 
 type MobileMemberRowProps = {

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/UserSidebarFooter.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/UserSidebarFooter.tsx
@@ -22,7 +22,7 @@ export const UserSidebarFooter: FC = () => {
 					<DropdownMenuTrigger asChild>
 						<button
 							type="button"
-							aria-label={`Account menu for ${user.name || user.username}`}
+							aria-label={`Account menu for ${user.username}`}
 							className="flex min-w-0 flex-1 items-center gap-2 bg-transparent border-0 cursor-pointer px-3 py-3 text-left hover:bg-surface-tertiary/50 transition-colors"
 						>
 							<Avatar
@@ -31,7 +31,7 @@ export const UserSidebarFooter: FC = () => {
 								size="sm"
 							/>
 							<span className="min-w-0 flex-1 truncate text-sm text-content-secondary">
-								{user.name || user.username}
+								{user.username}
 							</span>
 						</button>
 					</DropdownMenuTrigger>

--- a/site/src/pages/GroupsPage/GroupMembersPage.tsx
+++ b/site/src/pages/GroupsPage/GroupMembersPage.tsx
@@ -18,6 +18,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,
@@ -252,10 +253,7 @@ const GroupMemberRow: FC<GroupMemberRowProps> = ({
 							src={member.avatar_url}
 						/>
 					}
-					title={member.username}
-					subtitle={
-						member.is_service_account ? "Service Account" : member.email
-					}
+					{...userIdentity(member)}
 				/>
 			</TableCell>
 			<TableCell

--- a/site/src/pages/GroupsPage/UserAIBudgetOverrideDialog.tsx
+++ b/site/src/pages/GroupsPage/UserAIBudgetOverrideDialog.tsx
@@ -26,6 +26,7 @@ import { Alert } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import {
@@ -166,8 +167,7 @@ export const UserAIBudgetOverrideDialog: FC<
 								src={user.avatar_url}
 							/>
 						}
-						title={user.username}
-						subtitle={user.is_service_account ? "Service Account" : user.email}
+						{...userIdentity(user)}
 					/>
 				</div>
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersTable.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersTable.tsx
@@ -6,6 +6,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { PremiumBadge } from "#/components/Badges/Badges";
 import { Button } from "#/components/Button/Button";
 import {
@@ -132,8 +133,7 @@ const OrganizationMembersTableBody: React.FC<OrganizationMembersTableProps> = ({
 									size="lg"
 								/>
 							}
-							title={member.name || member.username}
-							subtitle={member.email}
+							{...userIdentity(member)}
 						/>
 					</TableCell>
 					<UserRoleCell

--- a/site/src/pages/TasksPage/UsersCombobox.tsx
+++ b/site/src/pages/TasksPage/UsersCombobox.tsx
@@ -158,7 +158,7 @@ function mapUsersToOptions(
 	return includeAuthenticatedUser(users)
 		.toSorted(sortSelectedFirst)
 		.map((user) => ({
-			label: user.name || user.username,
+			label: user.username,
 			value: user.username,
 			avatarUrl: user.avatar_url,
 		}));

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPageView.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPageView.tsx
@@ -10,6 +10,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,
@@ -370,11 +371,7 @@ const MembersTableBody: FC<MembersTableBodyProps> = ({
 			{templateACL.users.map((user) => (
 				<TableRow key={user.id}>
 					<TableCell>
-						<AvatarData
-							title={user.username}
-							subtitle={user.email}
-							src={user.avatar_url}
-						/>
+						<AvatarData {...userIdentity(user)} />
 					</TableCell>
 					<TableCell>
 						{canUpdatePermissions ? (

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/UserOrGroupAutocomplete.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/UserOrGroupAutocomplete.tsx
@@ -5,6 +5,7 @@ import { templaceACLAvailable } from "#/api/queries/templates";
 import type { Group, ReducedUser } from "#/api/typesGenerated";
 import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
 import { AvatarData } from "#/components/Avatar/AvatarData";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { getGroupSubtitle, isGroup } from "#/modules/groups";
 import { prepareQuery } from "#/utils/filters";
 
@@ -69,15 +70,15 @@ export const UserOrGroupAutocomplete: FC<UserOrGroupAutocompleteProps> = ({
 			}
 			renderOption={(option, isSelected) => (
 				<div className="flex items-center justify-between w-full">
-					<AvatarData
-						title={
-							isGroup(option)
-								? option.display_name || option.name
-								: option.username
-						}
-						subtitle={isGroup(option) ? getGroupSubtitle(option) : option.email}
-						src={option.avatar_url}
-					/>
+					{isGroup(option) ? (
+						<AvatarData
+							title={option.display_name || option.name}
+							subtitle={getGroupSubtitle(option)}
+							src={option.avatar_url}
+						/>
+					) : (
+						<AvatarData {...userIdentity(option)} />
+					)}
 					{isSelected && <CheckIcon className="size-4 shrink-0" />}
 				</div>
 			)}

--- a/site/src/pages/UsersPage/UsersTable.tsx
+++ b/site/src/pages/UsersPage/UsersTable.tsx
@@ -6,6 +6,7 @@ import type { GroupsByUserId } from "#/api/queries/groups";
 import type * as TypesGen from "#/api/typesGenerated";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { AvatarDataSkeleton } from "#/components/Avatar/AvatarDataSkeleton";
+import { userIdentity } from "#/components/Avatar/userIdentity";
 import { PremiumBadge } from "#/components/Badges/Badges";
 import { Button } from "#/components/Button/Button";
 import {
@@ -144,13 +145,7 @@ const UsersTableBody: React.FC<UsersTableProps> = ({
 			{users?.map((user) => (
 				<TableRow key={user.id} data-testid={`user-${user.id}`}>
 					<TableCell>
-						<AvatarData
-							title={user.username}
-							subtitle={
-								user.is_service_account ? "Service Account" : user.email
-							}
-							src={user.avatar_url}
-						/>
+						<AvatarData {...userIdentity(user)} />
 					</TableCell>
 
 					<UserRoleCell roles={user.roles} />


### PR DESCRIPTION
[DEVEX-448](https://linear.app/codercom/issue/DEVEX-448/normalize-user-identity-display-across-coder)

Add a shared `userIdentity()` helper that returns `title` (`username`), `subtitle` (`email`, or `"Service Account"`), and `src` (`avatar_url`), then route AvatarData and related identity call sites through it.

Fixes inconsistent surfaces that preferred full name over email (workspace and chat sharing member lists, org members) and single-line labels that used name || username. Compact owner/initiator rows now show username.