### PR TITLE
fix(coderd/notifications): skip markdown escaping for control-flow labels

### DIFF
--- a/coderd/notifications/dispatch/smtp_internal_test.go
+++ b/coderd/notifications/dispatch/smtp_internal_test.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	markdown "github.com/coder/coder/v2/coderd/render"
-
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
+	markdown "github.com/coder/coder/v2/coderd/render"
 )
 
 func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -26,6 +26,19 @@ const (
 	notificationsDefaultAppName = "Coder"
 )
 
+// controlFlowLabels are notification label keys whose values are machine-set
+// enums used in Go template control flow (e.g. {{if eq .Labels.limit_source
+// "user_override"}}) rather than rendered as text. They must not be
+// Markdown-escaped, or the escaping (for example turning "user_override" into
+// "user\_override") would break the comparison and silently drop conditional
+// content. Every key here must be assigned from a code or DB enum and must never
+// carry user input.
+var controlFlowLabels = []string{
+	// coderd/aibridgedserver sets this from the codersdk.AIBudgetLimitSource
+	// enum ("user_override" or "group").
+	"limit_source",
+}
+
 type decorateHelpersError struct {
 	inner error
 }
@@ -257,7 +270,11 @@ func (n *notifier) prepare(ctx context.Context, msg database.AcquireNotification
 	// passed to the dispatcher unmodified so that non-Markdown consumers (the
 	// webhook JSON, the SMTP greeting, and the plaintext email part) receive
 	// verbatim values rather than escaped ones.
-	sanitized := render.SanitizedPayload(payload)
+	//
+	// controlFlowLabels are excluded from escaping: they hold machine-set enum
+	// values used in Go template control flow, not rendered as text, so escaping
+	// them would break the comparison.
+	sanitized := render.SanitizedPayload(payload, controlFlowLabels...)
 
 	var title, body string
 	if title, err = render.GoTemplate(msg.TitleTemplate, sanitized, helpers); err != nil {

--- a/coderd/notifications/render/gotmpl.go
+++ b/coderd/notifications/render/gotmpl.go
@@ -64,13 +64,28 @@ func SanitizeMarkdown(s string) string {
 // template's `| html`, not by Markdown escaping), and the plaintext email part
 // is not Markdown. Escaping those in place left literal backslashes in every one
 // of them.
-func SanitizedPayload(p types.MessagePayload) types.MessagePayload {
+//
+// Label keys listed in skipLabels are left verbatim. These are machine-set enum
+// values used in Go template control flow (e.g. {{if eq .Labels.x "y"}}) rather
+// than rendered as text; escaping them (for example turning "user_override" into
+// "user\_override") would break the comparison. Every skipped key must be
+// assigned from a code or DB enum and must never carry user input.
+func SanitizedPayload(p types.MessagePayload, skipLabels ...string) types.MessagePayload {
+	skip := make(map[string]struct{}, len(skipLabels))
+	for _, k := range skipLabels {
+		skip[k] = struct{}{}
+	}
+
 	sanitized := p
 	sanitized.UserName = SanitizeMarkdown(p.UserName)
 	if p.Labels != nil {
 		// Copy the map so the caller's payload keeps its raw label values.
 		sanitized.Labels = make(map[string]string, len(p.Labels))
 		for k, v := range p.Labels {
+			if _, ok := skip[k]; ok {
+				sanitized.Labels[k] = v
+				continue
+			}
 			sanitized.Labels[k] = SanitizeMarkdown(v)
 		}
 	}

--- a/coderd/notifications/render/sanitize_test.go
+++ b/coderd/notifications/render/sanitize_test.go
@@ -191,6 +191,30 @@ func TestSanitizedPayload(t *testing.T) {
 		assert.Equal(t, "normaluser", sanitized.UserUsername)
 	})
 
+	t.Run("leaves skipped control-flow labels verbatim", func(t *testing.T) {
+		t.Parallel()
+		// Labels named in skipLabels hold machine-set enum values used in Go
+		// template control flow. Escaping them (e.g. "user_override" ->
+		// "user\_override") would break comparisons like
+		// {{if eq .Labels.limit_source "user_override"}}, so they must be left
+		// verbatim while every other user-controlled label is still escaped.
+		payload := types.MessagePayload{
+			UserName: "[evil](https://evil.example)",
+			Labels: map[string]string{
+				"limit_source": "user_override",
+				"username":     "## not a heading_value",
+			},
+		}
+		sanitized := render.SanitizedPayload(payload, "limit_source")
+
+		// Skipped label is untouched, including the underscore.
+		assert.Equal(t, "user_override", sanitized.Labels["limit_source"])
+
+		// Other labels and UserName are still escaped.
+		assert.Equal(t, "\\#\\# not a heading\\_value", sanitized.Labels["username"])
+		assert.Contains(t, sanitized.UserName, "\\[evil\\]")
+	})
+
 	t.Run("leaves the original payload untouched", func(t *testing.T) {
 		t.Parallel()
 		// The original must keep its raw values so non-Markdown consumers
@@ -263,6 +287,37 @@ This new user account was created {{if .Labels.created_account_user_name}}for **
 		assert.NotContains(t, body, "## URGENT")
 		// Should still contain escaped versions
 		assert.Contains(t, body, "\\[Click\\]")
+	})
+
+	t.Run("control-flow label comparison survives sanitization", func(t *testing.T) {
+		t.Parallel()
+		// Regression: the AI budget admin templates gate a line on
+		// {{if eq .Labels.limit_source "user_override"}}. Because the label
+		// value contains an underscore, escaping it would break the eq
+		// comparison and silently drop the line. Skipping the control-flow
+		// label keeps the comparison working while user-controlled labels stay
+		// escaped.
+		payload := types.MessagePayload{
+			Labels: map[string]string{
+				"username":     "[evil](https://evil.example)",
+				"limit_source": "user_override",
+			},
+		}
+		sanitized := render.SanitizedPayload(payload, "limit_source")
+
+		bodyTmpl := `User **{{.Labels.username}}** reached their limit.` + "\n\n" +
+			`{{- if eq .Labels.limit_source "user_override"}}` + "\n\n" +
+			`This limit is a per-user override.` + "\n" +
+			`{{- end}}`
+
+		body, err := render.GoTemplate(bodyTmpl, sanitized, nil)
+		require.NoError(t, err)
+
+		// The conditional line renders because limit_source was not escaped.
+		assert.Contains(t, body, "This limit is a per-user override.")
+		// The user-controlled label is still escaped.
+		assert.NotContains(t, body, "[evil](")
+		assert.Contains(t, body, "\\[evil\\]")
 	})
 
 	t.Run("bold formatting in template still works", func(t *testing.T) {

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetLimitReachedUser.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetLimitReachedUser.html.golden
@@ -30,7 +30,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>You've reached your monthly AI budget limit</title>
+    <title>You&#39;ve reached your monthly AI budget limit</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +45,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        You've reached your monthly AI budget limit
+        You&#39;ve reached your monthly AI budget limit
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetWarningUser.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetWarningUser.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>You're approaching your monthly AI budget limit</title>
+    <title>You&#39;re approaching your monthly AI budget limit</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        You're approaching your monthly AI budget limit
+        You&#39;re approaching your monthly AI budget limit
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>


### PR DESCRIPTION
## Problem

Commit [`07f79af`](https://github.com/coder/coder/commit/07f79af65b228bb560ac51cea7f97ae81223fe44) ("fix: markdown rendering improvements") made `notifier.prepare` render notification titles and bodies from a `SanitizedPayload` that Markdown-escapes **every** label value.

The AI budget admin templates (added concurrently in #27415, migration `000553`) gate a line on a control-flow comparison:

```gotmpl
{{- if eq .Labels.limit_source "user_override"}}
This limit is a per-user override.
{{- end}}
```

`limit_source` is a **machine-set enum** (`codersdk.AIBudgetLimitSource`: `user_override` / `group`), not user input. Markdown escaping turns `user_override` into `user\_override`, so the `eq` comparison fails and the conditional line silently disappears. This broke `TestNotificationTemplates_Golden` on `main` for the AI budget templates.

## Fix

- Add an explicit skip-list of control-flow label keys (`controlFlowLabels`, currently just `limit_source`) that are passed through verbatim. All other user-controlled values (display names, other labels) remain Markdown-escaped, preserving the injection hardening from `07f79af`.
- `SanitizedPayload` now accepts optional `skipLabels ...string`.
- Regenerate the two AI budget **user** golden files for the legitimate `<title>`/`<h1>` HTML escaping (`You're` -> `You&#39;re`) introduced by `07f79af`. The admin HTML and webhook goldens are unchanged because the conditional line is restored.

Why not just `make gen` the goldens? Blindly accepting them would ship a real behavioral regression: admins would stop seeing the "per-user override" line. The skip-list restores correct behavior; the goldens only change where escaping is genuinely correct (HTML contexts).

## Tests

- New unit coverage in `sanitize_test.go`: skipped control-flow labels stay verbatim while user-controlled labels are still escaped, and an end-to-end render test asserting the `eq .Labels.limit_source "user_override"` conditional still renders. These lock the behavior so the goldens can't be silently regenerated away again.
- `go test ./coderd/notifications/...` passes, including `TestNotificationTemplates_Golden`.

<details>
<summary>Verification</summary>

- Confirmed `limit_source` is the only `eq .Labels.*` literal comparison across all notification template bodies.
- Confirmed the value is always assigned from the `codersdk.AIBudgetLimitSource` enum in `coderd/aibridgedserver/notifications.go`, never from request input.
- Regenerated goldens diff is confined to HTML `<title>`/`<h1>`; no `&#39;` leaked into plaintext bodies or webhook JSON.

</details>

Generated by Coder Agents on behalf of @jdomeracki-coder.