### PR TITLE
refactor(site): update AI Governance licensing copy

### DIFF
--- a/site/src/components/Paywall/PaywallAIGovernance.tsx
+++ b/site/src/components/Paywall/PaywallAIGovernance.tsx
@@ -25,7 +25,7 @@ const PaywallAIGovernance = () => {
 				<PaywallDescription>
 					AI Gateway provides auditable visibility into user prompts and LLM
 					tool calls from developer tools within Coder Workspaces. AI Gateway
-					requires a Premium license with AI Governance add-on.
+					requires a Premium license.
 				</PaywallDescription>
 				<PaywallDocumentationLink href={docs("/ai-coder/ai-governance")}>
 					Learn about AI Governance

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -18,7 +18,7 @@ const aiGovernanceOverLimitWarningPrefix =
 const aiGovernanceNearLimitWarningPrefix =
 	LicenseAIGovernance90PercentWarningText.split("%d%%")[0];
 const AI_GOVERNANCE_NEAR_LIMIT_FALLBACK_MESSAGE =
-	"You are approaching your AI Governance add-on seat limit.";
+	"You are approaching your AI Governance seat limit.";
 
 const isAIGovernanceWarning = (message: string): boolean =>
 	message.startsWith(aiGovernanceNearLimitWarningPrefix) ||

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceUsersConsumptionChart.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceUsersConsumptionChart.stories.tsx
@@ -120,7 +120,7 @@ export const UsageBarFromLicenseClaims: Story = {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("750")).toBeInTheDocument();
 		await expect(
-			canvas.getByRole("heading", { name: "AI Governance add-on usage" }),
+			canvas.getByRole("heading", { name: "AI Governance usage" }),
 		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceUsersConsumptionChart.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceUsersConsumptionChart.tsx
@@ -34,11 +34,11 @@ export const AIGovernanceUsersConsumption: FC<
 			<div className="flex items-center justify-center rounded-lg border border-solid p-4">
 				<div className="flex flex-col items-center justify-center">
 					<div className="flex flex-col items-center justify-center">
-						<span className="text-base">AI Governance add-on usage</span>
+						<span className="text-base">AI Governance usage</span>
 						<span className="text-content-secondary text-center max-w-[464px] mt-2">
 							AI Governance is not included in your current license. Contact{" "}
 							<Link href="mailto:sales@coder.com">sales</Link> to upgrade your
-							license and unlock this addon.
+							license and unlock AI Governance.
 						</span>
 					</div>
 				</div>
@@ -48,7 +48,7 @@ export const AIGovernanceUsersConsumption: FC<
 
 	return (
 		<SeatUsageBarCard
-			title="AI Governance add-on usage"
+			title="AI Governance usage"
 			actual={aiGovernanceUserFeature?.actual}
 			limit={effectiveLimit}
 		/>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
@@ -65,7 +65,7 @@ export const ActiveAIGovernanceAddOnUsage: Story = {
 		await expect(canvas.getByText("1,923")).toBeInTheDocument();
 		await expect(canvas.getByText("2,500")).toBeInTheDocument();
 		await expect(
-			canvas.getByRole("heading", { name: "AI Governance add-on usage" }),
+			canvas.getByRole("heading", { name: "AI Governance usage" }),
 		).toBeInTheDocument();
 		await expect(canvas.getByText("512")).toBeInTheDocument();
 		await expect(canvas.getByText("1,000")).toBeInTheDocument();


### PR DESCRIPTION
Updates the remaining frontend description strings that still refer to AI Governance as a separately purchased "add-on", consistent with AI Governance now being included with a Premium license.

Stacked on #28075.

Changes:
- `LicenseBanner.tsx`: fallback near-limit message "AI Governance add-on seat limit" → "AI Governance seat limit"
- `PaywallAIGovernance.tsx`: "requires a Premium license with AI Governance add-on" → "requires a Premium license"
- `AIGovernanceUsersConsumptionChart.tsx`: card title "AI Governance add-on usage" → "AI Governance usage", and "unlock this addon" → "unlock AI Governance"
- Updated the Storybook stories that assert these strings

The "AI add-on" badge and seat-column labels are intentionally left untouched here; they are being removed in [a separate PR](https://github.com/coder/coder/pull/28004). Mechanism identifiers (e.g. `hasAiGovernanceAddOnLicense`) are also unchanged since the backend still emits addon claims.

_Generated by Coder Agents._