### PR TITLE
docs: refresh JFrog Artifactory integration guide for SaaS

### DIFF
--- a/docs/admin/integrations/jfrog-artifactory.md
+++ b/docs/admin/integrations/jfrog-artifactory.md
@@ -25,19 +25,22 @@ two type of modules that automate the JFrog Artifactory and Coder integration.
 
 ### JFrog-OAuth
 
-This module works with both JFrog SaaS (for example, `example.jfrog.io`) and self-hosted (on-premises) Artifactory. It uses Coder's [external-auth](../external-auth/index.md) feature so each user authenticates with Artifactory through an OAuth flow, and Coder issues a user-scoped access token to each workspace.
+This module works with both JFrog SaaS (for example, `example.jfrog.io`) and self-hosted (on-premises) Artifactory.
+It uses Coder's [external-auth](../external-auth/index.md) feature so each user authenticates with Artifactory through an OAuth flow, and Coder issues a user-scoped access token to each workspace.
 
 To set this up, follow these steps:
 
-1. Create an application integration in Artifactory. Use `https://CODER_URL/external-auth/jfrog/callback` (your Coder deployment URL) as the callback URL and `applied-permissions/user` as the scope.
+1. Create an application integration in Artifactory.
+   Use `https://CODER_URL/external-auth/jfrog/callback` (your Coder deployment URL) as the callback URL and `applied-permissions/user` as the scope.
 
    **JFrog SaaS** (`example.jfrog.io`): Create the integration from the JFrog Platform UI as an administrator:
 
    1. Go to **Administration > General Management > Manage Integrations**, or open `https://JFROG_URL/ui/admin/configuration/integrations/application` directly.
-   1. Click **New Integration** and select **External Applications**.
-   1. On the **Create New Application Integration** form, set **Application Name** to `Coder`, set **Application Type** to **Custom Integration**, enter the callback URL, then click **Generate Client ID & Secret**.
+   1. Select **New Integration**, then select **External Applications**.
+   1. On the **Create New Application Integration** form, set **Application Name** to `Coder`, set **Application Type** to **Custom Integration**, enter the callback URL, then select **Generate Client ID & Secret**.
 
-   **Self-hosted (on-premises)**: First register an integration template in your Helm chart `values.yaml`, then create the application integration in the UI and select that template as the **Application Type**. Replace `CODER_URL` with your Coder deployment URL:
+   **Self-hosted (on-premises)**: First register an integration template in your Helm chart `values.yaml`, then create the application integration in the UI and select that template as the **Application Type**.
+   Replace `CODER_URL` with your Coder deployment URL:
 
    ```yaml
    artifactory:
@@ -56,8 +59,8 @@ To set this up, follow these steps:
            scope: "applied-permissions/user"
    ```
 
-1. Add a new [external authentication](../external-auth/index.md) to Coder by setting these
-   environment variables in a manner consistent with your Coder deployment. Replace `JFROG_URL` with your JFrog Artifactory base URL, and the client ID and secret with the values from step 1:
+1. Add a new [external authentication](../external-auth/index.md) to Coder by setting these environment variables in a manner consistent with your Coder deployment.
+   Replace `JFROG_URL` with your JFrog Artifactory base URL, and the client ID and secret with the values from step 1:
 
    ```dotenv
    # JFrog Artifactory External Auth

--- a/docs/admin/integrations/jfrog-artifactory.md
+++ b/docs/admin/integrations/jfrog-artifactory.md
@@ -26,20 +26,22 @@ two type of modules that automate the JFrog Artifactory and Coder integration.
 ### JFrog-OAuth
 
 This module works with both JFrog SaaS (for example, `example.jfrog.io`) and self-hosted (on-premises) Artifactory.
-It uses Coder's [external-auth](../external-auth/index.md) feature so each user authenticates with Artifactory through an OAuth flow, and Coder issues a user-scoped access token to each workspace.
+It uses Coder's [external-auth](../external-auth/index.md) feature, so each user authenticates with Artifactory through an OAuth flow, and Coder issues a user-scoped access token to each workspace.
 
 To set this up, follow these steps:
 
 1. Create an application integration in Artifactory.
-   Use `https://CODER_URL/external-auth/jfrog/callback` (your Coder deployment URL) as the callback URL and `applied-permissions/user` as the scope.
+   Use `https://<CODER_URL>/external-auth/jfrog/callback` (your Coder deployment URL) as the callback URL and `applied-permissions/user` as the scope.
 
    **JFrog SaaS** (`example.jfrog.io`): Create the integration from the JFrog Platform UI as an administrator:
 
