### PR TITLE
fix(site): prefer permitted organization for chat creation

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { delay } from "msw";
 import {
 	expect,
 	fn,
@@ -9,7 +10,7 @@ import {
 	within,
 } from "storybook/test";
 import { API } from "#/api/api";
-import { permittedOrganizationsKey } from "#/api/queries/organizations";
+import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
@@ -23,10 +24,10 @@ import {
 	getReasoningEffortForModel,
 	saveReasoningEffortForModel,
 } from "../utils/reasoningEffort";
-import { AgentCreateForm } from "./AgentCreateForm";
+import { AgentCreateForm, emptyInputStorageKey } from "./AgentCreateForm";
 
-const permittedOrgsKey = permittedOrganizationsKey({
-	object: { resource_type: "chat", owner_id: "me" },
+const chatCreateOrganizationsQuery = permittedOrganizations({
+	object: { resource_type: "chat" },
 	action: "create",
 });
 
@@ -131,19 +132,27 @@ type Story = StoryObj<typeof AgentCreateForm>;
 
 const defaultArgs = meta.args;
 
-const mockPermittedOrganizations = (permissions: Record<string, boolean>) => {
+const mockPermittedOrganizations = (
+	permissions: Record<string, boolean>,
+	delayMs = 0,
+) => {
 	spyOn(API, "getOrganizations").mockResolvedValue([
 		MockDefaultOrganization,
 		MockOrganization2,
 	]);
-	spyOn(API, "checkAuthorization").mockResolvedValue(permissions);
+	spyOn(API, "checkAuthorization").mockImplementation(async () => {
+		if (delayMs > 0) {
+			await delay(delayMs);
+		}
+		return permissions;
+	});
 };
 
 export const Default: Story = {};
 
 const submitMessage = async (canvasElement: HTMLElement, message: string) => {
 	const canvas = within(canvasElement);
-	const input = canvas.getByTestId("chat-message-input");
+	const input = canvas.getByRole("textbox", { name: "Chat message" });
 	await userEvent.click(input);
 	await userEvent.keyboard(message);
 	await userEvent.click(canvas.getByRole("button", { name: "Send" }));
@@ -894,25 +903,76 @@ export const WithOrganizationPicker: Story = {
 		organizations: [MockDefaultOrganization, MockOrganization2],
 		queries: [
 			{
-				key: permittedOrgsKey,
-				data: [MockDefaultOrganization, MockOrganization2],
+				key: chatCreateOrganizationsQuery.queryKey,
+				data: [MockOrganization2, MockDefaultOrganization],
 			},
 		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// Verify the org picker rendered (component didn't crash).
-		await waitFor(() => {
-			expect(canvas.getByTestId("compact-org-selector")).toBeInTheDocument();
+		const organizationPicker = canvas.getByRole("button", {
+			name: "Organization: My Organization",
 		});
-		// Type into the chat input to trigger re-renders. If the
-		// permittedOrgs fallback is referentially unstable, this
-		// causes a render cascade that hits React's update limit.
-		const input = canvas.getByTestId("chat-message-input");
+		await expect(organizationPicker).toBeVisible();
+
+		const input = canvas.getByRole("textbox", { name: "Chat message" });
 		await userEvent.click(input);
 		await userEvent.keyboard("hello world");
-		// The org picker should still be present after typing.
-		expect(canvas.getByTestId("compact-org-selector")).toBeInTheDocument();
+		await expect(
+			canvas.getByRole("button", {
+				name: "Organization: My Organization",
+			}),
+		).toBeVisible();
+	},
+};
+
+export const RestrictedMultiOrganizationUser: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: chatCreateOrganizationsQuery.queryKey,
+				data: [MockOrganization2],
+			},
+		],
+	},
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+	},
+	play: async ({ canvasElement, args }) => {
+		await submitMessage(canvasElement, "test message");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: MockOrganization2.id,
+				}),
+			);
+		});
+	},
+};
+
+export const DelayedOrganizationAuthorization: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	beforeEach: () => {
+		localStorage.setItem(emptyInputStorageKey, "draft message");
+		mockPermittedOrganizations(
+			{
+				[MockDefaultOrganization.id]: true,
+				[MockOrganization2.id]: true,
+			},
+			1_500,
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const sendButton = canvas.getByRole("button", { name: "Send" });
+		await expect(sendButton).toBeDisabled();
+		await waitFor(() => expect(sendButton).toBeEnabled(), { timeout: 3_000 });
 	},
 };
 
@@ -922,7 +982,7 @@ export const OrgPickerTightSpacing: Story = {
 		organizations: [MockDefaultOrganization, MockOrganization2],
 		queries: [
 			{
-				key: permittedOrgsKey,
+				key: chatCreateOrganizationsQuery.queryKey,
 				data: [MockDefaultOrganization, MockOrganization2],
 			},
 		],
@@ -1008,8 +1068,6 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
-		// Deliberately do not pre-seed permittedOrgsKey. Let the
-		// mocked API calls drive the async permission resolution.
 	},
 	args: {
 		...defaultArgs,
@@ -1101,51 +1159,5 @@ export const PermittedOrgsResolvesToSubset: Story = {
 			throw new Error("Expected onCreateChat to receive options");
 		}
 		expect(options.organizationId).toBe(MockOrganization2.id);
-	},
-};
-
-/**
- * Member-scoped roles like agents-access grant chat:create only on
- * chats the user owns, so the per-org check must carry owner context
- * for the picker to render.
- */
-export const MemberScopedPermissionsShowOrgPicker: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-	},
-	beforeEach: () => {
-		spyOn(API, "getOrganizations").mockResolvedValue([
-			MockDefaultOrganization,
-			MockOrganization2,
-		]);
-		spyOn(API, "checkAuthorization").mockImplementation(async ({ checks }) =>
-			Object.fromEntries(
-				Object.entries(checks).map(([id, check]) => [
-					id,
-					check.object.owner_id === "me",
-				]),
-			),
-		);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const picker = await canvas.findByRole(
-			"button",
-			{ name: /^Organization:/ },
-			{ timeout: 3000 },
-		);
-		await userEvent.click(picker);
-		await screen.findByRole("option", {
-			name: MockDefaultOrganization.display_name,
-		});
-		await userEvent.click(
-			screen.getByRole("option", { name: MockOrganization2.display_name }),
-		);
-		expect(
-			canvas.getByRole("button", {
-				name: `Organization: ${MockOrganization2.display_name}`,
-			}),
-		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1218,35 +1218,16 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 
-		// Wait for the permitted orgs query to resolve. The org picker
-		// should disappear since no org is permitted.
+		// No permitted org anywhere: chat creation must be blocked, not
+		// fall back to the dashboard default org.
 		await waitFor(
 			() => {
-				expect(
-					canvas.queryByTestId("compact-org-selector"),
-				).not.toBeInTheDocument();
+				expect(canvas.getByText(/don't have permission/i)).toBeInTheDocument();
 			},
 			{ timeout: 3000 },
 		);
-
-		// Type a message and submit the form.
-		const input = canvas.getByTestId("chat-message-input");
-		await userEvent.click(input);
-		await userEvent.keyboard("test message");
-		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
-
-		// Verify onCreateChat was called with a non-empty organizationId.
-		await waitFor(() => {
-			expect(args.onCreateChat).toHaveBeenCalled();
-		});
-		const options = (args.onCreateChat as ReturnType<typeof fn>).mock
-			.calls[0]?.[0] as { organizationId: string } | undefined;
-		if (!options) {
-			throw new Error("Expected onCreateChat to receive options");
-		}
-		expect(options.organizationId).not.toBe("");
-		// It should fall back to the default org from the dashboard.
-		expect(options.organizationId).toBe(MockDefaultOrganization.id);
+		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+		expect(args.onCreateChat).not.toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1210,6 +1210,21 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 		onCreateChat: fn().mockResolvedValue(undefined),
 	},
 	beforeEach: () => {
+		localStorage.clear();
+		// Another org's persisted attachment must survive a visit while
+		// the user has no chat permission anywhere.
+		localStorage.setItem(
+			"agents.persisted-attachments",
+			JSON.stringify([
+				{
+					fileId: "file-other-org",
+					fileName: "keep.txt",
+					fileType: "text/plain",
+					lastModified: 1000,
+					organizationId: MockOrganization2.id,
+				},
+			]),
+		);
 		mockPermittedOrganizations({
 			[MockDefaultOrganization.id]: false,
 			[MockOrganization2.id]: false,
@@ -1225,6 +1240,9 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 		);
 		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
 		expect(args.onCreateChat).not.toHaveBeenCalled();
+		expect(
+			localStorage.getItem("agents.persisted-attachments") ?? "",
+		).toContain("file-other-org");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1104,10 +1104,27 @@ export const DelayedOrganizationAuthorization: Story = {
 			1_500,
 		);
 	},
+	args: {
+		...defaultArgs,
+		workspaceOptions: [
+			{
+				...MockWorkspace,
+				id: "ws-provisional",
+				name: "provisional-workspace",
+				organization_id: MockDefaultOrganization.id,
+			},
+		],
+	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const sendButton = canvas.getByRole("button", { name: "Send" });
 		await expect(sendButton).toBeDisabled();
+		// The workspace picker must be unreachable while the check is
+		// pending: its options come from the provisional fallback org.
+		// With the workspace callback gated, the whole menu disables.
+		await expect(
+			canvas.getByRole("button", { name: "More options" }),
+		).toBeDisabled();
 		// dispatchEvent returns false when a handler accepted the drop
 		// via preventDefault, giving a race-free accepted/ignored signal.
 		const dropFile = (name: string): boolean => {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1001,6 +1001,63 @@ export const RestrictedUserKeepsPersistedWorkspace: Story = {
 	},
 };
 
+export const RestrictedUserKeepsPersistedAttachments: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem(
+			"agents.persisted-attachments",
+			JSON.stringify([
+				{
+					fileId: "file-permitted-org",
+					fileName: "notes.txt",
+					fileType: "text/plain",
+					lastModified: 1700000000000,
+					organizationId: MockOrganization2.id,
+				},
+			]),
+		);
+		mockPermittedOrganizations({
+			[MockDefaultOrganization.id]: false,
+			[MockOrganization2.id]: true,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByLabelText("Remove notes.txt")).toBeInTheDocument();
+		});
+		const stored = localStorage.getItem("agents.persisted-attachments");
+		expect(stored).toContain("file-permitted-org");
+	},
+};
+
+export const OrganizationAuthorizationFailure: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem(emptyInputStorageKey, "draft message");
+		spyOn(API, "getOrganizations").mockResolvedValue([
+			MockDefaultOrganization,
+			MockOrganization2,
+		]);
+		spyOn(API, "checkAuthorization").mockRejectedValue(
+			new Error("authorization check failed"),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findAllByText(/authorization check failed/i);
+		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+	},
+};
+
 export const LoadingWorkspacesNeverSubmitsStoredWorkspace: Story = {
 	parameters: {
 		showOrganizations: true,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1269,11 +1269,14 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 			).not.toBeInTheDocument(),
 		);
 
+		// Re-permitting the default must not switch the form away from
+		// the fallback org the user is now composing under, nor
+		// resurrect the cleared workspace.
 		revocablePermissions[MockDefaultOrganization.id] = true;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
 			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
-				"Organization: My Organization",
+				"Organization: My Organization 2",
 			),
 		);
 		expect(

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1061,7 +1061,7 @@ export const OrganizationAuthorizationFailure: Story = {
 	},
 };
 
-export const LoadingWorkspacesNeverSubmitsStoredWorkspace: Story = {
+export const LoadingWorkspacesBlocksSendUntilValidated: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
@@ -1073,22 +1073,22 @@ export const LoadingWorkspacesNeverSubmitsStoredWorkspace: Story = {
 		isWorkspacesLoading: true,
 	},
 	beforeEach: () => {
+		localStorage.setItem(emptyInputStorageKey, "draft message");
 		localStorage.setItem("agents.selected-workspace-id", "ws-default-org");
 		mockPermittedOrganizations({
-			[MockDefaultOrganization.id]: false,
+			[MockDefaultOrganization.id]: true,
 			[MockOrganization2.id]: true,
 		});
 	},
 	play: async ({ canvasElement, args }) => {
-		await submitMessage(canvasElement, "test message");
-		await waitFor(() => {
-			expect(args.onCreateChat).toHaveBeenCalledWith(
-				expect.objectContaining({
-					organizationId: MockOrganization2.id,
-					workspaceId: undefined,
-				}),
-			);
-		});
+		const canvas = within(canvasElement);
+		// The picker renders only after the permission check settles, so
+		// once it appears every other Send gate has been decided.
+		await canvas.findByTestId("compact-org-selector");
+		// The stored workspace cannot be validated yet; sending now would
+		// silently drop the association, so Send stays disabled.
+		await expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+		expect(args.onCreateChat).not.toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1127,10 +1127,10 @@ export const DelayedOrganizationAuthorization: Story = {
 		expect(canvas.queryByLabelText("Remove drop.txt")).not.toBeInTheDocument();
 		// The pending option list is unfiltered, so the picker must stay hidden.
 		expect(
-			canvas.queryByTestId("compact-org-selector"),
+			canvas.queryByRole("button", { name: /organization/i }),
 		).not.toBeInTheDocument();
 		await waitFor(() => expect(sendButton).toBeEnabled(), { timeout: 3_000 });
-		await canvas.findByTestId("compact-org-selector");
+		await canvas.findByRole("button", { name: /organization/i });
 		// Positive control: once settled the same drop is accepted and
 		// attaches, so the pending-state assertions exercised a real path.
 		expect(dropFile("after.txt")).toBe(false);
@@ -1200,35 +1200,30 @@ export const RevokedSelectionDoesNotResurrect: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const trigger = await canvas.findByTestId("compact-org-selector");
-		await waitFor(() =>
-			expect(trigger).toHaveAccessibleName("Organization: My Organization"),
-		);
+		const trigger = await canvas.findByRole("button", {
+			name: "Organization: My Organization",
+		});
 		await userEvent.click(trigger);
 		await userEvent.click(
 			await screen.findByRole("option", { name: /My Organization 2/ }),
 		);
-		await waitFor(() =>
-			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
-				"Organization: My Organization 2",
-			),
-		);
+		await canvas.findByRole("button", {
+			name: "Organization: My Organization 2",
+		});
 
 		revocablePermissions[MockOrganization2.id] = false;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
 			expect(
-				canvas.queryByTestId("compact-org-selector"),
+				canvas.queryByRole("button", { name: /organization/i }),
 			).not.toBeInTheDocument(),
 		);
 
 		revocablePermissions[MockOrganization2.id] = true;
 		await revocableQueryClient?.invalidateQueries();
-		await waitFor(() =>
-			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
-				"Organization: My Organization",
-			),
-		);
+		await canvas.findByRole("button", {
+			name: "Organization: My Organization",
+		});
 	},
 };
 
