### PR TITLE
refactor(codersdk,cli,scaletest,site): add a shared workspace paging helper

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -474,29 +474,13 @@ func (r *RootCmd) configSSH() *serpent.Command {
 
 			if configOptions.noWildcard {
 				// Fetch all workspaces to generate individual host entries.
-				var wsNames []string
-				offset := 0
-				const pageSize = 100
-				for {
-					res, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-						Owner:  codersdk.Me,
-						Offset: offset,
-						Limit:  pageSize,
-					})
-					if err != nil {
-						return xerrors.Errorf("fetch workspaces: %w", err)
-					}
-					for _, ws := range res.Workspaces {
-						wsNames = append(wsNames, ws.Name)
-					}
-					// The endpoint applies its limit in SQL and then drops rows whose
-					// build or template the caller cannot read, so a page shorter than
-					// pageSize does not mean the result set is exhausted. Count is the
-					// total before the limit and offset are applied.
-					offset += pageSize
-					if offset >= res.Count {
-						break
-					}
+				workspaces, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{Owner: codersdk.Me})
+				if err != nil {
+					return xerrors.Errorf("fetch workspaces: %w", err)
+				}
+				wsNames := make([]string, 0, len(workspaces))
+				for _, ws := range workspaces {
+					wsNames = append(wsNames, ws.Name)
 				}
 				configOptions.workspaceNames = wsNames
 			}

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -551,8 +551,6 @@ func (r *prebuildTemplateCleanupRunner) Run(ctx context.Context, _ string, _ io.
 // caught in the cleanup. If template is non-empty only workspaces for that
 // template are returned.
 func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client, template string) ([]codersdk.Workspace, error) {
-	const pageSize = 100
-
 	templates, err := getScaletestPrebuildsTemplates(ctx, client, template)
 	if err != nil {
 		return nil, xerrors.Errorf("list scaletest prebuild templates: %w", err)
@@ -562,27 +560,16 @@ func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client
 	var result []codersdk.Workspace
 
 	for _, tmpl := range templates {
-		for page := 0; ; page++ {
-			resp, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-				Template: tmpl.Name,
-				Offset:   page * pageSize,
-				Limit:    pageSize,
-			})
-			if err != nil {
-				return nil, xerrors.Errorf("list workspaces for template %q (page %d): %w", tmpl.Name, page, err)
-			}
-			for _, ws := range resp.Workspaces {
-				if _, ok := seen[ws.ID]; !ok {
-					seen[ws.ID] = struct{}{}
-					result = append(result, ws)
-				}
-			}
-			// The endpoint applies its limit in SQL and then drops rows whose build
-			// or template the caller cannot read, so a page shorter than pageSize
-			// does not mean the result set is exhausted. Count is the total before
-			// the limit and offset are applied.
-			if (page+1)*pageSize >= resp.Count {
-				break
+		workspaces, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{
+			Template: tmpl.Name,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("list workspaces for template %q: %w", tmpl.Name, err)
+		}
+		for _, ws := range workspaces {
+			if _, ok := seen[ws.ID]; !ok {
+				seen[ws.ID] = struct{}{}
+				result = append(result, ws)
 			}
 		}
 	}
@@ -2223,8 +2210,6 @@ func (r *runnableTraceWrapper) GetMetrics() map[string]any {
 
 func getScaletestWorkspaces(ctx context.Context, client *codersdk.Client, owner, template string) ([]codersdk.Workspace, int, error) {
 	var (
-		pageNumber = 0
-		limit      = 100
 		workspaces []codersdk.Workspace
 		skipped    int
 	)
@@ -2240,40 +2225,24 @@ func getScaletestWorkspaces(ctx context.Context, client *codersdk.Client, owner,
 	}
 	noOwnerAccess := dv.Values != nil && dv.Values.DisableOwnerWorkspaceExec.Value()
 
-	for {
-		page, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Name:     "scaletest-",
-			Template: template,
-			Owner:    owner,
-			Offset:   pageNumber * limit,
-			Limit:    limit,
-		})
-		if err != nil {
-			return nil, 0, xerrors.Errorf("fetch scaletest workspaces page %d: %w", pageNumber, err)
-		}
+	all, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{
+		Name:     "scaletest-",
+		Template: template,
+		Owner:    owner,
+	})
+	if err != nil {
+		return nil, 0, xerrors.Errorf("fetch scaletest workspaces: %w", err)
+	}
 
-		pageNumber++
-
-		pageWorkspaces := make([]codersdk.Workspace, 0, len(page.Workspaces))
-		for _, w := range page.Workspaces {
-			if !loadtestutil.IsScaleTestWorkspace(w.Name, w.OwnerName) {
-				continue
-			}
-			if noOwnerAccess && w.OwnerID != me.ID {
-				skipped++
-				continue
-			}
-			pageWorkspaces = append(pageWorkspaces, w)
+	for _, w := range all {
+		if !loadtestutil.IsScaleTestWorkspace(w.Name, w.OwnerName) {
+			continue
 		}
-		workspaces = append(workspaces, pageWorkspaces...)
-
-		// The endpoint applies its limit in SQL and then drops rows whose build or
-		// template the caller cannot read, so a short or empty page does not mean
-		// the result set is exhausted. Count is the total before the limit and
-		// offset are applied.
-		if pageNumber*limit >= page.Count {
-			break
+		if noOwnerAccess && w.OwnerID != me.ID {
+			skipped++
+			continue
 		}
+		workspaces = append(workspaces, w)
 	}
 	return workspaces, skipped, nil
 }

--- a/cli/list.go
+++ b/cli/list.go
@@ -168,12 +168,12 @@ func (r *RootCmd) list() *serpent.Command {
 // convert workspaces to scheduleListRow.
 func QueryConvertWorkspaces[T any](ctx context.Context, client *codersdk.Client, filter codersdk.WorkspaceFilter, convertF func(time.Time, codersdk.Workspace) T) ([]T, error) {
 	var empty []T
-	workspaces, err := client.Workspaces(ctx, filter)
+	workspaces, err := client.AllWorkspaces(ctx, filter)
 	if err != nil {
 		return empty, xerrors.Errorf("query workspaces: %w", err)
 	}
-	converted := make([]T, len(workspaces.Workspaces))
-	for i, workspace := range workspaces.Workspaces {
+	converted := make([]T, len(workspaces))
+	for i, workspace := range workspaces {
 		converted[i] = convertF(time.Now(), workspace)
 	}
 	return converted, nil

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -171,7 +171,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 				return []string{}
 			}
 
-			res, err := client.Workspaces(inv.Context(), codersdk.WorkspaceFilter{
+			workspaces, err := client.AllWorkspaces(inv.Context(), codersdk.WorkspaceFilter{
 				Owner: codersdk.Me,
 			})
 			if err != nil {
@@ -181,7 +181,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 			var mu sync.Mutex
 			var completions []string
 			var wg sync.WaitGroup
-			for _, ws := range res.Workspaces {
+			for _, ws := range workspaces {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -632,6 +632,34 @@ func (c *Client) Workspaces(ctx context.Context, filter WorkspaceFilter) (Worksp
 	return wres, ReadBodyAsJSON(res, &wres)
 }
 
+// WorkspacePageSize is the number of rows AllWorkspaces requests per page.
+const WorkspacePageSize = 100
+
+// AllWorkspaces requests successive pages of workspaces matching the filter and
+// returns every row. Limit and Offset on the filter are ignored.
+//
+// The offset advances by the requested page size rather than by the number of
+// rows received. The endpoint applies its limit in SQL and then drops
+// workspaces whose build or template the caller cannot read, so a page shorter
+// than the page size does not mean the result set is exhausted. Count is the
+// total before the limit and offset are applied.
+func (c *Client) AllWorkspaces(ctx context.Context, filter WorkspaceFilter) ([]Workspace, error) {
+	filter.Limit = WorkspacePageSize
+	filter.Offset = 0
+	var all []Workspace
+	for {
+		page, err := c.Workspaces(ctx, filter)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page.Workspaces...)
+		filter.Offset += WorkspacePageSize
+		if filter.Offset >= page.Count {
+			return all, nil
+		}
+	}
+}
+
 // WorkspaceByOwnerAndName returns a workspace by the owner's UUID and the workspace's name.
 func (c *Client) WorkspaceByOwnerAndName(ctx context.Context, owner string, name string, params WorkspaceOptions) (Workspace, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/workspace/%s", owner, name), nil, func(r *http.Request) {

--- a/codersdk/workspaces_test.go
+++ b/codersdk/workspaces_test.go
@@ -2,311 +2,121 @@ package codersdk_test
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync/atomic"
+	"strconv"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestResolveWorkspace(t *testing.T) {
+func TestAllWorkspaces(t *testing.T) {
 	t.Parallel()
 
-	// writeJSON is a small helper that writes a JSON-encoded value
-	// with the given status code.
-	writeJSON := func(w http.ResponseWriter, status int, v any) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	// newClient serves pages of the given sizes, recording the limit and offset
+	// of every request. count is reported as the total on every response.
+	newClient := func(t *testing.T, count int, pageSizes ...int) (*codersdk.Client, *[][2]int) {
+		t.Helper()
+		var requests [][2]int
+		page := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+			requests = append(requests, [2]int{limit, offset})
 
-	// errResponse builds a codersdk.Response suitable for error
-	// replies.
-	errResponse := func(msg string) codersdk.Response {
-		return codersdk.Response{Message: msg}
-	}
-
-	// newWorkspace returns a Workspace with the given ID and name.
-	newWorkspace := func(id uuid.UUID, name string) codersdk.Workspace {
-		return codersdk.Workspace{ID: id, Name: name}
-	}
-
-	// Each table case configures a mock server with separate UUID
-	// and name endpoint behaviors, then calls ResolveWorkspace with
-	// the given identifier.
-	type endpointResponse struct {
-		status    int
-		workspace codersdk.Workspace
-		errMsg    string
-	}
-	tests := []struct {
-		name       string
-		identifier string
-		// uuidEndpoint configures GET /api/v2/workspaces/{workspace}.
-		// nil means the endpoint is not registered (404 from chi).
-		uuidEndpoint *endpointResponse
-		// nameEndpoint configures GET /api/v2/users/{user}/workspace/{workspace}.
-		// nil means the endpoint is not registered.
-		nameEndpoint *endpointResponse
-		// expectedOwner and expectedName are checked via assert inside
-		// the name endpoint handler (when non-empty).
-		expectedOwner string
-		expectedName  string
-		// Expected outcomes.
-		wantErr        bool
-		wantStatusCode int
-		wantUUIDHits   int64
-		wantNameHits   int64
-	}{
-		{
-			name:       "ByUUID",
-			identifier: "", // filled dynamically below
-			uuidEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			wantUUIDHits: 1,
-			wantNameHits: 0,
-		},
-		{
-			name:       "ByName",
-			identifier: "my-workspace",
-			nameEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			expectedOwner: "me",
-			expectedName:  "my-workspace",
-			wantUUIDHits:  0,
-			wantNameHits:  1,
-		},
-		{
-			name:       "ByOwnerAndName",
-			identifier: "alice/my-workspace",
-			nameEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			expectedOwner: "alice",
-			expectedName:  "my-workspace",
-			wantUUIDHits:  0,
-			wantNameHits:  1,
-		},
-		{
-			name:       "OwnerWithUUIDLikeName",
-			identifier: "alice/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-			nameEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			expectedOwner: "alice",
-			expectedName:  "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-			wantUUIDHits:  0,
-			wantNameHits:  1,
-		},
-		{
-			name:       "UUIDLikeNameFallback",
-			identifier: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-			uuidEndpoint: &endpointResponse{
-				status: http.StatusNotFound,
-				errMsg: "Resource not found.",
-			},
-			nameEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			expectedOwner: "me",
-			expectedName:  "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-			wantUUIDHits:  1,
-			wantNameHits:  1,
-		},
-		{
-			name:       "DashedUUIDNotFound",
-			identifier: "", // filled dynamically (standard dashed UUID)
-			uuidEndpoint: &endpointResponse{
-				status: http.StatusNotFound,
-				errMsg: "Resource not found.",
-			},
-			nameEndpoint: &endpointResponse{
-				status: http.StatusNotFound,
-				errMsg: "Resource not found.",
-			},
-			wantErr:        true,
-			wantStatusCode: http.StatusNotFound,
-			// NameValid rejects dashed UUIDs (36 chars), so the
-			// name endpoint should not be called.
-			wantUUIDHits: 1,
-			wantNameHits: 0,
-		},
-		{
-			name:       "NonNotFoundError",
-			identifier: "", // filled dynamically
-			uuidEndpoint: &endpointResponse{
-				status: http.StatusInternalServerError,
-				errMsg: "Internal server error.",
-			},
-			nameEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			wantErr:        true,
-			wantStatusCode: http.StatusInternalServerError,
-			wantUUIDHits:   1,
-			wantNameHits:   0,
-		},
-		{
-			name:       "NameNotFound",
-			identifier: "nonexistent",
-			nameEndpoint: &endpointResponse{
-				status: http.StatusNotFound,
-				errMsg: "Resource not found.",
-			},
-			expectedOwner:  "me",
-			expectedName:   "nonexistent",
-			wantErr:        true,
-			wantStatusCode: http.StatusNotFound,
-			wantUUIDHits:   0,
-			wantNameHits:   1,
-		},
-		{
-			name:       "Forbidden",
-			identifier: "", // filled dynamically
-			uuidEndpoint: &endpointResponse{
-				status: http.StatusForbidden,
-				errMsg: "Forbidden.",
-			},
-			nameEndpoint: &endpointResponse{
-				status: http.StatusOK,
-			},
-			wantErr:        true,
-			wantStatusCode: http.StatusForbidden,
-			wantUUIDHits:   1,
-			wantNameHits:   0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			wsID := uuid.New()
-			expected := newWorkspace(wsID, "test-workspace")
-
-			// When identifier is empty, use the workspace UUID
-			// (standard dashed format).
-			identifier := tt.identifier
-			if identifier == "" {
-				identifier = wsID.String()
+			rows := 0
+			if page < len(pageSizes) {
+				rows = pageSizes[page]
 			}
+			page++
+			workspaces := make([]codersdk.Workspace, rows)
 
-			var uuidHits, nameHits atomic.Int64
-			r := chi.NewRouter()
-
-			if tt.uuidEndpoint != nil {
-				ep := tt.uuidEndpoint
-				// Use the expected workspace in OK responses
-				// unless the test overrides it.
-				if ep.status == http.StatusOK && ep.workspace.ID == uuid.Nil {
-					ep.workspace = expected
-				}
-				r.Get("/api/v2/workspaces/{workspace}", func(w http.ResponseWriter, req *http.Request) {
-					uuidHits.Add(1)
-					if ep.errMsg != "" {
-						writeJSON(w, ep.status, errResponse(ep.errMsg))
-						return
-					}
-					writeJSON(w, ep.status, ep.workspace)
-				})
-			}
-
-			if tt.nameEndpoint != nil {
-				ep := tt.nameEndpoint
-				if ep.status == http.StatusOK && ep.workspace.ID == uuid.Nil {
-					ep.workspace = expected
-				}
-				r.Get("/api/v2/users/{user}/workspace/{workspace}", func(w http.ResponseWriter, req *http.Request) {
-					nameHits.Add(1)
-					if tt.expectedOwner != "" {
-						assert.Equal(t, tt.expectedOwner, chi.URLParam(req, "user"))
-					}
-					if tt.expectedName != "" {
-						assert.Equal(t, tt.expectedName, chi.URLParam(req, "workspace"))
-					}
-					if ep.errMsg != "" {
-						writeJSON(w, ep.status, errResponse(ep.errMsg))
-						return
-					}
-					writeJSON(w, ep.status, ep.workspace)
-				})
-			}
-
-			srv := httptest.NewServer(r)
-			defer srv.Close()
-
-			u, err := url.Parse(srv.URL)
-			require.NoError(t, err)
-			client := codersdk.New(u)
-
-			ws, err := client.ResolveWorkspace(t.Context(), identifier)
-			if tt.wantErr {
-				require.Error(t, err)
-				if tt.wantStatusCode != 0 {
-					var sdkErr *codersdk.Error
-					require.ErrorAs(t, err, &sdkErr)
-					require.Equal(t, tt.wantStatusCode, sdkErr.StatusCode())
-				}
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, expected.ID, ws.ID)
-			}
-
-			require.EqualValues(t, tt.wantUUIDHits, uuidHits.Load())
-			require.EqualValues(t, tt.wantNameHits, nameHits.Load())
-		})
-	}
-
-	// Cases that need a structurally different server setup.
-
-	t.Run("TransportError", func(t *testing.T) {
-		t.Parallel()
-
-		baseURL, err := url.Parse("http://example.com")
-		require.NoError(t, err)
-		client := codersdk.New(baseURL, codersdk.WithHTTPClient(&http.Client{
-			Transport: testutil.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
-				return nil, xerrors.New("transport error")
-			}),
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(codersdk.WorkspacesResponse{
+				Workspaces: workspaces,
+				Count:      count,
+			})
 		}))
-
-		_, err = client.ResolveWorkspace(t.Context(), uuid.NewString())
-		require.Error(t, err)
-
-		// Transport errors must not be swallowed by the 404
-		// fallback path. The error should NOT be a *codersdk.Error.
-		var sdkErr *codersdk.Error
-		require.False(t, errors.As(err, &sdkErr), "transport error should not be a codersdk.Error")
-	})
-
-	t.Run("InvalidIdentifier", func(t *testing.T) {
-		t.Parallel()
-
-		var hits atomic.Int64
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			hits.Add(1)
-			t.Errorf("unexpected HTTP request for invalid identifier: %s", req.URL.Path)
-		}))
-		defer srv.Close()
+		t.Cleanup(srv.Close)
 
 		u, err := url.Parse(srv.URL)
 		require.NoError(t, err)
-		client := codersdk.New(u)
+		return codersdk.New(u), &requests
+	}
 
-		_, err = client.ResolveWorkspace(t.Context(), "a/b/c")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "invalid workspace identifier: \"a/b/c\"")
-		require.EqualValues(t, 0, hits.Load(), "invalid identifiers should fail before any HTTP request")
+	t.Run("SinglePage", func(t *testing.T) {
+		t.Parallel()
+
+		client, requests := newClient(t, 3, 3)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		workspaces, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{})
+		require.NoError(t, err)
+		require.Len(t, workspaces, 3)
+		require.Equal(t, [][2]int{{codersdk.WorkspacePageSize, 0}}, *requests)
+	})
+
+	t.Run("AdvancesByPageSize", func(t *testing.T) {
+		t.Parallel()
+
+		const count = codersdk.WorkspacePageSize*2 + 10
+		client, requests := newClient(t, count,
+			codersdk.WorkspacePageSize, codersdk.WorkspacePageSize, 10)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		workspaces, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{})
+		require.NoError(t, err)
+		require.Len(t, workspaces, count)
+		require.Equal(t, [][2]int{
+			{codersdk.WorkspacePageSize, 0},
+			{codersdk.WorkspacePageSize, codersdk.WorkspacePageSize},
+			{codersdk.WorkspacePageSize, codersdk.WorkspacePageSize * 2},
+		}, *requests)
+	})
+
+	// A page can be shorter than the requested limit because the endpoint drops
+	// rows after applying the limit, so a short page must not end the scan.
+	t.Run("ShortPageContinues", func(t *testing.T) {
+		t.Parallel()
+
+		const count = codersdk.WorkspacePageSize + 20
+		client, requests := newClient(t, count, 40, 20)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		workspaces, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{})
+		require.NoError(t, err)
+		require.Len(t, workspaces, 60)
+		require.Len(t, *requests, 2)
+	})
+
+	t.Run("EmptyResult", func(t *testing.T) {
+		t.Parallel()
+
+		client, requests := newClient(t, 0, 0)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		workspaces, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{})
+		require.NoError(t, err)
+		require.Empty(t, workspaces)
+		require.Len(t, *requests, 1)
+	})
+
+	t.Run("OverridesCallerPagination", func(t *testing.T) {
+		t.Parallel()
+
+		client, requests := newClient(t, 1, 1)
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		_, err := client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{
+			Limit:  codersdk.WorkspacePageSize + 50,
+			Offset: 500,
+		})
+		require.NoError(t, err)
+		require.Equal(t, [][2]int{{codersdk.WorkspacePageSize, 0}}, *requests)
 	})
 }

--- a/scaletest/prebuilds/run.go
+++ b/scaletest/prebuilds/run.go
@@ -172,19 +172,19 @@ func (r *Runner) measureCreation(ctx context.Context, logger slog.Logger) error 
 	defer cancel()
 
 	tkr := r.cfg.Clock.TickerFunc(workspacesCtx, workspacePollInterval, func() error {
-		workspaces, err := r.client.Workspaces(workspacesCtx, codersdk.WorkspaceFilter{
+		workspaces, err := r.client.AllWorkspaces(workspacesCtx, codersdk.WorkspaceFilter{
 			Template: r.template.Name,
 		})
 		if err != nil {
 			return xerrors.Errorf("list workspaces: %w", err)
 		}
 
-		createdCount := len(workspaces.Workspaces)
+		createdCount := len(workspaces)
 		runningCount := 0
 		failedCount := 0
 		succeededCount := 0
 
-		for _, ws := range workspaces.Workspaces {
+		for _, ws := range workspaces {
 			switch ws.LatestBuild.Job.Status {
 			case codersdk.ProvisionerJobRunning:
 				runningCount++
@@ -228,13 +228,13 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 	// The reconciler may have created extra workspaces beyond the configured
 	// target (e.g. replacements for failed builds), so using targetNumWorkspaces
 	// as the denominator would undercount completed deletions.
-	initialWorkspaces, err := r.client.Workspaces(deletionCtx, codersdk.WorkspaceFilter{
+	initialWorkspaces, err := r.client.AllWorkspaces(deletionCtx, codersdk.WorkspaceFilter{
 		Template: r.template.Name,
 	})
 	if err != nil {
 		return xerrors.Errorf("list workspaces at deletion start: %w", err)
 	}
-	initialWorkspaceCount := len(initialWorkspaces.Workspaces)
+	initialWorkspaceCount := len(initialWorkspaces)
 
 	// retryCount tracks how many delete builds we've submitted per workspace.
 	// lastRetriedBuildID prevents submitting a second retry for the same failed
@@ -243,7 +243,7 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 	lastRetriedBuildID := make(map[uuid.UUID]uuid.UUID)
 
 	tkr := r.cfg.Clock.TickerFunc(deletionCtx, workspacePollInterval, func() error {
-		workspaces, err := r.client.Workspaces(deletionCtx, codersdk.WorkspaceFilter{
+		workspaces, err := r.client.AllWorkspaces(deletionCtx, codersdk.WorkspaceFilter{
 			Template: r.template.Name,
 		})
 		if err != nil {
@@ -255,7 +255,7 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 		failedCount := 0
 		exhaustedCount := 0
 
-		for _, ws := range workspaces.Workspaces {
+		for _, ws := range workspaces {
 			if ws.LatestBuild.Transition != codersdk.WorkspaceTransitionDelete {
 				// The reconciler hasn't submitted a delete build yet.
 				continue
@@ -298,7 +298,7 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 			}
 		}
 
-		completedCount := initialWorkspaceCount - len(workspaces.Workspaces)
+		completedCount := initialWorkspaceCount - len(workspaces)
 		createdCount += completedCount
 
 		r.cfg.Metrics.SetDeletionJobsCreated(createdCount, r.template.Name)
@@ -306,13 +306,13 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 		r.cfg.Metrics.SetDeletionJobsFailed(failedCount, r.template.Name)
 		r.cfg.Metrics.SetDeletionJobsCompleted(completedCount, r.template.Name)
 
-		if len(workspaces.Workspaces) == 0 {
+		if len(workspaces) == 0 {
 			return errTickerDone
 		}
 
 		// If every remaining workspace has exhausted all retries, fail
 		// immediately rather than waiting for the timeout.
-		if exhaustedCount > 0 && exhaustedCount == len(workspaces.Workspaces) {
+		if exhaustedCount > 0 && exhaustedCount == len(workspaces) {
 			return xerrors.Errorf("%d workspace(s) failed to delete after %d attempts", exhaustedCount, maxDeletionRetries+1)
 		}
 
@@ -408,7 +408,9 @@ func (r *Runner) Cleanup(ctx context.Context, _ string, logs io.Writer) error {
 	}
 
 	// Workspaces must be deleted before the template can be deleted.
-	workspaces, err := allWorkspacesForTemplate(ctx, r.client, r.template.Name)
+	workspaces, err := r.client.AllWorkspaces(ctx, codersdk.WorkspaceFilter{
+		Template: r.template.Name,
+	})
 	if err != nil {
 		return xerrors.Errorf("list workspaces for template %q: %w", r.template.Name, err)
 	}
@@ -459,32 +461,6 @@ func (r *Runner) Cleanup(ctx context.Context, _ string, logs io.Writer) error {
 
 	logger.Info(ctx, "template deleted successfully", slog.F("template_name", r.template.Name))
 	return nil
-}
-
-// allWorkspacesForTemplate returns all workspaces belonging to templateName,
-// paginating through results until exhausted.
-func allWorkspacesForTemplate(ctx context.Context, client *codersdk.Client, templateName string) ([]codersdk.Workspace, error) {
-	const pageSize = 100
-	var workspaces []codersdk.Workspace
-	for page := 0; ; page++ {
-		resp, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Template: templateName,
-			Offset:   page * pageSize,
-			Limit:    pageSize,
-		})
-		if err != nil {
-			return nil, xerrors.Errorf("list workspaces page %d: %w", page, err)
-		}
-		workspaces = append(workspaces, resp.Workspaces...)
-		// The endpoint applies its limit in SQL and then drops rows whose build or
-		// template the caller cannot read, so a page shorter than pageSize does not
-		// mean the result set is exhausted. Count is the total before the limit and
-		// offset are applied.
-		if (page+1)*pageSize >= resp.Count {
-			break
-		}
-	}
-	return workspaces, nil
 }
 
 //go:embed tf/main.tf.tpl

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -6,7 +6,12 @@ import {
 	MockWorkspace,
 	MockWorkspaceBuild,
 } from "#/testHelpers/entities";
-import { API, getURLWithSearchParams, ParameterValidationError } from "./api";
+import {
+	API,
+	getURLWithSearchParams,
+	ParameterValidationError,
+	WORKSPACE_PAGE_SIZE,
+} from "./api";
 import type * as TypesGen from "./typesGenerated";
 
 const axiosInstance = API.getAxiosInstance();
@@ -658,5 +663,63 @@ describe("api.ts", () => {
 				expectedError,
 			);
 		});
+	});
+});
+
+describe("getAllWorkspaces", () => {
+	const workspacePage = (count: number, rows: number) => ({
+		workspaces: Array.from({ length: rows }, (_, i) => ({
+			...MockWorkspace,
+			id: `ws-${i}`,
+		})),
+		count,
+	});
+
+	it("issues a single request when the total fits in one page", async () => {
+		const page = workspacePage(3, 3);
+		const getWorkspaces = vi
+			.spyOn(API, "getWorkspaces")
+			.mockResolvedValueOnce(page);
+
+		const result = await API.getAllWorkspaces({ q: "owner:me" });
+
+		expect(getWorkspaces).toHaveBeenCalledTimes(1);
+		expect(getWorkspaces).toHaveBeenCalledWith({
+			q: "owner:me",
+			limit: WORKSPACE_PAGE_SIZE,
+			offset: 0,
+		});
+		expect(result).toStrictEqual(page);
+	});
+
+	it("advances the offset by the page size until the total is reached", async () => {
+		const getWorkspaces = vi
+			.spyOn(API, "getWorkspaces")
+			.mockResolvedValueOnce(workspacePage(250, WORKSPACE_PAGE_SIZE))
+			.mockResolvedValueOnce(workspacePage(250, WORKSPACE_PAGE_SIZE))
+			.mockResolvedValueOnce(workspacePage(250, 50));
+
+		const result = await API.getAllWorkspaces();
+
+		expect(getWorkspaces.mock.calls.map(([req]) => req?.offset)).toStrictEqual([
+			0,
+			WORKSPACE_PAGE_SIZE,
+			WORKSPACE_PAGE_SIZE * 2,
+		]);
+		expect(result.workspaces).toHaveLength(250);
+		expect(result.count).toBe(250);
+	});
+
+	it("keeps requesting pages when a page is shorter than the page size", async () => {
+		const getWorkspaces = vi
+			.spyOn(API, "getWorkspaces")
+			.mockResolvedValueOnce(workspacePage(150, 40))
+			.mockResolvedValueOnce(workspacePage(150, 50));
+
+		const result = await API.getAllWorkspaces();
+
+		expect(getWorkspaces).toHaveBeenCalledTimes(2);
+		expect(result.workspaces).toHaveLength(90);
+		expect(result.count).toBe(150);
 	});
 });

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -46,6 +46,11 @@ import * as TypesGen from "./typesGenerated";
 export const SessionTokenCookie = "coder_session_token";
 
 /**
+ * WORKSPACE_PAGE_SIZE is the number of rows getAllWorkspaces requests per page.
+ */
+export const WORKSPACE_PAGE_SIZE = 100;
+
+/**
  * @param agentId
  * @returns {OneWayWebSocket} A OneWayWebSocket that emits Server-Sent Events.
  */
@@ -1257,6 +1262,32 @@ class ApiMethods {
 		const url = getURLWithSearchParams("/api/v2/workspaces", req);
 		const response = await this.axios.get<TypesGen.WorkspacesResponse>(url);
 		return response.data;
+	};
+
+	/**
+	 * Requests successive pages of workspaces until the offset reaches the total
+	 * the server reports. The offset advances by the page size rather than by the
+	 * number of rows received: the endpoint applies its limit in SQL and then
+	 * drops workspaces whose build or template the caller cannot read, so a short
+	 * page does not mean the result set is exhausted.
+	 */
+	getAllWorkspaces = async (
+		req: Omit<TypesGen.WorkspacesRequest, "limit" | "offset"> = {},
+	): Promise<TypesGen.WorkspacesResponse> => {
+		const workspaces: TypesGen.Workspace[] = [];
+		let count = 0;
+		let offset = 0;
+		do {
+			const page = await this.getWorkspaces({
+				...req,
+				limit: WORKSPACE_PAGE_SIZE,
+				offset,
+			});
+			workspaces.push(...page.workspaces);
+			count = page.count;
+			offset += WORKSPACE_PAGE_SIZE;
+		} while (offset < count);
+		return { workspaces, count };
 	};
 
 	getWorkspaceByOwnerAndName = async (

--- a/site/src/api/queries/workspaces.ts
+++ b/site/src/api/queries/workspaces.ts
@@ -229,6 +229,24 @@ export function workspaces(req: WorkspacesRequest = {}) {
 	} as const satisfies QueryOptions<WorkspacesResponse>;
 }
 
+type AllWorkspacesRequest = Omit<WorkspacesRequest, "limit" | "offset">;
+
+export function allWorkspacesKey(req: AllWorkspacesRequest = {}) {
+	// The `all` marker keeps this distinct from the single-page key for the same
+	// filter. The key stays two segments long with an object at the end so it is
+	// still matched by invalidateWorkspaceListQueries.
+	return [...workspacesQueryKeyPrefix, { ...req, all: true }] as const;
+}
+
+// allWorkspaces fetches every page of the filtered result set. Prefer a
+// server-side filter and a single page when the caller can express one.
+export function allWorkspaces(req: AllWorkspacesRequest = {}) {
+	return {
+		queryKey: allWorkspacesKey(req),
+		queryFn: () => API.getAllWorkspaces(req),
+	} as const satisfies QueryOptions<WorkspacesResponse>;
+}
+
 const isWorkspacesListQuery = (query: {
 	queryKey: readonly unknown[];
 }): boolean => {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -52,9 +52,9 @@ import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
 import { preferenceSettings } from "#/api/queries/users";
 import {
+	allWorkspaces,
 	workspaceById,
 	workspaceByIdKey,
-	workspaces,
 } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatMessagePart } from "#/api/typesGenerated";
@@ -949,7 +949,7 @@ const AgentChatPage: FC = () => {
 	const preferencesQuery = useQuery(preferenceSettings());
 	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
 	const mcpServersQuery = useQuery(mcpServerConfigs());
-	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
+	const workspacesQuery = useQuery(allWorkspaces({ q: "owner:me" }));
 	const workspaceOptions = getWorkspaceOptionsWithLinkedWorkspace(
 		workspacesQuery.data?.workspaces ?? [],
 		workspace,

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -13,7 +13,7 @@ import {
 	userChatProviderConfigs,
 } from "#/api/queries/chats";
 import { preferenceSettings } from "#/api/queries/users";
-import { workspaces } from "#/api/queries/workspaces";
+import { allWorkspaces } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { useWebpushNotifications } from "#/contexts/useWebpushNotifications";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
@@ -55,7 +55,7 @@ const AgentCreatePage: FC = () => {
 	);
 	const preferencesQuery = useQuery(preferenceSettings());
 	const mcpServersQuery = useQuery(mcpServerConfigs());
-	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
+	const workspacesQuery = useQuery(allWorkspaces({ q: "owner:me" }));
 	const createMutation = useMutation(createChat(queryClient));
 	const webPush = useWebpushNotifications();
 	const [chimeEnabled, setChimeEnabledState] = useState(getChimeEnabled);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -382,11 +382,11 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// Filter workspaces by the selected organization. We use
 	// client-side filtering of the full "owner:me" fetch rather
 	// than re-querying with an org filter because it avoids
-	// extra loading/error states on org change. The full list is
-	// already small (user's own workspaces) and limit: 0
-	// guarantees completeness. If workspace counts grow large
-	// enough to warrant pagination, this should switch to a
-	// server-side organization:<name> query filter.
+	// extra loading/error states on org change. The list is
+	// fetched page by page until exhausted, so it is complete.
+	// If workspace counts grow large enough that paging is
+	// costly, this should switch to a server-side
+	// organization:<name> query filter.
 	const filteredWorkspaces =
 		showOrganizations && selectedOrg
 			? workspaceOptions.filter((ws) => ws.organization_id === selectedOrg.id)


### PR DESCRIPTION
## Summary

Stacked on #28027.

Every caller that needed the full workspace list carried its own paging loop,
each with its own page size and termination rule. `codersdk.AllWorkspaces` now
owns that logic: it advances the offset by the requested page size and stops
once it reaches the total the response reports.

Callers routed through it: `cli/list.go` (`QueryConvertWorkspaces`),
`cli/ssh.go` (shell completion), `cli/configssh.go`, both `cli/exp_scaletest.go`
helpers, and all four sites in `scaletest/prebuilds/run.go`, including the two
poll loops that were not paginated at all. `allWorkspacesForTemplate` is
deleted.

The frontend gains the equivalent helper as `API.getAllWorkspaces`, exposed as
the `allWorkspaces` query and used by the agents pages. Its key carries an `all`
marker so it stays distinct from the single-page key while remaining matched by
workspace list invalidation.

`support/support.go` keeps its own loop: it needs the server-reported count for
the bundle and must stop early at `--workspaces-total-cap`.

## Testing

- `go test ./codersdk/ -run TestAllWorkspaces` (new: single page, offset
  progression, short page continues, empty result, caller pagination overridden)
- `go test ./cli/ -run 'TestList|TestConfigSSH'`
- `pnpm vitest run src/api/api.test.ts`

## Follow-ups

- [ ] `support/support.go`: request `min(cap, pageSize)` rather than a full page
      when `--workspaces-total-cap` is small; that also removes the
      `all[:capTotal]` trim.
- [ ] `support/support.go`: `Run` overwrites `Count` with the truncated length,
      contradicting the comment that says the server total is preserved.
- [ ] `support/support.go`: a 403 mid-loop yields a partial list alongside a
      full count, with only a warning log.
- [ ] The agents pages fetch every page on load and filter client side. A
      server-side `organization:` filter would avoid the fan-out.

---

_This pull request was created by [Coder Agents](https://coder.com) on behalf of @jscottmiller._
