### PR TITLE
docs: correct broken CLI commands and flags from drift sweep

### DIFF
--- a/docs/admin/infrastructure/scale-utility.md
+++ b/docs/admin/infrastructure/scale-utility.md
@@ -130,7 +130,7 @@ wish to clean up all workspaces, you can run the following command:
 ```sh
 coder exp scaletest cleanup \
     --cleanup-job-timeout 2h \
-    --cleanup-timeout 15min
+    --cleanup-timeout 15m
 ```
 
 This will delete all workspaces and users with the prefix `scaletest-`.

--- a/docs/admin/integrations/dx-data-cloud.md
+++ b/docs/admin/integrations/dx-data-cloud.md
@@ -30,10 +30,11 @@ If your organization already uses the Coder-DX integration, you can find a list 
 
 ### CLI
 
-Use `users list` to export the list of users to a CSV file:
+Use `users list` with `jq` to export the list of users to a CSV file:
 
 ```sh
-coder users list > users.csv
+coder users list --output json | \
+  jq -r '["username","email","created_at","status"], (.[] | [.username, .email, .created_at, .status]) | @csv' > users.csv
 ```
 
 Visit the [users list](../../reference/cli/users_list.md) documentation for more options.

--- a/docs/admin/users/index.md
+++ b/docs/admin/users/index.md
@@ -235,10 +235,11 @@ You can use the Coder CLI or API to retrieve your list of users.
 
 ### CLI
 
-Use `users list` to export the list of users to a CSV file:
+Use `users list` with `jq` to export the list of users to a CSV file:
 
 ```sh
-coder users list > users.csv
+coder users list --output json | \
+  jq -r '["username","email","created_at","status"], (.[] | [.username, .email, .created_at, .status]) | @csv' > users.csv
 ```
 
 Visit the [users list](../../reference/cli/users_list.md) documentation for more options.

--- a/docs/ai-coder/github-to-tasks.md
+++ b/docs/ai-coder/github-to-tasks.md
@@ -99,9 +99,6 @@ You must also set `coder-template-name` as part of this. The GHA example has thi
 ```sh
 # List all templates in your organization
 coder templates list
-
-# List templates in a specific organization
-coder templates list --org your-org-name
 ```
 
 You can also choose to modify the other [input parameters](https://github.com/coder/create-task-action?tab=readme-ov-file#inputs) to better fit your desired workflow.
@@ -229,7 +226,7 @@ Generate a new token with these permissions at `https://<your-coder-url>/deploym
 
 **Solution:**
 
-1. Verify the template name using: `coder templates list --org your-org-name`
+1. Verify the template name using: `coder templates list`
 1. Update the `coder-template-name` input in your workflow file to match exactly, or input secret or variable saved in GitHub
 1. Ensure the template exists in the organization specified by `coder-organization`
 

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -228,7 +228,7 @@ services or preview environments.
 
 You can also [share ports](./port-forwarding.md#sharing-ports) with other users,
 or [port-forward](./port-forwarding.md#the-coder-port-forward-command) through
-the CLI with `coder port forward`. Read more in the
+the CLI with `coder port-forward`. Read more in the
 [docs on workspace ports](./port-forwarding.md).
 
 ![Open Ports window](../../images/networking/listeningports.png)


### PR DESCRIPTION
## Summary

Corrects broken CLI commands and flags surfaced by the DOCS-637 full-corpus runtime drift sweep. Each fix was verified against the generated CLI reference (`docs/reference/cli/*`) and, where relevant, `codersdk` source.

## Changes

| Page | Fix |
|------|-----|
| `docs/user-guides/workspace-access/index.md` | `coder port forward` → `coder port-forward` (the space form is unrecognized; the command is hyphenated). |
| `docs/ai-coder/github-to-tasks.md` | Remove `coder templates list --org your-org-name` in two spots — `templates list` has no `--org` flag (`unknown flag: --org`). |
| `docs/admin/infrastructure/scale-utility.md` | `--cleanup-timeout 15min` → `15m` — Go durations reject the `min` unit (`invalid duration: unknown unit "min"`). |
| `docs/admin/integrations/dx-data-cloud.md` | `coder users list > users.csv` emitted a whitespace table, not CSV. Emit JSON and convert to real CSV with `jq`, mirroring the API tab on the same page and using the same columns as the default table view (`username,email,created_at,status`). |

## Notes / judgment calls

- **dx-data-cloud (CSV):** the page genuinely needs CSV (the DX CSM imports a CSV, and the API tab already produces one via `jq ... @csv`). `coder users list` only supports `--output table|json`, so the CLI tab now produces real CSV via `jq` rather than switching the page to JSON.
- **scale-utility `:109` left as-is:** `--target-users 0:100` is prefixed with "For dashboard traffic:", which correctly scopes it to the `scaletest dashboard` subcommand, so it is not drift.
- **Excluded — sessions-tokens `--lifetime=720h`:** the sweep flagged this because the throwaway SUT capped token lifetime at 168h, but `--max-token-lifetime` defaults to `876600h` (~100 years), so the example is valid on a default deployment. The `CODER_MAX_TOKEN_LIFETIME` dependency is also already documented in the page's "Set max token length" section. No change needed.

Linear: https://linear.app/codercom/issue/DOCS-641

> This PR was created with AI assistance (Coder Agents).