@@ -1268,11 +1263,9 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 
 		revocablePermissions[MockDefaultOrganization.id] = true;
 		await revocableQueryClient?.invalidateQueries();
-		await waitFor(() =>
-			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
-				"Organization: My Organization 2",
-			),
-		);
+		await canvas.findByRole("button", {
+			name: "Organization: My Organization 2",
+		});
 		expect(
 			canvas.queryByLabelText("Remove workspace default-workspace"),
 		).not.toBeInTheDocument();
@@ -1368,7 +1361,11 @@ export const RevokedPendingOrgClosesConfirmDialog: Story = {
 		await waitFor(() =>
 			expect(canvas.getByLabelText("Remove notes.txt")).toBeInTheDocument(),
 		);
-		await userEvent.click(await canvas.findByTestId("compact-org-selector"));
+		await userEvent.click(
+			await canvas.findByRole("button", {
+				name: "Organization: My Organization",
+			}),
+		);
 		await userEvent.click(
 			await screen.findByRole("option", { name: /My Organization 2/ }),
 		);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -12,7 +12,7 @@ import {
 	within,
 } from "storybook/test";
 import { API } from "#/api/api";
-import { permittedOrganizations } from "#/api/queries/organizations";
+import { permittedOrganizationsKey } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { MockChatModelConfig } from "#/testHelpers/chatModels";
@@ -29,7 +29,7 @@ import {
 } from "../utils/reasoningEffort";
 import { AgentCreateForm, emptyInputStorageKey } from "./AgentCreateForm";
 
-const chatCreateOrganizationsQuery = permittedOrganizations({
+const permittedOrgsKey = permittedOrganizationsKey({
 	object: { resource_type: "chat", owner_id: "me" },
 	action: "create",
 });
@@ -906,7 +906,7 @@ export const WithOrganizationPicker: Story = {
 		organizations: [MockDefaultOrganization, MockOrganization2],
 		queries: [
 			{
-				key: chatCreateOrganizationsQuery.queryKey,
+				key: permittedOrgsKey,
 				data: [MockOrganization2, MockDefaultOrganization],
 			},
 		],
@@ -1330,7 +1330,7 @@ export const SingleOrgIgnoresStalePermittedCache: Story = {
 		organizations: [MockDefaultOrganization],
 		queries: [
 			{
-				key: chatCreateOrganizationsQuery.queryKey,
+				key: permittedOrgsKey,
 				data: [MockOrganization2],
 			},
 		],
@@ -1406,7 +1406,7 @@ export const OrgPickerTightSpacing: Story = {
 		organizations: [MockDefaultOrganization, MockOrganization2],
 		queries: [
 			{
-				key: chatCreateOrganizationsQuery.queryKey,
+				key: permittedOrgsKey,
 				data: [MockDefaultOrganization, MockOrganization2],
 			},
 		],
@@ -1579,5 +1579,51 @@ export const PermittedOrgsResolvesToSubset: Story = {
 			throw new Error("Expected onCreateChat to receive options");
 		}
 		expect(options.organizationId).toBe(MockOrganization2.id);
+	},
+};
+
+/**
+ * Member-scoped roles like agents-access grant chat:create only on
+ * chats the user owns, so the per-org check must carry owner context
+ * for the picker to render.
+ */
+export const MemberScopedPermissionsShowOrgPicker: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	beforeEach: () => {
+		spyOn(API, "getOrganizations").mockResolvedValue([
+			MockDefaultOrganization,
+			MockOrganization2,
+		]);
+		spyOn(API, "checkAuthorization").mockImplementation(async ({ checks }) =>
+			Object.fromEntries(
+				Object.entries(checks).map(([id, check]) => [
+					id,
+					check.object.owner_id === "me",
+				]),
+			),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const picker = await canvas.findByRole(
+			"button",
+			{ name: /^Organization:/ },
+			{ timeout: 3000 },
+		);
+		await userEvent.click(picker);
+		await screen.findByRole("option", {
+			name: MockDefaultOrganization.display_name,
+		});
+		await userEvent.click(
+			screen.getByRole("option", { name: MockOrganization2.display_name }),
+		);
+		expect(
+			canvas.getByRole("button", {
+				name: `Organization: ${MockOrganization2.display_name}`,
+			}),
+		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { delay } from "msw";
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import {
 	expect,
 	fn,
@@ -1132,6 +1134,88 @@ export const DelayedOrganizationAuthorization: Story = {
 		expect(dropFile("after.txt")).toBe(false);
 		await waitFor(() =>
 			expect(canvas.getByLabelText("Remove after.txt")).toBeInTheDocument(),
+		);
+	},
+};
+
+// Mutable so the play function can change results between refetches;
+// the story-level QueryClient lets it drive those refetches, which the
+// preview decorator's client (staleTime: Infinity, inaccessible from
+// play) cannot.
+const revocablePermissions: Record<string, boolean> = {};
+let revocableQueryClient: QueryClient | undefined;
+
+export const RevokedSelectionDoesNotResurrect: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	decorators: [
+		(Story) => {
+			const [queryClient] = useState(
+				() =>
+					new QueryClient({
+						defaultOptions: {
+							queries: {
+								staleTime: Number.POSITIVE_INFINITY,
+								retry: false,
+							},
+						},
+					}),
+			);
+			revocableQueryClient = queryClient;
+			return (
+				<QueryClientProvider client={queryClient}>
+					<Story />
+				</QueryClientProvider>
+			);
+		},
+	],
+	beforeEach: () => {
+		revocablePermissions[MockDefaultOrganization.id] = true;
+		revocablePermissions[MockOrganization2.id] = true;
+		spyOn(API, "getOrganizations").mockResolvedValue([
+			MockDefaultOrganization,
+			MockOrganization2,
+		]);
+		spyOn(API, "checkAuthorization").mockImplementation(async () => ({
+			...revocablePermissions,
+		}));
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = await canvas.findByTestId("compact-org-selector");
+		await waitFor(() =>
+			expect(trigger).toHaveAccessibleName("Organization: My Organization"),
+		);
+		await userEvent.click(trigger);
+		await userEvent.click(
+			await screen.findByRole("option", { name: /My Organization 2/ }),
+		);
+		await waitFor(() =>
+			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
+				"Organization: My Organization 2",
+			),
+		);
+
+		// A refetch revokes the selected org; with one permitted org
+		// left, the picker unmounts and the default becomes effective.
+		revocablePermissions[MockOrganization2.id] = false;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(
+				canvas.queryByTestId("compact-org-selector"),
+			).not.toBeInTheDocument(),
+		);
+
+		// A later refetch re-permits it. The revoked selection must not
+		// resurrect and switch orgs without user action.
+		revocablePermissions[MockOrganization2.id] = true;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
+				"Organization: My Organization",
+			),
 		);
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1286,6 +1286,56 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 	},
 };
 
+export const EmptyPermittedSetPreservesStoredWorkspace: Story = {
+	...revocableStoryContext,
+	args: {
+		...defaultArgs,
+		workspaceOptions: [
+			{
+				...MockWorkspace,
+				id: "ws-org-2",
+				name: "org2-workspace",
+				organization_id: MockOrganization2.id,
+			},
+		],
+		workspaceCount: 1,
+	},
+	beforeEach: () => {
+		localStorage.setItem("agents.selected-workspace-id", "ws-org-2");
+		mockRevocablePermissions({
+			[MockDefaultOrganization.id]: false,
+			[MockOrganization2.id]: true,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() =>
+			expect(
+				canvas.getByLabelText("Remove workspace org2-workspace"),
+			).toBeInTheDocument(),
+		);
+
+		// A refetch that empties the permitted set blocks sending but is
+		// not an org change; the stored workspace must survive it.
+		revocablePermissions[MockOrganization2.id] = false;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(canvas.getByText(/don't have permission/i)).toBeInTheDocument(),
+		);
+
+		revocablePermissions[MockOrganization2.id] = true;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(
+				canvas.getByLabelText("Remove workspace org2-workspace"),
+			).toBeInTheDocument(),
+		);
+		expect(localStorage.getItem("agents.selected-workspace-id")).toBe(
+			"ws-org-2",
+		);
+	},
+};
+
 export const RevokedPendingOrgClosesConfirmDialog: Story = {
 	...revocableStoryContext,
 	beforeEach: () => {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1317,6 +1317,36 @@ export const EmptyPermittedSetPreservesStoredWorkspace: Story = {
 	},
 };
 
+export const SingleOrgIgnoresStalePermittedCache: Story = {
+	parameters: {
+		// showOrganizations is false (org count dropped to one), but the
+		// disabled query still holds a cached permitted list naming an
+		// org the dashboard no longer knows. It must be ignored.
+		showOrganizations: false,
+		organizations: [MockDefaultOrganization],
+		queries: [
+			{
+				key: chatCreateOrganizationsQuery.queryKey,
+				data: [MockOrganization2],
+			},
+		],
+	},
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+	},
+	play: async ({ canvasElement, args }) => {
+		await submitMessage(canvasElement, "test message");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: MockDefaultOrganization.id,
+				}),
+			);
+		});
+	},
+};
+
 export const RevokedPendingOrgClosesConfirmDialog: Story = {
 	...revocableStoryContext,
 	beforeEach: () => {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1319,9 +1319,6 @@ export const EmptyPermittedSetPreservesStoredWorkspace: Story = {
 
 export const SingleOrgIgnoresStalePermittedCache: Story = {
 	parameters: {
-		// showOrganizations is false (org count dropped to one), but the
-		// disabled query still holds a cached permitted list naming an
-		// org the dashboard no longer knows. It must be ignored.
 		showOrganizations: false,
 		organizations: [MockDefaultOrganization],
 		queries: [

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1217,9 +1217,6 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-
-		// No permitted org anywhere: chat creation must be blocked, not
-		// fall back to the dashboard default org.
 		await waitFor(
 			() => {
 				expect(canvas.getByText(/don't have permission/i)).toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1108,7 +1108,31 @@ export const DelayedOrganizationAuthorization: Story = {
 		const canvas = within(canvasElement);
 		const sendButton = canvas.getByRole("button", { name: "Send" });
 		await expect(sendButton).toBeDisabled();
+		// dispatchEvent returns false when a handler accepted the drop
+		// via preventDefault, giving a race-free accepted/ignored signal.
+		const dropFile = (name: string): boolean => {
+			const dataTransfer = new DataTransfer();
+			dataTransfer.items.add(new File(["hello"], name, { type: "text/plain" }));
+			return canvas.getByTestId("chat-composer").dispatchEvent(
+				new DragEvent("drop", {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer,
+				}),
+			);
+		};
+		// While the check is pending the composer must ignore drops: with
+		// no org context the file cannot upload, and post-settlement
+		// restoration would silently discard it.
+		expect(dropFile("drop.txt")).toBe(true);
+		expect(canvas.queryByLabelText("Remove drop.txt")).not.toBeInTheDocument();
 		await waitFor(() => expect(sendButton).toBeEnabled(), { timeout: 3_000 });
+		// Positive control: once settled the same drop is accepted and
+		// attaches, so the pending-state assertions exercised a real path.
+		expect(dropFile("after.txt")).toBe(false);
+		await waitFor(() =>
+			expect(canvas.getByLabelText("Remove after.txt")).toBeInTheDocument(),
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -963,6 +963,75 @@ export const RestrictedMultiOrganizationUser: Story = {
 	},
 };
 
+export const RestrictedUserKeepsPersistedWorkspace: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		workspaceOptions: [
+			{
+				...MockWorkspace,
+				id: "ws-permitted-org",
+				name: "permitted-workspace",
+				organization_id: MockOrganization2.id,
+			},
+		],
+		workspaceCount: 1,
+	},
+	beforeEach: () => {
+		localStorage.setItem("agents.selected-workspace-id", "ws-permitted-org");
+		mockPermittedOrganizations({
+			[MockDefaultOrganization.id]: false,
+			[MockOrganization2.id]: true,
+		});
+	},
+	play: async ({ canvasElement, args }) => {
+		await submitMessage(canvasElement, "test message");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: MockOrganization2.id,
+					workspaceId: "ws-permitted-org",
+				}),
+			);
+		});
+	},
+};
+
+export const LoadingWorkspacesNeverSubmitsStoredWorkspace: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		workspaceOptions: [],
+		isWorkspacesLoading: true,
+	},
+	beforeEach: () => {
+		localStorage.setItem("agents.selected-workspace-id", "ws-default-org");
+		mockPermittedOrganizations({
+			[MockDefaultOrganization.id]: false,
+			[MockOrganization2.id]: true,
+		});
+	},
+	play: async ({ canvasElement, args }) => {
+		await submitMessage(canvasElement, "test message");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: MockOrganization2.id,
+					workspaceId: undefined,
+				}),
+			);
+		});
+	},
+};
+
 export const DelayedOrganizationAuthorization: Story = {
 	parameters: {
 		showOrganizations: true,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1119,9 +1119,6 @@ export const DelayedOrganizationAuthorization: Story = {
 		const canvas = within(canvasElement);
 		const sendButton = canvas.getByRole("button", { name: "Send" });
 		await expect(sendButton).toBeDisabled();
-		// The workspace picker must be unreachable while the check is
-		// pending: its options come from the provisional fallback org.
-		// With the workspace callback gated, the whole menu disables.
 		await expect(
 			canvas.getByRole("button", { name: "More options" }),
 		).toBeDisabled();

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -936,9 +936,7 @@ export const RestrictedMultiOrganizationUser: Story = {
 			MockDefaultOrganization,
 			MockOrganization2,
 		]);
-		// Mirrors backend RBAC for roles like agents-access: chat:create
-		// is granted at member (owner) scope, so a check without
-		// owner_id "me" is denied in every org.
+		// Model agents-access: "me" supplies the owner for member-scoped chat:create.
 		spyOn(API, "checkAuthorization").mockImplementation(async ({ checks }) =>
 			Object.fromEntries(
 				Object.entries(checks).map(([id, check]) => [

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1068,7 +1068,6 @@ export const LoadingWorkspacesBlocksSendUntilValidated: Story = {
 	},
 	args: {
 		...defaultArgs,
-		onCreateChat: fn().mockResolvedValue(undefined),
 		workspaceOptions: [],
 		isWorkspacesLoading: true,
 	},
@@ -1080,15 +1079,13 @@ export const LoadingWorkspacesBlocksSendUntilValidated: Story = {
 			[MockOrganization2.id]: true,
 		});
 	},
-	play: async ({ canvasElement, args }) => {
+	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// The picker renders only after the permission check settles, so
-		// once it appears every other Send gate has been decided.
-		await canvas.findByTestId("compact-org-selector");
-		// The stored workspace cannot be validated yet; sending now would
-		// silently drop the association, so Send stays disabled.
+		// Wait for permissions to settle before checking workspace validation.
+		await canvas.findByRole("button", {
+			name: "Organization: My Organization",
+		});
 		await expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
-		expect(args.onCreateChat).not.toHaveBeenCalled();
 	},
 };
 
@@ -1269,9 +1266,6 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 			).not.toBeInTheDocument(),
 		);
 
-		// Re-permitting the default must not switch the form away from
-		// the fallback org the user is now composing under, nor
-		// resurrect the cleared workspace.
 		revocablePermissions[MockDefaultOrganization.id] = true;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
@@ -1298,7 +1292,6 @@ export const EmptyPermittedSetPreservesStoredWorkspace: Story = {
 				organization_id: MockOrganization2.id,
 			},
 		],
