### PR TITLE
fix(site/src/pages/AgentsPage): improve git panel color contrast

### DIFF
--- a/site/src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx
@@ -153,7 +153,7 @@ export const RemoteDiffPanel: FC<RemoteDiffPanelProps> = ({
 							href={pullRequestUrl}
 							target="_blank"
 							rel="noreferrer"
-							className="inline-flex items-center gap-1 rounded-sm border border-solid border-border-default px-2 text-[13px] font-medium leading-5 text-content-secondary no-underline transition-colors hover:bg-surface-secondary hover:text-content-primary"
+							className="inline-flex items-center gap-1 rounded-sm border border-solid border-border-default px-2 text-[13px] font-medium leading-5 text-content-primary no-underline transition-colors hover:bg-surface-secondary"
 						>
 							View PR
 							<ExternalLinkIcon className="size-3" />

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -298,9 +298,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 		itemPrimary: "Working",
 		itemSecondary: repoLabel(repoRoot),
 		stateClasses: "text-content-secondary",
-		icon: (
-			<CircleDotIcon className="!size-3.5 shrink-0 text-content-secondary" />
-		),
+		icon: <CircleDotIcon className="!size-3.5 shrink-0 text-content-warning" />,
 	}));
 
 	const items: ViewItem[] = [

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -297,8 +297,10 @@ export const GitPanel: FC<GitPanelProps> = ({
 		triggerIdentifier: repoLabel(repoRoot),
 		itemPrimary: "Working",
 		itemSecondary: repoLabel(repoRoot),
-		stateClasses: "text-content-warning",
-		icon: <CircleDotIcon className="!size-3.5 shrink-0 text-content-warning" />,
+		stateClasses: "text-content-secondary",
+		icon: (
+			<CircleDotIcon className="!size-3.5 shrink-0 text-content-secondary" />
+		),
 	}));
 
 	const items: ViewItem[] = [
@@ -702,7 +704,7 @@ const RepoHeader: FC<{
 					type="button"
 					onClick={onCommit}
 					disabled={!repo.unified_diff}
-					className="inline-flex cursor-pointer items-center gap-1 rounded-sm border border-solid border-border-default bg-transparent px-2 text-[13px] font-medium leading-5 text-content-secondary no-underline transition-colors hover:bg-surface-secondary hover:text-content-primary disabled:pointer-events-none disabled:opacity-50"
+					className="inline-flex cursor-pointer items-center gap-1 rounded-sm border border-solid border-border-default bg-transparent px-2 text-[13px] font-medium leading-5 text-content-primary no-underline transition-colors hover:bg-surface-secondary disabled:pointer-events-none disabled:opacity-50"
 				>
 					<CheckIcon className="size-3" />
 					Commit


### PR DESCRIPTION
## Summary

Follow-up to #27012 addressing color contrast in the git panel:

- The orange (`text-content-warning`) **Working** label failed color contrast. The label in the view switcher trigger and dropdown now uses `text-content-secondary`. The `CircleDotIcon` keeps its original `text-content-warning` color as a state indicator.
- The **Commit** and **View PR** buttons now use `text-content-primary` for their text and icons instead of `text-content-secondary`. The now-redundant `hover:text-content-primary` was dropped.

No behavior changes; class-only updates in `GitPanel.tsx` and `RemoteDiffPanel.tsx`.

## Testing

- `biome check` and `tsc --noEmit` pass on the touched files.
- Verified visually via Storybook screenshots of the GitPanel stories.

---

> Generated by Coder Agents on behalf of @tracyjohnsonux.