### PR TITLE
docs: fix prometheus metric name and slack webhook backtick

### DIFF
--- a/docs/admin/integrations/prometheus.md
+++ b/docs/admin/integrations/prometheus.md
@@ -364,7 +364,7 @@ The following metrics support native histograms:
 
 * `coderd_workspace_creation_duration_seconds`
 * `coderd_prebuilt_workspace_claim_duration_seconds`
-* `coderd_template_coderd_template_workspace_build_duration_seconds`
+* `coderd_template_workspace_build_duration_seconds`
 
 Native histograms are an **experimental** Prometheus feature that removes the need to predefine bucket boundaries and allows higher-resolution buckets that adapt to deployment characteristics.
 Whether a metric is exposed as classic or native depends entirely on the Prometheus server configuration (see [Prometheus docs](https://prometheus.io/docs/specs/native_histograms/) for details):

--- a/docs/admin/monitoring/notifications/slack.md
+++ b/docs/admin/monitoring/notifications/slack.md
@@ -196,7 +196,7 @@ To enable webhook integration in Coder, define the POST webhook endpoint
 matching the deployed Slack bot:
 
 ```sh
-export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook`
+export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook
 ```
 
 Finally, go to the **Notification Settings** in Coder and switch the notifier to


### PR DESCRIPTION
## What

Two small monitoring-doc fixes surfaced by the runtime drift sweep.

### `docs/admin/integrations/prometheus.md`
The native-histograms list showed `coderd_template_coderd_template_workspace_build_duration_seconds` (doubled `coderd_template_` prefix). The correct metric name, per the metrics table earlier on the same page and the generated metrics, is `coderd_template_workspace_build_duration_seconds`.

### `docs/admin/monitoring/notifications/slack.md`
The `CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT` export ended with a stray backtick:
```
export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook`
```
On paste, bash treats the trailing backtick as an unterminated command substitution and errors. Removed it.

Both reproduced during the runtime drift sweep and verified against `main`.

Linear: [DOCS-647](https://linear.app/codercom/issue/DOCS-647/docs-fix-monitoring-examples-prometheus-metric-name-slack-webhook)

> This PR was created with AI assistance (Coder Agents).