### PR TITLE
feat(scaletest/notifications): add optional user reuse (--reuse-users)

### DIFF
--- a/cli/exp_scaletest_notifications.go
+++ b/cli/exp_scaletest_notifications.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/httpmw"
 	notificationsLib "github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
@@ -66,6 +67,7 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 		dialTimeout             time.Duration
 		cleanupTimeout          time.Duration
 		noCleanup               bool
+		reuseUsers              bool
 		smtpAPIURL              string
 
 		tracingFlags    = &scaletestTracingFlags{}
@@ -76,11 +78,18 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "notifications",
 		Short: "Simulate notification delivery by connecting many users that listen for notifications.",
-		Long: "This creates dedicated scaletest users and deletes them afterwards.\n" +
+		Long: "By default this creates dedicated scaletest users and deletes them afterwards. With\n" +
+			"--reuse-users it instead reuses existing scaletest users, promoting a share of them to\n" +
+			"template admin so they receive the triggered notifications, and restores them afterwards.\n" +
+			"Reuse avoids the account-lifecycle notifications that creating users generates, so it\n" +
+			"measures only the notifications under test. Promoted users receive real inbox entries,\n" +
+			"and real email where the deployment has SMTP configured, which cleanup does not remove.\n" +
 			"\n" +
-			"Run only one instance of this command against a deployment at a time. Running it\n" +
-			"alongside another scaletest command that creates or deletes scaletest users can\n" +
-			"remove the users this run is connected as.",
+			"Run only one instance of this command against a deployment at a time. Concurrent runs\n" +
+			"select from the same scaletest user pool, so they can promote and then restore each\n" +
+			"other's users mid-run, and each run measures notifications the other triggered. The\n" +
+			"same applies to running it alongside another scaletest command that creates or deletes\n" +
+			"scaletest users, which can remove the users this run is connected as.",
 		Handler: func(inv *serpent.Invocation) (retErr error) {
 			ctx := inv.Context()
 			client, err := r.InitClient(inv)
@@ -112,6 +121,15 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 			// connection per user.
 			if setupConcurrency <= 0 {
 				return xerrors.Errorf("--setup-concurrency must be greater than 0")
+			}
+
+			// Reuse promotes real accounts and mints tokens on them. Skipping cleanup
+			// would leave both in place with no tooling to find them, and the usual
+			// recovery command deletes scaletest users outright, which destroys the pool
+			// reuse depends on. Creating users is the mode where leaving residue behind
+			// is a coherent request.
+			if noCleanup && reuseUsers {
+				return xerrors.Errorf("--no-cleanup cannot be used with --reuse-users: it would leave real users holding the template-admin role and a live API token")
 			}
 
 			if setupTimeout <= 0 {
@@ -238,19 +256,24 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 				return xerrors.Errorf("generate run id: %w", err)
 			}
 			runName := runArtifactName(runID)
+			tokenLifetime := testTimeout + cleanupTimeout + time.Hour
 
 			run := &scaletestRun{
-				logger:       logger,
-				stderr:       inv.Stderr,
-				metrics:      metrics,
-				client:       client,
-				setupClient:  setupClient,
-				orgID:        orgID,
-				concurrency:  concurrency,
-				noCleanup:    noCleanup,
-				userCount:    int(userCount),
-				adminCount:   int(templateAdminCount),
-				templateName: runName,
+				logger:        logger,
+				stderr:        inv.Stderr,
+				metrics:       metrics,
+				client:        client,
+				setupClient:   setupClient,
+				orgID:         orgID,
+				concurrency:   concurrency,
+				noCleanup:     noCleanup,
+				reuseUsers:    reuseUsers,
+				callerID:      me.ID,
+				userCount:     int(userCount),
+				adminCount:    int(templateAdminCount),
+				tokenName:     runName,
+				tokenLifetime: tokenLifetime,
+				templateName:  runName,
 			}
 
 			// Always clean up whatever the run created, even on interrupt, timeout, or a
@@ -435,7 +458,7 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 			Flag:          "user-count",
 			FlagShorthand: "c",
 			Env:           "CODER_SCALETEST_NOTIFICATION_USER_COUNT",
-			Description:   "Required: Total number of users to run as. Users are created and deleted by this command.",
+			Description:   "Required: Total number of users to run as. Users are created and deleted by default; pass --reuse-users to reuse existing scaletest users instead.",
 			Value:         serpent.Int64Of(&userCount),
 			Required:      true,
 		},
@@ -493,6 +516,12 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 			Default:     defaultPhaseTimeout.String(),
 			Description: "Timeout for the whole cleanup phase, covering users and the trigger template. Defaults to the same value as --setup-timeout, which creates the same work. Must be greater than 0; unlike the shared scaletest cleanup flags, 0 is not accepted as unlimited, which is why this uses its own environment variable.",
 			Value:       serpent.DurationOf(&cleanupTimeout),
