### PR TITLE
feat: update copy for AI Governance licensing change

### DIFF
--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -15,8 +15,8 @@ const (
 	LicenseExpiryClaim                          = "license_expires"
 	LicenseTelemetryRequiredErrorText           = "License requires telemetry but telemetry is disabled"
 	LicenseManagedAgentLimitExceededWarningText = "You have built more workspaces with managed agents than your license allows."
-	LicenseAIGovernance90PercentWarningText     = "You have used %d%% of your AI Governance add-on seats."
-	LicenseAIGovernanceOverLimitWarningText     = "Your organization is using %d of %d AI Governance add-on seats (%d over the limit)."
+	LicenseAIGovernance90PercentWarningText     = "You have used %d%% of your AI Governance seats."
+	LicenseAIGovernanceOverLimitWarningText     = "Your organization is using %d of %d AI Governance seats (%d over the limit)."
 )
 
 type AddLicenseRequest struct {

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -329,10 +329,10 @@ func LicensesEntitlements(
 	keys map[string]ed25519.PublicKey,
 	featureArguments FeatureArguments,
 ) (codersdk.Entitlements, error) {
-	// TODO: Remove this tracking once AI Bridge is enforced as an add-on license.
-	// Track if AI Bridge was explicitly granted via license Features (add-on)
+	// TODO: Remove this tracking once AI Gateway is enforced as an add-on license.
+	// Track if AI Gateway was explicitly granted via license Features (add-on)
 	// vs inherited from FeatureSet (Premium). Only explicit grants should
-	// suppress the soft warning for AI Bridge GA.
+	// suppress the soft warning for AI Gateway GA.
 	hasExplicitAIBridgeEntitlement := false
 
 	// Each valid license's FeatureUserLimit claim forms a candidate pairing of
@@ -465,9 +465,9 @@ func LicensesEntitlements(
 			})
 		}
 
-		// TODO: Remove this tracking once AI Bridge is enforced as an add-on license.
-		// Track explicit AI Bridge entitlement (add-on license). This is checked
-		// at the license level since AI Bridge may come from the FeatureSet
+		// TODO: Remove this tracking once AI Gateway is enforced as an add-on license.
+		// Track explicit AI Gateway entitlement (add-on license). This is checked
+		// at the license level since AI Gateway may come from the FeatureSet
 		// (Premium) rather than being explicitly listed in claims.Features.
 		// Only having the AI Governance addon should suppress the soft warning.
 		if slices.Contains(claims.Addons, codersdk.AddonAIGovernance) {
@@ -832,15 +832,15 @@ func LicensesEntitlements(
 			}
 		}
 
-		// TODO: Remove this soft warning block once AI Bridge is enforced as an add-on license.
-		// AI Bridge soft warning: Show warning when AI Bridge is enabled and
-		// entitled via Premium FeatureSet but not via explicit add-on license.
-		// This is a transitional warning as AI Bridge moves to GA and will
-		// require a separate add-on license in future versions.
+		// TODO: Remove this soft warning block once AI Gateway is enforced as a Premium feature.
+		// AI Gateway soft warning: Show warning when AI Gateway is enabled and
+		// entitled via Premium FeatureSet but not via an explicit AI Governance
+		// license. This is a transitional warning as AI Gateway moves to GA and
+		// will require a Premium license in future versions.
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		if aiBridgeFeature.Enabled && aiBridgeFeature.Entitlement.Entitled() && !hasExplicitAIBridgeEntitlement {
 			entitlements.Warnings = append(entitlements.Warnings,
-				"The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more.")
+				"AI Governance requires a Premium license. Please reach out to your account team or sales@coder.com to learn more.")
 		}
 	}
 

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -1610,11 +1610,11 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 		codersdk.FeatureAIBridge: false,
 	}
 
