### PR TITLE
fix(aibridge): use latest streaming chat usage instead of cross-chunk sum

### DIFF
--- a/aibridge/fixtures/fixtures.go
+++ b/aibridge/fixtures/fixtures.go
@@ -67,6 +67,9 @@ var (
 
 	//go:embed openai/chatcompletions/streaming_injected_tool_nonzero_index.txtar
 	OaiChatStreamingInjectedToolNonzeroIndex []byte
+
+	//go:embed openai/chatcompletions/streaming_cumulative_usage_injected_tool.txtar
+	OaiChatStreamingCumulativeUsageInjectedTool []byte
 )
 
 var (

--- a/aibridge/fixtures/openai/chatcompletions/streaming_cumulative_usage_injected_tool.txtar
+++ b/aibridge/fixtures/openai/chatcompletions/streaming_cumulative_usage_injected_tool.txtar
@@ -1,0 +1,30 @@
+Streaming response with cumulative usage on every JSON chunk and an injected tool call.
+
+-- request --
+{
+  "model": "gpt-4.1",
+  "messages": [
+    {
+      "role": "user",
+      "content": "list my coder workspaces"
+    }
+  ]
+}
+
+-- streaming --
+data: {"id":"chatcmpl-cumulative-tool","object":"chat.completion.chunk","created":1754479216,"model":"gpt-4.1","choices":[{"index":0,"delta":{"content":"Calling"}}],"usage":{"prompt_tokens":6000,"completion_tokens":10,"total_tokens":6010}}
+
+data: {"id":"chatcmpl-cumulative-tool","object":"chat.completion.chunk","created":1754479216,"model":"gpt-4.1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-cumulative","type":"function","function":{"name":"bmcp_coder_coder_list_workspaces","arguments":"{}"}}]}}],"usage":{"prompt_tokens":6000,"completion_tokens":20,"total_tokens":6020}}
+
+data: {"id":"chatcmpl-cumulative-tool","object":"chat.completion.chunk","created":1754479216,"model":"gpt-4.1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":6000,"completion_tokens":30,"total_tokens":6030}}
+
+data: [DONE]
+
+-- streaming/tool-call --
+data: {"id":"chatcmpl-cumulative-final","object":"chat.completion.chunk","created":1754479217,"model":"gpt-4.1","choices":[{"index":0,"delta":{"content":"Done"}}],"usage":{"prompt_tokens":6000,"completion_tokens":10,"total_tokens":6010}}
+
+data: {"id":"chatcmpl-cumulative-final","object":"chat.completion.chunk","created":1754479217,"model":"gpt-4.1","choices":[{"index":0,"delta":{"content":"."}}],"usage":{"prompt_tokens":6000,"completion_tokens":20,"total_tokens":6020}}
+
+data: {"id":"chatcmpl-cumulative-final","object":"chat.completion.chunk","created":1754479217,"model":"gpt-4.1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":6000,"completion_tokens":30,"total_tokens":6030}}
+
+data: [DONE]

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -270,9 +270,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 			prompt = nil
 		}
 
