### PR TITLE
docs: remove dead-end Next steps placeholder in start/local-deploy

### DIFF
--- a/docs/start/local-deploy.md
+++ b/docs/start/local-deploy.md
@@ -58,7 +58,3 @@ administrator account.
 
 Once you've signed in, you'll be brought to an empty workspaces page, which
 we'll soon populate with your first development environments.
-
-## Next steps
-
-TODO: Add link to next page.


### PR DESCRIPTION
## Summary

The getting-started page `docs/start/local-deploy.md` ended with a literal placeholder under `## Next steps`:

```
TODO: Add link to next page.
```

This dead-ends the day-zero onboarding golden path. Found in the DOCS-637 runtime drift sweep.

## Fix

Remove the placeholder `## Next steps` section. The `docs/start/` section is rendered by Fumadocs, which auto-generates next/previous navigation from sidebar order, so a manual "Next steps" section is redundant here.

## For review

- **Approach choice.** I removed the section rather than inserting a curated link, per the Fumadocs auto-nav behavior. If you'd rather keep a curated link (the getting-started order is local-deploy → first-template → first-workspace, so the target would be [Your first template](./first-template.md)), say so and I'll swap the removal for a link.
- **Mixed convention (out of scope here, flagging for a follow-up).** The three `docs/start/` pages are inconsistent: `first-template.md` keeps a curated `## Next steps` (→ `creating-templates.md`), `first-workspace.md` has none, and `local-deploy.md` had this placeholder. Worth standardizing on one pattern (all curated links, or all relying on auto-nav) in a separate change.
- I couldn't build the Fumadocs site from this repo to visually confirm the auto-nav renders for `docs/start/` (these files aren't in `docs/manifest.json`), so the auto-nav assumption rests on your note about how the section is wired.

Linear: https://linear.app/codercom/issue/DOCS-648

> This PR was created with AI assistance (Coder Agents).