-   1. Go to **Administration > General Management > Manage Integrations**, or open `https://JFROG_URL/ui/admin/configuration/integrations/application` directly.
-   1. Select **New Integration**, then select **External Applications**.
-   1. On the **Create New Application Integration** form, set **Application Name** to `Coder`, set **Application Type** to **Custom Integration**, enter the callback URL, then select **Generate Client ID & Secret**.
+   1. Go to **Administration** > **General Management** > **Manage Integrations**, or open `https://<JFROG_URL>/ui/admin/configuration/integrations/application` directly.
+   1. Select **New Integration**.
+   1. Select **External Applications**.
+   1. On the **Create New Application Integration** form, set **Application Name** to `Coder`, set **Application Type** to **Custom Integration**, and enter the callback URL.
+   1. Select **Generate Client ID & Secret**.
 
-   **Self-hosted (on-premises)**: First register an integration template in your Helm chart `values.yaml`, then create the application integration in the UI and select that template as the **Application Type**.
+   **Self-hosted (on-premises)**: First register an integration template in your Helm chart `values.yaml`, then create the application integration in the UI, and select that template as the **Application Type**.
    Replace `CODER_URL` with your Coder deployment URL:
 
    ```yaml

--- a/docs/admin/integrations/jfrog-artifactory.md
+++ b/docs/admin/integrations/jfrog-artifactory.md
@@ -25,12 +25,19 @@ two type of modules that automate the JFrog Artifactory and Coder integration.
 
 ### JFrog-OAuth
 
-This module is usable by JFrog self-hosted (on-premises) Artifactory as it
-requires configuring a custom integration. This integration benefits from Coder's [external-auth](../external-auth/index.md) feature allows each user to authenticate with Artifactory using an OAuth flow and issues user-scoped tokens to each user.
+This module works with both JFrog SaaS (for example, `example.jfrog.io`) and self-hosted (on-premises) Artifactory. It uses Coder's [external-auth](../external-auth/index.md) feature so each user authenticates with Artifactory through an OAuth flow, and Coder issues a user-scoped access token to each workspace.
 
 To set this up, follow these steps:
 
-1. Add the following to your Helm chart `values.yaml` for JFrog Artifactory. Replace `CODER_URL` with your JFrog Artifactory base URL:
+1. Create an application integration in Artifactory. Use `https://CODER_URL/external-auth/jfrog/callback` (your Coder deployment URL) as the callback URL and `applied-permissions/user` as the scope.
+
+   **JFrog SaaS** (`example.jfrog.io`): Create the integration from the JFrog Platform UI as an administrator:
+
+   1. Go to **Administration > General Management > Manage Integrations**, or open `https://JFROG_URL/ui/admin/configuration/integrations/application` directly.
+   1. Click **New Integration** and select **External Applications**.
+   1. On the **Create New Application Integration** form, set **Application Name** to `Coder`, set **Application Type** to **Custom Integration**, enter the callback URL, then click **Generate Client ID & Secret**.
+
+   **Self-hosted (on-premises)**: First register an integration template in your Helm chart `values.yaml`, then create the application integration in the UI and select that template as the **Application Type**. Replace `CODER_URL` with your Coder deployment URL:
 
    ```yaml
    artifactory:
@@ -49,12 +56,8 @@ To set this up, follow these steps:
            scope: "applied-permissions/user"
    ```
 