-		workspaceCount: 1,
 	},
 	beforeEach: () => {
 		localStorage.setItem("agents.selected-workspace-id", "ws-org-2");
@@ -1309,27 +1302,15 @@ export const EmptyPermittedSetPreservesStoredWorkspace: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await waitFor(() =>
-			expect(
-				canvas.getByLabelText("Remove workspace org2-workspace"),
-			).toBeInTheDocument(),
-		);
+		await canvas.findByLabelText("Remove workspace org2-workspace");
 
-		// A refetch that empties the permitted set blocks sending but is
-		// not an org change; the stored workspace must survive it.
 		revocablePermissions[MockOrganization2.id] = false;
 		await revocableQueryClient?.invalidateQueries();
-		await waitFor(() =>
-			expect(canvas.getByText(/don't have permission/i)).toBeInTheDocument(),
-		);
+		await canvas.findByText(/don't have permission/i);
 
 		revocablePermissions[MockOrganization2.id] = true;
 		await revocableQueryClient?.invalidateQueries();
-		await waitFor(() =>
-			expect(
-				canvas.getByLabelText("Remove workspace org2-workspace"),
-			).toBeInTheDocument(),
-		);
+		await canvas.findByLabelText("Remove workspace org2-workspace");
 		expect(localStorage.getItem("agents.selected-workspace-id")).toBe(
 			"ws-org-2",
 		);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -27,7 +27,7 @@ import {
 import { AgentCreateForm, emptyInputStorageKey } from "./AgentCreateForm";
 
 const chatCreateOrganizationsQuery = permittedOrganizations({
-	object: { resource_type: "chat" },
+	object: { resource_type: "chat", owner_id: "me" },
 	action: "create",
 });
 
@@ -930,12 +930,24 @@ export const RestrictedMultiOrganizationUser: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
-		queries: [
-			{
-				key: chatCreateOrganizationsQuery.queryKey,
-				data: [MockOrganization2],
-			},
-		],
+	},
+	beforeEach: () => {
+		spyOn(API, "getOrganizations").mockResolvedValue([
+			MockDefaultOrganization,
+			MockOrganization2,
+		]);
+		// Mirrors backend RBAC for roles like agents-access: chat:create
+		// is granted at member (owner) scope, so a check without
+		// owner_id "me" is denied in every org.
+		spyOn(API, "checkAuthorization").mockImplementation(async ({ checks }) =>
+			Object.fromEntries(
+				Object.entries(checks).map(([id, check]) => [
+					id,
+					check.object.owner_id === "me" &&
+						check.object.organization_id === MockOrganization2.id,
+				]),
+			),
+		);
 	},
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -22,6 +22,7 @@ import {
 	MockWorkspace,
 } from "#/testHelpers/entities";
 import { withDashboardProvider } from "#/testHelpers/storybook";
+import { persistedAttachmentsStorageKey } from "../hooks/useFileAttachments";
 import {
 	getReasoningEffortForModel,
 	saveReasoningEffortForModel,
@@ -1123,13 +1124,11 @@ export const DelayedOrganizationAuthorization: Story = {
 				}),
 			);
 		};
-		// While the check is pending the composer must ignore drops: with
-		// no org context the file cannot upload, and post-settlement
-		// restoration would silently discard it.
+		// Pending authorization leaves attachments without a valid org, so drops
+		// must be ignored.
 		expect(dropFile("drop.txt")).toBe(true);
 		expect(canvas.queryByLabelText("Remove drop.txt")).not.toBeInTheDocument();
-		// The picker must also stay hidden: its pending-state option list
-		// is the unfiltered dashboard fallback.
+		// The pending option list is unfiltered, so the picker must stay hidden.
 		expect(
 			canvas.queryByTestId("compact-org-selector"),
 		).not.toBeInTheDocument();
@@ -1144,10 +1143,9 @@ export const DelayedOrganizationAuthorization: Story = {
 	},
 };
 
-// Mutable so play functions can change results between refetches; the
-// story-level QueryClient lets them drive those refetches, which the
-// preview decorator's client (staleTime: Infinity, inaccessible from
-// play) cannot.
+// Mutable permissions let play functions change authorization across refetches.
+// The story-local QueryClient exposes those refetches; the preview client's
+// instance is inaccessible and uses infinite stale time.
 const revocablePermissions: Record<string, boolean> = {};
 let revocableQueryClient: QueryClient | undefined;
 
@@ -1185,17 +1183,23 @@ const mockRevocablePermissions = (permissions: Record<string, boolean>) => {
 	}));
 };
 
-export const RevokedSelectionDoesNotResurrect: Story = {
+const revocableStoryContext = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
 	},
 	decorators: [withRevocableQueryClient],
+};
+
+const allOrganizationsPermitted = {
+	[MockDefaultOrganization.id]: true,
+	[MockOrganization2.id]: true,
+};
+
+export const RevokedSelectionDoesNotResurrect: Story = {
+	...revocableStoryContext,
 	beforeEach: () => {
-		mockRevocablePermissions({
-			[MockDefaultOrganization.id]: true,
-			[MockOrganization2.id]: true,
-		});
+		mockRevocablePermissions(allOrganizationsPermitted);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1213,8 +1217,6 @@ export const RevokedSelectionDoesNotResurrect: Story = {
 			),
 		);
 
-		// A refetch revokes the selected org; with one permitted org
-		// left, the picker unmounts and the default becomes effective.
 		revocablePermissions[MockOrganization2.id] = false;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
@@ -1223,8 +1225,6 @@ export const RevokedSelectionDoesNotResurrect: Story = {
 			).not.toBeInTheDocument(),
 		);
 
-		// A later refetch re-permits it. The revoked selection must not
-		// resurrect and switch orgs without user action.
 		revocablePermissions[MockOrganization2.id] = true;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
@@ -1236,11 +1236,7 @@ export const RevokedSelectionDoesNotResurrect: Story = {
 };
 
 export const RevokedOrgChangeClearsStoredWorkspace: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-	},
-	decorators: [withRevocableQueryClient],
+	...revocableStoryContext,
 	args: {
 		...defaultArgs,
 		workspaceOptions: [
@@ -1255,10 +1251,7 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 	},
 	beforeEach: () => {
 		localStorage.setItem("agents.selected-workspace-id", "ws-default-org");
-		mockRevocablePermissions({
-			[MockDefaultOrganization.id]: true,
-			[MockOrganization2.id]: true,
-		});
+		mockRevocablePermissions(allOrganizationsPermitted);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1268,8 +1261,6 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 			).toBeInTheDocument(),
 		);
 
-		// A refetch revokes the workspace's org, changing the effective
-		// org; the stored workspace must be dropped, not just masked.
 		revocablePermissions[MockDefaultOrganization.id] = false;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
@@ -1278,7 +1269,6 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 			).not.toBeInTheDocument(),
 		);
 
-		// Re-permitting the org must not resurrect the workspace.
 		revocablePermissions[MockDefaultOrganization.id] = true;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
@@ -1294,15 +1284,11 @@ export const RevokedOrgChangeClearsStoredWorkspace: Story = {
 };
 
 export const RevokedPendingOrgClosesConfirmDialog: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-	},