+		},
+		{
+			Flag:        "reuse-users",
+			Env:         "CODER_SCALETEST_NOTIFICATION_REUSE_USERS",
+			Description: "Reuse existing scaletest users instead of creating new ones. Avoids the account-lifecycle notifications that user creation generates, so only the notifications under test are measured. Reused users are promoted to template admin for the run and restored afterwards, but the notifications they receive are not removed.",
+			Value:       serpent.BoolOf(&reuseUsers),
 		},
 		{
 			Flag:        "smtp-api-url",
@@ -738,9 +767,13 @@ type scaletestRun struct {
 	concurrency int
 	noCleanup   bool
 
-	userCount    int
-	adminCount   int
-	templateName string
+	reuseUsers    bool
+	callerID      uuid.UUID
+	userCount     int
+	adminCount    int
+	tokenName     string
+	tokenLifetime time.Duration
+	templateName  string
 
 	// users is filled by setup and read by cleanup, so a failure part-way through
 	// setup still tears down what it managed to create.
@@ -748,8 +781,8 @@ type scaletestRun struct {
 }
 
 // setup clears any stale trigger template and makes the users the runners connect
-// as. It is bounded by the caller's context and runs at most concurrency requests
-// at a time.
+// as, either creating them or reusing existing scaletest users. It is bounded by
+// the caller's context and runs at most concurrency requests at a time.
 func (r *scaletestRun) setup(ctx context.Context) error {
 	// A template stranded by an earlier killed run would accumulate. Per-run names
 	// keep one from breaking this run, so this only stops the pile-up and failing to
@@ -761,6 +794,9 @@ func (r *scaletestRun) setup(ctx context.Context) error {
 		}
 	}
 
+	if r.reuseUsers {
+		return r.prepareExistingUsers(ctx)
+	}
 	return r.createUsers(ctx)
 }
 
@@ -809,10 +845,42 @@ func (r *scaletestRun) createUsers(ctx context.Context) error {
 	})
 }
 
