### PR TITLE
feat: tolerate unusable runtime hours claims and decode -1 allocation as unlimited

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -425,7 +425,7 @@ type UsagePeriod struct {
 // 2. The usage period has a greater end date (note: only certain features use usage periods)
 // 3. Graceful & capable > Entitled & not capable (only if both have "Actual" values)
 // 4. The entitlement is greater
-// 5. The limit is greater
+// 5. The limit is greater (except a nil limit on a usage period feature means unlimited, outranking any set limit)
 // 6. Enabled is greater than disabled
 // 7. The actual is greater
 //
@@ -469,11 +469,19 @@ func (f Feature) Compare(b Feature) int {
 		return entitlementDifference
 	}
 
-	// If the entitlement is the same, then we can compare the limits.
+	// If the entitlement is the same, then we can compare the limits. A nil
+	// limit on a usage period feature means unlimited, so it outranks any set
+	// limit; on other features a nil limit loses to a set one.
 	if f.Limit == nil && b.Limit != nil {
+		if bothHaveUsagePeriod {
+			return 1
+		}
 		return -1
 	}
 	if f.Limit != nil && b.Limit == nil {
+		if bothHaveUsagePeriod {
+			return -1
+		}
 		return 1
 	}
 	if f.Limit != nil && b.Limit != nil {

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -1225,6 +1225,31 @@ func TestFeatureComparison(t *testing.T) {
 			},
 			Expected: 1,
 		},
+		{
+			// A nil limit on a usage period feature means unlimited, so it
+			// outranks a set limit on an exact usage period tie.
+			Name: "UnlimitedUsagePeriodOutranksMeteredOnTie",
+			A: codersdk.Feature{
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     true,
+				UsagePeriod: &codersdk.UsagePeriod{
+					IssuedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					Start:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					End:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			B: codersdk.Feature{
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     true,
+				Limit:       ptr.Ref(int64(100)),
+				UsagePeriod: &codersdk.UsagePeriod{
+					IssuedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					Start:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					End:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			Expected: 1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -17,6 +17,19 @@ const (
 	LicenseManagedAgentLimitExceededWarningText = "You have built more workspaces with managed agents than your license allows."
 	LicenseAIGovernance90PercentWarningText     = "You have used %d%% of your AI Governance add-on seats."
 	LicenseAIGovernanceOverLimitWarningText     = "Your organization is using %d of %d AI Governance add-on seats (%d over the limit)."
+	// LicenseManagedAgentUsageUnavailableErrorText is emitted when the
+	// managed agent usage query fails while computing entitlements; the
+	// cause is logged server-side. It travels in the entitlements Errors
+	// channel so the alertable coderd_license_errors gauge counts
+	// measurement failures, but the dashboard recognizes the exact text and
+	// renders it as a muted diagnostic rather than a license error.
+	LicenseManagedAgentUsageUnavailableErrorText = "Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details."
+	// LicenseAgentRuntimeHoursClaimsIgnoredWarningText is emitted when a
+	// license carries unusable Coder Agent runtime hour claims (see
+	// decodeAgentRuntimeHours in enterprise/coderd/license); the logs name
+	// the license and the dropped claims. The dashboard renders the exact
+	// text as a muted diagnostic without a sales link.
+	LicenseAgentRuntimeHoursClaimsIgnoredWarningText = "A license contains unusable Coder Agent runtime hour claims, which were ignored. The rest of that license is unaffected. Check the coderd logs for the affected license and claims, and contact support to have the license re-issued."
 )
 
 type AddLicenseRequest struct {

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -17,7 +17,6 @@ const (
 	LicenseManagedAgentLimitExceededWarningText      = "You have built more workspaces with managed agents than your license allows."
 	LicenseAIGovernance90PercentWarningText          = "You have used %d%% of your AI Governance add-on seats."
 	LicenseAIGovernanceOverLimitWarningText          = "Your organization is using %d of %d AI Governance add-on seats (%d over the limit)."
-	LicenseManagedAgentUsageUnavailableErrorText     = "Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details."
 	LicenseAgentRuntimeHoursClaimsIgnoredWarningText = "A license contains unusable Coder Agent runtime hour claims, which were ignored. The rest of that license is unaffected. Check the coderd logs for the affected license and claims, and contact support to have the license re-issued."
 )
 

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -12,23 +12,12 @@ import (
 )
 
 const (
-	LicenseExpiryClaim                          = "license_expires"
-	LicenseTelemetryRequiredErrorText           = "License requires telemetry but telemetry is disabled"
-	LicenseManagedAgentLimitExceededWarningText = "You have built more workspaces with managed agents than your license allows."
-	LicenseAIGovernance90PercentWarningText     = "You have used %d%% of your AI Governance add-on seats."
-	LicenseAIGovernanceOverLimitWarningText     = "Your organization is using %d of %d AI Governance add-on seats (%d over the limit)."
-	// LicenseManagedAgentUsageUnavailableErrorText is emitted when the
-	// managed agent usage query fails while computing entitlements; the
-	// cause is logged server-side. It travels in the entitlements Errors
-	// channel so the alertable coderd_license_errors gauge counts
-	// measurement failures, but the dashboard recognizes the exact text and
-	// renders it as a muted diagnostic rather than a license error.
-	LicenseManagedAgentUsageUnavailableErrorText = "Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details."
-	// LicenseAgentRuntimeHoursClaimsIgnoredWarningText is emitted when a
-	// license carries unusable Coder Agent runtime hour claims (see
-	// decodeAgentRuntimeHours in enterprise/coderd/license); the logs name
-	// the license and the dropped claims. The dashboard renders the exact
-	// text as a muted diagnostic without a sales link.
+	LicenseExpiryClaim                               = "license_expires"
+	LicenseTelemetryRequiredErrorText                = "License requires telemetry but telemetry is disabled"
+	LicenseManagedAgentLimitExceededWarningText      = "You have built more workspaces with managed agents than your license allows."
+	LicenseAIGovernance90PercentWarningText          = "You have used %d%% of your AI Governance add-on seats."
+	LicenseAIGovernanceOverLimitWarningText          = "Your organization is using %d of %d AI Governance add-on seats (%d over the limit)."
+	LicenseManagedAgentUsageUnavailableErrorText     = "Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details."
 	LicenseAgentRuntimeHoursClaimsIgnoredWarningText = "A license contains unusable Coder Agent runtime hour claims, which were ignored. The rest of that license is unaffected. Check the coderd logs for the affected license and claims, and contact support to have the license re-issued."
 )
 

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -92,6 +92,12 @@ func TestEntitlements(t *testing.T) {
 		// Enable all features
 		features := make(license.Features)
 		for _, feature := range codersdk.FeatureNames {
+			if feature == codersdk.FeatureAgentRuntimeHours {
+				// The feature name is not a valid license claim; the
+				// feature is encoded as its allocation claim.
+				features[license.ClaimAgentRuntimeHoursAllocation] = 1
+				continue
+			}
 			features[feature] = 1
 		}
 		features[codersdk.FeatureUserLimit] = 100

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -237,10 +237,6 @@ func (opts *LicenseOptions) ManagedAgentLimit(limit int64) *LicenseOptions {
 	return opts.Feature(codersdk.FeatureManagedAgentLimit, limit)
 }
 
-// AgentRuntimeHours sets the Coder Agent runtime hour claims. A nil softLimit
-// or hardLimit omits that claim, which a license is allowed to do; a non-nil
-// value is emitted verbatim, so tests can express explicit zero or negative
-// claims.
 func (opts *LicenseOptions) AgentRuntimeHours(allocation int64, softLimit, hardLimit *int64) *LicenseOptions {
 	opts.Feature(license.ClaimAgentRuntimeHoursAllocation, allocation)
 	if softLimit != nil {

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -237,6 +237,21 @@ func (opts *LicenseOptions) ManagedAgentLimit(limit int64) *LicenseOptions {
 	return opts.Feature(codersdk.FeatureManagedAgentLimit, limit)
 }
 
+// AgentRuntimeHours sets the Coder Agent runtime hour claims. A nil softLimit
+// or hardLimit omits that claim, which a license is allowed to do; a non-nil
+// value is emitted verbatim, so tests can express explicit zero or negative
+// claims.
+func (opts *LicenseOptions) AgentRuntimeHours(allocation int64, softLimit, hardLimit *int64) *LicenseOptions {
+	opts.Feature(license.ClaimAgentRuntimeHoursAllocation, allocation)
+	if softLimit != nil {
+		opts.Feature(license.ClaimAgentRuntimeHoursLimitSoft, *softLimit)
+	}
+	if hardLimit != nil {
+		opts.Feature(license.ClaimAgentRuntimeHoursLimitHard, *hardLimit)
+	}
+	return opts
+}
+
 func (opts *LicenseOptions) Feature(name codersdk.FeatureName, value int64) *LicenseOptions {
 	if opts.Features == nil {
 		opts.Features = license.Features{}

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -932,9 +932,10 @@ const (
 // codersdk.FeatureAgentRuntimeHours feature; see decodeAgentRuntimeHours.
 const (
 	// ClaimAgentRuntimeHoursAllocation is the purchased runtime-hour
-	// allocation for the license term. It becomes the feature's Limit. A
-	// negative allocation is ignored, in which case the license does not
-	// grant the feature.
+	// allocation for the license term. It becomes the feature's Limit.
+	// AgentRuntimeHoursUnlimitedAllocation (-1) is reserved to mean
+	// unlimited; any other negative allocation is ignored, in which case
+	// the license does not grant the feature.
 	ClaimAgentRuntimeHoursAllocation = "agent_runtime_hours_allocation"
 	// ClaimAgentRuntimeHoursLimitSoft is the advisory warning threshold. It
 	// becomes the feature's SoftLimit when 0 < soft < allocation and is
@@ -945,6 +946,12 @@ const (
 	// hard >= allocation, and is ignored otherwise.
 	ClaimAgentRuntimeHoursLimitHard = "agent_runtime_hours_limit_hard"
 )
+
+// AgentRuntimeHoursUnlimitedAllocation is the reserved
+// ClaimAgentRuntimeHoursAllocation value meaning the license grants
+// unlimited runtime hours. It decodes to an enabled feature with a nil
+// Limit. Mirrored in github.com/coder/license.
+const AgentRuntimeHoursUnlimitedAllocation int64 = -1
 
 var (
 	ValidMethods = []string{"EdDSA"}
@@ -991,6 +998,15 @@ func isAgentRuntimeHoursClaim(name codersdk.FeatureName) bool {
 // claims, but Actual is still measured and published. CODAGT-856 will make a
 // zero allocation force a concurrency-limited mode; that mode does not exist
 // yet.
+//
+// An AgentRuntimeHoursUnlimitedAllocation (-1) allocation grants the feature
+// enabled with a nil Limit, meaning unlimited. Threshold claims alongside it
+// have nothing to threshold against, so they are dropped with the warning,
+// keeping an incorrectly issued license visible. Note that
+// codersdk.Feature.Compare ranks a nil Limit below a set one, so on an exact
+// issued-at and expiry tie a metered license outranks an unlimited one; ties
+// never happen for separately issued licenses, so this edge is documented
+// rather than special-cased.
 func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement, usagePeriod codersdk.UsagePeriod) (feature codersdk.Feature, granted bool, ignoredClaims []string) {
 	if _, ok := features[codersdk.FeatureAgentRuntimeHours]; ok {
 		ignoredClaims = append(ignoredClaims, string(codersdk.FeatureAgentRuntimeHours))
@@ -999,6 +1015,20 @@ func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement
 	allocation, allocOk := features[ClaimAgentRuntimeHoursAllocation]
 	soft, softOk := features[ClaimAgentRuntimeHoursLimitSoft]
 	hard, hardOk := features[ClaimAgentRuntimeHoursLimitHard]
+
+	if allocOk && allocation == AgentRuntimeHoursUnlimitedAllocation {
+		if softOk {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitSoft)
+		}
+		if hardOk {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitHard)
+		}
+		return codersdk.Feature{
+			Enabled:     true,
+			Entitlement: entitlement,
+			UsagePeriod: &usagePeriod,
+		}, true, ignoredClaims
+	}
 
 	if !allocOk || allocation < 0 {
 		if allocOk && allocation < 0 {

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -960,8 +960,7 @@ func isAgentRuntimeHoursClaim(name codersdk.FeatureName) bool {
 // look healthy.
 //
 // A zero allocation grants the feature disabled, but Actual is still
-// measured and published. CODAGT-856 will make a zero allocation force a
-// concurrency-limited mode; that mode does not exist yet.
+// measured and published.
 func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement, usagePeriod codersdk.UsagePeriod) (feature codersdk.Feature, granted bool, ignoredClaims []string) {
 	if _, ok := features[codersdk.FeatureAgentRuntimeHours]; ok {
 		ignoredClaims = append(ignoredClaims, string(codersdk.FeatureAgentRuntimeHours))

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -115,8 +115,8 @@ func Entitlements(
 			// licenses (e.g. higher hard limit) to account for additional
 			// usage.
 			//
-			// nolint:gocritic // Reading usage events requires the usage publisher subject.
-			return db.GetTotalUsageDCManagedAgentsV1(dbauthz.AsUsagePublisher(ctx), database.GetTotalUsageDCManagedAgentsV1Params{
+			// nolint:gocritic // Requires permission to read all workspaces to read managed agent count.
+			return db.GetTotalUsageDCManagedAgentsV1(dbauthz.AsSystemRestricted(ctx), database.GetTotalUsageDCManagedAgentsV1Params{
 				StartDate: startTime,
 				EndDate:   endTime,
 			})
@@ -709,17 +709,24 @@ func LicensesEntitlements(
 	if entitlements.HasLicense && agentLimit.UsagePeriod != nil {
 		// Calculate the amount of agents between the usage period start and
 		// end.
-		managedAgentCount, ok, err := measureUsage(ctx, &entitlements,
-			featureArguments.Logger, featureArguments.ManagedAgentCountFn, *agentLimit.UsagePeriod,
-			"managed agent count", codersdk.LicenseManagedAgentUsageUnavailableErrorText)
-		if err != nil {
-			return entitlements, err
+		var (
+			managedAgentCount int64
+			err               = xerrors.New("dev error: managed agent count function is not set")
+		)
+		if featureArguments.ManagedAgentCountFn != nil {
+			managedAgentCount, err = featureArguments.ManagedAgentCountFn(ctx, agentLimit.UsagePeriod.Start, agentLimit.UsagePeriod.End)
 		}
-		if ok {
+		if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) {
+			// If the context is canceled, we want to bail the entire
+			// LicensesEntitlements call.
+			return entitlements, xerrors.Errorf("get managed agent count: %w", err)
+		}
+		if err != nil {
+			entitlements.Errors = append(entitlements.Errors, fmt.Sprintf("Error getting managed agent count: %s", err.Error()))
+			// no return
+		} else {
 			agentLimit.Actual = &managedAgentCount
-			// Write directly rather than via AddFeature so its Compare
-			// cannot drop the update.
-			entitlements.Features[codersdk.FeatureManagedAgentLimit] = agentLimit
+			entitlements.AddFeature(codersdk.FeatureManagedAgentLimit, agentLimit)
 
 			// Only issue warnings if the feature is enabled.
 			if agentLimit.Enabled && agentLimit.Limit != nil && managedAgentCount >= *agentLimit.Limit {
@@ -856,39 +863,6 @@ func LicensesEntitlements(
 	entitlements.RefreshedAt = now
 
 	return entitlements, nil
-}
-
-// measureUsage runs fn over the feature's usage period. A nil fn or a
-// failure with a dead context fails the whole call; any other failure logs
-// the cause and publishes unavailableText instead. It returns the measured
-// value and true only on success.
-func measureUsage(
-	ctx context.Context,
-	entitlements *codersdk.Entitlements,
-	logger slog.Logger,
-	fn func(ctx context.Context, from time.Time, to time.Time) (int64, error),
-	usagePeriod codersdk.UsagePeriod,
-	what string,
-	unavailableText string,
-) (int64, bool, error) {
-	if fn == nil {
-		return 0, false, xerrors.Errorf("developer error: no closure provided to measure %s usage", what)
-	}
-	value, err := fn(ctx, usagePeriod.Start, usagePeriod.End)
-	switch {
-	case err != nil && ctx.Err() != nil:
-		// Do not classify cancellation by error shape instead of ctx.Err():
-		// Postgres raises SQLSTATE 57014 (query_canceled) for
-		// statement_timeout kills as well as client cancels, and aborting on
-		// those would fail every entitlements refresh on a deployment whose
-		// statement_timeout is shorter than a usage query.
-		return 0, false, xerrors.Errorf("get %s: %w", what, err)
-	case err != nil:
-		logger.Error(ctx, fmt.Sprintf("get %s for entitlements", what), slog.Error(err))
-		entitlements.Errors = append(entitlements.Errors, unavailableText)
-		return 0, false, nil
-	}
-	return value, true, nil
 }
 
 func appendAIGovernanceSeatLimitWarning(warnings []string, actual int64, limit int64) []string {

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -93,6 +93,7 @@ func Entitlements(
 	}
 
 	entitlements, err := LicensesEntitlements(ctx, now, licenses, enablements, keys, FeatureArguments{
+		Logger:                logger,
 		ActiveUserCount:       activeUserCount,
 		ActiveAISeatCount:     activeAISeatCount,
 		ReplicaCount:          replicaCount,
@@ -114,8 +115,8 @@ func Entitlements(
 			// licenses (e.g. higher hard limit) to account for additional
 			// usage.
 			//
-			// nolint:gocritic // Requires permission to read all workspaces to read managed agent count.
-			return db.GetTotalUsageDCManagedAgentsV1(dbauthz.AsSystemRestricted(ctx), database.GetTotalUsageDCManagedAgentsV1Params{
+			// nolint:gocritic // Reading usage events requires the usage publisher subject.
+			return db.GetTotalUsageDCManagedAgentsV1(dbauthz.AsUsagePublisher(ctx), database.GetTotalUsageDCManagedAgentsV1Params{
 				StartDate: startTime,
 				EndDate:   endTime,
 			})
@@ -129,6 +130,9 @@ func Entitlements(
 }
 
 type FeatureArguments struct {
+	// Logger receives the causes behind operator-facing diagnostics whose
+	// published message is a stable text. The zero value discards them.
+	Logger                slog.Logger
 	ActiveUserCount       int64
 	ActiveAISeatCount     int64
 	ReplicaCount          int
@@ -508,11 +512,8 @@ func LicensesEntitlements(
 				continue
 			}
 
-			// Agent runtime hours are encoded as up to three claims and are
-			// decoded together after this loop, see
-			// decodeAgentRuntimeHours. The feature name itself is never a
-			// valid claim. The allocation must come from the dedicated claim
-			// so it is validated against the soft and hard limits.
+			// Agent runtime hour claims are decoded together after this
+			// loop; see decodeAgentRuntimeHours.
 			if featureName == codersdk.FeatureAgentRuntimeHours ||
 				isAgentRuntimeHoursClaim(featureName) {
 				continue
@@ -577,14 +578,25 @@ func LicensesEntitlements(
 			}
 		}
 
-		// The loop above skips Agent runtime hours because the
-		// three claims that encode them decode into a single feature.
-		if feature, ok := decodeAgentRuntimeHours(claims.Features, entitlement, codersdk.UsagePeriod{
+		runtimeFeature, granted, ignoredClaims := decodeAgentRuntimeHours(claims.Features, entitlement, codersdk.UsagePeriod{
 			IssuedAt: claims.IssuedAt.Time,
 			Start:    usagePeriodStart,
 			End:      usagePeriodEnd,
-		}); ok {
-			entitlements.AddFeature(codersdk.FeatureAgentRuntimeHours, feature)
+		})
+		if granted {
+			entitlements.AddFeature(codersdk.FeatureAgentRuntimeHours, runtimeFeature)
+		}
+		if len(ignoredClaims) > 0 {
+			// The published warning is a stable text, so the details a
+			// support case needs go to the log.
+			featureArguments.Logger.Warn(ctx, "ignored unusable Coder Agent runtime hour claims in license",
+				slog.F("license_id", license.UUID),
+				slog.F("ignored_claims", ignoredClaims),
+			)
+			if !slices.Contains(entitlements.Warnings, codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText) {
+				entitlements.Warnings = append(entitlements.Warnings,
+					codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText)
+			}
 		}
 
 		addonFeatures := make(map[codersdk.FeatureName]codersdk.Feature)
@@ -701,24 +713,18 @@ func LicensesEntitlements(
 	if entitlements.HasLicense && agentLimit.UsagePeriod != nil {
 		// Calculate the amount of agents between the usage period start and
 		// end.
-		var (
-			managedAgentCount int64
-			err               = xerrors.New("dev error: managed agent count function is not set")
-		)
-		if featureArguments.ManagedAgentCountFn != nil {
-			managedAgentCount, err = featureArguments.ManagedAgentCountFn(ctx, agentLimit.UsagePeriod.Start, agentLimit.UsagePeriod.End)
-		}
-		if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) {
-			// If the context is canceled, we want to bail the entire
-			// LicensesEntitlements call.
-			return entitlements, xerrors.Errorf("get managed agent count: %w", err)
-		}
+		managedAgentCount, ok, err := measureUsage(ctx, &entitlements,
+			featureArguments.Logger, featureArguments.ManagedAgentCountFn, *agentLimit.UsagePeriod,
+			"managed agent count", codersdk.LicenseManagedAgentUsageUnavailableErrorText)
 		if err != nil {
-			entitlements.Errors = append(entitlements.Errors, fmt.Sprintf("Error getting managed agent count: %s", err.Error()))
-			// no return
-		} else {
+			return entitlements, err
+		}
+		if ok {
 			agentLimit.Actual = &managedAgentCount
-			entitlements.AddFeature(codersdk.FeatureManagedAgentLimit, agentLimit)
+			// Written back directly: the feature contest is already
+			// settled, so AddFeature's Compare must not get a chance to
+			// drop the write.
+			entitlements.Features[codersdk.FeatureManagedAgentLimit] = agentLimit
 
 			// Only issue warnings if the feature is enabled.
 			if agentLimit.Enabled && agentLimit.Limit != nil && managedAgentCount >= *agentLimit.Limit {
@@ -857,6 +863,42 @@ func LicensesEntitlements(
 	return entitlements, nil
 }
 
+// measureUsage runs one usage query over the feature's usage period and owns
+// the shared failure policy: a nil fn is a wiring bug and fails the whole
+// LicensesEntitlements call; a failure with a dead context fails the call
+// without logging; any other failure logs the cause and publishes the stable
+// unavailableText instead. It returns the measured value and true only on
+// success.
+func measureUsage(
+	ctx context.Context,
+	entitlements *codersdk.Entitlements,
+	logger slog.Logger,
+	fn func(ctx context.Context, from time.Time, to time.Time) (int64, error),
+	usagePeriod codersdk.UsagePeriod,
+	what string,
+	unavailableText string,
+) (int64, bool, error) {
+	if fn == nil {
+		return 0, false, xerrors.Errorf("developer error: no closure provided to measure %s usage", what)
+	}
+	value, err := fn(ctx, usagePeriod.Start, usagePeriod.End)
+	switch {
+	case err != nil && ctx.Err() != nil:
+		// The computation's own context is dead, so abort the whole call
+		// without logging. Do not classify by error shape instead: Postgres
+		// raises SQLSTATE 57014 (query_canceled) for statement_timeout kills
+		// as well as client cancels, and aborting on those would fail every
+		// entitlements refresh on a deployment whose statement_timeout is
+		// shorter than a usage query.
+		return 0, false, xerrors.Errorf("get %s: %w", what, err)
+	case err != nil:
+		logger.Error(ctx, fmt.Sprintf("get %s for entitlements", what), slog.Error(err))
+		entitlements.Errors = append(entitlements.Errors, unavailableText)
+		return 0, false, nil
+	}
+	return value, true, nil
+}
+
 func appendAIGovernanceSeatLimitWarning(warnings []string, actual int64, limit int64) []string {
 	if limit <= 0 {
 		return warnings
@@ -885,23 +927,22 @@ const (
 	VersionClaim          = "version"
 )
 
-// Agent runtime hour license claims. These are the canonical claim names
-// minted by github.com/coder/license. All three claims map to the single
-// codersdk.FeatureAgentRuntimeHours feature and are validated together when
-// the license is parsed, see validateClaims.
-//
-// The unit for all three claims is hours.
+// Agent runtime hour license claims, minted by github.com/coder/license.
+// All three are in hours and decode together into the single
+// codersdk.FeatureAgentRuntimeHours feature; see decodeAgentRuntimeHours.
 const (
 	// ClaimAgentRuntimeHoursAllocation is the purchased runtime-hour
-	// allocation for the license term. It becomes the feature's Limit.
+	// allocation for the license term. It becomes the feature's Limit. A
+	// negative allocation is ignored, in which case the license does not
+	// grant the feature.
 	ClaimAgentRuntimeHoursAllocation = "agent_runtime_hours_allocation"
 	// ClaimAgentRuntimeHoursLimitSoft is the advisory warning threshold. It
-	// must satisfy 0 <= soft < allocation, so it may only be set when the
-	// allocation is greater than 0. It becomes the feature's SoftLimit.
+	// becomes the feature's SoftLimit when 0 < soft < allocation and is
+	// ignored otherwise.
 	ClaimAgentRuntimeHoursLimitSoft = "agent_runtime_hours_limit_soft"
-	// ClaimAgentRuntimeHoursLimitHard is the enforcement ceiling. It must be
-	// absent or >= allocation, and may only be set when the allocation is
-	// greater than 0. It becomes the feature's HardLimit.
+	// ClaimAgentRuntimeHoursLimitHard is the enforcement ceiling. It becomes
+	// the feature's HardLimit when the allocation is greater than 0 and
+	// hard >= allocation, and is ignored otherwise.
 	ClaimAgentRuntimeHoursLimitHard = "agent_runtime_hours_limit_hard"
 )
 
@@ -917,19 +958,12 @@ var (
 	ErrMultipleIssues        = xerrors.New("license has multiple issues; contact support")
 	ErrMissingAccountType    = xerrors.New("license must contain valid account type")
 	ErrMissingAccountID      = xerrors.New("license must contain valid account ID")
-
-	ErrMissingAgentRuntimeHoursAllocation        = xerrors.Errorf("license has agent runtime hours soft or hard limit claims but is missing the %s claim", ClaimAgentRuntimeHoursAllocation)
-	ErrInvalidAgentRuntimeHoursAllocation        = xerrors.Errorf("license has an invalid %s claim; it must not be negative", ClaimAgentRuntimeHoursAllocation)
-	ErrInvalidAgentRuntimeHoursSoftLimit         = xerrors.Errorf("license has an invalid %s claim; it must be at least 0 and less than %s", ClaimAgentRuntimeHoursLimitSoft, ClaimAgentRuntimeHoursAllocation)
-	ErrInvalidAgentRuntimeHoursHardLimit         = xerrors.Errorf("license has an invalid %s claim; it must be greater than or equal to %s", ClaimAgentRuntimeHoursLimitHard, ClaimAgentRuntimeHoursAllocation)
-	ErrAgentRuntimeHoursLimitsWithZeroAllocation = xerrors.Errorf("license has agent runtime hours soft or hard limit claims but the %s claim is 0", ClaimAgentRuntimeHoursAllocation)
 )
 
 type Features map[codersdk.FeatureName]int64
 
-// isAgentRuntimeHoursClaim reports whether the claim name is one of the three
-// claims that encode the codersdk.FeatureAgentRuntimeHours feature. These
-// claims are decoded together, see decodeAgentRuntimeHours.
+// isAgentRuntimeHoursClaim reports whether name is one of the three claims
+// decoded by decodeAgentRuntimeHours.
 func isAgentRuntimeHoursClaim(name codersdk.FeatureName) bool {
 	switch name {
 	case ClaimAgentRuntimeHoursAllocation,
@@ -941,62 +975,65 @@ func isAgentRuntimeHoursClaim(name codersdk.FeatureName) bool {
 	}
 }
 
-// decodeAgentRuntimeHours builds the codersdk.FeatureAgentRuntimeHours feature
-// from the claims that encode it. It reports false when the license carries no
-// allocation claim, in which case the license does not grant the feature.
+// decodeAgentRuntimeHours builds the codersdk.FeatureAgentRuntimeHours
+// feature from its claims. granted is false when there is no usable
+// allocation claim; per-claim validity rules live on the Claim* constants
+// above.
 //
-// The claim combination is validated when the license is parsed, see
-// Features.validateAgentRuntimeHours. The allocation is never negative here
-// and the soft and hard limits are only present alongside a positive
-// allocation.
-func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement, usagePeriod codersdk.UsagePeriod) (codersdk.Feature, bool) {
-	allocation, ok := features[ClaimAgentRuntimeHoursAllocation]
-	if !ok {
-		return codersdk.Feature{}, false
+// Unusable claims are dropped, never license-invalidating: rejecting a
+// signed license over a cosmetic threshold claim would drop the deployment
+// to unlicensed. ignoredClaims names each dropped claim (including the
+// feature name itself minted as a claim, the most plausible issuer mistake)
+// so the caller can warn and log instead of letting an incorrectly issued
+// license look healthy.
+//
+// A zero allocation grants the feature disabled and drops both threshold
+// claims, but Actual is still measured and published. CODAGT-856 will make a
+// zero allocation force a concurrency-limited mode; that mode does not exist
+// yet.
+func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement, usagePeriod codersdk.UsagePeriod) (feature codersdk.Feature, granted bool, ignoredClaims []string) {
+	if _, ok := features[codersdk.FeatureAgentRuntimeHours]; ok {
+		ignoredClaims = append(ignoredClaims, string(codersdk.FeatureAgentRuntimeHours))
 	}
 
-	feature := codersdk.Feature{
+	allocation, allocOk := features[ClaimAgentRuntimeHoursAllocation]
+	soft, softOk := features[ClaimAgentRuntimeHoursLimitSoft]
+	hard, hardOk := features[ClaimAgentRuntimeHoursLimitHard]
+
+	if !allocOk || allocation < 0 {
+		if allocOk && allocation < 0 {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursAllocation)
+		}
+		if softOk {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitSoft)
+		}
+		if hardOk {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitHard)
+		}
+		return codersdk.Feature{}, false, ignoredClaims
+	}
+
+	feature = codersdk.Feature{
 		Enabled:     allocation > 0,
 		Entitlement: entitlement,
 		Limit:       &allocation,
 		UsagePeriod: &usagePeriod,
 	}
-	if soft, ok := features[ClaimAgentRuntimeHoursLimitSoft]; ok {
-		feature.SoftLimit = &soft
-	}
-	if hard, ok := features[ClaimAgentRuntimeHoursLimitHard]; ok {
-		feature.HardLimit = &hard
-	}
-	return feature, true
-}
-
-// validateAgentRuntimeHours validates the relationship between the agent
-// runtime hour claims. Invalid combinations reject the entire license.
-func (f Features) validateAgentRuntimeHours() error {
-	allocation, hasAllocation := f[ClaimAgentRuntimeHoursAllocation]
-	soft, hasSoft := f[ClaimAgentRuntimeHoursLimitSoft]
-	hard, hasHard := f[ClaimAgentRuntimeHoursLimitHard]
-	if !hasAllocation {
-		if hasSoft || hasHard {
-			return ErrMissingAgentRuntimeHoursAllocation
+	if softOk {
+		if soft > 0 && soft < allocation {
+			feature.SoftLimit = &soft
+		} else {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitSoft)
 		}
-		return nil
 	}
-	if allocation < 0 {
-		return ErrInvalidAgentRuntimeHoursAllocation
+	if hardOk {
+		if allocation > 0 && hard >= allocation {
+			feature.HardLimit = &hard
+		} else {
+			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitHard)
+		}
 	}
-	// A zero allocation disables the feature.
-	// A zero hard limit is not permitted.
-	if allocation == 0 && (hasSoft || hasHard) {
-		return ErrAgentRuntimeHoursLimitsWithZeroAllocation
-	}
-	if hasSoft && (soft < 0 || soft >= allocation) {
-		return ErrInvalidAgentRuntimeHoursSoftLimit
-	}
-	if hasHard && hard < allocation {
-		return ErrInvalidAgentRuntimeHoursHardLimit
-	}
-	return nil
+	return feature, true, ignoredClaims
 }
 
 // Claims is the full set of claims in a license.
@@ -1088,9 +1125,6 @@ func validateClaims(tok *jwt.Token) (*Claims, error) {
 		}
 		if claims.AccountID == "" {
 			return nil, ErrMissingAccountID
-		}
-		if err := claims.Features.validateAgentRuntimeHours(); err != nil {
-			return nil, err
 		}
 		return claims, nil
 	}

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -930,7 +930,7 @@ const (
 	// the license does not grant the feature.
 	ClaimAgentRuntimeHoursAllocation = "agent_runtime_hours_allocation"
 	// ClaimAgentRuntimeHoursLimitSoft is the advisory warning threshold. It
-	// becomes the feature's SoftLimit when 0 < soft < allocation and is
+	// becomes the feature's SoftLimit when 0 <= soft < allocation and is
 	// ignored otherwise.
 	ClaimAgentRuntimeHoursLimitSoft = "agent_runtime_hours_limit_soft"
 	// ClaimAgentRuntimeHoursLimitHard is the enforcement ceiling. It becomes
@@ -1031,7 +1031,7 @@ func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement
 		UsagePeriod: &usagePeriod,
 	}
 	if softOk {
-		if soft > 0 && soft < allocation {
+		if soft >= 0 && soft < allocation {
 			feature.SoftLimit = &soft
 		} else {
 			ignoredClaims = append(ignoredClaims, ClaimAgentRuntimeHoursLimitSoft)

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -130,8 +130,6 @@ func Entitlements(
 }
 
 type FeatureArguments struct {
-	// Logger receives the causes behind operator-facing diagnostics whose
-	// published message is a stable text. The zero value discards them.
 	Logger                slog.Logger
 	ActiveUserCount       int64
 	ActiveAISeatCount     int64
@@ -587,8 +585,6 @@ func LicensesEntitlements(
 			entitlements.AddFeature(codersdk.FeatureAgentRuntimeHours, runtimeFeature)
 		}
 		if len(ignoredClaims) > 0 {
-			// The published warning is a stable text, so the details a
-			// support case needs go to the log.
 			featureArguments.Logger.Warn(ctx, "ignored unusable Coder Agent runtime hour claims in license",
 				slog.F("license_id", license.UUID),
 				slog.F("ignored_claims", ignoredClaims),
@@ -721,9 +717,8 @@ func LicensesEntitlements(
 		}
 		if ok {
 			agentLimit.Actual = &managedAgentCount
-			// Written back directly: the feature contest is already
-			// settled, so AddFeature's Compare must not get a chance to
-			// drop the write.
+			// Write directly rather than via AddFeature so its Compare
+			// cannot drop the update.
 			entitlements.Features[codersdk.FeatureManagedAgentLimit] = agentLimit
 
 			// Only issue warnings if the feature is enabled.
@@ -863,12 +858,10 @@ func LicensesEntitlements(
 	return entitlements, nil
 }
 
-// measureUsage runs one usage query over the feature's usage period and owns
-// the shared failure policy: a nil fn is a wiring bug and fails the whole
-// LicensesEntitlements call; a failure with a dead context fails the call
-// without logging; any other failure logs the cause and publishes the stable
-// unavailableText instead. It returns the measured value and true only on
-// success.
+// measureUsage runs fn over the feature's usage period. A nil fn or a
+// failure with a dead context fails the whole call; any other failure logs
+// the cause and publishes unavailableText instead. It returns the measured
+// value and true only on success.
 func measureUsage(
 	ctx context.Context,
 	entitlements *codersdk.Entitlements,
@@ -884,12 +877,11 @@ func measureUsage(
 	value, err := fn(ctx, usagePeriod.Start, usagePeriod.End)
 	switch {
 	case err != nil && ctx.Err() != nil:
-		// The computation's own context is dead, so abort the whole call
-		// without logging. Do not classify by error shape instead: Postgres
-		// raises SQLSTATE 57014 (query_canceled) for statement_timeout kills
-		// as well as client cancels, and aborting on those would fail every
-		// entitlements refresh on a deployment whose statement_timeout is
-		// shorter than a usage query.
+		// Do not classify cancellation by error shape instead of ctx.Err():
+		// Postgres raises SQLSTATE 57014 (query_canceled) for
+		// statement_timeout kills as well as client cancels, and aborting on
+		// those would fail every entitlements refresh on a deployment whose
+		// statement_timeout is shorter than a usage query.
 		return 0, false, xerrors.Errorf("get %s: %w", what, err)
 	case err != nil:
 		logger.Error(ctx, fmt.Sprintf("get %s for entitlements", what), slog.Error(err))
@@ -987,26 +979,15 @@ func isAgentRuntimeHoursClaim(name codersdk.FeatureName) bool {
 // allocation claim; per-claim validity rules live on the Claim* constants
 // above.
 //
-// Unusable claims are dropped, never license-invalidating: rejecting a
-// signed license over a cosmetic threshold claim would drop the deployment
-// to unlicensed. ignoredClaims names each dropped claim (including the
-// feature name itself minted as a claim, the most plausible issuer mistake)
-// so the caller can warn and log instead of letting an incorrectly issued
-// license look healthy.
+// Unusable claims are dropped rather than invalidating the license, since
+// rejecting a signed license over a cosmetic claim would drop the deployment
+// to unlicensed. Each dropped claim is returned in ignoredClaims so the
+// caller can warn and log instead of letting an incorrectly issued license
+// look healthy.
 //
-// A zero allocation grants the feature disabled and drops both threshold
-// claims, but Actual is still measured and published. CODAGT-856 will make a
-// zero allocation force a concurrency-limited mode; that mode does not exist
-// yet.
-//
-// An AgentRuntimeHoursUnlimitedAllocation (-1) allocation grants the feature
-// enabled with a nil Limit, meaning unlimited. Threshold claims alongside it
-// have nothing to threshold against, so they are dropped with the warning,
-// keeping an incorrectly issued license visible. Note that
-// codersdk.Feature.Compare ranks a nil Limit below a set one, so on an exact
-// issued-at and expiry tie a metered license outranks an unlimited one; ties
-// never happen for separately issued licenses, so this edge is documented
-// rather than special-cased.
+// A zero allocation grants the feature disabled, but Actual is still
+// measured and published. CODAGT-856 will make a zero allocation force a
+// concurrency-limited mode; that mode does not exist yet.
 func decodeAgentRuntimeHours(features Features, entitlement codersdk.Entitlement, usagePeriod codersdk.UsagePeriod) (feature codersdk.Feature, granted bool, ignoredClaims []string) {
 	if _, ok := features[codersdk.FeatureAgentRuntimeHours]; ok {
 		ignoredClaims = append(ignoredClaims, string(codersdk.FeatureAgentRuntimeHours))

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -1,9 +1,11 @@
 package license_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"testing"
 	"time"
@@ -13,12 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
+	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
@@ -29,6 +36,42 @@ import (
 // authorizer. The callers below never enable the workspace-capable
 // licensing experiment, so it is never asked to authorize anything.
 var testAuthorizer = rbac.NewCachingAuthorizer(prometheus.NewRegistry())
+
+// premiumRuntimeHoursFixture returns a mock store primed with a Premium
+// license carrying runtime hour claims (allocation 100, soft limit 80, hard
+// limit 120) plus the store expectations every entitlements refresh consumes
+// before usage is measured. Callers add expectations for the usage queries
+// under test.
+func premiumRuntimeHoursFixture(t *testing.T) (*dbmock.MockStore, *coderdenttest.LicenseOptions) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	mDB := dbmock.NewMockStore(ctrl)
+
+	licenseOpts := (&coderdenttest.LicenseOptions{
+		FeatureSet: codersdk.FeatureSetPremium,
+		IssuedAt:   dbtime.Now().Add(-2 * time.Hour).Truncate(time.Second),
+		NotBefore:  dbtime.Now().Add(-time.Hour).Truncate(time.Second),
+		GraceAt:    dbtime.Now().Add(time.Hour * 24 * 60).Truncate(time.Second), // 60 days to remove warning
+		ExpiresAt:  dbtime.Now().Add(time.Hour * 24 * 90).Truncate(time.Second), // 90 days to remove warning
+		// The addon marks AI Bridge as explicitly entitled, suppressing
+		// the unrelated "AI Governance add-on is required to use AI
+		// Gateway" warning that Premium would otherwise produce.
+	}).UserLimit(100).AIGovernanceAddon(100).AgentRuntimeHours(100, ptr.Ref[int64](80), ptr.Ref[int64](120))
+
+	lic := database.License{
+		ID:  1,
+		JWT: coderdenttest.GenerateLicense(t, *licenseOpts),
+		Exp: licenseOpts.ExpiresAt,
+	}
+
+	mDB.EXPECT().GetUnexpiredLicenses(gomock.Any()).Return([]database.License{lic}, nil)
+	mDB.EXPECT().GetActiveUserCount(gomock.Any(), false).Return(int64(1), nil)
+	mDB.EXPECT().GetActiveAISeatCount(gomock.Any()).Return(int64(0), nil)
+	mDB.EXPECT().GetTemplatesWithFilter(gomock.Any(), gomock.Any()).Return([]database.Template{}, nil)
+
+	return mDB, licenseOpts
+}
 
 func TestEntitlements(t *testing.T) {
 	t.Parallel()
@@ -920,6 +963,63 @@ func TestEntitlements(t *testing.T) {
 		require.Equal(t, codersdk.LicenseManagedAgentLimitExceededWarningText, entitlements.Warnings[0])
 	})
 
+	t.Run("UsageQueryErrorsAreLoggedAndStable", func(t *testing.T) {
+		t.Parallel()
+
+		// Drive the real Entitlements closure with a mock database so
+		// measureUsage's failure path is exercised end to end: the cause
+		// must land in the coderd log, which the stable payload text points
+		// at, and must not land on the unauthenticated entitlements payload.
+		mDB, _ := premiumRuntimeHoursFixture(t)
+
+		mDB.EXPECT().
+			GetTotalUsageDCManagedAgentsV1(gomock.Any(), gomock.Any()).
+			Return(int64(0), xerrors.New("kaboom managed"))
+
+		// The error-level logs are the behavior under test, so the default
+		// failing test logger cannot be used.
+		var logBuf bytes.Buffer
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).
+			AppendSinks(sloghuman.Sink(&logBuf))
+
+		entitlements, err := license.Entitlements(context.Background(), logger, mDB, 1, 0, coderdenttest.Keys, all, testAuthorizer, nil)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+
+		// The failure surfaces its stable text without the raw cause,
+		// on the channel the codersdk constant docs prescribe.
+		require.Contains(t, entitlements.Errors, codersdk.LicenseManagedAgentUsageUnavailableErrorText)
+		for _, entry := range append(entitlements.Errors, entitlements.Warnings...) {
+			require.NotContains(t, entry, "kaboom")
+		}
+
+		logs := logBuf.String()
+		require.Contains(t, logs, "get managed agent count for entitlements")
+		require.Contains(t, logs, "kaboom managed")
+	})
+
+	t.Run("UsageQueryCancelDoesNotLogError", func(t *testing.T) {
+		t.Parallel()
+
+		// A query failing while the refresh's own context is canceled,
+		// e.g. during shutdown, aborts the whole entitlements refresh and
+		// must not log a false query-failure alarm at error level.
+		mDB, _ := premiumRuntimeHoursFixture(t)
+
+		mDB.EXPECT().
+			GetTotalUsageDCManagedAgentsV1(gomock.Any(), gomock.Any()).
+			Return(int64(0), context.Canceled)
+
+		var logBuf bytes.Buffer
+		logger := testutil.Logger(t).AppendSinks(sloghuman.Sink(&logBuf))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := license.Entitlements(ctx, logger, mDB, 1, 0, coderdenttest.Keys, all, testAuthorizer, nil)
+		require.ErrorContains(t, err, "get managed agent count")
+		require.NotContains(t, logBuf.String(), "get managed agent count for entitlements")
+	})
+
 	t.Run("AIGovernanceSeatWarnings", func(t *testing.T) {
 		t.Parallel()
 
@@ -1299,6 +1399,12 @@ func TestLicenseEntitlements(t *testing.T) {
 		Licenses    []*coderdenttest.LicenseOptions
 		Enablements map[codersdk.FeatureName]bool
 		Arguments   license.FeatureArguments
+		// KeepNilManagedAgentCountFn skips the default ManagedAgentCountFn
+		// injection below so the nil dev-error path can be exercised.
+		KeepNilManagedAgentCountFn bool
+		// CancelContext cancels the context passed to LicensesEntitlements
+		// before the call, exercising the usage-measurement abort policy.
+		CancelContext bool
 
 		ExpectedErrorContains string
 		AssertEntitlements    func(t *testing.T, entitlements codersdk.Entitlements)
@@ -1551,6 +1657,59 @@ func TestLicenseEntitlements(t *testing.T) {
 			},
 		},
 		{
+			// A query failure is surfaced as a stable text in Errors (see
+			// the codersdk constant docs for the channel choice) and
+			// leaves Actual unset without aborting the rest of the
+			// entitlements.
+			Name: "ManagedAgentLimit/QueryError",
+			Licenses: []*coderdenttest.LicenseOptions{
+				enterpriseLicense().UserLimit(100).ManagedAgentLimit(100),
+			},
+			Arguments: license.FeatureArguments{
+				ManagedAgentCountFn: func(_ context.Context, _, _ time.Time) (int64, error) {
+					return 0, xerrors.New("kaboom")
+				},
+			},
+			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
+				assertNoWarnings(t, entitlements)
+				require.Len(t, entitlements.Errors, 1)
+				assert.Equal(t, codersdk.LicenseManagedAgentUsageUnavailableErrorText, entitlements.Errors[0])
+				// The raw error is logged rather than exposed on the
+				// unauthenticated entitlements payload.
+				assert.NotContains(t, entitlements.Errors[0], "kaboom")
+				feature := entitlements.Features[codersdk.FeatureManagedAgentLimit]
+				assert.Nil(t, feature.Actual)
+			},
+		},
+		{
+			// Forgetting to wire ManagedAgentCountFn is a dev error:
+			// production always provides the closure, so it fails the whole
+			// call loudly instead of degrading into an operator-facing
+			// message.
+			Name: "ManagedAgentLimit/NilFnDevError",
+			Licenses: []*coderdenttest.LicenseOptions{
+				enterpriseLicense().UserLimit(100).ManagedAgentLimit(100),
+			},
+			KeepNilManagedAgentCountFn: true,
+			ExpectedErrorContains:      "developer error: no closure provided to measure managed agent count usage",
+		},
+		{
+			// A failure while the computation's own context is canceled
+			// aborts the whole call rather than degrading to an
+			// entitlements error.
+			Name: "ManagedAgentLimit/ContextCanceled",
+			Licenses: []*coderdenttest.LicenseOptions{
+				enterpriseLicense().UserLimit(100).ManagedAgentLimit(100),
+			},
+			CancelContext: true,
+			Arguments: license.FeatureArguments{
+				ManagedAgentCountFn: func(_ context.Context, _, _ time.Time) (int64, error) {
+					return 0, context.Canceled
+				},
+			},
+			ExpectedErrorContains: "get managed agent count",
+		},
+		{
 			Name: "ExternalTemplate",
 			Licenses: []*coderdenttest.LicenseOptions{
 				enterpriseLicense().UserLimit(100),
@@ -1581,13 +1740,18 @@ func TestLicenseEntitlements(t *testing.T) {
 			}
 
 			// Default to 0 managed agent count.
-			if tc.Arguments.ManagedAgentCountFn == nil {
+			if tc.Arguments.ManagedAgentCountFn == nil && !tc.KeepNilManagedAgentCountFn {
 				tc.Arguments.ManagedAgentCountFn = func(ctx context.Context, from time.Time, to time.Time) (int64, error) {
 					return 0, nil
 				}
 			}
-
-			entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, tc.Enablements, coderdenttest.Keys, tc.Arguments)
+			ctx := context.Background()
+			if tc.CancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			entitlements, err := license.LicensesEntitlements(ctx, time.Now(), generatedLicenses, tc.Enablements, coderdenttest.Keys, tc.Arguments)
 			if tc.ExpectedErrorContains != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.ExpectedErrorContains)
@@ -1612,6 +1776,15 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 
 	aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more."
 
+	// A Premium license grants a managed agent limit by default, and a nil
+	// usage closure is a hard developer error, so these subtests wire a
+	// zero-usage measurement closure.
+	zeroUsageArgs := license.FeatureArguments{
+		ManagedAgentCountFn: func(_ context.Context, _, _ time.Time) (int64, error) {
+			return 0, nil
+		},
+	}
+
 	t.Run("NoAddon_AIBridgeOff", func(t *testing.T) {
 		t.Parallel()
 		// License without addon and AI Bridge disabled should NOT show warning.
@@ -1631,7 +1804,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, zeroUsageArgs)
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1658,7 +1831,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, zeroUsageArgs)
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1690,7 +1863,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, zeroUsageArgs)
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1721,7 +1894,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, zeroUsageArgs)
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1734,7 +1907,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 		t.Parallel()
 		// No license with AI Bridge enabled should NOT show the soft warning
 		// (it will show the generic "not entitled" warning instead).
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), []database.License{}, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), []database.License{}, aiBridgeEnabledEnablements, coderdenttest.Keys, zeroUsageArgs)
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -2535,15 +2708,22 @@ func TestAgentRuntimeHoursLicenses(t *testing.T) {
 	})
 }
 
-// TestAgentRuntimeHoursClaimValidation ensures invalid combinations of the
-// agent runtime hour claims reject the entire license.
-func TestAgentRuntimeHoursClaimValidation(t *testing.T) {
+// TestAgentRuntimeHoursClaimTolerance pins decodeAgentRuntimeHours's
+// tolerate-and-warn contract; see that function's doc for the rationale.
+func TestAgentRuntimeHoursClaimTolerance(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name        string
-		features    license.Features
-		expectedErr error
+		name     string
+		features license.Features
+
+		// expectFeature is nil when the feature must be absent.
+		expectFeature *codersdk.Feature
+		// expectClaimsIgnored is true when at least one present claim is
+		// dropped, which must surface the claims-ignored warning: tolerating
+		// a claim and signaling nothing would make an incorrectly issued license
+		// undetectable from the deployment.
+		expectClaimsIgnored bool
 	}{
 		{
 			name: "AllClaims",
@@ -2552,69 +2732,38 @@ func TestAgentRuntimeHoursClaimValidation(t *testing.T) {
 				license.ClaimAgentRuntimeHoursLimitSoft:  80,
 				license.ClaimAgentRuntimeHoursLimitHard:  120,
 			},
+			expectFeature: &codersdk.Feature{
+				Enabled:   true,
+				Limit:     ptr.Ref[int64](100),
+				SoftLimit: ptr.Ref[int64](80),
+				HardLimit: ptr.Ref[int64](120),
+			},
 		},
 		{
 			name: "AllocationOnly",
 			features: license.Features{
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 			},
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
+			},
 		},
 		{
+			// A zero soft limit would warn at zero usage forever, so it is
+			// dropped rather than rejecting the license. The canonical way
+			// to express "no soft limit" is omitting the claim, so a
+			// present-but-dropped zero still warns.
 			name: "ZeroSoft",
 			features: license.Features{
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 				license.ClaimAgentRuntimeHoursLimitSoft:  0,
 			},
-		},
-		{
-			name: "HardEqualsAllocation",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: 100,
-				license.ClaimAgentRuntimeHoursLimitHard:  100,
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
 			},
-		},
-		{
-			name: "ZeroAllocation",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: 0,
-			},
-		},
-		{
-			name: "ZeroAllocationWithZeroHard",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: 0,
-				license.ClaimAgentRuntimeHoursLimitHard:  0,
-			},
-			expectedErr: license.ErrAgentRuntimeHoursLimitsWithZeroAllocation,
-		},
-		{
-			name: "ZeroAllocationWithPositiveHard",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: 0,
-				license.ClaimAgentRuntimeHoursLimitHard:  1000,
-			},
-			expectedErr: license.ErrAgentRuntimeHoursLimitsWithZeroAllocation,
-		},
-		{
-			name: "SoftWithoutAllocation",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursLimitSoft: 80,
-			},
-			expectedErr: license.ErrMissingAgentRuntimeHoursAllocation,
-		},
-		{
-			name: "HardWithoutAllocation",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursLimitHard: 120,
-			},
-			expectedErr: license.ErrMissingAgentRuntimeHoursAllocation,
-		},
-		{
-			name: "NegativeAllocation",
-			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: -1,
-			},
-			expectedErr: license.ErrInvalidAgentRuntimeHoursAllocation,
+			expectClaimsIgnored: true,
 		},
 		{
 			name: "NegativeSoft",
@@ -2622,15 +2771,25 @@ func TestAgentRuntimeHoursClaimValidation(t *testing.T) {
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 				license.ClaimAgentRuntimeHoursLimitSoft:  -1,
 			},
-			expectedErr: license.ErrInvalidAgentRuntimeHoursSoftLimit,
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
+			},
+			expectClaimsIgnored: true,
 		},
 		{
+			// A soft limit at or above the allocation could never fire
+			// before the allocation warning supersedes it.
 			name: "SoftEqualsAllocation",
 			features: license.Features{
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 				license.ClaimAgentRuntimeHoursLimitSoft:  100,
 			},
-			expectedErr: license.ErrInvalidAgentRuntimeHoursSoftLimit,
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
+			},
+			expectClaimsIgnored: true,
 		},
 		{
 			name: "SoftAboveAllocation",
@@ -2638,15 +2797,23 @@ func TestAgentRuntimeHoursClaimValidation(t *testing.T) {
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 				license.ClaimAgentRuntimeHoursLimitSoft:  150,
 			},
-			expectedErr: license.ErrInvalidAgentRuntimeHoursSoftLimit,
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
+			},
+			expectClaimsIgnored: true,
 		},
 		{
-			name: "SoftWithZeroAllocation",
+			name: "HardEqualsAllocation",
 			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: 0,
-				license.ClaimAgentRuntimeHoursLimitSoft:  0,
+				license.ClaimAgentRuntimeHoursAllocation: 100,
+				license.ClaimAgentRuntimeHoursLimitHard:  100,
 			},
-			expectedErr: license.ErrAgentRuntimeHoursLimitsWithZeroAllocation,
+			expectFeature: &codersdk.Feature{
+				Enabled:   true,
+				Limit:     ptr.Ref[int64](100),
+				HardLimit: ptr.Ref[int64](100),
+			},
 		},
 		{
 			name: "HardBelowAllocation",
@@ -2654,7 +2821,83 @@ func TestAgentRuntimeHoursClaimValidation(t *testing.T) {
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 				license.ClaimAgentRuntimeHoursLimitHard:  99,
 			},
-			expectedErr: license.ErrInvalidAgentRuntimeHoursHardLimit,
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			name: "ZeroAllocation",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursAllocation: 0,
+			},
+			expectFeature: &codersdk.Feature{
+				Enabled: false,
+				Limit:   ptr.Ref[int64](0),
+			},
+		},
+		{
+			// A zero allocation has no hour budget, so threshold claims
+			// alongside it are dropped, with the warning.
+			name: "ZeroAllocationWithLimits",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursAllocation: 0,
+				license.ClaimAgentRuntimeHoursLimitSoft:  80,
+				license.ClaimAgentRuntimeHoursLimitHard:  1000,
+			},
+			expectFeature: &codersdk.Feature{
+				Enabled: false,
+				Limit:   ptr.Ref[int64](0),
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			name: "NegativeAllocation",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursAllocation: -1,
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			name: "SoftWithoutAllocation",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursLimitSoft: 80,
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			name: "HardWithoutAllocation",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursLimitHard: 120,
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			// The feature name itself is never a valid claim: the
+			// allocation must come from the dedicated claim. It is the
+			// shape every other metered feature uses, so a license minting
+			// it is the most plausible issuer mistake and must warn
+			// rather than being dropped silently.
+			name: "FeatureNameAsClaim",
+			features: license.Features{
+				codersdk.FeatureAgentRuntimeHours: 100,
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			// The feature name claim is dropped (with the warning) even
+			// when a usable allocation claim grants the feature.
+			name: "FeatureNameAlongsideAllocation",
+			features: license.Features{
+				codersdk.FeatureAgentRuntimeHours:        50,
+				license.ClaimAgentRuntimeHoursAllocation: 100,
+			},
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+				Limit:   ptr.Ref[int64](100),
+			},
+			expectClaimsIgnored: true,
 		},
 	}
 
@@ -2662,46 +2905,115 @@ func TestAgentRuntimeHoursClaimValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			jwt := coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
-				Features: tc.features,
-			})
-			_, err := license.ParseClaims(jwt, coderdenttest.Keys)
-			if tc.expectedErr == nil {
-				require.NoError(t, err)
+			features := license.Features{
+				codersdk.FeatureUserLimit: 100,
+			}
+			maps.Copy(features, tc.features)
+			lic := database.License{
+				ID:         1,
+				UploadedAt: time.Now(),
+				Exp:        time.Now().Add(time.Hour),
+				UUID:       uuid.New(),
+				JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+					Features: features,
+				}),
+			}
+
+			var logBuf bytes.Buffer
+			entitlements, err := license.LicensesEntitlements(
+				context.Background(), time.Now(), []database.License{lic},
+				map[codersdk.FeatureName]bool{}, coderdenttest.Keys, license.FeatureArguments{
+					Logger: slog.Make(sloghuman.Sink(&logBuf)),
+				},
+			)
+			require.NoError(t, err)
+
+			// The license as a whole survives: unrelated paid features are
+			// unaffected by an unusable runtime hour claim.
+			require.Empty(t, entitlements.Errors)
+			require.True(t, entitlements.HasLicense)
+			userLimit := entitlements.Features[codersdk.FeatureUserLimit]
+			require.NotNil(t, userLimit.Limit)
+			require.EqualValues(t, 100, *userLimit.Limit)
+
+			// Dropped claims are tolerated but never silent: the operator
+			// sees the stable warning, and the log names the license and
+			// the dropped claims for support.
+			if tc.expectClaimsIgnored {
+				require.Contains(t, entitlements.Warnings,
+					codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText)
+				logs := logBuf.String()
+				require.Contains(t, logs, "ignored unusable Coder Agent runtime hour claims in license")
+				require.Contains(t, logs, lic.UUID.String())
+			} else {
+				require.NotContains(t, entitlements.Warnings,
+					codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText)
+				require.Empty(t, logBuf.String())
+			}
+
+			// Every known feature name has a default entry in the map, so
+			// "the license does not grant the feature" surfaces as the
+			// default: no limit, no usage period, not enabled.
+			feature := entitlements.Features[codersdk.FeatureAgentRuntimeHours]
+			if tc.expectFeature == nil {
+				require.Nil(t, feature.Limit, "feature must not be granted")
+				require.Nil(t, feature.UsagePeriod, "feature must not be granted")
+				require.False(t, feature.Enabled)
 				return
 			}
-			require.ErrorIs(t, err, tc.expectedErr)
+			require.NotNil(t, feature.UsagePeriod, "feature must be granted")
+			require.Equal(t, tc.expectFeature.Enabled, feature.Enabled)
+			require.Equal(t, tc.expectFeature.Limit, feature.Limit)
+			require.Equal(t, tc.expectFeature.SoftLimit, feature.SoftLimit)
+			require.Equal(t, tc.expectFeature.HardLimit, feature.HardLimit)
 		})
 	}
 
-	// An invalid license already stored in the database is rejected entirely
-	// and produces an entitlements error.
-	t.Run("EntitlementsError", func(t *testing.T) {
+	t.Run("WarningDeduplicatedAcrossLicenses", func(t *testing.T) {
 		t.Parallel()
 
-		lic := database.License{
-			ID:         1,
-			UploadedAt: time.Now(),
-			Exp:        time.Now().Add(time.Hour),
-			UUID:       uuid.New(),
-			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
-				Features: license.Features{
-					license.ClaimAgentRuntimeHoursAllocation: 100,
-					license.ClaimAgentRuntimeHoursLimitSoft:  150,
-				},
-			}),
+		// Two licenses with unusable claims must publish the stable warning
+		// once, or the banner would stack identical texts, while the log
+		// names each affected license so the operator can tell which ones
+		// need re-issuing.
+		newLicense := func(id int32) database.License {
+			return database.License{
+				ID:         id,
+				UploadedAt: time.Now(),
+				Exp:        time.Now().Add(time.Hour),
+				UUID:       uuid.New(),
+				JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+					Features: license.Features{
+						codersdk.FeatureUserLimit: 100,
+						// A threshold without an allocation is unusable.
+						license.ClaimAgentRuntimeHoursLimitSoft: 80,
+					},
+				}),
+			}
 		}
+		licenses := []database.License{newLicense(1), newLicense(2)}
 
+		var logBuf bytes.Buffer
 		entitlements, err := license.LicensesEntitlements(
-			context.Background(), time.Now(), []database.License{lic},
-			map[codersdk.FeatureName]bool{}, coderdenttest.Keys, license.FeatureArguments{},
+			context.Background(), time.Now(), licenses,
+			map[codersdk.FeatureName]bool{}, coderdenttest.Keys, license.FeatureArguments{
+				Logger: slog.Make(sloghuman.Sink(&logBuf)),
+			},
 		)
 		require.NoError(t, err)
-		require.Len(t, entitlements.Errors, 1)
-		require.Contains(t, entitlements.Errors[0], fmt.Sprintf("Invalid license (%s) parsing claims", lic.UUID))
-		require.False(t, entitlements.HasLicense)
-		feature := entitlements.Features[codersdk.FeatureAgentRuntimeHours]
-		require.Equal(t, codersdk.EntitlementNotEntitled, feature.Entitlement)
+
+		warningCount := 0
+		for _, warning := range entitlements.Warnings {
+			if warning == codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText {
+				warningCount++
+			}
+		}
+		require.Equal(t, 1, warningCount, "the claims-ignored warning must appear exactly once")
+
+		logs := logBuf.String()
+		for _, lic := range licenses {
+			require.Contains(t, logs, lic.UUID.String())
+		}
 	})
 }
 

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -2857,20 +2857,19 @@ func TestAgentRuntimeHoursClaimTolerance(t *testing.T) {
 			},
 		},
 		{
-			// A zero soft limit would warn at zero usage forever, so it is
-			// dropped rather than rejecting the license. The canonical way
-			// to express "no soft limit" is omitting the claim, so a
-			// present-but-dropped zero still warns.
+			// A zero soft limit is valid (0 <= soft < allocation) and warns
+			// from the start of the usage period. Omitting the claim is the
+			// way to express "no soft limit".
 			name: "ZeroSoft",
 			features: license.Features{
 				license.ClaimAgentRuntimeHoursAllocation: 100,
 				license.ClaimAgentRuntimeHoursLimitSoft:  0,
 			},
 			expectFeature: &codersdk.Feature{
-				Enabled: true,
-				Limit:   ptr.Ref[int64](100),
+				Enabled:   true,
+				Limit:     ptr.Ref[int64](100),
+				SoftLimit: ptr.Ref[int64](0),
 			},
-			expectClaimsIgnored: true,
 		},
 		{
 			name: "NegativeSoft",

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -15,11 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -36,42 +34,6 @@ import (
 // authorizer. The callers below never enable the workspace-capable
 // licensing experiment, so it is never asked to authorize anything.
 var testAuthorizer = rbac.NewCachingAuthorizer(prometheus.NewRegistry())
-
-// premiumRuntimeHoursFixture returns a mock store primed with a Premium
-// license carrying runtime hour claims (allocation 100, soft limit 80, hard
-// limit 120) plus the store expectations every entitlements refresh consumes
-// before usage is measured. Callers add expectations for the usage queries
-// under test.
-func premiumRuntimeHoursFixture(t *testing.T) (*dbmock.MockStore, *coderdenttest.LicenseOptions) {
-	t.Helper()
-
-	ctrl := gomock.NewController(t)
-	mDB := dbmock.NewMockStore(ctrl)
-
-	licenseOpts := (&coderdenttest.LicenseOptions{
-		FeatureSet: codersdk.FeatureSetPremium,
-		IssuedAt:   dbtime.Now().Add(-2 * time.Hour).Truncate(time.Second),
-		NotBefore:  dbtime.Now().Add(-time.Hour).Truncate(time.Second),
-		GraceAt:    dbtime.Now().Add(time.Hour * 24 * 60).Truncate(time.Second), // 60 days to remove warning
-		ExpiresAt:  dbtime.Now().Add(time.Hour * 24 * 90).Truncate(time.Second), // 90 days to remove warning
-		// The addon marks AI Bridge as explicitly entitled, suppressing
-		// the unrelated "AI Governance add-on is required to use AI
-		// Gateway" warning that Premium would otherwise produce.
-	}).UserLimit(100).AIGovernanceAddon(100).AgentRuntimeHours(100, ptr.Ref[int64](80), ptr.Ref[int64](120))
-
-	lic := database.License{
-		ID:  1,
-		JWT: coderdenttest.GenerateLicense(t, *licenseOpts),
-		Exp: licenseOpts.ExpiresAt,
-	}
-
-	mDB.EXPECT().GetUnexpiredLicenses(gomock.Any()).Return([]database.License{lic}, nil)
-	mDB.EXPECT().GetActiveUserCount(gomock.Any(), false).Return(int64(1), nil)
-	mDB.EXPECT().GetActiveAISeatCount(gomock.Any()).Return(int64(0), nil)
-	mDB.EXPECT().GetTemplatesWithFilter(gomock.Any(), gomock.Any()).Return([]database.Template{}, nil)
-
-	return mDB, licenseOpts
-}
 
 func TestEntitlements(t *testing.T) {
 	t.Parallel()
@@ -963,62 +925,6 @@ func TestEntitlements(t *testing.T) {
 		require.Equal(t, codersdk.LicenseManagedAgentLimitExceededWarningText, entitlements.Warnings[0])
 	})
 
-	t.Run("UsageQueryErrorsAreLoggedAndStable", func(t *testing.T) {
-		t.Parallel()
-
-		// Drive the real Entitlements closure with a mock database so
-		// measureUsage's failure path is exercised end to end: the cause
-		// must land in the coderd log, which the stable payload text points
-		// at, and must not land on the unauthenticated entitlements payload.
-		mDB, _ := premiumRuntimeHoursFixture(t)
-
-		mDB.EXPECT().
-			GetTotalUsageDCManagedAgentsV1(gomock.Any(), gomock.Any()).
-			Return(int64(0), xerrors.New("kaboom managed"))
-
-		// The error-level logs are the behavior under test, so the default
-		// failing test logger cannot be used.
-		var logBuf bytes.Buffer
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).
-			AppendSinks(sloghuman.Sink(&logBuf))
-
-		entitlements, err := license.Entitlements(context.Background(), logger, mDB, 1, 0, coderdenttest.Keys, all, testAuthorizer, nil)
-		require.NoError(t, err)
-		require.True(t, entitlements.HasLicense)
-
-		// The failure surfaces its stable text without the raw cause.
-		require.Contains(t, entitlements.Errors, codersdk.LicenseManagedAgentUsageUnavailableErrorText)
-		for _, entry := range append(entitlements.Errors, entitlements.Warnings...) {
-			require.NotContains(t, entry, "kaboom")
-		}
-
-		logs := logBuf.String()
-		require.Contains(t, logs, "get managed agent count for entitlements")
-		require.Contains(t, logs, "kaboom managed")
-	})
-
-	t.Run("UsageQueryCancelDoesNotLogError", func(t *testing.T) {
-		t.Parallel()
-
-		// A query failing while the refresh's own context is canceled,
-		// e.g. during shutdown, aborts the whole entitlements refresh and
-		// must not log a false query-failure alarm at error level.
-		mDB, _ := premiumRuntimeHoursFixture(t)
-
-		mDB.EXPECT().
-			GetTotalUsageDCManagedAgentsV1(gomock.Any(), gomock.Any()).
-			Return(int64(0), context.Canceled)
-
-		var logBuf bytes.Buffer
-		logger := testutil.Logger(t).AppendSinks(sloghuman.Sink(&logBuf))
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		_, err := license.Entitlements(ctx, logger, mDB, 1, 0, coderdenttest.Keys, all, testAuthorizer, nil)
-		require.ErrorContains(t, err, "get managed agent count")
-		require.NotContains(t, logBuf.String(), "get managed agent count for entitlements")
-	})
-
 	t.Run("AIGovernanceSeatWarnings", func(t *testing.T) {
 		t.Parallel()
 
@@ -1398,12 +1304,6 @@ func TestLicenseEntitlements(t *testing.T) {
 		Licenses    []*coderdenttest.LicenseOptions
 		Enablements map[codersdk.FeatureName]bool
 		Arguments   license.FeatureArguments
-		// KeepNilManagedAgentCountFn skips the default ManagedAgentCountFn
-		// injection below so the nil dev-error path can be exercised.
-		KeepNilManagedAgentCountFn bool
-		// CancelContext cancels the context passed to LicensesEntitlements
-		// before the call, exercising the usage-measurement abort policy.
-		CancelContext bool
 
 		ExpectedErrorContains string
 		AssertEntitlements    func(t *testing.T, entitlements codersdk.Entitlements)
@@ -1656,58 +1556,6 @@ func TestLicenseEntitlements(t *testing.T) {
 			},
 		},
 		{
-			// A query failure is surfaced as a stable text in Errors and
-			// leaves Actual unset without aborting the rest of the
-			// entitlements.
-			Name: "ManagedAgentLimit/QueryError",
-			Licenses: []*coderdenttest.LicenseOptions{
-				enterpriseLicense().UserLimit(100).ManagedAgentLimit(100),
-			},
-			Arguments: license.FeatureArguments{
-				ManagedAgentCountFn: func(_ context.Context, _, _ time.Time) (int64, error) {
-					return 0, xerrors.New("kaboom")
-				},
-			},
-			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
-				assertNoWarnings(t, entitlements)
-				require.Len(t, entitlements.Errors, 1)
-				assert.Equal(t, codersdk.LicenseManagedAgentUsageUnavailableErrorText, entitlements.Errors[0])
-				// The raw error is logged rather than exposed on the
-				// unauthenticated entitlements payload.
-				assert.NotContains(t, entitlements.Errors[0], "kaboom")
-				feature := entitlements.Features[codersdk.FeatureManagedAgentLimit]
-				assert.Nil(t, feature.Actual)
-			},
-		},
-		{
-			// Forgetting to wire ManagedAgentCountFn is a dev error:
-			// production always provides the closure, so it fails the whole
-			// call loudly instead of degrading into an operator-facing
-			// message.
-			Name: "ManagedAgentLimit/NilFnDevError",
-			Licenses: []*coderdenttest.LicenseOptions{
-				enterpriseLicense().UserLimit(100).ManagedAgentLimit(100),
-			},
-			KeepNilManagedAgentCountFn: true,
-			ExpectedErrorContains:      "developer error: no closure provided to measure managed agent count usage",
-		},
-		{
-			// A failure while the computation's own context is canceled
-			// aborts the whole call rather than degrading to an
-			// entitlements error.
-			Name: "ManagedAgentLimit/ContextCanceled",
-			Licenses: []*coderdenttest.LicenseOptions{
-				enterpriseLicense().UserLimit(100).ManagedAgentLimit(100),
-			},
-			CancelContext: true,
-			Arguments: license.FeatureArguments{
-				ManagedAgentCountFn: func(_ context.Context, _, _ time.Time) (int64, error) {
-					return 0, context.Canceled
-				},
-			},
-			ExpectedErrorContains: "get managed agent count",
-		},
-		{
 			Name: "ExternalTemplate",
 			Licenses: []*coderdenttest.LicenseOptions{
 				enterpriseLicense().UserLimit(100),
@@ -1738,18 +1586,13 @@ func TestLicenseEntitlements(t *testing.T) {
 			}
 
 			// Default to 0 managed agent count.
-			if tc.Arguments.ManagedAgentCountFn == nil && !tc.KeepNilManagedAgentCountFn {
+			if tc.Arguments.ManagedAgentCountFn == nil {
 				tc.Arguments.ManagedAgentCountFn = func(ctx context.Context, from time.Time, to time.Time) (int64, error) {
 					return 0, nil
 				}
 			}
-			ctx := context.Background()
-			if tc.CancelContext {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithCancel(ctx)
-				cancel()
-			}
-			entitlements, err := license.LicensesEntitlements(ctx, time.Now(), generatedLicenses, tc.Enablements, coderdenttest.Keys, tc.Arguments)
+
+			entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, tc.Enablements, coderdenttest.Keys, tc.Arguments)
 			if tc.ExpectedErrorContains != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.ExpectedErrorContains)
@@ -1774,15 +1617,6 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 
 	aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more."
 
-	// A Premium license grants a managed agent limit by default, and a nil
-	// usage closure is a hard developer error, so these subtests wire a
-	// zero-usage measurement closure.
-	zeroUsageArgs := license.FeatureArguments{
-		ManagedAgentCountFn: func(_ context.Context, _, _ time.Time) (int64, error) {
-			return 0, nil
-		},
-	}
-
 	t.Run("NoAddon_AIBridgeOff", func(t *testing.T) {
 		t.Parallel()
 		// License without addon and AI Bridge disabled should NOT show warning.
@@ -1802,7 +1636,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, zeroUsageArgs)
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1829,7 +1663,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, zeroUsageArgs)
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1861,7 +1695,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, zeroUsageArgs)
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeDisabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1892,7 +1726,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 			},
 		}
 
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, zeroUsageArgs)
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), generatedLicenses, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
@@ -1905,7 +1739,7 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 		t.Parallel()
 		// No license with AI Bridge enabled should NOT show the soft warning
 		// (it will show the generic "not entitled" warning instead).
-		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), []database.License{}, aiBridgeEnabledEnablements, coderdenttest.Keys, zeroUsageArgs)
+		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), []database.License{}, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -2501,6 +2501,55 @@ func TestAgentRuntimeHoursLicenses(t *testing.T) {
 		require.NotNil(t, feature.UsagePeriod)
 	})
 
+	// An unlimited (-1) allocation grants the feature enabled with no Limit,
+	// which the API serves as an omitted "limit" field, the shape the UI
+	// already renders as "Unlimited".
+	t.Run("UnlimitedAllocation", func(t *testing.T) {
+		t.Parallel()
+
+		lic := database.License{
+			ID:         1,
+			UploadedAt: time.Now(),
+			Exp:        time.Now().Add(time.Hour),
+			UUID:       uuid.New(),
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				Features: license.Features{
+					license.ClaimAgentRuntimeHoursAllocation: license.AgentRuntimeHoursUnlimitedAllocation,
+				},
+			}),
+		}
+
+		entitlements, err := license.LicensesEntitlements(
+			context.Background(), time.Now(), []database.License{lic},
+			map[codersdk.FeatureName]bool{}, coderdenttest.Keys, license.FeatureArguments{},
+		)
+		require.NoError(t, err)
+		require.Empty(t, entitlements.Errors)
+		require.NotContains(t, entitlements.Warnings,
+			codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText)
+
+		feature := entitlements.Features[codersdk.FeatureAgentRuntimeHours]
+		require.Equal(t, codersdk.EntitlementEntitled, feature.Entitlement)
+		require.True(t, feature.Enabled)
+		require.Nil(t, feature.Limit)
+		require.Nil(t, feature.SoftLimit)
+		require.Nil(t, feature.HardLimit)
+		require.NotNil(t, feature.UsagePeriod)
+
+		// The entitlements JSON served by GET /api/v2/entitlements omits
+		// "limit" entirely for the unlimited feature.
+		data, err := json.Marshal(entitlements)
+		require.NoError(t, err)
+		var raw struct {
+			Features map[codersdk.FeatureName]map[string]any `json:"features"`
+		}
+		require.NoError(t, json.Unmarshal(data, &raw))
+		rawFeature := raw.Features[codersdk.FeatureAgentRuntimeHours]
+		require.Equal(t, true, rawFeature["enabled"])
+		require.NotContains(t, rawFeature, "limit")
+		require.Contains(t, rawFeature, "usage_period")
+	})
+
 	// The license with the newest issued-at claim wins, even if another
 	// license was loaded first or has a larger allocation. The soft and hard
 	// limits come from the winning license.
@@ -2853,9 +2902,48 @@ func TestAgentRuntimeHoursClaimTolerance(t *testing.T) {
 			expectClaimsIgnored: true,
 		},
 		{
+			// An unlimited allocation grants the feature with no Limit and
+			// no warning: -1 is the canonical unlimited encoding, not an
+			// issuance mistake.
+			name: "UnlimitedAllocation",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursAllocation: license.AgentRuntimeHoursUnlimitedAllocation,
+			},
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+			},
+		},
+		{
+			// Threshold claims alongside an unlimited allocation have
+			// nothing to threshold against; the grant survives but the
+			// issuance mistake must stay visible via the warning.
+			name: "UnlimitedWithSoft",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursAllocation: license.AgentRuntimeHoursUnlimitedAllocation,
+				license.ClaimAgentRuntimeHoursLimitSoft:  80,
+			},
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			name: "UnlimitedWithHard",
+			features: license.Features{
+				license.ClaimAgentRuntimeHoursAllocation: license.AgentRuntimeHoursUnlimitedAllocation,
+				license.ClaimAgentRuntimeHoursLimitHard:  120,
+			},
+			expectFeature: &codersdk.Feature{
+				Enabled: true,
+			},
+			expectClaimsIgnored: true,
+		},
+		{
+			// Only exactly -1 is the unlimited sentinel; any other negative
+			// allocation stays unusable.
 			name: "NegativeAllocation",
 			features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: -1,
+				license.ClaimAgentRuntimeHoursAllocation: -2,
 			},
 			expectClaimsIgnored: true,
 		},

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -986,8 +986,7 @@ func TestEntitlements(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, entitlements.HasLicense)
 
-		// The failure surfaces its stable text without the raw cause,
-		// on the channel the codersdk constant docs prescribe.
+		// The failure surfaces its stable text without the raw cause.
 		require.Contains(t, entitlements.Errors, codersdk.LicenseManagedAgentUsageUnavailableErrorText)
 		for _, entry := range append(entitlements.Errors, entitlements.Warnings...) {
 			require.NotContains(t, entry, "kaboom")
@@ -1657,8 +1656,7 @@ func TestLicenseEntitlements(t *testing.T) {
 			},
 		},
 		{
-			// A query failure is surfaced as a stable text in Errors (see
-			// the codersdk constant docs for the channel choice) and
+			// A query failure is surfaced as a stable text in Errors and
 			// leaves Actual unset without aborting the rest of the
 			// entitlements.
 			Name: "ManagedAgentLimit/QueryError",

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -2616,6 +2616,66 @@ func TestAgentRuntimeHoursLicenses(t *testing.T) {
 		}
 	})
 
+	// When an unlimited and a metered license are minted with identical
+	// issued-at and expiry claims, the unlimited grant must win the tie,
+	// regardless of load order.
+	t.Run("UnlimitedOutranksMeteredOnTie", func(t *testing.T) {
+		t.Parallel()
+
+		// JWT NumericDate claims have second granularity, so truncate to
+		// keep the round-tripped issued-at values identical.
+		iat := time.Now().Add(-time.Minute).Truncate(time.Second)
+		nbf := iat
+		exp := iat.Add(time.Hour).Truncate(time.Second)
+		unlimited := database.License{
+			ID:         1,
+			UploadedAt: time.Now(),
+			Exp:        exp,
+			UUID:       uuid.New(),
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				IssuedAt:  iat,
+				NotBefore: nbf,
+				ExpiresAt: exp,
+				Features: license.Features{
+					license.ClaimAgentRuntimeHoursAllocation: license.AgentRuntimeHoursUnlimitedAllocation,
+				},
+			}),
+		}
+		metered := database.License{
+			ID:         2,
+			UploadedAt: time.Now(),
+			Exp:        exp,
+			UUID:       uuid.New(),
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				IssuedAt:  iat,
+				NotBefore: nbf,
+				ExpiresAt: exp,
+				Features: license.Features{
+					license.ClaimAgentRuntimeHoursAllocation: 100,
+					license.ClaimAgentRuntimeHoursLimitSoft:  80,
+					license.ClaimAgentRuntimeHoursLimitHard:  120,
+				},
+			}),
+		}
+
+		for _, order := range [][]database.License{
+			{unlimited, metered},
+			{metered, unlimited},
+		} {
+			entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), order, map[codersdk.FeatureName]bool{}, coderdenttest.Keys, license.FeatureArguments{})
+			require.NoError(t, err)
+
+			feature, ok := entitlements.Features[codersdk.FeatureAgentRuntimeHours]
+			require.True(t, ok, "feature %s not found", codersdk.FeatureAgentRuntimeHours)
+			require.Equal(t, codersdk.EntitlementEntitled, feature.Entitlement)
+			require.True(t, feature.Enabled)
+			require.Nil(t, feature.Limit)
+			require.Nil(t, feature.SoftLimit)
+			require.Nil(t, feature.HardLimit)
+			require.NotNil(t, feature.UsagePeriod)
+		}
+	})
+
 	// A newer license without soft/hard limits must fully replace an older
 	// license that carried them; the limits must not merge across licenses.
 	t.Run("SoftHardRideAlongWithWinner", func(t *testing.T) {

--- a/enterprise/coderd/licenses_test.go
+++ b/enterprise/coderd/licenses_test.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
@@ -105,35 +106,41 @@ func TestPostLicense(t *testing.T) {
 		require.Contains(t, errResp.Message, "Invalid license")
 	})
 
-	t.Run("InvalidAgentRuntimeClaims", func(t *testing.T) {
+	t.Run("UnusableAgentRuntimeClaims", func(t *testing.T) {
 		t.Parallel()
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{DontAddLicense: true})
-		// A soft limit claim without an allocation claim rejects the whole
-		// license.
+		// A soft limit claim without an allocation claim is unusable, but it
+		// never rejects the whole license: the license stays valid, the
+		// runtime hours feature is simply not granted, and the dropped claim
+		// is surfaced as a warning. See decodeAgentRuntimeHours.
 		lic := coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
 			Features: license.Features{
+				codersdk.FeatureUserLimit:               100,
 				license.ClaimAgentRuntimeHoursLimitSoft: 80,
 			},
 		})
 		_, err := client.AddLicense(context.Background(), codersdk.AddLicenseRequest{
 			License: lic,
 		})
-		errResp := &codersdk.Error{}
-		require.ErrorAs(t, err, &errResp)
-		require.Equal(t, http.StatusBadRequest, errResp.StatusCode())
-		require.Contains(t, errResp.Message, "Invalid license")
+		require.NoError(t, err)
+		// The claims round-trip through GET /api/v2/entitlements.
+		//nolint:gocritic // This test asserts license state, not authz behavior.
+		entitlements, err := client.Entitlements(context.Background())
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.Empty(t, entitlements.Errors)
+		require.Contains(t, entitlements.Warnings,
+			codersdk.LicenseAgentRuntimeHoursClaimsIgnoredWarningText)
+		feature := entitlements.Features[codersdk.FeatureAgentRuntimeHours]
+		require.Nil(t, feature.Limit)
+		require.Nil(t, feature.UsagePeriod)
 	})
 
 	t.Run("AgentRuntimeClaims", func(t *testing.T) {
 		t.Parallel()
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{DontAddLicense: true})
-		coderdenttest.AddLicense(t, client, coderdenttest.LicenseOptions{
-			Features: license.Features{
-				license.ClaimAgentRuntimeHoursAllocation: 100,
-				license.ClaimAgentRuntimeHoursLimitSoft:  80,
-				license.ClaimAgentRuntimeHoursLimitHard:  120,
-			},
-		})
+		coderdenttest.AddLicense(t, client,
+			*(&coderdenttest.LicenseOptions{}).AgentRuntimeHours(100, ptr.Ref[int64](80), ptr.Ref[int64](120)))
 		// The claims round-trip through GET /api/v2/entitlements.
 		//nolint:gocritic // This test asserts license state, not authz behavior.
 		entitlements, err := client.Entitlements(context.Background())

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5758,11 +5758,34 @@ export const LicenseAIGovernanceOverLimitWarningText =
 	"Your organization is using %d of %d AI Governance add-on seats (%d over the limit).";
 
 // From codersdk/licenses.go
+/**
+ * LicenseAgentRuntimeHoursClaimsIgnoredWarningText is emitted when a
+ * license carries unusable Coder Agent runtime hour claims (see
+ * decodeAgentRuntimeHours in enterprise/coderd/license); the logs name
+ * the license and the dropped claims. The dashboard renders the exact
+ * text as a muted diagnostic without a sales link.
+ */
+export const LicenseAgentRuntimeHoursClaimsIgnoredWarningText =
+	"A license contains unusable Coder Agent runtime hour claims, which were ignored. The rest of that license is unaffected. Check the coderd logs for the affected license and claims, and contact support to have the license re-issued.";
+
+// From codersdk/licenses.go
 export const LicenseExpiryClaim = "license_expires";
 
 // From codersdk/licenses.go
 export const LicenseManagedAgentLimitExceededWarningText =
 	"You have built more workspaces with managed agents than your license allows.";
+
+// From codersdk/licenses.go
+/**
+ * LicenseManagedAgentUsageUnavailableErrorText is emitted when the
+ * managed agent usage query fails while computing entitlements; the
+ * cause is logged server-side. It travels in the entitlements Errors
+ * channel so the alertable coderd_license_errors gauge counts
+ * measurement failures, but the dashboard recognizes the exact text and
+ * renders it as a muted diagnostic rather than a license error.
+ */
+export const LicenseManagedAgentUsageUnavailableErrorText =
+	"Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details.";
 
 // From codersdk/licenses.go
 export const LicenseTelemetryRequiredErrorText =

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5769,10 +5769,6 @@ export const LicenseManagedAgentLimitExceededWarningText =
 	"You have built more workspaces with managed agents than your license allows.";
 
 // From codersdk/licenses.go
-export const LicenseManagedAgentUsageUnavailableErrorText =
-	"Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details.";
-
-// From codersdk/licenses.go
 export const LicenseTelemetryRequiredErrorText =
 	"License requires telemetry but telemetry is disabled";
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5758,13 +5758,6 @@ export const LicenseAIGovernanceOverLimitWarningText =
 	"Your organization is using %d of %d AI Governance add-on seats (%d over the limit).";
 
 // From codersdk/licenses.go
-/**
- * LicenseAgentRuntimeHoursClaimsIgnoredWarningText is emitted when a
- * license carries unusable Coder Agent runtime hour claims (see
- * decodeAgentRuntimeHours in enterprise/coderd/license); the logs name
- * the license and the dropped claims. The dashboard renders the exact
- * text as a muted diagnostic without a sales link.
- */
 export const LicenseAgentRuntimeHoursClaimsIgnoredWarningText =
 	"A license contains unusable Coder Agent runtime hour claims, which were ignored. The rest of that license is unaffected. Check the coderd logs for the affected license and claims, and contact support to have the license re-issued.";
 
@@ -5776,14 +5769,6 @@ export const LicenseManagedAgentLimitExceededWarningText =
 	"You have built more workspaces with managed agents than your license allows.";
 
 // From codersdk/licenses.go
-/**
- * LicenseManagedAgentUsageUnavailableErrorText is emitted when the
- * managed agent usage query fails while computing entitlements; the
- * cause is logged server-side. It travels in the entitlements Errors
- * channel so the alertable coderd_license_errors gauge counts
- * measurement failures, but the dashboard recognizes the exact text and
- * renders it as a muted diagnostic rather than a license error.
- */
 export const LicenseManagedAgentUsageUnavailableErrorText =
 	"Unable to determine managed agent usage. The reported count is unavailable until the next successful refresh; workspaces are unaffected. Check the coderd logs for details.";
 

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -1,8 +1,10 @@
 import type { FC } from "react";
 import {
+	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
 	LicenseAIGovernance90PercentWarningText,
 	LicenseAIGovernanceOverLimitWarningText,
 	LicenseManagedAgentLimitExceededWarningText,
+	LicenseManagedAgentUsageUnavailableErrorText,
 	LicenseTelemetryRequiredErrorText,
 } from "#/api/typesGenerated";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
@@ -24,8 +26,32 @@ const isAIGovernanceWarning = (message: string): boolean =>
 	message.startsWith(aiGovernanceNearLimitWarningPrefix) ||
 	message.startsWith(aiGovernanceOverLimitWarningPrefix);
 
-const isAIGovernanceNearLimitWarning = (message: string): boolean =>
-	message.startsWith(aiGovernanceNearLimitWarningPrefix);
+// Substitutes the given values into the template's %d placeholders in order.
+// No other fmt verb, width, or flag is implemented.
+const formatLicenseMessage = (template: string, ...values: number[]): string =>
+	values.reduce(
+		(message, value) => message.replace("%d", `${value}`),
+		template,
+	);
+
+// Diagnostics about the license or the usage measurement rather than about
+// usage itself. They render muted, without the exceedance heading or a sales
+// link. The "unavailable" pair arrives via entitlements.errors but must not
+// render as license errors; see LicenseManagedAgentUsageUnavailableErrorText.
+const diagnosticMessages: readonly string[] = [
+	LicenseManagedAgentUsageUnavailableErrorText,
+	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
+];
+
+const isDiagnosticMessage = (message: string): boolean =>
+	diagnosticMessages.includes(message);
+
+// Advisories and diagnostics render in the muted variant: nothing is wrong
+// yet, so they must be visually distinct from warnings that demand action,
+// such as exceeding a license limit.
+const isMutedWarning = (message: string): boolean =>
+	message.startsWith(aiGovernanceNearLimitWarningPrefix) ||
+	isDiagnosticMessage(message);
 
 const aiGovernanceOverLimitMessage = (
 	feature: ReturnType<
@@ -48,9 +74,12 @@ const aiGovernanceOverLimitMessage = (
 	}
 
 	const overLimitSeats = actual - limit;
-	return LicenseAIGovernanceOverLimitWarningText.replace("%d", `${actual}`)
-		.replace("%d", `${limit}`)
-		.replace("%d", `${overLimitSeats}`);
+	return formatLicenseMessage(
+		LicenseAIGovernanceOverLimitWarningText,
+		actual,
+		limit,
+		overLimitSeats,
+	);
 };
 
 const aiGovernanceNearLimitMessage = (
@@ -99,7 +128,7 @@ const normalizeAIGovernanceWarning = (
 	);
 };
 
-const messageLink = (message: string): LicenseBannerLink => {
+const messageLink = (message: string): LicenseBannerLink | undefined => {
 	if (message === LicenseManagedAgentLimitExceededWarningText) {
 		return {
 			href: docs("/ai-coder/ai-governance"),
@@ -114,6 +143,11 @@ const messageLink = (message: string): LicenseBannerLink => {
 			label: "Contact sales@coder.com if you need an exception.",
 			showExternalIcon: false,
 		};
+	}
+	// Diagnostics point the operator at the logs or support, so they do not
+	// get a sales link.
+	if (isDiagnosticMessage(message)) {
+		return undefined;
 	}
 	return {
 		href: "mailto:sales@coder.com",
@@ -146,12 +180,16 @@ export const LicenseBanner: FC = () => {
 	const messages: LicenseBannerMessage[] = [
 		...errors.map((message) => ({
 			message,
-			variant: "error" as const,
+			// Measurement diagnostics travel in the errors channel but are
+			// not license errors; see diagnosticMessages.
+			variant: isDiagnosticMessage(message)
+				? ("warning" as const)
+				: ("error" as const),
 			link: messageLink(message),
 		})),
 		...normalizedWarnings.map((message) => ({
 			message,
-			variant: isAIGovernanceNearLimitWarning(message)
+			variant: isMutedWarning(message)
 				? ("warning" as const)
 				: ("warningProminent" as const),
 			link: messageLink(message),

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -176,22 +176,22 @@ export const LicenseBanner: FC = () => {
 	);
 
 	const messages: LicenseBannerMessage[] = [
-		...errors.map((message) => ({
-			message,
-			// Measurement diagnostics travel in the errors channel but are
-			// not license errors; see diagnosticMessages.
-			variant: isDiagnosticMessage(message)
-				? ("warning" as const)
-				: ("error" as const),
-			link: messageLink(message),
-		})),
-		...normalizedWarnings.map((message) => ({
-			message,
-			variant: isMutedWarning(message)
-				? ("warning" as const)
-				: ("warningProminent" as const),
-			link: messageLink(message),
-		})),
+		...errors.map(
+			(message): LicenseBannerMessage => ({
+				message,
+				// Measurement diagnostics travel in the errors channel but are
+				// not license errors; see diagnosticMessages.
+				variant: isDiagnosticMessage(message) ? "warning" : "error",
+				link: messageLink(message),
+			}),
+		),
+		...normalizedWarnings.map(
+			(message): LicenseBannerMessage => ({
+				message,
+				variant: isMutedWarning(message) ? "warning" : "warningProminent",
+				link: messageLink(message),
+			}),
+		),
 	];
 
 	if (messages.length === 0) {

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -36,8 +36,7 @@ const formatLicenseMessage = (template: string, ...values: number[]): string =>
 
 // Diagnostics about the license or the usage measurement rather than about
 // usage itself. They render muted, without the exceedance heading or a sales
-// link. The "unavailable" pair arrives via entitlements.errors but must not
-// render as license errors; see LicenseManagedAgentUsageUnavailableErrorText.
+// link, even when they arrive via entitlements.errors.
 const diagnosticMessages: readonly string[] = [
 	LicenseManagedAgentUsageUnavailableErrorText,
 	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
@@ -46,9 +45,8 @@ const diagnosticMessages: readonly string[] = [
 const isDiagnosticMessage = (message: string): boolean =>
 	diagnosticMessages.includes(message);
 
-// Advisories and diagnostics render in the muted variant: nothing is wrong
-// yet, so they must be visually distinct from warnings that demand action,
-// such as exceeding a license limit.
+// Advisories and diagnostics render muted to stay visually distinct from
+// warnings that demand action, such as exceeding a license limit.
 const isMutedWarning = (message: string): boolean =>
 	message.startsWith(aiGovernanceNearLimitWarningPrefix) ||
 	isDiagnosticMessage(message);

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -43,11 +43,10 @@ const diagnosticMessages: readonly string[] = [
 const isDiagnosticMessage = (message: string): boolean =>
 	diagnosticMessages.includes(message);
 
-// Advisories and diagnostics render muted to stay visually distinct from
-// warnings that demand action, such as exceeding a license limit.
-const isMutedWarning = (message: string): boolean =>
-	message.startsWith(aiGovernanceNearLimitWarningPrefix) ||
-	isDiagnosticMessage(message);
+// Advisories render muted to stay visually distinct from warnings that
+// demand action, such as exceeding a license limit.
+const isAdvisoryMessage = (message: string): boolean =>
+	message.startsWith(aiGovernanceNearLimitWarningPrefix);
 
 const aiGovernanceOverLimitMessage = (
 	feature: ReturnType<
@@ -140,15 +139,33 @@ const messageLink = (message: string): LicenseBannerLink | undefined => {
 			showExternalIcon: false,
 		};
 	}
-	// Diagnostics point the operator at the logs or support, so they do not
-	// get a sales link.
-	if (isDiagnosticMessage(message)) {
-		return undefined;
-	}
 	return {
 		href: "mailto:sales@coder.com",
 		label: "Contact sales@coder.com.",
 		showExternalIcon: false,
+	};
+};
+
+// Classifies a raw entitlements message once and carries the result as
+// structured message data, so rendering branches on the message's kind and
+// variant fields rather than re-matching display text.
+const toBannerMessage = (
+	message: string,
+	channel: "errors" | "warnings",
+): LicenseBannerMessage => {
+	// Measurement diagnostics travel in the errors channel but are not
+	// license errors. They render muted and without a sales link: they point
+	// the operator at the logs, not at sales.
+	if (isDiagnosticMessage(message)) {
+		return { message, variant: "warning", kind: "diagnostic" };
+	}
+	if (channel === "errors") {
+		return { message, variant: "error", link: messageLink(message) };
+	}
+	return {
+		message,
+		variant: isAdvisoryMessage(message) ? "warning" : "warningProminent",
+		link: messageLink(message),
 	};
 };
 
@@ -174,21 +191,9 @@ export const LicenseBanner: FC = () => {
 	);
 
 	const messages: LicenseBannerMessage[] = [
-		...errors.map(
-			(message): LicenseBannerMessage => ({
-				message,
-				// Measurement diagnostics travel in the errors channel but are
-				// not license errors; see diagnosticMessages.
-				variant: isDiagnosticMessage(message) ? "warning" : "error",
-				link: messageLink(message),
-			}),
-		),
-		...normalizedWarnings.map(
-			(message): LicenseBannerMessage => ({
-				message,
-				variant: isMutedWarning(message) ? "warning" : "warningProminent",
-				link: messageLink(message),
-			}),
+		...errors.map((message) => toBannerMessage(message, "errors")),
+		...normalizedWarnings.map((message) =>
+			toBannerMessage(message, "warnings"),
 		),
 	];
 

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -4,7 +4,6 @@ import {
 	LicenseAIGovernance90PercentWarningText,
 	LicenseAIGovernanceOverLimitWarningText,
 	LicenseManagedAgentLimitExceededWarningText,
-	LicenseManagedAgentUsageUnavailableErrorText,
 	LicenseTelemetryRequiredErrorText,
 } from "#/api/typesGenerated";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
@@ -38,7 +37,6 @@ const formatLicenseMessage = (template: string, ...values: number[]): string =>
 // usage itself. They render muted, without the exceedance heading or a sales
 // link, even when they arrive via entitlements.errors.
 const diagnosticMessages: readonly string[] = [
-	LicenseManagedAgentUsageUnavailableErrorText,
 	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
 ];
 

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -5,7 +5,6 @@ import {
 	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
 	LicenseAIGovernance90PercentWarningText,
 	LicenseManagedAgentLimitExceededWarningText,
-	LicenseManagedAgentUsageUnavailableErrorText,
 	LicenseTelemetryRequiredErrorText,
 } from "#/api/typesGenerated";
 import {
@@ -306,14 +305,6 @@ const playMutedDiagnostic =
 		).not.toBeInTheDocument();
 	};
 
-export const ManagedAgentUsageUnavailable: Story = {
-	render: () =>
-		renderLicenseBanner({
-			errors: [LicenseManagedAgentUsageUnavailableErrorText],
-		}),
-	play: playMutedDiagnostic(LicenseManagedAgentUsageUnavailableErrorText),
-};
-
 export const AgentRuntimeHoursClaimsIgnored: Story = {
 	render: () =>
 		renderLicenseBanner({
@@ -326,7 +317,6 @@ export const AgentRuntimeHoursClaimsIgnored: Story = {
 export const UsageDiagnosticsOnlyHeading: Story = {
 	render: () =>
 		renderLicenseBanner({
-			errors: [LicenseManagedAgentUsageUnavailableErrorText],
 			warnings: [LicenseAgentRuntimeHoursClaimsIgnoredWarningText],
 		}),
 	play: async ({ canvasElement }) => {

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
 import {
+	type Entitlements,
+	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
 	LicenseAIGovernance90PercentWarningText,
 	LicenseManagedAgentLimitExceededWarningText,
+	LicenseManagedAgentUsageUnavailableErrorText,
 	LicenseTelemetryRequiredErrorText,
 } from "#/api/typesGenerated";
 import {
@@ -180,30 +183,24 @@ export const ManagedAgentLimitExceededWithOtherWarnings: Story = {
 	},
 };
 
-const renderLicenseBannerWithAIGovernance = ({
-	actual,
-	entitlement = "entitled",
-	limit,
+const renderLicenseBanner = ({
+	errors = [],
 	warnings = [],
+	features = {},
 }: {
-	actual: number;
-	entitlement?: "entitled" | "grace_period" | "not_entitled";
-	limit?: number;
+	errors?: string[];
 	warnings?: string[];
+	features?: Partial<Entitlements["features"]>;
 }) => {
 	const mockDashboardValue: DashboardValue = {
 		entitlements: {
 			...MockEntitlements,
 			has_license: true,
+			errors,
 			warnings,
 			features: {
 				...MockEntitlements.features,
-				ai_governance_user_limit: {
-					enabled: true,
-					entitlement,
-					actual,
-					...(limit !== undefined ? { limit } : {}),
-				},
+				...features,
 			},
 		},
 		experiments: MockExperiments,
@@ -215,11 +212,38 @@ const renderLicenseBannerWithAIGovernance = ({
 	};
 
 	return (
-		<DashboardContext.Provider value={mockDashboardValue}>
+		<DashboardContext value={mockDashboardValue}>
 			<LicenseBanner />
-		</DashboardContext.Provider>
+		</DashboardContext>
 	);
 };
+
+const renderLicenseBannerWithAIGovernance = ({
+	actual,
+	entitlement = "entitled",
+	limit,
+	warnings = [],
+}: {
+	actual: number;
+	entitlement?: "entitled" | "grace_period" | "not_entitled";
+	limit?: number;
+	warnings?: string[];
+}) =>
+	renderLicenseBanner({
+		warnings,
+		features: {
+			ai_governance_user_limit: {
+				enabled: true,
+				entitlement,
+				actual,
+				...(limit !== undefined ? { limit } : {}),
+			},
+		},
+	});
+
+// Without the data-variant assertions, every story would keep passing with
+// the muted/prominent classifier disabled.
+const mutedVariant = "warning";
 
 export const AIGovernanceNearLimit: Story = {
 	render: () =>
@@ -230,9 +254,13 @@ export const AIGovernanceNearLimit: Story = {
 		}),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByRole("status")).toHaveTextContent(
+		const banner = canvas.getByRole("status");
+		await expect(banner).toHaveTextContent(
 			"You have used 95% of your AI Governance add-on seats.",
 		);
+		// Pins the AI Governance near-limit branch of isMutedWarning,
+		// independently of the runtime soft-limit branch below.
+		await expect(banner).toHaveAttribute("data-variant", mutedVariant);
 		await expect(
 			canvas.getByRole("link", { name: /Contact sales@coder\.com/i }),
 		).toHaveAttribute("href", "mailto:sales@coder.com");
@@ -265,5 +293,58 @@ export const AIGovernanceOverLimitGracePeriod: Story = {
 		await expect(canvas.getByRole("status")).toHaveTextContent(
 			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
 		);
+	},
+};
+
+// Each entry of the frontend's diagnosticMessages set is pinned on both
+// properties the set drives: the muted variant and the suppressed sales
+// link. The "unavailable" message arrives on the errors channel; see the
+// LicenseManagedAgentUsageUnavailableErrorText doc for why.
+const playMutedDiagnostic =
+	(message: string): Story["play"] =>
+	async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByRole("status");
+		await expect(banner).toHaveTextContent(message);
+		await expect(banner).toHaveAttribute("data-variant", mutedVariant);
+		await expect(
+			canvas.queryByRole("link", { name: /Contact sales@coder\.com/i }),
+		).not.toBeInTheDocument();
+	};
+
+export const ManagedAgentUsageUnavailable: Story = {
+	render: () =>
+		renderLicenseBanner({
+			errors: [LicenseManagedAgentUsageUnavailableErrorText],
+		}),
+	play: playMutedDiagnostic(LicenseManagedAgentUsageUnavailableErrorText),
+};
+
+export const AgentRuntimeHoursClaimsIgnored: Story = {
+	render: () =>
+		renderLicenseBanner({
+			warnings: [LicenseAgentRuntimeHoursClaimsIgnoredWarningText],
+		}),
+	play: playMutedDiagnostic(LicenseAgentRuntimeHoursClaimsIgnoredWarningText),
+};
+
+// An all-diagnostic banner must not claim license limits were exceeded.
+export const UsageDiagnosticsOnlyHeading: Story = {
+	render: () =>
+		renderLicenseBanner({
+			errors: [LicenseManagedAgentUsageUnavailableErrorText],
+			warnings: [LicenseAgentRuntimeHoursClaimsIgnoredWarningText],
+		}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByRole("status");
+		await expect(banner).toHaveAttribute("data-variant", mutedVariant);
+		await expect(canvas.getByText("License notices")).toBeInTheDocument();
+		await expect(
+			canvas.queryByText("Your license limits have been exceeded"),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByText("License errors require attention"),
+		).not.toBeInTheDocument();
 	},
 };

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -59,6 +59,10 @@ export const TwoWarnings: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("status")).toBeInTheDocument();
+		await expect(
+			canvas.getByText("Your license limits have been exceeded"),
+		).toBeInTheDocument();
 		await expect(
 			canvas.queryByRole("button", { name: "Show more" }),
 		).not.toBeInTheDocument();
@@ -241,10 +245,6 @@ const renderLicenseBannerWithAIGovernance = ({
 		},
 	});
 
-// Without the data-variant assertions, every story would keep passing with
-// the muted/prominent classifier disabled.
-const mutedVariant = "warning";
-
 export const AIGovernanceNearLimit: Story = {
 	render: () =>
 		renderLicenseBannerWithAIGovernance({
@@ -258,9 +258,6 @@ export const AIGovernanceNearLimit: Story = {
 		await expect(banner).toHaveTextContent(
 			"You have used 95% of your AI Governance add-on seats.",
 		);
-		// Pins the AI Governance near-limit branch of isMutedWarning,
-		// independently of the runtime soft-limit branch below.
-		await expect(banner).toHaveAttribute("data-variant", mutedVariant);
 		await expect(
 			canvas.getByRole("link", { name: /Contact sales@coder\.com/i }),
 		).toHaveAttribute("href", "mailto:sales@coder.com");
@@ -296,17 +293,16 @@ export const AIGovernanceOverLimitGracePeriod: Story = {
 	},
 };
 
-// Each entry of the frontend's diagnosticMessages set is pinned on both
-// properties the set drives: the muted variant and the suppressed sales
+// Each diagnostic pins role=status (not alert) and a suppressed sales
 // link. The "unavailable" message arrives on the errors channel; see the
-// LicenseManagedAgentUsageUnavailableErrorText doc for why.
+// LicenseManagedAgentUsageUnavailableErrorText doc for why. Background
+// mutedness is covered by the visual snapshot.
 const playMutedDiagnostic =
 	(message: string): Story["play"] =>
 	async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = canvas.getByRole("status");
 		await expect(banner).toHaveTextContent(message);
-		await expect(banner).toHaveAttribute("data-variant", mutedVariant);
 		await expect(
 			canvas.queryByRole("link", { name: /Contact sales@coder\.com/i }),
 		).not.toBeInTheDocument();
@@ -337,8 +333,7 @@ export const UsageDiagnosticsOnlyHeading: Story = {
 		}),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const banner = canvas.getByRole("status");
-		await expect(banner).toHaveAttribute("data-variant", mutedVariant);
+		await expect(canvas.getByRole("status")).toBeInTheDocument();
 		await expect(canvas.getByText("License notices")).toBeInTheDocument();
 		await expect(
 			canvas.queryByText("Your license limits have been exceeded"),

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -260,6 +260,9 @@ export const AIGovernanceNearLimit: Story = {
 		await expect(
 			canvas.getByRole("link", { name: /Contact sales@coder\.com/i }),
 		).toHaveAttribute("href", "mailto:sales@coder.com");
+		// A lone advisory is muted but not a diagnostic, so it renders
+		// without the notices heading.
+		await expect(canvas.queryByText("License notices")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -294,9 +294,7 @@ export const AIGovernanceOverLimitGracePeriod: Story = {
 };
 
 // Each diagnostic pins role=status (not alert) and a suppressed sales
-// link. The "unavailable" message arrives on the errors channel; see the
-// LicenseManagedAgentUsageUnavailableErrorText doc for why. Background
-// mutedness is covered by the visual snapshot.
+// link. Background mutedness is covered by the visual snapshot.
 const playMutedDiagnostic =
 	(message: string): Story["play"] =>
 	async ({ canvasElement }) => {

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -70,9 +70,8 @@ const getBannerVariant = (
 	return hasProminentWarning ? "warningProminent" : "warning";
 };
 
-// The muted variant only wins when every message is muted (see
-// getBannerVariant), which means advisories and diagnostics: nothing has
-// been exceeded, so the heading must not assert exceedance.
+// The muted "warning" variant means every message is an advisory or
+// diagnostic, so the heading must not assert exceedance.
 const bannerTitle = (variant: LicenseBannerVariant): string => {
 	switch (variant) {
 		case "error":

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -151,9 +151,6 @@ export const LicenseBannerView: React.FC<LicenseBannerViewProps> = ({
 	return (
 		<div
 			role={bannerRole(bannerVariant)}
-			// The muted/prominent distinction otherwise only reaches the DOM
-			// as a background class, which tests must not assert on.
-			data-variant={bannerVariant}
 			className={cn(bannerVariants({ variant: bannerVariant }))}
 		>
 			<div className="flex min-w-0 flex-1 items-start gap-2">

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -25,6 +25,10 @@ export interface LicenseBannerLink {
 export interface LicenseBannerMessage {
 	message: string;
 	variant: LicenseBannerVariant;
+	// Diagnostics about the license or the usage measurement rather than
+	// about usage itself. They keep the "License notices" heading even when
+	// they are the only message, since the muted text needs that context.
+	kind?: "diagnostic";
 	link?: LicenseBannerLink;
 }
 
@@ -146,6 +150,9 @@ export const LicenseBannerView: React.FC<LicenseBannerViewProps> = ({
 	const bannerVariant = getBannerVariant(messages);
 	const visibleMessages = messages.slice(0, 2);
 	const hiddenMessages = messages.slice(2);
+	// A lone diagnostic keeps the heading: without it the muted banner is an
+	// unexplained sentence. Other single messages stay heading-less.
+	const showHeading = !isSingleMessage || messages[0].kind === "diagnostic";
 
 	return (
 		<div
@@ -159,20 +166,20 @@ export const LicenseBannerView: React.FC<LicenseBannerViewProps> = ({
 					/>
 				</div>
 				<div className="flex min-w-0 flex-1 flex-col gap-2">
+					{showHeading && (
+						<div className="text-sm font-semibold leading-6 text-content-primary">
+							{bannerTitle(bannerVariant)}
+						</div>
+					)}
 					{isSingleMessage ? (
 						<div className="flex min-h-6 items-center text-xs leading-4 text-content-primary">
 							<LicenseMessageText entry={messages[0]} />
 						</div>
 					) : (
-						<>
-							<div className="text-sm font-semibold leading-6 text-content-primary">
-								{bannerTitle(bannerVariant)}
-							</div>
-							<ExpandableLicenseMessageList
-								hiddenMessages={hiddenMessages}
-								visibleMessages={visibleMessages}
-							/>
-						</>
+						<ExpandableLicenseMessageList
+							hiddenMessages={hiddenMessages}
+							visibleMessages={visibleMessages}
+						/>
 					)}
 				</div>
 			</div>

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -70,10 +70,19 @@ const getBannerVariant = (
 	return hasProminentWarning ? "warningProminent" : "warning";
 };
 
-const bannerTitle = (variant: LicenseBannerVariant): string =>
-	variant === "error"
-		? "License errors require attention"
-		: "Your license limits have been exceeded";
+// The muted variant only wins when every message is muted (see
+// getBannerVariant), which means advisories and diagnostics: nothing has
+// been exceeded, so the heading must not assert exceedance.
+const bannerTitle = (variant: LicenseBannerVariant): string => {
+	switch (variant) {
+		case "error":
+			return "License errors require attention";
+		case "warningProminent":
+			return "Your license limits have been exceeded";
+		case "warning":
+			return "License notices";
+	}
+};
 
 const bannerRole = (variant: LicenseBannerVariant): "alert" | "status" =>
 	variant === "error" ? "alert" : "status";
@@ -142,6 +151,9 @@ export const LicenseBannerView: React.FC<LicenseBannerViewProps> = ({
 	return (
 		<div
 			role={bannerRole(bannerVariant)}
+			// The muted/prominent distinction otherwise only reaches the DOM
+			// as a background class, which tests must not assert on.
+			data-variant={bannerVariant}
 			className={cn(bannerVariants({ variant: bannerVariant }))}
 		>
 			<div className="flex min-w-0 flex-1 items-start gap-2">


### PR DESCRIPTION
Two coupled changes to the license/entitlements layer, preparing for runtime-hours usage reporting.

**Tolerate unusable runtime hour claims.** Unusable `agent_runtime_hours_*` claim combinations no longer reject the whole license: rejecting a signed license over a cosmetic threshold claim would drop the deployment to unlicensed. `decodeAgentRuntimeHours` drops the unusable claims, surfaces the stable `LicenseAgentRuntimeHoursClaimsIgnoredWarningText` (deduplicated across licenses), and logs the affected license and claims through the new `FeatureArguments.Logger`; `validateAgentRuntimeHours` and its license-invalidating errors are removed. The dashboard recognizes the stable diagnostic text and renders it muted, with a "License notices" heading instead of the exceedance heading and without a sales link.

**Unlimited allocation.** An `agent_runtime_hours_allocation` claim of exactly `-1` (`AgentRuntimeHoursUnlimitedAllocation`, mirrored in coder/license) is reserved to mean unlimited: it decodes to an enabled feature with no `limit` in `/api/v2/entitlements`, the shape the UI already renders as "Unlimited". Threshold claims alongside it have nothing to threshold against, so they are dropped with the claims-ignored warning, and any other negative allocation remains unusable. The issuer-side counterpart (refusing to mint `-1` together with threshold claims) is coder/license#49.

The managed agent measurement path is intentionally untouched: managed agents are deprecated and slated for removal, so the shared usage-measurement failure policy (`measureUsage`) now lands in #27985 next to its runtime-hours consumer instead of converting a doomed call site here.

Part 2 of a 3-PR stack splitting up #27796 (see there for review history). Stack: #27983 → this PR → #27985.