-		if lastUsage := processor.getLastUsage(); lastUsage.CompletionTokens > 0 {
-			// If the usage information is set, track it.
-			// The API will send usage information when the response terminates, which will happen if a tool call is invoked.
+		if lastUsage := processor.lastUsage; lastUsage.CompletionTokens > 0 {
 			i.recordTokenUsage(streamCtx, processor.getMsgID(), lastUsage)
 		}
 
@@ -412,24 +410,19 @@ func (i *StreamingInterception) getInjectedToolByName(name string) *mcp.Tool {
 	return i.mcpProxy.GetTool(name)
 }
 
-// Mashals received stream chunk.
-// Overrides id (since proxy obscures injected tool call invocations).
-// If usage field was set in original chunk overrides it to culminative usage.
-//
 // sjson is used instead of normal struct marshaling so forwarded data
 // is as close to the original as possible. Structs from openai library lack
 // `omitzero/omitempty` annotations which adds additional empty fields
 // when marshaling structs. Those additional empty fields can break Codex client.
 func (i *StreamingInterception) marshalChunk(chunk *openai.ChatCompletionChunk, id uuid.UUID, prc *streamProcessor) ([]byte, error) {
+	// Normalize the response ID because injected tool calls span multiple upstream invocations.
 	sj, err := sjson.Set(chunk.RawJSON(), "id", id.String())
 	if err != nil {
 		return nil, xerrors.Errorf("marshal chunk id failed: %w", err)
 	}
 
-	// If usage information is available, relay the cumulative usage once all tool invocations have completed.
 	if chunk.JSON.Usage.Valid() {
-		u := prc.getCumulativeUsage()
-		sj, err = sjson.Set(sj, "usage", u)
+		sj, err = sjson.Set(sj, "usage", prc.lastUsage)
 		if err != nil {
 			return nil, xerrors.Errorf("marshal chunk usage failed: %w", err)
 		}
@@ -503,9 +496,7 @@ type streamProcessor struct {
 	pendingToolCall     bool
 	getInjectedToolFunc func(string) *mcp.Tool
 
-	// Token handling.
-	lastUsage       openai.CompletionUsage
-	cumulativeUsage openai.CompletionUsage
+	lastUsage openai.CompletionUsage
 }
 
 func newStreamProcessor(ctx context.Context, logger slog.Logger, isToolInjectedFunc func(string) *mcp.Tool) *streamProcessor {
@@ -525,9 +516,11 @@ func (s *streamProcessor) process(chunk openai.ChatCompletionChunk) bool {
 		// Potentially not fatal, move along in best effort...
 	}
 
-	// Accumulate token usage.
-	s.lastUsage = chunk.Usage
-	s.cumulativeUsage = sumUsage(s.cumulativeUsage, chunk.Usage)
+	// Some providers emit cumulative usage snapshots on every chunk, so the
+	// latest valid usage is authoritative. Never sum across chunks.
+	if chunk.JSON.Usage.Valid() {
+		s.lastUsage = chunk.Usage
+	}
 
 	// If the stream has reached a terminal state (i.e. call a tool), and this tool is injected,
 	// then it must not be relayed.
@@ -614,14 +607,6 @@ func (s *streamProcessor) getLastCompletion() *openai.ChatCompletionMessage {
 	}
 
 	return &s.acc.Choices[0].Message
-}
-
-func (s *streamProcessor) getLastUsage() openai.CompletionUsage {
-	return s.lastUsage
-}
-
-func (s *streamProcessor) getCumulativeUsage() openai.CompletionUsage {
-	return s.cumulativeUsage
 }
 
 // compactToolCalls removes nil/empty tool call entries (without an ID).

--- a/aibridge/intercept/chatcompletions/streaming_internal_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_internal_test.go
@@ -59,9 +59,7 @@ func TestStreamProcessorUsage(t *testing.T) {
 			t.Parallel()
 
 			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
-			rec := &testutil.MockRecorder{}
 			interceptor := NewStreamingInterceptor(uuid.New(), nil, intercept.Config{}, nil, nil, otel.Tracer("test"))
-			interceptor.Setup(logger, rec, nil)
 			processor := newStreamProcessor(t.Context(), logger, nil)
 
 			var relayed []byte
@@ -89,12 +87,6 @@ func TestStreamProcessorUsage(t *testing.T) {
 			assert.Equal(t, tt.wantPromptTokens, usage.PromptTokens)
 			assert.Equal(t, tt.wantCompletionTokens, usage.CompletionTokens)
 			assert.Equal(t, tt.wantTotalTokens, usage.TotalTokens)
-			interceptor.recordTokenUsage(t.Context(), processor.getMsgID(), usage)
-
-			recorded := rec.RecordedTokenUsages()
-			require.Len(t, recorded, 1)
-			assert.Equal(t, tt.wantPromptTokens, recorded[0].Input)
-			assert.Equal(t, tt.wantCompletionTokens, recorded[0].Output)
 		})
 	}
 }

--- a/aibridge/intercept/chatcompletions/streaming_internal_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_internal_test.go
@@ -1,6 +1,8 @@
 package chatcompletions
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +18,86 @@ import (
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 )
+
+func TestStreamProcessorUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		chunks               []string
+		wantPromptTokens     int64
+		wantCompletionTokens int64
+		wantTotalTokens      int64
+	}{
+		{
+			name: "cumulative snapshots with trailing usage-less chunk",
+			chunks: []string{
+				`{"id":"chatcmpl-cumulative","choices":[{"index":0,"delta":{"content":"one"}}],"usage":{"prompt_tokens":6000,"completion_tokens":10,"total_tokens":6010}}`,
+				`{"id":"chatcmpl-cumulative","choices":[{"index":0,"delta":{"content":" two"}}],"usage":{"prompt_tokens":6000,"completion_tokens":20,"total_tokens":6020}}`,
+				`{"id":"chatcmpl-cumulative","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":6000,"completion_tokens":30,"total_tokens":6030}}`,
+				`{"id":"chatcmpl-cumulative","choices":[]}`,
+			},
+			wantPromptTokens:     6000,
+			wantCompletionTokens: 30,
+			wantTotalTokens:      6030,
+		},
+		{
+			name: "usage only on final chunk",
+			chunks: []string{
+				`{"id":"chatcmpl-final","choices":[{"index":0,"delta":{"content":"one"}}]}`,
+				`{"id":"chatcmpl-final","choices":[{"index":0,"delta":{"content":" two"}}]}`,
+				`{"id":"chatcmpl-final","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":6000,"completion_tokens":30,"total_tokens":6030}}`,
+			},
+			wantPromptTokens:     6000,
+			wantCompletionTokens: 30,
+			wantTotalTokens:      6030,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+			rec := &testutil.MockRecorder{}
+			interceptor := NewStreamingInterceptor(uuid.New(), nil, intercept.Config{}, nil, nil, otel.Tracer("test"))
+			interceptor.Setup(logger, rec, nil)
+			processor := newStreamProcessor(t.Context(), logger, nil)
+
+			var relayed []byte
+			for _, rawChunk := range tt.chunks {
+				var chunk openai.ChatCompletionChunk
+				require.NoError(t, json.Unmarshal([]byte(rawChunk), &chunk))
+				require.True(t, processor.process(chunk))
+				if chunk.JSON.Usage.Valid() {
+					var err error
+					relayed, err = interceptor.marshalChunk(&chunk, interceptor.ID(), processor)
+					require.NoError(t, err)
+				}
+			}
+
+			var payload struct {
+				Usage openai.CompletionUsage `json:"usage"`
+			}
+			relayed = bytes.TrimSuffix(bytes.TrimPrefix(relayed, []byte("data: ")), []byte("\n\n"))
+			require.NoError(t, json.Unmarshal(relayed, &payload))
+			assert.Equal(t, tt.wantPromptTokens, payload.Usage.PromptTokens)
+			assert.Equal(t, tt.wantCompletionTokens, payload.Usage.CompletionTokens)
+			assert.Equal(t, tt.wantTotalTokens, payload.Usage.TotalTokens)
+
+			usage := processor.lastUsage
+			assert.Equal(t, tt.wantPromptTokens, usage.PromptTokens)
+			assert.Equal(t, tt.wantCompletionTokens, usage.CompletionTokens)
+			assert.Equal(t, tt.wantTotalTokens, usage.TotalTokens)
+			interceptor.recordTokenUsage(t.Context(), processor.getMsgID(), usage)
+
+			recorded := rec.RecordedTokenUsages()
+			require.Len(t, recorded, 1)
+			assert.Equal(t, tt.wantPromptTokens, recorded[0].Input)
+			assert.Equal(t, tt.wantCompletionTokens, recorded[0].Output)
+		})
+	}
+}
 
 // Test that when the upstream provider returns an error before streaming starts,
 // the error status code and body are correctly relayed to the client.

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -837,6 +837,41 @@ func TestOpenAIChatCompletions(t *testing.T) {
 		}
 	})
 
