### PR TITLE
feat(cli): add progress reporting to notifications scaletest

### DIFF
--- a/cli/exp_scaletest_notifications.go
+++ b/cli/exp_scaletest_notifications.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,6 +33,7 @@ import (
 	"github.com/coder/coder/v2/scaletest/harness"
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
 	"github.com/coder/coder/v2/scaletest/notifications"
+	"github.com/coder/quartz"
 	"github.com/coder/serpent"
 )
 
@@ -50,6 +52,9 @@ func runArtifactName(runID string) string {
 // scaletestIdleConnTimeout keeps pooled connections warm across the setup and
 // SMTP request phases instead of re-dialing per request.
 const scaletestIdleConnTimeout = 60 * time.Second
+
+// progressInterval is how often a long setup or cleanup phase reports progress.
+const progressInterval = 15 * time.Second
 
 // defaultPhaseTimeout bounds the setup and cleanup phases. Both flags take their
 // default from here so they cannot drift apart: the two phases do the same amount
@@ -287,10 +292,10 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 					// stranded template behind.
 					_, _ = fmt.Fprintf(inv.Stderr,
 						"\nCleaning up %d users and the trigger template, bounded by --cleanup-timeout=%s.\n"+
-							"This can take several minutes at scale.\n"+
+							"This can take several minutes at scale and reports progress every %s.\n"+
 							"Please do not kill this process: users may be left with the template-admin\n"+
 							"role and live API tokens. Interrupt again to abort cleanup deliberately.\n",
-						len(run.users), cleanupTimeout)
+						len(run.users), cleanupTimeout, progressInterval)
 
 					cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
 					defer cleanupCancel()