-// cleanupUsers deletes the users this run created.
+func (r *scaletestRun) prepareExistingUsers(ctx context.Context) error {
+	_, _ = fmt.Fprintf(r.stderr, "Selecting %d existing users (%d template admins)...\n", r.userCount, r.adminCount)
+	selected, err := selectExistingUsers(ctx, r.setupClient, r.callerID, r.userCount)
+	if err != nil {
+		return xerrors.Errorf("select existing users: %w", err)
+	}
+
+	r.users = make([]preparedUser, len(selected))
+	for i, u := range selected {
+		r.users[i] = preparedUser{
+			origin:  originReused,
+			user:    u,
+			isAdmin: i < r.adminCount,
+		}
+	}
+
+	_, _ = fmt.Fprintf(r.stderr, "Preparing %d users with %d concurrent workers...\n", len(r.users), r.concurrency)
+	return forEachUser(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
+		if err := prepareUser(ctx, r.setupClient, r.tokenName, r.tokenLifetime, pu); err != nil {
+			r.metrics.AddError("prepare_user")
+			return xerrors.Errorf("prepare user %q: %w", pu.user.ID, err)
+		}
+		return nil
+	})
+}
+
+// cleanupUsers restores reused users or deletes created ones, whichever this run
+// set up.
 func (r *scaletestRun) cleanupUsers(ctx context.Context) error {
 	if len(r.users) == 0 {
 		return nil
+	}
+	if r.reuseUsers {
+		return forEachUserBestEffort(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
+			return restoreUser(ctx, r.metrics, r.setupClient, pu)
+		})
 	}
 	return forEachUserBestEffort(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
 		return deleteUser(ctx, r.metrics, r.setupClient, pu)
@@ -924,17 +992,23 @@ func forEachUserBestEffort(ctx context.Context, users []preparedUser, limit int,
 }
 
 // preparedUser is a user made ready to connect for the run, authenticated with
-// a session token, plus the metadata cleanup needs to delete it. A new user is
-// created and logged in, and cleanup deletes it by ID.
+// a session token, plus the metadata each setup path needs to clean it up.
+//
+// It is produced by one of two mutually exclusive paths:
+//   - create: a new user is created and logged in; cleanup deletes it by ID.
+//   - reuse: an existing scaletest user is promoted (if admin) and issued a
+//     minted token; cleanup revokes the token and removes only that role.
 //
 // userOrigin records where a prepared user came from, which decides what cleanup
-// is allowed to do to it. A user this run did not create must never be deleted,
-// and the sink enforces that rather than trusting its callers.
+// is allowed to do to it. Deleting a reused account or demoting a created one are
+// both wrong, and the sinks enforce that rather than trusting their callers.
 type userOrigin int
 
 const (
 	// originCreated means this run created the user and must delete it.
 	originCreated userOrigin = iota
+	// originReused means the user predates this run and must survive it.
+	originReused
 )
 
 type preparedUser struct {
@@ -944,9 +1018,196 @@ type preparedUser struct {
 	// isAdmin marks a user designated as a template admin for the run.
 	isAdmin bool
 
-	// id identifies the user within the run; the create runner generates the
-	// username and email from it.
+	// Reuse path only.
+	tokenID string
+
+	// Create path only. id identifies the user within the run; the create runner
+	// generates the username and email from it.
 	id string
+}
+
+// selectExistingUsers returns userCount existing scaletest users, failing fast
+// unless at least that many are present.
+//
+// Only users whose username carries the scaletest prefix are eligible, as created
+// by this command or by any other scaletest command that leaves its users behind.
+// That keeps the run from promoting real accounts, and it means the residue of a
+// hard kill stays reclaimable with "coder exp scaletest cleanup", which enumerates
+// a superset of them.
+//
+// Also excluded: excludeID (the caller running the test), service accounts, and
+// users that already hold the owner or template-admin role, so promoting a subset
+// adds exactly the intended new recipients and restores cleanly. Note that
+// deleting a template notifies every template admin and owner in the deployment,
+// so pre-existing admins receive the notification too and are not measured.
+//
+// The query filters to active users because a suspended or dormant user cannot
+// receive notifications, and to password login because scaletest users are
+// created with passwords.
+//
+// The users endpoint returns results ordered by username, so the returned slice
+// is stable across runs without any additional sorting.
+func selectExistingUsers(ctx context.Context, client *codersdk.Client, excludeID uuid.UUID, userCount int) ([]codersdk.User, error) {
+	// Page rather than asking for every user at once: on the large deployments this
+	// command targets that is a single very large query, and the loop can stop as
+	// soon as enough eligible users are found.
+	const pageSize = 1000
+	pool := make([]codersdk.User, 0, userCount)
+	for offset := 0; len(pool) < userCount; offset += pageSize {
+		resp, err := client.Users(ctx, codersdk.UsersRequest{
+			Status:    codersdk.UserStatusActive,
+			LoginType: []codersdk.LoginType{codersdk.LoginTypePassword},
+			// Narrow server-side so a deployment with many users does not page all of
+			// them back. This is a substring match across username, email, and name, so
+			// the exact prefix check below still decides eligibility.
+			Search: loadtestutil.ScaleTestPrefix + "-",
+			Pagination: codersdk.Pagination{
+				Limit:  pageSize,
+				Offset: offset,
+			},
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("list users: %w", err)
+		}
+		for _, u := range resp.Users {
+			if u.ID == excludeID || u.IsServiceAccount {
+				continue
+			}
+			// Require the username prefix rather than loadtestutil.IsScaleTestUser,
+			// which also matches on the scaletest email domain. This is deliberately the
+			// narrower test: it is a subset of what "coder exp scaletest cleanup"
+			// reclaims, so anything promoted here stays reclaimable, while an account
+			// that merely has a scaletest-looking address is never touched.
+			if !strings.HasPrefix(u.Username, loadtestutil.ScaleTestPrefix+"-") {
+				continue
+			}
+			if userHasRole(u, codersdk.RoleOwner) || userHasRole(u, codersdk.RoleTemplateAdmin) {
+				continue
+			}
+			pool = append(pool, u)
+			if len(pool) == userCount {
+				break
+			}
+		}
+		if len(resp.Users) < pageSize {
+			break
+		}
+	}
+
+	if len(pool) < userCount {
+		return nil, xerrors.Errorf("notifications scaletest requires %d eligible users but only %d are present: "+
+			"eligible means an active %s- user with password login that is not the caller, a service account, "+
+			"an owner, or already a template admin. Run without --reuse-users to create users instead",
+			userCount, len(pool), loadtestutil.ScaleTestPrefix)
+	}
+
+	return pool, nil
+}
+
+// prepareUser promotes the user to template admin (when designated) and mints a
+// token authenticating as that user, filling in the mutable fields of pu.
+func prepareUser(ctx context.Context, client *codersdk.Client, tokenName string, tokenLifetime time.Duration, pu *preparedUser) error {
+	if pu.isAdmin {
+		// Add template-admin to the roles the user already holds. Cleanup removes
+		// only this role, so roles granted by anyone else during the run survive.
+		current, err := currentRoleNames(ctx, client, pu.user.ID)
+		if err != nil {
+			return err
+		}
+		// Selection excludes users that already hold the role, so finding it here
+		// means it was granted between selection and now. Skip the redundant write;
+		// cleanup removes the role either way, which is the state selection expected.
+		if !slices.Contains(current, codersdk.RoleTemplateAdmin) {
+			if _, err := client.UpdateUserRoles(ctx, pu.user.ID.String(), codersdk.UpdateRoles{
+				Roles: append(current, codersdk.RoleTemplateAdmin),
+			}); err != nil {
+				return xerrors.Errorf("promote to template admin: %w", err)
+			}
+		}
+	}
+
+	// Name the token after this run and give it a bounded lifetime. Without both, a
+	// token orphaned by a hard kill is indistinguishable from the user's own and
+	// lives for the deployment default, 7 days out of the box.
+	//
+	// Requesting a lifetime at all subjects the request to the deployment's
+	// max-token-lifetime, which a request with no lifetime skips entirely. The cap
+	// for non-owners defaults to 100 years, so this normally passes, but a
+	// deployment that lowers it below the run budget will reject the request. That
+	// is worth reporting rather than silently falling back to the 7-day default.
+	// The token is left at the default scope. The runner only reads one inbox
+	// endpoint, so inbox_notification:read would be the right scope, but that is not
+	// in coderd's external scope catalog (rbac.IsExternalScope) and the tokens API
+	// rejects it. Narrowing this needs that catalog to change first.
+	tokenRes, err := client.CreateToken(ctx, pu.user.ID.String(), codersdk.CreateTokenRequest{
+		TokenName: tokenName,
+		Lifetime:  tokenLifetime,
+	})
+	if err != nil {
+		return xerrors.Errorf("create token with lifetime %s (deployment max-token-lifetime must allow it): %w", tokenLifetime, err)
+	}
+	tokenID, _, err := httpmw.SplitAPIToken(tokenRes.Key)
+	if err != nil {
+		return xerrors.Errorf("parse minted token: %w", err)
+	}
+	pu.sessionToken = tokenRes.Key
+	pu.tokenID = tokenID
+
+	return nil
+}
+
+// restoreUser revokes the minted token and removes the template-admin role this
+// test added, returning the joined errors of any failures. It never deletes users.
+//
+// Whether to remove the role is decided by reading the user's roles at cleanup
+// time, not by recording what this run believes it did. A promotion can commit on
+// the server and still return an error to the client, from a reset connection or
+// a deadline that fires after the write, so a client-side record misses exactly
+// the case that leaves an elevated role on an account.
+//
+// Only users this run designated as admins are considered, so a role granted to a
+// user it never intended to promote is left alone. Among those, selection excludes
+// users that already hold template-admin, so one carrying it at cleanup acquired it
+// during this run. A grant made by someone else inside that window is
+// indistinguishable from ours and is removed too, which is acceptable because reuse
+// only ever selects disposable scaletest accounts.
+func restoreUser(ctx context.Context, metrics *notifications.Metrics, client *codersdk.Client, u *preparedUser) error {
+	// The mirror of the guard in deleteUser: a created user is deleted, never
+	// restored, so restoring one means the caller mixed up the two paths.
+	if u.origin != originReused {
+		return xerrors.Errorf("refusing to restore user %q that this run created", u.user.ID)
+	}
+	if u.user.ID == uuid.Nil {
+		return nil
+	}
+	var errs error
+	if u.tokenID != "" {
+		if err := client.DeleteAPIKey(ctx, u.user.ID.String(), u.tokenID); err != nil {
+			metrics.AddError("revoke_token")
+			errs = errors.Join(errs, xerrors.Errorf("revoke token for user %q: %w", u.user.ID, err))
+		}
+	}
+	if !u.isAdmin {
+		return errs
+	}
+	current, err := currentRoleNames(ctx, client, u.user.ID)
+	if err != nil {
+		metrics.AddError("demote_user")
+		return errors.Join(errs, err)
+	}
+	// Nothing to undo, so no write and no audit entry for a user setup never
+	// reached.
+	if !slices.Contains(current, codersdk.RoleTemplateAdmin) {
+		return errs
+	}
+	remaining := slices.DeleteFunc(current, func(role string) bool {
+		return role == codersdk.RoleTemplateAdmin
+	})
+	if _, err := client.UpdateUserRoles(ctx, u.user.ID.String(), codersdk.UpdateRoles{Roles: remaining}); err != nil {
+		metrics.AddError("demote_user")
+		errs = errors.Join(errs, xerrors.Errorf("demote user %q: %w", u.user.ID, err))
+	}
+	return errs
 }
 
 // createAndLoginUser creates the user in orgID and logs in to obtain a session
@@ -1036,4 +1297,22 @@ func deleteUser(ctx context.Context, metrics *notifications.Metrics, client *cod
 
 func userHasRole(user codersdk.User, role string) bool {
 	return slices.ContainsFunc(user.Roles, func(r codersdk.SlimRole) bool { return r.Name == role })
+}
+
+func userRoleNames(user codersdk.User) []string {
+	names := make([]string, 0, len(user.Roles))
+	for _, r := range user.Roles {
+		names = append(names, r.Name)
+	}
+	return names
+}
+
+// currentRoleNames fetches the user's site role names as they are right now,
+// rather than relying on a value captured earlier in the run.
+func currentRoleNames(ctx context.Context, client *codersdk.Client, userID uuid.UUID) ([]string, error) {
+	user, err := client.User(ctx, userID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("fetch roles for user %q: %w", userID, err)
+	}
+	return userRoleNames(user), nil
 }

--- a/cli/exp_scaletest_notifications_internal_test.go
+++ b/cli/exp_scaletest_notifications_internal_test.go
@@ -4,11 +4,14 @@ package cli
 
 import (
 	"context"
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,11 +23,293 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
 	"github.com/coder/coder/v2/scaletest/notifications"
 	"github.com/coder/coder/v2/testutil"
 )
+
+const testTokenName = "scaletest-notifications-test"
+
+// createScaletestUser creates a user whose name matches the scaletest pattern, so
+// it is eligible for reuse by selectExistingUsers.
+func createScaletestUser(ctx context.Context, t *testing.T, client *codersdk.Client, orgID uuid.UUID, id string, roles ...string) codersdk.User {
+	t.Helper()
+
+	pu := &preparedUser{origin: originCreated, id: id}
+	require.NoError(t, createAndLoginUser(ctx, client, orgID, pu))
+	require.True(t, strings.HasPrefix(pu.user.Username, loadtestutil.ScaleTestPrefix+"-"),
+		"created user must carry the scaletest username prefix reuse requires")
+	if len(roles) > 0 {
+		updated, err := client.UpdateUserRoles(ctx, pu.user.ID.String(), codersdk.UpdateRoles{Roles: roles})
+		require.NoError(t, err)
+		return updated
+	}
+	return pu.user
+}
+
+func TestSelectExistingUsers(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+
+	const poolSize = 5
+	for i := range poolSize {
+		createScaletestUser(ctx, t, client, firstUser.OrganizationID, strconv.Itoa(i))
+	}
+
+	// Ineligible users that the filters must skip. Without these the role and
+	// service-account branches never execute and the assertions below are vacuous.
+	excludedAdmin := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "admin", codersdk.RoleTemplateAdmin)
+	excludedOwner := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "owner", codersdk.RoleOwner)
+	// Service accounts are a Premium feature and cannot be created against this
+	// AGPL test server, so that exclusion is covered by the filter alone.
+	// A non-scaletest user must be skipped even though it is otherwise eligible.
+	_, excludedRealUser := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+	require.False(t, loadtestutil.IsScaleTestUser(excludedRealUser.Username, excludedRealUser.Email))
+
+	const userCount = 4
+	selected, err := selectExistingUsers(ctx, client, firstUser.UserID, userCount)
+	require.NoError(t, err)
+	require.Len(t, selected, userCount)
+
+	for _, u := range selected {
+		require.NotEqual(t, firstUser.UserID, u.ID, "the caller is excluded")
+		require.NotEqual(t, excludedAdmin.ID, u.ID, "existing template admins are excluded")
+		require.NotEqual(t, excludedOwner.ID, u.ID, "owners are excluded")
+		require.NotEqual(t, excludedRealUser.ID, u.ID, "non-scaletest users are excluded")
+		require.True(t, loadtestutil.IsScaleTestUser(u.Username, u.Email))
+		require.False(t, userHasRole(u, codersdk.RoleOwner))
+		require.False(t, userHasRole(u, codersdk.RoleTemplateAdmin))
+	}
+}
+
+func TestSelectExistingUsersFailsFast(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+
+	// Plenty of users exist, but none of them are scaletest users, so none are
+	// eligible for reuse.
+	for range 3 {
+		coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+	}
+	createScaletestUser(ctx, t, client, firstUser.OrganizationID, "0")
+
+	_, err := selectExistingUsers(ctx, client, firstUser.UserID, 5)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires 5 eligible users but only 1 are present")
+	require.Contains(t, err.Error(), "--reuse-users")
+}
+
+func TestPrepareAndRestoreUsers(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	// One reused user already holds a site role, which must survive the
+	// promote/restore round trip.
+	auditor := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "auditor", rbac.RoleAuditor().Name)
+
+	const poolSize = 4
+	for i := range poolSize - 1 {
+		createScaletestUser(ctx, t, client, firstUser.OrganizationID, strconv.Itoa(i))
+	}
+
+	selected, err := selectExistingUsers(ctx, client, firstUser.UserID, poolSize)
+	require.NoError(t, err)
+
+	candidates := make([]preparedUser, len(selected))
+	var sawAuditor bool
+	for i, u := range selected {
+		isAdmin := u.ID == auditor.ID || i == 0
+		if u.ID == auditor.ID {
+			sawAuditor = true
+			require.True(t, userHasRole(u, codersdk.RoleAuditor))
+		}
+		candidates[i] = preparedUser{origin: originReused, user: u, isAdmin: isAdmin}
+	}
+	require.True(t, sawAuditor, "auditor should be among the selected users")
+
+	err = forEachUser(ctx, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
+		return prepareUser(ctx, client, testTokenName, time.Hour, pu)
+	})
+	require.NoError(t, err)
+
+	for _, pu := range candidates {
+		require.NotEmpty(t, pu.sessionToken)
+		require.NotEmpty(t, pu.tokenID)
+
+		// The minted token must authenticate as the prepared user.
+		userClient := codersdk.New(client.URL, codersdk.WithSessionToken(pu.sessionToken))
+		me, err := userClient.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		require.Equal(t, pu.user.ID, me.ID)
+
+		// The token is named after the run so orphans can be found, and expires.
+		keys, err := client.Tokens(ctx, pu.user.ID.String(), codersdk.TokensFilter{})
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		require.Equal(t, testTokenName, keys[0].TokenName)
+		require.WithinDuration(t, time.Now().Add(time.Hour), keys[0].ExpiresAt, time.Minute)
+
+		got, err := client.User(ctx, pu.user.ID.String())
+		require.NoError(t, err)
+		require.Equal(t, pu.isAdmin, userHasRole(got, codersdk.RoleTemplateAdmin))
+		if pu.user.ID == auditor.ID {
+			require.True(t, userHasRole(got, codersdk.RoleAuditor), "promotion preserves existing roles")
+		}
+	}
+
+	// A role granted while the run is in flight must survive cleanup, which is the
+	// reason cleanup subtracts template-admin instead of replaying a snapshot.
+	midRun := candidates[0]
+	current, err := currentRoleNames(ctx, client, midRun.user.ID)
+	require.NoError(t, err)
+	_, err = client.UpdateUserRoles(ctx, midRun.user.ID.String(), codersdk.UpdateRoles{
+		Roles: append(current, rbac.RoleUserAdmin().Name),
+	})
+	require.NoError(t, err)
+
+	err = forEachUserBestEffort(ctx, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
+		return restoreUser(ctx, metrics, client, pu)
+	})
+	require.NoError(t, err)
+
+	for _, pu := range candidates {
+		got, err := client.User(ctx, pu.user.ID.String())
+		require.NoError(t, err)
+		require.False(t, userHasRole(got, codersdk.RoleTemplateAdmin), "template admin is removed")
+
+		if pu.user.ID == auditor.ID {
+			require.True(t, userHasRole(got, codersdk.RoleAuditor), "pre-existing roles are kept")
+		}
+		if pu.user.ID == midRun.user.ID {
+			require.True(t, userHasRole(got, codersdk.RoleUserAdmin), "roles granted mid-run are kept")
+		}
+
+		userClient := codersdk.New(client.URL, codersdk.WithSessionToken(pu.sessionToken))
+		_, err = userClient.User(ctx, codersdk.Me)
+		require.Error(t, err)
+	}
+
+	users, err := client.Users(ctx, codersdk.UsersRequest{})
+	require.NoError(t, err)
+	require.Len(t, users.Users, poolSize+1)
+}
+
+// TestRestoreUserWithoutRoleMakesNoWrite covers a user setup designated as an
+// admin but never reached, which is what a mid-setup abort leaves behind. Cleanup
+// must leave its roles alone rather than writing a role set it never changed.
+func TestRestoreUserWithoutRoleMakesNoWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	user := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "0", rbac.RoleAuditor().Name)
+	candidate := preparedUser{origin: originReused, user: user, isAdmin: true}
+
+	require.NoError(t, restoreUser(ctx, metrics, client, &candidate))
+
+	got, err := client.User(ctx, user.ID.String())
+	require.NoError(t, err)
+	require.True(t, userHasRole(got, codersdk.RoleAuditor), "existing roles are untouched")
+	require.False(t, userHasRole(got, codersdk.RoleTemplateAdmin))
+}
+
+// TestRestoreUserIgnoresUserItNeverPromoted covers the other direction: a user this
+// run never designated as an admin must keep a template-admin role granted by
+// anyone else, since removing it would be an unaudited privilege change this test
+// has no business making.
+func TestRestoreUserIgnoresUserItNeverPromoted(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	user := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "0")
+	// Granted by someone else while the run was in flight.
+	_, err := client.UpdateUserRoles(ctx, user.ID.String(), codersdk.UpdateRoles{
+		Roles: []string{codersdk.RoleTemplateAdmin},
+	})
+	require.NoError(t, err)
+
+	candidate := preparedUser{origin: originReused, user: user, isAdmin: false}
+	require.NoError(t, restoreUser(ctx, metrics, client, &candidate))
+
+	got, err := client.User(ctx, user.ID.String())
+	require.NoError(t, err)
+	require.True(t, userHasRole(got, codersdk.RoleTemplateAdmin),
+		"a role this run never granted must survive cleanup")
+}
+
+// TestRestoreUserRemovesRoleCommittedDespiteError is the case a client-side record
+// of the promotion cannot cover: the role update commits on the server and the
+// client still sees an error. Cleanup must reconcile the account from the server's
+// state, or a real account keeps template-admin.
+func TestRestoreUserRemovesRoleCommittedDespiteError(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	user := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "0")
+
+	// The role update reaches the server and commits; only its response is broken,
+	// which is what a reset connection or a post-write deadline looks like here.
+	brokenClient := brokenResponseClient(t, client, http.MethodPut, "/roles")
+
+	pu := &preparedUser{origin: originReused, user: user, isAdmin: true}
+	err := prepareUser(ctx, brokenClient, testTokenName, time.Hour, pu)
+	require.ErrorContains(t, err, "promote to template admin")
+
+	// The promotion really happened despite the error the client saw.
+	got, err := client.User(ctx, user.ID.String())
+	require.NoError(t, err)
+	require.True(t, userHasRole(got, codersdk.RoleTemplateAdmin),
+		"the server committed the promotion")
+
+	// Cleanup reads that state and undoes it, even though this run recorded no
+	// successful promotion.
+	require.NoError(t, restoreUser(ctx, metrics, client, pu))
+
+	got, err = client.User(ctx, user.ID.String())
+	require.NoError(t, err)
+	require.False(t, userHasRole(got, codersdk.RoleTemplateAdmin),
+		"cleanup removes a role the server holds regardless of what the client recorded")
+}
+
+func TestPrepareUsersFatalOnFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	// A user that does not exist makes token minting fail, which must be fatal.
+	candidate := preparedUser{
+		user: codersdk.User{ReducedUser: codersdk.ReducedUser{MinimalUser: codersdk.MinimalUser{ID: uuid.New()}}},
+	}
+
+	err := prepareUser(ctx, client, testTokenName, time.Hour, &candidate)
+	require.ErrorContains(t, err, "create token")
+	require.Empty(t, candidate.sessionToken)
+}
 
 func TestCreateAndDeleteUsers(t *testing.T) {
 	t.Parallel()
@@ -100,6 +385,29 @@ func failingPathClient(t *testing.T, target *codersdk.Client, failPath string) *
 	return client
 }
 
