### PR TITLE
chore(coderd/x/chatd): bump computer-use models to current frontier releases

### DIFF
--- a/coderd/x/chatd/chattool/computeruse.go
+++ b/coderd/x/chatd/chattool/computeruse.go
@@ -21,10 +21,13 @@ import (
 
 const (
 	// ComputerUseAnthropicModelName is the default Anthropic model used for
-	// computer use subagents.
-	ComputerUseAnthropicModelName = "claude-opus-4-6"
-	// ComputerUseOpenAIModelName is the default OpenAI model used for computer use.
-	ComputerUseOpenAIModelName = "gpt-5.5"
+	// computer use subagents. It must support the computer_20251124 tool
+	// version pinned in ComputerUseProviderTool.
+	ComputerUseAnthropicModelName = "claude-opus-5"
+	// ComputerUseOpenAIModelName is the default OpenAI model used for computer
+	// use. It must be served over the Responses API, which carries the GA
+	// computer_use tool.
+	ComputerUseOpenAIModelName = "gpt-5.6-sol"
 )
 
 // SupportedComputerUseProviders returns the providers supported by computer use.

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -244,9 +244,9 @@ func TestPrepareGenerationComputerUseIgnoresChatTransportOverride(t *testing.T) 
 	require.NoError(t, err)
 	t.Cleanup(prepared.Cleanup)
 
-	// The computer-use model (gpt-5.5) is Responses-selected by the SDK and
-	// its client ignores the config's forced Chat Completions, so the
-	// options must be the Responses type or the SDK discards them.
+	// The computer-use model is Responses-selected by the SDK and its client
+	// ignores the config's forced Chat Completions, so the options must be the
+	// Responses type or the SDK discards them.
 	_, ok := prepared.ProviderOptions[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
 	require.True(t, ok, "%T", prepared.ProviderOptions[fantasyopenai.Name])
 

--- a/coderd/x/chatd/model_routing_internal_test.go
+++ b/coderd/x/chatd/model_routing_internal_test.go
@@ -728,7 +728,10 @@ func TestResolveComputerUseModel_AIGatewayMissingAPIKeyID(t *testing.T) {
 	require.False(t, debugEnabled)
 	require.Empty(t, resolvedProvider)
 	require.Empty(t, resolvedModel)
-	require.Contains(t, err.Error(), `resolve computer use model for provider "openai" model "gpt-5.5"`)
+	require.Contains(t, err.Error(), fmt.Sprintf(
+		`resolve computer use model for provider "openai" model %q`,
+		chattool.ComputerUseOpenAIModelName,
+	))
 	require.Contains(t, err.Error(), "active turn API key ID")
 }
 


### PR DESCRIPTION
Bumps the hardcoded computer-use models to the current frontier releases. Nothing else changes: the models stay hardcoded, and admins still pick only the provider.

| Provider | Before | After |
|----------|--------|-------|
| Anthropic | `claude-opus-4-6` | `claude-opus-5` |
| OpenAI | `gpt-5.5` | `gpt-5.6-sol` |

Also switched a test assertion from the hardcoded `gpt-5.5` string to `chattool.ComputerUseOpenAIModelName` so the next bump stays a one-line change.

## Validation

Both constraints that gate these constants were checked rather than assumed:

- **Anthropic:** `claude-opus-5` supports the `computer_20251124` tool version pinned in `ComputerUseProviderTool`, so no tool version or beta header change is needed. `computer_20251124` is still the newest version available in both `fantasyanthropic` and upstream.
- **OpenAI:** `gpt-5.6-sol` must be served over the Responses API or the GA `computer_use` tool does not exist. `fantasyopenai.IsResponsesModel` matches any ID containing `gpt-5`, so it is. Same flagship tier and pricing as `gpt-5.5` (1.05M context), with `gpt-5.6` as an alias.
- Both IDs exist under the direct `anthropic` and `openai` providers in `prices.json`, so cost attribution keeps working.

Tests run: `TestDefaultComputerUseModel`, `TestResolveComputerUseModel*`, `TestPrepareGenerationComputerUseIgnoresChatTransportOverride`, and the full `chattool` package.

> [!NOTE]
> `claude-opus-5` is missing from the `anthropic` entry in `scripts/aibridgepricesgen/curation.json` while `azure`, `bedrock`, `openrouter`, and `vercel` all list it. That affects the admin Models panel, not this code path, and will be fixed in a separate PR.

Related to [CODAGT-893](https://linear.app/codercom/issue/CODAGT-893/make-computer-use-model-configurable). Making the model admin-configurable is tracked there and is not addressed here; this just gets us off the older models in the meantime.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻
