### PR TITLE
docs: remove invalid `--yes` flag from `coder template version promote`

### DIFF
--- a/docs/tutorials/testing-templates.md
+++ b/docs/tutorials/testing-templates.md
@@ -131,5 +131,5 @@ jobs:
       - name: Promote template version
         if: success()
         run: |
-          coder template version promote --template=$TEMPLATE_NAME --template-version=${{ steps.name.outputs.version_name }} --yes
+          coder template version promote --template=$TEMPLATE_NAME --template-version=${{ steps.name.outputs.version_name }}
 ```


### PR DESCRIPTION
## What

Remove the invalid `--yes` flag from the `coder template version promote` command in the CI/CD publishing example.

## Why

`docs/tutorials/testing-templates.md` documents, in the GitHub Actions "Promote template version" step:

```
coder template version promote --template=$TEMPLATE_NAME --template-version=... --yes
```

The `promote` subcommand has no `--yes`/confirmation flag, so the command exits with `unknown flag: --yes` and breaks the documented CI workflow. This is a golden-path (automation) breaker.

Verified against the generated reference `docs/reference/cli/templates_versions_promote.md` (flags are only `--template`, `--template-version`, `-O/--org`), and reproduced against a live deployment during the runtime drift sweep. The command is non-interactive, so no confirmation flag is needed.

## Change

Single line: drop ` --yes`.

Linear: [DOCS-640](https://linear.app/codercom/issue/DOCS-640/docs-remove-invalid-yes-flag-from-coder-template-version-promote)

> This PR was created with AI assistance (Coder Agents).