### PR TITLE
fix(site/src/pages/AgentsPage/components): derive diff cache keys from patch content

### DIFF
--- a/coderd/notifications/dispatch/smtp_internal_test.go
+++ b/coderd/notifications/dispatch/smtp_internal_test.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	markdown "github.com/coder/coder/v2/coderd/render"
-
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
+	markdown "github.com/coder/coder/v2/coderd/render"
 )
 
 func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetLimitReachedAdmin.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetLimitReachedAdmin.html.golden
@@ -17,8 +17,6 @@ User alice has reached their monthly AI budget limit ($1000.00). Subsequent=
 
 Effective group: Engineering
 
-This limit is a per-user override.
-
 AI budget period: July 1, 2026 - August 1, 2026
 
 
@@ -55,8 +53,6 @@ argin: 8px 0 32px; line-height: 1.5;">
 limit ($1000.00). Subsequent requests will be blocked.</p>
 
 <p>Effective group: <strong>Engineering</strong></p>
-
-<p>This limit is a per-user override.</p>
 
 <p>AI budget period: July 1, 2026 - August 1, 2026</p>
       </div>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetLimitReachedUser.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetLimitReachedUser.html.golden
@@ -30,7 +30,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>You've reached your monthly AI budget limit</title>
+    <title>You&#39;ve reached your monthly AI budget limit</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +45,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        You've reached your monthly AI budget limit
+        You&#39;ve reached your monthly AI budget limit
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetWarningUser.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIBudgetWarningUser.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>You're approaching your monthly AI budget limit</title>
+    <title>You&#39;re approaching your monthly AI budget limit</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        You're approaching your monthly AI budget limit
+        You&#39;re approaching your monthly AI budget limit
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateAIBudgetLimitReachedAdmin.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateAIBudgetLimitReachedAdmin.json.golden
@@ -24,6 +24,6 @@
   },
   "title": "alice has reached their monthly AI budget limit",
   "title_markdown": "alice has reached their monthly AI budget limit",
-  "body": "User alice has reached their monthly AI budget limit ($1000.00). Subsequent requests will be blocked.\n\nEffective group: Engineering\n\nThis limit is a per-user override.\n\nAI budget period: July 1, 2026 - August 1, 2026",
-  "body_markdown": "User **alice** has reached their monthly AI budget limit ($1000.00). Subsequent requests will be blocked.\n\nEffective group: **Engineering**\n\nThis limit is a per-user override.\n\nAI budget period: July 1, 2026 - August 1, 2026"
+  "body": "User alice has reached their monthly AI budget limit ($1000.00). Subsequent requests will be blocked.\n\nEffective group: Engineering\n\nAI budget period: July 1, 2026 - August 1, 2026",
+  "body_markdown": "User **alice** has reached their monthly AI budget limit ($1000.00). Subsequent requests will be blocked.\n\nEffective group: **Engineering**\n\nAI budget period: July 1, 2026 - August 1, 2026"
 }

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -874,6 +874,19 @@ describe("buildEditDiff", () => {
 		const hasContext = hunk.hunkContent.some((c) => c.type === "context");
 		expect(hasContext).toBe(true);
 	});
