### PR TITLE
fix(codersdk/licenses.go): read trial claim instead of misspelled trail

### DIFF
--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -57,8 +57,8 @@ func (l *License) ExpiresAt() (time.Time, error) {
 }
 
 func (l *License) Trial() bool {
-	if trail, ok := l.Claims["trail"].(bool); ok {
-		return trail
+	if trial, ok := l.Claims["trial"].(bool); ok {
+		return trial
 	}
 	return false
 }


### PR DESCRIPTION
## What this fixes

`codersdk.License.Trial()` looked up the JWT claim `"trail"` (a typo) instead of `"trial"`, the actual claim name set by license issuance (`enterprise/coderd/license/license.go`). Since no license contains a `"trail"` claim, the method always returned `false`.

The only consumer is `coder licenses list` (via `cli/cliutil/license.go`), so the CLI never reported a license as a trial even when it was one. The web UI is unaffected because it reads `claims.trial` directly.

## Changes

- Read the `"trial"` claim in `License.Trial()`.

## Testing

- `go build` / `go vet` on `codersdk` and `cli/cliutil`.
- `go test -run 'TestLicensesListFake|TestLicensesListReal' ./enterprise/cli` passes.
