### PR TITLE
docs: correct nginx X-Forwarded-Proto and certbot instructions flavor

### DIFF
--- a/docs/tutorials/reverse-proxy-nginx.md
+++ b/docs/tutorials/reverse-proxy-nginx.md
@@ -54,7 +54,7 @@ you're using `coder.example.com` as your subdomain.
 ## Install and configure LetsEncrypt Certbot
 
 1. Install LetsEncrypt Certbot: Refer to the
-   [CertBot documentation](https://certbot.eff.org/instructions?ws=apache&os=ubuntufocal&tab=wildcard).
+   [CertBot documentation](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal&tab=wildcard).
    Be sure to pick the wildcard tab and select your DNS provider for
    instructions to install the necessary DNS plugin.
 
@@ -134,7 +134,7 @@ providers, refer to the
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-           proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+           proxy_set_header X-Forwarded-Proto $scheme;
            add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
        }
    }


### PR DESCRIPTION
## What

Two fixes to the nginx reverse-proxy tutorial.

### `X-Forwarded-Proto` (line 137)
The config set:
```nginx
proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
```
`$http_x_forwarded_proto` is the value of a client-supplied request header, which a client can spoof and which is usually empty for a direct request. In an nginx TLS-terminating reverse proxy this should be `$scheme`, which nginx sets from the actual connection (`https`). Using the raw client header can break Coder's scheme detection and secure-cookie handling.

### Certbot link flavor (line 57)
The Certbot instructions link used `?ws=apache` in an nginx guide; changed to `?ws=nginx` so readers get nginx instructions.

Surfaced by the runtime drift sweep; verified against `main`.

Linear: [DOCS-642](https://linear.app/codercom/issue/DOCS-642/docs-fix-reverse-proxy-nginx-x-forwarded-proto-dollarscheme-certbot)

> This PR was created with AI assistance (Coder Agents).