### PR TITLE
fix(cli,support,scaletest): terminate workspace paging on server count

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -489,10 +489,14 @@ func (r *RootCmd) configSSH() *serpent.Command {
 					for _, ws := range res.Workspaces {
 						wsNames = append(wsNames, ws.Name)
 					}
-					if len(res.Workspaces) < pageSize {
+					// The endpoint applies its limit in SQL and then drops rows whose
+					// build or template the caller cannot read, so a page shorter than
+					// pageSize does not mean the result set is exhausted. Count is the
+					// total before the limit and offset are applied.
+					offset += pageSize
+					if offset >= res.Count {
 						break
 					}
-					offset += pageSize
 				}
 				configOptions.workspaceNames = wsNames
 			}

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -577,7 +577,11 @@ func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client
 					result = append(result, ws)
 				}
 			}
-			if len(resp.Workspaces) < pageSize {
+			// The endpoint applies its limit in SQL and then drops rows whose build
+			// or template the caller cannot read, so a page shorter than pageSize
+			// does not mean the result set is exhausted. Count is the total before
+			// the limit and offset are applied.
+			if (page+1)*pageSize >= resp.Count {
 				break
 			}
 		}
@@ -2249,9 +2253,6 @@ func getScaletestWorkspaces(ctx context.Context, client *codersdk.Client, owner,
 		}
 
 		pageNumber++
-		if len(page.Workspaces) == 0 {
-			break
-		}
 
 		pageWorkspaces := make([]codersdk.Workspace, 0, len(page.Workspaces))
 		for _, w := range page.Workspaces {
@@ -2265,6 +2266,14 @@ func getScaletestWorkspaces(ctx context.Context, client *codersdk.Client, owner,
 			pageWorkspaces = append(pageWorkspaces, w)
 		}
 		workspaces = append(workspaces, pageWorkspaces...)
+
+		// The endpoint applies its limit in SQL and then drops rows whose build or
+		// template the caller cannot read, so a short or empty page does not mean
+		// the result set is exhausted. Count is the total before the limit and
+		// offset are applied.
+		if pageNumber*limit >= page.Count {
+			break
+		}
 	}
 	return workspaces, skipped, nil
 }

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2820,6 +2820,10 @@ func convertWorkspaces(
 		appStatusesByWorkspaceID[appStatus.WorkspaceID] = appStatus
 	}
 
+	var (
+		missingBuilds    int
+		missingTemplates int
+	)
 	apiWorkspaces := make([]codersdk.Workspace, 0, len(workspaces))
 	for _, workspace := range workspaces {
 		// If any data is missing from the workspace, just skip returning
@@ -2829,10 +2833,12 @@ func convertWorkspaces(
 		// fields?
 		build, exists := buildByWorkspaceID[workspace.ID]
 		if !exists {
+			missingBuilds++
 			continue
 		}
 		template, exists := templateByID[workspace.TemplateID]
 		if !exists {
+			missingTemplates++
 			continue
 		}
 		appStatus := appStatusesByWorkspaceID[workspace.ID]
@@ -2853,6 +2859,20 @@ func convertWorkspaces(
 
 		apiWorkspaces = append(apiWorkspaces, w)
 	}
+
+	// Dropped workspaces make the returned slice shorter than the rows it was
+	// built from, which callers cannot distinguish from an exhausted result
+	// set when the rows came from a limited query.
+	if dropped := len(workspaces) - len(apiWorkspaces); dropped > 0 {
+		logger.Warn(ctx, "dropped workspaces missing build or template data",
+			slog.F("requester_id", requesterID),
+			slog.F("rows", len(workspaces)),
+			slog.F("dropped", dropped),
+			slog.F("missing_builds", missingBuilds),
+			slog.F("missing_templates", missingTemplates),
+		)
+	}
+
 	return apiWorkspaces, nil
 }
 

--- a/scaletest/prebuilds/run.go
+++ b/scaletest/prebuilds/run.go
@@ -476,7 +476,11 @@ func allWorkspacesForTemplate(ctx context.Context, client *codersdk.Client, temp
 			return nil, xerrors.Errorf("list workspaces page %d: %w", page, err)
 		}
 		workspaces = append(workspaces, resp.Workspaces...)
-		if len(resp.Workspaces) < pageSize {
+		// The endpoint applies its limit in SQL and then drops rows whose build or
+		// template the caller cannot read, so a page shorter than pageSize does not
+		// mean the result set is exhausted. Count is the total before the limit and
+		// offset are applied.
+		if (page+1)*pageSize >= resp.Count {
 			break
 		}
 	}

--- a/support/support.go
+++ b/support/support.go
@@ -303,10 +303,15 @@ func DeploymentInfo(ctx context.Context, client *codersdk.Client, log slog.Logge
 				}
 				break
 			}
-			if offset+len(resp.Workspaces) >= count || len(resp.Workspaces) == 0 {
+			// The offset advances by the requested limit rather than the number of
+			// rows returned. The endpoint applies its limit in SQL and then drops
+			// rows whose build or template the caller cannot read, so advancing by
+			// len(resp.Workspaces) would re-request rows already collected. Count is
+			// the total before the limit and offset are applied.
+			offset += limit
+			if offset >= count {
 				break
 			}
-			offset += len(resp.Workspaces)
 		}
 		if d.Workspaces != nil {
 			// Replace with aggregated list


### PR DESCRIPTION
## Summary

`convertWorkspaces` in `coderd/workspaces.go` drops rows whose build or template
the caller cannot read, but `/api/v2/workspaces` applies its limit in SQL and
reports `Count` from before the limit and offset. A page can therefore be shorter
than the requested limit while rows remain.

Five paging loops assumed the opposite. Four stopped on a short or fully filtered
page and truncated their results; `support/support.go` also advanced the offset by
the number of rows returned, re-requesting rows it had already collected. Each loop
now advances the offset by the requested page size and stops once it reaches
`Count`.

- `support/support.go`
- `cli/configssh.go` (`--no-wildcard`)
- `cli/exp_scaletest.go` (`getScaletestPrebuildWorkspaces`, `getScaletestWorkspaces`)
- `scaletest/prebuilds/run.go` (`allWorkspacesForTemplate`)

`convertWorkspaces` also now warns with the dropped count split by reason. The
discrepancy was previously invisible: nothing logged it, and no response field
distinguished a filtered page from an exhausted one.

## Testing

- `make pre-commit`
- `go test ./support/ -run TestRun`
- `go test ./cli/ -run TestConfigSSH`

<details>
<summary>Reachable drop paths</summary>

`workspaceData` fetches builds and app statuses as `AsSystemRestricted`, and a
workspace and its first build are inserted in one transaction, so a missing build
is not reachable in practice. Templates come from `GetTemplatesWithFilter`, which
is authz-filtered and hardcodes `deleted = false`, giving two real causes:

- **Deleted template with surviving workspaces.** `deleteTemplate` permits
  deletion when only prebuild workspaces remain and defers cleanup to the
  reconciler, so for that window a deployment-wide listing counts prebuilds that
  conversion then drops.
- **Unreadable template.** The org-member floor role grants no `template.read`, so
  member access comes from the default everyone-group ACL. Disabling that access,
  editing the ACL, removing a user from a group, or sharing a workspace with a user
  who lacks template access strands existing workspaces permanently.

A single dropped row anywhere before the last page was enough to truncate the rest,
so the impact does not scale with the number of unreadable rows. It requires the
caller's authorized set to exceed the page size: 100 for `config-ssh`, 200 for
`support bundle`.

</details>

---

_This pull request was created by [Coder Agents](https://coder.com) on behalf of @jscottmiller._
