### PR TITLE
docs: AI Governance included in all Premium and Agents licenses

### DIFF
--- a/docs/ai-coder/ai-governance.md
+++ b/docs/ai-coder/ai-governance.md
@@ -43,33 +43,33 @@ or without Coder's AI Governance features.
 Organizations adopting AI coding tools at scale often encounter operational and
 security challenges that traditional developer tooling doesn't address.
 
-### Auditing AI activity across teams
+### Audit AI activity across teams
 
 Without centralized monitoring, teams have no way to understand how AI tools are
 being used across the organization. AI Gateway provides audit trails of prompts,
 token usage, and tool invocations, giving administrators insight into AI
 adoption patterns and potential issues.
 
-### Restricting agent network access
+### Restrict agent network access
 
 AI agents can make arbitrary network requests, potentially accessing unauthorized services or exfiltrating data.
 Agent Firewall enforces process-level policies that restrict which domains agents can reach and what actions they can perform,
 preventing unintended data exposure and destructive operations like `rm -rf`.
 
-### Centralizing API key management
+### Centralize API key management
 
 Managing individual API keys for AI providers across hundreds of developers
 creates security risks and administrative overhead. AI Gateway centralizes
 authentication so users authenticate through Coder, eliminating the need to
 distribute and rotate provider API keys.
 
-### Standardizing MCP tools and servers
+### Standardize MCP tools and servers
 
 Different teams may use different MCP servers and tools with varying security
 postures. AI Gateway enables centralized MCP administration, allowing
 organizations to define approved tools and servers that all users can access.
 
-### Measuring AI adoption and spend
+### Measure AI adoption and spend
 
 Without usage data, it's hard to justify AI tooling investments or identify
 high-leverage use cases. AI Gateway captures metrics on token spend, adoption
@@ -120,12 +120,6 @@ may also consume agent workspace builds.
 
 ### Agent Workspace Build Limits
 
-Without proper controls and sandboxing, it is not recommended to open up Coder
-Tasks to a large audience in the enterprise. Community deployments include 1,000
-Agent Workspace Builds, primarily for proof-of-concept use and basic workflows.
-Community deployments do not have access to
-[AI Gateway](./ai-gateway/index.md) or [Agent Firewall](./agent-firewall/index.md).
-
 Premium and Agents deployments include a shared usage pool of Agent Workspace
 Builds for automated workflows, along with limits that scale proportionately with
 user count. Usage counts are measured and sent to Coder via
@@ -134,7 +128,7 @@ features continue to function normally even if the limit is breached. Admins
 will receive a warning to [contact their account team](https://coder.com/contact)
 to remediate.
 
-### Tracking Agent Workspace Builds
+### Track Agent Workspace Builds
 
 Admins can monitor Agent Workspace Build usage from the Coder dashboard.
 Navigate to **Deployment** > **Licenses** to view current usage against your
@@ -145,7 +139,7 @@ entitlement limits.
 <small>Agent Workspace Build usage showing current consumption against
 entitlement limits in the Licenses page.</small>
 
-## Identifying AI seat consumers
+## Identify AI seat consumers
 
 When AI Governance is enabled, the **Users** table and
 **Organization Members** table display an **AI** column that shows

--- a/docs/ai-coder/ai-governance.md
+++ b/docs/ai-coder/ai-governance.md
@@ -7,8 +7,9 @@ development environments. As adoption grows, many enterprises also need
 observability, management, and policy controls to support secure and auditable
 AI rollouts.
 
-AI Governance is included with a Premium license. Each Premium user gets access
-to a set of features that help organizations safely roll out AI tooling at scale:
+AI Governance is included with all Premium and Agents licenses. Each user gets
+access to a set of features that help organizations safely roll out AI tooling
+at scale:
 
 - [AI Gateway](./ai-gateway/index.md): LLM gateway to audit AI sessions, central
   MCP server management, and policy enforcement
@@ -16,7 +17,7 @@ to a set of features that help organizations safely roll out AI tooling at scale
   agents, restricting which domains can be accessed by AI agents
 
 > [!NOTE]
-> AI Gateway and Agent Firewall require a Premium license.
+> AI Gateway and Agent Firewall require a Premium or Agents license.
 > Community deployments cannot access these features.
 
 ## Who should use AI Governance
@@ -79,7 +80,7 @@ rates, and usage patterns to inform decisions about AI strategy.
 Starting with Coder v2.30 (February 2026), AI Gateway and Agent Firewall are
 generally available as part of AI Governance.
 
-To learn more about AI Governance, pricing, or trial options, reach out to your
+To learn more about AI Governance or to get in touch, reach out to your
 [Coder account team](https://coder.com/contact/sales).
 
 ## How Coder Tasks usage is measured
@@ -120,14 +121,14 @@ may also consume agent workspace builds.
 ### Agent Workspace Build Limits
 
 Without proper controls and sandboxing, it is not recommended to open up Coder
-Tasks to a large audience in the enterprise. Both Community and Premium
-deployments include 1,000 Agent Workspace Builds, primarily for proof-of-concept
-use and basic workflows. Community deployments do not have access to
+Tasks to a large audience in the enterprise. Community deployments include 1,000
+Agent Workspace Builds, primarily for proof-of-concept use and basic workflows.
+Community deployments do not have access to
 [AI Gateway](./ai-gateway/index.md) or [Agent Firewall](./agent-firewall/index.md).
 
-Premium deployments include a shared usage pool of Agent Workspace Builds for
-automated workflows, along with limits that scale proportionately with user
-count. Usage counts are measured and sent to Coder via
+Premium and Agents deployments include a shared usage pool of Agent Workspace
+Builds for automated workflows, along with limits that scale proportionately with
+user count. Usage counts are measured and sent to Coder via
 [usage data reporting](./usage-data-reporting.md). Coder Tasks and other AI
 features continue to function normally even if the limit is breached. Admins
 will receive a warning to [contact their account team](https://coder.com/contact)
@@ -146,8 +147,8 @@ entitlement limits in the Licenses page.</small>
 
 ## Identifying AI seat consumers
 
-When AI Governance is licensed, the **Users** table and
-**Organization Members** table display an **AI add-on** column that shows
+When AI Governance is enabled, the **Users** table and
+**Organization Members** table display an **AI** column that shows
 whether each user is consuming an AI seat:
 
 - A green check icon indicates the user is actively consuming an AI seat.


### PR DESCRIPTION
AI Governance is no longer an add-on — it's included in all Premium and Agents licenses.

**Changes:**
- Opening paragraph: "included with a Premium license" → "included with all Premium and Agents licenses"
- `[!NOTE]` block: "require a Premium license" → "require a Premium or Agents license"
- GA status section: removed "pricing, or trial options" framing
- Agent Workspace Build Limits: added Agents alongside Premium; removed the outdated "Both Community and Premium" phrasing that implied Community got the same pool
- Identifying AI seat consumers: updated "When AI Governance is licensed" → "When AI Governance is enabled" and removed "add-on" terminology from the column description

---
*Generated by Coder Agents*