### PR TITLE
refactor(site): add `<Drawer />` and migrate build logs drawer

### DIFF
--- a/site/src/components/Drawer/Drawer.stories.tsx
+++ b/site/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+import { Button } from "#/components/Button/Button";
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from "./Drawer";
+
+const meta: Meta<typeof Drawer> = {
+	title: "components/Drawer",
+	component: Drawer,
+	args: {
+		children: (
+			<>
+				<DrawerTrigger asChild>
+					<Button>Open Drawer</Button>
+				</DrawerTrigger>
+				<DrawerContent>
+					<DrawerHeader>
+						<DrawerTitle>Example Drawer Title</DrawerTitle>
+						<DrawerDescription>Drawer description text</DrawerDescription>
+					</DrawerHeader>
+					<DrawerFooter>
+						<DrawerClose asChild>
+							<Button variant="outline">Cancel</Button>
+						</DrawerClose>
+						<Button>Submit</Button>
+					</DrawerFooter>
+				</DrawerContent>
+			</>
+		),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+export const Closed: Story = {};
+
+export const Open: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Open Drawer" }));
+		// The drawer renders into a portal on `document.body`, so query the screen.
+		await waitFor(() =>
+			expect(screen.getByText("Example Drawer Title")).toBeInTheDocument(),
+		);
+	},
+};
+
+export const OpenLeft: Story = {
+	args: {
+		direction: "left",
+		children: (
+			<>
+				<DrawerTrigger asChild>
+					<Button>Open Left Drawer</Button>
+				</DrawerTrigger>
+				<DrawerContent>
+					<DrawerHeader>
+						<DrawerTitle>Left-side drawer</DrawerTitle>
+						<DrawerDescription>
+							Drawers can slide in from any edge via the direction prop.
+						</DrawerDescription>
+					</DrawerHeader>
+					<DrawerFooter>
+						<DrawerClose asChild>
+							<Button variant="outline">Close</Button>
+						</DrawerClose>
+					</DrawerFooter>
+				</DrawerContent>
+			</>
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Open Left Drawer" }),
+		);
+		await waitFor(() =>
+			expect(screen.getByText("Left-side drawer")).toBeInTheDocument(),
+		);
+	},
+};
+
+export const CloseWithButton: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Open Drawer" }));
+		await waitFor(() =>
+			expect(screen.getByText("Example Drawer Title")).toBeInTheDocument(),
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		await waitFor(() =>
+			expect(
+				screen.queryByText("Example Drawer Title"),
+			).not.toBeInTheDocument(),
+		);
+	},
+};

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -34,10 +34,10 @@ const DrawerOverlay: React.FC<
 	return (
 		<DialogPrimitive.Overlay
 			className={cn(
-				`fixed inset-0 z-50 bg-overlay [animation-timing-function:cubic-bezier(0.32,0.72,0,1)]
-				data-[state=open]:animate-in data-[state=closed]:animate-out
-				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
-				data-[state=open]:duration-300 data-[state=closed]:duration-100`,
+				"fixed inset-0 z-50 bg-overlay",
+				"data-[state=open]:animate-in data-[state=closed]:animate-out",
+				"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+				"data-[state=open]:duration-300 data-[state=closed]:duration-100",
 				className,
 			)}
 			{...props}

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -48,7 +48,7 @@ const DrawerOverlay: React.FC<
 
 const drawerContentVariants = cva(
 	cn(
-		"fixed z-50 flex h-auto flex-col bg-surface-primary outline-none will-change-transform",
+		"fixed z-50 flex h-auto flex-col bg-surface-tertiary outline-none will-change-transform",
 		"data-[state=open]:animate-in data-[state=closed]:animate-out",
 		"data-[state=open]:duration-500 data-[state=closed]:duration-300",
 	),

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -47,20 +47,30 @@ const DrawerOverlay: React.FC<
 };
 
 const drawerContentVariants = cva(
-	`fixed z-50 flex h-auto flex-col bg-surface-primary outline-none will-change-transform
-	data-[state=open]:animate-in data-[state=closed]:animate-out
-	data-[state=open]:duration-500 data-[state=closed]:duration-300`,
+	cn(
+		"fixed z-50 flex h-auto flex-col bg-surface-primary outline-none will-change-transform",
+		"data-[state=open]:animate-in data-[state=closed]:animate-out",
+		"data-[state=open]:duration-500 data-[state=closed]:duration-300",
+	),
 	{
 		variants: {
 			direction: {
-				top: `inset-x-0 top-0 max-h-[80vh] w-full border-b border-border
-					data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top`,
-				bottom: `inset-x-0 bottom-0 max-h-[80vh] w-full border-t border-border
-					data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom`,
-				left: `inset-y-0 left-0 h-full w-3/4 border-r border-border sm:max-w-sm
-					data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left`,
-				right: `inset-y-0 right-0 h-full w-3/4 border-l border-border sm:max-w-sm
-					data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right`,
+				top: cn(
+					"inset-x-0 top-0 max-h-[80vh] w-full border-b border-border",
+					"data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top",
+				),
+				bottom: cn(
+					"inset-x-0 bottom-0 max-h-[80vh] w-full border-t border-border",
+					"data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+				),
+				left: cn(
+					"inset-y-0 left-0 h-full w-3/4 border-r border-border sm:max-w-sm",
+					"data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
+				),
+				right: cn(
+					"inset-y-0 right-0 h-full w-3/4 border-l border-border sm:max-w-sm",
+					"data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
+				),
 			},
 		},
 		defaultVariants: {

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,13 +1,3 @@
-/**
- * A drawer (a.k.a. "sheet") that slides in from an edge of the screen.
- *
- * This mirrors the shadcn/ui drawer API (`Drawer`, `DrawerTrigger`,
- * `DrawerContent`, ...) but is implemented directly on top of Radix UI's
- * Dialog primitive rather than depending on the `vaul` package, which is
- * currently unmaintained. Radix Dialog already ships with the accessibility,
- * focus management, and open/close state we need, so this only adds the
- * edge positioning and slide animations on top of it.
- */
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { createContext, useContext } from "react";
 import { cn } from "#/utils/cn";
@@ -47,7 +37,7 @@ const DrawerOverlay: React.FC<
 				`fixed inset-0 z-50 bg-overlay [animation-timing-function:cubic-bezier(0.32,0.72,0,1)]
 				data-[state=open]:animate-in data-[state=closed]:animate-out
 				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
-				data-[state=open]:duration-500 data-[state=closed]:duration-300`,
+				data-[state=open]:duration-300 data-[state=closed]:duration-100`,
 				className,
 			)}
 			{...props}
@@ -76,10 +66,9 @@ export const DrawerContent: React.FC<
 			<DrawerOverlay />
 			<DialogPrimitive.Content
 				className={cn(
-					`fixed z-50 flex h-auto flex-col bg-surface-primary outline-none
-					will-change-transform [animation-timing-function:cubic-bezier(0.32,0.72,0,1)]
-					data-[state=open]:animate-in data-[state=closed]:animate-out
-					data-[state=open]:duration-500 data-[state=closed]:duration-300`,
+					"fixed z-50 flex h-auto flex-col bg-surface-primary outline-none will-change-transform",
+					"data-[state=open]:animate-in data-[state=closed]:animate-out",
+					"data-[state=open]:duration-500 data-[state=closed]:duration-300",
 					directionClasses[direction],
 					className,
 				)}

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,3 +1,4 @@
+import { cva } from "class-variance-authority";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { createContext, useContext } from "react";
 import { cn } from "#/utils/cn";
@@ -45,16 +46,28 @@ const DrawerOverlay: React.FC<
 	);
 };
 
-const directionClasses: Record<DrawerDirection, string> = {
-	top: `inset-x-0 top-0 max-h-[80vh] w-full border-b border-border
-		data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top`,
-	bottom: `inset-x-0 bottom-0 max-h-[80vh] w-full border-t border-border
-		data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom`,
-	left: `inset-y-0 left-0 h-full w-3/4 border-r border-border sm:max-w-sm
-		data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left`,
-	right: `inset-y-0 right-0 h-full w-3/4 border-l border-border sm:max-w-sm
-		data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right`,
-};
+const drawerContentVariants = cva(
+	`fixed z-50 flex h-auto flex-col bg-surface-primary outline-none will-change-transform
+	data-[state=open]:animate-in data-[state=closed]:animate-out
+	data-[state=open]:duration-500 data-[state=closed]:duration-300`,
+	{
+		variants: {
+			direction: {
+				top: `inset-x-0 top-0 max-h-[80vh] w-full border-b border-border
+					data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top`,
+				bottom: `inset-x-0 bottom-0 max-h-[80vh] w-full border-t border-border
+					data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom`,
+				left: `inset-y-0 left-0 h-full w-3/4 border-r border-border sm:max-w-sm
+					data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left`,
+				right: `inset-y-0 right-0 h-full w-3/4 border-l border-border sm:max-w-sm
+					data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right`,
+			},
+		},
+		defaultVariants: {
+			direction: "right",
+		},
+	},
+);
 
 export const DrawerContent: React.FC<
 	React.ComponentPropsWithRef<typeof DialogPrimitive.Content>
@@ -65,13 +78,7 @@ export const DrawerContent: React.FC<
 		<DrawerPortal>
 			<DrawerOverlay />
 			<DialogPrimitive.Content
-				className={cn(
-					"fixed z-50 flex h-auto flex-col bg-surface-primary outline-none will-change-transform",
-					"data-[state=open]:animate-in data-[state=closed]:animate-out",
-					"data-[state=open]:duration-500 data-[state=closed]:duration-300",
-					directionClasses[direction],
-					className,
-				)}
+				className={cn(drawerContentVariants({ direction }), className)}
 				{...props}
 			>
 				{children}

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -44,9 +44,10 @@ const DrawerOverlay: React.FC<
 	return (
 		<DialogPrimitive.Overlay
 			className={cn(
-				`fixed inset-0 z-50 bg-overlay
+				`fixed inset-0 z-50 bg-overlay [animation-timing-function:cubic-bezier(0.32,0.72,0,1)]
 				data-[state=open]:animate-in data-[state=closed]:animate-out
-				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
+				data-[state=open]:duration-500 data-[state=closed]:duration-300`,
 				className,
 			)}
 			{...props}
@@ -76,7 +77,7 @@ export const DrawerContent: React.FC<
 			<DialogPrimitive.Content
 				className={cn(
 					`fixed z-50 flex h-auto flex-col bg-surface-primary outline-none
-					transition ease-in-out
+					will-change-transform [animation-timing-function:cubic-bezier(0.32,0.72,0,1)]
 					data-[state=open]:animate-in data-[state=closed]:animate-out
 					data-[state=open]:duration-500 data-[state=closed]:duration-300`,
 					directionClasses[direction],

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,140 @@
+/**
+ * A drawer (a.k.a. "sheet") that slides in from an edge of the screen.
+ *
+ * This mirrors the shadcn/ui drawer API (`Drawer`, `DrawerTrigger`,
+ * `DrawerContent`, ...) but is implemented directly on top of Radix UI's
+ * Dialog primitive rather than depending on the `vaul` package, which is
+ * currently unmaintained. Radix Dialog already ships with the accessibility,
+ * focus management, and open/close state we need, so this only adds the
+ * edge positioning and slide animations on top of it.
+ */
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { createContext, useContext } from "react";
+import { cn } from "#/utils/cn";
+
+type DrawerDirection = "top" | "bottom" | "left" | "right";
+
+const DrawerDirectionContext = createContext<DrawerDirection>("right");
+
+type DrawerProps = React.ComponentPropsWithRef<typeof DialogPrimitive.Root> & {
+	/** The edge of the screen the drawer slides in from. Defaults to "right". */
+	direction?: DrawerDirection;
+};
+
+export const Drawer: React.FC<DrawerProps> = ({
+	direction = "right",
+	...props
+}) => {
+	return (
+		<DrawerDirectionContext.Provider value={direction}>
+			<DialogPrimitive.Root {...props} />
+		</DrawerDirectionContext.Provider>
+	);
+};
+
+export const DrawerTrigger = DialogPrimitive.Trigger;
+
+export const DrawerClose = DialogPrimitive.Close;
+
+const DrawerPortal = DialogPrimitive.Portal;
+
+const DrawerOverlay: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Overlay>
+> = ({ className, ...props }) => {
+	return (
+		<DialogPrimitive.Overlay
+			className={cn(
+				`fixed inset-0 z-50 bg-overlay
+				data-[state=open]:animate-in data-[state=closed]:animate-out
+				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+const directionClasses: Record<DrawerDirection, string> = {
+	top: `inset-x-0 top-0 max-h-[80vh] w-full border-b border-border
+		data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top`,
+	bottom: `inset-x-0 bottom-0 max-h-[80vh] w-full border-t border-border
+		data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom`,
+	left: `inset-y-0 left-0 h-full w-3/4 border-r border-border sm:max-w-sm
+		data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left`,
+	right: `inset-y-0 right-0 h-full w-3/4 border-l border-border sm:max-w-sm
+		data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right`,
+};
+
+export const DrawerContent: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Content>
+> = ({ className, children, ...props }) => {
+	const direction = useContext(DrawerDirectionContext);
+
+	return (
+		<DrawerPortal>
+			<DrawerOverlay />
+			<DialogPrimitive.Content
+				className={cn(
+					`fixed z-50 flex h-auto flex-col bg-surface-primary outline-none
+					transition ease-in-out
+					data-[state=open]:animate-in data-[state=closed]:animate-out
+					data-[state=open]:duration-500 data-[state=closed]:duration-300`,
+					directionClasses[direction],
+					className,
+				)}
+				{...props}
+			>
+				{children}
+			</DialogPrimitive.Content>
+		</DrawerPortal>
+	);
+};
+
+export const DrawerHeader: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn("flex flex-col gap-0.5 p-4 md:gap-1.5", className)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerTitle: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Title>
+> = ({ className, ...props }) => {
+	return (
+		<DialogPrimitive.Title
+			className={cn(
+				"text-lg font-semibold leading-none tracking-tight text-content-primary",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerDescription: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Description>
+> = ({ className, ...props }) => {
+	return (
+		<DialogPrimitive.Description
+			className={cn("text-sm text-content-secondary", className)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
+import { useRef, useState } from "react";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { JobError } from "#/api/queries/templates";
+import { Button } from "#/components/Button/Button";
 import {
 	MockProvisionerJob,
 	MockTemplateVersion,
@@ -37,6 +39,42 @@ export const CloseWithEscape: Story = {
 	play: async ({ args }) => {
 		await userEvent.keyboard("{Escape}");
 		await waitFor(() => expect(args.onClose).toHaveBeenCalled());
+	},
+};
+
+// When opened from a button outside the drawer, focus must return to that
+// button on close instead of falling back to the document body.
+export const RestoresFocusToOpener: Story = {
+	render: () => {
+		const [open, setOpen] = useState(false);
+		const openerRef = useRef<HTMLButtonElement>(null);
+		return (
+			<>
+				<Button ref={openerRef} onClick={() => setOpen(true)}>
+					Show build logs
+				</Button>
+				<BuildLogsDrawer
+					open={open}
+					onClose={() => setOpen(false)}
+					openerRef={openerRef}
+					error={undefined}
+					templateVersion={undefined}
+					variablesSectionRef={{ current: null }}
+				/>
+			</>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const opener = canvas.getByRole("button", { name: "Show build logs" });
+		await userEvent.click(opener);
+		await waitFor(() =>
+			expect(screen.getByText("Creating template...")).toBeInTheDocument(),
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: "Close build logs" }),
+		);
+		await waitFor(() => expect(opener).toHaveFocus());
 	},
 };
 

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof BuildLogsDrawer> = {
 	args: {
 		open: true,
 		onClose: fn(),
+		onFillVariables: fn(),
 	},
 };
 
@@ -43,7 +44,8 @@ export const CloseWithEscape: Story = {
 };
 
 // When opened from a button outside the drawer, focus must return to that
-// button on close instead of falling back to the document body.
+// button on close instead of falling back to the document body. The parent
+// owns this via `onCloseAutoFocus`.
 export const RestoresFocusToOpener: Story = {
 	render: () => {
 		const [open, setOpen] = useState(false);
@@ -56,10 +58,13 @@ export const RestoresFocusToOpener: Story = {
 				<BuildLogsDrawer
 					open={open}
 					onClose={() => setOpen(false)}
-					openerRef={openerRef}
+					onFillVariables={fn()}
+					onCloseAutoFocus={(event) => {
+						event.preventDefault();
+						openerRef.current?.focus();
+					}}
 					error={undefined}
 					templateVersion={undefined}
-					variablesSectionRef={{ current: null }}
 				/>
 			</>
 		);

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
 import { JobError } from "#/api/queries/templates";
 import {
 	MockProvisionerJob,
@@ -13,6 +14,7 @@ const meta: Meta<typeof BuildLogsDrawer> = {
 	component: BuildLogsDrawer,
 	args: {
 		open: true,
+		onClose: fn(),
 	},
 };
 
@@ -20,6 +22,23 @@ export default meta;
 type Story = StoryObj<typeof BuildLogsDrawer>;
 
 export const Loading: Story = {};
+
+export const CloseWithButton: Story = {
+	play: async ({ args }) => {
+		// The drawer portals its content onto `document.body`, so query the screen.
+		await userEvent.click(
+			screen.getByRole("button", { name: "Close build logs" }),
+		);
+		await waitFor(() => expect(args.onClose).toHaveBeenCalled());
+	},
+};
+
+export const CloseWithEscape: Story = {
+	play: async ({ args }) => {
+		await userEvent.keyboard("{Escape}");
+		await waitFor(() => expect(args.onClose).toHaveBeenCalled());
+	},
+};
 
 export const MissingVariables: Story = {
 	args: {

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -67,7 +67,7 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 			>
 				<div className="flex h-full flex-col">
 					<header
-						className="flex items-center justify-between border-b border-border px-6 bg-surface-tertiary"
+						className="flex items-center justify-between border-b border-border px-6 bg-surface-secondary"
 						style={{ height: navHeight }}
 					>
 						<DrawerTitle className="m-0 text-base font-medium">

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -1,5 +1,5 @@
 import { TriangleAlertIcon, XIcon } from "lucide-react";
-import type { FC } from "react";
+import { type FC, useRef } from "react";
 import { JobError } from "#/api/queries/templates";
 import type { TemplateVersion } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
@@ -20,6 +20,11 @@ type BuildLogsDrawerProps = {
 	error: unknown;
 	open: boolean;
 	onClose: () => void;
+	/**
+	 * The element that opened the drawer. Focus returns here on close because,
+	 * unlike a `DrawerTrigger`, the opener lives outside the drawer's tree.
+	 */
+	openerRef?: React.RefObject<HTMLElement | null>;
 	templateVersion: TemplateVersion | undefined;
 	variablesSectionRef: React.RefObject<HTMLDivElement | null>;
 };
@@ -30,8 +35,12 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	variablesSectionRef,
 	open,
 	onClose,
+	openerRef,
 }) => {
 	const logs = useWatchVersionLogs(templateVersion);
+	// Set when a close should keep focus on the variables input (the "Fill
+	// variables" flow) rather than returning it to the opener.
+	const preserveVariablesFocusRef = useRef(false);
 
 	const isMissingVariables =
 		error instanceof JobError &&
@@ -52,7 +61,26 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 			}}
 			direction="right"
 		>
-			<DrawerContent className="!w-[min(800px,100%)] !max-w-full">
+			<DrawerContent
+				className="!w-[min(800px,100%)] !max-w-full"
+				onCloseAutoFocus={(event) => {
+					// Radix focuses a DrawerTrigger on close by default, but this drawer
+					// has none, so restore focus to the opener (or the variables input
+					// for the "Fill variables" flow) to avoid dropping keyboard users on
+					// the document body.
+					if (preserveVariablesFocusRef.current) {
+						preserveVariablesFocusRef.current = false;
+						event.preventDefault();
+						variablesSectionRef.current?.querySelector("input")?.focus();
+						return;
+					}
+					const opener = openerRef?.current;
+					if (opener?.isConnected) {
+						event.preventDefault();
+						opener.focus();
+					}
+				}}
+			>
 				<div className="flex h-full flex-col">
 					<header
 						className="flex items-center justify-between border-b border-border px-6 bg-surface-secondary"
@@ -75,9 +103,7 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 								variablesSectionRef.current?.scrollIntoView({
 									behavior: "smooth",
 								});
-								const firstVariableInput =
-									variablesSectionRef.current?.querySelector("input");
-								firstVariableInput?.focus();
+								preserveVariablesFocusRef.current = true;
 								onClose();
 							}}
 						/>

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -1,5 +1,5 @@
 import { TriangleAlertIcon, XIcon } from "lucide-react";
-import { type FC, useRef } from "react";
+import type { FC } from "react";
 import { JobError } from "#/api/queries/templates";
 import type { TemplateVersion } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
@@ -20,27 +20,27 @@ type BuildLogsDrawerProps = {
 	error: unknown;
 	open: boolean;
 	onClose: () => void;
+	/** Invoked when the user opts to fill the missing template variables. */
+	onFillVariables: () => void;
 	/**
-	 * The element that opened the drawer. Focus returns here on close because,
-	 * unlike a `DrawerTrigger`, the opener lives outside the drawer's tree.
+	 * Forwarded to the drawer's `onCloseAutoFocus`. The drawer has no trigger,
+	 * so the parent owns where focus lands on close (e.g. the opener button).
 	 */
-	openerRef?: React.RefObject<HTMLElement | null>;
+	onCloseAutoFocus?: React.ComponentProps<
+		typeof DrawerContent
+	>["onCloseAutoFocus"];
 	templateVersion: TemplateVersion | undefined;
-	variablesSectionRef: React.RefObject<HTMLDivElement | null>;
 };
 
 export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	templateVersion,
 	error,
-	variablesSectionRef,
 	open,
 	onClose,
-	openerRef,
+	onFillVariables,
+	onCloseAutoFocus,
 }) => {
 	const logs = useWatchVersionLogs(templateVersion);
-	// Set when a close should keep focus on the variables input (the "Fill
-	// variables" flow) rather than returning it to the opener.
-	const preserveVariablesFocusRef = useRef(false);
 
 	const isMissingVariables =
 		error instanceof JobError &&
@@ -63,23 +63,7 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 		>
 			<DrawerContent
 				className="!w-[min(800px,100%)] !max-w-full"
-				onCloseAutoFocus={(event) => {
-					// Radix focuses a DrawerTrigger on close by default, but this drawer
-					// has none, so restore focus to the opener (or the variables input
-					// for the "Fill variables" flow) to avoid dropping keyboard users on
-					// the document body.
-					if (preserveVariablesFocusRef.current) {
-						preserveVariablesFocusRef.current = false;
-						event.preventDefault();
-						variablesSectionRef.current?.querySelector("input")?.focus();
-						return;
-					}
-					const opener = openerRef?.current;
-					if (opener?.isConnected) {
-						event.preventDefault();
-						opener.focus();
-					}
-				}}
+				onCloseAutoFocus={onCloseAutoFocus}
 			>
 				<div className="flex h-full flex-col">
 					<header
@@ -98,15 +82,7 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 					</header>
 
 					{isMissingVariables ? (
-						<MissingVariablesBanner
-							onFillVariables={() => {
-								variablesSectionRef.current?.scrollIntoView({
-									behavior: "smooth",
-								});
-								preserveVariablesFocusRef.current = true;
-								onClose();
-							}}
-						/>
+						<MissingVariablesBanner onFillVariables={onFillVariables} />
 					) : (
 						<>
 							{(matchingProvisioners === 0 || !hasLogs) && (

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -1,9 +1,14 @@
-import Drawer from "@mui/material/Drawer";
 import { TriangleAlertIcon, XIcon } from "lucide-react";
 import type { FC } from "react";
 import { JobError } from "#/api/queries/templates";
 import type { TemplateVersion } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerTitle,
+} from "#/components/Drawer/Drawer";
 import { Loader } from "#/components/Loader/Loader";
 import { AlertVariant } from "#/modules/provisioners/ProvisionerAlert";
 import { ProvisionerStatusAlert } from "#/modules/provisioners/ProvisionerStatusAlert";
@@ -23,7 +28,8 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	templateVersion,
 	error,
 	variablesSectionRef,
-	...drawerProps
+	open,
+	onClose,
 }) => {
 	const logs = useWatchVersionLogs(templateVersion);
 
@@ -37,52 +43,66 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	const hasLogs = logs && logs.length > 0;
 
 	return (
-		<Drawer anchor="right" {...drawerProps}>
-			<div className="flex h-full w-[800px] flex-col">
-				<header
-					className="flex items-center justify-between border-b border-border px-6"
-					style={{ height: navHeight }}
-				>
-					<h3 className="m-0 text-base font-medium">Creating template...</h3>
-					<Button size="icon-lg" variant="subtle" onClick={drawerProps.onClose}>
-						<XIcon />
-						<span className="sr-only">Close build logs</span>
-					</Button>
-				</header>
+		<Drawer
+			open={open}
+			onOpenChange={(isOpen) => {
+				if (!isOpen) {
+					onClose();
+				}
+			}}
+			direction="right"
+		>
+			<DrawerContent className="!w-[min(800px,100%)] !max-w-full">
+				<div className="flex h-full flex-col">
+					<header
+						className="flex items-center justify-between border-b border-border px-6 bg-surface-secondary"
+						style={{ height: navHeight }}
+					>
+						<DrawerTitle className="m-0 text-base font-medium">
+							Creating template...
+						</DrawerTitle>
+						<DrawerClose asChild>
+							<Button size="icon-lg" variant="subtle">
+								<XIcon />
+								<span className="sr-only">Close build logs</span>
+							</Button>
+						</DrawerClose>
+					</header>
 
-				{isMissingVariables ? (
-					<MissingVariablesBanner
-						onFillVariables={() => {
-							variablesSectionRef.current?.scrollIntoView({
-								behavior: "smooth",
-							});
-							const firstVariableInput =
-								variablesSectionRef.current?.querySelector("input");
-							firstVariableInput?.focus();
-							drawerProps.onClose();
-						}}
-					/>
-				) : (
-					<>
-						{(matchingProvisioners === 0 || !hasLogs) && (
-							<ProvisionerStatusAlert
-								matchingProvisioners={matchingProvisioners}
-								availableProvisioners={availableProvisioners}
-								tags={templateVersion?.job.tags ?? {}}
-								variant={AlertVariant.Inline}
-							/>
-						)}
+					{isMissingVariables ? (
+						<MissingVariablesBanner
+							onFillVariables={() => {
+								variablesSectionRef.current?.scrollIntoView({
+									behavior: "smooth",
+								});
+								const firstVariableInput =
+									variablesSectionRef.current?.querySelector("input");
+								firstVariableInput?.focus();
+								onClose();
+							}}
+						/>
+					) : (
+						<>
+							{(matchingProvisioners === 0 || !hasLogs) && (
+								<ProvisionerStatusAlert
+									matchingProvisioners={matchingProvisioners}
+									availableProvisioners={availableProvisioners}
+									tags={templateVersion?.job.tags ?? {}}
+									variant={AlertVariant.Inline}
+								/>
+							)}
 
-						{hasLogs ? (
-							<section className="flex-1 overflow-auto bg-surface-primary">
-								<WorkspaceBuildLogs logs={logs} className="border-0" />
-							</section>
-						) : (
-							<Loader />
-						)}
-					</>
-				)}
-			</div>
+							{hasLogs ? (
+								<section className="flex-1 overflow-auto bg-surface-primary">
+									<WorkspaceBuildLogs logs={logs} className="border-0" />
+								</section>
+							) : (
+								<Loader />
+							)}
+						</>
+					)}
+				</div>
+			</DrawerContent>
 		</Drawer>
 	);
 };

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -67,7 +67,7 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 			>
 				<div className="flex h-full flex-col">
 					<header
-						className="flex items-center justify-between border-b border-border px-6 bg-surface-secondary"
+						className="flex items-center justify-between border-b border-border px-6 bg-surface-tertiary"
 						style={{ height: navHeight }}
 					>
 						<DrawerTitle className="m-0 text-base font-medium">

--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
@@ -24,6 +24,9 @@ const CreateTemplatePage: FC = () => {
 	// close. The drawer is opened from buttons outside its tree, so Radix has no
 	// trigger to fall back to.
 	const buildLogsOpenerRef = useRef<HTMLElement | null>(null);
+	// Keeps focus on the variables input (rather than the opener) when the drawer
+	// closes via the "Fill variables" action.
+	const preserveVariablesFocusRef = useRef(false);
 
 	const openBuildLogs = () => {
 		buildLogsOpenerRef.current =
@@ -31,6 +34,30 @@ const CreateTemplatePage: FC = () => {
 				? document.activeElement
 				: null;
 		setIsBuildLogsOpen(true);
+	};
+
+	const fillVariables = () => {
+		variablesSectionRef.current?.scrollIntoView({ behavior: "smooth" });
+		preserveVariablesFocusRef.current = true;
+		setIsBuildLogsOpen(false);
+	};
+
+	const restoreFocusOnDrawerClose = (event: Event) => {
+		// Radix focuses a DrawerTrigger on close by default, but this drawer has
+		// none. Return focus to the variables input for the "Fill variables" flow,
+		// otherwise to whatever opened the drawer, so keyboard users are not
+		// dropped onto the document body.
+		if (preserveVariablesFocusRef.current) {
+			preserveVariablesFocusRef.current = false;
+			event.preventDefault();
+			variablesSectionRef.current?.querySelector("input")?.focus();
+			return;
+		}
+		const opener = buildLogsOpenerRef.current;
+		if (opener?.isConnected) {
+			event.preventDefault();
+			opener.focus();
+		}
 	};
 
 	const pageViewProps: CreateTemplatePageViewProps = {
@@ -72,9 +99,9 @@ const CreateTemplatePage: FC = () => {
 				error={createTemplateMutation.error}
 				open={isBuildLogsOpen}
 				onClose={() => setIsBuildLogsOpen(false)}
-				openerRef={buildLogsOpenerRef}
+				onFillVariables={fillVariables}
+				onCloseAutoFocus={restoreFocusOnDrawerClose}
 				templateVersion={templateVersion}
-				variablesSectionRef={variablesSectionRef}
 			/>
 		</>
 	);

--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
@@ -20,10 +20,22 @@ const CreateTemplatePage: FC = () => {
 	const [templateVersion, setTemplateVersion] = useState<TemplateVersion>();
 	const createTemplateMutation = useMutation(createTemplate());
 	const variablesSectionRef = useRef<HTMLDivElement>(null);
+	// Remember what had focus when the drawer opened so it can be restored on
+	// close. The drawer is opened from buttons outside its tree, so Radix has no
+	// trigger to fall back to.
+	const buildLogsOpenerRef = useRef<HTMLElement | null>(null);
+
+	const openBuildLogs = () => {
+		buildLogsOpenerRef.current =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
+		setIsBuildLogsOpen(true);
+	};
 
 	const pageViewProps: CreateTemplatePageViewProps = {
 		onCreateTemplate: async (options) => {
-			setIsBuildLogsOpen(true);
+			openBuildLogs();
 			const template = await createTemplateMutation.mutateAsync({
 				...options,
 				onCreateVersion: setTemplateVersion,
@@ -36,7 +48,7 @@ const CreateTemplatePage: FC = () => {
 				{ state: { justCreated: true } },
 			);
 		},
-		onOpenBuildLogsDrawer: () => setIsBuildLogsOpen(true),
+		onOpenBuildLogsDrawer: openBuildLogs,
 		error: createTemplateMutation.error,
 		isCreating: createTemplateMutation.isPending,
 		variablesSectionRef,
@@ -60,6 +72,7 @@ const CreateTemplatePage: FC = () => {
 				error={createTemplateMutation.error}
 				open={isBuildLogsOpen}
 				onClose={() => setIsBuildLogsOpen(false)}
+				openerRef={buildLogsOpenerRef}
 				templateVersion={templateVersion}
 				variablesSectionRef={variablesSectionRef}
 			/>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Follow-up to #27798. That PR introduced a shared `Drawer` primitive by adding [`vaul`](https://github.com/emilkowalski/vaul) as a dependency. As raised in review, `vaul` is currently unmaintained, and this drawer is the only place in the UI using that concept.

This PR takes the [suggested](https://github.com/coder/coder/pull/27798#pullrequestreview-4901095865) route: a dead-simple, self-owned drawer that covers this one case well, built directly on Radix UI's `Dialog` (already a dependency via `radix-ui`) instead of `vaul`. It keeps the same shadcn-style API (`Drawer`, `DrawerTrigger`, `DrawerContent`, `DrawerHeader`, `DrawerFooter`, `DrawerTitle`, `DrawerDescription`, `DrawerClose`) so usage stays familiar, and migrates `CreateTemplatePage`'s `BuildLogsDrawer` off MUI onto it.

### What changed

- Add `site/src/components/Drawer/Drawer.tsx`: a reusable drawer/sheet built on `radix-ui` `Dialog`. Supports a `direction` prop (`top`/`bottom`/`left`/`right`, default `right`) with slide animations via `tailwindcss-animate`. No new dependencies.
- Migrate `BuildLogsDrawer` from `@mui/material/Drawer` to the new component. Desktop panel stays at 800px via `min(800px, 100%)` so it stays within the viewport on mobile.
- Storybook coverage with `play()` functions for both the generic `Drawer` (open/close, direction) and `BuildLogsDrawer` (close via the X button and via Escape assert `onClose`), addressing the earlier P1 review note about covering the controlled close path.

### Why Radix instead of vaul

- `radix-ui` `Dialog` is already a dependency and provides accessibility, focus management, and open/close state.
- No dependency on an unmaintained package for a single-use concept.
- `vaul`'s drag-to-dismiss gesture is not needed for this build-logs use case.