### PR TITLE
fix(site/src/pages/TemplateBuilder): validate customizations form before submit

### DIFF
--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -17,7 +17,11 @@ import type {
 	SelectedBaseMeta,
 	TemplateBuilderWizardState,
 } from "./wizardState";
-import { toCreateTemplateRequest, toSelectedBaseMeta } from "./wizardState";
+import {
+	type CustomizationsFormValues,
+	toCreateTemplateRequest,
+	toSelectedBaseMeta,
+} from "./wizardState";
 
 const TemplateBuilderPage: FC = () => {
 	const navigate = useNavigate();
@@ -109,8 +113,11 @@ const TemplateBuilderPage: FC = () => {
 		return <Navigate to="/templates/new" replace />;
 	}
 
-	const handleCreate = (state: TemplateBuilderWizardState) => {
-		const req = toCreateTemplateRequest(state);
+	const handleCreate = (
+		state: TemplateBuilderWizardState,
+		customizations: CustomizationsFormValues,
+	) => {
+		const req = toCreateTemplateRequest(state, customizations);
 		const durationSeconds = (Date.now() - state.enteredAt) / 1000;
 
 		createMutation.mutate(req, {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -191,12 +191,9 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 		navigateToStep(nearestVisible(target, state));
 	};
 
-	const handleCreate = useCallback(
-		(values: CustomizationsFormValues) => {
-			onCreateTemplate(state, values);
-		},
-		[onCreateTemplate, state],
-	);
+	const handleCreate = (values: CustomizationsFormValues) => {
+		onCreateTemplate(state, values);
+	};
 
 	const handleProvisionerStatusChange = useCallback(
 		(value: boolean | undefined) => {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -47,8 +47,12 @@ import {
 	WIZARD_STEPS,
 } from "./steps";
 import { TemplateAlternatives } from "./TemplateAlternatives";
-import { TemplateCustomizationsStep } from "./TemplateCustomizationsStep";
 import {
+	TEMPLATE_CUSTOMIZATIONS_FORM_ID,
+	TemplateCustomizationsStep,
+} from "./TemplateCustomizationsStep";
+import {
+	type CustomizationsFormValues,
 	initWizardState,
 	type SelectedBaseMeta,
 	type TemplateBuilderWizardState,
@@ -60,7 +64,10 @@ interface TemplateBuilderPageViewProps {
 	error: unknown;
 	basesData: TemplateBuilderBasesResponse | undefined;
 	preselectedBase?: SelectedBaseMeta;
-	onCreateTemplate: (state: TemplateBuilderWizardState) => void;
+	onCreateTemplate: (
+		state: TemplateBuilderWizardState,
+		customizations: CustomizationsFormValues,
+	) => void;
 	createError: Error | null;
 	isCreating: boolean;
 	onClearCreateError?: () => void;
@@ -165,10 +172,6 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	};
 
 	const handleNext = () => {
-		if (isLastStep) {
-			onCreateTemplate(state);
-			return;
-		}
 		navigateToStep(nextIndex);
 	};
 
@@ -187,6 +190,13 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 		}
 		navigateToStep(nearestVisible(target, state));
 	};
+
+	const handleCreate = useCallback(
+		(values: CustomizationsFormValues) => {
+			onCreateTemplate(state, values);
+		},
+		[onCreateTemplate, state],
+	);
 
 	const handleProvisionerStatusChange = useCallback(
 		(value: boolean | undefined) => {
@@ -305,6 +315,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 							handleProvisionerStatusChange,
 							handleDeselectModule,
 							registerModuleRef,
+							handleCreate,
 						)}
 					</div>
 
@@ -317,9 +328,19 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 								Back
 							</Button>
 						)}
-						<Button onClick={handleNext} disabled={!canContinue}>
-							{isLastStep ? "Create Template" : "Continue"}
-						</Button>
+						{isLastStep ? (
+							<Button
+								type="submit"
+								form={TEMPLATE_CUSTOMIZATIONS_FORM_ID}
+								disabled={state.hasProvisioners === false}
+							>
+								Create Template
+							</Button>
+						) : (
+							<Button onClick={handleNext} disabled={!canContinue}>
+								Continue
+							</Button>
+						)}
 					</div>
 
 					{currentStep.id === "base-infra" && <TemplateAlternatives />}
@@ -361,6 +382,7 @@ function renderStepContent(
 	onProvisionerStatusChange: (value: boolean | undefined) => void,
 	onRemoveModule: (moduleId: string) => void,
 	registerModuleRef: (moduleId: string, node: HTMLDivElement | null) => void,
+	onCreate: (values: CustomizationsFormValues) => void,
 ): ReactNode {
 	switch (stepId) {
 		case "base-infra":
@@ -416,13 +438,7 @@ function renderStepContent(
 					{createError != null && <ErrorAlert error={createError} />}
 					<TemplateCustomizationsStep
 						state={state}
-						onChangeField={(field, value) =>
-							dispatch({
-								type: "SET_CUSTOMIZATION",
-								field,
-								value,
-							})
-						}
+						onCreate={onCreate}
 						onProvisionerStatusChange={onProvisionerStatusChange}
 					/>
 				</>
@@ -455,7 +471,7 @@ function computeCanContinue(
 				moduleVarMap,
 			);
 		case "customizations":
-			return state.name.trim() !== "" && state.hasProvisioners !== false;
+			return state.hasProvisioners !== false;
 		default:
 			return true;
 	}

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import {
+	getProvisionerDaemonsKey,
+	permittedOrganizations,
+} from "#/api/queries/organizations";
+import { Button } from "#/components/Button/Button";
+import {
+	MockDefaultOrganization,
+	MockOrganization,
+	MockOrganization2,
+	MockProvisioner,
+} from "#/testHelpers/entities";
+import {
+	TEMPLATE_CUSTOMIZATIONS_FORM_ID,
+	TemplateCustomizationsStep,
+} from "./TemplateCustomizationsStep";
+import {
+	initialWizardState,
+	type TemplateBuilderWizardState,
+} from "./wizardState";
+
+const baseState: TemplateBuilderWizardState = {
+	...initialWizardState,
+	baseTemplateId: "docker",
+	selectedBase: {
+		id: "docker",
+		name: "Docker Containers",
+		iconUrl: "/icon/docker.svg",
+		hasParameters: false,
+		hasPrerequisites: false,
+	},
+	name: "docker",
+	displayName: "Docker Containers",
+	description: "Run workspaces as Docker containers",
+	icon: "/icon/docker.svg",
+};
+
+const permittedOrgsKey = permittedOrganizations({
+	object: { resource_type: "template" },
+	action: "create",
+}).queryKey;
+
+const provisionersKey = (organizationId: string) =>
+	getProvisionerDaemonsKey(organizationId);
+
+const meta: Meta<typeof TemplateCustomizationsStep> = {
+	title: "pages/TemplateBuilder/TemplateCustomizationsStep",
+	component: TemplateCustomizationsStep,
+	args: {
+		state: baseState,
+		onCreate: fn(),
+		onProvisionerStatusChange: fn(),
+	},
+	parameters: {
+		queries: [
+			{ key: permittedOrgsKey, data: [MockOrganization, MockOrganization2] },
+		],
+	},
+	// The "Create Template" submit button lives in the wizard's shared nav bar,
+	// outside this component. It is associated with the form via the `form`
+	// attribute, so the stories render an equivalent button to exercise submit.
+	decorators: [
+		(Story) => (
+			<div className="flex flex-col gap-6">
+				<Story />
+				<Button type="submit" form={TEMPLATE_CUSTOMIZATIONS_FORM_ID}>
+					Create Template
+				</Button>
+			</div>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof TemplateCustomizationsStep>;
+
+export const MultipleOrganizations: Story = {};
+
+// Submitting without choosing an organization surfaces an aggregated error at
+// the top of the step instead of an inline field error, and does not call
+// onCreate.
+export const MissingOrganizationError: Story = {
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByTestId("organization-autocomplete");
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Create Template" }),
+		);
+		await canvas.findByText("Select an organization to continue.");
+		await expect(args.onCreate).not.toHaveBeenCalled();
+	},
+};
+
+// A single permitted organization is auto-selected, so a valid form submits and
+// forwards the selected organization id to onCreate.
+export const SingleOrganizationSubmits: Story = {
+	parameters: {
+		queries: [
+			{ key: permittedOrgsKey, data: [MockDefaultOrganization] },
+			{
+				key: provisionersKey(MockDefaultOrganization.id),
+				data: [MockProvisioner],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		// Wait for the auto-selected org to render in the autocomplete.
+		await canvas.findByText(MockDefaultOrganization.display_name);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Create Template" }),
+		);
+		await expect(args.onCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				organization_id: MockDefaultOrganization.id,
+				name: "docker",
+			}),
+		);
+	},
+};
+
+// A missing template ID surfaces the name validation message at the top of the
+// step and blocks submission.
+export const MissingNameError: Story = {
+	args: {
+		state: { ...baseState, name: "" },
+	},
+	parameters: {
+		queries: [
+			{ key: permittedOrgsKey, data: [MockDefaultOrganization] },
+			{
+				key: provisionersKey(MockDefaultOrganization.id),
+				data: [MockProvisioner],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText(MockDefaultOrganization.display_name);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Create Template" }),
+		);
+		await canvas.findByText("Please enter a template id.");
+		await expect(args.onCreate).not.toHaveBeenCalled();
+	},
+};

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
@@ -77,9 +77,8 @@ type Story = StoryObj<typeof TemplateCustomizationsStep>;
 
 export const MultipleOrganizations: Story = {};
 
-// Submitting without choosing an organization surfaces an aggregated error at
-// the top of the step instead of an inline field error, and does not call
-// onCreate.
+// Submitting without choosing an organization surfaces an inline error under
+// the organization field and does not call onCreate.
 export const MissingOrganizationError: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
@@ -120,8 +119,8 @@ export const SingleOrganizationSubmits: Story = {
 	},
 };
 
-// A missing template ID surfaces the name validation message at the top of the
-// step and blocks submission.
+// A missing template ID surfaces the name validation message inline under the
+// ID field and blocks submission.
 export const MissingNameError: Story = {
 	args: {
 		state: { ...baseState, name: "" },

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
@@ -41,9 +41,6 @@ const permittedOrgsKey = permittedOrganizations({
 	action: "create",
 }).queryKey;
 
-const provisionersKey = (organizationId: string) =>
-	getProvisionerDaemonsKey(organizationId);
-
 const meta: Meta<typeof TemplateCustomizationsStep> = {
 	title: "pages/TemplateBuilder/TemplateCustomizationsStep",
 	component: TemplateCustomizationsStep,
@@ -98,7 +95,7 @@ export const SingleOrganizationSubmits: Story = {
 		queries: [
 			{ key: permittedOrgsKey, data: [MockDefaultOrganization] },
 			{
-				key: provisionersKey(MockDefaultOrganization.id),
+				key: getProvisionerDaemonsKey(MockDefaultOrganization.id),
 				data: [MockProvisioner],
 			},
 		],
@@ -129,7 +126,7 @@ export const MissingNameError: Story = {
 		queries: [
 			{ key: permittedOrgsKey, data: [MockDefaultOrganization] },
 			{
-				key: provisionersKey(MockDefaultOrganization.id),
+				key: getProvisionerDaemonsKey(MockDefaultOrganization.id),
 				data: [MockProvisioner],
 			},
 		],

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -220,7 +220,7 @@ export const TemplateCustomizationsStep: FC<
 
 const ProvisionerWarning: FC = () => {
 	return (
-		<Alert severity="warning" prominent className="my-4">
+		<Alert severity="error" prominent className="my-4">
 			This organization does not have any provisioners. Before you create a
 			template, you&apos;ll need to configure a provisioner.{" "}
 			<Link href={docs("/admin/provisioners#organization-scoped-provisioners")}>

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -9,8 +9,8 @@ import {
 import type { Organization } from "#/api/typesGenerated";
 import { Alert } from "#/components/Alert/Alert";
 import { Avatar } from "#/components/Avatar/Avatar";
+import { FormField } from "#/components/FormField/FormField";
 import { IconField } from "#/components/IconField/IconField";
-import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Link } from "#/components/Link/Link";
 import { OrganizationAutocomplete } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
@@ -19,9 +19,11 @@ import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
+import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,
+	getFormHelpers,
 	iconValidator,
 	nameValidator,
 } from "#/utils/formUtils";
@@ -77,6 +79,10 @@ export const TemplateCustomizationsStep: FC<
 		validationSchema,
 		onSubmit: (values) => onCreate(values),
 	});
+	const getFieldHelpers = getFormHelpers(form);
+	const descriptionField = getFieldHelpers("description");
+	const iconField = getFieldHelpers("icon");
+	const organizationField = getFieldHelpers("organization_id");
 
 	// Display object for the autocomplete; the Formik field only stores the id.
 	const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
@@ -108,13 +114,6 @@ export const TemplateCustomizationsStep: FC<
 		void form.setFieldValue("organization_id", org?.id ?? "");
 	};
 
-	// Aggregate validation messages and show them at the top of the step so the
-	// horizontal two-column layout is not disturbed by inline field errors.
-	const errorMessages = Object.values(form.errors).filter(
-		(message): message is string => Boolean(message),
-	);
-	const showErrorSummary = form.submitCount > 0 && errorMessages.length > 0;
-
 	return (
 		<form
 			id={TEMPLATE_CUSTOMIZATIONS_FORM_ID}
@@ -127,20 +126,6 @@ export const TemplateCustomizationsStep: FC<
 				Add additional configurations.
 			</TemplateBuilderSubtitle>
 
-			{showErrorSummary && (
-				<Alert severity="error" className="my-4">
-					{errorMessages.length === 1 ? (
-						errorMessages[0]
-					) : (
-						<ul className="m-0 pl-4 list-disc">
-							{errorMessages.map((message) => (
-								<li key={message}>{message}</li>
-							))}
-						</ul>
-					)}
-				</Alert>
-			)}
-
 			{showProvisionerWarning && <ProvisionerWarning />}
 
 			<div className="flex gap-8">
@@ -150,15 +135,12 @@ export const TemplateCustomizationsStep: FC<
 				{/* Two-column form grid */}
 				<div className="grid grid-cols-2 gap-x-6 gap-y-6 content-start">
 					{/* Left column */}
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="template-display-name">Display name</Label>
-						<Input
-							{...form.getFieldProps("display_name")}
-							id="template-display-name"
-							placeholder="My Template"
-							aria-invalid={Boolean(form.errors.display_name)}
-						/>
-					</div>
+					<FormField
+						field={getFieldHelpers("display_name")}
+						label="Display name"
+						id="template-display-name"
+						placeholder="My Template"
+					/>
 
 					{/* Right column */}
 					{orgOptions.length > 0 && (
@@ -176,6 +158,11 @@ export const TemplateCustomizationsStep: FC<
 								onChange={handleOrgChange}
 								options={orgOptions}
 							/>
+							{organizationField.error && (
+								<span className="text-xs text-content-destructive">
+									{organizationField.helperText}
+								</span>
+							)}
 						</div>
 					)}
 
@@ -187,14 +174,24 @@ export const TemplateCustomizationsStep: FC<
 							id="template-description"
 							placeholder="Describe what this template is for"
 							rows={3}
-							aria-invalid={Boolean(form.errors.description)}
+							aria-invalid={descriptionField.error}
+							className={cn(
+								descriptionField.error && "border-border-destructive",
+							)}
 						/>
+						{descriptionField.error && (
+							<span className="text-xs text-content-destructive">
+								{descriptionField.helperText}
+							</span>
+						)}
 						<p className="text-xs text-content-secondary">
 							Used by both humans and Agents to identify templates.
 						</p>
 
 						<IconField
 							value={form.values.icon}
+							error={iconField.error}
+							helperText={iconField.helperText}
 							onChange={(e) => {
 								const target = e.target as HTMLInputElement;
 								void form.setFieldValue("icon", target.value);
@@ -206,24 +203,15 @@ export const TemplateCustomizationsStep: FC<
 					</div>
 
 					{/* Right column */}
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="template-name">
-							ID
-							<span className="text-xs font-bold text-content-destructive ml-1">
-								*
-							</span>
-						</Label>
-						<Input
-							{...form.getFieldProps("name")}
-							id="template-name"
-							placeholder="my-template"
-							aria-required
-							aria-invalid={Boolean(form.errors.name)}
-						/>
-						<p className="text-xs text-content-secondary">
-							Used to identify the template in URLs and the API.
-						</p>
-					</div>
+					<FormField
+						field={getFieldHelpers("name", {
+							helperText: "Used to identify the template in URLs and the API.",
+						})}
+						label="ID"
+						required
+						id="template-name"
+						placeholder="my-template"
+					/>
 				</div>
 			</div>
 		</form>

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -101,13 +101,12 @@ export const TemplateCustomizationsStep: FC<
 	}, [hasProvisioners, onProvisionerStatusChange]);
 
 	// Auto-select when exactly one org is available.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: form.setFieldValue is stable
 	useEffect(() => {
 		if (orgOptions.length === 1 && !selectedOrg) {
 			setSelectedOrg(orgOptions[0]);
 			void form.setFieldValue("organization_id", orgOptions[0].id);
 		}
-	}, [orgOptions, selectedOrg]);
+	}, [orgOptions, selectedOrg, form]);
 
 	const handleOrgChange = (org: Organization | null) => {
 		setSelectedOrg(org);

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -1,5 +1,7 @@
+import { useFormik } from "formik";
 import { type FC, useEffect, useState } from "react";
 import { useQuery } from "react-query";
+import * as Yup from "yup";
 import {
 	permittedOrganizations,
 	provisionerDaemons,
@@ -18,23 +20,44 @@ import {
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
 import { docs } from "#/utils/docs";
+import {
+	displayNameValidator,
+	iconValidator,
+	nameValidator,
+} from "#/utils/formUtils";
 import type {
+	CustomizationsFormValues,
 	SelectedBaseMeta,
 	TemplateBuilderWizardState,
 } from "./wizardState";
 
+export const TEMPLATE_CUSTOMIZATIONS_FORM_ID = "template-customizations-form";
+
+const MAX_DESCRIPTION_CHAR_LIMIT = 128;
+
+const validationSchema = Yup.object({
+	name: nameValidator("Template ID"),
+	display_name: displayNameValidator("Display name"),
+	description: Yup.string().max(
+		MAX_DESCRIPTION_CHAR_LIMIT,
+		"Please enter a description that is less than or equal to 128 characters.",
+	),
+	icon: iconValidator,
+	// An organization is always required: the page is gated on the create-
+	// template permission, so there is always at least one permitted org, and
+	// it is auto-selected when only one is available.
+	organization_id: Yup.string().required("Select an organization to continue."),
+});
+
 interface TemplateCustomizationsStepProps {
 	state: TemplateBuilderWizardState;
-	onChangeField: (
-		field: "organizationId" | "name" | "displayName" | "description" | "icon",
-		value: string,
-	) => void;
+	onCreate: (values: CustomizationsFormValues) => void;
 	onProvisionerStatusChange: (hasProvisioners: boolean | undefined) => void;
 }
 
 export const TemplateCustomizationsStep: FC<
 	TemplateCustomizationsStepProps
-> = ({ state, onChangeField, onProvisionerStatusChange }) => {
+> = ({ state, onCreate, onProvisionerStatusChange }) => {
 	const permittedOrgsQuery = useQuery(
 		permittedOrganizations({
 			object: { resource_type: "template" },
@@ -43,6 +66,19 @@ export const TemplateCustomizationsStep: FC<
 	);
 	const orgOptions = permittedOrgsQuery.data ?? [];
 
+	const form = useFormik<CustomizationsFormValues>({
+		initialValues: {
+			organization_id: "",
+			name: state.name,
+			display_name: state.displayName,
+			description: state.description,
+			icon: state.icon,
+		},
+		validationSchema,
+		onSubmit: (values) => onCreate(values),
+	});
+
+	// Display object for the autocomplete; the Formik field only stores the id.
 	const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
 
 	const { data: provisioners } = useQuery({
@@ -59,24 +95,51 @@ export const TemplateCustomizationsStep: FC<
 	}, [hasProvisioners, onProvisionerStatusChange]);
 
 	// Auto-select when exactly one org is available.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: form.setFieldValue is stable
 	useEffect(() => {
 		if (orgOptions.length === 1 && !selectedOrg) {
 			setSelectedOrg(orgOptions[0]);
-			onChangeField("organizationId", orgOptions[0].id);
+			void form.setFieldValue("organization_id", orgOptions[0].id);
 		}
-	}, [orgOptions, selectedOrg, onChangeField]);
+	}, [orgOptions, selectedOrg]);
 
 	const handleOrgChange = (org: Organization | null) => {
 		setSelectedOrg(org);
-		onChangeField("organizationId", org?.id ?? "");
+		void form.setFieldValue("organization_id", org?.id ?? "");
 	};
 
+	// Aggregate validation messages and show them at the top of the step so the
+	// horizontal two-column layout is not disturbed by inline field errors.
+	const errorMessages = Object.values(form.errors).filter(
+		(message): message is string => Boolean(message),
+	);
+	const showErrorSummary = form.submitCount > 0 && errorMessages.length > 0;
+
 	return (
-		<div className="min-w-[654px]">
+		<form
+			id={TEMPLATE_CUSTOMIZATIONS_FORM_ID}
+			onSubmit={form.handleSubmit}
+			noValidate
+			className="min-w-[654px]"
+		>
 			<TemplateBuilderTitle>Customizations</TemplateBuilderTitle>
 			<TemplateBuilderSubtitle>
 				Add additional configurations.
 			</TemplateBuilderSubtitle>
+
+			{showErrorSummary && (
+				<Alert severity="error" className="my-4">
+					{errorMessages.length === 1 ? (
+						errorMessages[0]
+					) : (
+						<ul className="m-0 pl-4 list-disc">
+							{errorMessages.map((message) => (
+								<li key={message}>{message}</li>
+							))}
+						</ul>
+					)}
+				</Alert>
+			)}
 
 			{showProvisionerWarning && <ProvisionerWarning />}
 
@@ -90,10 +153,10 @@ export const TemplateCustomizationsStep: FC<
 					<div className="flex flex-col gap-2">
 						<Label htmlFor="template-display-name">Display name</Label>
 						<Input
+							{...form.getFieldProps("display_name")}
 							id="template-display-name"
-							value={state.displayName}
-							onChange={(e) => onChangeField("displayName", e.target.value)}
 							placeholder="My Template"
+							aria-invalid={Boolean(form.errors.display_name)}
 						/>
 					</div>
 
@@ -120,23 +183,25 @@ export const TemplateCustomizationsStep: FC<
 					<div className="flex flex-col gap-2">
 						<Label htmlFor="template-description">Description</Label>
 						<Textarea
+							{...form.getFieldProps("description")}
 							id="template-description"
-							value={state.description}
-							onChange={(e) => onChangeField("description", e.target.value)}
 							placeholder="Describe what this template is for"
 							rows={3}
+							aria-invalid={Boolean(form.errors.description)}
 						/>
 						<p className="text-xs text-content-secondary">
 							Used by both humans and Agents to identify templates.
 						</p>
 
 						<IconField
-							value={state.icon}
+							value={form.values.icon}
 							onChange={(e) => {
 								const target = e.target as HTMLInputElement;
-								onChangeField("icon", target.value);
+								void form.setFieldValue("icon", target.value);
 							}}
-							onPickEmoji={(value) => onChangeField("icon", value)}
+							onPickEmoji={(value) => {
+								void form.setFieldValue("icon", value);
+							}}
 						/>
 					</div>
 
@@ -149,11 +214,11 @@ export const TemplateCustomizationsStep: FC<
 							</span>
 						</Label>
 						<Input
+							{...form.getFieldProps("name")}
 							id="template-name"
-							value={state.name}
-							onChange={(e) => onChangeField("name", e.target.value)}
 							placeholder="my-template"
 							aria-required
+							aria-invalid={Boolean(form.errors.name)}
 						/>
 						<p className="text-xs text-content-secondary">
 							Used to identify the template in URLs and the API.
@@ -161,7 +226,7 @@ export const TemplateCustomizationsStep: FC<
 					</div>
 				</div>
 			</div>
-		</div>
+		</form>
 	);
 };
 

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -347,20 +347,14 @@ describe("wizardReducer", () => {
 					field: "description",
 					value: "A test template",
 				},
-				{
-					type: "SET_CUSTOMIZATION",
-					field: "organizationId",
-					value: "org-123",
-				},
 			]);
 			expect(state.displayName).toBe("My Template");
 			expect(state.description).toBe("A test template");
-			expect(state.organizationId).toBe("org-123");
 		});
 	});
 
 	describe("RESET_CUSTOMIZATIONS", () => {
-		it("clears org and provisioner state but keeps base-derived fields", () => {
+		it("clears provisioner state but keeps base-derived fields", () => {
 			const state = reduce([
 				{
 					type: "SET_BASE",
@@ -373,15 +367,9 @@ describe("wizardReducer", () => {
 						hasPrerequisites: false,
 					},
 				},
-				{
-					type: "SET_CUSTOMIZATION",
-					field: "organizationId",
-					value: "org-123",
-				},
 				{ type: "SET_HAS_PROVISIONERS", value: true },
 				{ type: "RESET_CUSTOMIZATIONS" },
 			]);
-			expect(state.organizationId).toBeUndefined();
 			expect(state.hasProvisioners).toBeUndefined();
 			// Base-derived fields survive so re-entering the step stays filled.
 			expect(state.name).toBe("docker");
@@ -524,14 +512,19 @@ describe("toCreateTemplateRequest", () => {
 		const state: TemplateBuilderWizardState = {
 			...initialWizardState,
 			baseTemplateId: "docker",
-			organizationId: "org-123",
 			name: "my-template",
 			displayName: "My Template",
 			description: "A test template",
 			icon: "/icon/docker.svg",
 			modules: [{ id: "code-server" }],
 		};
-		const request = toCreateTemplateRequest(state);
+		const request = toCreateTemplateRequest(state, {
+			organization_id: "org-123",
+			name: "my-template",
+			display_name: "My Template",
+			description: "A test template",
+			icon: "/icon/docker.svg",
+		});
 		expect(request.base_template_id).toBe("docker");
 		expect(request.organization_id).toBe("org-123");
 		expect(request.name).toBe("my-template");
@@ -547,7 +540,13 @@ describe("toCreateTemplateRequest", () => {
 			baseTemplateId: "docker",
 			name: "my-template",
 		};
-		const request = toCreateTemplateRequest(state);
+		const request = toCreateTemplateRequest(state, {
+			organization_id: "",
+			name: "my-template",
+			display_name: "",
+			description: "",
+			icon: "",
+		});
 		expect(request.display_name).toBeUndefined();
 		expect(request.description).toBeUndefined();
 		expect(request.icon).toBeUndefined();

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -71,7 +71,6 @@ export type TemplateBuilderWizardState = {
 	baseTemplateId: string | null;
 	baseVariableValues: Record<string, string>;
 	modules: TemplateBuilderComposeModule[];
-	organizationId?: string;
 	hasProvisioners: boolean | undefined;
 	name: string;
 	displayName: string;
@@ -144,7 +143,7 @@ export type WizardAction =
 	  }
 	| {
 			type: "SET_CUSTOMIZATION";
-			field: "organizationId" | "name" | "displayName" | "description" | "icon";
+			field: "name" | "displayName" | "description" | "icon";
 			value: string;
 	  }
 	| { type: "SET_HAS_PROVISIONERS"; value: boolean | undefined }
@@ -211,12 +210,12 @@ export function wizardReducer(
 				hasProvisioners: action.value,
 			};
 		case "RESET_CUSTOMIZATIONS":
-			// Reset only organization and provisioner detection so re-entering the
-			// step re-runs org auto-select cleanly. The base-derived fields are
-			// left intact (they are re-seeded by SET_BASE when the base changes).
+			// Reset provisioner detection so re-entering the step re-detects
+			// provisioners. The organization lives in the step's form and is
+			// re-selected on remount; base-derived fields are left intact (they
+			// are re-seeded by SET_BASE when the base changes).
 			return {
 				...state,
-				organizationId: undefined,
 				hasProvisioners: undefined,
 			};
 		case "RESET":
@@ -253,18 +252,31 @@ export const toComposeRequest = (
 };
 
 /**
- * Project wizard state into the API request shape for the
- * create-template endpoint.
+ * Values owned by the Formik-backed customizations step. Kept separate from
+ * the reducer state, which only seeds their initial (base-derived) defaults.
+ */
+export type CustomizationsFormValues = {
+	organization_id: string;
+	name: string;
+	display_name: string;
+	description: string;
+	icon: string;
+};
+
+/**
+ * Project wizard state and the submitted customization values into the API
+ * request shape for the create-template endpoint.
  */
 export const toCreateTemplateRequest = (
 	state: TemplateBuilderWizardState,
+	customizations: CustomizationsFormValues,
 ): TemplateBuilderCreateTemplateRequest => {
 	return {
 		...toComposeRequest(state),
-		organization_id: state.organizationId ?? "",
-		name: state.name,
-		display_name: state.displayName || undefined,
-		description: state.description || undefined,
-		icon: state.icon || undefined,
+		organization_id: customizations.organization_id,
+		name: customizations.name,
+		display_name: customizations.display_name || undefined,
+		description: customizations.description || undefined,
+		icon: customizations.icon || undefined,
 	};
 };

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -210,10 +210,7 @@ export function wizardReducer(
 				hasProvisioners: action.value,
 			};
 		case "RESET_CUSTOMIZATIONS":
-			// Reset provisioner detection so re-entering the step re-detects
-			// provisioners. The organization lives in the step's form and is
-			// re-selected on remount; base-derived fields are left intact (they
-			// are re-seeded by SET_BASE when the base changes).
+			// Re-detect provisioners when the step is re-entered.
 			return {
 				...state,
 				hasProvisioners: undefined,


### PR DESCRIPTION
## Summary

Fixes the unhelpful backend error when creating a template in the Template Builder with no organization selected ([DEVEX-744](https://linear.app/codercom/issue/DEVEX-744)).

The customizations step is now a Formik form with a Yup schema. Validation runs on submit and errors are presented inline or in a single `Alert` at the top of the step. Only valid submits reach the create API, so an empty organization now shows "Select an organization to continue." instead of hitting the backend. A genuinely invalid selection still surfaces the backend's message via the existing error alert.

## Changes

- `TemplateCustomizationsStep.tsx`: Formik + Yup form; organization is always required (the page is gated on the create-template permission, so there is always at least one permitted org and it is auto-selected when only one exists); aggregated top-of-step error summary.
- `TemplateBuilderPageView.tsx`: the wizard's "Create Template" button submits the step form via the `form` attribute; added `onCreate` plumbing; relaxed the customizations continue gate to the provisioner check.
- `wizardState.ts`: `toCreateTemplateRequest(state, customizations)` builds the request from the submitted form values; removed the now-vestigial `organizationId` from the reducer.
- `TemplateBuilderPage.tsx`: adapts the create call to the new signature.
- `TemplateCustomizationsStep.stories.tsx`: interaction tests for missing organization, missing name, single-org auto-select, and valid submit.

## Testing

- `pnpm --dir site exec tsc -p . --noEmit` (clean)
- `pnpm --dir site exec biome check src/pages/TemplateBuilder` (clean)
- `wizardState.test.ts` (27 passed) and `TemplateCustomizationsStep.stories.tsx` (4 passed)

https://github.com/user-attachments/assets/2931e67d-f1ad-4405-accc-1ca3f24ec118

<details>
<summary>Implementation plan</summary>

# DEVEX-744: Form validation for the Template Builder customizations step

## Problem

In the new Template Builder wizard, creating a template with **no organization selected** produces an unhelpful backend error (empty `organization_id` sent to the API). There is no client-side validation on the final "Customizations" step: `computeCanContinue` only checks `name` and provisioner availability, so the "Create Template" button is enabled even when the organization is missing.

The customizations form is a **horizontal two-column grid**. Showing per-field inline errors (Formik `helperText`) would push fields down and break column alignment. We want **validation before submit**, with messages **aggregated at the top** of the step rather than inline under fields.

## Decision (confirmed with user)

- **Formik-wrap the customizations step** (idiomatic, mirrors the old `CreateTemplateForm`), rather than ad-hoc reducer validation.
- **Validate organization + all required fields** (organization, template ID/name, plus display name/description/icon format limits), reusing the shared Yup validators in `utils/formUtils.ts`.

## Approach

Make `TemplateCustomizationsStep` a Formik form that is the source of truth for the five customization fields. Validate on submit; render an aggregated error summary Alert at the top of the step. Connect the wizard's existing "Create Template" button (which lives in the parent nav bar) to the child form using the standard `form="<id>" type="submit"` HTML association, so no imperative handle or extra callback is needed. Only valid submits reach the API.

### Steps

1. `TemplateCustomizationsStep.tsx`: convert to Formik with a Yup schema (`nameValidator`, `displayNameValidator`, description max 128, `iconValidator`, organization always required); initial values seeded from wizard state; aggregated error Alert at the top; keep provisioner reporting and org auto-select.
2. `TemplateBuilderPageView.tsx`: wire the last-step button to submit the form via the `form` attribute; add an `onCreate` prop; relax the customizations continue gate to the provisioner check.
3. `wizardState.ts`: `toCreateTemplateRequest(state, customizations)` composes the request from base/modules in state plus submitted values.
4. `TemplateBuilderPage.tsx`: adapt `handleCreate`.

### Behavior notes

- A genuinely invalid organization still surfaces the backend's message via the existing `createError` alert; only the empty-org case is caught client-side.
- Unsaved edits to display name/description/icon are discarded when navigating Back off the last step (Formik unmounts and re-seeds from base defaults), matching the wizard's existing reset semantics.

## Post-plan refinements (from review)

- Organization is unconditionally required (removed the conditional `orgRequired`), since the page is permission-gated and always has at least one permitted org.
- `toCreateTemplateRequest` keeps the submitted form values authoritative (no fallback to state, which would resurrect optional fields a user deliberately cleared).
- Removed the now-dead `organizationId` field from the reducer state.
- Story reuses the real query-key builders and the shared `Button` component.

## Testing

- Storybook interaction tests for the customizations step (missing org, missing name, single-org auto-select, valid submit).
- Updated `wizardState.test.ts` for the new `toCreateTemplateRequest` signature.

</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
