### PR TITLE
feat: unhide --oidc-redirect-url server option

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -807,6 +807,12 @@ OIDC OPTIONS:
       --oidc-name-field string, $CODER_OIDC_NAME_FIELD (default: name)
           OIDC claim field to use as the name.
 
+      --oidc-redirect-url url, $CODER_OIDC_REDIRECT_URL
+          Optional override of the default redirect url which uses the
+          deployment's access url. Useful in situations where a deployment has
+          more than 1 domain. Using this setting can also break OIDC, so use
+          with caution.
+
       --oidc-group-regex-filter regexp, $CODER_OIDC_GROUP_REGEX_FILTER (default: .*)
           If provided any group name not matching the regex is ignored. This
           allows for filtering out groups that are not needed. This filter is

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3087,9 +3087,6 @@ communicating directly.`,
 			Value:      &c.OIDC.RedirectURL,
 			Group:      &deploymentGroupOIDC,
 			UseInstead: nil,
-			// In most deployments, this setting can only complicate and break OIDC.
-			// So hide it, and only surface it to the small number of users that need it.
-			Hidden: true,
 		},
 		{
 			Name: "OIDC Auto Repair Links",

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -1593,6 +1593,14 @@ OIDC claim field to use as the name.
 - YAML key: `oidc.nameField`
 - Default value: `name`
 
+### Redirect URL
+
+Optional override of the default redirect url which uses the deployment's access url. Useful in situations where a deployment has more than 1 domain. Using this setting can also break OIDC, so use with caution.
+
+- Environment variable: `CODER_OIDC_REDIRECT_URL`
+- CLI flag: [`--oidc-redirect-url`](../../reference/cli/server.md#--oidc-redirect-url)
+- YAML key: `oidc.oidc-redirect-url`
+
 ### Regex group filter
 
 If provided any group name not matching the regex is ignored. This allows for filtering out groups that are not needed. This filter is applied after the group mapping.

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -722,6 +722,16 @@ The custom text to show on the error page informing about disabled OIDC signups.
 
 OIDC issuer urls must match in the request, the id_token 'iss' claim, and in the well-known configuration. This flag disables that requirement, and can lead to an insecure OIDC configuration. It is not recommended to use this flag.
 
+### --oidc-redirect-url
+
+|             |                                       |
+|-------------|---------------------------------------|
+| Type        | <code>url</code>                      |
+| Environment | <code>$CODER_OIDC_REDIRECT_URL</code> |
+| YAML        | <code>oidc.oidc-redirect-url</code>   |
+
+Optional override of the default redirect url which uses the deployment's access url. Useful in situations where a deployment has more than 1 domain. Using this setting can also break OIDC, so use with caution.
+
 ### --telemetry
 
 |             |                                      |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -808,6 +808,12 @@ OIDC OPTIONS:
       --oidc-name-field string, $CODER_OIDC_NAME_FIELD (default: name)
           OIDC claim field to use as the name.
 
+      --oidc-redirect-url url, $CODER_OIDC_REDIRECT_URL
+          Optional override of the default redirect url which uses the
+          deployment's access url. Useful in situations where a deployment has
+          more than 1 domain. Using this setting can also break OIDC, so use
+          with caution.
+
       --oidc-group-regex-filter regexp, $CODER_OIDC_GROUP_REGEX_FILTER (default: .*)
           If provided any group name not matching the regex is ignored. This
           allows for filtering out groups that are not needed. This filter is


### PR DESCRIPTION
Unhides the `--oidc-redirect-url` / `CODER_OIDC_REDIRECT_URL` server option so it appears in `coder server --help` and the deployment configuration docs.

- Removed `Hidden: true` from the option in `codersdk/deployment.go`
- Regenerated CLI golden files and docs via `make gen`

---

> Generated with Coder Agents on behalf of @Emyrk