### PR TITLE
refactor(site): reimplement CreateTemplatePage build logs drawer on Base UI

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -37,6 +37,7 @@
 		"#/*": "./src/*"
 	},
 	"dependencies": {
+		"@base-ui-components/react": "1.0.0-rc.0",
 		"@dnd-kit/core": "6.3.1",
 		"@dnd-kit/sortable": "10.0.0",
 		"@dnd-kit/utilities": "3.2.2",
@@ -116,7 +117,6 @@
 		"ufuzzy": "npm:@leeoniya/ufuzzy@1.0.10",
 		"unique-names-generator": "4.7.1",
 		"uuid": "14.0.0",
-		"vaul": "1.1.2",
 		"websocket-ts": "2.3.0",
 		"yup": "1.7.1"
 	},

--- a/site/package.json
+++ b/site/package.json
@@ -116,6 +116,7 @@
 		"ufuzzy": "npm:@leeoniya/ufuzzy@1.0.10",
 		"unique-names-generator": "4.7.1",
 		"uuid": "14.0.0",
+		"vaul": "1.1.2",
 		"websocket-ts": "2.3.0",
 		"yup": "1.7.1"
 	},

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   .:
     dependencies:
+      '@base-ui-components/react':
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -269,9 +272,6 @@ importers:
       uuid:
         specifier: 11.1.1
         version: 11.1.1
-      vaul:
-        specifier: 1.1.2
-        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       websocket-ts:
         specifier: 2.3.0
         version: 2.3.0
@@ -591,6 +591,29 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==, tarball: https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui-components/react@1.0.0-rc.0':
+    resolution: {integrity: sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ==, tarball: https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-rc.0.tgz}
+    engines: {node: '>=14.0.0'}
+    deprecated: Package was renamed to @base-ui/react
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui-components/utils@0.2.2':
+    resolution: {integrity: sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==, tarball: https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.2.2.tgz}
+    deprecated: Package was renamed to @base-ui/utils
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@biomejs/biome@2.4.10':
     resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==, tarball: https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.10.tgz}
@@ -5580,6 +5603,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==, tarball: https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==, tarball: https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz}
+
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==, tarball: https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz}
 
@@ -6231,12 +6257,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==, tarball: https://registry.npmjs.org/vary/-/vary-1.1.2.tgz}
     engines: {node: '>= 0.8'}
 
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==, tarball: https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==, tarball: https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz}
 
@@ -6732,6 +6752,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-ui-components/react@1.0.0-rc.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@base-ui-components/utils': 0.2.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      reselect: 5.2.0
+      tabbable: 6.4.0
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui-components/utils@0.2.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@biomejs/biome@2.4.10':
     optionalDependencies:
@@ -12214,6 +12259,8 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  reselect@5.2.0: {}
+
   resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
@@ -12937,15 +12984,6 @@ snapshots:
       typescript: 6.0.2
 
   vary@1.1.2: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       uuid:
         specifier: 11.1.1
         version: 11.1.1
+      vaul:
+        specifier: 1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       websocket-ts:
         specifier: 2.3.0
         version: 2.3.0
@@ -6227,6 +6230,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==, tarball: https://registry.npmjs.org/vary/-/vary-1.1.2.tgz}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==, tarball: https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==, tarball: https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz}
@@ -12928,6 +12937,15 @@ snapshots:
       typescript: 6.0.2
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:

--- a/site/src/components/Drawer/Drawer.stories.tsx
+++ b/site/src/components/Drawer/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { Button } from "#/components/Button/Button";
 import {
 	Drawer,
@@ -18,18 +18,14 @@ const meta: Meta<typeof Drawer> = {
 	args: {
 		children: (
 			<>
-				<DrawerTrigger asChild>
-					<Button>Open Drawer</Button>
-				</DrawerTrigger>
+				<DrawerTrigger render={<Button>Open Drawer</Button>} />
 				<DrawerContent>
 					<DrawerHeader>
 						<DrawerTitle>Example Drawer Title</DrawerTitle>
 						<DrawerDescription>Drawer description text</DrawerDescription>
 					</DrawerHeader>
 					<DrawerFooter>
-						<DrawerClose asChild>
-							<Button variant="outline">Cancel</Button>
-						</DrawerClose>
+						<DrawerClose render={<Button variant="outline">Cancel</Button>} />
 						<Button>Submit</Button>
 					</DrawerFooter>
 				</DrawerContent>
@@ -45,6 +41,21 @@ export const OpenDrawer: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button", { name: "Open Drawer" }));
+		await expect(await screen.findByRole("dialog")).toBeInTheDocument();
+	},
+};
+
+export const CloseDrawer: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Open Drawer" }));
+		const dialog = await screen.findByRole("dialog");
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Cancel" }),
+		);
+		await waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
 	},
 };
 