-	decorators: [withRevocableQueryClient],
+	...revocableStoryContext,
 	beforeEach: () => {
 		localStorage.clear();
 		localStorage.setItem(
-			"agents.persisted-attachments",
+			persistedAttachmentsStorageKey,
 			JSON.stringify([
 				{
 					fileId: "file-default-org",
@@ -1313,10 +1299,7 @@ export const RevokedPendingOrgClosesConfirmDialog: Story = {
 				},
 			]),
 		);
-		mockRevocablePermissions({
-			[MockDefaultOrganization.id]: true,
-			[MockOrganization2.id]: true,
-		});
+		mockRevocablePermissions(allOrganizationsPermitted);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1332,8 +1315,6 @@ export const RevokedPendingOrgClosesConfirmDialog: Story = {
 			"Changing organization will remove your current attachments.",
 		);
 
-		// Revoking the pending org while its confirmation dialog is open
-		// must close the dialog before Continue can destroy attachments.
 		revocablePermissions[MockOrganization2.id] = false;
 		await revocableQueryClient?.invalidateQueries();
 		await waitFor(() =>
@@ -1449,7 +1430,7 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 		// Another org's persisted attachment must survive a visit while
 		// the user has no chat permission anywhere.
 		localStorage.setItem(
-			"agents.persisted-attachments",
+			persistedAttachmentsStorageKey,
 			JSON.stringify([
 				{
 					fileId: "file-other-org",
@@ -1476,7 +1457,7 @@ export const PermittedOrgsResolvesToEmpty: Story = {
 		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
 		expect(args.onCreateChat).not.toHaveBeenCalled();
 		expect(
-			localStorage.getItem("agents.persisted-attachments") ?? "",
+			localStorage.getItem(persistedAttachmentsStorageKey) ?? "",
 		).toContain("file-other-org");
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { delay } from "msw";
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -1128,7 +1128,13 @@ export const DelayedOrganizationAuthorization: Story = {
 		// restoration would silently discard it.
 		expect(dropFile("drop.txt")).toBe(true);
 		expect(canvas.queryByLabelText("Remove drop.txt")).not.toBeInTheDocument();
+		// The picker must also stay hidden: its pending-state option list
+		// is the unfiltered dashboard fallback.
+		expect(
+			canvas.queryByTestId("compact-org-selector"),
+		).not.toBeInTheDocument();
 		await waitFor(() => expect(sendButton).toBeEnabled(), { timeout: 3_000 });
+		await canvas.findByTestId("compact-org-selector");
 		// Positive control: once settled the same drop is accepted and
 		// attaches, so the pending-state assertions exercised a real path.
 		expect(dropFile("after.txt")).toBe(false);
@@ -1138,49 +1144,58 @@ export const DelayedOrganizationAuthorization: Story = {
 	},
 };
 
-// Mutable so the play function can change results between refetches;
-// the story-level QueryClient lets it drive those refetches, which the
+// Mutable so play functions can change results between refetches; the
+// story-level QueryClient lets them drive those refetches, which the
 // preview decorator's client (staleTime: Infinity, inaccessible from
 // play) cannot.
 const revocablePermissions: Record<string, boolean> = {};
 let revocableQueryClient: QueryClient | undefined;
+
+const withRevocableQueryClient: Decorator = (Story) => {
+	const [queryClient] = useState(
+		() =>
+			new QueryClient({
+				defaultOptions: {
+					queries: {
+						staleTime: Number.POSITIVE_INFINITY,
+						retry: false,
+					},
+				},
+			}),
+	);
+	revocableQueryClient = queryClient;
+	return (
+		<QueryClientProvider client={queryClient}>
+			<Story />
+		</QueryClientProvider>
+	);
+};
+
+const mockRevocablePermissions = (permissions: Record<string, boolean>) => {
+	for (const key of Object.keys(revocablePermissions)) {
+		delete revocablePermissions[key];
+	}
+	Object.assign(revocablePermissions, permissions);
+	spyOn(API, "getOrganizations").mockResolvedValue([
+		MockDefaultOrganization,
+		MockOrganization2,
+	]);
+	spyOn(API, "checkAuthorization").mockImplementation(async () => ({
+		...revocablePermissions,
+	}));
+};
 
 export const RevokedSelectionDoesNotResurrect: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
 	},
-	decorators: [
-		(Story) => {
-			const [queryClient] = useState(
-				() =>
-					new QueryClient({
-						defaultOptions: {
-							queries: {
-								staleTime: Number.POSITIVE_INFINITY,
-								retry: false,
-							},
-						},
-					}),
-			);
-			revocableQueryClient = queryClient;
-			return (
-				<QueryClientProvider client={queryClient}>
-					<Story />
-				</QueryClientProvider>
-			);
-		},
-	],
+	decorators: [withRevocableQueryClient],
 	beforeEach: () => {
-		revocablePermissions[MockDefaultOrganization.id] = true;
-		revocablePermissions[MockOrganization2.id] = true;
-		spyOn(API, "getOrganizations").mockResolvedValue([
-			MockDefaultOrganization,
-			MockOrganization2,
-		]);
-		spyOn(API, "checkAuthorization").mockImplementation(async () => ({
-			...revocablePermissions,
-		}));
+		mockRevocablePermissions({
+			[MockDefaultOrganization.id]: true,
+			[MockOrganization2.id]: true,
+		});
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -1217,6 +1232,118 @@ export const RevokedSelectionDoesNotResurrect: Story = {
 				"Organization: My Organization",
 			),
 		);
+	},
+};
+
+export const RevokedOrgChangeClearsStoredWorkspace: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	decorators: [withRevocableQueryClient],
+	args: {
+		...defaultArgs,
+		workspaceOptions: [
+			{
+				...MockWorkspace,
+				id: "ws-default-org",
+				name: "default-workspace",
+				organization_id: MockDefaultOrganization.id,
+			},
+		],
+		workspaceCount: 1,
+	},
+	beforeEach: () => {
+		localStorage.setItem("agents.selected-workspace-id", "ws-default-org");
+		mockRevocablePermissions({
+			[MockDefaultOrganization.id]: true,
+			[MockOrganization2.id]: true,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() =>
+			expect(
+				canvas.getByLabelText("Remove workspace default-workspace"),
+			).toBeInTheDocument(),
+		);
+
+		// A refetch revokes the workspace's org, changing the effective
+		// org; the stored workspace must be dropped, not just masked.
+		revocablePermissions[MockDefaultOrganization.id] = false;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(
+				canvas.queryByLabelText("Remove workspace default-workspace"),
+			).not.toBeInTheDocument(),
+		);
+
+		// Re-permitting the org must not resurrect the workspace.
+		revocablePermissions[MockDefaultOrganization.id] = true;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(canvas.getByTestId("compact-org-selector")).toHaveAccessibleName(
+				"Organization: My Organization",
+			),
+		);
+		expect(
+			canvas.queryByLabelText("Remove workspace default-workspace"),
+		).not.toBeInTheDocument();
+		expect(localStorage.getItem("agents.selected-workspace-id")).toBeNull();
+	},
+};
+
+export const RevokedPendingOrgClosesConfirmDialog: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	decorators: [withRevocableQueryClient],
+	beforeEach: () => {
+		localStorage.clear();
+		localStorage.setItem(
+			"agents.persisted-attachments",
+			JSON.stringify([
+				{
+					fileId: "file-default-org",
+					fileName: "notes.txt",
+					fileType: "text/plain",
+					lastModified: 1700000000000,
+					organizationId: MockDefaultOrganization.id,
+				},
+			]),
+		);
+		mockRevocablePermissions({
+			[MockDefaultOrganization.id]: true,
+			[MockOrganization2.id]: true,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await waitFor(() =>
+			expect(canvas.getByLabelText("Remove notes.txt")).toBeInTheDocument(),
+		);
+		await userEvent.click(await canvas.findByTestId("compact-org-selector"));
+		await userEvent.click(
+			await screen.findByRole("option", { name: /My Organization 2/ }),
+		);
+		await body.findByText(
+			"Changing organization will remove your current attachments.",
+		);
+
+		// Revoking the pending org while its confirmation dialog is open
+		// must close the dialog before Continue can destroy attachments.
+		revocablePermissions[MockOrganization2.id] = false;
+		await revocableQueryClient?.invalidateQueries();
+		await waitFor(() =>
+			expect(
+				body.queryByText(
+					"Changing organization will remove your current attachments.",
+				),
+			).not.toBeInTheDocument(),
+		);
+		expect(canvas.getByLabelText("Remove notes.txt")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -298,6 +298,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// restoration so nothing acts on an org the user may not have.
 	const orgSelectionSettled =
 		!showOrganizations || permittedOrgsQuery.data !== undefined;
+	// A resolved-but-empty permitted set means chat creation is denied
+	// everywhere; effectiveOrg's dashboard fallback must not be sendable.
+	const noPermittedOrgs =
+		showOrganizations && permittedOrgsQuery.data?.length === 0;
 	const effectiveOrg =
 		selectedOrg && permittedOrgs.some((org) => org.id === selectedOrg.id)
 			? selectedOrg
@@ -376,7 +380,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		saveReasoningEffortForModel(selectedModel, value);
 	};
 
-	const isForbidden = !canCreateChat;
+	const isForbidden = !canCreateChat || noPermittedOrgs;
 
 	// Filter workspaces by the selected organization. We use
 	// client-side filtering of the full "owner:me" fetch rather

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -433,19 +433,18 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			filteredWorkspaces.some((ws) => ws.id === selectedWorkspaceId))
 			? selectedWorkspaceId
 			: null;
-	// While the list loads, effectiveWorkspaceId is display-only: a
-	// stored workspace may belong to an org the user cannot chat in,
-	// so only a workspace confirmed in the effective org is submitted.
-	const submittableWorkspaceId = isWorkspacesLoading
-		? null
-		: effectiveWorkspaceId;
+	// A stored workspace cannot be validated against the effective org
+	// until the list loads; sending then would silently drop the
+	// association, so Send stays disabled instead.
+	const workspaceValidationPending =
+		selectedWorkspaceId !== null && isWorkspacesLoading;
 
 	const handleSend = async (message: string, fileIDs?: string[]) => {
 		submitDraft();
 		await onCreateChat({
 			message,
 			fileIDs,
-			workspaceId: submittableWorkspaceId ?? undefined,
+			workspaceId: effectiveWorkspaceId ?? undefined,
 			model: submittedModel,
 			reasoningEffort: effectiveReasoningEffort,
 			organizationId,
@@ -578,6 +577,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							!orgSelectionSettled ||
 							// Sending before adoption would omit persisted files not yet restored.
 							!organizationAdopted ||
+							workspaceValidationPending ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
 							Boolean(aiGatewayDisabled)

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -479,6 +479,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		handleWorkspaceChange(null);
 		resetAttachments();
 	});
+	// Permission updates can change effectiveOrg without invoking the selection handlers.
 	useEffect(() => {
 		if (previousEffectiveOrgId.current === effectiveOrg?.id) {
 			return;
@@ -535,6 +536,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 								if (orgChanged && attachments.length > 0) {
 									setPendingOrgChange(newOrg);
 									return;
+								}
+								if (orgChanged) {
+									previousEffectiveOrgId.current = newOrg.id;
+									handleWorkspaceChange(null);
 								}
 								setSelectedOrg(newOrg);
 							}}
@@ -604,6 +609,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				hideCancel={false}
 				confirmText="Continue"
 				onConfirm={() => {
+					if (!pendingOrgChange) {
+						return;
+					}
+					previousEffectiveOrgId.current = pendingOrgChange.id;
+					resetAttachments();
+					handleWorkspaceChange(null);
 					setSelectedOrg(pendingOrgChange);
 					setPendingOrgChange(null);
 				}}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useEffectEvent, useRef, useState } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
@@ -271,35 +271,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		: undefined;
 	const initialOrg =
 		organizations.find((o) => o.is_default) ?? organizations[0];
+	// effectiveWorkspaceId nulls a stored selection outside the effective org's
+	// filtered workspace list without deleting it. Preserve the stored value
+	// because the permitted-organizations query may resolve after mount and
+	// change the effective org.
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
-		() => {
-			const stored = localStorage.getItem(selectedWorkspaceIdStorageKey);
-			if (!stored) return null;
-
-			// The stored value is kept optimistically until workspaces
-			// load. effectiveWorkspaceId (computed after render) drops
-			// it if it doesn't match the current org's workspaces.
-			if (workspaceOptions.length === 0) return stored;
-
-			// Validate the stored workspace still exists and belongs
-			// to the initial org. Without this, a workspace from a
-			// previously selected org persists across sessions and
-			// gets submitted even though it's hidden from the picker.
-			const workspace = workspaceOptions.find((ws) => ws.id === stored);
-			if (!workspace) {
-				localStorage.removeItem(selectedWorkspaceIdStorageKey);
-				return null;
-			}
-			if (
-				showOrganizations &&
-				initialOrg &&
-				workspace.organization_id !== initialOrg.id
-			) {
-				localStorage.removeItem(selectedWorkspaceIdStorageKey);
-				return null;
-			}
-			return stored;
-		},
+		() => localStorage.getItem(selectedWorkspaceIdStorageKey),
 	);
 	const [selectedOrg, setSelectedOrg] = useState<TypesGen.Organization | null>(
 		null,
@@ -324,7 +301,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				initialOrg ??
 				null);
 	const organizationId = effectiveOrg?.id ?? "";
-	const previousEffectiveOrgId = useRef(effectiveOrg?.id);
 	const [planModeEnabled, setPlanModeEnabled] = useState(false);
 	const hasModelOptions = modelOptions.length > 0;
 	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
@@ -416,13 +392,19 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			filteredWorkspaces.some((ws) => ws.id === selectedWorkspaceId))
 			? selectedWorkspaceId
 			: null;
+	// While the list loads, effectiveWorkspaceId is display-only: a
+	// stored workspace may belong to an org the user cannot chat in,
+	// so only a workspace confirmed in the effective org is submitted.
+	const submittableWorkspaceId = isWorkspacesLoading
+		? null
+		: effectiveWorkspaceId;
 
 	const handleSend = async (message: string, fileIDs?: string[]) => {
 		submitDraft();
 		await onCreateChat({
 			message,
 			fileIDs,
-			workspaceId: effectiveWorkspaceId ?? undefined,
+			workspaceId: submittableWorkspaceId ?? undefined,
 			model: submittedModel,
 			reasoningEffort: effectiveReasoningEffort,
 			organizationId,
@@ -477,19 +459,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 	};
 
-	const resetOrgScopedState = useEffectEvent(() => {
-		handleWorkspaceChange(null);
-		resetAttachments();
-	});
-	// Permission updates can change effectiveOrg without invoking the selection handlers.
-	useEffect(() => {
-		if (previousEffectiveOrgId.current === effectiveOrg?.id) {
-			return;
-		}
-		previousEffectiveOrgId.current = effectiveOrg?.id;
-		resetOrgScopedState();
-	}, [effectiveOrg?.id]);
-
 	return (
 		<>
 			<div className="order-last flex min-h-0 flex-none items-end justify-center overflow-auto px-4 pb-4 sm:order-none sm:h-full sm:flex-1 sm:items-center">
@@ -540,7 +509,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 									return;
 								}
 								if (orgChanged) {
-									previousEffectiveOrgId.current = newOrg.id;
 									handleWorkspaceChange(null);
 								}
 								setSelectedOrg(newOrg);
@@ -614,7 +582,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					if (!pendingOrgChange) {
 						return;
 					}
-					previousEffectiveOrgId.current = pendingOrgChange.id;
 					resetAttachments();
 					handleWorkspaceChange(null);
 					setSelectedOrg(pendingOrgChange);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -436,7 +436,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		handleRemoveAttachment,
 		resetAttachments,
 	} = useFileAttachments(
-		orgSelectionSettled ? organizationId || undefined : undefined,
+		// With no permitted org, effectiveOrg falls back to an org the
+		// user cannot chat in; restoring against it would prune other
+		// orgs' persisted attachments.
+		orgSelectionSettled && !noPermittedOrgs
+			? organizationId || undefined
+			: undefined,
 		{
 			persist: true,
 			provider: getProviderForModelOption(modelOptions, selectedModel),

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -632,9 +632,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						onMCPAuthComplete={onMCPAuthComplete}
 						workspaceOptions={filteredWorkspaces}
 						selectedWorkspaceId={effectiveWorkspaceId}
-						// Before settlement the options come from the provisional
-						// fallback org; a pick would overwrite the stored
-						// workspace with a foreign-org value.
+						// Do not persist a workspace until its organization is authorized.
 						onWorkspaceChange={
 							orgSelectionSettled && !noPermittedOrgs
 								? handleWorkspaceChange

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -315,6 +315,15 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	) {
 		setSelectedOrg(null);
 	}
+	// Same rule for a pending change awaiting confirmation: closing the
+	// dialog prevents confirming into an org that was just revoked.
+	if (
+		pendingOrgChange &&
+		orgSelectionSettled &&
+		!permittedOrgs.some((org) => org.id === pendingOrgChange.id)
+	) {
+		setPendingOrgChange(null);
+	}
 	const effectiveOrg =
 		selectedOrg && permittedOrgs.some((org) => org.id === selectedOrg.id)
 			? selectedOrg
@@ -323,6 +332,24 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				initialOrg ??
 				null);
 	const organizationId = effectiveOrg?.id ?? "";
+	// A settled permission refetch that changes the effective org must
+	// also drop the stored workspace, mirroring user-driven org changes;
+	// left latent, it would resurrect and submit if the old org became
+	// effective again. Initial settlement records the org without
+	// clearing so a persisted workspace survives first load. Render-time
+	// state adjustment; the storage entry is removed post-commit below.
+	const [lastSettledOrgId, setLastSettledOrgId] = useState<string | null>(null);
+	if (orgSelectionSettled && organizationId !== lastSettledOrgId) {
+		setLastSettledOrgId(organizationId);
+		if (lastSettledOrgId !== null) {
+			setSelectedWorkspaceId(null);
+		}
+	}
+	useEffect(() => {
+		if (selectedWorkspaceId === null) {
+			localStorage.removeItem(selectedWorkspaceIdStorageKey);
+		}
+	}, [selectedWorkspaceId]);
 	const [planModeEnabled, setPlanModeEnabled] = useState(false);
 	const hasModelOptions = modelOptions.length > 0;
 	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
@@ -529,23 +556,28 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					{permittedOrgsQuery.error != null && (
 						<ErrorAlert error={permittedOrgsQuery.error} />
 					)}
-					{showOrganizations && permittedOrgs.length > 1 && (
-						<CompactOrgSelector
-							value={effectiveOrg}
-							options={permittedOrgs}
-							onChange={(newOrg) => {
-								const orgChanged = newOrg.id !== effectiveOrg?.id;
-								if (orgChanged && attachments.length > 0) {
-									setPendingOrgChange(newOrg);
-									return;
-								}
-								if (orgChanged) {
-									handleWorkspaceChange(null);
-								}
-								setSelectedOrg(newOrg);
-							}}
-						/>
-					)}
+					{/* Hidden until settled: before then the list is the
+					    unfiltered dashboard fallback, and selecting a
+					    never-permitted org would destroy workspace state. */}
+					{showOrganizations &&
+						orgSelectionSettled &&
+						permittedOrgs.length > 1 && (
+							<CompactOrgSelector
+								value={effectiveOrg}
+								options={permittedOrgs}
+								onChange={(newOrg) => {
+									const orgChanged = newOrg.id !== effectiveOrg?.id;
+									if (orgChanged && attachments.length > 0) {
+										setPendingOrgChange(newOrg);
+										return;
+									}
+									if (orgChanged) {
+										handleWorkspaceChange(null);
+									}
+									setSelectedOrg(newOrg);
+								}}
+							/>
+						)}
 					<AgentChatInput
 						onSend={handleSendWithAttachments}
 						sendShortcut={sendShortcut}
@@ -620,10 +652,16 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					if (!pendingOrgChange) {
 						return;
 					}
+					setPendingOrgChange(null);
+					// A revoking refetch can land after this render's
+					// closure was created; re-check before destroying
+					// attachment and workspace state.
+					if (!permittedOrgs.some((org) => org.id === pendingOrgChange.id)) {
+						return;
+					}
 					resetAttachments();
 					handleWorkspaceChange(null);
 					setSelectedOrg(pendingOrgChange);
-					setPendingOrgChange(null);
 				}}
 				onClose={() => setPendingOrgChange(null)}
 			/>

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -428,6 +428,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	};
 
 	const {
+		organizationAdopted,
 		attachments,
 		textContents,
 		uploadStates,
@@ -539,6 +540,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							isCreating ||
 							isForbidden ||
 							!orgSelectionSettled ||
+							// Until adoption, a send would omit persisted files
+							// the hook has not yet restored.
+							!organizationAdopted ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
 							Boolean(aiGatewayDisabled)
@@ -558,12 +562,11 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						planModeEnabled={planModeEnabled}
 						onPlanModeToggle={setPlanModeEnabled}
 						attachments={attachments}
-						// Until the attachment hook has a real org, a dropped or
-						// pasted file cannot upload and would be discarded by
-						// restoration once the org settles.
-						onAttach={
-							orgSelectionSettled && !noPermittedOrgs ? handleAttach : undefined
-						}
+						// Until the attachment hook has adopted a real org, a
+						// dropped or pasted file cannot upload and would be
+						// discarded by restoration when adoption completes.
+						// Adoption implies the org settled and is permitted.
+						onAttach={organizationAdopted ? handleAttach : undefined}
 						onRemoveAttachment={handleRemoveAttachment}
 						uploadStates={uploadStates}
 						previewUrls={previewUrls}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -301,18 +301,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// permitted set.
 	const noPermittedOrgs =
 		showOrganizations && permittedOrgsQuery.data?.length === 0;
-	// Drop an explicit selection the moment a permission refetch
-	// invalidates it. Left latent, a later refetch that re-permits the
-	// org would silently switch back without user action, discarding
-	// the effective org's attachment state. Render-time state
-	// adjustment, not an effect, per the React "adjusting state when
-	// props change" pattern; effectiveOrg already ignores the invalid
-	// selection in this same render.
-	if (
-		selectedOrg &&
-		orgSelectionSettled &&
-		!permittedOrgs.some((org) => org.id === selectedOrg.id)
-	) {
+	const selectedOrgIsPermitted =
+		selectedOrg !== null &&
+		permittedOrgs.some((org) => org.id === selectedOrg.id);
+	// Clear invalid selections during render so re-permission cannot silently
+	// restore them and switch attachment state. effectiveOrg already ignores
+	// the invalid selection in this render.
+	if (selectedOrg && orgSelectionSettled && !selectedOrgIsPermitted) {
 		setSelectedOrg(null);
 	}
 	// Same rule for a pending change awaiting confirmation: closing the
@@ -325,19 +320,16 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		setPendingOrgChange(null);
 	}
 	const effectiveOrg =
-		selectedOrg && permittedOrgs.some((org) => org.id === selectedOrg.id)
+		selectedOrg && selectedOrgIsPermitted
 			? selectedOrg
 			: (permittedOrgs.find((org) => org.is_default) ??
 				permittedOrgs[0] ??
 				initialOrg ??
 				null);
 	const organizationId = effectiveOrg?.id ?? "";
-	// A settled permission refetch that changes the effective org must
-	// also drop the stored workspace, mirroring user-driven org changes;
-	// left latent, it would resurrect and submit if the old org became
-	// effective again. Initial settlement records the org without
-	// clearing so a persisted workspace survives first load. Render-time
-	// state adjustment; the storage entry is removed post-commit below.
+	// Clear a workspace when a settled permission refetch changes org, but
+	// preserve it on initial settlement. Render-time adjustment prevents stale
+	// selection from resurfacing before localStorage is cleared post-commit.
 	const [lastSettledOrgId, setLastSettledOrgId] = useState<string | null>(null);
 	if (orgSelectionSettled && organizationId !== lastSettledOrgId) {
 		setLastSettledOrgId(organizationId);
@@ -478,9 +470,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		handleRemoveAttachment,
 		resetAttachments,
 	} = useFileAttachments(
-		// With no permitted org, effectiveOrg falls back to an org the
-		// user cannot chat in; restoring against it would prune other
-		// orgs' persisted attachments.
+		// Avoid restoring against effectiveOrg's fallback when no org is permitted;
+		// that would prune attachments persisted for other orgs.
 		orgSelectionSettled && !noPermittedOrgs
 			? organizationId || undefined
 			: undefined,
@@ -556,9 +547,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					{permittedOrgsQuery.error != null && (
 						<ErrorAlert error={permittedOrgsQuery.error} />
 					)}
-					{/* Hidden until settled: before then the list is the
-					    unfiltered dashboard fallback, and selecting a
-					    never-permitted org would destroy workspace state. */}
+					{/* The pre-settlement list is the unfiltered dashboard fallback;
+					    selecting from it could destroy existing workspace state. */}
 					{showOrganizations &&
 						orgSelectionSettled &&
 						permittedOrgs.length > 1 && (
@@ -586,8 +576,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							isCreating ||
 							isForbidden ||
 							!orgSelectionSettled ||
-							// Until adoption, a send would omit persisted files
-							// the hook has not yet restored.
+							// Sending before adoption would omit persisted files not yet restored.
 							!organizationAdopted ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
@@ -608,10 +597,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						planModeEnabled={planModeEnabled}
 						onPlanModeToggle={setPlanModeEnabled}
 						attachments={attachments}
-						// Until the attachment hook has adopted a real org, a
-						// dropped or pasted file cannot upload and would be
-						// discarded by restoration when adoption completes.
-						// Adoption implies the org settled and is permitted.
+						// Files attached before org adoption cannot upload and would be discarded
+						// when restoration completes.
 						onAttach={organizationAdopted ? handleAttach : undefined}
 						onRemoveAttachment={handleRemoveAttachment}
 						uploadStates={uploadStates}
@@ -653,9 +640,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						return;
 					}
 					setPendingOrgChange(null);
-					// A revoking refetch can land after this render's
-					// closure was created; re-check before destroying
-					// attachment and workspace state.
+					// Recheck authorization because a refetch may revoke the pending org
+					// after this render created the closure.
 					if (!permittedOrgs.some((org) => org.id === pendingOrgChange.id)) {
 						return;
 					}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -301,6 +301,20 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// permitted set.
 	const noPermittedOrgs =
 		showOrganizations && permittedOrgsQuery.data?.length === 0;
+	// Drop an explicit selection the moment a permission refetch
+	// invalidates it. Left latent, a later refetch that re-permits the
+	// org would silently switch back without user action, discarding
+	// the effective org's attachment state. Render-time state
+	// adjustment, not an effect, per the React "adjusting state when
+	// props change" pattern; effectiveOrg already ignores the invalid
+	// selection in this same render.
+	if (
+		selectedOrg &&
+		orgSelectionSettled &&
+		!permittedOrgs.some((org) => org.id === selectedOrg.id)
+	) {
+		setSelectedOrg(null);
+	}
 	const effectiveOrg =
 		selectedOrg && permittedOrgs.some((org) => org.id === selectedOrg.id)
 			? selectedOrg

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -293,6 +293,11 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		enabled: showOrganizations,
 	});
 	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
+	// Until the permitted query produces data (still loading, or failed),
+	// the org selection is provisional: block sending and attachment
+	// restoration so nothing acts on an org the user may not have.
+	const orgSelectionSettled =
+		!showOrganizations || permittedOrgsQuery.data !== undefined;
 	const effectiveOrg =
 		selectedOrg && permittedOrgs.some((org) => org.id === selectedOrg.id)
 			? selectedOrg
@@ -427,10 +432,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		handleAttach,
 		handleRemoveAttachment,
 		resetAttachments,
-	} = useFileAttachments(organizationId || undefined, {
-		persist: true,
-		provider: getProviderForModelOption(modelOptions, selectedModel),
-	});
+	} = useFileAttachments(
+		orgSelectionSettled ? organizationId || undefined : undefined,
+		{
+			persist: true,
+			provider: getProviderForModelOption(modelOptions, selectedModel),
+		},
+	);
 
 	const handleSendWithAttachments = async (message: string) => {
 		const fileIds: string[] = [];
@@ -522,7 +530,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						isDisabled={
 							isCreating ||
 							isForbidden ||
-							(showOrganizations && permittedOrgsQuery.isLoading) ||
+							!orgSelectionSettled ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
 							Boolean(aiGatewayDisabled)

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -327,6 +327,19 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				initialOrg ??
 				null);
 	const organizationId = effectiveOrg?.id ?? "";
+	// Record a settled fallback-derived org as the selection; left null, a
+	// later refetch that re-permits a revoked default would silently switch
+	// the form away from the org the user is composing under. Only permitted
+	// orgs are recorded, otherwise the invalidation above would clear the
+	// record on the next render and loop.
+	if (
+		orgSelectionSettled &&
+		!selectedOrg &&
+		effectiveOrg &&
+		permittedOrgs.some((org) => org.id === effectiveOrg.id)
+	) {
+		setSelectedOrg(effectiveOrg);
+	}
 	// Clear a workspace when a settled permission refetch changes org, but
 	// preserve it on initial settlement. Render-time adjustment prevents stale
 	// selection from resurfacing before localStorage is cleared post-commit.

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -308,7 +308,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		useState<TypesGen.Organization | null>(null);
 	const permittedOrgsQuery = useQuery({
 		...permittedOrganizations({
-			object: { resource_type: "chat" },
+			// owner_id scopes the check to the current user; roles like
+			// agents-access grant chat:create only at member (owner) scope,
+			// which an ownerless check can never match.
+			object: { resource_type: "chat", owner_id: "me" },
 			action: "create",
 		}),
 		enabled: showOrganizations,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -558,7 +558,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						planModeEnabled={planModeEnabled}
 						onPlanModeToggle={setPlanModeEnabled}
 						attachments={attachments}
-						onAttach={handleAttach}
+						// Until the attachment hook has a real org, a dropped or
+						// pasted file cannot upload and would be discarded by
+						// restoration once the org settles.
+						onAttach={
+							orgSelectionSettled && !noPermittedOrgs ? handleAttach : undefined
+						}
 						onRemoveAttachment={handleRemoveAttachment}
 						uploadStates={uploadStates}
 						previewUrls={previewUrls}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -292,7 +292,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}),
 		enabled: showOrganizations,
 	});
-	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
+	// A disabled query retains cached data, so once showOrganizations
+	// turns false (org count dropped to one) the dashboard list is
+	// authoritative; the stale permitted list could keep a removed org
+	// selected and submitting.
+	const permittedOrgs = showOrganizations
+		? (permittedOrgsQuery.data ?? organizations)
+		: organizations;
 	// Treat the dashboard org as provisional until permissions resolve so
 	// sends and persisted attachments cannot use an unpermitted org.
 	const orgSelectionSettled =

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -293,13 +293,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		enabled: showOrganizations,
 	});
 	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
