### PR TITLE
docs: update JFrog-Token module source path and version

### DIFF
--- a/docs/admin/integrations/jfrog-artifactory.md
+++ b/docs/admin/integrations/jfrog-artifactory.md
@@ -109,8 +109,8 @@ To set this up, follow these steps:
    }
 
    module "jfrog" {
-     source                   = "registry.coder.com/modules/jfrog-token/coder"
-     version                  = "1.0.30"
+     source                   = "registry.coder.com/coder/jfrog-token/coder"
+     version                  = "1.2.2"
      agent_id                 = coder_agent.example.id
      jfrog_url                = "https://XXXX.jfrog.io"
      artifactory_access_token = var.artifactory_access_token


### PR DESCRIPTION
## Summary

Updates the JFrog-Token example in the integration guide to the current module source path and version. The section already documents SaaS and self-hosted support; this fixes the stale registry reference.

## Changes

- Update source to `registry.coder.com/coder/jfrog-token/coder`.
- Bump the example version from `1.0.30` to `1.2.2`.

Preview: https://coder.com/docs/@matifali/jfrog-token-docs-refresh/admin/integrations/jfrog-artifactory#jfrog-token

Follow-up to #28005.

🤖 Generated with [Claude Code](https://claude.ai/code)

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑‍💻