@@ -836,7 +841,7 @@ func (r *scaletestRun) createUsers(ctx context.Context) error {
 
 	_, _ = fmt.Fprintf(r.stderr, "Creating %d users (%d template admins) with %d concurrent workers...\n",
 		r.userCount, r.adminCount, r.concurrency)
-	return forEachUser(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
+	return forEachUser(ctx, newProgress(r.stderr, "Created"), r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
 		if err := createAndLoginUser(ctx, createClient, r.orgID, pu); err != nil {
 			r.metrics.AddError("create_user")
 			return xerrors.Errorf("create user %q: %w", pu.id, err)
@@ -862,7 +867,7 @@ func (r *scaletestRun) prepareExistingUsers(ctx context.Context) error {
 	}
 
 	_, _ = fmt.Fprintf(r.stderr, "Preparing %d users with %d concurrent workers...\n", len(r.users), r.concurrency)
-	return forEachUser(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
+	return forEachUser(ctx, newProgress(r.stderr, "Prepared"), r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
 		if err := prepareUser(ctx, r.setupClient, r.tokenName, r.tokenLifetime, pu); err != nil {
 			r.metrics.AddError("prepare_user")
 			return xerrors.Errorf("prepare user %q: %w", pu.user.ID, err)
@@ -878,11 +883,11 @@ func (r *scaletestRun) cleanupUsers(ctx context.Context) error {
 		return nil
 	}
 	if r.reuseUsers {
-		return forEachUserBestEffort(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
+		return forEachUserBestEffort(ctx, newProgress(r.stderr, "Restored"), r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
 			return restoreUser(ctx, r.metrics, r.setupClient, pu)
 		})
 	}
-	return forEachUserBestEffort(ctx, r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
+	return forEachUserBestEffort(ctx, newProgress(r.stderr, "Deleted"), r.users, r.concurrency, func(ctx context.Context, pu *preparedUser) error {
 		return deleteUser(ctx, r.metrics, r.setupClient, pu)
 	})
 }
@@ -947,10 +952,67 @@ func boundPool(limit int) func(*http.Transport) {
 	}
 }
 
-// forEachUser runs fn once per user, at most limit at a time. The first error
-// cancels the shared context so in-flight and pending calls stop early, and that
-// error is returned. limit must be positive, which the CLI validates.
-func forEachUser(ctx context.Context, users []preparedUser, limit int, fn func(context.Context, *preparedUser) error) error {
+// progress periodically reports how far a long phase has got. Setup and cleanup
+// can each run for minutes at scale, and an operator who reads silence as a hang
+// may kill the process, which is the one exit the deferred cleanup cannot cover.
+//
+// The zero value reports nothing, which is what tests want.
+type progress struct {
+	w     io.Writer
+	clock quartz.Clock
+	verb  string
+}
+
+func newProgress(w io.Writer, verb string) progress {
+	return progress{w: w, clock: quartz.NewReal(), verb: verb}
+}
+
+// watch reports on a timer until the returned function is called, which waits for
+// the reporter to finish so its output cannot interleave with the caller's.
+//
+// The timer matters more than the count: if a phase wedges on one slow request
+// the count stops advancing, and only a ticking line separates that from slow
+// progress.
+func (p progress) watch(ctx context.Context, total int, completed *atomic.Int64) (stop func()) {
+	if p.w == nil || total == 0 {
+		return func() {}
+	}
+	clock := p.clock
+	if clock == nil {
+		clock = quartz.NewReal()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		started := clock.Now()
+		ticker := clock.NewTicker(progressInterval, "progress")
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_, _ = fmt.Fprintf(p.w, "  %s %d/%d users, %s elapsed\n",
+					p.verb, completed.Load(), total, clock.Since(started).Round(time.Second))
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-stopped
+	}
+}
+
+// forEachUser runs fn once per user, at most limit at a time, reporting progress
+// through p. The first error cancels the shared context so in-flight and pending
+// calls stop early, and that error is returned. limit must be positive, which the
+// CLI validates.
+func forEachUser(ctx context.Context, p progress, users []preparedUser, limit int, fn func(context.Context, *preparedUser) error) error {
+	var completed atomic.Int64
+	stopProgress := p.watch(ctx, len(users), &completed)
+	defer stopProgress()
+
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.SetLimit(limit)
 	for i := range users {
@@ -959,16 +1021,25 @@ func forEachUser(ctx context.Context, users []preparedUser, limit int, fn func(c
 			if err := egCtx.Err(); err != nil {
 				return err
 			}
-			return fn(egCtx, pu)
+			if err := fn(egCtx, pu); err != nil {
+				return err
+			}
+			completed.Add(1)
+			return nil
 		})
 	}
 	return eg.Wait()
 }
 
-// forEachUserBestEffort runs fn once per user, at most limit at a time. Every call
-// runs to completion even when one fails, and all returned errors are joined.
-// Cleanup uses this so a single failure cannot abandon the remaining users.
-func forEachUserBestEffort(ctx context.Context, users []preparedUser, limit int, fn func(context.Context, *preparedUser) error) error {
+// forEachUserBestEffort runs fn once per user, at most limit at a time, reporting
+// progress through p. Every call runs to completion even when one fails, and all
+// returned errors are joined. Cleanup uses this so a single failure cannot abandon
+// the remaining users.
+func forEachUserBestEffort(ctx context.Context, p progress, users []preparedUser, limit int, fn func(context.Context, *preparedUser) error) error {
+	var completed atomic.Int64
+	stopProgress := p.watch(ctx, len(users), &completed)
+	defer stopProgress()
+
 	var (
 		mu   sync.Mutex
 		errs error
@@ -984,6 +1055,7 @@ func forEachUserBestEffort(ctx context.Context, users []preparedUser, limit int,
 				mu.Unlock()
 				return nil
 			}
+			completed.Add(1)
 			return nil
 		})
 	}

--- a/cli/exp_scaletest_notifications_internal_test.go
+++ b/cli/exp_scaletest_notifications_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
 	"github.com/coder/coder/v2/scaletest/notifications"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 const testTokenName = "scaletest-notifications-test"
@@ -139,7 +140,7 @@ func TestPrepareAndRestoreUsers(t *testing.T) {
 	}
 	require.True(t, sawAuditor, "auditor should be among the selected users")
 
-	err = forEachUser(ctx, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
+	err = forEachUser(ctx, progress{}, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
 		return prepareUser(ctx, client, testTokenName, time.Hour, pu)
 	})
 	require.NoError(t, err)
@@ -179,7 +180,7 @@ func TestPrepareAndRestoreUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = forEachUserBestEffort(ctx, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
+	err = forEachUserBestEffort(ctx, progress{}, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
 		return restoreUser(ctx, metrics, client, pu)
 	})
 	require.NoError(t, err)
@@ -326,7 +327,7 @@ func TestCreateAndDeleteUsers(t *testing.T) {
 		candidates[i] = preparedUser{origin: originCreated, isAdmin: i < adminCount, id: strconv.Itoa(i)}
 	}
 
-	err := forEachUser(ctx, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
+	err := forEachUser(ctx, progress{}, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
 		return createAndLoginUser(ctx, client, firstUser.OrganizationID, pu)
 	})
 	require.NoError(t, err)
@@ -351,7 +352,7 @@ func TestCreateAndDeleteUsers(t *testing.T) {
 		require.Equal(t, i < adminCount, userHasRole(got, codersdk.RoleTemplateAdmin))
 	}
 
-	err = forEachUserBestEffort(ctx, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
+	err = forEachUserBestEffort(ctx, progress{}, candidates, 2, func(ctx context.Context, pu *preparedUser) error {
 		return deleteUser(ctx, metrics, client, pu)
 	})
 	require.NoError(t, err)
@@ -506,7 +507,7 @@ func TestForEachUser(t *testing.T) {
 		// before the next starts and the assertion holds for any limit.
 		atLimit := make(chan struct{})
 		var once sync.Once
-		err := forEachUser(ctx, users, limit, func(_ context.Context, pu *preparedUser) error {
+		err := forEachUser(ctx, progress{}, users, limit, func(_ context.Context, pu *preparedUser) error {
 			n := inFlight.Add(1)
 			if n == int64(limit) {
 				once.Do(func() { close(atLimit) })
@@ -538,7 +539,7 @@ func TestForEachUser(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 		called := false
-		err := forEachUser(ctx, nil, 3, func(context.Context, *preparedUser) error {
+		err := forEachUser(ctx, progress{}, nil, 3, func(context.Context, *preparedUser) error {
 			called = true
 			return nil
 		})
@@ -557,7 +558,7 @@ func TestForEachUser(t *testing.T) {
 		// Both users run concurrently under the limit. The second only fails once the
 		// first is known to be inside fn, so the first is guaranteed to observe the
 		// cancellation instead of being skipped before it starts.
-		err := forEachUser(ctx, users, 2, func(ctx context.Context, pu *preparedUser) error {
+		err := forEachUser(ctx, progress{}, users, 2, func(ctx context.Context, pu *preparedUser) error {
 			if pu.user.ID == users[0].user.ID {
 				close(siblingRunning)
 				select {
@@ -590,7 +591,7 @@ func TestForEachUserBestEffort(t *testing.T) {
 	)
 	// Every user is processed and its error joined; a failure never cancels the
 	// others, which is what stops one failed demotion abandoning the rest.
-	err := forEachUserBestEffort(ctx, users, 2, func(ctx context.Context, pu *preparedUser) error {
+	err := forEachUserBestEffort(ctx, progress{}, users, 2, func(ctx context.Context, pu *preparedUser) error {
 		mu.Lock()
 		processed++
 		if ctx.Err() != nil {
@@ -668,6 +669,83 @@ func TestTriggerRecorder(t *testing.T) {
 		require.NoError(t, rec.record(expectedID))
 		// Recording twice would panic on the closed channel, so it is rejected.
 		require.ErrorContains(t, rec.record(expectedID), "triggered more than once")
+	})
+}
+
+// chanWriter delivers each write to a channel so a test can wait for output
+// instead of polling, and so the reporter goroutine cannot race the assertions.
+type chanWriter struct {
+	ch chan string
+}
+
+func (c chanWriter) Write(p []byte) (int, error) {
+	c.ch <- string(p)
+	return len(p), nil
+}
+
+// TestProgressWatch covers the reporting that tells an operator a long phase is
+// working rather than hung. It uses a mock clock, so it proves the ticker fires
+// without waiting for real time to pass.
+func TestProgressWatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReportsOnTick", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		mClock := quartz.NewMock(t)
+		w := chanWriter{ch: make(chan string, 8)}
+		trap := mClock.Trap().NewTicker("progress")
+		defer trap.Close()
+
+		p := progress{w: w, clock: mClock, verb: "Prepared"}
+		var completed atomic.Int64
+		stop := p.watch(ctx, 10, &completed)
+		defer stop()
+
+		// Wait for the reporter to create its ticker before advancing.
+		trap.MustWait(ctx).MustRelease(ctx)
+
+		completed.Store(3)
+		mClock.Advance(progressInterval).MustWait(ctx)
+		require.Contains(t, testutil.TryReceive(ctx, t, w.ch), "Prepared 3/10 users")
+
+		// It keeps reporting, which is what distinguishes slow progress from a hang.
+		completed.Store(7)
+		mClock.Advance(progressInterval).MustWait(ctx)
+		require.Contains(t, testutil.TryReceive(ctx, t, w.ch), "Prepared 7/10 users")
+	})
+
+	t.Run("StopEndsReporting", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		mClock := quartz.NewMock(t)
+		w := chanWriter{ch: make(chan string, 8)}
+		trap := mClock.Trap().NewTicker("progress")
+		defer trap.Close()
+
+		p := progress{w: w, clock: mClock, verb: "Deleted"}
+		var completed atomic.Int64
+		stop := p.watch(ctx, 4, &completed)
+		trap.MustWait(ctx).MustRelease(ctx)
+
+		// stop waits for the reporter to exit, so no further output can arrive to
+		// interleave with the caller's own.
+		stop()
+		mClock.Advance(progressInterval).MustWait(ctx)
+		require.Empty(t, w.ch)
+	})
+
+	t.Run("ZeroValueReportsNothing", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		var completed atomic.Int64
+		// The zero value has no writer, so watch must be a no-op rather than panic
+		// on its nil clock.
+		stop := progress{}.watch(ctx, 10, &completed)
+		stop()
 	})
 }
 


### PR DESCRIPTION
This PR is the third in a stack that supersedes https://github.com/coder/coder/pull/27717.

In this PR we add progress logging so operators can see what the load generator pod is doing while setup and cleanup run. At scale these phases take minutes, and without output an operator can mistake a slow-but-healthy run for a hang and kill the process, which is the one exit the deferred cleanup can't cover. When the --reuse-user flag is used this can potentially leave behind promoted users and live tokens behind, see the previous PR.

The change adds a progress tracker that, on a 15s interval, writes a line to stderr showing completed/total and elapsed time for the current phase (creating, preparing, deleting, or restoring users).