+// brokenResponseClient returns a client whose requests reach the real deployment
+// and take effect, but whose response to method+pathSuffix is replaced with an
+// error. That reproduces a write that commits server-side while the client sees a
+// failure, which no client-side record of the outcome can represent.
+func brokenResponseClient(t *testing.T, target *codersdk.Client, method, pathSuffix string) *codersdk.Client {
+	t.Helper()
+
+	proxy := httputil.NewSingleHostReverseProxy(target.URL)
+	proxy.ErrorLog = log.New(io.Discard, "", 0)
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if resp.Request.Method == method && strings.HasSuffix(resp.Request.URL.Path, pathSuffix) {
+			return xerrors.New("injected response failure")
+		}
+		return nil
+	}
+	srv := httptest.NewServer(proxy)
+	t.Cleanup(srv.Close)
+
+	proxyURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	return codersdk.New(proxyURL, codersdk.WithSessionToken(target.SessionToken()))
+}
+
 // TestCreateAndLoginUserCapturesPartialUser covers why createAndLoginUser assigns
 // pu.user before checking the error: creation can succeed while a later step
 // fails, and cleanup needs the ID to reclaim the user.
@@ -136,6 +444,34 @@ func TestCreateAndLoginUserCapturesPartialUser(t *testing.T) {
 
 	// A candidate with no ID must be a no-op rather than an error.
 	require.NoError(t, deleteUser(ctx, metrics, client, &preparedUser{origin: originCreated, id: "never"}))
+}
+
+// TestRestoreUserContinuesAfterTokenFailure covers restoreUser's internal
+// continue-on-error: a failed token revoke must not stop the demotion, since
+// leaving template-admin on a user is the worse of the two residues.
+func TestRestoreUserContinuesAfterTokenFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	user := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "0")
+	pu := &preparedUser{origin: originReused, user: user, isAdmin: true}
+	require.NoError(t, prepareUser(ctx, client, testTokenName, time.Hour, pu))
+
+	// A token ID that does not exist makes the revoke fail while leaving the
+	// promotion in place.
+	pu.tokenID = "0123456789"
+
+	err := restoreUser(ctx, metrics, client, pu)
+	require.Error(t, err, "the revoke failure is reported")
+
+	// The demotion still happened despite that failure.
+	got, err := client.User(ctx, pu.user.ID.String())
+	require.NoError(t, err)
+	require.False(t, userHasRole(got, codersdk.RoleTemplateAdmin))
 }
 
 func makeTestUsers(n int) []preparedUser {
@@ -333,6 +669,31 @@ func TestTriggerRecorder(t *testing.T) {
 		// Recording twice would panic on the closed channel, so it is rejected.
 		require.ErrorContains(t, rec.record(expectedID), "triggered more than once")
 	})