+
+	it("keys diffs by patch content, not by file name", () => {
+		const first = buildEditDiff("file.ts", [{ search: "old", replace: "new" }]);
+		const sameAgain = buildEditDiff("file.ts", [
+			{ search: "old", replace: "new" },
+		]);
+		const different = buildEditDiff("file.ts", [
+			{ search: "old", replace: "other" },
+		]);
+		expect(first?.cacheKey).toMatch(/^content-/);
+		expect(first?.cacheKey).toBe(sameAgain?.cacheKey);
+		expect(first?.cacheKey).not.toBe(different?.cacheKey);
+	});
 });
 
 describe("stripSvnIndexHeaders", () => {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -2,6 +2,7 @@ import type { FileDiffMetadata } from "@pierre/diffs";
 import { parsePatchFiles } from "@pierre/diffs";
 import * as Diff from "diff";
 import * as Yup from "yup";
+import { getContentCacheKeyPrefix } from "../../DiffViewer/diffCacheKey";
 import { asRecord, asString, isValid } from "../runtimeTypeUtils";
 
 export type ToolStatus = "completed" | "error" | "running";
@@ -464,10 +465,13 @@ export const getFileContentForViewer = (
  * null when the input is empty or the parser produces no files.
  * Shared between the write_file diff builder, the synthetic
  * edit_files diff builder, and the server-supplied diff parser.
+ * The cache key prefix is derived from the patch text so repeated
+ * edits of the same path never share a worker-pool highlight entry.
  */
 const parseSingleFileDiff = (raw: string): FileDiffMetadata | null => {
 	if (!raw) return null;
-	const parsed = parsePatchFiles(stripSvnIndexHeaders(raw));
+	const stripped = stripSvnIndexHeaders(raw);
+	const parsed = parsePatchFiles(stripped, getContentCacheKeyPrefix(stripped));
 	if (!parsed.length || !parsed[0].files.length) return null;
 	return parsed[0].files[0];
 };

--- a/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts
@@ -1,4 +1,7 @@
-import { getDiffCacheKeyPrefix } from "./diffCacheKey";
+import {
+	getContentCacheKeyPrefix,
+	getDiffCacheKeyPrefix,
+} from "./diffCacheKey";
 
 describe("getDiffCacheKeyPrefix", () => {
 	it("returns the same key for the same scope and query update time", () => {
@@ -17,5 +20,23 @@ describe("getDiffCacheKeyPrefix", () => {
 		expect(getDiffCacheKeyPrefix("chat-123", 101)).not.toBe(
 			getDiffCacheKeyPrefix("chat-456", 101),
 		);
+	});
+});
+
+describe("getContentCacheKeyPrefix", () => {
+	it("returns the same prefix for identical text", () => {
+		expect(getContentCacheKeyPrefix("--- a\n+++ a\n")).toBe(
+			getContentCacheKeyPrefix("--- a\n+++ a\n"),
+		);
+	});
+
+	it("returns different prefixes for different text", () => {
+		expect(getContentCacheKeyPrefix("--- a\n+++ a\n-x\n+y\n")).not.toBe(
+			getContentCacheKeyPrefix("--- a\n+++ a\n-x\n+z\n"),
+		);
+	});
+
+	it("prefixes keys so they never collide with bare file names", () => {
+		expect(getContentCacheKeyPrefix("anything")).toMatch(/^content-[0-9a-f]+$/);
 	});
 });

--- a/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts
@@ -10,3 +10,26 @@ export const getDiffCacheKeyPrefix = (
 	prefix: string,
 	dataUpdatedAt: number,
 ): string => `${prefix}-${dataUpdatedAt}`;
+
+/**
+ * Build a content-derived worker-pool cache key prefix for `@pierre/diffs`.
+ *
+ * The worker pool caches highlighted ASTs keyed only by each file's
+ * `cacheKey`, and the diff components default that key to the file name.
+ * Two different diff bodies for the same path would then share one cache
+ * entry, and rendering the newer diff against the older highlighted AST
+ * throws inside the renderer. Hashing the patch text keeps the key stable
+ * across re-renders and remounts while staying specific to the exact diff
+ * body.
+ */
+export const getContentCacheKeyPrefix = (text: string): string => {
+	// FNV-1a. The key only needs to separate different patch bodies for the
+	// same path while an older AST is cached, so a 32-bit checksum is plenty;
+	// crypto.subtle is async and cannot run in the render path.
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < text.length; i++) {
+		hash ^= text.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return `content-${(hash >>> 0).toString(16)}`;
+};

--- a/site/src/pages/AgentsPage/components/DiffViewer/useParsedDiff.test.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/useParsedDiff.test.ts
@@ -1,6 +1,7 @@
 import { parsePatchFiles } from "@pierre/diffs";
+import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { dedupeFilesByName } from "./useParsedDiff";
+import { dedupeFilesByName, useParsedDiff } from "./useParsedDiff";
 
 // Two `diff --git` sections for the same post-image path. `parsePatchFiles`
 // emits one FileDiffMetadata per section, so this is the exact shape that made
@@ -84,5 +85,42 @@ describe("dedupeFilesByName", () => {
 
 	it("returns an empty array unchanged", () => {
 		expect(dedupeFilesByName([])).toEqual([]);
+	});
+});
+
+describe("useParsedDiff", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("derives a content-specific cache key when no prefix is supplied", () => {
+		const { result } = renderHook(() => useParsedDiff(uniqueFilesDiff));
+
+		expect(result.current).toHaveLength(2);
+		// Keys are content-derived instead of bare file names, so a
+		// later diff body for the same path cannot reuse this AST.
+		for (const file of result.current) {
+			expect(file.cacheKey).toMatch(/^content-/);
+		}
+		expect(result.current[0].cacheKey).not.toBe(result.current[1].cacheKey);
+	});
+
+	it("keeps an explicit prefix when one is supplied", () => {
+		const { result } = renderHook(() =>
+			useParsedDiff(uniqueFilesDiff, "chat-1-123"),
+		);
+
+		expect(result.current[0].cacheKey).toMatch(/^chat-1-123-/);
+	});
+
+	it("gives different bodies different keys", () => {
+		const first = renderHook(() => useParsedDiff(uniqueFilesDiff));
+		const second = renderHook(() =>
+			useParsedDiff(uniqueFilesDiff.replace("const a = 2", "const a = 3")),
+		);
+
+		expect(first.result.current[0].cacheKey).not.toBe(
+			second.result.current[0].cacheKey,
+		);
 	});
 });

--- a/site/src/pages/AgentsPage/components/DiffViewer/useParsedDiff.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/useParsedDiff.ts
@@ -1,6 +1,7 @@
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { parsePatchFiles } from "@pierre/diffs";
 import { useMemo } from "react";
+import { getContentCacheKeyPrefix } from "./diffCacheKey";
 
 // A single diff body can list the same post-image path more than once: the
 // server may concatenate several `git diff` outputs, or one patch may carry
@@ -39,10 +40,12 @@ export function useParsedDiff(
 ): FileDiffMetadata[] {
 	return useMemo(() => {
 		if (!diffString) return [];
+		// Without a prefix the diff components default every cacheKey to
+		// the file name, so two bodies for the same path collide in the
+		// worker pool and the renderer throws on the stale AST.
+		const prefix = cacheKeyPrefix ?? getContentCacheKeyPrefix(diffString);
 		try {
-			const files = parsePatchFiles(diffString, cacheKeyPrefix).flatMap(
-				(p) => p.files,
-			);
+			const files = parsePatchFiles(diffString, prefix).flatMap((p) => p.files);
 			return dedupeFilesByName(files);
 		} catch (e) {
 			console.error("Failed to parse diff:", e);


### PR DESCRIPTION
## Problem

Since the `@pierre/diffs` bump to 1.3.3 (#27932), the chat UI intermittently shows a red error box instead of a tool diff:

```
DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null, something is wrong
```

The 1.3.x web components default each parsed diff's `cacheKey` to the file name, and the singleton worker pool caches highlighted ASTs by that key alone. Two different diff bodies for the same path (e.g. consecutive `edit_files` turns on one file, or a re-render after a later edit) therefore share one cache entry, and rendering the newer diff against the older highlighted AST throws inside the renderer. Upstream tracks this as pierrecomputer/pierre#1052; #964 documents the same throw path. The existing `RemoteDiffPanel` already works around it by passing a unique `cacheKeyPrefix`, but the chat tool renderers and `LocalDiffPanel` parse without one.

## Fix

Derive the `cacheKeyPrefix` from the patch text (FNV-1a checksum) so keys are specific to the exact diff body while staying stable across re-renders and remounts:

- `parseSingleFileDiff` (shared by the `write_file` diff builder, the synthetic `edit_files` builder, and the server-supplied diff parser) now passes a content-derived prefix.
- `useParsedDiff` falls back to the same prefix when a caller supplies none, which also fixes `LocalDiffPanel`. Explicit prefixes (`RemoteDiffPanel`'s timestamp-scoped key) still win.

A 32-bit checksum is deliberate: the key only needs to separate different patch bodies for the same path while an older AST is cached, and `crypto.subtle` is async so it cannot run in the render path.

The first commit is an unrelated prerequisite: main is currently not `make gen`/`make fmt` clean (its `gen` and `fmt` CI jobs are red), and the mandatory pre-commit hook fails on any unstaged change. That drift is a mechanical follow-up to 07f79af65b, which sanitized notification labels before template rendering but regenerated only the Docker-free goldens; the AI budget templates' `eq .Labels.limit_source "user_override"` condition no longer matches because `SanitizeMarkdown` escapes the underscore. Kept as a separate commit so it can be dropped or split out.

<details>
<summary>Root-cause trace (agent tool call to renderer crash)</summary>

1. Chat agent invokes `edit_files` (`coderd/x/chatd/chattool/editfiles.go`), which calls the workspace agent's `POST /api/v0/edit-files` with `IncludeDiff: true`.
2. The agent applies edits and computes a unified diff per file with go-udiff (`agent/agentfiles/files.go`), returned as `FileEditResponse.Files[].Diff`.
3. chatd stores the tool result as a JSON `tool-result` message part; the frontend pairs it with the tool call (`messageParsing.ts`).
4. `Tool.tsx` dispatches to `EditFilesRenderer`, which parses the server diff (or synthesizes one from the args via `Diff.createPatch`) through `parseSingleFileDiff` in `ChatElements/tools/utils.ts`. Before this fix, `parsePatchFiles` was called **without** a `cacheKeyPrefix`, so the parsed `FileDiffMetadata` had no `cacheKey`.
5. `EditFilesTool.tsx` renders `<FileDiff fileDiff=...>`. The `@pierre/diffs` component assigns `cacheKey = fileDiff.name` when absent (`components/FileDiff.js:472`).
6. `DiffHunksRenderer.renderDiff` consults the singleton worker pool's highlight cache keyed only by that `cacheKey` (`worker/WorkerPoolManager.js:76-77`, entries stored at :653/:701).
7. A stale hit returns the highlighted AST built for the *earlier* diff of the same path; `processDiffResult` walks the new hunks and indexes the old, shorter `code.additionLines`/`deletionLines` arrays (`renderers/DiffHunksRenderer.js:646-651`), both `undefined`, and throws. The component catches it and renders the error box via `applyErrorToDOM`.

Reproduced locally against the shipped 1.3.3 library by seeding the pool cache with a first diff's result and rendering a second diff of the same path; with content-derived keys the lookup misses and rendering succeeds.
</details>

---

Generated with Coder Agents.