-	aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more."
+	aiGatewayWarningMessage := "AI Governance requires a Premium license. Please reach out to your account team or sales@coder.com to learn more."
 
 	t.Run("NoAddon_AIBridgeOff", func(t *testing.T) {
 		t.Parallel()
-		// License without addon and AI Bridge disabled should NOT show warning.
+		// License without addon and AI Gateway disabled should NOT show warning.
 		lo := (&coderdenttest.LicenseOptions{
 			AccountType: "salesforce",
 			AccountID:   "test",
@@ -1636,12 +1636,12 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		assert.False(t, aiBridgeFeature.Enabled)
-		require.NotContains(t, entitlements.Warnings, aiBridgeWarningMessage)
+		require.NotContains(t, entitlements.Warnings, aiGatewayWarningMessage)
 	})
 
 	t.Run("NoAddon_AIBridgeOn", func(t *testing.T) {
 		t.Parallel()
-		// License without addon and AI Bridge enabled SHOULD show warning.
+		// License without addon and AI Gateway enabled SHOULD show warning.
 		lo := (&coderdenttest.LicenseOptions{
 			AccountType: "salesforce",
 			AccountID:   "test",
@@ -1664,12 +1664,12 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		assert.True(t, aiBridgeFeature.Enabled)
 		assert.Equal(t, codersdk.EntitlementEntitled, aiBridgeFeature.Entitlement)
-		require.Contains(t, entitlements.Warnings, aiBridgeWarningMessage)
+		require.Contains(t, entitlements.Warnings, aiGatewayWarningMessage)
 	})
 
 	t.Run("Addon_AIBridgeOff", func(t *testing.T) {
 		t.Parallel()
-		// License with addon and AI Bridge disabled should NOT show warning.
+		// License with addon and AI Gateway disabled should NOT show warning.
 		lo := (&coderdenttest.LicenseOptions{
 			AccountType: "salesforce",
 			AccountID:   "test",
@@ -1695,12 +1695,12 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		assert.False(t, aiBridgeFeature.Enabled)
-		require.NotContains(t, entitlements.Warnings, aiBridgeWarningMessage)
+		require.NotContains(t, entitlements.Warnings, aiGatewayWarningMessage)
 	})
 
 	t.Run("Addon_AIBridgeOn", func(t *testing.T) {
 		t.Parallel()
-		// License with addon and AI Bridge enabled should NOT show warning.
+		// License with addon and AI Gateway enabled should NOT show warning.
 		lo := (&coderdenttest.LicenseOptions{
 			AccountType: "salesforce",
 			AccountID:   "test",
@@ -1727,19 +1727,19 @@ func TestAIBridgeSoftWarning(t *testing.T) {
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		assert.True(t, aiBridgeFeature.Enabled)
 		assert.Equal(t, codersdk.EntitlementEntitled, aiBridgeFeature.Entitlement)
-		require.NotContains(t, entitlements.Warnings, aiBridgeWarningMessage)
+		require.NotContains(t, entitlements.Warnings, aiGatewayWarningMessage)
 	})
 
 	t.Run("NoLicense_AIBridgeOn", func(t *testing.T) {
 		t.Parallel()
-		// No license with AI Bridge enabled should NOT show the soft warning
+		// No license with AI Gateway enabled should NOT show the soft warning
 		// (it will show the generic "not entitled" warning instead).
 		entitlements, err := license.LicensesEntitlements(context.Background(), time.Now(), []database.License{}, aiBridgeEnabledEnablements, coderdenttest.Keys, license.FeatureArguments{})
 		require.NoError(t, err)
 
 		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
 		assert.Equal(t, codersdk.EntitlementNotEntitled, aiBridgeFeature.Entitlement)
-		require.NotContains(t, entitlements.Warnings, aiBridgeWarningMessage)
+		require.NotContains(t, entitlements.Warnings, aiGatewayWarningMessage)
 	})
 }
 
@@ -2734,13 +2734,13 @@ func TestAIGovernanceAddon(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, entitlements.HasLicense)
 
-		// AI Bridge should be enabled without warning when addon is present.
+		// AI Gateway should be enabled without warning when addon is present.
 		aibridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
-		require.True(t, aibridgeFeature.Enabled, "AI Bridge should be enabled when addon is present and enablements are set")
-		aiBridgeWarningMessage := "The AI Governance add-on is required to use AI Gateway. Please reach out to your account team or sales@coder.com to learn more."
-		require.NotContains(t, entitlements.Warnings, aiBridgeWarningMessage, "AI Bridge warning should not appear when AI Governance addon is present")
+		require.True(t, aibridgeFeature.Enabled, "AI Gateway should be enabled when addon is present and enablements are set")
+		aiGatewayWarningMessage := "AI Governance requires a Premium license. Please reach out to your account team or sales@coder.com to learn more."
+		require.NotContains(t, entitlements.Warnings, aiGatewayWarningMessage, "AI Gateway warning should not appear when AI Governance addon is present")
 
-		// require.Equal(t, codersdk.EntitlementEntitled, aibridgeFeature.Entitlement, "AI Bridge should be entitled when addon is present")
+		// require.Equal(t, codersdk.EntitlementEntitled, aibridgeFeature.Entitlement, "AI Gateway should be entitled when addon is present")
 
 		// TODO: Readd this test once Boundary is enforced as an add-on license.
 		// boundaryFeature := entitlements.Features[codersdk.FeatureBoundary]
@@ -2766,11 +2766,11 @@ func TestAIGovernanceAddon(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, entitlements.HasLicense)
 
-		// TODO: Readd this test once AI Bridge is enforced as an add-on license.
-		// AI Bridge should not be entitled.
+		// TODO: Readd this test once AI Gateway is enforced as an add-on license.
+		// AI Gateway should not be entitled.
 		// aibridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
-		// require.False(t, aibridgeFeature.Enabled, "AI Bridge should not be enabled when addon is absent")
-		// require.Equal(t, codersdk.EntitlementNotEntitled, aibridgeFeature.Entitlement, "AI Bridge should not be entitled when addon is absent")
+		// require.False(t, aibridgeFeature.Enabled, "AI Gateway should not be enabled when addon is absent")
+		// require.Equal(t, codersdk.EntitlementNotEntitled, aibridgeFeature.Entitlement, "AI Gateway should not be entitled when addon is absent")
 
 		// TODO: Readd this test once Boundary is enforced as an add-on license.
 		// boundaryFeature := entitlements.Features[codersdk.FeatureBoundary]
@@ -2804,11 +2804,11 @@ func TestAIGovernanceAddon(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, entitlements.HasLicense)
 
-		// TODO: Readd this test once AI Bridge is enforced as an add-on license.
+		// TODO: Readd this test once AI Gateway is enforced as an add-on license.
 		// AI Governance features should be enabled but in grace period.
 		// aibridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
-		// require.True(t, aibridgeFeature.Enabled, "AI Bridge should be enabled during grace period")
-		// require.Equal(t, codersdk.EntitlementGracePeriod, aibridgeFeature.Entitlement, "AI Bridge should be in grace period")
+		// require.True(t, aibridgeFeature.Enabled, "AI Gateway should be enabled during grace period")
+		// require.Equal(t, codersdk.EntitlementGracePeriod, aibridgeFeature.Entitlement, "AI Gateway should be in grace period")
 
 		// TODO: Readd this test once Boundary is enforced as an add-on license.
 		// boundaryFeature := entitlements.Features[codersdk.FeatureBoundary]
@@ -2835,10 +2835,10 @@ func TestAIGovernanceAddon(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, entitlements.HasLicense)
 
-		// TODO: Readd this test once AI Bridge is enforced as an add-on license.
+		// TODO: Readd this test once AI Gateway is enforced as an add-on license.
 		// aibridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
-		// require.False(t, aibridgeFeature.Enabled, "AI Bridge should not be enabled without enablements")
-		// require.Equal(t, codersdk.EntitlementEntitled, aibridgeFeature.Entitlement, "AI Bridge should still be entitled")
+		// require.False(t, aibridgeFeature.Enabled, "AI Gateway should not be enabled without enablements")
+		// require.Equal(t, codersdk.EntitlementEntitled, aibridgeFeature.Entitlement, "AI Gateway should still be entitled")
 
 		// TODO: Readd this test once Boundary is enforced as an add-on license.
 		// boundaryFeature := entitlements.Features[codersdk.FeatureBoundary]
@@ -2872,11 +2872,11 @@ func TestAIGovernanceAddon(t *testing.T) {
 		require.Len(t, entitlements.Errors, 1)
 		require.Equal(t, "Feature AI Governance User Limit must be set when using the AI Governance addon.", entitlements.Errors[0])
 
-		// TODO: Readd this test once AI Bridge is enforced as an add-on license.
+		// TODO: Readd this test once AI Gateway is enforced as an add-on license.
 		// AI Governance features should not be entitled when validation fails.
 		// aibridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
-		// require.False(t, aibridgeFeature.Enabled, "AI Bridge should not be enabled when addon validation fails")
-		// require.Equal(t, codersdk.EntitlementNotEntitled, aibridgeFeature.Entitlement, "AI Bridge should not be entitled when addon validation fails")
+		// require.False(t, aibridgeFeature.Enabled, "AI Gateway should not be enabled when addon validation fails")
+		// require.Equal(t, codersdk.EntitlementNotEntitled, aibridgeFeature.Entitlement, "AI Gateway should not be entitled when addon validation fails")
 
 		// TODO: Readd this test once Boundary is enforced as an add-on license.
 		// boundaryFeature := entitlements.Features[codersdk.FeatureBoundary]

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5716,11 +5716,11 @@ export interface License {
 
 // From codersdk/licenses.go
 export const LicenseAIGovernance90PercentWarningText =
-	"You have used %d%% of your AI Governance add-on seats.";
+	"You have used %d%% of your AI Governance seats.";
 
 // From codersdk/licenses.go
 export const LicenseAIGovernanceOverLimitWarningText =
-	"Your organization is using %d of %d AI Governance add-on seats (%d over the limit).";
+	"Your organization is using %d of %d AI Governance seats (%d over the limit).";
 
 // From codersdk/licenses.go
 export const LicenseExpiryClaim = "license_expires";

--- a/site/src/modules/dashboard/DashboardLayout.test.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.test.tsx
@@ -78,9 +78,7 @@ test("hides AI Governance seat warnings for non-admin users", async () => {
 		permissions: MockNoPermissions,
 	});
 
-	expect(
-		screen.queryByText(/AI Governance add-on seats/),
-	).not.toBeInTheDocument();
+	expect(screen.queryByText(/AI Governance seats/)).not.toBeInTheDocument();
 });
 
 test("shows AI Governance over-limit warning in LicenseBanner for admin users", async () => {
@@ -91,9 +89,7 @@ test("shows AI Governance over-limit warning in LicenseBanner for admin users", 
 	});
 
 	expect(
-		screen.getByText(
-			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
-		),
+		screen.getByText(/110 of 100 AI Governance seats \(10 over the limit\)/),
 	).toBeInTheDocument();
 });
 

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -231,7 +231,7 @@ export const AIGovernanceNearLimit: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByRole("status")).toHaveTextContent(
-			"You have used 95% of your AI Governance add-on seats.",
+			"You have used 95% of your AI Governance seats.",
 		);
 		await expect(
 			canvas.getByRole("link", { name: /Contact sales@coder\.com/i }),
@@ -248,7 +248,7 @@ export const AIGovernanceOverLimitFromFeature: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByRole("status")).toHaveTextContent(
-			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
+			/110 of 100 AI Governance seats \(10 over the limit\)/,
 		);
 	},
 };
@@ -263,7 +263,7 @@ export const AIGovernanceOverLimitGracePeriod: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByRole("status")).toHaveTextContent(
-			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
+			/110 of 100 AI Governance seats \(10 over the limit\)/,
 		);
 	},
 };


### PR DESCRIPTION
AI Governance is no longer a separately purchased add-on and is now included with the Premium feature set. This PR updates the backend user-facing strings that still referenced the old "add-on" model, and renames AI Bridge to AI Gateway in the touched lines.

Changes:
- `codersdk` AI Governance warning constants: dropped "add-on" from the seat warning text
- `enterprise/coderd/license`: updated the AI Gateway soft-warning message to reference the Premium license instead of an add-on, and updated related comments
- Regenerated `site/src/api/typesGenerated.ts` from the changed SDK constants
- Updated backend tests and the frontend test/story assertions derived from the changed strings

The licensing mechanism itself is unchanged; only user-facing copy and comments were touched.

_Generated by Coder Agents._