-	// Until the permitted query produces data (still loading, or failed),
-	// the org selection is provisional: block sending and attachment
-	// restoration so nothing acts on an org the user may not have.
+	// Treat the dashboard org as provisional until permissions resolve so
+	// sends and persisted attachments cannot use an unpermitted org.
 	const orgSelectionSettled =
 		!showOrganizations || permittedOrgsQuery.data !== undefined;
-	// A resolved-but-empty permitted set means chat creation is denied
-	// everywhere; effectiveOrg's dashboard fallback must not be sendable.
+	// Prevent effectiveOrg's dashboard fallback from bypassing an empty
+	// permitted set.
 	const noPermittedOrgs =
 		showOrganizations && permittedOrgsQuery.data?.length === 0;
 	const effectiveOrg =

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -292,10 +292,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}),
 		enabled: showOrganizations,
 	});
-	// A disabled query retains cached data, so once showOrganizations
-	// turns false (org count dropped to one) the dashboard list is
-	// authoritative; the stale permitted list could keep a removed org
-	// selected and submitting.
+	// Disabled queries retain cached data. When the dashboard hides organization
+	// selection, its organization list is authoritative so a removed org cannot
+	// remain selected for submission.
 	const permittedOrgs = showOrganizations
 		? (permittedOrgsQuery.data ?? organizations)
 		: organizations;

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -632,7 +632,14 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						onMCPAuthComplete={onMCPAuthComplete}
 						workspaceOptions={filteredWorkspaces}
 						selectedWorkspaceId={effectiveWorkspaceId}
-						onWorkspaceChange={handleWorkspaceChange}
+						// Before settlement the options come from the provisional
+						// fallback org; a pick would overwrite the stored
+						// workspace with a foreign-org value.
+						onWorkspaceChange={
+							orgSelectionSettled && !noPermittedOrgs
+								? handleWorkspaceChange
+								: undefined
+						}
 						isWorkspaceLoading={isWorkspacesLoading}
 						canConfigureAgentSetup={canConfigureAgentSetup}
 						providerCount={providerCount}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -343,8 +343,15 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// Clear a workspace when a settled permission refetch changes org, but
 	// preserve it on initial settlement. Render-time adjustment prevents stale
 	// selection from resurfacing before localStorage is cleared post-commit.
+	// An empty permitted set is skipped: its dashboard fallback is not a real
+	// org change (sends are blocked), and clearing would permanently delete a
+	// workspace that should return when the org is re-permitted.
 	const [lastSettledOrgId, setLastSettledOrgId] = useState<string | null>(null);
