### PR TITLE
fix(coderd/x/agenthooks/dispatch): deflake TestDispatcherTimeoutNoRetry

### DIFF
--- a/coderd/x/agenthooks/dispatch/dispatcher_internal_test.go
+++ b/coderd/x/agenthooks/dispatch/dispatcher_internal_test.go
@@ -197,19 +197,18 @@ func TestDispatcherTimeoutNoRetry(t *testing.T) {
 
 	event := newTestEvent(t, agenthooks.EventStop, agenthooks.StopData{})
 	var requests atomic.Int32
-	release := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// A real server cannot guarantee the handler runs before the short
+	// dispatch deadline on a loaded machine, so the transport records the
+	// attempt synchronously and blocks until the deadline expires.
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests.Add(1)
-		w.WriteHeader(http.StatusOK)
-		assert.NoError(t, http.NewResponseController(w).Flush())
-		<-release
-	}))
-	t.Cleanup(server.Close)
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
 
-	_, _, err := newTestDispatcher(t, server.Client(), server.URL, 50*time.Millisecond).Dispatch(
+	_, _, err := newTestDispatcher(t, client, "https://hooks.example.com/coder", 50*time.Millisecond).Dispatch(
 		testutil.Context(t, testutil.WaitLong), event,
 	)
-	close(release)
 	assertDispatchErrorClass(t, err, ResultTimeout)
 	require.Equal(t, int32(1), requests.Load())
 }

--- a/coderd/x/agenthooks/dispatch/dispatcher_internal_test.go
+++ b/coderd/x/agenthooks/dispatch/dispatcher_internal_test.go
@@ -199,11 +199,15 @@ func TestDispatcherTimeoutNoRetry(t *testing.T) {
 	var requests atomic.Int32
 	// A real server cannot guarantee the handler runs before the short
 	// dispatch deadline on a loaded machine, so the transport records the
-	// attempt synchronously and blocks until the deadline expires.
+	// attempt synchronously. The successful response with a body that blocks
+	// until the deadline expires keeps the read-path timeout branch covered.
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requests.Add(1)
-		<-req.Context().Done()
-		return nil, req.Context().Err()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       contextBlockedBody{ctx: req.Context()},
+			Request:    req,
+		}, nil
 	})}
 
 	_, _, err := newTestDispatcher(t, client, "https://hooks.example.com/coder", 50*time.Millisecond).Dispatch(
@@ -707,6 +711,15 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
+
+type contextBlockedBody struct{ ctx context.Context }
+
+func (b contextBlockedBody) Read([]byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (contextBlockedBody) Close() error { return nil }
 
 func TestDispatcherCapacityClassRequired(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes the `TestDispatcherTimeoutNoRetry` flake from [CODAGT-919](https://linear.app/codercom/issue/CODAGT-919/flake-testdispatchertimeoutnoretry).

## Problem

The test asserted `requests.Load() == 1` where the counter was incremented inside an `httptest` handler, under a hard 50 ms dispatch timeout. On a loaded runner (observed on the `test-go-pg (windows-2022)` gauntlet) the deadline expired before the handler was scheduled, so timeout classification succeeded but the request count observed 0.

## Fix

Replace the real server with a `roundTripFunc` transport stub (helper already in the file) that records the attempt synchronously, blocks on `req.Context().Done()`, and returns the context error. The dispatcher's own 50 ms deadline still genuinely expires and takes the timeout classification path in `post()`, and a retry regression would synchronously invoke the stub a second time, so both assertions keep guarding the same behavior without depending on scheduler timing.

## Validation

- `go test ./coderd/x/agenthooks/dispatch -run '^TestDispatcherTimeoutNoRetry$' -count=100` and `-race -count=40` pass; full package suite passes with `-race`.
- Red toggle: disabling the timeout classification branch in `dispatcher.go` fails the test with `expected: "timeout", actual: "protocol_error"`, confirming the test still guards that branch.

> Mux acted on Mike's behalf to create this PR.