+}
+
+// TestUserSinksRefuseWrongOrigin covers the guards that keep the two cleanup paths
+// from crossing: deleting a reused account is unrecoverable, and restoring a
+// created one means the caller mixed up the paths.
+func TestUserSinksRefuseWrongOrigin(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := coderdtest.New(t, nil)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	user := createScaletestUser(ctx, t, client, firstUser.OrganizationID, "0")
+
+	reused := &preparedUser{origin: originReused, user: user, isAdmin: true}
+	require.ErrorContains(t, deleteUser(ctx, metrics, client, reused), "did not create")
+
+	created := &preparedUser{origin: originCreated, user: user, isAdmin: true}
+	require.ErrorContains(t, restoreUser(ctx, metrics, client, created), "this run created")
+
+	// The refusal is real: the user still exists.
+	got, err := client.User(ctx, user.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, user.ID, got.ID)
 }
 
 // createEmptyTemplate creates a template with the given name so a test can assert

--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/loadtestutil"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -293,6 +295,13 @@ func TestScaleTestNotifications_ValidatesArgs(t *testing.T) {
 			errorContains: "--setup-timeout must be greater than 0",
 		},
 		{
+			// Skipping cleanup in reuse mode would leave real accounts promoted with
+			// live tokens and no tooling to find them.
+			name:          "NoCleanupWithReuse",
+			args:          []string{"--user-count", "1", "--reuse-users", "--no-cleanup"},
+			errorContains: "--no-cleanup cannot be used with --reuse-users",
+		},
+		{
 			// The connect phase must leave room to trigger and observe, or the run
 			// measures nothing.
 			name:          "DialTimeoutNotLessThanTimeout",
@@ -319,6 +328,46 @@ func TestScaleTestNotifications_ValidatesArgs(t *testing.T) {
 			require.ErrorContains(t, err, tc.errorContains)
 		})
 	}