-	if (orgSelectionSettled && organizationId !== lastSettledOrgId) {
+	if (
+		orgSelectionSettled &&
+		!noPermittedOrgs &&
+		organizationId !== lastSettledOrgId
+	) {
 		setLastSettledOrgId(organizationId);
 		if (lastSettledOrgId !== null) {
 			setSelectedWorkspaceId(null);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -308,9 +308,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		useState<TypesGen.Organization | null>(null);
 	const permittedOrgsQuery = useQuery({
 		...permittedOrganizations({
-			// owner_id scopes the check to the current user; roles like
-			// agents-access grant chat:create only at member (owner) scope,
-			// which an ownerless check can never match.
+			// agents-access grants chat:create only at member scope. "me" is
+			// replaced with the caller ID so that permission can match.
 			object: { resource_type: "chat", owner_id: "me" },
 			action: "create",
 		}),

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -327,11 +327,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				initialOrg ??
 				null);
 	const organizationId = effectiveOrg?.id ?? "";
-	// Record a settled fallback-derived org as the selection; left null, a
-	// later refetch that re-permits a revoked default would silently switch
-	// the form away from the org the user is composing under. Only permitted
-	// orgs are recorded, otherwise the invalidation above would clear the
-	// record on the next render and loop.
+	// Adopt a permitted fallback so later refetches cannot switch the form to a
+	// re-permitted default. The permission guard also avoids a render loop.
 	if (
 		orgSelectionSettled &&
 		!selectedOrg &&
@@ -340,12 +337,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	) {
 		setSelectedOrg(effectiveOrg);
 	}
-	// Clear a workspace when a settled permission refetch changes org, but
-	// preserve it on initial settlement. Render-time adjustment prevents stale
-	// selection from resurfacing before localStorage is cleared post-commit.
-	// An empty permitted set is skipped: its dashboard fallback is not a real
-	// org change (sends are blocked), and clearing would permanently delete a
-	// workspace that should return when the org is re-permitted.
+	// Clear a workspace after a settled org change, before its localStorage value
+	// is cleared post-commit. An empty permission set has no selectable org, so
+	// preserve the workspace until its org is re-permitted.
 	const [lastSettledOrgId, setLastSettledOrgId] = useState<string | null>(null);
 	if (
 		orgSelectionSettled &&

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -302,11 +302,27 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		},
 	);
 	const [selectedOrg, setSelectedOrg] = useState<TypesGen.Organization | null>(
-		initialOrg ?? null,
+		null,
 	);
 	const [pendingOrgChange, setPendingOrgChange] =
 		useState<TypesGen.Organization | null>(null);
-	const organizationId = selectedOrg?.id ?? "";
+	const permittedOrgsQuery = useQuery({
+		...permittedOrganizations({
+			object: { resource_type: "chat" },
+			action: "create",
+		}),
+		enabled: showOrganizations,
+	});
+	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
+	const effectiveOrg =
+		selectedOrg && permittedOrgs.some((org) => org.id === selectedOrg.id)
+			? selectedOrg
+			: (permittedOrgs.find((org) => org.is_default) ??
+				permittedOrgs[0] ??
+				initialOrg ??
+				null);
+	const organizationId = effectiveOrg?.id ?? "";
+	const previousEffectiveOrgId = useRef(effectiveOrg?.id);
 	const [planModeEnabled, setPlanModeEnabled] = useState(false);
 	const hasModelOptions = modelOptions.length > 0;
 	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
@@ -388,8 +404,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	// enough to warrant pagination, this should switch to a
 	// server-side organization:<name> query filter.
 	const filteredWorkspaces =
-		showOrganizations && selectedOrg
-			? workspaceOptions.filter((ws) => ws.organization_id === selectedOrg.id)
+		showOrganizations && effectiveOrg
+			? workspaceOptions.filter((ws) => ws.organization_id === effectiveOrg.id)
 			: workspaceOptions;
 
 	const effectiveWorkspaceId =
@@ -459,49 +475,17 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 	};
 
-	const permittedOrgsQuery = useQuery({
-		...permittedOrganizations({
-			object: { resource_type: "chat", owner_id: "me" },
-			action: "create",
-		}),
-		enabled: showOrganizations,
-	});
-	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
-
-	// Reconcile selectedOrg when permission filtering removes it.
-	// Only pure state setters run during render; side effects
-	// (localStorage, blob URL cleanup) run in the effect below.
-	const [prevPermittedOrgs, setPrevPermittedOrgs] = useState(permittedOrgs);
-	const [orgWasAdjusted, setOrgWasAdjusted] = useState(false);
-	if (permittedOrgs !== prevPermittedOrgs) {
-		setPrevPermittedOrgs(permittedOrgs);
-		if (selectedOrg && !permittedOrgs.some((o) => o.id === selectedOrg.id)) {
-			// Fall back through: first permitted org, then the
-			// dashboard default. Never null out selectedOrg.
-			// organizationId must always be a valid UUID for the
-			// create-chat request.
-			const nextOrg = permittedOrgs[0] ?? initialOrg ?? null;
-			setSelectedOrg(nextOrg);
-			if (nextOrg?.id !== selectedOrg.id) {
-				setOrgWasAdjusted(true);
-			}
-		}
-	}
-
-	// Clean up workspace and attachment state after a programmatic
-	// org change from permission filtering. These calls have side
-	// effects (localStorage, blob URL revocation) that must not
-	// run during render.
-	const onOrgAdjusted = useEffectEvent(() => {
+	const resetOrgScopedState = useEffectEvent(() => {
 		handleWorkspaceChange(null);
 		resetAttachments();
 	});
 	useEffect(() => {
-		if (orgWasAdjusted) {
-			setOrgWasAdjusted(false);
-			onOrgAdjusted();
+		if (previousEffectiveOrgId.current === effectiveOrg?.id) {
+			return;
 		}
-	}, [orgWasAdjusted]);
+		previousEffectiveOrgId.current = effectiveOrg?.id;
+		resetOrgScopedState();
+	}, [effectiveOrg?.id]);
 
 	return (
 		<>
@@ -544,16 +528,13 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					)}
 					{showOrganizations && permittedOrgs.length > 1 && (
 						<CompactOrgSelector
-							value={selectedOrg}
+							value={effectiveOrg}
 							options={permittedOrgs}
 							onChange={(newOrg) => {
-								const orgChanged = newOrg.id !== selectedOrg?.id;
+								const orgChanged = newOrg.id !== effectiveOrg?.id;
 								if (orgChanged && attachments.length > 0) {
 									setPendingOrgChange(newOrg);
 									return;
-								}
-								if (orgChanged) {
-									handleWorkspaceChange(null);
 								}
 								setSelectedOrg(newOrg);
 							}}
@@ -566,6 +547,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						isDisabled={
 							isCreating ||
 							isForbidden ||
+							(showOrganizations && permittedOrgsQuery.isLoading) ||
 							isPersonalModelOverridesLoading ||
 							!hasModelOptions ||
 							Boolean(aiGatewayDisabled)
@@ -622,8 +604,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 				hideCancel={false}
 				confirmText="Continue"
 				onConfirm={() => {
-					resetAttachments();
-					handleWorkspaceChange(null);
 					setSelectedOrg(pendingOrgChange);
 					setPendingOrgChange(null);
 				}}

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	persistedAttachmentsStorageKey,
+	useFileAttachments,
+} from "./useFileAttachments";
+
+const persistEntry = (fileId: string, fileName: string, orgId: string) => ({
+	fileId,
+	fileName,
+	fileType: "text/plain",
+	lastModified: 1000,
+	organizationId: orgId,
+});
+
+const uploadedFileIds = (
+	result: ReturnType<typeof useFileAttachments>,
+): string[] =>
+	[...result.uploadStates.values()].flatMap((state) =>
+		state.status === "uploaded" && state.fileId ? [state.fileId] : [],
+	);
+
+describe("useFileAttachments org scoping", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("defers restoration until the org is known", () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([persistEntry("file-b", "b.txt", "org-b")]),
+		);
+		const { result, rerender } = renderHook(
+			({ orgId }: { orgId: string | undefined }) =>
+				useFileAttachments(orgId, { persist: true }),
+			{ initialProps: { orgId: undefined as string | undefined } },
+		);
+
+		expect(result.current.attachments).toHaveLength(0);
+		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toContain(
+			"file-b",
+		);
+
+		rerender({ orgId: "org-b" });
+		expect(uploadedFileIds(result.current)).toStrictEqual(["file-b"]);
+	});
+
+	it("drops another org's attachments when the org changes", async () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
+		);
+		const { result, rerender } = renderHook(
+			({ orgId }: { orgId: string | undefined }) =>
+				useFileAttachments(orgId, { persist: true }),
+			{ initialProps: { orgId: "org-a" as string | undefined } },
+		);
+		expect(uploadedFileIds(result.current)).toStrictEqual(["file-a"]);
+
+		// A send after this switch must not carry org-a's file IDs.
+		rerender({ orgId: "org-b" });
+		await waitFor(() => {
+			expect(uploadedFileIds(result.current)).toStrictEqual([]);
+		});
+		expect(
+			localStorage.getItem(persistedAttachmentsStorageKey) ?? "",
+		).not.toContain("file-a");
+	});
+});

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -181,9 +181,6 @@ describe("useFileAttachments org scoping", () => {
 			expect(uploadedFileIds(result.current)).toStrictEqual(["file-a"]);
 		});
 
-		// Losing the org entirely (empty permitted set) must hide the
-		// previous org's attachments so they cannot be removed, while
-		// keeping them persisted for when the org returns.
 		rerender({ orgId: undefined });
 		expect(result.current.attachments).toStrictEqual([]);
 		expect(uploadedFileIds(result.current)).toStrictEqual([]);

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -1,5 +1,5 @@
 import { render, renderHook, waitFor } from "@testing-library/react";
-import type { FC } from "react";
+import { type FC, Suspense } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	persistedAttachmentsStorageKey,
@@ -93,5 +93,26 @@ describe("useFileAttachments org scoping", () => {
 			(entry) => entry.orgId === "org-b" && entry.fileIds.includes("file-a"),
 		);
 		expect(leaked).toStrictEqual([]);
+	});
+
+	it("does not prune storage during a render that never commits", () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
+		);
+		// Suspending after the hook call abandons the render before
+		// commit, the same discard concurrent rendering can perform.
+		const Suspender: FC<{ orgId: string }> = ({ orgId }) => {
+			useFileAttachments(orgId, { persist: true });
+			throw new Promise(() => {});
+		};
+		render(
+			<Suspense fallback={null}>
+				<Suspender orgId="org-b" />
+			</Suspense>,
+		);
+		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toContain(
+			"file-a",
+		);
 	});
 });

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -1,4 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, waitFor } from "@testing-library/react";
+import type { FC } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	persistedAttachmentsStorageKey,
@@ -56,8 +57,6 @@ describe("useFileAttachments org scoping", () => {
 			{ initialProps: { orgId: "org-a" as string | undefined } },
 		);
 		expect(uploadedFileIds(result.current)).toStrictEqual(["file-a"]);
-
-		// A send after this switch must not carry org-a's file IDs.
 		rerender({ orgId: "org-b" });
 		await waitFor(() => {
 			expect(uploadedFileIds(result.current)).toStrictEqual([]);
@@ -65,5 +64,35 @@ describe("useFileAttachments org scoping", () => {
 		expect(
 			localStorage.getItem(persistedAttachmentsStorageKey) ?? "",
 		).not.toContain("file-a");
+	});
+
+	it("never exposes the previous org's file IDs in any render", async () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
+		);
+		// Log the hook output of every render, including the
+		// intermediate commit between the org changing and the
+		// adoption effect running; that window must expose nothing.
+		const renderLog: { orgId: string; fileIds: string[] }[] = [];
+		const Probe: FC<{ orgId: string }> = ({ orgId }) => {
+			const result = useFileAttachments(orgId, { persist: true });
+			renderLog.push({ orgId, fileIds: uploadedFileIds(result) });
+			return null;
+		};
+		const { rerender } = render(<Probe orgId="org-a" />);
+		expect(renderLog.at(-1)).toStrictEqual({
+			orgId: "org-a",
+			fileIds: ["file-a"],
+		});
+
+		rerender(<Probe orgId="org-b" />);
+		await waitFor(() => {
+			expect(renderLog.at(-1)?.fileIds).toStrictEqual([]);
+		});
+		const leaked = renderLog.filter(
+			(entry) => entry.orgId === "org-b" && entry.fileIds.includes("file-a"),
+		);
+		expect(leaked).toStrictEqual([]);
 	});
 });

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -29,6 +29,19 @@ const renderAttachments = (initialProps: { orgId: string | undefined }) =>
 		{ initialProps },
 	);
 