+	t.Run("streaming cumulative usage with injected tool", func(t *testing.T) {
+		t.Parallel()
+
+		bridgeServer, mockMCP, resp := setupInjectedToolTest(
+			t,
+			fixtures.OaiChatStreamingCumulativeUsageInjectedTool,
+			true,
+			defaultTracer,
+			pathOpenAIChatCompletions,
+			nil,
+		)
+		defer resp.Body.Close()
+
+		sp := aibridge.NewSSEParser()
+		require.NoError(t, sp.Parse(resp.Body))
+
+		var finalUsage gjson.Result
+		events := sp.MessageEvents()
+		for i := len(events) - 1; i >= 0; i-- {
+			if usage := gjson.Get(events[i].Data, "usage"); usage.Exists() {
+				finalUsage = usage
+				break
+			}
+		}
+
+		require.True(t, finalUsage.Exists())
+		require.EqualValues(t, 6000, finalUsage.Get("prompt_tokens").Int())
+		require.EqualValues(t, 30, finalUsage.Get("completion_tokens").Int())
+		require.EqualValues(t, 6030, finalUsage.Get("total_tokens").Int())
+		require.EqualValues(t, 12000, bridgeServer.Recorder.TotalInputTokens())
+		require.EqualValues(t, 60, bridgeServer.Recorder.TotalOutputTokens())
+		require.Len(t, mockMCP.getCallsByTool(mockToolName), 1)
+		bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
+	})
+
 	t.Run("streaming injected tool call edge cases", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Problem

CODAGT-906: chats using OpenAI-compatible backends (e.g. poolside) through the AI Bridge persist token usage inflated 105x-640x, which falsely triggers automatic chat compaction on every turn.

The chat-completions streaming interceptor summed usage across every SSE chunk of one upstream stream and rewrote each relayed usage-bearing chunk with that running sum. Spec-compliant OpenAI emits usage once (final chunk with `stream_options.include_usage`), so the sum equals the final value. vLLM-style backends emit cumulative usage snapshots on every chunk, so the relayed final usage becomes roughly `N_chunks x prompt_tokens` (e.g. 417,012 persisted for a ~6,000-token context). chatd persists that value per assistant message and its compaction trigger reads it as context occupancy.

## Fix

Track the latest usage-bearing chunk's raw usage (last-wins) in the stream processor, updating only when a chunk actually carries usage so a trailing usage-less chunk cannot zero it. `marshalChunk` relays that value and `recordTokenUsage` records the same value, unifying relayed and recorded usage. Last-wins is correct for both shapes: a single final usage chunk, and cumulative snapshots where each snapshot already includes all prior tokens.

Per-iteration semantics are unchanged: each tool-loop iteration has its own processor, and the final iteration's usage is what the client sees.

## Tests

- `TestStreamProcessorUsage` (internal): cumulative snapshots with a trailing usage-less chunk, and the spec-compliant final-only shape; asserts relayed and recorded usage equal the last snapshot.
- New txtar fixture `streaming_cumulative_usage_injected_tool.txtar` with per-chunk cumulative usage plus an injected tool call; asserts client-visible final usage through the full interceptor.
- Red-green verified: with the fix reverted, the internal test reports zeroed usage (trailing chunk overwrite) and the fixture test reports 18000 summed prompt tokens instead of 6000.

The blocking (non-streaming) path deliberately keeps its cross-iteration summation for external clients and is untouched. Remote dogfood UAT validated chat streaming, tool calls, plausible usage numbers, and zero spurious compactions.

> Mux acted on Mike's behalf to author this change.
