### PR TITLE
fix(site): make delete dialog confirmation text use primary color

### DIFF
--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -100,6 +100,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 						<Label htmlFor={confirmId}>Workspace name</Label>
 						<Input
 							id={confirmId}
+							className="text-content-primary"
 							name="confirmation"
 							autoComplete="off"
 							autoFocus


### PR DESCRIPTION
## Summary

In the workspace delete confirmation dialog, the text typed into the "Workspace name" confirmation field rendered in the same secondary color as the placeholder, making it hard to distinguish entered text from the placeholder.

The shared `Input` component uses `text-inherit`, so it picked up the dialog description's secondary text color. This sets the confirmation input's text to `text-content-primary` (white on dark), while the placeholder remains `text-content-secondary`.

## Changes

- `WorkspaceDeleteDialog.tsx`: add `className="text-content-primary"` to the confirmation `Input`.


##### Before

https://github.com/user-attachments/assets/88dbb230-feb6-416c-b516-9cc92950a0b8

##### After

https://github.com/user-attachments/assets/74296b9e-cbdf-40fe-ba3d-6fbcf5d4a9d5

---

_This PR was generated by Coder Agents on behalf of @jeremyruppel._