### PR TITLE
fix: disable keep-alives on mock aibridged to prevent stale-conn EOF

### DIFF
--- a/enterprise/aibridgeproxyd/reload_test.go
+++ b/enterprise/aibridgeproxyd/reload_test.go
@@ -154,6 +154,11 @@ func newReloadTestHarness(t *testing.T) *reloadTestHarness {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("aibridged"))
 	}))
+	// The proxy reuses pooled connections to aibridged, but net/http will
+	// not retry a POST on a closed pooled conn, so a stale reuse fails
+	// with a bare EOF on Windows. Force a fresh conn per request.
+	// https://github.com/coder/internal/issues/1564 (AIGOV-430)
+	bridged.Config.SetKeepAlivesEnabled(false)
 	t.Cleanup(bridged.Close)
 
 	store := &providerStore{}


### PR DESCRIPTION
Fixes the Windows-only `TestProxy_HotReloadRouting` EOF flake (AIGOV-430 / [internal#1564](https://github.com/coder/internal/issues/1564)).

## Root cause

The proxy forwards MITM'd requests to aibridged over a keep-alive-pooled `http.Transport`. net/http will not retry a POST on a reused-but-closed pooled connection (a POST isn't replayable), so a stale reuse of a conn the mock aibridged has closed surfaces as a bare `EOF` on the Windows runner. goproxy turns that upstream round-trip error into a closed MITM connection, so the test client sees `Post "https://alpha.invalid/v1/messages": EOF`.

This is a stale pooled-connection reuse failure, not a routing or hot-reload bug: `Reload()` is a synchronous atomic router swap and never touches the upstream transport.

## Fix

`bridged.Config.SetKeepAlivesEnabled(false)` on the mock aibridged backend forces a fresh proxy→aibridged connection per request, eliminating the stale-reuse failure by construction. No production changes.

## Verification

- `go test -race` of the reload family passes repeatedly (`-count=10`, earlier `-count=20` and full package `-race`).
- Cannot reproduce the Windows closed-socket semantics on a Linux runner, so this removes the failure class rather than proving it; Windows CI is the confirmation.

Closes https://linear.app/codercom/issue/AIGOV-430

---

Generated by a Coder agent.