### PR TITLE
fix(site): use server-side workspace restart orchestration

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -1,3 +1,4 @@
+import { AxiosError, type AxiosResponse } from "axios";
 import {
 	MockProvisionerJob,
 	MockStoppedWorkspace,
@@ -516,7 +517,7 @@ describe("api.ts", () => {
 				.mockResolvedValue(MockProvisionerJob);
 			const getWorkspaceBuilds = vi
 				.spyOn(API, "getWorkspaceBuilds")
-				.mockRejectedValueOnce(new Error("network blip"))
+				.mockRejectedValueOnce(new AxiosError("Network Error", "ERR_NETWORK"))
 				.mockResolvedValue([childBuild]);
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
@@ -525,6 +526,26 @@ describe("api.ts", () => {
 
 			expect(getWorkspaceBuilds).toHaveBeenCalledTimes(2);
 			expect(waitForBuild).toHaveBeenNthCalledWith(2, childBuild);
+		});
+
+		it("rejects immediately when a builds request fails permanently", async () => {
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild").mockResolvedValue(MockProvisionerJob);
+			const forbidden = new AxiosError(
+				"Request failed with status code 403",
+				"ERR_BAD_REQUEST",
+				undefined,
+				undefined,
+				{ status: 403 } as AxiosResponse,
+			);
+			const getWorkspaceBuilds = vi
+				.spyOn(API, "getWorkspaceBuilds")
+				.mockRejectedValue(forbidden);
+
+			await expect(
+				API.restartWorkspace({ workspace: MockWorkspace }),
+			).rejects.toBe(forbidden);
+			expect(getWorkspaceBuilds).toHaveBeenCalledTimes(1);
 		});
 
 		it("skips intervening non-start builds when discovering the child", async () => {

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -423,9 +423,7 @@ describe("api.ts", () => {
 				.mockResolvedValueOnce(MockProvisionerJob)
 				.mockResolvedValueOnce(MockProvisionerJob);
 			vi.spyOn(API, "getWorkspaceBuildByNumber").mockResolvedValue(childBuild);
-			const startWorkspace = vi
-				.spyOn(API, "startWorkspace")
-				.mockResolvedValue(childBuild);
+			const startWorkspace = vi.spyOn(API, "startWorkspace");
 
 			await API.restartWorkspace({
 				workspace: MockWorkspace,
@@ -442,22 +440,6 @@ describe("api.ts", () => {
 				},
 			});
 			expect(startWorkspace).not.toHaveBeenCalled();
-		});
-
-		it("does not pin the follow-up start to a template version", async () => {
-			const postWorkspaceBuild = vi
-				.spyOn(API, "postWorkspaceBuild")
-				.mockResolvedValue(stopBuild);
-			vi.spyOn(API, "waitForBuild").mockResolvedValueOnce({
-				...MockProvisionerJob,
-				status: "canceled",
-			});
-
-			await API.restartWorkspace({ workspace: MockWorkspace });
-
-			const request = postWorkspaceBuild.mock.calls[0][1];
-			expect(request.on_success).toBeDefined();
-			expect(request.on_success).not.toHaveProperty("template_version_id");
 		});
 
 		it("does not look for a follow-up build when the stop is canceled", async () => {
@@ -520,18 +502,8 @@ describe("api.ts", () => {
 				);
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
-			let settled = false;
-			void restart.then(
-				() => {
-					settled = true;
-				},
-				() => {
-					settled = true;
-				},
-			);
 
 			await vi.advanceTimersByTimeAsync(59_999);
-			expect(settled).toBe(false);
 			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(false);
 
 			await vi.advanceTimersByTimeAsync(1);

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -5,6 +5,7 @@ import {
 	MockTemplateVersion2,
 	MockWorkspace,
 	MockWorkspaceBuild,
+	MockWorkspaceBuildStop,
 } from "#/testHelpers/entities";
 import { API, getURLWithSearchParams, ParameterValidationError } from "./api";
 import type * as TypesGen from "./typesGenerated";
@@ -368,6 +369,176 @@ describe("api.ts", () => {
 					},
 				);
 			});
+		});
+	});
+
+	describe("restartWorkspace", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+			vi.restoreAllMocks();
+		});
+
+		const stopBuild: TypesGen.WorkspaceBuild = {
+			...MockWorkspaceBuildStop,
+			build_number: 7,
+		};
+		const childBuild: TypesGen.WorkspaceBuild = {
+			...MockWorkspaceBuild,
+			build_number: stopBuild.build_number + 1,
+			id: "child-build",
+			transition: "start",
+		};
+		const buildParameters: TypesGen.WorkspaceBuildParameter[] = [
+			{ name: "region", value: "us-east" },
+		];
+		const notFoundError = {
+			isAxiosError: true,
+			response: { status: 404 },
+		};
+
+		it("forwards an abort signal when fetching a workspace build", async () => {
+			const controller = new AbortController();
+			const get = vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({
+				data: childBuild,
+			});
+
+			await API.getWorkspaceBuildByNumber(
+				childBuild.workspace_owner_name,
+				childBuild.workspace_name,
+				childBuild.build_number,
+				controller.signal,
+			);
+
+			expect(get).toHaveBeenCalledWith(
+				`/api/v2/users/${childBuild.workspace_owner_name}/workspace/${childBuild.workspace_name}/builds/${childBuild.build_number}`,
+				{ signal: controller.signal },
+			);
+		});
+
+		it("submits one stop build with a follow-up start", async () => {
+			const postWorkspaceBuild = vi
+				.spyOn(API, "postWorkspaceBuild")
+				.mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild")
+				.mockResolvedValueOnce(MockProvisionerJob)
+				.mockResolvedValueOnce(MockProvisionerJob);
+			vi.spyOn(API, "getWorkspaceBuildByNumber").mockResolvedValue(childBuild);
+			const startWorkspace = vi
+				.spyOn(API, "startWorkspace")
+				.mockResolvedValue(childBuild);
+
+			await API.restartWorkspace({
+				workspace: MockWorkspace,
+				buildParameters,
+			});
+
+			expect(postWorkspaceBuild).toHaveBeenCalledOnce();
+			expect(postWorkspaceBuild).toHaveBeenCalledWith(MockWorkspace.id, {
+				transition: "stop",
+				reason: "dashboard",
+				on_success: {
+					transition: "start",
+					rich_parameter_values: buildParameters,
+				},
+			});
+			expect(startWorkspace).not.toHaveBeenCalled();
+		});
+
+		it("does not pin the follow-up start to a template version", async () => {
+			const postWorkspaceBuild = vi
+				.spyOn(API, "postWorkspaceBuild")
+				.mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild").mockResolvedValueOnce({
+				...MockProvisionerJob,
+				status: "canceled",
+			});
+
+			await API.restartWorkspace({ workspace: MockWorkspace });
+
+			const request = postWorkspaceBuild.mock.calls[0][1];
+			expect(request.on_success).toBeDefined();
+			expect(request.on_success).not.toHaveProperty("template_version_id");
+		});
+
+		it("does not look for a follow-up build when the stop is canceled", async () => {
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild").mockResolvedValueOnce({
+				...MockProvisionerJob,
+				status: "canceled",
+			});
+			const getWorkspaceBuildByNumber = vi.spyOn(
+				API,
+				"getWorkspaceBuildByNumber",
+			);
+
+			await API.restartWorkspace({ workspace: MockWorkspace });
+
+			expect(getWorkspaceBuildByNumber).not.toHaveBeenCalled();
+		});
+
+		it("waits for the server-created child build after the stop succeeds", async () => {
+			vi.useFakeTimers();
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			const waitForBuild = vi
+				.spyOn(API, "waitForBuild")
+				.mockResolvedValueOnce(MockProvisionerJob)
+				.mockResolvedValueOnce(MockProvisionerJob);
+			const getWorkspaceBuildByNumber = vi
+				.spyOn(API, "getWorkspaceBuildByNumber")
+				.mockRejectedValueOnce(notFoundError)
+				.mockResolvedValue(childBuild);
+
+			const restart = API.restartWorkspace({ workspace: MockWorkspace });
+			await vi.advanceTimersByTimeAsync(1000);
+			await restart;
+
+			expect(getWorkspaceBuildByNumber).toHaveBeenCalledTimes(2);
+			expect(getWorkspaceBuildByNumber).toHaveBeenCalledWith(
+				stopBuild.workspace_owner_name,
+				stopBuild.workspace_name,
+				stopBuild.build_number + 1,
+				expect.any(AbortSignal),
+			);
+			expect(waitForBuild).toHaveBeenNthCalledWith(1, stopBuild);
+			expect(waitForBuild).toHaveBeenNthCalledWith(2, childBuild);
+		});
+
+		it("stops waiting when the follow-up build is not created in time", async () => {
+			vi.useFakeTimers();
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild").mockResolvedValue(MockProvisionerJob);
+			const getWorkspaceBuildByNumber = vi
+				.spyOn(API, "getWorkspaceBuildByNumber")
+				.mockImplementation(
+					(_username, _workspaceName, _buildNumber, signal) => {
+						return new Promise((_, reject) => {
+							signal?.addEventListener("abort", () =>
+								reject(new Error("canceled")),
+							);
+						});
+					},
+				);
+
+			const restart = API.restartWorkspace({ workspace: MockWorkspace });
+			let settled = false;
+			void restart.then(
+				() => {
+					settled = true;
+				},
+				() => {
+					settled = true;
+				},
+			);
+
+			await vi.advanceTimersByTimeAsync(59_999);
+			expect(settled).toBe(false);
+			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(false);
+
+			await vi.advanceTimersByTimeAsync(1);
+			await expect(restart).rejects.toThrow(
+				"The workspace stopped but the follow-up start build was not created.",
+			);
+			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(true);
 		});
 	});
 

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -503,7 +503,7 @@ describe("api.ts", () => {
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
 
-			await vi.advanceTimersByTimeAsync(59_999);
+			await vi.advanceTimersByTimeAsync(179_999);
 			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(false);
 
 			await vi.advanceTimersByTimeAsync(1);

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -490,14 +490,17 @@ describe("api.ts", () => {
 				});
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
+			// Attach the rejection handler before the deadline fires so the
+			// rejection is never unhandled.
+			const rejection = expect(restart).rejects.toThrow(
+				"The workspace stopped, but the server did not start it again.",
+			);
 
 			await vi.advanceTimersByTimeAsync(179_999);
 			expect(getWorkspaceBuilds.mock.calls[0][2]?.aborted).toBe(false);
 
 			await vi.advanceTimersByTimeAsync(1);
-			await expect(restart).rejects.toThrow(
-				"The workspace stopped, but the server did not start it again.",
-			);
+			await rejection;
 			expect(getWorkspaceBuilds.mock.calls[0][2]?.aborted).toBe(true);
 		});
 	});

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -508,7 +508,7 @@ describe("api.ts", () => {
 
 			await vi.advanceTimersByTimeAsync(1);
 			await expect(restart).rejects.toThrow(
-				"The workspace stopped but the follow-up start build was not created.",
+				"The workspace stopped, but the server did not start it again.",
 			);
 			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(true);
 		});

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -458,8 +458,8 @@ describe("api.ts", () => {
 				.mockResolvedValueOnce(MockProvisionerJob);
 			const getWorkspaceBuilds = vi
 				.spyOn(API, "getWorkspaceBuilds")
-				.mockResolvedValueOnce([stopBuild])
-				.mockResolvedValue([childBuild, stopBuild]);
+				.mockResolvedValueOnce([])
+				.mockResolvedValue([childBuild]);
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
 			await vi.advanceTimersByTimeAsync(1000);
@@ -468,11 +468,87 @@ describe("api.ts", () => {
 			expect(getWorkspaceBuilds).toHaveBeenCalledTimes(2);
 			expect(getWorkspaceBuilds).toHaveBeenCalledWith(
 				stopBuild.workspace_id,
-				{ limit: 5 },
+				{ since: stopBuild.created_at, limit: 25 },
 				expect.any(AbortSignal),
 			);
 			expect(waitForBuild).toHaveBeenNthCalledWith(1, stopBuild);
 			expect(waitForBuild).toHaveBeenNthCalledWith(2, childBuild);
+		});
+
+		it("rejects when the stop build fails", async () => {
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild").mockRejectedValueOnce({
+				...MockProvisionerJob,
+				status: "failed",
+			});
+			const getWorkspaceBuilds = vi.spyOn(API, "getWorkspaceBuilds");
+
+			await expect(
+				API.restartWorkspace({ workspace: MockWorkspace }),
+			).rejects.toMatchObject({ status: "failed" });
+			expect(getWorkspaceBuilds).not.toHaveBeenCalled();
+		});
+
+		it("omits build parameters from the follow-up start when none are given", async () => {
+			const postWorkspaceBuild = vi
+				.spyOn(API, "postWorkspaceBuild")
+				.mockResolvedValue(stopBuild);
+			vi.spyOn(API, "waitForBuild").mockResolvedValue(MockProvisionerJob);
+			vi.spyOn(API, "getWorkspaceBuilds").mockResolvedValue([childBuild]);
+
+			await API.restartWorkspace({ workspace: MockWorkspace });
+
+			expect(postWorkspaceBuild).toHaveBeenCalledWith(MockWorkspace.id, {
+				transition: "stop",
+				reason: "dashboard",
+				on_success: {
+					transition: "start",
+					rich_parameter_values: undefined,
+				},
+			});
+		});
+
+		it("keeps polling when a builds request fails transiently", async () => {
+			vi.useFakeTimers();
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			const waitForBuild = vi
+				.spyOn(API, "waitForBuild")
+				.mockResolvedValue(MockProvisionerJob);
+			const getWorkspaceBuilds = vi
+				.spyOn(API, "getWorkspaceBuilds")
+				.mockRejectedValueOnce(new Error("network blip"))
+				.mockResolvedValue([childBuild]);
+
+			const restart = API.restartWorkspace({ workspace: MockWorkspace });
+			await vi.advanceTimersByTimeAsync(1000);
+			await restart;
+
+			expect(getWorkspaceBuilds).toHaveBeenCalledTimes(2);
+			expect(waitForBuild).toHaveBeenNthCalledWith(2, childBuild);
+		});
+
+		it("skips intervening non-start builds when discovering the child", async () => {
+			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
+			const waitForBuild = vi
+				.spyOn(API, "waitForBuild")
+				.mockResolvedValue(MockProvisionerJob);
+			const interveningStop: TypesGen.WorkspaceBuild = {
+				...MockWorkspaceBuildStop,
+				id: "intervening-stop",
+				build_number: stopBuild.build_number + 1,
+			};
+			const laterChild: TypesGen.WorkspaceBuild = {
+				...childBuild,
+				build_number: stopBuild.build_number + 2,
+			};
+			vi.spyOn(API, "getWorkspaceBuilds").mockResolvedValue([
+				laterChild,
+				interveningStop,
+			]);
+
+			await API.restartWorkspace({ workspace: MockWorkspace });
+
+			expect(waitForBuild).toHaveBeenNthCalledWith(2, laterChild);
 		});
 
 		it("stops waiting when the follow-up build is not created in time", async () => {

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -391,26 +391,20 @@ describe("api.ts", () => {
 		const buildParameters: TypesGen.WorkspaceBuildParameter[] = [
 			{ name: "region", value: "us-east" },
 		];
-		const notFoundError = {
-			isAxiosError: true,
-			response: { status: 404 },
-		};
-
-		it("forwards an abort signal when fetching a workspace build", async () => {
+		it("forwards an abort signal when listing workspace builds", async () => {
 			const controller = new AbortController();
 			const get = vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({
-				data: childBuild,
+				data: [childBuild],
 			});
 
-			await API.getWorkspaceBuildByNumber(
-				childBuild.workspace_owner_name,
-				childBuild.workspace_name,
-				childBuild.build_number,
+			await API.getWorkspaceBuilds(
+				stopBuild.workspace_id,
+				undefined,
 				controller.signal,
 			);
 
 			expect(get).toHaveBeenCalledWith(
-				`/api/v2/users/${childBuild.workspace_owner_name}/workspace/${childBuild.workspace_name}/builds/${childBuild.build_number}`,
+				`/api/v2/workspaces/${stopBuild.workspace_id}/builds`,
 				{ signal: controller.signal },
 			);
 		});
@@ -422,7 +416,7 @@ describe("api.ts", () => {
 			vi.spyOn(API, "waitForBuild")
 				.mockResolvedValueOnce(MockProvisionerJob)
 				.mockResolvedValueOnce(MockProvisionerJob);
-			vi.spyOn(API, "getWorkspaceBuildByNumber").mockResolvedValue(childBuild);
+			vi.spyOn(API, "getWorkspaceBuilds").mockResolvedValue([childBuild]);
 			const startWorkspace = vi.spyOn(API, "startWorkspace");
 
 			await API.restartWorkspace({
@@ -448,14 +442,11 @@ describe("api.ts", () => {
 				...MockProvisionerJob,
 				status: "canceled",
 			});
-			const getWorkspaceBuildByNumber = vi.spyOn(
-				API,
-				"getWorkspaceBuildByNumber",
-			);
+			const getWorkspaceBuilds = vi.spyOn(API, "getWorkspaceBuilds");
 
 			await API.restartWorkspace({ workspace: MockWorkspace });
 
-			expect(getWorkspaceBuildByNumber).not.toHaveBeenCalled();
+			expect(getWorkspaceBuilds).not.toHaveBeenCalled();
 		});
 
 		it("waits for the server-created child build after the stop succeeds", async () => {
@@ -465,20 +456,19 @@ describe("api.ts", () => {
 				.spyOn(API, "waitForBuild")
 				.mockResolvedValueOnce(MockProvisionerJob)
 				.mockResolvedValueOnce(MockProvisionerJob);
-			const getWorkspaceBuildByNumber = vi
-				.spyOn(API, "getWorkspaceBuildByNumber")
-				.mockRejectedValueOnce(notFoundError)
-				.mockResolvedValue(childBuild);
+			const getWorkspaceBuilds = vi
+				.spyOn(API, "getWorkspaceBuilds")
+				.mockResolvedValueOnce([stopBuild])
+				.mockResolvedValue([childBuild, stopBuild]);
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
 			await vi.advanceTimersByTimeAsync(1000);
 			await restart;
 
-			expect(getWorkspaceBuildByNumber).toHaveBeenCalledTimes(2);
-			expect(getWorkspaceBuildByNumber).toHaveBeenCalledWith(
-				stopBuild.workspace_owner_name,
-				stopBuild.workspace_name,
-				stopBuild.build_number + 1,
+			expect(getWorkspaceBuilds).toHaveBeenCalledTimes(2);
+			expect(getWorkspaceBuilds).toHaveBeenCalledWith(
+				stopBuild.workspace_id,
+				{ limit: 5 },
 				expect.any(AbortSignal),
 			);
 			expect(waitForBuild).toHaveBeenNthCalledWith(1, stopBuild);
@@ -489,28 +479,26 @@ describe("api.ts", () => {
 			vi.useFakeTimers();
 			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
 			vi.spyOn(API, "waitForBuild").mockResolvedValue(MockProvisionerJob);
-			const getWorkspaceBuildByNumber = vi
-				.spyOn(API, "getWorkspaceBuildByNumber")
-				.mockImplementation(
-					(_username, _workspaceName, _buildNumber, signal) => {
-						return new Promise((_, reject) => {
-							signal?.addEventListener("abort", () =>
-								reject(new Error("canceled")),
-							);
-						});
-					},
-				);
+			const getWorkspaceBuilds = vi
+				.spyOn(API, "getWorkspaceBuilds")
+				.mockImplementation((_workspaceId, _req, signal) => {
+					return new Promise((_, reject) => {
+						signal?.addEventListener("abort", () =>
+							reject(new Error("canceled")),
+						);
+					});
+				});
 
 			const restart = API.restartWorkspace({ workspace: MockWorkspace });
 
 			await vi.advanceTimersByTimeAsync(179_999);
-			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(false);
+			expect(getWorkspaceBuilds.mock.calls[0][2]?.aborted).toBe(false);
 
 			await vi.advanceTimersByTimeAsync(1);
 			await expect(restart).rejects.toThrow(
 				"The workspace stopped, but the server did not start it again.",
 			);
-			expect(getWorkspaceBuildByNumber.mock.calls[0][3]?.aborted).toBe(true);
+			expect(getWorkspaceBuilds.mock.calls[0][2]?.aborted).toBe(true);
 		});
 	});
 

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -1,4 +1,4 @@
-import { AxiosError, type AxiosResponse } from "axios";
+import { AxiosError, AxiosHeaders } from "axios";
 import {
 	MockProvisionerJob,
 	MockStoppedWorkspace,
@@ -531,12 +531,19 @@ describe("api.ts", () => {
 		it("rejects immediately when a builds request fails permanently", async () => {
 			vi.spyOn(API, "postWorkspaceBuild").mockResolvedValue(stopBuild);
 			vi.spyOn(API, "waitForBuild").mockResolvedValue(MockProvisionerJob);
+			const config = { headers: new AxiosHeaders() };
 			const forbidden = new AxiosError(
 				"Request failed with status code 403",
-				"ERR_BAD_REQUEST",
+				AxiosError.ERR_BAD_REQUEST,
+				config,
 				undefined,
-				undefined,
-				{ status: 403 } as AxiosResponse,
+				{
+					data: null,
+					status: 403,
+					statusText: "Forbidden",
+					headers: {},
+					config,
+				},
 			);
 			const getWorkspaceBuilds = vi
 				.spyOn(API, "getWorkspaceBuilds")

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1276,11 +1276,9 @@ class ApiMethods {
 		username: string,
 		workspaceName: string,
 		buildNumber: number,
-		signal?: AbortSignal,
 	): Promise<TypesGen.WorkspaceBuild> => {
 		const response = await this.axios.get<TypesGen.WorkspaceBuild>(
 			`/api/v2/users/${username}/workspace/${workspaceName}/builds/${buildNumber}`,
-			{ signal },
 		);
 
 		return response.data;
@@ -1318,6 +1316,7 @@ class ApiMethods {
 	private waitForRestartBuild = async (
 		stopBuild: TypesGen.WorkspaceBuild,
 	): Promise<TypesGen.WorkspaceBuild> => {
+		const childBuildNumber = stopBuild.build_number + 1;
 		// The server orchestrator may create the child build up to ~2 minutes
 		// after the stop succeeds (30s backup poll plus up to 3 attempts spaced
 		// 30s apart), so the deadline must outlast that retry lifecycle.
@@ -1326,19 +1325,22 @@ class ApiMethods {
 		try {
 			while (!controller.signal.aborted) {
 				try {
-					return await this.getWorkspaceBuildByNumber(
-						stopBuild.workspace_owner_name,
-						stopBuild.workspace_name,
-						stopBuild.build_number + 1,
+					const builds = await this.getWorkspaceBuilds(
+						stopBuild.workspace_id,
+						{ limit: 5 },
 						controller.signal,
 					);
+					const childBuild = builds.find(
+						(build) => build.build_number === childBuildNumber,
+					);
+					if (childBuild) {
+						return childBuild;
+					}
 				} catch (error) {
 					if (controller.signal.aborted) {
 						break;
 					}
-					if (!isAxiosError(error) || error.response?.status !== 404) {
-						throw error;
-					}
+					throw error;
 				}
 				await delay(1000);
 			}
@@ -1830,9 +1832,11 @@ class ApiMethods {
 	getWorkspaceBuilds = async (
 		workspaceId: string,
 		req?: TypesGen.WorkspaceBuildsRequest,
+		signal?: AbortSignal,
 	) => {
 		const response = await this.axios.get<TypesGen.WorkspaceBuild[]>(
 			getURLWithSearchParams(`/api/v2/workspaces/${workspaceId}/builds`, req),
+			{ signal },
 		);
 
 		return response.data;

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1276,10 +1276,12 @@ class ApiMethods {
 		username: string,
 		workspaceName: string,
 		buildNumber: number,
+		signal?: AbortSignal,
 	): Promise<TypesGen.WorkspaceBuild> => {
-		const response = await this.axios.get<TypesGen.WorkspaceBuild>(
-			`/api/v2/users/${username}/workspace/${workspaceName}/builds/${buildNumber}`,
-		);
+		const url = `/api/v2/users/${username}/workspace/${workspaceName}/builds/${buildNumber}`;
+		const response = await this.axios.get<TypesGen.WorkspaceBuild>(url, {
+			signal,
+		});
 
 		return response.data;
 	};
@@ -1311,6 +1313,53 @@ class ApiMethods {
 				return res(latestJobInfo);
 			})();
 		});
+	};
+
+	private waitForRestartBuild = async (
+		stopBuild: TypesGen.WorkspaceBuild,
+	): Promise<TypesGen.WorkspaceBuild> => {
+		const deadline = Date.now() + 60_000;
+		const timeoutError = new Error(
+			"The workspace stopped but the follow-up start build was not created.",
+		);
+
+		const controller = new AbortController();
+		const timeoutId = setTimeout(
+			() => controller.abort(),
+			Math.max(0, deadline - Date.now()),
+		);
+		try {
+			while (true) {
+				const remainingTime = deadline - Date.now();
+				if (remainingTime <= 0) {
+					throw timeoutError;
+				}
+
+				try {
+					return await this.getWorkspaceBuildByNumber(
+						stopBuild.workspace_owner_name,
+						stopBuild.workspace_name,
+						stopBuild.build_number + 1,
+						controller.signal,
+					);
+				} catch (error) {
+					if (controller.signal.aborted) {
+						throw timeoutError;
+					}
+					if (!isAxiosError(error) || error.response?.status !== 404) {
+						throw error;
+					}
+				}
+
+				const delayTime = Math.min(1000, deadline - Date.now());
+				if (delayTime <= 0) {
+					throw timeoutError;
+				}
+				await delay(delayTime);
+			}
+		} finally {
+			clearTimeout(timeoutId);
+		}
 	};
 
 	postWorkspaceBuild = async (
@@ -1411,21 +1460,21 @@ class ApiMethods {
 		workspace,
 		buildParameters,
 	}: RestartWorkspaceParameters): Promise<void> => {
-		const stopBuild = await this.stopWorkspace(workspace.id);
+		const stopBuild = await this.postWorkspaceBuild(workspace.id, {
+			transition: "stop",
+			reason: "dashboard",
+			on_success: {
+				transition: "start",
+				rich_parameter_values: buildParameters,
+			},
+		});
 		const awaitedStopBuild = await this.waitForBuild(stopBuild);
 
-		// If the restart is canceled halfway through, make sure we bail
 		if (awaitedStopBuild?.status === "canceled") {
 			return;
 		}
 
-		const startBuild = await this.startWorkspace(
-			workspace.id,
-			workspace.latest_build.template_version_id,
-			undefined,
-			buildParameters,
-		);
-
+		const startBuild = await this.waitForRestartBuild(stopBuild);
 		await this.waitForBuild(startBuild);
 	};
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1313,10 +1313,9 @@ class ApiMethods {
 		});
 	};
 
-	private waitForRestartBuild = async (
+	private waitForRestartChildBuild = async (
 		stopBuild: TypesGen.WorkspaceBuild,
 	): Promise<TypesGen.WorkspaceBuild> => {
-		const childBuildNumber = stopBuild.build_number + 1;
 		// The server orchestrator may create the child build up to ~2 minutes
 		// after the stop succeeds (30s backup poll plus up to 3 attempts spaced
 		// 30s apart), so the deadline must outlast that retry lifecycle.
@@ -1327,22 +1326,31 @@ class ApiMethods {
 				try {
 					const builds = await this.getWorkspaceBuilds(
 						stopBuild.workspace_id,
-						{ limit: 5 },
+						{ since: stopBuild.created_at, limit: 25 },
 						controller.signal,
 					);
-					const childBuild = builds.find(
-						(build) => build.build_number === childBuildNumber,
-					);
+					// Other builds (autostart, lifecycle cleanup, another actor)
+					// can land between the stop and the orchestrator's child, so
+					// the child is not guaranteed to be stop + 1. Builds arrive
+					// newest-first; the child is the oldest post-stop start build.
+					const childBuild = builds
+						.filter(
+							(build) =>
+								build.transition === "start" &&
+								build.build_number > stopBuild.build_number,
+						)
+						.at(-1);
 					if (childBuild) {
 						return childBuild;
 					}
-				} catch (error) {
+				} catch {
+					// Tolerate transient poll failures; the deadline below is the
+					// only failure surface.
 					if (controller.signal.aborted) {
 						break;
 					}
-					throw error;
 				}
-				await delay(1000);
+				await delay(1000, controller.signal);
 			}
 		} finally {
 			clearTimeout(timeoutId);
@@ -1466,7 +1474,7 @@ class ApiMethods {
 			return;
 		}
 
-		const startBuild = await this.waitForRestartBuild(stopBuild);
+		const startBuild = await this.waitForRestartChildBuild(stopBuild);
 		await this.waitForBuild(startBuild);
 	};
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1278,10 +1278,10 @@ class ApiMethods {
 		buildNumber: number,
 		signal?: AbortSignal,
 	): Promise<TypesGen.WorkspaceBuild> => {
-		const url = `/api/v2/users/${username}/workspace/${workspaceName}/builds/${buildNumber}`;
-		const response = await this.axios.get<TypesGen.WorkspaceBuild>(url, {
-			signal,
-		});
+		const response = await this.axios.get<TypesGen.WorkspaceBuild>(
+			`/api/v2/users/${username}/workspace/${workspaceName}/builds/${buildNumber}`,
+			{ signal },
+		);
 
 		return response.data;
 	};
@@ -1318,23 +1318,10 @@ class ApiMethods {
 	private waitForRestartBuild = async (
 		stopBuild: TypesGen.WorkspaceBuild,
 	): Promise<TypesGen.WorkspaceBuild> => {
-		const deadline = Date.now() + 60_000;
-		const timeoutError = new Error(
-			"The workspace stopped but the follow-up start build was not created.",
-		);
-
 		const controller = new AbortController();
-		const timeoutId = setTimeout(
-			() => controller.abort(),
-			Math.max(0, deadline - Date.now()),
-		);
+		const timeoutId = setTimeout(() => controller.abort(), 60_000);
 		try {
-			while (true) {
-				const remainingTime = deadline - Date.now();
-				if (remainingTime <= 0) {
-					throw timeoutError;
-				}
-
+			while (!controller.signal.aborted) {
 				try {
 					return await this.getWorkspaceBuildByNumber(
 						stopBuild.workspace_owner_name,
@@ -1344,22 +1331,20 @@ class ApiMethods {
 					);
 				} catch (error) {
 					if (controller.signal.aborted) {
-						throw timeoutError;
+						break;
 					}
 					if (!isAxiosError(error) || error.response?.status !== 404) {
 						throw error;
 					}
 				}
-
-				const delayTime = Math.min(1000, deadline - Date.now());
-				if (delayTime <= 0) {
-					throw timeoutError;
-				}
-				await delay(delayTime);
+				await delay(1000);
 			}
 		} finally {
 			clearTimeout(timeoutId);
 		}
+		throw new Error(
+			"The workspace stopped but the follow-up start build was not created.",
+		);
 	};
 
 	postWorkspaceBuild = async (

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1318,8 +1318,11 @@ class ApiMethods {
 	private waitForRestartBuild = async (
 		stopBuild: TypesGen.WorkspaceBuild,
 	): Promise<TypesGen.WorkspaceBuild> => {
+		// The server orchestrator may create the child build up to ~2 minutes
+		// after the stop succeeds (30s backup poll plus up to 3 attempts spaced
+		// 30s apart), so the deadline must outlast that retry lifecycle.
 		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 60_000);
+		const timeoutId = setTimeout(() => controller.abort(), 180_000);
 		try {
 			while (!controller.signal.aborted) {
 				try {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1329,10 +1329,9 @@ class ApiMethods {
 						{ since: stopBuild.created_at, limit: 25 },
 						controller.signal,
 					);
-					// Other builds (autostart, lifecycle cleanup, another actor)
-					// can land between the stop and the orchestrator's child, so
-					// the child is not guaranteed to be stop + 1. Builds arrive
-					// newest-first; the child is the oldest post-stop start build.
+					// Other actors (autostart, lifecycle cleanup) can insert builds
+					// between the stop and the orchestrator's child, so take the
+					// oldest post-stop start build from the newest-first response.
 					const childBuild = builds
 						.filter(
 							(build) =>

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1346,7 +1346,9 @@ class ApiMethods {
 			clearTimeout(timeoutId);
 		}
 		throw new Error(
-			"The workspace stopped but the follow-up start build was not created.",
+			"The workspace stopped, but the server did not start it again. " +
+				"This can happen when the current build parameters are no longer valid for the template. " +
+				"Start the workspace manually from the workspace page.",
 		);
 	};
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1342,11 +1342,21 @@ class ApiMethods {
 					if (childBuild) {
 						return childBuild;
 					}
-				} catch {
-					// Tolerate transient poll failures; the deadline below is the
-					// only failure surface.
+				} catch (error) {
 					if (controller.signal.aborted) {
 						break;
+					}
+					// Keep polling through transient failures until the deadline,
+					// but surface permanent responses (auth loss, deleted
+					// workspace) immediately.
+					const isTransient =
+						isAxiosError(error) &&
+						(error.response === undefined ||
+							error.response.status >= 500 ||
+							error.response.status === 408 ||
+							error.response.status === 429);
+					if (!isTransient) {
+						throw error;
 					}
 				}
 				await delay(1000, controller.signal);

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -26,6 +26,7 @@ import {
 	MockWorkspace,
 	MockWorkspaceBuild,
 	MockWorkspaceBuildDelete,
+	MockWorkspaceBuildStop,
 } from "#/testHelpers/entities";
 import {
 	type RenderWithAuthOptions,
@@ -194,24 +195,36 @@ describe("WorkspacePage", () => {
 		await testButton(MockWorkspace, "Stop", stopWorkspaceMock);
 	});
 
-	it("requests a stop when the user presses Restart", async () => {
-		const stopWorkspaceMock = vi
-			.spyOn(API, "stopWorkspace")
-			.mockResolvedValueOnce(MockWorkspaceBuild);
+	it("requests an orchestrated restart when the user presses Restart", async () => {
+		const childBuild = {
+			...MockWorkspaceBuild,
+			build_number: MockWorkspaceBuildStop.build_number + 1,
+		};
+		const postWorkspaceBuild = vi
+			.spyOn(API, "postWorkspaceBuild")
+			.mockResolvedValueOnce(MockWorkspaceBuildStop);
+		vi.spyOn(API, "waitForBuild").mockResolvedValue(MockWorkspaceBuild.job);
+		vi.spyOn(API, "getWorkspaceBuildByNumber").mockResolvedValue(childBuild);
+		const startWorkspace = vi.spyOn(API, "startWorkspace");
 
-		// Render
 		await renderWorkspacePage(MockWorkspace);
 
-		// Actions
 		const user = userEvent.setup();
 		await user.click(screen.getByTestId("workspace-restart-button"));
 		const confirmButton = await screen.findByTestId("confirm-button");
 		await user.click(confirmButton);
 
-		// Assertions
 		await waitFor(() => {
-			expect(stopWorkspaceMock).toBeCalled();
+			expect(postWorkspaceBuild).toHaveBeenCalledOnce();
 		});
+		expect(postWorkspaceBuild).toHaveBeenCalledWith(
+			MockWorkspace.id,
+			expect.objectContaining({
+				transition: "stop",
+				on_success: expect.objectContaining({ transition: "start" }),
+			}),
+		);
+		expect(startWorkspace).not.toHaveBeenCalled();
 	});
 
 	it("requests cancellation when the user presses Cancel", async () => {

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -194,25 +194,6 @@ describe("WorkspacePage", () => {
 		await testButton(MockWorkspace, "Stop", stopWorkspaceMock);
 	});
 
-	it("requests an orchestrated restart when the user presses Restart", async () => {
-		const restartWorkspaceMock = vi
-			.spyOn(API, "restartWorkspace")
-			.mockResolvedValueOnce(undefined);
-
-		await renderWorkspacePage(MockWorkspace);
-
-		const user = userEvent.setup();
-		await user.click(screen.getByTestId("workspace-restart-button"));
-		const confirmButton = await screen.findByTestId("confirm-button");
-		await user.click(confirmButton);
-
-		await waitFor(() => {
-			expect(restartWorkspaceMock).toHaveBeenCalledWith(
-				expect.objectContaining({ workspace: MockWorkspace }),
-			);
-		});
-	});
-
 	it("requests cancellation when the user presses Cancel", async () => {
 		server.use(
 			http.get("/api/v2/users/:userId/workspace/:workspaceName", () => {

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -26,7 +26,6 @@ import {
 	MockWorkspace,
 	MockWorkspaceBuild,
 	MockWorkspaceBuildDelete,
-	MockWorkspaceBuildStop,
 } from "#/testHelpers/entities";
 import {
 	type RenderWithAuthOptions,
@@ -196,16 +195,9 @@ describe("WorkspacePage", () => {
 	});
 
 	it("requests an orchestrated restart when the user presses Restart", async () => {
-		const childBuild = {
-			...MockWorkspaceBuild,
-			build_number: MockWorkspaceBuildStop.build_number + 1,
-		};
-		const postWorkspaceBuild = vi
-			.spyOn(API, "postWorkspaceBuild")
-			.mockResolvedValueOnce(MockWorkspaceBuildStop);
-		vi.spyOn(API, "waitForBuild").mockResolvedValue(MockWorkspaceBuild.job);
-		vi.spyOn(API, "getWorkspaceBuildByNumber").mockResolvedValue(childBuild);
-		const startWorkspace = vi.spyOn(API, "startWorkspace");
+		const restartWorkspaceMock = vi
+			.spyOn(API, "restartWorkspace")
+			.mockResolvedValueOnce(undefined);
 
 		await renderWorkspacePage(MockWorkspace);
 
@@ -215,16 +207,10 @@ describe("WorkspacePage", () => {
 		await user.click(confirmButton);
 
 		await waitFor(() => {
-			expect(postWorkspaceBuild).toHaveBeenCalledOnce();
+			expect(restartWorkspaceMock).toHaveBeenCalledWith(
+				expect.objectContaining({ workspace: MockWorkspace }),
+			);
 		});
-		expect(postWorkspaceBuild).toHaveBeenCalledWith(
-			MockWorkspace.id,
-			expect.objectContaining({
-				transition: "stop",
-				on_success: expect.objectContaining({ transition: "start" }),
-			}),
-		);
-		expect(startWorkspace).not.toHaveBeenCalled();
 	});
 
 	it("requests cancellation when the user presses Cancel", async () => {

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -73,7 +73,9 @@ export const RestartDialog: Story = {
 		await waitFor(() =>
 			expect(dialog).toHaveTextContent(/delete non-persistent data/),
 		);
-		expect(dialog).not.toHaveTextContent(/latest active version/);
+		expect(dialog).toHaveTextContent(
+			/The workspace will start using the template's active version/,
+		);
 	},
 };
 
@@ -85,7 +87,7 @@ export const RestartDialogOutdatedWorkspace: Story = {
 		const dialog = await openRestartDialog(canvasElement);
 		await waitFor(() =>
 			expect(dialog).toHaveTextContent(
-				/This workspace will start using the template's latest active version/,
+				/The workspace will start using the template's active version/,
 			),
 		);
 	},

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -5,13 +5,13 @@ import { buildInfoKey } from "#/api/queries/buildInfo";
 import { templateVersion } from "#/api/queries/templates";
 import { agentListeningPorts } from "#/api/queries/workspaces";
 import type { Workspace } from "#/api/typesGenerated";
+import type { WorkspacePermissions } from "#/modules/workspaces/permissions";
 import * as Mocks from "#/testHelpers/entities";
 import {
 	withAuthProvider,
 	withDashboardProvider,
 	withProxyProvider,
 } from "#/testHelpers/storybook";
-import type { WorkspacePermissions } from "../../modules/workspaces/permissions";
 import { WorkspaceReadyPage } from "./WorkspaceReadyPage";
 
 const permissions: WorkspacePermissions = {

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -72,9 +72,7 @@ const openRestartDialog = async (canvasElement: HTMLElement) => {
 export const RestartDialog: Story = {
 	play: async ({ canvasElement }) => {
 		const dialog = await openRestartDialog(canvasElement);
-		await waitFor(() =>
-			expect(dialog).toHaveTextContent(/delete non-persistent data/),
-		);
+		expect(dialog).toHaveTextContent(/delete non-persistent data/);
 		expect(dialog).toHaveTextContent(
 			/The workspace will start using the template's active version/,
 		);
@@ -90,10 +88,8 @@ export const RestartDialogOutdatedWorkspace: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const dialog = await openRestartDialog(canvasElement);
-		await waitFor(() =>
-			expect(dialog).toHaveTextContent(
-				/The workspace will start using the template's active version/,
-			),
+		expect(dialog).toHaveTextContent(
+			/The workspace will start using the template's active version/,
 		);
 	},
 };

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -4,6 +4,7 @@ import { API } from "#/api/api";
 import { buildInfoKey } from "#/api/queries/buildInfo";
 import { templateVersion } from "#/api/queries/templates";
 import { agentListeningPorts } from "#/api/queries/workspaces";
+import type { Workspace } from "#/api/typesGenerated";
 import * as Mocks from "#/testHelpers/entities";
 import {
 	withAuthProvider,
@@ -21,6 +22,18 @@ const permissions: WorkspacePermissions = {
 	deleteFailedWorkspace: true,
 };
 
+const workspaceQueries = (workspace: Workspace) => [
+	{ key: buildInfoKey, data: Mocks.MockBuildInfo },
+	{
+		key: agentListeningPorts(Mocks.MockWorkspaceAgent.id).queryKey,
+		data: Mocks.MockListeningPortsResponse,
+	},
+	{
+		key: templateVersion(workspace.template_active_version_id).queryKey,
+		data: Mocks.MockTemplateVersion,
+	},
+];
+
 const meta: Meta<typeof WorkspaceReadyPage> = {
 	title: "pages/WorkspacePage/WorkspaceReadyPage",
 	component: WorkspaceReadyPage,
@@ -30,18 +43,7 @@ const meta: Meta<typeof WorkspaceReadyPage> = {
 		permissions,
 	},
 	parameters: {
-		queries: [
-			{ key: buildInfoKey, data: Mocks.MockBuildInfo },
-			{
-				key: agentListeningPorts(Mocks.MockWorkspaceAgent.id).queryKey,
-				data: Mocks.MockListeningPortsResponse,
-			},
-			{
-				key: templateVersion(Mocks.MockWorkspace.template_active_version_id)
-					.queryKey,
-				data: Mocks.MockTemplateVersion,
-			},
-		],
+		queries: workspaceQueries(Mocks.MockWorkspace),
 		user: Mocks.MockUserOwner,
 	},
 	decorators: [withAuthProvider, withDashboardProvider, withProxyProvider()],
@@ -82,6 +84,9 @@ export const RestartDialog: Story = {
 export const RestartDialogOutdatedWorkspace: Story = {
 	args: {
 		workspace: Mocks.MockRunningOutdatedWorkspace,
+	},
+	parameters: {
+		queries: workspaceQueries(Mocks.MockRunningOutdatedWorkspace),
 	},
 	play: async ({ canvasElement }) => {
 		const dialog = await openRestartDialog(canvasElement);

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { API } from "#/api/api";
+import * as Mocks from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+	withProxyProvider,
+} from "#/testHelpers/storybook";
+import type { WorkspacePermissions } from "../../modules/workspaces/permissions";
+import { WorkspaceReadyPage } from "./WorkspaceReadyPage";
+
+const permissions: WorkspacePermissions = {
+	readWorkspace: true,
+	shareWorkspace: true,
+	updateWorkspace: true,
+	updateWorkspaceVersion: true,
+	deleteFailedWorkspace: true,
+};
+
+const meta: Meta<typeof WorkspaceReadyPage> = {
+	title: "pages/WorkspacePage/WorkspaceReadyPage",
+	component: WorkspaceReadyPage,
+	args: {
+		workspace: Mocks.MockWorkspace,
+		template: Mocks.MockTemplate,
+		permissions,
+	},
+	parameters: {
+		queries: [
+			{ key: ["buildInfo"], data: Mocks.MockBuildInfo },
+			{
+				key: ["portForward", Mocks.MockWorkspaceAgent.id],
+				data: Mocks.MockListeningPortsResponse,
+			},
+			{
+				key: [
+					"templateVersion",
+					Mocks.MockWorkspace.template_active_version_id,
+				],
+				data: Mocks.MockTemplateVersion,
+			},
+		],
+		user: Mocks.MockUserOwner,
+	},
+	decorators: [withAuthProvider, withDashboardProvider, withProxyProvider()],
+	beforeEach: () => {
+		spyOn(API, "getDynamicParameters").mockResolvedValue([]);
+		spyOn(API, "workspaceBuildTimings").mockResolvedValue({
+			provisioner_timings: [],
+			agent_script_timings: [],
+			agent_connection_timings: [],
+		});
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof WorkspaceReadyPage>;
+
+const openRestartDialog = async (canvasElement: HTMLElement) => {
+	const body = within(canvasElement.ownerDocument.body);
+	const restartButton = await body.findByRole("button", {
+		name: /^restart…$/i,
+	});
+	await userEvent.click(restartButton);
+	return await body.findByRole("dialog");
+};
+
+export const RestartDialog: Story = {
+	play: async ({ canvasElement }) => {
+		const dialog = await openRestartDialog(canvasElement);
+		await waitFor(() =>
+			expect(dialog).toHaveTextContent(/delete non-persistent data/),
+		);
+		expect(dialog).not.toHaveTextContent(/latest active version/);
+	},
+};
+
+export const RestartDialogOutdatedWorkspace: Story = {
+	args: {
+		workspace: Mocks.MockRunningOutdatedWorkspace,
+	},
+	play: async ({ canvasElement }) => {
+		const dialog = await openRestartDialog(canvasElement);
+		await waitFor(() =>
+			expect(dialog).toHaveTextContent(
+				/This workspace will start using the template's latest active version/,
+			),
+		);
+	},
+};

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -4,7 +4,6 @@ import { API } from "#/api/api";
 import { buildInfoKey } from "#/api/queries/buildInfo";
 import { templateVersion } from "#/api/queries/templates";
 import { agentListeningPorts } from "#/api/queries/workspaces";
-import type { Workspace } from "#/api/typesGenerated";
 import type { WorkspacePermissions } from "#/modules/workspaces/permissions";
 import * as Mocks from "#/testHelpers/entities";
 import {
@@ -22,18 +21,6 @@ const permissions: WorkspacePermissions = {
 	deleteFailedWorkspace: true,
 };
 
-const workspaceQueries = (workspace: Workspace) => [
-	{ key: buildInfoKey, data: Mocks.MockBuildInfo },
-	{
-		key: agentListeningPorts(Mocks.MockWorkspaceAgent.id).queryKey,
-		data: Mocks.MockListeningPortsResponse,
-	},
-	{
-		key: templateVersion(workspace.template_active_version_id).queryKey,
-		data: Mocks.MockTemplateVersion,
-	},
-];
-
 const meta: Meta<typeof WorkspaceReadyPage> = {
 	title: "pages/WorkspacePage/WorkspaceReadyPage",
 	component: WorkspaceReadyPage,
@@ -43,7 +30,6 @@ const meta: Meta<typeof WorkspaceReadyPage> = {
 		permissions,
 	},
 	parameters: {
-		queries: workspaceQueries(Mocks.MockWorkspace),
 		user: Mocks.MockUserOwner,
 	},
 	decorators: [withAuthProvider, withDashboardProvider, withProxyProvider()],
@@ -70,6 +56,24 @@ const openRestartDialog = async (canvasElement: HTMLElement) => {
 };
 
 export const RestartDialog: Story = {
+	parameters: {
+		queries: [
+			{ key: buildInfoKey, data: Mocks.MockBuildInfo },
+			{
+				key: agentListeningPorts(
+					Mocks.MockWorkspace.latest_build.resources.flatMap(
+						(resource) => resource.agents ?? [],
+					)[0].id,
+				).queryKey,
+				data: Mocks.MockListeningPortsResponse,
+			},
+			{
+				key: templateVersion(Mocks.MockWorkspace.template_active_version_id)
+					.queryKey,
+				data: Mocks.MockTemplateVersion,
+			},
+		],
+	},
 	play: async ({ canvasElement }) => {
 		const dialog = await openRestartDialog(canvasElement);
 		expect(dialog).toHaveTextContent(/delete non-persistent data/);
@@ -84,7 +88,23 @@ export const RestartDialogOutdatedWorkspace: Story = {
 		workspace: Mocks.MockRunningOutdatedWorkspace,
 	},
 	parameters: {
-		queries: workspaceQueries(Mocks.MockRunningOutdatedWorkspace),
+		queries: [
+			{ key: buildInfoKey, data: Mocks.MockBuildInfo },
+			{
+				key: agentListeningPorts(
+					Mocks.MockRunningOutdatedWorkspace.latest_build.resources.flatMap(
+						(resource) => resource.agents ?? [],
+					)[0].id,
+				).queryKey,
+				data: Mocks.MockListeningPortsResponse,
+			},
+			{
+				key: templateVersion(
+					Mocks.MockRunningOutdatedWorkspace.template_active_version_id,
+				).queryKey,
+				data: Mocks.MockTemplateVersion,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const dialog = await openRestartDialog(canvasElement);
@@ -95,6 +115,24 @@ export const RestartDialogOutdatedWorkspace: Story = {
 };
 
 export const ConfirmRestart: Story = {
+	parameters: {
+		queries: [
+			{ key: buildInfoKey, data: Mocks.MockBuildInfo },
+			{
+				key: agentListeningPorts(
+					Mocks.MockWorkspace.latest_build.resources.flatMap(
+						(resource) => resource.agents ?? [],
+					)[0].id,
+				).queryKey,
+				data: Mocks.MockListeningPortsResponse,
+			},
+			{
+				key: templateVersion(Mocks.MockWorkspace.template_active_version_id)
+					.queryKey,
+				data: Mocks.MockTemplateVersion,
+			},
+		],
+	},
 	beforeEach: () => {
 		spyOn(API, "restartWorkspace").mockResolvedValue(undefined);
 	},

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
+import { buildInfoKey } from "#/api/queries/buildInfo";
+import { templateVersion } from "#/api/queries/templates";
+import { agentListeningPorts } from "#/api/queries/workspaces";
 import * as Mocks from "#/testHelpers/entities";
 import {
 	withAuthProvider,
@@ -28,16 +31,14 @@ const meta: Meta<typeof WorkspaceReadyPage> = {
 	},
 	parameters: {
 		queries: [
-			{ key: ["buildInfo"], data: Mocks.MockBuildInfo },
+			{ key: buildInfoKey, data: Mocks.MockBuildInfo },
 			{
-				key: ["portForward", Mocks.MockWorkspaceAgent.id],
+				key: agentListeningPorts(Mocks.MockWorkspaceAgent.id).queryKey,
 				data: Mocks.MockListeningPortsResponse,
 			},
 			{
-				key: [
-					"templateVersion",
-					Mocks.MockWorkspace.template_active_version_id,
-				],
+				key: templateVersion(Mocks.MockWorkspace.template_active_version_id)
+					.queryKey,
 				data: Mocks.MockTemplateVersion,
 			},
 		],

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.stories.tsx
@@ -92,3 +92,20 @@ export const RestartDialogOutdatedWorkspace: Story = {
 		);
 	},
 };
+
+export const ConfirmRestart: Story = {
+	beforeEach: () => {
+		spyOn(API, "restartWorkspace").mockResolvedValue(undefined);
+	},
+	play: async ({ canvasElement }) => {
+		const dialog = await openRestartDialog(canvasElement);
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Restart" }),
+		);
+		await waitFor(() =>
+			expect(API.restartWorkspace).toHaveBeenCalledWith(
+				expect.objectContaining({ workspace: Mocks.MockWorkspace }),
+			),
+		);
+	},
+};

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -385,6 +385,8 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 					<>
 						Restarting your workspace will stop all running processes and{" "}
 						<strong>delete non-persistent data</strong>.
+						{workspace.outdated &&
+							" This workspace will start using the template's latest active version."}
 					</>
 				}
 			/>

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -384,9 +384,9 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 				description={
 					<>
 						Restarting your workspace will stop all running processes and{" "}
-						<strong>delete non-persistent data</strong>.
-						{workspace.outdated &&
-							" This workspace will start using the template's latest active version."}
+						<strong>delete non-persistent data</strong>. The workspace will
+						start using the template's active version, which may include an
+						update.
 					</>
 				}
 			/>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
@@ -156,7 +156,32 @@ export const RestartFailureShowsErrorToast: Story = {
 				},
 			],
 		}),
-		queries: workspaceQueries(autostopDisabledWorkspace),
+		queries: [
+			{
+				key: workspaceByOwnerAndNameKey(
+					autostopDisabledWorkspace.owner_name,
+					autostopDisabledWorkspace.name,
+				),
+				data: autostopDisabledWorkspace,
+			},
+			{
+				key: ["workspaces", autostopDisabledWorkspace.id, "permissions"],
+				data: {
+					readWorkspace: true,
+					shareWorkspace: true,
+					updateWorkspace: true,
+					updateWorkspaceVersion: true,
+					deleteFailedWorkspace: true,
+				} satisfies WorkspacePermissions,
+			},
+			{
+				key: templateByNameKey(
+					autostopDisabledWorkspace.organization_id,
+					autostopDisabledWorkspace.template_name,
+				),
+				data: MockTemplate,
+			},
+		],
 	},
 	beforeEach: () => {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
@@ -210,7 +235,32 @@ export const ChangingAutostopValueShowsRestartDialog: Story = {
 export const RestartDialogWarnsAboutTemplateUpdate: Story = {
 	parameters: {
 		reactRouter: workspaceRouterParameters(MockWorkspace),
-		queries: workspaceQueries(MockWorkspace),
+		queries: [
+			{
+				key: workspaceByOwnerAndNameKey(
+					MockWorkspace.owner_name,
+					MockWorkspace.name,
+				),
+				data: MockWorkspace,
+			},
+			{
+				key: ["workspaces", MockWorkspace.id, "permissions"],
+				data: {
+					readWorkspace: true,
+					shareWorkspace: true,
+					updateWorkspace: true,
+					updateWorkspaceVersion: true,
+					deleteFailedWorkspace: true,
+				} satisfies WorkspacePermissions,
+			},
+			{
+				key: templateByNameKey(
+					MockWorkspace.organization_id,
+					MockWorkspace.template_name,
+				),
+				data: MockTemplate,
+			},
+		],
 	},
 	beforeEach: () => {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(MockWorkspace);

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Outlet } from "react-router";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import {
 	reactRouterOutlet,
@@ -8,6 +9,7 @@ import { API } from "#/api/api";
 import { templateByNameKey } from "#/api/queries/templates";
 import { workspaceByOwnerAndNameKey } from "#/api/queries/workspaces";
 import type { Workspace } from "#/api/typesGenerated";
+import { Toaster } from "#/components/Toaster/Toaster";
 import type { WorkspacePermissions } from "#/modules/workspaces/permissions";
 import {
 	MockPrebuiltWorkspace,
@@ -121,6 +123,62 @@ export const ApplyLaterKeepsUserOnSchedulePage: Story = {
 		);
 		expect(restartSpy).not.toHaveBeenCalled();
 		await canvas.findByLabelText("Enable Autostop");
+	},
+};
+
+export const RestartFailureShowsErrorToast: Story = {
+	parameters: {
+		// Confirming the restart navigates to the workspace page, so this
+		// story needs that route plus a layout-level Toaster that stays
+		// mounted across the navigation, like the production app root.
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `/@${autostopDisabledWorkspace.owner_name}/${autostopDisabledWorkspace.name}/settings/schedule`,
+			},
+			routing: [
+				{
+					element: (
+						<>
+							<Outlet />
+							<Toaster />
+						</>
+					),
+					children: [
+						...reactRouterOutlet(
+							{ path: "/:username/:workspace/settings/schedule" },
+							<WorkspaceSchedulePage />,
+						),
+						{
+							path: "/:username/:workspace",
+							element: <div>Workspace Page</div>,
+						},
+					],
+				},
+			],
+		}),
+		queries: workspaceQueries(autostopDisabledWorkspace),
+	},
+	beforeEach: () => {
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			autostopDisabledWorkspace,
+		);
+		spyOn(API, "restartWorkspace").mockRejectedValue(
+			new Error(
+				"The workspace stopped, but the server did not start it again.",
+			),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const user = userEvent.setup();
+		await user.click(await canvas.findByLabelText("Enable Autostop"));
+		await user.click(await canvas.findByRole("button", { name: /save/i }));
+		await body.findByText("Restart workspace?");
+		await user.click(await body.findByRole("button", { name: /^restart$/i }));
+		await body.findByText(
+			`Failed to restart workspace "${MockWorkspace.name}".`,
+		);
 	},
 };
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
@@ -149,17 +149,13 @@ export const ChangingAutostopValueShowsRestartDialog: Story = {
 	},
 };
 
-const outdatedWorkspace: Workspace = { ...MockWorkspace, outdated: true };
-
 export const RestartDialogWarnsAboutTemplateUpdate: Story = {
 	parameters: {
-		reactRouter: workspaceRouterParameters(outdatedWorkspace),
-		queries: workspaceQueries(outdatedWorkspace),
+		reactRouter: workspaceRouterParameters(MockWorkspace),
+		queries: workspaceQueries(MockWorkspace),
 	},
 	beforeEach: () => {
-		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
-			outdatedWorkspace,
-		);
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(MockWorkspace);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -173,7 +169,7 @@ export const RestartDialogWarnsAboutTemplateUpdate: Story = {
 		await user.click(await canvas.findByRole("button", { name: /save/i }));
 		await body.findByText("Restart workspace?");
 		await body.findByText(
-			/Restarting now will also update the workspace to the template's latest active version/,
+			/The restarted workspace will use the template's active version/,
 		);
 	},
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
@@ -149,6 +149,35 @@ export const ChangingAutostopValueShowsRestartDialog: Story = {
 	},
 };
 
+const outdatedWorkspace: Workspace = { ...MockWorkspace, outdated: true };
+
+export const RestartDialogWarnsAboutTemplateUpdate: Story = {
+	parameters: {
+		reactRouter: workspaceRouterParameters(outdatedWorkspace),
+		queries: workspaceQueries(outdatedWorkspace),
+	},
+	beforeEach: () => {
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			outdatedWorkspace,
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const user = userEvent.setup();
+		const ttlInput = await canvas.findByLabelText(
+			"Time until shutdown (hours)",
+		);
+		await user.clear(ttlInput);
+		await user.type(ttlInput, "4");
+		await user.click(await canvas.findByRole("button", { name: /save/i }));
+		await body.findByText("Restart workspace?");
+		await body.findByText(
+			/Restarting now will also update the workspace to the template's latest active version/,
+		);
+	},
+};
+
 export const DisablingAutostopSkipsRestartDialog: Story = {
 	parameters: {
 		reactRouter: workspaceRouterParameters(MockWorkspace),

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.stories.tsx
@@ -7,7 +7,10 @@ import {
 } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
 import { templateByNameKey } from "#/api/queries/templates";
-import { workspaceByOwnerAndNameKey } from "#/api/queries/workspaces";
+import {
+	workspaceByOwnerAndNameKey,
+	workspacePermissions,
+} from "#/api/queries/workspaces";
 import type { Workspace } from "#/api/typesGenerated";
 import { Toaster } from "#/components/Toaster/Toaster";
 import type { WorkspacePermissions } from "#/modules/workspaces/permissions";
@@ -165,7 +168,7 @@ export const RestartFailureShowsErrorToast: Story = {
 				data: autostopDisabledWorkspace,
 			},
 			{
-				key: ["workspaces", autostopDisabledWorkspace.id, "permissions"],
+				key: workspacePermissions(autostopDisabledWorkspace).queryKey,
 				data: {
 					readWorkspace: true,
 					shareWorkspace: true,
@@ -244,7 +247,7 @@ export const RestartDialogWarnsAboutTemplateUpdate: Story = {
 				data: MockWorkspace,
 			},
 			{
-				key: ["workspaces", MockWorkspace.id, "permissions"],
+				key: workspacePermissions(MockWorkspace).queryKey,
 				data: {
 					readWorkspace: true,
 					shareWorkspace: true,

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -69,6 +69,10 @@ const WorkspaceSchedulePage: FC = () => {
 	const [isConfirmingApply, setIsConfirmingApply] = useState(false);
 	const { mutate: restartWorkspace } = useMutation({
 		mutationFn: () => API.restartWorkspace({ workspace }),
+		onError: (error) =>
+			toast.error(`Failed to restart workspace "${workspaceName}".`, {
+				description: getErrorDetail(error),
+			}),
 	});
 
 	return (

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -164,11 +164,7 @@ const WorkspaceSchedulePage: FC = () => {
 			<ConfirmDialog
 				open={isConfirmingApply}
 				title="Restart workspace?"
-				description={
-					workspace.outdated
-						? "Would you like to restart your workspace now to apply your new autostop setting, or let it apply after your next workspace start? Restarting now will also update the workspace to the template's latest active version."
-						: "Would you like to restart your workspace now to apply your new autostop setting, or let it apply after your next workspace start?"
-				}
+				description="Would you like to restart your workspace now to apply your new autostop setting, or let it apply after your next workspace start? The restarted workspace will use the template's active version, which may include an update."
 				confirmText="Restart"
 				cancelText="Apply later"
 				hideCancel={false}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -164,7 +164,11 @@ const WorkspaceSchedulePage: FC = () => {
 			<ConfirmDialog
 				open={isConfirmingApply}
 				title="Restart workspace?"
-				description="Would you like to restart your workspace now to apply your new autostop setting, or let it apply after your next workspace start?"
+				description={
+					workspace.outdated
+						? "Would you like to restart your workspace now to apply your new autostop setting, or let it apply after your next workspace start? Restarting now will also update the workspace to the template's latest active version."
+						: "Would you like to restart your workspace now to apply your new autostop setting, or let it apply after your next workspace start?"
+				}
 				confirmText="Restart"
 				cancelText="Apply later"
 				hideCancel={false}

--- a/site/src/utils/delay.test.ts
+++ b/site/src/utils/delay.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { delay } from "./delay";
+
+describe("delay", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("resolves after the given time", async () => {
+		let resolved = false;
+		void delay(1000).then(() => {
+			resolved = true;
+		});
+
+		await vi.advanceTimersByTimeAsync(999);
+		expect(resolved).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(resolved).toBe(true);
+	});
+
+	it("resolves early when the signal aborts", async () => {
+		const controller = new AbortController();
+		let resolved = false;
+		void delay(60_000, controller.signal).then(() => {
+			resolved = true;
+		});
+
+		controller.abort();
+		await vi.advanceTimersByTimeAsync(0);
+		expect(resolved).toBe(true);
+	});
+
+	it("resolves immediately for an already-aborted signal", async () => {
+		let resolved = false;
+		void delay(60_000, AbortSignal.abort()).then(() => {
+			resolved = true;
+		});
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(resolved).toBe(true);
+	});
+});

--- a/site/src/utils/delay.ts
+++ b/site/src/utils/delay.ts
@@ -1,4 +1,16 @@
-export const delay = (ms: number): Promise<void> =>
+export const delay = (ms: number, signal?: AbortSignal): Promise<void> =>
 	new Promise((res) => {
-		setTimeout(res, ms);
+		if (signal?.aborted) {
+			res();
+			return;
+		}
+		const onAbort = () => {
+			clearTimeout(timeoutId);
+			res();
+		};
+		const timeoutId = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			res();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
 	});


### PR DESCRIPTION
Migrates the web UI restart flow to the server-side restart orchestration API added in coder/coder#25757[-coder/coder#25759](<https://github.com/-coder/coder/issues/25759>) (coder/coder#5800). Closes [DEVEX-758](https://linear.app/codercom/issue/DEVEX-758/migrate-web-ui-restart-flow-to-new-restart-api-functionality).

## Changes

`API.restartWorkspace` previously orchestrated a restart client-side: POST a stop build, poll it to completion, then POST a start build pinned to the previous template version and poll that too. If the browser tab went away mid-restart, the workspace stayed stopped.

Now it sends a single build request: `transition: "stop"`, `reason: "dashboard"`, and `on_success: { transition: "start", rich_parameter_values }`. The server persists the follow-up start intent atomically with the stop build and creates the start build after the stop succeeds, so the restart survives the client. The client keeps waiting for display only (the React Query mutation still spans the whole cycle, preserving the "Restarting" button state): it waits for the stop build, then discovers the server-created child build (the oldest post-stop start build, queried with `since` so intervening builds cannot hide it) for up to 180s to cover the orchestrator's retry lifecycle, tolerating transient poll failures, then waits for the child build. Schedule-page restarts now surface failures as an error toast instead of discarding them.

Behavior change: the request omits `on_success.template_version_id` because pinning requires template-update permission, so the follow-up start uses the template's active version at start time. Restarting an outdated workspace therefore also updates it; both restart confirmation dialogs warn about this unconditionally, since the active version can change between confirmation and start.

## Testing

* `restartWorkspace` unit tests: single POST shape with `on_success` (with and without build parameters), canceled-stop bail, failed-stop rejection, child discovery that skips intervening non-start builds, transient poll-failure tolerance, and the 180s deadline with in-flight request cancellation (red-green verified).
* Storybook interaction coverage for both restart dialogs, the confirm flow, and the schedule-page failure toast.
* Remote dogfood UAT passed: one build POST per restart (payload verified via devtools), stop then orchestrator-created start in build history, "Restarting" state through the full cycle, and schedule-page apply-now restart.

Known follow-ups (out of scope):

* `WorkspaceParametersPage` still uses its own client-side stop-then-start flow when saving parameter changes on a running workspace; it can migrate to `on_success.rich_parameter_values` in a separate PR.
* The API does not expose orchestration status, so when the server permanently fails to create the follow-up start build (for example, stored parameters that are invalid for the active template version), the UI can only report an actionable timeout after the discovery deadline. Exposing the orchestration's terminal error is a backend change that would let the dashboard fail fast.
* The same missing surface means the client discovers the child build heuristically (oldest post-stop start build) and hardcodes a deadline derived from the orchestrator's internal retry timing. The wait is display-only (workspace state stays correct); exposing the orchestration's child build ID would remove both guesses.

> Mux acted on Mike's behalf to create this PR.