+}
+
+// TestScaleTestNotifications_ReuseFailsFast checks that --reuse-users refuses to run
+// when too few eligible scaletest users exist, rather than promoting whatever it can
+// find, and that the error tells the operator what eligible means.
+func TestScaleTestNotifications_ReuseFailsFast(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitMedium)
+	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	client := coderdtest.New(t, &coderdtest.Options{Logger: &log})
+	firstUser := coderdtest.CreateFirstUser(t, client)
+
+	// A real (non-scaletest) user must not be considered eligible for promotion.
+	_, realUser := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+
+	inv, root := clitest.New(t, "exp", "scaletest", "notifications",
+		"--user-count", "2",
+		"--reuse-users",
+		"--timeout", "10s",
+		"--dial-timeout", "1s",
+		"--scaletest-prometheus-address", "127.0.0.1:0",
+		"--scaletest-prometheus-wait", "0s",
+	)
+	// The command requires an admin: it lists users, updates roles, mints tokens,
+	// and creates templates.
+	//nolint:gocritic // This scaletest command must run as an admin.
+	clitest.SetupConfig(t, client, root)
+	err := inv.WithContext(ctx).Run()
+	require.ErrorContains(t, err, "requires 2 eligible users")
+
+	// The real user must be untouched: no promotion, no minted token.
+	got, err := client.User(ctx, realUser.ID.String())
+	require.NoError(t, err)
+	for _, role := range got.Roles {
+		require.NotEqual(t, codersdk.RoleTemplateAdmin, role.Name, "a real user must not be promoted")
+	}
+	tokens, err := client.Tokens(ctx, realUser.ID.String(), codersdk.TokensFilter{})
+	require.NoError(t, err)
+	require.Empty(t, tokens)
 }
 
 // TestScaleTestNotifications_CleanupRunsAfterFailure checks the guarantee that the