-1. Create a new Application Integration by going to
-   `https://JFROG_URL/ui/admin/configuration/integrations/app-integrations/new` and select the
-   Application Type as the integration you created in step 1 or `Custom Integration` if you are using SaaS instance i.e. example.jfrog.io.
-
 1. Add a new [external authentication](../external-auth/index.md) to Coder by setting these
-   environment variables in a manner consistent with your Coder deployment. Replace `JFROG_URL` with your JFrog Artifactory base URL:
+   environment variables in a manner consistent with your Coder deployment. Replace `JFROG_URL` with your JFrog Artifactory base URL, and the client ID and secret with the values from step 1:
 
    ```dotenv
    # JFrog Artifactory External Auth
@@ -73,8 +76,8 @@ To set this up, follow these steps:
    ```tf
    module "jfrog" {
      count          = data.coder_workspace.me.start_count
-     source         = "registry.coder.com/modules/jfrog-oauth/coder"
-     version        = "1.0.19"
+     source         = "registry.coder.com/coder/jfrog-oauth/coder"
+     version        = "1.2.4"
      agent_id       = coder_agent.example.id
      jfrog_url      = "https://example.jfrog.io"
      username_field = "username" # If you are using GitHub to login to both Coder and Artifactory, use username_field = "username"

--- a/docs/admin/integrations/jfrog-artifactory.md
+++ b/docs/admin/integrations/jfrog-artifactory.md
@@ -77,7 +77,7 @@ To set this up, follow these steps:
    module "jfrog" {
      count          = data.coder_workspace.me.start_count
      source         = "registry.coder.com/coder/jfrog-oauth/coder"
-     version        = "1.2.4"
+     version        = "~> 1.0"
      agent_id       = coder_agent.example.id
      jfrog_url      = "https://example.jfrog.io"
      username_field = "username" # If you are using GitHub to login to both Coder and Artifactory, use username_field = "username"
@@ -113,7 +113,7 @@ To set this up, follow these steps:
 
    module "jfrog" {
      source                   = "registry.coder.com/coder/jfrog-token/coder"
-     version                  = "1.2.2"
+     version                  = "~> 1.0"
      agent_id                 = coder_agent.example.id
      jfrog_url                = "https://XXXX.jfrog.io"
      artifactory_access_token = var.artifactory_access_token

--- a/docs/admin/integrations/jfrog-artifactory.md
+++ b/docs/admin/integrations/jfrog-artifactory.md
@@ -112,8 +112,8 @@ To set this up, follow these steps:
    }
 
    module "jfrog" {
-     source                   = "registry.coder.com/modules/jfrog-token/coder"
-     version                  = "1.0.30"
+     source                   = "registry.coder.com/coder/jfrog-token/coder"
+     version                  = "1.2.2"
      agent_id                 = coder_agent.example.id
      jfrog_url                = "https://XXXX.jfrog.io"
      artifactory_access_token = var.artifactory_access_token


### PR DESCRIPTION
## Summary

Refreshes the JFrog Artifactory integration guide to cover JFrog SaaS. The JFrog-OAuth section previously implied the module was self-hosted only and mixed the SaaS and self-hosted setup into one ambiguous step.

## Changes

- **JFrog-OAuth**: State the module works with both JFrog SaaS and self-hosted (on-premises) Artifactory.
- **JFrog-OAuth**: Split setup into a SaaS UI flow (**External Applications** > **Custom Integration**) and a self-hosted Helm integration-template flow.
- **JFrog-OAuth**: Update the module example to `registry.coder.com/coder/jfrog-oauth/coder`, `1.2.4`.
- **JFrog-Token**: Update the stale example to `registry.coder.com/coder/jfrog-token/coder`, `1.2.2`.

## Validation

- `markdownlint-cli2` passes on the file.
- No emdash/endash.

Preview: https://coder.com/docs/@matifali/jfrog-oauth-docs-saas/admin/integrations/jfrog-artifactory#jfrog-oauth

Related to the registry README refresh in coder/registry#1040.

🤖 Generated with [Claude Code](https://claude.ai/code)

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑‍💻