@@ -53,9 +64,7 @@ export const OpenRightDrawer: Story = {
 		direction: "right",
 		children: (
 			<>
-				<DrawerTrigger asChild>
-					<Button>Open Right Drawer</Button>
-				</DrawerTrigger>
+				<DrawerTrigger render={<Button>Open Right Drawer</Button>} />
 				<DrawerContent className="sm:max-w-md">
 					<DrawerHeader>
 						<DrawerTitle>Right-side drawer</DrawerTitle>
@@ -64,9 +73,7 @@ export const OpenRightDrawer: Story = {
 						</DrawerDescription>
 					</DrawerHeader>
 					<DrawerFooter>
-						<DrawerClose asChild>
-							<Button variant="outline">Close</Button>
-						</DrawerClose>
+						<DrawerClose render={<Button variant="outline">Close</Button>} />
 					</DrawerFooter>
 				</DrawerContent>
 			</>
@@ -77,5 +84,6 @@ export const OpenRightDrawer: Story = {
 		await userEvent.click(
 			canvas.getByRole("button", { name: "Open Right Drawer" }),
 		);
+		await expect(await screen.findByRole("dialog")).toBeInTheDocument();
 	},
 };

--- a/site/src/components/Drawer/Drawer.stories.tsx
+++ b/site/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import { Button } from "#/components/Button/Button";
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from "./Drawer";
+
+const meta: Meta<typeof Drawer> = {
+	title: "components/Drawer",
+	component: Drawer,
+	args: {
+		children: (
+			<>
+				<DrawerTrigger asChild>
+					<Button>Open Drawer</Button>
+				</DrawerTrigger>
+				<DrawerContent>
+					<DrawerHeader>
+						<DrawerTitle>Example Drawer Title</DrawerTitle>
+						<DrawerDescription>Drawer description text</DrawerDescription>
+					</DrawerHeader>
+					<DrawerFooter>
+						<DrawerClose asChild>
+							<Button variant="outline">Cancel</Button>
+						</DrawerClose>
+						<Button>Submit</Button>
+					</DrawerFooter>
+				</DrawerContent>
+			</>
+		),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+export const OpenDrawer: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Open Drawer" }));
+	},
+};
+
+export const OpenRightDrawer: Story = {
+	args: {
+		direction: "right",
+		children: (
+			<>
+				<DrawerTrigger asChild>
+					<Button>Open Right Drawer</Button>
+				</DrawerTrigger>
+				<DrawerContent className="sm:max-w-md">
+					<DrawerHeader>
+						<DrawerTitle>Right-side drawer</DrawerTitle>
+						<DrawerDescription>
+							Drawers can open from any side via the direction prop.
+						</DrawerDescription>
+					</DrawerHeader>
+					<DrawerFooter>
+						<DrawerClose asChild>
+							<Button variant="outline">Close</Button>
+						</DrawerClose>
+					</DrawerFooter>
+				</DrawerContent>
+			</>
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Open Right Drawer" }),
+		);
+	},
+};

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,131 @@
+/**
+ * Copied from shadcn/ui on 08/04/2026
+ * @see {@link https://ui.shadcn.com/docs/components/drawer}
+ */
+import { Drawer as DrawerPrimitive } from "vaul";
+import { cn } from "#/utils/cn";
+
+export const Drawer: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Root>
+> = ({ shouldScaleBackground = true, ...props }) => {
+	return (
+		<DrawerPrimitive.Root
+			shouldScaleBackground={shouldScaleBackground}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerTrigger = DrawerPrimitive.Trigger;
+
+export const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerOverlay: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Overlay>
+> = ({ className, ...props }) => {
+	return (
+		<DrawerPrimitive.Overlay
+			className={cn(
+				`fixed inset-0 z-50 bg-overlay
+				data-[state=open]:animate-in data-[state=closed]:animate-out
+				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerContent: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Content>
+> = ({ className, children, ...props }) => {
+	return (
+		<DrawerPortal>
+			<DrawerOverlay />
+			<DrawerPrimitive.Content
+				className={cn(
+					"group/drawer-content fixed z-50 flex h-auto flex-col bg-surface-primary outline-none",
+					`data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0
+					data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh]
+					data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=top]:border-border`,
+					`data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0
+					data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh]
+					data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=bottom]:border-border`,
+					`data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0
+					data-[vaul-drawer-direction=right]:h-full data-[vaul-drawer-direction=right]:w-3/4
+					data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:border-border
+					data-[vaul-drawer-direction=right]:sm:max-w-sm`,
+					`data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0
+					data-[vaul-drawer-direction=left]:h-full data-[vaul-drawer-direction=left]:w-3/4
+					data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:border-border
+					data-[vaul-drawer-direction=left]:sm:max-w-sm`,
+					className,
+				)}
+				{...props}
+			>
+				<div
+					className={`mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-surface-tertiary
+					group-data-[vaul-drawer-direction=bottom]/drawer-content:block`}
+				/>
+				{children}
+			</DrawerPrimitive.Content>
+		</DrawerPortal>
+	);
+};
+
+export const DrawerHeader: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn(
+				`flex flex-col gap-0.5 p-4
+				group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center
+				group-data-[vaul-drawer-direction=top]/drawer-content:text-center
+				md:gap-1.5 md:text-left`,
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerTitle: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Title>
+> = ({ className, ...props }) => {
+	return (
+		<DrawerPrimitive.Title
+			className={cn(
+				"text-lg font-semibold leading-none tracking-tight text-content-primary",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export const DrawerDescription: React.FC<
+	React.ComponentPropsWithRef<typeof DrawerPrimitive.Description>
+> = ({ className, ...props }) => {
+	return (
+		<DrawerPrimitive.Description
+			className={cn("text-sm text-content-secondary", className)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,36 +1,49 @@
 /**
- * Copied from shadcn/ui on 08/04/2026
+ * Adapted from shadcn/ui's Drawer, reimplemented on top of Base UI's Dialog
+ * primitive instead of the unmaintained `vaul` package. Base UI has no
+ * dedicated drawer, so the slide-in behavior is layered on the Dialog parts
+ * with the same public API shadcn exposes.
  * @see {@link https://ui.shadcn.com/docs/components/drawer}
+ * @see {@link https://base-ui.com/react/components/dialog}
  */
-import { Drawer as DrawerPrimitive } from "vaul";
+import { Dialog as DialogPrimitive } from "@base-ui-components/react/dialog";
+import { createContext, useContext } from "react";
 import { cn } from "#/utils/cn";
 
-export const Drawer: React.FC<
-	React.ComponentPropsWithRef<typeof DrawerPrimitive.Root>
-> = ({ shouldScaleBackground = true, ...props }) => {
+type DrawerDirection = "top" | "bottom" | "left" | "right";
+
+const DrawerDirectionContext = createContext<DrawerDirection>("right");
+
+type DrawerProps = React.ComponentPropsWithRef<typeof DialogPrimitive.Root> & {
+	direction?: DrawerDirection;
+};
+
+export const Drawer: React.FC<DrawerProps> = ({
+	direction = "right",
+	...props
+}) => {
 	return (
-		<DrawerPrimitive.Root
-			shouldScaleBackground={shouldScaleBackground}
-			{...props}
-		/>
+		<DrawerDirectionContext.Provider value={direction}>
+			<DialogPrimitive.Root {...props} />
+		</DrawerDirectionContext.Provider>
 	);
 };
 
-export const DrawerTrigger = DrawerPrimitive.Trigger;
+export const DrawerTrigger = DialogPrimitive.Trigger;
 
-export const DrawerClose = DrawerPrimitive.Close;
+export const DrawerClose = DialogPrimitive.Close;
 
-const DrawerPortal = DrawerPrimitive.Portal;
+const DrawerPortal = DialogPrimitive.Portal;
 
 const DrawerOverlay: React.FC<
-	React.ComponentPropsWithRef<typeof DrawerPrimitive.Overlay>
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Backdrop>
 > = ({ className, ...props }) => {
 	return (
-		<DrawerPrimitive.Overlay
+		<DialogPrimitive.Backdrop
 			className={cn(
 				`fixed inset-0 z-50 bg-overlay
-				data-[state=open]:animate-in data-[state=closed]:animate-out
-				data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+				data-[open]:animate-in data-[closed]:animate-out
+				data-[closed]:fade-out-0 data-[open]:fade-in-0`,
 				className,
 			)}
 			{...props}
@@ -38,39 +51,41 @@ const DrawerOverlay: React.FC<
 	);
 };
 
+const directionClasses: Record<DrawerDirection, string> = {
+	top: `inset-x-0 top-0 mb-24 max-h-[80vh] rounded-b-lg border-b border-border
+		data-[open]:slide-in-from-top data-[closed]:slide-out-to-top`,
+	bottom: `inset-x-0 bottom-0 mt-24 max-h-[80vh] rounded-t-lg border-t border-border
+		data-[open]:slide-in-from-bottom data-[closed]:slide-out-to-bottom`,
+	right: `inset-y-0 right-0 h-full w-3/4 border-l border-border sm:max-w-sm
+		data-[open]:slide-in-from-right data-[closed]:slide-out-to-right`,
+	left: `inset-y-0 left-0 h-full w-3/4 border-r border-border sm:max-w-sm
+		data-[open]:slide-in-from-left data-[closed]:slide-out-to-left`,
+};
+
 export const DrawerContent: React.FC<
-	React.ComponentPropsWithRef<typeof DrawerPrimitive.Content>
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Popup>
 > = ({ className, children, ...props }) => {
+	const direction = useContext(DrawerDirectionContext);
 	return (
 		<DrawerPortal>
 			<DrawerOverlay />
-			<DrawerPrimitive.Content
+			<DialogPrimitive.Popup
+				data-drawer-direction={direction}
 				className={cn(
-					"group/drawer-content fixed z-50 flex h-auto flex-col bg-surface-primary outline-none",
-					`data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0
-					data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh]
-					data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=top]:border-border`,
-					`data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0
-					data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh]
-					data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=bottom]:border-border`,
-					`data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0
-					data-[vaul-drawer-direction=right]:h-full data-[vaul-drawer-direction=right]:w-3/4
-					data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:border-border
-					data-[vaul-drawer-direction=right]:sm:max-w-sm`,
-					`data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0
-					data-[vaul-drawer-direction=left]:h-full data-[vaul-drawer-direction=left]:w-3/4
-					data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:border-border
-					data-[vaul-drawer-direction=left]:sm:max-w-sm`,
+					`group/drawer-content fixed z-50 flex h-auto flex-col bg-surface-primary outline-none
+					transition ease-in-out data-[open]:animate-in data-[closed]:animate-out
+					data-[closed]:duration-300 data-[open]:duration-500`,
+					directionClasses[direction],
 					className,
 				)}
 				{...props}
 			>
 				<div
 					className={`mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-surface-tertiary
