### PR TITLE
fix: hide the favorite button for workspaces you don't own

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
@@ -211,30 +211,12 @@ export const CancelHiddenForUser: Story = {
 	},
 };
 
-export const FavoriteShownForOwner: Story = {
-	args: {
-		workspace: Mocks.MockWorkspace,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await expect(
-			canvas.getByRole("button", { name: "Favorite" }),
-		).toBeVisible();
-	},
-};
-
 export const FavoriteHiddenForNonOwner: Story = {
 	args: {
 		workspace: Mocks.MockWorkspace,
 	},
 	parameters: {
 		user: Mocks.MockUserMember,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await expect(
-			canvas.queryByRole("button", { name: "Favorite" }),
-		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
@@ -211,6 +211,33 @@ export const CancelHiddenForUser: Story = {
 	},
 };
 
+export const FavoriteShownForOwner: Story = {
+	args: {
+		workspace: Mocks.MockWorkspace,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("button", { name: "Favorite" }),
+		).toBeVisible();
+	},
+};
+
+export const FavoriteHiddenForNonOwner: Story = {
+	args: {
+		workspace: Mocks.MockWorkspace,
+	},
+	parameters: {
+		user: Mocks.MockUserMember,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.queryByRole("button", { name: "Favorite" }),
+		).not.toBeInTheDocument();
+	},
+};
+
 export const OpenDownloadLogs: Story = {
 	args: {
 		workspace: Mocks.MockWorkspace,

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -178,11 +178,15 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
 
 			{canCancel && <CancelButton handleAction={handleCancel} />}
 
-			<FavoriteButton
-				workspaceID={workspace.id}
-				isFavorite={workspace.favorite}
-				onToggle={handleToggleFavorite}
-			/>
+			{/* Favorite status is stored on the workspace itself rather than per
+			user, so the API only lets the owner toggle it. */}
+			{user.id === workspace.owner_id && (
+				<FavoriteButton
+					workspaceID={workspace.id}
+					isFavorite={workspace.favorite}
+					onToggle={handleToggleFavorite}
+				/>
+			)}
 
 			{permissions.shareWorkspace && (
 				<ShareButton

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -178,8 +178,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
 
 			{canCancel && <CancelButton handleAction={handleCancel} />}
 
-			{/* Favorite status is stored on the workspace itself rather than per
-			user, so the API only lets the owner toggle it. */}
+			{/* Only the owner can favorite a workspace. */}
 			{user.id === workspace.owner_id && (
 				<FavoriteButton
 					workspaceID={workspace.id}


### PR DESCRIPTION
Favorite status lives on the workspace row rather than in a per-user relation, so the API only lets a workspace's owner toggle it. The button was rendered for everyone, so viewing someone else's workspace offered a star that always looked un-favorited and failed with a 403, surfaced through the "Error building workspace" dialog.

Hides the button unless you own the workspace, with stories covering both cases.

---

Made with [Coder Agents](https://coder.com/) on behalf of @aslilac.
