### PR TITLE
docs: fix P2/P3 typos and syntax errors from drift sweep

### DIFF
--- a/docs/about/contributing/modules.md
+++ b/docs/about/contributing/modules.md
@@ -342,7 +342,7 @@ Use the version bump script to update versions:
 
    ```sh
    git add .
-   git commit -m "feat(git-clone):add git-clone module"
+   git commit -m "feat(git-clone): add git-clone module"
    ```
 
 4. **Open a pull request**:

--- a/docs/admin/networking/port-forwarding.md
+++ b/docs/admin/networking/port-forwarding.md
@@ -78,7 +78,7 @@ where each segment of hostnames must not exceed 63 characters. If your app
 name, agent name, workspace name and username exceed 63 characters in the
 hostname, port forwarding via the dashboard will not work.
 
-### From an coder_app resource
+### From a coder_app resource
 
 One way to port forward is to configure a `coder_app` resource in the
 workspace's template. This approach shows a visual application icon in the

--- a/docs/admin/templates/extending-templates/variables.md
+++ b/docs/admin/templates/extending-templates/variables.md
@@ -51,7 +51,7 @@ and predictability.
 If you encounter a situation where you need to override template settings for
 variables, you can employ a straightforward solution:
 
-1. Create a `terraform.tfvars` file in in the template directory:
+1. Create a `terraform.tfvars` file in the template directory:
 
    ```tf
    coder_image = newimage:tag

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -241,7 +241,7 @@ role sync at the organization level.
 1. Confirm you have the [Coder CLI](../../install/index.md) installed and are
    logged in with a user who is an Owner or has an Organization Admin role.
 
-1. To fetch the current group sync settings for an organization, run the
+1. To fetch the current role sync settings for an organization, run the
    following:
 
    ```sh
@@ -388,7 +388,7 @@ settings, a user's memberships will update when they log out and log back in.
             "cbdcf774-4123-4118-8cd9-b3f502c84dfb"
          ],
          "sales": [
-            "d79144d9-b30a-555a-9af8-7dac83b2q4ec",
+            "d79144d9-b30a-555a-9af8-7dac83b2q4ec"
          ]
       },
       "organization_assign_default": true

--- a/docs/ai-coder/tasks-migration.md
+++ b/docs/ai-coder/tasks-migration.md
@@ -76,7 +76,7 @@ Below is a minimal illustrative example of a Coder Tasks template pre-2.28.0.
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder
+      source = "coder/coder"
     }
   }
 }
@@ -132,8 +132,8 @@ Example (**not** a full template):
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder
-      version = ">= 2.13.0
+      source = "coder/coder"
+      version = ">= 2.13.0"
     }
   }
 }

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -26,7 +26,7 @@ customization options, keyboard shortcuts, and troubleshooting guides.
 
 ## SSH
 
-### Through with the CLI
+### Through the CLI
 
 Coder will use the optimal path for an SSH connection (determined by your
 deployment's [networking configuration](../../admin/infrastructure/index.md))


### PR DESCRIPTION
## Summary

High-confidence textual subset of the DOCS-637 **P2/P3** drift batch (31 findings total). These 8 fixes are pure typo / grammar / syntax corrections verified directly against the doc source, so they carry no risk of misreconstructed command output.

## Changes (6 files)

| Page | Fix |
|------|-----|
| `docs/admin/templates/extending-templates/variables.md` | Remove doubled word: "file in in the template directory" → "file in the template directory". |
| `docs/admin/networking/port-forwarding.md` | Grammar: heading "From an coder_app resource" → "From a coder_app resource". |
| `docs/user-guides/workspace-access/index.md` | Malformed heading "Through with the CLI" → "Through the CLI". |
| `docs/about/contributing/modules.md` | Conventional-commit example missing the required space: `feat(git-clone):add` → `feat(git-clone): add`. |
| `docs/ai-coder/tasks-migration.md` | Add missing closing double-quotes on Terraform `source`/`version` in two snippets that would fail `terraform` parsing. |
| `docs/admin/users/idp-sync.md` | Role Sync section said "group sync settings" (copy-paste from the Group Sync section); remove an invalid trailing comma from a JSON output example. |

## Deferred (remaining ~23 P2/P3 items, not in this PR)

The rest of the batch is stale **command-output** samples (column/schema changes, sample values) and items that need a content decision (e.g. `--psk` now deprecated in favor of `--key`; `--address` deprecated; an undocumented retention flag). Those need live-output reconstruction or a call on direction, so they're left for follow-up work, consistent with the issue's "handle after the P0/P1 fixes land" guidance. One catalog row (`reverse-proxy-nginx.md:57`, certbot `ws=apache`) is already handled by #28086 and is excluded here.

Linear: https://linear.app/codercom/issue/DOCS-646

> This PR was created with AI assistance (Coder Agents).