@@ -354,6 +403,78 @@ func TestScaleTestNotifications_CleanupRunsAfterFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, users.Users, 1, "created users must be cleaned up after a post-setup failure")
 	require.Equal(t, firstUser.UserID, users.Users[0].ID)
+
+	// The trigger template must not be left behind to poison later runs.
+	templates, err := client.TemplatesByOrganization(ctx, firstUser.OrganizationID)
+	require.NoError(t, err)
+	for _, tpl := range templates {
+		require.NotContains(t, tpl.Name, "notifications-", "trigger template must be cleaned up")
+	}
+}
+
+// TestScaleTestNotifications_ReuseCleanupRunsAfterFailure is the reuse-path
+// counterpart to TestScaleTestNotifications_CleanupRunsAfterFailure. It pins the
+// half of the cleanup wiring where the residue lands on accounts the run does not
+// own: a reused user left holding template-admin and a live token is the failure
+// mode this command was reviewed hardest for.
+func TestScaleTestNotifications_ReuseCleanupRunsAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	client := coderdtest.New(t, &coderdtest.Options{Logger: &log})
+	firstUser := coderdtest.CreateFirstUser(t, client)
+
+	// Seed a pool the reuse path is allowed to select from. Only usernames carrying
+	// the scaletest prefix are eligible.
+	const poolSize = 2
+	pool := make([]codersdk.User, 0, poolSize)
+	for i := range poolSize {
+		_, user := coderdtest.CreateAnotherUserMutators(t, client, firstUser.OrganizationID, nil,
+			func(r *codersdk.CreateUserRequestWithOrgs) {
+				r.Username = fmt.Sprintf("%s-reuse-%d", loadtestutil.ScaleTestPrefix, i)
+			})
+		pool = append(pool, user)
+	}
+
+	// A dial timeout this short guarantees the run fails after setup promoted the
+	// users and minted their tokens, which is the window cleanup must cover.
+	inv, root := clitest.New(t, "exp", "scaletest", "notifications",
+		"--user-count", "2",
+		"--template-admin-percentage", "50",
+		"--reuse-users",
+		"--timeout", "5s",
+		"--dial-timeout", "1s",
+		"--scaletest-prometheus-address", "127.0.0.1:0",
+		"--scaletest-prometheus-wait", "0s",
+	)
+	// The command requires an admin: it lists users, updates roles, mints tokens,
+	// and creates templates.
+	//nolint:gocritic // This scaletest command must run as an admin.
+	clitest.SetupConfig(t, client, root)
+	err := inv.WithContext(ctx).Run()
+	require.Error(t, err, "the run must fail")
+
+	// Reused users are restored, never deleted: they belong to the deployment.
+	users, err := client.Users(ctx, codersdk.UsersRequest{})
+	require.NoError(t, err)
+	require.Len(t, users.Users, poolSize+1, "reused users must survive cleanup")
+
+	for _, seeded := range pool {
+		got, err := client.User(ctx, seeded.ID.String())
+		require.NoError(t, err)
+
+		// The promotion is undone, so no reused account keeps elevated access.
+		for _, role := range got.Roles {
+			require.NotEqual(t, codersdk.RoleTemplateAdmin, role.Name,
+				"reused user %q must not keep the template-admin role", got.Username)
+		}
+
+		// The minted token is revoked, so no reused account keeps a live credential.
+		tokens, err := client.Tokens(ctx, got.ID.String(), codersdk.TokensFilter{})
+		require.NoError(t, err)
+		require.Empty(t, tokens, "reused user %q must not keep a live token", got.Username)
+	}
 
 	// The trigger template must not be left behind to poison later runs.
 	templates, err := client.TemplatesByOrganization(ctx, firstUser.OrganizationID)


