### PR TITLE
docs: fix Helm TLS/ingress value keys in admin/setup

### DIFF
--- a/docs/admin/setup/index.md
+++ b/docs/admin/setup/index.md
@@ -99,12 +99,14 @@ working directory prior to step 1.
    ```yaml
    coder:
      tls:
-         secretName:
+       secretNames:
          - coder-tls
 
      # Alternatively, if you use an Ingress controller to terminate TLS,
      # set the following values:
      ingress:
+       enable: true
+       tls:
          enable: true
          secretName: coder-tls
          wildcardSecretName: coder-tls


### PR DESCRIPTION
## What

Fix the Helm values in the TLS setup step of `docs/admin/setup/index.md`. The documented keys are silently ignored by the chart, so TLS appears configured but isn't.

## Changes

- `coder.tls.secretName` (singular) → `coder.tls.secretNames` (a list). The chart key is `secretNames`.
- `coder.ingress.secretName` / `coder.ingress.wildcardSecretName` → nested under `coder.ingress.tls.secretName` / `coder.ingress.tls.wildcardSecretName`, where the chart actually reads them.
- Added `coder.ingress.tls.enable: true` so the ingress-termination example actually enables TLS.

All keys verified against `helm/coder/values.yaml` on `main` (`coder.tls.secretNames`, `coder.ingress.tls.{enable,secretName,wildcardSecretName}`). Surfaced by the runtime drift sweep. The example now parses to the correct chart structure.

Linear: [DOCS-643](https://linear.app/codercom/issue/DOCS-643/docs-fix-helm-tlsingress-value-keys-in-adminsetup-secretnames)

> This PR was created with AI assistance (Coder Agents).