### PR TITLE
docs(docs/install/releases): backport release calendar to release/2.36

### DIFF
--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -80,13 +80,13 @@ pages.
 | Release name                                     | Release Date      | Status                   | Latest Release                                                   |
 |--------------------------------------------------|-------------------|--------------------------|------------------------------------------------------------------|
 | [2.29](https://coder.com/changelog/coder-2-29)   | December 02, 2025 | Extended Support Release | [v2.29.19](https://github.com/coder/coder/releases/tag/v2.29.19) |
-| [2.30](https://coder.com/changelog/coder-2-30)   | February 03, 2026 | Not Supported            | [v2.30.9](https://github.com/coder/coder/releases/tag/v2.30.9)   |
 | [2.31](https://coder.com/changelog/coder-2-31)   | February 23, 2026 | Not Supported            | [v2.31.14](https://github.com/coder/coder/releases/tag/v2.31.14) |
 | [2.32](https://coder.com/changelog/coder-2-32)   | April 14, 2026    | Not Supported            | [v2.32.10](https://github.com/coder/coder/releases/tag/v2.32.10) |
-| [2.33](https://coder.com/changelog/coder-2-33)   | May 05, 2026      | Security Support         | [v2.33.11](https://github.com/coder/coder/releases/tag/v2.33.11) |
-| [2.34](https://coder.com/changelog/coder-2-34)   | June 02, 2026     | Stable (ESR)             | [v2.34.6](https://github.com/coder/coder/releases/tag/v2.34.6)   |
-| [2.35](https://coder.com/changelog/coder-2-35-1) | July 07, 2026     | Mainline                 | [v2.35.2](https://github.com/coder/coder/releases/tag/v2.35.2)   |
-| 2.36                                             |                   | Not Released             | N/A                                                              |
+| [2.33](https://coder.com/changelog/coder-2-33)   | May 05, 2026      | Not Supported            | [v2.33.11](https://github.com/coder/coder/releases/tag/v2.33.11) |
+| [2.34](https://coder.com/changelog/coder-2-34)   | June 02, 2026     | Security Support         | [v2.34.8](https://github.com/coder/coder/releases/tag/v2.34.8)   |
+| [2.35](https://coder.com/changelog/coder-2-35-1) | July 07, 2026     | Stable                   | [v2.35.4](https://github.com/coder/coder/releases/tag/v2.35.4)   |
+| [2.36](https://coder.com/changelog/coder-2-36)   | August 04, 2026   | Mainline                 | [v2.36.0](https://github.com/coder/coder/releases/tag/v2.36.0)   |
+| 2.37                                             |                   | Not Released             | N/A                                                              |
 <!-- RELEASE_CALENDAR_END -->
 
 > [!TIP]


### PR DESCRIPTION
Backport the current release calendar from `main` to `release/2.36` so the versioned `v2.36` docs page shows the correct schedule instead of the stale one frozen when the branch was cut.

_Opened as a draft by Coder Agents on behalf of @mtojek._