### PR DESCRIPTION
This PR is the second in a stack that supersedes https://github.com/coder/coder/pull/27717.

In this PR we're introducing an alternative execution path for further addressing the overhead cost associated with the user setup portion of the notifications load generator.

# Background
Currently the notifications load generator has two main issues.

The first is that it creates new users, promotes some portion of them to template admins, then creates and deletes a template. The goal here is to measure the delivery timing of the notifications to the template admins about the template deletion, but the first issue is that we also have written the load generator such that user creation and deletion notifications are sent into the system as well. This results in roughly an order of magnitude more notifications being processed through the system than one might expect.

A second issue stems from the fact that we do the user setup, login, and websocket connection establishment via a separate connection each per runner. This means that for a notifications scenario of 20k users we actually end up establishing 60k connections. Even though they may not all be open concurrently, this can overwhelm some portions of the scaletest cluster infrastructure just as a result of using so many ports for the load balancer, service -> pod connection establishment, etc.

# This PRs Fix

The fix contained in this PR addresses the first issue by introducing a new `--reuse-users flag`. This flag is meant to be used only in dedicated scaletest clusters or otherwise ephemeral, throwaway environments. In our own scaletest clusters we use the `create workspaces` command with `--no-cleanup` to provision a fixed number of users (and a workspace per user), so by the time we run a load generator there are already many existing users.

With `--reuse-users`, the notifications load generator selects from those existing scaletest users instead of creating its own (failing fast if there aren't enough). It promotes the required number to template admin and mints a short-lived API token for each selected user to establish their websocket connection (we don't have their passwords, so we can't log in as them). 

Because no users are created or deleted, the coderd side never emits the account-lifecycle notifications that fan out to every admin, which is the order-of-magnitude notification overhead described above.

On cleanup it restores the deployment to its prior state: it revokes every minted token and removes the template-admin role from exactly the users it promoted (leaving any roles granted elsewhere intact). Because reuse operates on real, pre-existing accounts, we prohibit `--reuse-users` from being used with `--no-cleanup` since that would potentially strand real users holding elevated roles and live tokens.