+const mockDeferredUpload = (): ((value: { id: string }) => void) => {
+	let resolve: ((value: { id: string }) => void) | undefined;
+	vi.spyOn(API.experimental, "uploadChatFile").mockReturnValue(
+		new Promise<{ id: string }>((res) => {
+			resolve = res;
+		}),
+	);
+	if (!resolve) {
+		throw new Error("Promise executor did not run synchronously");
+	}
+	return resolve;
+};
+
 describe("useFileAttachments org scoping", () => {
 	beforeEach(() => {
 		localStorage.clear();
@@ -118,12 +131,7 @@ describe("useFileAttachments org scoping", () => {
 	});
 
 	it("discards an upload that completes after another org was adopted", async () => {
-		let resolveUpload!: (value: { id: string }) => void;
-		vi.spyOn(API.experimental, "uploadChatFile").mockReturnValue(
-			new Promise<{ id: string }>((resolve) => {
-				resolveUpload = resolve;
-			}),
-		);
+		const resolveUpload = mockDeferredUpload();
 		const { result, rerender } = renderAttachments({ orgId: "org-a" });
 		act(() => {
 			result.current.startUpload(new File(["x"], "x.txt"));
@@ -144,12 +152,7 @@ describe("useFileAttachments org scoping", () => {
 	});
 
 	it("discards an upload that spans an org round trip", async () => {
-		let resolveUpload!: (value: { id: string }) => void;
-		vi.spyOn(API.experimental, "uploadChatFile").mockReturnValue(
-			new Promise<{ id: string }>((resolve) => {
-				resolveUpload = resolve;
-			}),
-		);
+		const resolveUpload = mockDeferredUpload();
 		const { result, rerender } = renderAttachments({ orgId: "org-a" });
 		act(() => {
 			result.current.startUpload(new File(["x"], "x.txt"));

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -95,6 +95,27 @@ describe("useFileAttachments org scoping", () => {
 		expect(leaked).toStrictEqual([]);
 	});
 
+	it("reports adoption only after the post-commit effect", () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
+		);
+		const log: { adopted: boolean; fileIds: string[] }[] = [];
+		const Probe: FC<{ orgId: string }> = ({ orgId }) => {
+			const result = useFileAttachments(orgId, { persist: true });
+			log.push({
+				adopted: result.organizationAdopted,
+				fileIds: uploadedFileIds(result),
+			});
+			return null;
+		};
+		render(<Probe orgId="org-a" />);
+		// The commit that supplies the org must not report adoption; the
+		// persisted file is only restored (and sendable) afterwards.
+		expect(log[0]).toStrictEqual({ adopted: false, fileIds: [] });
+		expect(log.at(-1)).toStrictEqual({ adopted: true, fileIds: ["file-a"] });
+	});
+
 	it("does not prune storage during a render that never commits", () => {
 		localStorage.setItem(
 			persistedAttachmentsStorageKey,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -2,6 +2,7 @@ import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { type FC, Suspense } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "#/api/api";
+import { createDeferred } from "#/testHelpers/deferred";
 import {
 	persistedAttachmentsStorageKey,
 	useFileAttachments,
@@ -30,16 +31,11 @@ const renderAttachments = (initialProps: { orgId: string | undefined }) =>
 	);
 
 const mockDeferredUpload = (): ((value: { id: string }) => void) => {
-	let resolve: ((value: { id: string }) => void) | undefined;
+	const deferred = createDeferred<{ id: string }>();
 	vi.spyOn(API.experimental, "uploadChatFile").mockReturnValue(
-		new Promise<{ id: string }>((res) => {
-			resolve = res;
-		}),
+		deferred.promise,
 	);
-	if (!resolve) {
-		throw new Error("Promise executor did not run synchronously");
-	}
-	return resolve;
+	return deferred.resolve;
 };
 
 describe("useFileAttachments org scoping", () => {
@@ -124,8 +120,6 @@ describe("useFileAttachments org scoping", () => {
 			return null;
 		};
 		render(<Probe orgId="org-a" />);
-		// The commit that supplies the org must not report adoption; the
-		// persisted file is only restored (and sendable) afterwards.
 		expect(log[0]).toStrictEqual({ adopted: false, fileIds: [] });
 		expect(log.at(-1)).toStrictEqual({ adopted: true, fileIds: ["file-a"] });
 	});
@@ -158,8 +152,7 @@ describe("useFileAttachments org scoping", () => {
 			result.current.startUpload(new File(["x"], "x.txt"));
 		});
 
-		// A -> B -> A: stateOrgId matches the upload's org again, so only
-		// the adoption epoch can tell the completion is stale.
+		// After A -> B -> A, only the adoption epoch distinguishes the stale upload.
 		rerender({ orgId: "org-b" });
 		await waitFor(() => {
 			expect(result.current.organizationAdopted).toBe(true);
@@ -183,8 +176,7 @@ describe("useFileAttachments org scoping", () => {
 			persistedAttachmentsStorageKey,
 			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
 		);
-		// Suspending after the hook call abandons the render before
-		// commit, the same discard concurrent rendering can perform.
+		// Suspending after the hook runs simulates a render React abandons before commit.
 		const Suspender: FC<{ orgId: string }> = ({ orgId }) => {
 			useFileAttachments(orgId, { persist: true });
 			throw new Promise(() => {});

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -171,6 +171,32 @@ describe("useFileAttachments org scoping", () => {
 		).not.toContain("file-x");
 	});
 
+	it("hides attachments when authorization leaves no org", async () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
+		);
+		const { result, rerender } = renderAttachments({ orgId: "org-a" });
+		await waitFor(() => {
+			expect(uploadedFileIds(result.current)).toStrictEqual(["file-a"]);
+		});
+
+		// Losing the org entirely (empty permitted set) must hide the
+		// previous org's attachments so they cannot be removed, while
+		// keeping them persisted for when the org returns.
+		rerender({ orgId: undefined });
+		expect(result.current.attachments).toStrictEqual([]);
+		expect(uploadedFileIds(result.current)).toStrictEqual([]);
+		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toContain(
+			"file-a",
+		);
+
+		rerender({ orgId: "org-a" });
+		await waitFor(() => {
+			expect(uploadedFileIds(result.current)).toStrictEqual(["file-a"]);
+		});
+	});
+
 	it("does not prune storage during a render that never commits", () => {
 		localStorage.setItem(
 			persistedAttachmentsStorageKey,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -143,6 +143,38 @@ describe("useFileAttachments org scoping", () => {
 		).not.toContain("file-x");
 	});
 
+	it("discards an upload that spans an org round trip", async () => {
+		let resolveUpload!: (value: { id: string }) => void;
+		vi.spyOn(API.experimental, "uploadChatFile").mockReturnValue(
+			new Promise<{ id: string }>((resolve) => {
+				resolveUpload = resolve;
+			}),
+		);
+		const { result, rerender } = renderAttachments({ orgId: "org-a" });
+		act(() => {
+			result.current.startUpload(new File(["x"], "x.txt"));
+		});
+
+		// A -> B -> A: stateOrgId matches the upload's org again, so only
+		// the adoption epoch can tell the completion is stale.
+		rerender({ orgId: "org-b" });
+		await waitFor(() => {
+			expect(result.current.organizationAdopted).toBe(true);
+		});
+		rerender({ orgId: "org-a" });
+		await waitFor(() => {
+			expect(result.current.organizationAdopted).toBe(true);
+		});
+		await act(async () => {
+			resolveUpload({ id: "file-x" });
+		});
+
+		expect(uploadedFileIds(result.current)).toStrictEqual([]);
+		expect(
+			localStorage.getItem(persistedAttachmentsStorageKey) ?? "",
+		).not.toContain("file-x");
+	});
+
 	it("does not prune storage during a render that never commits", () => {
 		localStorage.setItem(
 			persistedAttachmentsStorageKey,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -1,6 +1,7 @@
-import { render, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { type FC, Suspense } from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "#/api/api";
 import {
 	persistedAttachmentsStorageKey,
 	useFileAttachments,
@@ -114,6 +115,32 @@ describe("useFileAttachments org scoping", () => {
 		// persisted file is only restored (and sendable) afterwards.
 		expect(log[0]).toStrictEqual({ adopted: false, fileIds: [] });
 		expect(log.at(-1)).toStrictEqual({ adopted: true, fileIds: ["file-a"] });
+	});
+
+	it("discards an upload that completes after another org was adopted", async () => {
+		let resolveUpload!: (value: { id: string }) => void;
+		vi.spyOn(API.experimental, "uploadChatFile").mockReturnValue(
+			new Promise<{ id: string }>((resolve) => {
+				resolveUpload = resolve;
+			}),
+		);
+		const { result, rerender } = renderAttachments({ orgId: "org-a" });
+		act(() => {
+			result.current.startUpload(new File(["x"], "x.txt"));
+		});
+
+		rerender({ orgId: "org-b" });
+		await waitFor(() => {
+			expect(result.current.organizationAdopted).toBe(true);
+		});
+		await act(async () => {
+			resolveUpload({ id: "file-x" });
+		});
+
+		expect(uploadedFileIds(result.current)).toStrictEqual([]);
+		expect(
+			localStorage.getItem(persistedAttachmentsStorageKey) ?? "",
+		).not.toContain("file-x");
 	});
 
 	it("does not prune storage during a render that never commits", () => {

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -21,6 +21,13 @@ const uploadedFileIds = (
 		state.status === "uploaded" && state.fileId ? [state.fileId] : [],
 	);
 
+const renderAttachments = (initialProps: { orgId: string | undefined }) =>
+	renderHook(
+		({ orgId }: { orgId: string | undefined }) =>
+			useFileAttachments(orgId, { persist: true }),
+		{ initialProps },
+	);
+
 describe("useFileAttachments org scoping", () => {
 	beforeEach(() => {
 		localStorage.clear();
@@ -31,11 +38,7 @@ describe("useFileAttachments org scoping", () => {
 			persistedAttachmentsStorageKey,
 			JSON.stringify([persistEntry("file-b", "b.txt", "org-b")]),
 		);
-		const { result, rerender } = renderHook(
-			({ orgId }: { orgId: string | undefined }) =>
-				useFileAttachments(orgId, { persist: true }),
-			{ initialProps: { orgId: undefined as string | undefined } },
-		);
+		const { result, rerender } = renderAttachments({ orgId: undefined });
 
 		expect(result.current.attachments).toHaveLength(0);
 		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toContain(
@@ -51,11 +54,7 @@ describe("useFileAttachments org scoping", () => {
 			persistedAttachmentsStorageKey,
 			JSON.stringify([persistEntry("file-a", "a.txt", "org-a")]),
 		);
-		const { result, rerender } = renderHook(
-			({ orgId }: { orgId: string | undefined }) =>
-				useFileAttachments(orgId, { persist: true }),
-			{ initialProps: { orgId: "org-a" as string | undefined } },
-		);
+		const { result, rerender } = renderAttachments({ orgId: "org-a" });
 		expect(uploadedFileIds(result.current)).toStrictEqual(["file-a"]);
 		rerender({ orgId: "org-b" });
 		await waitFor(() => {

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -223,6 +223,23 @@ export function useFileAttachments(
 		return () => revokePreviewUrls();
 	}, []);
 
+	// Upload completions capture the org they started under. By the time
+	// they resolve, adoption may have replaced state with another org's;
+	// applying then would leak an entry into the new org's map and
+	// persist the file ID under the abandoned org, where a later
+	// adoption flip could resurrect it.
+	const commitUploadOutcome = useEffectEvent(
+		(file: File, uploadOrgId: string, state: UploadState) => {
+			if (persist && stateOrgId !== uploadOrgId) {
+				return;
+			}
+			setUploadStates((prev) => new Map(prev).set(file, state));
+			if (persist && state.status === "uploaded" && state.fileId) {
+				addPersistedAttachment(file, state.fileId, uploadOrgId);
+			}
+		},
+	);
+
 	const startUpload = (file: File) => {
 		if (!organizationId) {
 			setUploadStates((prev) =>
@@ -234,25 +251,17 @@ export function useFileAttachments(
 			return;
 		}
 
-		const shouldPersist = persist && Boolean(organizationId);
+		const uploadOrgId = organizationId;
 		const isImage = file.type.startsWith("image/");
 
 		setUploadStates((prev) => new Map(prev).set(file, { status: "uploading" }));
 		void (async () => {
 			try {
-				const result = await API.experimental.uploadChatFile(
-					file,
-					organizationId,
-				);
-				setUploadStates((prev) =>
-					new Map(prev).set(file, {
-						status: "uploaded",
-						fileId: result.id,
-					}),
-				);
-				if (shouldPersist) {
-					addPersistedAttachment(file, result.id, organizationId!);
-				}
+				const result = await API.experimental.uploadChatFile(file, uploadOrgId);
+				commitUploadOutcome(file, uploadOrgId, {
+					status: "uploaded",
+					fileId: result.id,
+				});
 				if (isImage) {
 					// Pre-warm the HTTP cache so the timeline can
 					// render the image instantly after send. Text
@@ -260,13 +269,10 @@ export function useFileAttachments(
 					void fetch(getChatFileURL(result.id));
 				}
 			} catch (err: unknown) {
-				const errorMessage = formatAgentAttachmentUploadError(err);
-				setUploadStates((prev) =>
-					new Map(prev).set(file, {
-						status: "error",
-						error: errorMessage,
-					}),
-				);
+				commitUploadOutcome(file, uploadOrgId, {
+					status: "error",
+					error: formatAgentAttachmentUploadError(err),
+				});
 			}
 		})();
 	};

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -539,15 +539,13 @@ export function useFileAttachments(
 		}
 	};
 
-	// Between a permission-driven org change committing and the
-	// adoption effect running, state still belongs to the previous
-	// org. Expose it as empty so a send in that window cannot pair
-	// the old org's file IDs with the new org.
+	// Whenever adopted state does not belong to the current org, expose it
+	// as empty: between an org change committing and the adoption effect
+	// running, a send could pair the old org's file IDs with the new org,
+	// and when authorization leaves no org at all, remove buttons could
+	// still delete the previous org's persisted attachments.
 	const orgMismatch =
-		persist &&
-		stateOrgId !== null &&
-		Boolean(organizationId) &&
-		stateOrgId !== organizationId;
+		persist && stateOrgId !== null && stateOrgId !== organizationId;
 
 	return {
 		organizationAdopted:

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -53,8 +53,7 @@ function restorePersistedAttachments(currentOrgId: string): {
 	previewUrls: Map<File, string>;
 } {
 	// Skip when org ID isn't loaded yet so we don't prune valid
-	// entries. The initializer runs once, so callers must wait for
-	// the org ID before mounting.
+	// entries; restoration is deferred until the org is known.
 	if (!currentOrgId) {
 		return {
 			attachments: [],
@@ -192,19 +191,23 @@ export function useFileAttachments(
 		providerRef.current = provider;
 	}, [provider]);
 
-	const [restored] = useState(() =>
-		persist
-			? restorePersistedAttachments(organizationId ?? "")
-			: {
-					attachments: [] as File[],
-					uploadStates: new Map<File, UploadState>(),
-					previewUrls: new Map<File, string>(),
-				},
+	const [attachments, setAttachments] = useState<File[]>([]);
+	const [uploadStates, setUploadStates] = useState(
+		() => new Map<File, UploadState>(),
 	);
-
-	const [attachments, setAttachments] = useState<File[]>(restored.attachments);
-	const [uploadStates, setUploadStates] = useState(restored.uploadStates);
-	const [previewUrls, setPreviewUrls] = useState(restored.previewUrls);
+	const [previewUrls, setPreviewUrls] = useState(() => new Map<File, string>());
+	// Restore lazily on the first render with a known org rather than
+	// at mount: the caller's org can be provisional until permission
+	// checks resolve, and restoring with the wrong org prunes valid
+	// entries from storage.
+	const [hasRestored, setHasRestored] = useState(!persist);
+	if (!hasRestored && organizationId) {
+		setHasRestored(true);
+		const restored = restorePersistedAttachments(organizationId);
+		setAttachments(restored.attachments);
+		setUploadStates(restored.uploadStates);
+		setPreviewUrls(restored.previewUrls);
+	}
 	const [textContents, setTextContents] = useState(
 		() => new Map<File, string>(),
 	);

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -199,10 +199,13 @@ export function useFileAttachments(
 	// Restore lazily on the first render with a known org rather than
 	// at mount: the caller's org can be provisional until permission
 	// checks resolve, and restoring with the wrong org prunes valid
-	// entries from storage.
-	const [hasRestored, setHasRestored] = useState(!persist);
-	if (!hasRestored && organizationId) {
-		setHasRestored(true);
+	// entries from storage. stateOrgId records which org the current
+	// attachment state belongs to.
+	const [stateOrgId, setStateOrgId] = useState<string | null>(
+		persist ? null : "",
+	);
+	if (persist && stateOrgId === null && organizationId) {
+		setStateOrgId(organizationId);
 		const restored = restorePersistedAttachments(organizationId);
 		setAttachments(restored.attachments);
 		setUploadStates(restored.uploadStates);
@@ -275,6 +278,33 @@ export function useFileAttachments(
 	// checks this before swapping in a replacement so a dismissed
 	// file can't be resurrected. WeakSet lets entries get GC'd.
 	const abandonedResizesRef = useRef<WeakSet<File>>(new WeakSet());
+
+	// A permission refetch can change the caller's org without any user
+	// action. Attachments belong to the org they were uploaded to, so
+	// drop them (revoking blob previews) and restore the new org's
+	// persisted entries instead of sending stale file IDs cross-org.
+	const adoptOrganization = useEffectEvent((orgId: string) => {
+		for (const file of attachments) {
+			abandonedResizesRef.current.add(file);
+		}
+		revokePreviewUrls();
+		setTextContents(new Map());
+		setStateOrgId(orgId);
+		const restored = restorePersistedAttachments(orgId);
+		setAttachments(restored.attachments);
+		setUploadStates(restored.uploadStates);
+		setPreviewUrls(restored.previewUrls);
+	});
+	useEffect(() => {
+		if (
+			persist &&
+			stateOrgId &&
+			organizationId &&
+			stateOrgId !== organizationId
+		) {
+			adoptOrganization(organizationId);
+		}
+	}, [persist, stateOrgId, organizationId]);
 
 	type AttachItem = { file: File; needsResize: boolean };
 

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -195,19 +195,12 @@ export function useFileAttachments(
 		() => new Map<File, UploadState>(),
 	);
 	const [previewUrls, setPreviewUrls] = useState(() => new Map<File, string>());
-	// Delay restoration until an org is supplied. A provisional org would
-	// prune entries for the eventual org; stateOrgId tracks which org owns
-	// the in-memory attachment state.
+	// stateOrgId tracks which org owns the in-memory attachment state.
+	// It stays null until an org is supplied because restoring against
+	// a provisional org would prune entries for the eventual org.
 	const [stateOrgId, setStateOrgId] = useState<string | null>(
 		persist ? null : "",
 	);
-	if (persist && stateOrgId === null && organizationId) {
-		setStateOrgId(organizationId);
-		const restored = restorePersistedAttachments(organizationId);
-		setAttachments(restored.attachments);
-		setUploadStates(restored.uploadStates);
-		setPreviewUrls(restored.previewUrls);
-	}
 	const [textContents, setTextContents] = useState(
 		() => new Map<File, string>(),
 	);
@@ -278,7 +271,9 @@ export function useFileAttachments(
 
 	// Permission refetches can change the caller's org without user action.
 	// Replace org-scoped attachment state so stale file IDs cannot be sent
-	// to another org.
+	// to another org. Runs post-commit (never during render) because
+	// restorePersistedAttachments prunes other orgs' localStorage entries,
+	// which must not happen from a render React may abandon.
 	const adoptOrganization = useEffectEvent((orgId: string) => {
 		for (const file of attachments) {
 			abandonedResizesRef.current.add(file);
@@ -292,12 +287,7 @@ export function useFileAttachments(
 		setPreviewUrls(restored.previewUrls);
 	});
 	useEffect(() => {
-		if (
-			persist &&
-			stateOrgId &&
-			organizationId &&
-			stateOrgId !== organizationId
-		) {
+		if (persist && organizationId && stateOrgId !== organizationId) {
 			adoptOrganization(organizationId);
 		}
 	}, [persist, stateOrgId, organizationId]);

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -52,8 +52,7 @@ function restorePersistedAttachments(currentOrgId: string): {
 	uploadStates: Map<File, UploadState>;
 	previewUrls: Map<File, string>;
 } {
-	// Skip when org ID isn't loaded yet so we don't prune valid
-	// entries; restoration is deferred until the org is known.
+	// An unknown org must not prune entries persisted for the eventual org.
 	if (!currentOrgId) {
 		return {
 			attachments: [],
@@ -196,11 +195,9 @@ export function useFileAttachments(
 		() => new Map<File, UploadState>(),
 	);
 	const [previewUrls, setPreviewUrls] = useState(() => new Map<File, string>());
-	// Restore lazily on the first render with a known org rather than
-	// at mount: the caller's org can be provisional until permission
-	// checks resolve, and restoring with the wrong org prunes valid
-	// entries from storage. stateOrgId records which org the current
-	// attachment state belongs to.
+	// Delay restoration until an org is supplied. A provisional org would
+	// prune entries for the eventual org; stateOrgId tracks which org owns
+	// the in-memory attachment state.
 	const [stateOrgId, setStateOrgId] = useState<string | null>(
 		persist ? null : "",
 	);
@@ -279,10 +276,9 @@ export function useFileAttachments(
 	// file can't be resurrected. WeakSet lets entries get GC'd.
 	const abandonedResizesRef = useRef<WeakSet<File>>(new WeakSet());
 
-	// A permission refetch can change the caller's org without any user
-	// action. Attachments belong to the org they were uploaded to, so
-	// drop them (revoking blob previews) and restore the new org's
-	// persisted entries instead of sending stale file IDs cross-org.
+	// Permission refetches can change the caller's org without user action.
+	// Replace org-scoped attachment state so stale file IDs cannot be sent
+	// to another org.
 	const adoptOrganization = useEffectEvent((orgId: string) => {
 		for (const file of attachments) {
 			abandonedResizesRef.current.add(file);
@@ -541,11 +537,21 @@ export function useFileAttachments(
 		}
 	};
 
+	// Between a permission-driven org change committing and the
+	// adoption effect running, state still belongs to the previous
+	// org. Expose it as empty so a send in that window cannot pair
+	// the old org's file IDs with the new org.
+	const orgMismatch =
+		persist &&
+		stateOrgId !== null &&
+		Boolean(organizationId) &&
+		stateOrgId !== organizationId;
+
 	return {
-		attachments,
-		textContents,
-		uploadStates,
-		previewUrls,
+		attachments: orgMismatch ? [] : attachments,
+		textContents: orgMismatch ? new Map<File, string>() : textContents,
+		uploadStates: orgMismatch ? new Map<File, UploadState>() : uploadStates,
+		previewUrls: orgMismatch ? new Map<File, string>() : previewUrls,
 		handleAttach,
 		handleRemoveAttachment,
 		startUpload,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -162,6 +162,13 @@ function clearPersistedAttachments() {
 }
 
 interface UseFileAttachmentsReturn {
+	/**
+	 * True once the in-memory attachment state belongs to the supplied
+	 * organization. Adoption happens in a post-commit effect, so during
+	 * the commit that first supplies (or changes) the org this is false;
+	 * callers should keep attach and send controls disabled until then.
+	 */
+	organizationAdopted: boolean;
 	attachments: File[];
 	textContents: Map<File, string>;
 	uploadStates: Map<File, UploadState>;
@@ -538,6 +545,8 @@ export function useFileAttachments(
 		stateOrgId !== organizationId;
 
 	return {
+		organizationAdopted:
+			!persist || (Boolean(organizationId) && stateOrgId === organizationId),
 		attachments: orgMismatch ? [] : attachments,
 		textContents: orgMismatch ? new Map<File, string>() : textContents,
 		uploadStates: orgMismatch ? new Map<File, UploadState>() : uploadStates,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -223,14 +223,20 @@ export function useFileAttachments(
 		return () => revokePreviewUrls();
 	}, []);
 
-	// Upload completions capture the org they started under. By the time
-	// they resolve, adoption may have replaced state with another org's;
-	// applying then would leak an entry into the new org's map and
-	// persist the file ID under the abandoned org, where a later
-	// adoption flip could resurrect it.
+	// Bumped on every adoption. Upload completions capture the epoch they
+	// started under and are discarded after any adoption since, even an
+	// A-to-B-to-A round trip that restores the original stateOrgId;
+	// applying a stale completion would persist the file ID and let a
+	// later restoration resurrect an abandoned upload.
+	const adoptionEpochRef = useRef(0);
 	const commitUploadOutcome = useEffectEvent(
-		(file: File, uploadOrgId: string, state: UploadState) => {
-			if (persist && stateOrgId !== uploadOrgId) {
+		(
+			file: File,
+			uploadOrgId: string,
+			uploadEpoch: number,
+			state: UploadState,
+		) => {
+			if (persist && adoptionEpochRef.current !== uploadEpoch) {
 				return;
 			}
 			setUploadStates((prev) => new Map(prev).set(file, state));
@@ -252,13 +258,14 @@ export function useFileAttachments(
 		}
 
 		const uploadOrgId = organizationId;
+		const uploadEpoch = adoptionEpochRef.current;
 		const isImage = file.type.startsWith("image/");
 
 		setUploadStates((prev) => new Map(prev).set(file, { status: "uploading" }));
 		void (async () => {
 			try {
 				const result = await API.experimental.uploadChatFile(file, uploadOrgId);
-				commitUploadOutcome(file, uploadOrgId, {
+				commitUploadOutcome(file, uploadOrgId, uploadEpoch, {
 					status: "uploaded",
 					fileId: result.id,
 				});
@@ -269,7 +276,7 @@ export function useFileAttachments(
 					void fetch(getChatFileURL(result.id));
 				}
 			} catch (err: unknown) {
-				commitUploadOutcome(file, uploadOrgId, {
+				commitUploadOutcome(file, uploadOrgId, uploadEpoch, {
 					status: "error",
 					error: formatAgentAttachmentUploadError(err),
 				});
@@ -288,6 +295,7 @@ export function useFileAttachments(
 	// restorePersistedAttachments prunes other orgs' localStorage entries,
 	// which must not happen from a render React may abandon.
 	const adoptOrganization = useEffectEvent((orgId: string) => {
+		adoptionEpochRef.current += 1;
 		for (const file of attachments) {
 			abandonedResizesRef.current.add(file);
 		}

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -163,10 +163,8 @@ function clearPersistedAttachments() {
 
 interface UseFileAttachmentsReturn {
 	/**
-	 * True once the in-memory attachment state belongs to the supplied
-	 * organization. Adoption happens in a post-commit effect, so during
-	 * the commit that first supplies (or changes) the org this is false;
-	 * callers should keep attach and send controls disabled until then.
+	 * True after the post-commit effect assigns in-memory attachment state to
+	 * the supplied organization. Keep attach and send controls disabled until then.
 	 */
 	organizationAdopted: boolean;
 	attachments: File[];
@@ -202,12 +200,9 @@ export function useFileAttachments(
 		() => new Map<File, UploadState>(),
 	);
 	const [previewUrls, setPreviewUrls] = useState(() => new Map<File, string>());
-	// stateOrgId tracks which org owns the in-memory attachment state.
-	// It stays null until an org is supplied because restoring against
-	// a provisional org would prune entries for the eventual org.
-	const [stateOrgId, setStateOrgId] = useState<string | null>(
-		persist ? null : "",
-	);
+	// Persisted state remains unowned until post-commit org adoption; restoring
+	// against a provisional org would prune entries for the eventual org.
+	const [stateOrgId, setStateOrgId] = useState<string | null>(null);
 	const [textContents, setTextContents] = useState(
 		() => new Map<File, string>(),
 	);
@@ -223,11 +218,9 @@ export function useFileAttachments(
 		return () => revokePreviewUrls();
 	}, []);
 
-	// Bumped on every adoption. Upload completions capture the epoch they
-	// started under and are discarded after any adoption since, even an
-	// A-to-B-to-A round trip that restores the original stateOrgId;
-	// applying a stale completion would persist the file ID and let a
-	// later restoration resurrect an abandoned upload.
+	// Every adoption invalidates older upload completions, including A-to-B-to-A
+	// round trips where stateOrgId matches again. Otherwise a stale completion
+	// could persist and later restore an abandoned upload.
 	const adoptionEpochRef = useRef(0);
 	const commitUploadOutcome = useEffectEvent(
 		(
@@ -289,11 +282,9 @@ export function useFileAttachments(
 	// file can't be resurrected. WeakSet lets entries get GC'd.
 	const abandonedResizesRef = useRef<WeakSet<File>>(new WeakSet());
 
-	// Permission refetches can change the caller's org without user action.
-	// Replace org-scoped attachment state so stale file IDs cannot be sent
-	// to another org. Runs post-commit (never during render) because
-	// restorePersistedAttachments prunes other orgs' localStorage entries,
-	// which must not happen from a render React may abandon.
+	// Permission refetches can change the org without user action. Replace state
+	// after commit so stale file IDs cannot cross orgs and an abandoned render
+	// cannot prune localStorage through restorePersistedAttachments.
 	const adoptOrganization = useEffectEvent((orgId: string) => {
 		adoptionEpochRef.current += 1;
 		for (const file of attachments) {

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -539,11 +539,8 @@ export function useFileAttachments(
 		}
 	};
 
-	// Whenever adopted state does not belong to the current org, expose it
-	// as empty: between an org change committing and the adoption effect
-	// running, a send could pair the old org's file IDs with the new org,
-	// and when authorization leaves no org at all, remove buttons could
-	// still delete the previous org's persisted attachments.
+	// Hide state that belongs to another organization. Exposing it could send
+	// stale file IDs or remove persisted attachments from the previous org.
 	const orgMismatch =
 		persist && stateOrgId !== null && stateOrgId !== organizationId;
 


### PR DESCRIPTION
Fixes first-send 403s for multi-org users who lack `chat:create` in the deployment default organization (CODAGT-892). Two frontend defects combined to send chat creation to the wrong organization:

1. The Agents create form initialized its organization selection permission-blind to the default org and only corrected it when the `permittedOrganizations` authcheck result *transitioned*, so a fast first send raced the check, and on warm-query-cache remounts the correction never ran at all: the wrong org stayed selected permanently while the org picker was hidden.
2. The permitted-organizations authcheck itself sent no `owner_id`, so roles that grant `chat:create` at member (owner) scope, such as `agents-access` (Coder Agents User, the exact role in the customer report), were denied in every organization and the form always fell back to the default org. This part was split out and already landed on main via #28076; after rebasing, this PR relies on that fix and keeps its stricter regression stories around it.

## Changes

- Derive the effective organization at render time: keep the user's explicit pick only while it is still permitted, otherwise fall back to the permitted default org, then the first permitted org, then the dashboard default. Replaces the transition-based reconciliation, which could not fire when the query cache was already warm on mount.
- Keep user-driven org cleanup (workspace selection, attachments) in the picker/dialog event handlers; permission-driven changes are handled by render-time state adjustments and the attachment hook's post-commit adoption effect.
- Disable Send until the permitted-organizations check settles and the attachment hook has adopted the effective org; hide the org picker and disable the workspace picker until the check settles (their pre-settlement options come from the unfiltered dashboard fallback, so a pick could persist a foreign-org workspace).
- Scope persisted attachments to their organization in `useFileAttachments`: restoration defers until a permitted org is known, permission-driven org changes replace attachment state post-commit, in-flight uploads are invalidated by an adoption epoch (including A-to-B-to-A round trips), and no render exposes another org's file IDs, including when authorization resolves to no org at all.
- Revalidate org-scoped state on permission refetches: a revoked explicit selection clears instead of lying latent, a settled effective-org change drops the stored workspace, and the org-change confirmation dialog closes (and re-checks on confirm) when its pending org is revoked.
- Rebase reconciliation with #28076: the stories use its `permittedOrganizationsKey` helper and retain its `MemberScopedPermissionsShowOrgPicker` regression story alongside this PR's stricter member-scope stories.

The backend RBAC rejection was correct; this is frontend-only.

## Testing

- Red-green: every guard above was verified by reverting it and confirming exactly its guarding story or unit test fails (whole-file runs).
- `pnpm -C site check`, `pnpm -C site lint`, `pnpm -C site lint:types`, full `AgentCreateForm.stories.tsx` (42 pass), `useFileAttachments.test.tsx` (8 pass), re-run after the rebase onto main.
- Dogfood UAT on a licensed multi-org dev deployment at this branch: a restricted user with `agents-access` only in a non-default org sends first and warm-remount messages successfully (201, payload carries the permitted org, no 403); admin picker, workspace filtering, and attachment org-change dialog verified. Round 2 of UAT caught the missing `owner_id` (now landed via #28076); round 3 re-verified end to end.

> Mux created this PR on Mike's behalf.