-					group-data-[vaul-drawer-direction=bottom]/drawer-content:block`}
+					group-data-[drawer-direction=bottom]/drawer-content:block`}
 				/>
 				{children}
-			</DrawerPrimitive.Content>
+			</DialogPrimitive.Popup>
 		</DrawerPortal>
 	);
 };
@@ -83,8 +98,8 @@ export const DrawerHeader: React.FC<React.ComponentPropsWithRef<"div">> = ({
 		<div
 			className={cn(
 				`flex flex-col gap-0.5 p-4
-				group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center
-				group-data-[vaul-drawer-direction=top]/drawer-content:text-center
+				group-data-[drawer-direction=bottom]/drawer-content:text-center
+				group-data-[drawer-direction=top]/drawer-content:text-center
 				md:gap-1.5 md:text-left`,
 				className,
 			)}
@@ -106,10 +121,10 @@ export const DrawerFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
 };
 
 export const DrawerTitle: React.FC<
-	React.ComponentPropsWithRef<typeof DrawerPrimitive.Title>
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Title>
 > = ({ className, ...props }) => {
 	return (
-		<DrawerPrimitive.Title
+		<DialogPrimitive.Title
 			className={cn(
 				"text-lg font-semibold leading-none tracking-tight text-content-primary",
 				className,
@@ -120,10 +135,10 @@ export const DrawerTitle: React.FC<
 };
 
 export const DrawerDescription: React.FC<
-	React.ComponentPropsWithRef<typeof DrawerPrimitive.Description>
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Description>
 > = ({ className, ...props }) => {
 	return (
-		<DrawerPrimitive.Description
+		<DialogPrimitive.Description
 			className={cn("text-sm text-content-secondary", className)}
 			{...props}
 		/>

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -61,11 +61,9 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 						<DrawerTitle className="m-0 text-base font-medium">
 							Creating template...
 						</DrawerTitle>
-						<DrawerClose asChild>
-							<Button size="icon-lg" variant="subtle">
-								<XIcon />
-								<span className="sr-only">Close build logs</span>
-							</Button>
+						<DrawerClose render={<Button size="icon-lg" variant="subtle" />}>
+							<XIcon />
+							<span className="sr-only">Close build logs</span>
 						</DrawerClose>
 					</header>
 

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.tsx
@@ -1,9 +1,14 @@
-import Drawer from "@mui/material/Drawer";
 import { TriangleAlertIcon, XIcon } from "lucide-react";
 import type { FC } from "react";
 import { JobError } from "#/api/queries/templates";
 import type { TemplateVersion } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerTitle,
+} from "#/components/Drawer/Drawer";
 import { Loader } from "#/components/Loader/Loader";
 import { AlertVariant } from "#/modules/provisioners/ProvisionerAlert";
 import { ProvisionerStatusAlert } from "#/modules/provisioners/ProvisionerStatusAlert";
@@ -23,7 +28,8 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	templateVersion,
 	error,
 	variablesSectionRef,
-	...drawerProps
+	open,
+	onClose,
 }) => {
 	const logs = useWatchVersionLogs(templateVersion);
 
@@ -37,52 +43,66 @@ export const BuildLogsDrawer: FC<BuildLogsDrawerProps> = ({
 	const hasLogs = logs && logs.length > 0;
 
 	return (
-		<Drawer anchor="right" {...drawerProps}>
-			<div className="flex h-full w-[800px] flex-col">
-				<header
-					className="flex items-center justify-between border-b border-border px-6"
-					style={{ height: navHeight }}
-				>
-					<h3 className="m-0 text-base font-medium">Creating template...</h3>
-					<Button size="icon-lg" variant="subtle" onClick={drawerProps.onClose}>
-						<XIcon />
-						<span className="sr-only">Close build logs</span>
-					</Button>
-				</header>
+		<Drawer
+			open={open}
+			onOpenChange={(isOpen) => {
+				if (!isOpen) {
+					onClose();
+				}
+			}}
+			direction="right"
+		>
+			<DrawerContent className="!w-[min(800px,100%)] !max-w-full">
+				<div className="flex h-full flex-col">
+					<header
+						className="flex items-center justify-between border-b border-border px-6 bg-surface-secondary"
+						style={{ height: navHeight }}
+					>
+						<DrawerTitle className="m-0 text-base font-medium">
+							Creating template...
+						</DrawerTitle>
+						<DrawerClose asChild>
+							<Button size="icon-lg" variant="subtle">
+								<XIcon />
+								<span className="sr-only">Close build logs</span>
+							</Button>
+						</DrawerClose>
+					</header>
 
-				{isMissingVariables ? (
-					<MissingVariablesBanner
-						onFillVariables={() => {
-							variablesSectionRef.current?.scrollIntoView({
-								behavior: "smooth",
-							});
-							const firstVariableInput =
-								variablesSectionRef.current?.querySelector("input");
-							firstVariableInput?.focus();
-							drawerProps.onClose();
-						}}
-					/>
-				) : (
-					<>
-						{(matchingProvisioners === 0 || !hasLogs) && (
-							<ProvisionerStatusAlert
-								matchingProvisioners={matchingProvisioners}
-								availableProvisioners={availableProvisioners}
-								tags={templateVersion?.job.tags ?? {}}
-								variant={AlertVariant.Inline}
-							/>
-						)}
+					{isMissingVariables ? (
+						<MissingVariablesBanner
+							onFillVariables={() => {
+								variablesSectionRef.current?.scrollIntoView({
+									behavior: "smooth",
+								});
+								const firstVariableInput =
+									variablesSectionRef.current?.querySelector("input");
+								firstVariableInput?.focus();
+								onClose();
+							}}
+						/>
+					) : (
+						<>
+							{(matchingProvisioners === 0 || !hasLogs) && (
+								<ProvisionerStatusAlert
+									matchingProvisioners={matchingProvisioners}
+									availableProvisioners={availableProvisioners}
+									tags={templateVersion?.job.tags ?? {}}
+									variant={AlertVariant.Inline}
+								/>
+							)}
 
-						{hasLogs ? (
-							<section className="flex-1 overflow-auto bg-surface-primary">
-								<WorkspaceBuildLogs logs={logs} className="border-0" />
-							</section>
-						) : (
-							<Loader />
-						)}
-					</>
-				)}
-			</div>
+							{hasLogs ? (
+								<section className="flex-1 overflow-auto bg-surface-primary">
+									<WorkspaceBuildLogs logs={logs} className="border-0" />
+								</section>
+							) : (
+								<Loader />
+							)}
+						</>
+					)}
+				</div>
+			</DrawerContent>
 		</Drawer>
 	);
 };


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Replaces the unmaintained [`vaul`](https://github.com/emilkowalski/vaul) dependency with a shared `Drawer` primitive built on [Base UI](https://base-ui.com)'s `Dialog`, then migrates the Create Template `BuildLogsDrawer` onto it. This is an alternative to #27798 that answers the review question about whether Base UI can cover this one drawer use case.

## What changed

- Adds `@base-ui-components/react` and drops `vaul`.
- New `site/src/components/Drawer/Drawer.tsx` keeps the shadcn-derived public API (`Drawer`, `DrawerTrigger`, `DrawerClose`, `DrawerContent`, `DrawerHeader`, `DrawerFooter`, `DrawerTitle`, `DrawerDescription`) but is implemented on Base UI's `Dialog` parts.
- `direction` (`top` | `bottom` | `left` | `right`) is preserved via context, with slide/fade animations driven by `tailwindcss-animate` off Base UI's `data-open`/`data-closed` attributes.
- `BuildLogsDrawer` keeps the 800px desktop panel and `min(800px, 100%)` mobile clamp.
- Storybook stories exercise open **and** close paths via `play` functions, covering the controlled close callback.

## Notes for reviewers

- Base UI composes via the `render` prop rather than Radix/Vaul's `asChild`, so `DrawerClose`/`DrawerTrigger` consumers use `render={<Button .../>}`.
- Base UI's `Dialog` is modal by default (focus trap + scroll lock) and closes on outside click / Escape, matching the previous behavior.

<details>
<summary>Decision log</summary>

- **Why Base UI Dialog, not a bespoke component:** Base UI has no dedicated drawer, but its `Dialog` provides the portal, backdrop, focus management, and controlled open state a drawer needs. Layering slide-in styling on top keeps the same footprint shadcn's drawer had, without a maintenance-orphaned dependency.
- **API parity:** Kept every exported part name so the migration is a drop-in for the existing `BuildLogsDrawer` and any future consumers, aside from the `asChild` -> `render` composition change that Base UI mandates.
- **Animations:** Reused `tailwindcss-animate` (already in the repo) and mapped shadcn's `data-[state=open|closed]` selectors onto Base UI's `data-open`/`data-closed`, so the visual behavior is unchanged.
- **Direction:** Implemented via React context + a `data-drawer-direction` attribute on the popup, replacing Vaul's automatic `data-vaul-drawer-direction`.
- **Validation:** `tsc`, Biome, and the Drawer + BuildLogsDrawer Storybook interaction tests all pass locally.

</details>

Related: #27798 · DEVEX-251