### PR TITLE
perf: store workspace agent session counts as JSONB

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -1714,55 +1714,74 @@ func TemplateVersionTerraformValues(t testing.TB, db database.Store, orig databa
 	return v
 }
 
+// WorkspaceAgentStat inserts a workspace agent stat row. Seed the
+// session_counts column by setting SessionCounts on orig, for example with
+// the SessionCounts helper:
+//
+//	WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+//		SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
+//	})
 func WorkspaceAgentStat(t testing.TB, db database.Store, orig database.WorkspaceAgentStat) database.WorkspaceAgentStat {
 	if orig.ConnectionsByProto == nil {
 		orig.ConnectionsByProto = json.RawMessage([]byte("{}"))
 	}
 	jsonProto := []byte(fmt.Sprintf("[%s]", orig.ConnectionsByProto))
 
+	// The insert rejects null session count elements.
+	jsonCounts := orig.SessionCounts
+	if jsonCounts == nil {
+		jsonCounts = json.RawMessage("{}")
+	}
+
 	params := database.InsertWorkspaceAgentStatsParams{
-		ID:                          []uuid.UUID{takeFirst(orig.ID, uuid.New())},
-		CreatedAt:                   []time.Time{takeFirst(orig.CreatedAt, dbtime.Now())},
-		UserID:                      []uuid.UUID{takeFirst(orig.UserID, uuid.New())},
-		TemplateID:                  []uuid.UUID{takeFirst(orig.TemplateID, uuid.New())},
-		WorkspaceID:                 []uuid.UUID{takeFirst(orig.WorkspaceID, uuid.New())},
-		AgentID:                     []uuid.UUID{takeFirst(orig.AgentID, uuid.New())},
-		ConnectionsByProto:          jsonProto,
-		ConnectionCount:             []int64{takeFirst(orig.ConnectionCount, 0)},
-		RxPackets:                   []int64{takeFirst(orig.RxPackets, 0)},
-		RxBytes:                     []int64{takeFirst(orig.RxBytes, 0)},
-		TxPackets:                   []int64{takeFirst(orig.TxPackets, 0)},
-		TxBytes:                     []int64{takeFirst(orig.TxBytes, 0)},
-		SessionCountVSCode:          []int64{takeFirst(orig.SessionCountVSCode, 0)},
-		SessionCountJetBrains:       []int64{takeFirst(orig.SessionCountJetBrains, 0)},
-		SessionCountReconnectingPTY: []int64{takeFirst(orig.SessionCountReconnectingPTY, 0)},
-		SessionCountSSH:             []int64{takeFirst(orig.SessionCountSSH, 0)},
-		ConnectionMedianLatencyMS:   []float64{takeFirst(orig.ConnectionMedianLatencyMS, 0)},
-		Usage:                       []bool{takeFirst(orig.Usage, false)},
+		ID:                        []uuid.UUID{takeFirst(orig.ID, uuid.New())},
+		CreatedAt:                 []time.Time{takeFirst(orig.CreatedAt, dbtime.Now())},
+		UserID:                    []uuid.UUID{takeFirst(orig.UserID, uuid.New())},
+		TemplateID:                []uuid.UUID{takeFirst(orig.TemplateID, uuid.New())},
+		WorkspaceID:               []uuid.UUID{takeFirst(orig.WorkspaceID, uuid.New())},
+		AgentID:                   []uuid.UUID{takeFirst(orig.AgentID, uuid.New())},
+		ConnectionsByProto:        jsonProto,
+		ConnectionCount:           []int64{takeFirst(orig.ConnectionCount, 0)},
+		RxPackets:                 []int64{takeFirst(orig.RxPackets, 0)},
+		RxBytes:                   []int64{takeFirst(orig.RxBytes, 0)},
+		TxPackets:                 []int64{takeFirst(orig.TxPackets, 0)},
+		TxBytes:                   []int64{takeFirst(orig.TxBytes, 0)},
+		SessionCounts:             json.RawMessage(fmt.Sprintf("[%s]", jsonCounts)),
+		ConnectionMedianLatencyMS: []float64{takeFirst(orig.ConnectionMedianLatencyMS, 0)},
+		Usage:                     []bool{takeFirst(orig.Usage, false)},
 	}
 	err := db.InsertWorkspaceAgentStats(genCtx, params)
 	require.NoError(t, err, "insert workspace agent stat")
 
 	return database.WorkspaceAgentStat{
-		ID:                          params.ID[0],
-		CreatedAt:                   params.CreatedAt[0],
-		UserID:                      params.UserID[0],
-		AgentID:                     params.AgentID[0],
-		WorkspaceID:                 params.WorkspaceID[0],
-		TemplateID:                  params.TemplateID[0],
-		ConnectionsByProto:          orig.ConnectionsByProto,
-		ConnectionCount:             params.ConnectionCount[0],
-		RxPackets:                   params.RxPackets[0],
-		RxBytes:                     params.RxBytes[0],
-		TxPackets:                   params.TxPackets[0],
-		TxBytes:                     params.TxBytes[0],
-		ConnectionMedianLatencyMS:   params.ConnectionMedianLatencyMS[0],
-		SessionCountVSCode:          params.SessionCountVSCode[0],
-		SessionCountJetBrains:       params.SessionCountJetBrains[0],
-		SessionCountReconnectingPTY: params.SessionCountReconnectingPTY[0],
-		SessionCountSSH:             params.SessionCountSSH[0],
-		Usage:                       params.Usage[0],
+		ID:                        params.ID[0],
+		CreatedAt:                 params.CreatedAt[0],
+		UserID:                    params.UserID[0],
+		AgentID:                   params.AgentID[0],
+		WorkspaceID:               params.WorkspaceID[0],
+		TemplateID:                params.TemplateID[0],
+		ConnectionsByProto:        orig.ConnectionsByProto,
+		ConnectionCount:           params.ConnectionCount[0],
+		RxPackets:                 params.RxPackets[0],
+		RxBytes:                   params.RxBytes[0],
+		TxPackets:                 params.TxPackets[0],
+		TxBytes:                   params.TxBytes[0],
+		ConnectionMedianLatencyMS: params.ConnectionMedianLatencyMS[0],
+		Usage:                     params.Usage[0],
+		SessionCounts:             jsonCounts,
 	}
+}
+
+// SessionCounts marshals counts for the SessionCounts seed field of
+// WorkspaceAgentStat.
+func SessionCounts(t testing.TB, counts map[string]int64) json.RawMessage {
+	t.Helper()
+	if counts == nil {
+		counts = map[string]int64{}
+	}
+	raw, err := json.Marshal(counts)
+	require.NoError(t, err, "marshal session counts")
+	return raw
 }
 
 func OAuth2ProviderApp(t testing.TB, db database.Store, seed database.OAuth2ProviderApp) database.OAuth2ProviderApp {

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -392,7 +392,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 		ConnectionCount:           1,
 		ConnectionMedianLatencyMS: 1,
 		RxBytes:                   1111,
-		SessionCountSSH:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 	})
 
 	// Stat inserted 180 days - 2 hour ago, should not be deleted before rollup.
@@ -401,7 +401,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 		ConnectionCount:           1,
 		ConnectionMedianLatencyMS: 1,
 		RxBytes:                   2222,
-		SessionCountSSH:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 	})
 
 	// Stat inserted 179 days - 4 hour ago, should not be deleted at all.
@@ -410,7 +410,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 		ConnectionCount:           1,
 		ConnectionMedianLatencyMS: 1,
 		RxBytes:                   3333,
-		SessionCountSSH:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 	})
 
 	// when

--- a/coderd/database/dbrollup/dbrollup_test.go
+++ b/coderd/database/dbrollup/dbrollup_test.go
@@ -75,7 +75,7 @@ func TestRollup_TwoInstancesUseLocking(t *testing.T) {
 		CreatedAt:                 refTime.Add(-time.Minute),
 		ConnectionMedianLatencyMS: 1,
 		ConnectionCount:           1,
-		SessionCountSSH:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 	})
 
 	closeRolluper := func(rolluper *dbrollup.Rolluper, resume chan struct{}) {
@@ -163,7 +163,7 @@ func TestRollupTemplateUsageStats(t *testing.T) {
 		CreatedAt:                 anHourAndSixMonthsAgo.AddDate(0, 0, -1),
 		ConnectionMedianLatencyMS: 1,
 		ConnectionCount:           1,
-		SessionCountSSH:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 	})
 	_ = dbgen.WorkspaceAppStat(t, db, database.WorkspaceAppStat{
 		UserID:           user.ID,
@@ -176,24 +176,24 @@ func TestRollupTemplateUsageStats(t *testing.T) {
 
 	// Stats inserted 6 months - 1 day ago, should be rolled up.
 	wags1 := dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-		TemplateID:                  tpl.ID,
-		WorkspaceID:                 ws.ID,
-		AgentID:                     agent.ID,
-		UserID:                      user.ID,
-		CreatedAt:                   anHourAndSixMonthsAgo.AddDate(0, 0, 1),
-		ConnectionMedianLatencyMS:   1,
-		ConnectionCount:             1,
-		SessionCountReconnectingPTY: 1,
+		TemplateID:                tpl.ID,
+		WorkspaceID:               ws.ID,
+		AgentID:                   agent.ID,
+		UserID:                    user.ID,
+		CreatedAt:                 anHourAndSixMonthsAgo.AddDate(0, 0, 1),
+		ConnectionMedianLatencyMS: 1,
+		ConnectionCount:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"reconnecting_pty": 1}),
 	})
 	wags2 := dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-		TemplateID:                  tpl.ID,
-		WorkspaceID:                 ws.ID,
-		AgentID:                     agent.ID,
-		UserID:                      user.ID,
-		CreatedAt:                   wags1.CreatedAt.Add(time.Minute),
-		ConnectionMedianLatencyMS:   1,
-		ConnectionCount:             1,
-		SessionCountReconnectingPTY: 1,
+		TemplateID:                tpl.ID,
+		WorkspaceID:               ws.ID,
+		AgentID:                   agent.ID,
+		UserID:                    user.ID,
+		CreatedAt:                 wags1.CreatedAt.Add(time.Minute),
+		ConnectionMedianLatencyMS: 1,
+		ConnectionCount:           1,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"reconnecting_pty": 1}),
 	})
 	// wags2 and waps1 overlap, so total usage is 4 - 1.
 	waps1 := dbgen.WorkspaceAppStat(t, db, database.WorkspaceAppStat{

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -3964,12 +3964,11 @@ CREATE TABLE workspace_agent_stats (
     tx_packets bigint DEFAULT 0 NOT NULL,
     tx_bytes bigint DEFAULT 0 NOT NULL,
     connection_median_latency_ms double precision DEFAULT '-1'::integer NOT NULL,
-    session_count_vscode bigint DEFAULT 0 NOT NULL,
-    session_count_jetbrains bigint DEFAULT 0 NOT NULL,
-    session_count_reconnecting_pty bigint DEFAULT 0 NOT NULL,
-    session_count_ssh bigint DEFAULT 0 NOT NULL,
-    usage boolean DEFAULT false NOT NULL
+    usage boolean DEFAULT false NOT NULL,
+    session_counts jsonb DEFAULT '{}'::jsonb NOT NULL
 );
+
+COMMENT ON COLUMN workspace_agent_stats.session_counts IS 'Positive session counts keyed by the canonical app name reported by the agent.';
 
 CREATE TABLE workspace_agent_volume_resource_monitors (
     agent_id uuid NOT NULL,
@@ -5105,7 +5104,7 @@ COMMENT ON INDEX workspace_agent_scripts_workspace_agent_id_idx IS 'Foreign key 
 
 CREATE INDEX workspace_agent_startup_logs_id_agent_id_idx ON workspace_agent_logs USING btree (agent_id, id);
 
-CREATE INDEX workspace_agent_stats_template_id_created_at_user_id_idx ON workspace_agent_stats USING btree (template_id, created_at, user_id) INCLUDE (session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, connection_median_latency_ms) WHERE (connection_count > 0);
+CREATE INDEX workspace_agent_stats_template_id_created_at_user_id_idx ON workspace_agent_stats USING btree (template_id, created_at, user_id) INCLUDE (connection_median_latency_ms) WHERE (connection_count > 0);
 
 COMMENT ON INDEX workspace_agent_stats_template_id_created_at_user_id_idx IS 'Support index for template insights endpoint to build interval reports faster.';
 

--- a/coderd/database/migrations/000590_workspace_agent_session_counts.down.sql
+++ b/coderd/database/migrations/000590_workspace_agent_session_counts.down.sql
@@ -1,0 +1,23 @@
+ALTER TABLE workspace_agent_stats
+	ADD COLUMN session_count_vscode bigint DEFAULT 0 NOT NULL,
+	ADD COLUMN session_count_jetbrains bigint DEFAULT 0 NOT NULL,
+	ADD COLUMN session_count_reconnecting_pty bigint DEFAULT 0 NOT NULL,
+	ADD COLUMN session_count_ssh bigint DEFAULT 0 NOT NULL;
+
+-- Restore the four known session counts. Other keys are discarded.
+UPDATE workspace_agent_stats
+SET
+	session_count_vscode = COALESCE((session_counts ->> 'vscode')::bigint, 0),
+	session_count_jetbrains = COALESCE((session_counts ->> 'jetbrains')::bigint, 0),
+	session_count_reconnecting_pty = COALESCE((session_counts ->> 'reconnecting_pty')::bigint, 0),
+	session_count_ssh = COALESCE((session_counts ->> 'ssh')::bigint, 0)
+WHERE session_counts <> '{}'::jsonb;
+
+DROP INDEX workspace_agent_stats_template_id_created_at_user_id_idx;
+
+ALTER TABLE workspace_agent_stats
+	DROP COLUMN session_counts;
+
+CREATE INDEX workspace_agent_stats_template_id_created_at_user_id_idx ON workspace_agent_stats USING btree (template_id, created_at, user_id) INCLUDE (session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, connection_median_latency_ms) WHERE (connection_count > 0);
+
+COMMENT ON INDEX workspace_agent_stats_template_id_created_at_user_id_idx IS 'Support index for template insights endpoint to build interval reports faster.';

--- a/coderd/database/migrations/000590_workspace_agent_session_counts.up.sql
+++ b/coderd/database/migrations/000590_workspace_agent_session_counts.up.sql
@@ -1,0 +1,78 @@
+LOCK TABLE workspace_agent_stats IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+DECLARE
+	latest_rollup_start timestamptz;
+	backlog_start timestamptz;
+	backlog_end timestamptz;
+BEGIN
+	SELECT MAX(start_time) INTO latest_rollup_start FROM template_usage_stats;
+
+	-- Every row the rollup has not consumed yet has to be converted below, and
+	-- the table stays locked for all of them. Measure the rollup against the
+	-- data rather than against the clock: a deployment shut down over a weekend
+	-- records nothing while it is off, and an idle deployment leaves the
+	-- watermark behind because there is nothing to roll up. Neither has a
+	-- backlog, and neither takes noticeably longer to convert.
+	SELECT MIN(created_at), MAX(created_at)
+	INTO backlog_start, backlog_end
+	FROM workspace_agent_stats
+	WHERE (latest_rollup_start IS NULL OR created_at >= latest_rollup_start)
+		AND (
+			session_count_vscode > 0
+			OR session_count_jetbrains > 0
+			OR session_count_reconnecting_pty > 0
+			OR session_count_ssh > 0
+		);
+
+	IF backlog_end - backlog_start > interval '24 hours' THEN
+		RAISE WARNING 'migration 000590 found % of workspace agent stats that template usage stats never rolled up', justify_hours(backlog_end - backlog_start)
+			USING DETAIL = format(
+				'This migration converts every workspace_agent_stats row the rollup has not consumed, %s through %s, and holds ACCESS EXCLUSIVE on the table until it finishes. Expect the migration to take longer than usual; do not interrupt it.',
+				backlog_start, backlog_end
+			),
+			HINT = 'A backlog this wide usually means the rollup is failing or blocked: after the upgrade, check coderd logs for "failed to rollup data", and check pg_locks for a session holding the rollup advisory lock.';
+	END IF;
+END
+$$;
+
+ALTER TABLE workspace_agent_stats
+	ADD COLUMN session_counts jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+COMMENT ON COLUMN workspace_agent_stats.session_counts IS 'Positive session counts keyed by the canonical app name reported by the agent.';
+
+-- Convert the window DeleteOldWorkspaceAgentStats retains plus everything the
+-- rollup has not consumed yet, which is what the rollups and operational
+-- statistics still read. Anything older has already been rolled up. When
+-- nothing has ever rolled up there is no watermark to fall back on, so convert
+-- every row rather than roll old activity up as zero minutes later.
+UPDATE workspace_agent_stats
+SET session_counts = jsonb_strip_nulls(jsonb_build_object(
+	'vscode', CASE WHEN session_count_vscode > 0 THEN session_count_vscode END,
+	'jetbrains', CASE WHEN session_count_jetbrains > 0 THEN session_count_jetbrains END,
+	'reconnecting_pty', CASE WHEN session_count_reconnecting_pty > 0 THEN session_count_reconnecting_pty END,
+	'ssh', CASE WHEN session_count_ssh > 0 THEN session_count_ssh END
+))
+WHERE created_at >= (
+	SELECT COALESCE(MAX(start_time) - interval '1 day', '-infinity'::timestamptz)
+	FROM template_usage_stats
+)
+	AND (
+		session_count_vscode > 0
+		OR session_count_jetbrains > 0
+		OR session_count_reconnecting_pty > 0
+		OR session_count_ssh > 0
+	);
+
+-- Recreate the index without the dropped columns in its INCLUDE list.
+DROP INDEX workspace_agent_stats_template_id_created_at_user_id_idx;
+
+ALTER TABLE workspace_agent_stats
+	DROP COLUMN session_count_vscode,
+	DROP COLUMN session_count_jetbrains,
+	DROP COLUMN session_count_reconnecting_pty,
+	DROP COLUMN session_count_ssh;
+
+CREATE INDEX workspace_agent_stats_template_id_created_at_user_id_idx ON workspace_agent_stats USING btree (template_id, created_at, user_id) INCLUDE (connection_median_latency_ms) WHERE (connection_count > 0);
+
+COMMENT ON INDEX workspace_agent_stats_template_id_created_at_user_id_idx IS 'Support index for template insights endpoint to build interval reports faster.';

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -3089,6 +3089,155 @@ func TestMigration000565OAuth2ClientTypeConstraint(t *testing.T) {
 	}
 }
 
+//nolint:tparallel,paralleltest // Subtests share one database with transaction-local fixtures.
+func TestMigration000590WorkspaceAgentSessionCounts(t *testing.T) {
+	t.Parallel()
+
+	const priorMigrationVersion = 589
+
+	sqlDB := testSQLDB(t)
+	next, err := migrations.Stepper(sqlDB)
+	require.NoError(t, err)
+	for {
+		version, more, err := next()
+		require.NoError(t, err)
+		if !more {
+			t.Fatalf("migration %d not found", priorMigrationVersion)
+		}
+		if version == priorMigrationVersion {
+			break
+		}
+	}
+
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
+	migrationSQL, err := os.ReadFile("000590_workspace_agent_session_counts.up.sql")
+	require.NoError(t, err)
+
+	// Everything the rollup has not consumed converts, no matter how far the
+	// watermark lags. Rows the rollup already consumed convert to '{}': the
+	// insights queries read them from template_usage_stats instead. wantCounts
+	// is ordered oldest row first.
+	tests := []struct {
+		name              string
+		statsAgeHours     []int
+		sessionCount      int
+		watermarkAgeHours []int
+		wantCounts        []string
+	}{
+		{name: "empty database"},
+		{name: "no watermark and brief activity", statsAgeHours: []int{0}, sessionCount: 2, wantCounts: []string{`{"vscode": 2}`}},
+		{name: "no watermark and idle stats", statsAgeHours: []int{0}, wantCounts: []string{`{}`}},
+		{name: "no watermark and a long activity backlog", statsAgeHours: []int{48, 0}, sessionCount: 2, wantCounts: []string{`{"vscode": 2}`, `{"vscode": 2}`}},
+		// Without a watermark there is nothing in template_usage_stats to fall
+		// back on, so even ancient activity converts rather than roll up as
+		// zero minutes later.
+		{name: "no watermark and expired activity", statsAgeHours: []int{181 * 24}, sessionCount: 2, wantCounts: []string{`{"vscode": 2}`}},
+		// A weekend shutoff records nothing while coderd is down, so the
+		// watermark is days old with only the minutes before the shutoff
+		// behind it.
+		{name: "weekend shutoff", statsAgeHours: []int{63}, sessionCount: 2, watermarkAgeHours: []int{64}, wantCounts: []string{`{"vscode": 2}`}},
+		{name: "idle since the last rollup", statsAgeHours: []int{0}, watermarkAgeHours: []int{48}, wantCounts: []string{`{}`}},
+		{name: "stalled rollup", statsAgeHours: []int{47, 0}, sessionCount: 2, watermarkAgeHours: []int{48}, wantCounts: []string{`{"vscode": 2}`, `{"vscode": 2}`}},
+		{name: "activity already rolled up", statsAgeHours: []int{50}, sessionCount: 2, watermarkAgeHours: []int{25}, wantCounts: []string{`{}`}},
+		{name: "fresh watermark", statsAgeHours: []int{0}, sessionCount: 2, watermarkAgeHours: []int{23}, wantCounts: []string{`{"vscode": 2}`}},
+		{name: "latest watermark wins", statsAgeHours: []int{0}, sessionCount: 2, watermarkAgeHours: []int{25, 23}, wantCounts: []string{`{"vscode": 2}`}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx, err := sqlDB.BeginTx(ctx, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = tx.Rollback() })
+
+			for _, ageHours := range tt.statsAgeHours {
+				_, err = tx.ExecContext(ctx, `
+					INSERT INTO workspace_agent_stats (
+						id, created_at, user_id, agent_id, workspace_id, template_id,
+						connection_count, session_count_vscode
+					) VALUES (
+						gen_random_uuid(), statement_timestamp() - $1::bigint * interval '1 hour',
+						gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 1, $2
+					)
+				`, ageHours, tt.sessionCount)
+				require.NoError(t, err)
+			}
+
+			for _, ageHours := range tt.watermarkAgeHours {
+				_, err = tx.ExecContext(ctx, `
+					INSERT INTO template_usage_stats (
+						start_time, end_time, template_id, user_id, median_latency_ms,
+						usage_mins, ssh_mins, sftp_mins, reconnecting_pty_mins,
+						vscode_mins, jetbrains_mins, app_usage_mins
+					) VALUES (
+						statement_timestamp() - $1::bigint * interval '1 hour',
+						statement_timestamp() - $1::bigint * interval '1 hour' + interval '30 minutes',
+						gen_random_uuid(), gen_random_uuid(), NULL, 0, 0, 0, 0, 0, 0, NULL
+					)
+				`, ageHours)
+				require.NoError(t, err)
+			}
+
+			_, err = tx.ExecContext(ctx, string(migrationSQL))
+			require.NoError(t, err)
+
+			rows, err := tx.QueryContext(ctx, `SELECT session_counts FROM workspace_agent_stats ORDER BY created_at`)
+			require.NoError(t, err)
+			defer rows.Close()
+			var gotCounts []string
+			for rows.Next() {
+				var sessionCounts []byte
+				require.NoError(t, rows.Scan(&sessionCounts))
+				gotCounts = append(gotCounts, string(sessionCounts))
+			}
+			require.NoError(t, rows.Err())
+			require.Len(t, gotCounts, len(tt.wantCounts))
+			for i, want := range tt.wantCounts {
+				require.JSONEq(t, want, gotCounts[i])
+			}
+		})
+	}
+
+	// The down migration has columns for the four known apps only, so a count
+	// under any other name is lost.
+	t.Run("down restores known apps only", func(t *testing.T) {
+		tx, err := sqlDB.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tx.Rollback() })
+
+		_, err = tx.ExecContext(ctx, string(migrationSQL))
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO workspace_agent_stats (
+				id, created_at, user_id, agent_id, workspace_id, template_id,
+				connection_count, session_counts
+			) VALUES (
+				gen_random_uuid(), statement_timestamp(), gen_random_uuid(),
+				gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 1,
+				'{"vscode": 2, "some_future_ide": 3}'::jsonb
+			)
+		`)
+		require.NoError(t, err)
+
+		downSQL, err := os.ReadFile("000590_workspace_agent_session_counts.down.sql")
+		require.NoError(t, err)
+		_, err = tx.ExecContext(ctx, string(downSQL))
+		require.NoError(t, err)
+
+		var vscode, jetbrains, reconnectingPTY, ssh int64
+		err = tx.QueryRowContext(ctx, `
+			SELECT session_count_vscode, session_count_jetbrains,
+				session_count_reconnecting_pty, session_count_ssh
+			FROM workspace_agent_stats
+		`).Scan(&vscode, &jetbrains, &reconnectingPTY, &ssh)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, vscode)
+		require.EqualValues(t, 0, jetbrains)
+		require.EqualValues(t, 0, reconnectingPTY)
+		require.EqualValues(t, 0, ssh)
+	})
+}
+
 // TestMigration000566OAuth2AuthMethodBackfill covers the repair the backfill
 // exists for, which the testdata/fixtures run does not reach: its only
 // oauth2_provider_apps row seeds no token_endpoint_auth_method at all, so the

--- a/coderd/database/migrations/testdata/fixtures/000590_workspace_agent_session_counts.up.sql
+++ b/coderd/database/migrations/testdata/fixtures/000590_workspace_agent_session_counts.up.sql
@@ -1,0 +1,8 @@
+INSERT INTO workspace_agent_stats (
+	id, created_at, user_id, agent_id, workspace_id, template_id,
+	connection_count, connection_median_latency_ms, session_counts
+) VALUES (
+	'4a382ba5-6e57-4a58-991e-d4ac4f6c1012', NOW(),
+	gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid(),
+	1, 1, '{"vscode": 2, "some_future_ide": 1}'::jsonb
+);

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -6711,24 +6711,22 @@ type WorkspaceAgentScriptTiming struct {
 }
 
 type WorkspaceAgentStat struct {
-	ID                          uuid.UUID       `db:"id" json:"id"`
-	CreatedAt                   time.Time       `db:"created_at" json:"created_at"`
-	UserID                      uuid.UUID       `db:"user_id" json:"user_id"`
-	AgentID                     uuid.UUID       `db:"agent_id" json:"agent_id"`
-	WorkspaceID                 uuid.UUID       `db:"workspace_id" json:"workspace_id"`
-	TemplateID                  uuid.UUID       `db:"template_id" json:"template_id"`
-	ConnectionsByProto          json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
-	ConnectionCount             int64           `db:"connection_count" json:"connection_count"`
-	RxPackets                   int64           `db:"rx_packets" json:"rx_packets"`
-	RxBytes                     int64           `db:"rx_bytes" json:"rx_bytes"`
-	TxPackets                   int64           `db:"tx_packets" json:"tx_packets"`
-	TxBytes                     int64           `db:"tx_bytes" json:"tx_bytes"`
-	ConnectionMedianLatencyMS   float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
-	SessionCountVSCode          int64           `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountJetBrains       int64           `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY int64           `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	SessionCountSSH             int64           `db:"session_count_ssh" json:"session_count_ssh"`
-	Usage                       bool            `db:"usage" json:"usage"`
+	ID                        uuid.UUID       `db:"id" json:"id"`
+	CreatedAt                 time.Time       `db:"created_at" json:"created_at"`
+	UserID                    uuid.UUID       `db:"user_id" json:"user_id"`
+	AgentID                   uuid.UUID       `db:"agent_id" json:"agent_id"`
+	WorkspaceID               uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID                uuid.UUID       `db:"template_id" json:"template_id"`
+	ConnectionsByProto        json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount           int64           `db:"connection_count" json:"connection_count"`
+	RxPackets                 int64           `db:"rx_packets" json:"rx_packets"`
+	RxBytes                   int64           `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets                 int64           `db:"tx_packets" json:"tx_packets"`
+	TxBytes                   int64           `db:"tx_bytes" json:"tx_bytes"`
+	ConnectionMedianLatencyMS float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
+	Usage                     bool            `db:"usage" json:"usage"`
+	// Positive session counts keyed by the canonical app name reported by the agent.
+	SessionCounts json.RawMessage `db:"session_counts" json:"session_counts"`
 }
 
 type WorkspaceAgentVolumeResourceMonitor struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1031,7 +1031,6 @@ type sqlcQuerier interface {
 	GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]GetWorkspaceAgentScriptsByAgentIDsRow, error)
 	GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error)
 	GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
-	// `minute_buckets` could return 0 rows if there are no usage stats since `created_at`.
 	GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error)
 	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
 	GetWorkspaceAgentsByInstanceID(ctx context.Context, authInstanceID string) ([]WorkspaceAgent, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -59,13 +59,13 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 1,
-			SessionCountVSCode:        1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 2,
-			SessionCountVSCode:        1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 1,
-			SessionCountVSCode:        1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
 			// Ensure this stat is newer!
@@ -102,7 +102,7 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 2,
-			SessionCountVSCode:        1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
 		require.NoError(t, err)
@@ -136,21 +136,19 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountSSH:    4,
-			SessionCountVSCode: 3,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 4, "vscode": 3}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:          insertTime.Add(-time.Minute),
-			AgentID:            agentID,
-			SessionCountVSCode: 1,
-			Usage:              true,
+			CreatedAt:     insertTime.Add(-time.Minute),
+			AgentID:       agentID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:                   insertTime.Add(-time.Minute),
-			AgentID:                     agentID,
-			SessionCountReconnectingPTY: 1,
-			Usage:                       true,
+			CreatedAt:     insertTime.Add(-time.Minute),
+			AgentID:       agentID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"reconnecting_pty": 1}),
 		})
 
 		// Latest stats
@@ -160,21 +158,19 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 2,
-			// Should be ignored
-			SessionCountSSH:    3,
-			SessionCountVSCode: 1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:          insertTime,
-			AgentID:            agentID,
-			SessionCountVSCode: 1,
-			Usage:              true,
+			CreatedAt:     insertTime,
+			AgentID:       agentID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:       insertTime,
-			AgentID:         agentID,
-			SessionCountSSH: 1,
-			Usage:           true,
+			CreatedAt:     insertTime,
+			AgentID:       agentID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
 		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
@@ -188,6 +184,36 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 		require.Equal(t, int64(1), stats.SessionCountSSH)
 		require.Equal(t, int64(0), stats.SessionCountReconnectingPTY)
 		require.Equal(t, int64(0), stats.SessionCountJetBrains)
+	})
+
+	t.Run("ExcludesStatsBeforeCutoffInSameMinute", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		authz := rbac.NewAuthorizer(prometheus.NewRegistry())
+		db = dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		ctx := context.Background()
+		agentID := uuid.New()
+		minute := dbtime.Now().Add(-2 * time.Minute).Truncate(time.Minute)
+		cutoff := minute.Add(30 * time.Second)
+
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			CreatedAt:     minute.Add(10 * time.Second),
+			AgentID:       agentID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 4}),
+		})
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			CreatedAt:     minute.Add(40 * time.Second),
+			AgentID:       agentID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
+		})
+
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, cutoff)
+		require.NoError(t, err)
+		require.Zero(t, stats.SessionCountVSCode)
+		require.Equal(t, int64(1), stats.SessionCountSSH)
 	})
 
 	t.Run("NoUsage", func(t *testing.T) {
@@ -207,9 +233,7 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   3,
 			RxBytes:                   4,
 			ConnectionMedianLatencyMS: 2,
-			// Should be ignored
-			SessionCountSSH:    3,
-			SessionCountVSCode: 1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 
 		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
@@ -710,6 +734,63 @@ func TestGetProvisionerDaemonsWithStatusByOrganization(t *testing.T) {
 	})
 }
 
+func TestGetTemplateInsightsByTemplate(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	startTime := dbtime.Now().Add(-10 * time.Minute).Truncate(time.Minute)
+	endTime := startTime.Add(2 * time.Minute)
+
+	insertStat := func(offset time.Duration, templateID, userID, workspaceID uuid.UUID, connections int64, counts map[string]int64) {
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			CreatedAt:       startTime.Add(offset),
+			TemplateID:      templateID,
+			UserID:          userID,
+			WorkspaceID:     workspaceID,
+			AgentID:         uuid.New(),
+			ConnectionCount: connections,
+			SessionCounts:   dbgen.SessionCounts(t, counts),
+		})
+	}
+
+	templateID := uuid.New()
+	userID := uuid.New()
+	workspaceID := uuid.New()
+	otherWorkspaceID := uuid.New()
+
+	// Activity is deduplicated by user and minute.
+	insertStat(5*time.Second, templateID, userID, workspaceID, 1, map[string]int64{"ssh": 1, "vscode": 1})
+	insertStat(20*time.Second, templateID, userID, workspaceID, 0, map[string]int64{"jetbrains": 1, "vscode": 1})
+	insertStat(40*time.Second, templateID, userID, otherWorkspaceID, 0, map[string]int64{"reconnecting_pty": 1, "vscode": 1})
+	insertStat(time.Minute+5*time.Second, templateID, userID, otherWorkspaceID, 1, map[string]int64{"ssh": 1, "vscode": 1})
+
+	// Unknown apps do not contribute activity or active users.
+	insertStat(10*time.Second, templateID, uuid.New(), uuid.New(), 1, map[string]int64{"unknown": 1})
+
+	// Unknown activity cannot supply a connection for known activity.
+	noKnownConnectionTemplateID := uuid.New()
+	noKnownConnectionUserID := uuid.New()
+	insertStat(15*time.Second, noKnownConnectionTemplateID, noKnownConnectionUserID, uuid.New(), 0, map[string]int64{"vscode": 1})
+	insertStat(30*time.Second, noKnownConnectionTemplateID, noKnownConnectionUserID, uuid.New(), 1, map[string]int64{"unknown": 1})
+
+	insights, err := db.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{
+		StartTime: startTime,
+		EndTime:   endTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []database.GetTemplateInsightsByTemplateRow{
+		{
+			TemplateID:                  templateID,
+			ActiveUsers:                 1,
+			UsageVscodeSeconds:          120,
+			UsageJetbrainsSeconds:       60,
+			UsageReconnectingPtySeconds: 60,
+			UsageSshSeconds:             120,
+		},
+	}, insights)
+}
+
 func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 	t.Parallel()
 
@@ -742,18 +823,16 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountVSCode: 3,
-			SessionCountSSH:    1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 1}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:          insertTime.Add(-time.Minute),
-			AgentID:            agentID1,
-			WorkspaceID:        workspaceID1,
-			TemplateID:         templateID1,
-			UserID:             userID1,
-			SessionCountVSCode: 1,
-			Usage:              true,
+			CreatedAt:     insertTime.Add(-time.Minute),
+			AgentID:       agentID1,
+			WorkspaceID:   workspaceID1,
+			TemplateID:    templateID1,
+			UserID:        userID1,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 
 		// Latest workspace 1 stats
@@ -766,27 +845,25 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   2,
 			RxBytes:                   2,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountVSCode: 3,
-			SessionCountSSH:    4,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 4}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:          insertTime,
-			AgentID:            agentID1,
-			WorkspaceID:        workspaceID1,
-			TemplateID:         templateID1,
-			UserID:             userID1,
-			SessionCountVSCode: 1,
-			Usage:              true,
+			CreatedAt:     insertTime,
+			AgentID:       agentID1,
+			WorkspaceID:   workspaceID1,
+			TemplateID:    templateID1,
+			UserID:        userID1,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:             insertTime,
-			AgentID:               agentID1,
-			WorkspaceID:           workspaceID1,
-			TemplateID:            templateID1,
-			UserID:                userID1,
-			SessionCountJetBrains: 1,
-			Usage:                 true,
+			CreatedAt:     insertTime,
+			AgentID:       agentID1,
+			WorkspaceID:   workspaceID1,
+			TemplateID:    templateID1,
+			UserID:        userID1,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"jetbrains": 1}),
 		})
 
 		// Latest workspace 2 stats
@@ -809,27 +886,25 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   2,
 			RxBytes:                   3,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountVSCode: 3,
-			SessionCountSSH:    4,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 4}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:       insertTime,
-			AgentID:         agentID2,
-			WorkspaceID:     workspaceID2,
-			TemplateID:      templateID2,
-			UserID:          userID2,
-			SessionCountSSH: 1,
-			Usage:           true,
+			CreatedAt:     insertTime,
+			AgentID:       agentID2,
+			WorkspaceID:   workspaceID2,
+			TemplateID:    templateID2,
+			UserID:        userID2,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:             insertTime,
-			AgentID:               agentID2,
-			WorkspaceID:           workspaceID2,
-			TemplateID:            templateID2,
-			UserID:                userID2,
-			SessionCountJetBrains: 1,
-			Usage:                 true,
+			CreatedAt:     insertTime,
+			AgentID:       agentID2,
+			WorkspaceID:   workspaceID2,
+			TemplateID:    templateID2,
+			UserID:        userID2,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"jetbrains": 1}),
 		})
 
 		reqTime := dbtime.Now().Add(-time.Hour)
@@ -873,9 +948,7 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			TxBytes:                   3,
 			RxBytes:                   4,
 			ConnectionMedianLatencyMS: 2,
-			// Should be ignored
-			SessionCountSSH:    3,
-			SessionCountVSCode: 1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 
 		stats, err := db.GetWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
@@ -1040,18 +1113,16 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			TxBytes:                   1,
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountVSCode: 3,
-			SessionCountSSH:    1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 1}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:          insertTime.Add(-time.Minute),
-			AgentID:            agent1.ID,
-			WorkspaceID:        workspace1.ID,
-			TemplateID:         template1.ID,
-			UserID:             user1.ID,
-			SessionCountVSCode: 1,
-			Usage:              true,
+			CreatedAt:     insertTime.Add(-time.Minute),
+			AgentID:       agent1.ID,
+			WorkspaceID:   workspace1.ID,
+			TemplateID:    template1.ID,
+			UserID:        user1.ID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 
 		// Latest workspace 1 stats
@@ -1064,27 +1135,25 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			TxBytes:                   2,
 			RxBytes:                   2,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountVSCode: 4,
-			SessionCountSSH:    3,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 4, "ssh": 3}), // Should be ignored.
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:             insertTime,
-			AgentID:               agent1.ID,
-			WorkspaceID:           workspace1.ID,
-			TemplateID:            template1.ID,
-			UserID:                user1.ID,
-			SessionCountJetBrains: 1,
-			Usage:                 true,
+			CreatedAt:     insertTime,
+			AgentID:       agent1.ID,
+			WorkspaceID:   workspace1.ID,
+			TemplateID:    template1.ID,
+			UserID:        user1.ID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"jetbrains": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:                   insertTime,
-			AgentID:                     agent1.ID,
-			WorkspaceID:                 workspace1.ID,
-			TemplateID:                  template1.ID,
-			UserID:                      user1.ID,
-			SessionCountReconnectingPTY: 1,
-			Usage:                       true,
+			CreatedAt:     insertTime,
+			AgentID:       agent1.ID,
+			WorkspaceID:   workspace1.ID,
+			TemplateID:    template1.ID,
+			UserID:        user1.ID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"reconnecting_pty": 1}),
 		})
 
 		// Latest workspace 2 stats
@@ -1099,22 +1168,22 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			ConnectionMedianLatencyMS: 1,
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:          insertTime,
-			AgentID:            agent2.ID,
-			WorkspaceID:        workspace2.ID,
-			TemplateID:         template2.ID,
-			UserID:             user2.ID,
-			SessionCountVSCode: 1,
-			Usage:              true,
+			CreatedAt:     insertTime,
+			AgentID:       agent2.ID,
+			WorkspaceID:   workspace2.ID,
+			TemplateID:    template2.ID,
+			UserID:        user2.ID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
-			CreatedAt:       insertTime,
-			AgentID:         agent2.ID,
-			WorkspaceID:     workspace2.ID,
-			TemplateID:      template2.ID,
-			UserID:          user2.ID,
-			SessionCountSSH: 1,
-			Usage:           true,
+			CreatedAt:     insertTime,
+			AgentID:       agent2.ID,
+			WorkspaceID:   workspace2.ID,
+			TemplateID:    template2.ID,
+			UserID:        user2.ID,
+			Usage:         true,
+			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
 		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
@@ -1181,9 +1250,7 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			RxBytes:                   4,
 			TxBytes:                   5,
 			ConnectionMedianLatencyMS: 1,
-			// Should be ignored
-			SessionCountVSCode: 3,
-			SessionCountSSH:    1,
+			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 1}), // Should be ignored.
 		})
 
 		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -16831,25 +16831,17 @@ func (q *sqlQuerier) GetTemplateInsightsByInterval(ctx context.Context, arg GetT
 
 const getTemplateInsightsByTemplate = `-- name: GetTemplateInsightsByTemplate :many
 WITH
-	-- This CTE is used to truncate agent usage into minute buckets, then
-	-- flatten the users agent usage within the template so that usage in
-	-- multiple workspaces under one template is only counted once for
-	-- every minute (per user).
-	insights AS (
+	-- Deduplicate activity by template, user, and minute.
+	minute_activity AS (
 		SELECT
 			template_id,
 			user_id,
-			COUNT(DISTINCT CASE WHEN session_count_ssh > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			-- TODO(mafredri): Enable when we have the column.
-			-- COUNT(DISTINCT CASE WHEN session_count_sftp > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS sftp_mins,
-			COUNT(DISTINCT CASE WHEN session_count_reconnecting_pty > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN session_count_vscode > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN session_count_jetbrains > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
-			-- NOTE(mafredri): The agent stats are currently very unreliable, and
-			-- sometimes the connections are missing, even during active sessions.
-			-- Since we can't fully rely on this, we check for "any connection
-			-- within this bucket". A better solution here would be preferable.
-			MAX(connection_count) > 0 AS has_connection
+			date_trunc('minute', created_at) AS minute,
+			BOOL_OR((session_counts ->> 'ssh')::bigint > 0) AS ssh,
+			BOOL_OR((session_counts ->> 'reconnecting_pty')::bigint > 0) AS reconnecting_pty,
+			BOOL_OR((session_counts ->> 'vscode')::bigint > 0) AS vscode,
+			BOOL_OR((session_counts ->> 'jetbrains')::bigint > 0) AS jetbrains,
+			BOOL_OR(connection_count > 0) AS has_connection
 		FROM
 			workspace_agent_stats
 		WHERE
@@ -16857,13 +16849,29 @@ WITH
 			AND created_at < $2::timestamptz
 			-- Inclusion criteria to filter out empty results.
 			AND (
-				session_count_ssh > 0
-				-- TODO(mafredri): Enable when we have the column.
-				-- OR session_count_sftp > 0
-				OR session_count_reconnecting_pty > 0
-				OR session_count_vscode > 0
-				OR session_count_jetbrains > 0
+				(session_counts ->> 'ssh')::bigint > 0
+				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
+				OR (session_counts ->> 'vscode')::bigint > 0
+				OR (session_counts ->> 'jetbrains')::bigint > 0
 			)
+		GROUP BY
+			template_id, user_id, minute
+	),
+	insights AS (
+		SELECT
+			template_id,
+			user_id,
+			COUNT(*) FILTER (WHERE ssh) AS ssh_mins,
+			COUNT(*) FILTER (WHERE reconnecting_pty) AS reconnecting_pty_mins,
+			COUNT(*) FILTER (WHERE vscode) AS vscode_mins,
+			COUNT(*) FILTER (WHERE jetbrains) AS jetbrains_mins,
+			-- NOTE(mafredri): The agent stats are currently very unreliable, and
+			-- sometimes the connections are missing, even during active sessions.
+			-- Since we can't fully rely on this, we check for "any connection
+			-- within this bucket". A better solution here would be preferable.
+			BOOL_OR(has_connection) AS has_connection
+		FROM
+			minute_activity
 		GROUP BY
 			template_id, user_id
 	)
@@ -17473,27 +17481,11 @@ WITH
 			template_id,
 			user_id,
 			-- Store each unique minute bucket for later merge between datasets.
-			array_agg(
-				DISTINCT CASE
-				WHEN
-					session_count_ssh > 0
-					-- TODO(mafredri): Enable when we have the column.
-					-- OR session_count_sftp > 0
-					OR session_count_reconnecting_pty > 0
-					OR session_count_vscode > 0
-					OR session_count_jetbrains > 0
-				THEN
-					date_trunc('minute', created_at)
-				ELSE
-					NULL
-				END
-			) AS minute_buckets,
-			COUNT(DISTINCT CASE WHEN session_count_ssh > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			-- TODO(mafredri): Enable when we have the column.
-			-- COUNT(DISTINCT CASE WHEN session_count_sftp > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS sftp_mins,
-			COUNT(DISTINCT CASE WHEN session_count_reconnecting_pty > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN session_count_vscode > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN session_count_jetbrains > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
+			array_agg(DISTINCT date_trunc('minute', created_at)) AS minute_buckets,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'ssh')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'reconnecting_pty')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'vscode')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'jetbrains')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
 			-- NOTE(mafredri): The agent stats are currently very unreliable, and
 			-- sometimes the connections are missing, even during active sessions.
 			-- Since we can't fully rely on this, we check for "any connection
@@ -17508,12 +17500,10 @@ WITH
 			AND created_at < NOW()
 			-- Inclusion criteria to filter out empty results.
 			AND (
-				session_count_ssh > 0
-				-- TODO(mafredri): Enable when we have the column.
-				-- OR session_count_sftp > 0
-				OR session_count_reconnecting_pty > 0
-				OR session_count_vscode > 0
-				OR session_count_jetbrains > 0
+				(session_counts ->> 'ssh')::bigint > 0
+				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
+				OR (session_counts ->> 'vscode')::bigint > 0
+				OR (session_counts ->> 'jetbrains')::bigint > 0
 			)
 		GROUP BY
 			time_bucket, template_id, user_id
@@ -35953,30 +35943,27 @@ func (q *sqlQuerier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {
 
 const getDeploymentWorkspaceAgentStats = `-- name: GetDeploymentWorkspaceAgentStats :one
 WITH stats AS (
-    SELECT
-        agent_id,
-        created_at,
-        rx_bytes,
-        tx_bytes,
-        connection_median_latency_ms,
-        session_count_vscode,
-        session_count_ssh,
-        session_count_jetbrains,
-        session_count_reconnecting_pty,
-        ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at DESC) AS rn
-    FROM workspace_agent_stats
-    WHERE created_at > $1
+	SELECT
+		agent_id,
+		created_at,
+		rx_bytes,
+		tx_bytes,
+		connection_median_latency_ms,
+		session_counts,
+		ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+	FROM workspace_agent_stats
+	WHERE created_at > $1
 )
 SELECT
-    coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
-    coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
+	coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
+	coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
-    coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
-    coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-    coalesce(SUM(session_count_vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-    coalesce(SUM(session_count_ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-    coalesce(SUM(session_count_jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-    coalesce(SUM(session_count_reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
+	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
+	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
+	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
+	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
 `
 
@@ -36018,46 +36005,36 @@ WITH agent_stats AS (
 	 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 ),
-minute_buckets AS (
+latest_minutes AS (
 	SELECT
 		agent_id,
-		date_trunc('minute', created_at) AS minute_bucket,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
+		MAX(date_trunc('minute', created_at)) AS minute_bucket
 	FROM
 		workspace_agent_stats
 	WHERE
 		created_at >= $1
-		AND created_at < date_trunc('minute', now())  -- Exclude current partial minute
-		AND usage = true
+		-- Exclude the current partial minute.
+		AND created_at < date_trunc('minute', now())
+		AND usage
 	GROUP BY
-		agent_id,
-		minute_bucket
-),
-latest_buckets AS (
-	SELECT DISTINCT ON (agent_id)
-		agent_id,
-		minute_bucket,
-		session_count_vscode,
-		session_count_jetbrains,
-		session_count_reconnecting_pty,
-		session_count_ssh
-	FROM
-		minute_buckets
-	ORDER BY
-		agent_id,
-		minute_bucket DESC
+		agent_id
 ),
 latest_agent_stats AS (
-    SELECT
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-    FROM
-        latest_buckets
+	SELECT
+		coalesce(SUM((stats.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((stats.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((stats.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((stats.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+	FROM
+		latest_minutes
+	JOIN
+		workspace_agent_stats AS stats
+	ON
+		stats.agent_id = latest_minutes.agent_id
+		AND stats.created_at >= $1
+		AND stats.created_at >= latest_minutes.minute_bucket
+		AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
+		AND stats.usage
 )
 SELECT workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats, latest_agent_stats
 `
@@ -36108,14 +36085,16 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, usage, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
-	) AS a WHERE a.rn = 1 GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
+	) AS a
+	WHERE a.rn = 1
+	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
 SELECT user_id, agent_stats.agent_id, workspace_id, template_id, aggregated_from, workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, latest_agent_stats.agent_id, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id
 `
@@ -36189,14 +36168,14 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
-		coalesce(SUM(connection_count), 0)::bigint AS connection_count,
-		coalesce(MAX(connection_median_latency_ms), 0)::float AS connection_median_latency_ms
+		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
+		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, usage, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
@@ -36278,72 +36257,38 @@ func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, create
 }
 
 const getWorkspaceAgentUsageStats = `-- name: GetWorkspaceAgentUsageStats :many
-WITH agent_stats AS (
+WITH stats AS (
 	SELECT
-		user_id,
-		agent_id,
-		workspace_id,
-		template_id,
-		MIN(created_at)::timestamptz AS aggregated_from,
-		coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
-		coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
-		coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_50,
-		coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_95
+		id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts,
+		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
+		created_at > $1 AND connection_median_latency_ms > 0 AS reports_latency,
+		usage AND date_trunc('minute', created_at) = MAX(date_trunc('minute', created_at)) FILTER (
+			-- Exclude the current partial minute.
+			WHERE usage AND created_at < date_trunc('minute', now())
+		) OVER (PARTITION BY agent_id) AS in_latest_usage_minute
 	FROM workspace_agent_stats
-	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
-	WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
-	GROUP BY user_id, agent_id, workspace_id, template_id
-),
-minute_buckets AS (
-	SELECT
-		agent_id,
-		date_trunc('minute', created_at) AS minute_bucket,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-	FROM
-		workspace_agent_stats
-	WHERE
-		created_at >= $1
-		AND created_at < date_trunc('minute', now())  -- Exclude current partial minute
-		AND usage = true
-	GROUP BY
-		agent_id,
-		minute_bucket,
-		user_id,
-		agent_id,
-		workspace_id,
-		template_id
-),
-latest_buckets AS (
-	SELECT DISTINCT ON (agent_id)
-		agent_id,
-		session_count_vscode,
-		session_count_ssh,
-		session_count_jetbrains,
-		session_count_reconnecting_pty
-	FROM
-		minute_buckets
-	ORDER BY
-		agent_id,
-		minute_bucket DESC
+	WHERE created_at >= $1
 )
-SELECT user_id,
-agent_stats.agent_id,
-workspace_id,
-template_id,
-aggregated_from,
-workspace_rx_bytes,
-workspace_tx_bytes,
-workspace_connection_latency_50,
-workspace_connection_latency_95,
-coalesce(latest_buckets.agent_id,agent_stats.agent_id) AS agent_id,
-coalesce(session_count_vscode, 0)::bigint AS session_count_vscode,
-coalesce(session_count_ssh, 0)::bigint AS session_count_ssh,
-coalesce(session_count_jetbrains, 0)::bigint AS session_count_jetbrains,
-coalesce(session_count_reconnecting_pty, 0)::bigint AS session_count_reconnecting_pty
-FROM agent_stats LEFT JOIN latest_buckets ON agent_stats.agent_id = latest_buckets.agent_id
+SELECT
+	user_id,
+	agent_id,
+	workspace_id,
+	template_id,
+	MIN(created_at) FILTER (WHERE reports_latency)::timestamptz AS aggregated_from,
+	coalesce(SUM(rx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_rx_bytes,
+	coalesce(SUM(tx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_tx_bytes,
+	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_50,
+	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_95,
+	-- Repeated so this row keeps the same layout as GetWorkspaceAgentStats, which
+	-- telemetry converts between.
+	agent_id,
+	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
+	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
+	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
+FROM stats
+GROUP BY user_id, agent_id, workspace_id, template_id
+HAVING BOOL_OR(reports_latency)
 `
 
 type GetWorkspaceAgentUsageStatsRow struct {
@@ -36363,7 +36308,6 @@ type GetWorkspaceAgentUsageStatsRow struct {
 	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-// `minute_buckets` could return 0 rows if there are no usage stats since `created_at`.
 func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error) {
 	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats, createdAt)
 	if err != nil {
@@ -36418,15 +36362,15 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		agent_id,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM((session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count
 	FROM workspace_agent_stats
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
-	WHERE usage = true AND created_at > now() - '1 minute'::interval
+	WHERE usage AND created_at > now() - '1 minute'::interval
 	GROUP BY user_id, agent_id, workspace_id
 )
 SELECT
@@ -36521,10 +36465,7 @@ INSERT INTO
 		rx_bytes,
 		tx_packets,
 		tx_bytes,
-		session_count_vscode,
-		session_count_jetbrains,
-		session_count_reconnecting_pty,
-		session_count_ssh,
+		session_counts,
 		connection_median_latency_ms,
 		usage
 	)
@@ -36541,33 +36482,27 @@ SELECT
 	unnest($10 :: bigint[]) AS rx_bytes,
 	unnest($11 :: bigint[]) AS tx_packets,
 	unnest($12 :: bigint[]) AS tx_bytes,
-	unnest($13 :: bigint[]) AS session_count_vscode,
-	unnest($14 :: bigint[]) AS session_count_jetbrains,
-	unnest($15 :: bigint[]) AS session_count_reconnecting_pty,
-	unnest($16 :: bigint[]) AS session_count_ssh,
-	unnest($17 :: double precision[]) AS connection_median_latency_ms,
-	unnest($18 :: boolean[]) AS usage
+	jsonb_array_elements($13 :: jsonb) AS session_counts,
+	unnest($14 :: double precision[]) AS connection_median_latency_ms,
+	unnest($15 :: boolean[]) AS usage
 `
 
 type InsertWorkspaceAgentStatsParams struct {
-	ID                          []uuid.UUID     `db:"id" json:"id"`
-	CreatedAt                   []time.Time     `db:"created_at" json:"created_at"`
-	UserID                      []uuid.UUID     `db:"user_id" json:"user_id"`
-	WorkspaceID                 []uuid.UUID     `db:"workspace_id" json:"workspace_id"`
-	TemplateID                  []uuid.UUID     `db:"template_id" json:"template_id"`
-	AgentID                     []uuid.UUID     `db:"agent_id" json:"agent_id"`
-	ConnectionsByProto          json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
-	ConnectionCount             []int64         `db:"connection_count" json:"connection_count"`
-	RxPackets                   []int64         `db:"rx_packets" json:"rx_packets"`
-	RxBytes                     []int64         `db:"rx_bytes" json:"rx_bytes"`
-	TxPackets                   []int64         `db:"tx_packets" json:"tx_packets"`
-	TxBytes                     []int64         `db:"tx_bytes" json:"tx_bytes"`
-	SessionCountVSCode          []int64         `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountJetBrains       []int64         `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY []int64         `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	SessionCountSSH             []int64         `db:"session_count_ssh" json:"session_count_ssh"`
-	ConnectionMedianLatencyMS   []float64       `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
-	Usage                       []bool          `db:"usage" json:"usage"`
+	ID                        []uuid.UUID     `db:"id" json:"id"`
+	CreatedAt                 []time.Time     `db:"created_at" json:"created_at"`
+	UserID                    []uuid.UUID     `db:"user_id" json:"user_id"`
+	WorkspaceID               []uuid.UUID     `db:"workspace_id" json:"workspace_id"`
+	TemplateID                []uuid.UUID     `db:"template_id" json:"template_id"`
+	AgentID                   []uuid.UUID     `db:"agent_id" json:"agent_id"`
+	ConnectionsByProto        json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount           []int64         `db:"connection_count" json:"connection_count"`
+	RxPackets                 []int64         `db:"rx_packets" json:"rx_packets"`
+	RxBytes                   []int64         `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets                 []int64         `db:"tx_packets" json:"tx_packets"`
+	TxBytes                   []int64         `db:"tx_bytes" json:"tx_bytes"`
+	SessionCounts             json.RawMessage `db:"session_counts" json:"session_counts"`
+	ConnectionMedianLatencyMS []float64       `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
+	Usage                     []bool          `db:"usage" json:"usage"`
 }
 
 func (q *sqlQuerier) InsertWorkspaceAgentStats(ctx context.Context, arg InsertWorkspaceAgentStatsParams) error {
@@ -36584,10 +36519,7 @@ func (q *sqlQuerier) InsertWorkspaceAgentStats(ctx context.Context, arg InsertWo
 		pq.Array(arg.RxBytes),
 		pq.Array(arg.TxPackets),
 		pq.Array(arg.TxBytes),
-		pq.Array(arg.SessionCountVSCode),
-		pq.Array(arg.SessionCountJetBrains),
-		pq.Array(arg.SessionCountReconnectingPTY),
-		pq.Array(arg.SessionCountSSH),
+		arg.SessionCounts,
 		pq.Array(arg.ConnectionMedianLatencyMS),
 		pq.Array(arg.Usage),
 	)

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -148,25 +148,17 @@ FROM
 -- GetTemplateInsightsByTemplate is used for Prometheus metrics. Keep
 -- in sync with GetTemplateInsights and UpsertTemplateUsageStats.
 WITH
-	-- This CTE is used to truncate agent usage into minute buckets, then
-	-- flatten the users agent usage within the template so that usage in
-	-- multiple workspaces under one template is only counted once for
-	-- every minute (per user).
-	insights AS (
+	-- Deduplicate activity by template, user, and minute.
+	minute_activity AS (
 		SELECT
 			template_id,
 			user_id,
-			COUNT(DISTINCT CASE WHEN session_count_ssh > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			-- TODO(mafredri): Enable when we have the column.
-			-- COUNT(DISTINCT CASE WHEN session_count_sftp > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS sftp_mins,
-			COUNT(DISTINCT CASE WHEN session_count_reconnecting_pty > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN session_count_vscode > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN session_count_jetbrains > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
-			-- NOTE(mafredri): The agent stats are currently very unreliable, and
-			-- sometimes the connections are missing, even during active sessions.
-			-- Since we can't fully rely on this, we check for "any connection
-			-- within this bucket". A better solution here would be preferable.
-			MAX(connection_count) > 0 AS has_connection
+			date_trunc('minute', created_at) AS minute,
+			BOOL_OR((session_counts ->> 'ssh')::bigint > 0) AS ssh,
+			BOOL_OR((session_counts ->> 'reconnecting_pty')::bigint > 0) AS reconnecting_pty,
+			BOOL_OR((session_counts ->> 'vscode')::bigint > 0) AS vscode,
+			BOOL_OR((session_counts ->> 'jetbrains')::bigint > 0) AS jetbrains,
+			BOOL_OR(connection_count > 0) AS has_connection
 		FROM
 			workspace_agent_stats
 		WHERE
@@ -174,13 +166,29 @@ WITH
 			AND created_at < @end_time::timestamptz
 			-- Inclusion criteria to filter out empty results.
 			AND (
-				session_count_ssh > 0
-				-- TODO(mafredri): Enable when we have the column.
-				-- OR session_count_sftp > 0
-				OR session_count_reconnecting_pty > 0
-				OR session_count_vscode > 0
-				OR session_count_jetbrains > 0
+				(session_counts ->> 'ssh')::bigint > 0
+				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
+				OR (session_counts ->> 'vscode')::bigint > 0
+				OR (session_counts ->> 'jetbrains')::bigint > 0
 			)
+		GROUP BY
+			template_id, user_id, minute
+	),
+	insights AS (
+		SELECT
+			template_id,
+			user_id,
+			COUNT(*) FILTER (WHERE ssh) AS ssh_mins,
+			COUNT(*) FILTER (WHERE reconnecting_pty) AS reconnecting_pty_mins,
+			COUNT(*) FILTER (WHERE vscode) AS vscode_mins,
+			COUNT(*) FILTER (WHERE jetbrains) AS jetbrains_mins,
+			-- NOTE(mafredri): The agent stats are currently very unreliable, and
+			-- sometimes the connections are missing, even during active sessions.
+			-- Since we can't fully rely on this, we check for "any connection
+			-- within this bucket". A better solution here would be preferable.
+			BOOL_OR(has_connection) AS has_connection
+		FROM
+			minute_activity
 		GROUP BY
 			template_id, user_id
 	)
@@ -559,27 +567,11 @@ WITH
 			template_id,
 			user_id,
 			-- Store each unique minute bucket for later merge between datasets.
-			array_agg(
-				DISTINCT CASE
-				WHEN
-					session_count_ssh > 0
-					-- TODO(mafredri): Enable when we have the column.
-					-- OR session_count_sftp > 0
-					OR session_count_reconnecting_pty > 0
-					OR session_count_vscode > 0
-					OR session_count_jetbrains > 0
-				THEN
-					date_trunc('minute', created_at)
-				ELSE
-					NULL
-				END
-			) AS minute_buckets,
-			COUNT(DISTINCT CASE WHEN session_count_ssh > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			-- TODO(mafredri): Enable when we have the column.
-			-- COUNT(DISTINCT CASE WHEN session_count_sftp > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS sftp_mins,
-			COUNT(DISTINCT CASE WHEN session_count_reconnecting_pty > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN session_count_vscode > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN session_count_jetbrains > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
+			array_agg(DISTINCT date_trunc('minute', created_at)) AS minute_buckets,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'ssh')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'reconnecting_pty')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'vscode')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
+			COUNT(DISTINCT CASE WHEN (session_counts ->> 'jetbrains')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
 			-- NOTE(mafredri): The agent stats are currently very unreliable, and
 			-- sometimes the connections are missing, even during active sessions.
 			-- Since we can't fully rely on this, we check for "any connection
@@ -594,12 +586,10 @@ WITH
 			AND created_at < NOW()
 			-- Inclusion criteria to filter out empty results.
 			AND (
-				session_count_ssh > 0
-				-- TODO(mafredri): Enable when we have the column.
-				-- OR session_count_sftp > 0
-				OR session_count_reconnecting_pty > 0
-				OR session_count_vscode > 0
-				OR session_count_jetbrains > 0
+				(session_counts ->> 'ssh')::bigint > 0
+				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
+				OR (session_counts ->> 'vscode')::bigint > 0
+				OR (session_counts ->> 'jetbrains')::bigint > 0
 			)
 		GROUP BY
 			time_bucket, template_id, user_id

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -13,10 +13,7 @@ INSERT INTO
 		rx_bytes,
 		tx_packets,
 		tx_bytes,
-		session_count_vscode,
-		session_count_jetbrains,
-		session_count_reconnecting_pty,
-		session_count_ssh,
+		session_counts,
 		connection_median_latency_ms,
 		usage
 	)
@@ -33,10 +30,7 @@ SELECT
 	unnest(@rx_bytes :: bigint[]) AS rx_bytes,
 	unnest(@tx_packets :: bigint[]) AS tx_packets,
 	unnest(@tx_bytes :: bigint[]) AS tx_bytes,
-	unnest(@session_count_vscode :: bigint[]) AS session_count_vscode,
-	unnest(@session_count_jetbrains :: bigint[]) AS session_count_jetbrains,
-	unnest(@session_count_reconnecting_pty :: bigint[]) AS session_count_reconnecting_pty,
-	unnest(@session_count_ssh :: bigint[]) AS session_count_ssh,
+	jsonb_array_elements(@session_counts :: jsonb) AS session_counts,
 	unnest(@connection_median_latency_ms :: double precision[]) AS connection_median_latency_ms,
 	unnest(@usage :: boolean[]) AS usage;
 
@@ -73,30 +67,27 @@ WHERE
 
 -- name: GetDeploymentWorkspaceAgentStats :one
 WITH stats AS (
-    SELECT
-        agent_id,
-        created_at,
-        rx_bytes,
-        tx_bytes,
-        connection_median_latency_ms,
-        session_count_vscode,
-        session_count_ssh,
-        session_count_jetbrains,
-        session_count_reconnecting_pty,
-        ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at DESC) AS rn
-    FROM workspace_agent_stats
-    WHERE created_at > $1
+	SELECT
+		agent_id,
+		created_at,
+		rx_bytes,
+		tx_bytes,
+		connection_median_latency_ms,
+		session_counts,
+		ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+	FROM workspace_agent_stats
+	WHERE created_at > $1
 )
 SELECT
-    coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
-    coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
+	coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
+	coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
-    coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
-    coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-    coalesce(SUM(session_count_vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-    coalesce(SUM(session_count_ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-    coalesce(SUM(session_count_jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-    coalesce(SUM(session_count_reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
+	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
+	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
+	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
+	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
 FROM stats;
 
 -- name: GetDeploymentWorkspaceAgentUsageStats :one
@@ -110,46 +101,36 @@ WITH agent_stats AS (
 	 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 ),
-minute_buckets AS (
+latest_minutes AS (
 	SELECT
 		agent_id,
-		date_trunc('minute', created_at) AS minute_bucket,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
+		MAX(date_trunc('minute', created_at)) AS minute_bucket
 	FROM
 		workspace_agent_stats
 	WHERE
 		created_at >= $1
-		AND created_at < date_trunc('minute', now())  -- Exclude current partial minute
-		AND usage = true
+		-- Exclude the current partial minute.
+		AND created_at < date_trunc('minute', now())
+		AND usage
 	GROUP BY
-		agent_id,
-		minute_bucket
-),
-latest_buckets AS (
-	SELECT DISTINCT ON (agent_id)
-		agent_id,
-		minute_bucket,
-		session_count_vscode,
-		session_count_jetbrains,
-		session_count_reconnecting_pty,
-		session_count_ssh
-	FROM
-		minute_buckets
-	ORDER BY
-		agent_id,
-		minute_bucket DESC
+		agent_id
 ),
 latest_agent_stats AS (
-    SELECT
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-    FROM
-        latest_buckets
+	SELECT
+		coalesce(SUM((stats.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((stats.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((stats.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((stats.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+	FROM
+		latest_minutes
+	JOIN
+		workspace_agent_stats AS stats
+	ON
+		stats.agent_id = latest_minutes.agent_id
+		AND stats.created_at >= $1
+		AND stats.created_at >= latest_minutes.minute_bucket
+		AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
+		AND stats.usage
 )
 SELECT * FROM agent_stats, latest_agent_stats;
 
@@ -172,85 +153,52 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
 		SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
-	) AS a WHERE a.rn = 1 GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
+	) AS a
+	WHERE a.rn = 1
+	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
 SELECT * FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id;
 
 -- name: GetWorkspaceAgentUsageStats :many
-WITH agent_stats AS (
+WITH stats AS (
 	SELECT
-		user_id,
-		agent_id,
-		workspace_id,
-		template_id,
-		MIN(created_at)::timestamptz AS aggregated_from,
-		coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
-		coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
-		coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_50,
-		coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_95
+		*,
+		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
+		created_at > $1 AND connection_median_latency_ms > 0 AS reports_latency,
+		usage AND date_trunc('minute', created_at) = MAX(date_trunc('minute', created_at)) FILTER (
+			-- Exclude the current partial minute.
+			WHERE usage AND created_at < date_trunc('minute', now())
+		) OVER (PARTITION BY agent_id) AS in_latest_usage_minute
 	FROM workspace_agent_stats
-	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
-	WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
-	GROUP BY user_id, agent_id, workspace_id, template_id
-),
-minute_buckets AS (
-	SELECT
-		agent_id,
-		date_trunc('minute', created_at) AS minute_bucket,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
-	FROM
-		workspace_agent_stats
-	WHERE
-		created_at >= $1
-		AND created_at < date_trunc('minute', now())  -- Exclude current partial minute
-		AND usage = true
-	GROUP BY
-		agent_id,
-		minute_bucket,
-		user_id,
-		agent_id,
-		workspace_id,
-		template_id
-),
-latest_buckets AS (
-	SELECT DISTINCT ON (agent_id)
-		agent_id,
-		session_count_vscode,
-		session_count_ssh,
-		session_count_jetbrains,
-		session_count_reconnecting_pty
-	FROM
-		minute_buckets
-	ORDER BY
-		agent_id,
-		minute_bucket DESC
+	WHERE created_at >= $1
 )
-SELECT user_id,
-agent_stats.agent_id,
-workspace_id,
-template_id,
-aggregated_from,
-workspace_rx_bytes,
-workspace_tx_bytes,
-workspace_connection_latency_50,
-workspace_connection_latency_95,
--- `minute_buckets` could return 0 rows if there are no usage stats since `created_at`.
-coalesce(latest_buckets.agent_id,agent_stats.agent_id) AS agent_id,
-coalesce(session_count_vscode, 0)::bigint AS session_count_vscode,
-coalesce(session_count_ssh, 0)::bigint AS session_count_ssh,
-coalesce(session_count_jetbrains, 0)::bigint AS session_count_jetbrains,
-coalesce(session_count_reconnecting_pty, 0)::bigint AS session_count_reconnecting_pty
-FROM agent_stats LEFT JOIN latest_buckets ON agent_stats.agent_id = latest_buckets.agent_id;
+SELECT
+	user_id,
+	agent_id,
+	workspace_id,
+	template_id,
+	MIN(created_at) FILTER (WHERE reports_latency)::timestamptz AS aggregated_from,
+	coalesce(SUM(rx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_rx_bytes,
+	coalesce(SUM(tx_bytes) FILTER (WHERE reports_latency), 0)::bigint AS workspace_tx_bytes,
+	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_50,
+	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE reports_latency)), -1)::FLOAT AS workspace_connection_latency_95,
+	-- Repeated so this row keeps the same layout as GetWorkspaceAgentStats, which
+	-- telemetry converts between.
+	agent_id,
+	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
+	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
+	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
+FROM stats
+GROUP BY user_id, agent_id, workspace_id, template_id
+HAVING BOOL_OR(reports_latency);
 
 -- name: GetWorkspaceAgentStatsAndLabels :many
 WITH agent_stats AS (
@@ -266,12 +214,12 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
-		coalesce(SUM(connection_count), 0)::bigint AS connection_count,
-		coalesce(MAX(connection_median_latency_ms), 0)::float AS connection_median_latency_ms
+		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
+		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
 		SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats
@@ -320,15 +268,15 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		agent_id,
-		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,
-		coalesce(SUM(session_count_ssh), 0)::bigint AS session_count_ssh,
-		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM((session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
+		coalesce(SUM((session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
+		coalesce(SUM((session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count
 	FROM workspace_agent_stats
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
-	WHERE usage = true AND created_at > now() - '1 minute'::interval
+	WHERE usage AND created_at > now() - '1 minute'::interval
 	GROUP BY user_id, agent_id, workspace_id
 )
 SELECT

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -3,7 +3,6 @@ package metricscache_test
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -308,28 +307,14 @@ func TestCache_DeploymentStats(t *testing.T) {
 		DeploymentStats: time.Minute,
 	}, false)
 
-	err := db.InsertWorkspaceAgentStats(context.Background(), database.InsertWorkspaceAgentStatsParams{
-		ID:                 []uuid.UUID{uuid.New()},
-		CreatedAt:          []time.Time{clock.Now()},
-		WorkspaceID:        []uuid.UUID{uuid.New()},
-		UserID:             []uuid.UUID{uuid.New()},
-		TemplateID:         []uuid.UUID{uuid.New()},
-		AgentID:            []uuid.UUID{uuid.New()},
-		ConnectionsByProto: json.RawMessage(`[{}]`),
-
-		RxPackets:                   []int64{0},
-		RxBytes:                     []int64{1},
-		TxPackets:                   []int64{0},
-		TxBytes:                     []int64{1},
-		ConnectionCount:             []int64{1},
-		SessionCountVSCode:          []int64{1},
-		SessionCountJetBrains:       []int64{0},
-		SessionCountReconnectingPTY: []int64{0},
-		SessionCountSSH:             []int64{0},
-		ConnectionMedianLatencyMS:   []float64{10},
-		Usage:                       []bool{false},
+	dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+		CreatedAt:                 clock.Now(),
+		RxBytes:                   1,
+		TxBytes:                   1,
+		ConnectionCount:           1,
+		ConnectionMedianLatencyMS: 10,
+		SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 	})
-	require.NoError(t, err)
 
 	// Wait for both ticker functions to be created (template build times and deployment stats)
 	tickerTrap.MustWait(ctx).MustRelease(ctx)

--- a/coderd/workspacestats/batcher.go
+++ b/coderd/workspacestats/batcher.go
@@ -37,9 +37,9 @@ type DBBatcher struct {
 	mu sync.Mutex
 	// TODO: make this a buffered chan instead?
 	buf *database.InsertWorkspaceAgentStatsParams
-	// NOTE: we batch this separately as it's a jsonb field and
-	// pq.Array + unnest doesn't play nicely with this.
+	// These objects are marshaled into positional arrays on flush.
 	connectionsByProto []map[string]int64
+	sessionCounts      []map[string]int64
 	batchSize          int
 
 	// tickCh is used to periodically flush the buffer.
@@ -140,6 +140,17 @@ func (b *DBBatcher) Add(
 	st *agentproto.Stats,
 	usage bool,
 ) {
+	// Normalize and cap outside the lock.
+	sessionCounts := normalizedSessionCounts(st)
+	if len(sessionCounts) > maxSessionCountEntries {
+		b.log.Warn(context.Background(), "too many distinct session types, overflow counted under unknown",
+			slog.F("agent_id", agentID),
+			slog.F("reported", len(sessionCounts)),
+			slog.F("max", maxSessionCountEntries),
+		)
+	}
+	sessionCounts = capSessionCounts(sessionCounts)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -152,19 +163,14 @@ func (b *DBBatcher) Add(
 	b.buf.TemplateID = append(b.buf.TemplateID, templateID)
 	b.buf.WorkspaceID = append(b.buf.WorkspaceID, workspaceID)
 
-	// Store the connections by proto separately as it's a jsonb field. We marshal on flush.
-	// b.buf.ConnectionsByProto = append(b.buf.ConnectionsByProto, st.ConnectionsByProto)
 	b.connectionsByProto = append(b.connectionsByProto, st.ConnectionsByProto)
+	b.sessionCounts = append(b.sessionCounts, sessionCounts)
 
 	b.buf.ConnectionCount = append(b.buf.ConnectionCount, st.ConnectionCount)
 	b.buf.RxPackets = append(b.buf.RxPackets, st.RxPackets)
 	b.buf.RxBytes = append(b.buf.RxBytes, st.RxBytes)
 	b.buf.TxPackets = append(b.buf.TxPackets, st.TxPackets)
 	b.buf.TxBytes = append(b.buf.TxBytes, st.TxBytes)
-	b.buf.SessionCountVSCode = append(b.buf.SessionCountVSCode, st.SessionCountVscode)
-	b.buf.SessionCountJetBrains = append(b.buf.SessionCountJetBrains, st.SessionCountJetbrains)
-	b.buf.SessionCountReconnectingPTY = append(b.buf.SessionCountReconnectingPTY, st.SessionCountReconnectingPty)
-	b.buf.SessionCountSSH = append(b.buf.SessionCountSSH, st.SessionCountSsh)
 	b.buf.ConnectionMedianLatencyMS = append(b.buf.ConnectionMedianLatencyMS, st.ConnectionMedianLatencyMs)
 	b.buf.Usage = append(b.buf.Usage, usage)
 
@@ -245,6 +251,14 @@ func (b *DBBatcher) flush(ctx context.Context, forced bool, reason string) {
 		b.buf.ConnectionsByProto = payload
 	}
 
+	sessionCountsPayload, err := json.Marshal(b.sessionCounts)
+	if err != nil {
+		b.log.Error(ctx, "unable to marshal agent session counts, dropping data", slog.Error(err))
+		b.buf.SessionCounts = json.RawMessage(`[]`)
+	} else {
+		b.buf.SessionCounts = sessionCountsPayload
+	}
+
 	// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 	err = b.store.InsertWorkspaceAgentStats(ctx, *b.buf)
 	elapsed := time.Since(start)
@@ -263,27 +277,25 @@ func (b *DBBatcher) flush(ctx context.Context, forced bool, reason string) {
 // initBuf resets the buffer. b MUST be locked.
 func (b *DBBatcher) initBuf(size int) {
 	b.buf = &database.InsertWorkspaceAgentStatsParams{
-		ID:                          make([]uuid.UUID, 0, b.batchSize),
-		CreatedAt:                   make([]time.Time, 0, b.batchSize),
-		UserID:                      make([]uuid.UUID, 0, b.batchSize),
-		WorkspaceID:                 make([]uuid.UUID, 0, b.batchSize),
-		TemplateID:                  make([]uuid.UUID, 0, b.batchSize),
-		AgentID:                     make([]uuid.UUID, 0, b.batchSize),
-		ConnectionsByProto:          json.RawMessage("[]"),
-		ConnectionCount:             make([]int64, 0, b.batchSize),
-		RxPackets:                   make([]int64, 0, b.batchSize),
-		RxBytes:                     make([]int64, 0, b.batchSize),
-		TxPackets:                   make([]int64, 0, b.batchSize),
-		TxBytes:                     make([]int64, 0, b.batchSize),
-		SessionCountVSCode:          make([]int64, 0, b.batchSize),
-		SessionCountJetBrains:       make([]int64, 0, b.batchSize),
-		SessionCountReconnectingPTY: make([]int64, 0, b.batchSize),
-		SessionCountSSH:             make([]int64, 0, b.batchSize),
-		ConnectionMedianLatencyMS:   make([]float64, 0, b.batchSize),
-		Usage:                       make([]bool, 0, b.batchSize),
+		ID:                        make([]uuid.UUID, 0, b.batchSize),
+		CreatedAt:                 make([]time.Time, 0, b.batchSize),
+		UserID:                    make([]uuid.UUID, 0, b.batchSize),
+		WorkspaceID:               make([]uuid.UUID, 0, b.batchSize),
+		TemplateID:                make([]uuid.UUID, 0, b.batchSize),
+		AgentID:                   make([]uuid.UUID, 0, b.batchSize),
+		ConnectionsByProto:        json.RawMessage("[]"),
+		ConnectionCount:           make([]int64, 0, b.batchSize),
+		RxPackets:                 make([]int64, 0, b.batchSize),
+		RxBytes:                   make([]int64, 0, b.batchSize),
+		TxPackets:                 make([]int64, 0, b.batchSize),
+		TxBytes:                   make([]int64, 0, b.batchSize),
+		SessionCounts:             json.RawMessage("[]"),
+		ConnectionMedianLatencyMS: make([]float64, 0, b.batchSize),
+		Usage:                     make([]bool, 0, b.batchSize),
 	}
 
 	b.connectionsByProto = make([]map[string]int64, 0, size)
+	b.sessionCounts = make([]map[string]int64, 0, size)
 }
 
 func (b *DBBatcher) resetBuf() {
@@ -299,11 +311,9 @@ func (b *DBBatcher) resetBuf() {
 	b.buf.RxBytes = b.buf.RxBytes[:0]
 	b.buf.TxPackets = b.buf.TxPackets[:0]
 	b.buf.TxBytes = b.buf.TxBytes[:0]
-	b.buf.SessionCountVSCode = b.buf.SessionCountVSCode[:0]
-	b.buf.SessionCountJetBrains = b.buf.SessionCountJetBrains[:0]
-	b.buf.SessionCountReconnectingPTY = b.buf.SessionCountReconnectingPTY[:0]
-	b.buf.SessionCountSSH = b.buf.SessionCountSSH[:0]
+	b.buf.SessionCounts = json.RawMessage(`[]`)
 	b.buf.ConnectionMedianLatencyMS = b.buf.ConnectionMedianLatencyMS[:0]
 	b.buf.Usage = b.buf.Usage[:0]
 	b.connectionsByProto = b.connectionsByProto[:0]
+	b.sessionCounts = b.sessionCounts[:0]
 }

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
@@ -59,22 +60,38 @@ func TestBatchStats(t *testing.T) {
 	require.NoError(t, err, "should not error getting stats")
 	require.Empty(t, stats, "should have no stats for workspace")
 
-	// Given: a single data point is added for workspace
+	// Given: a stat per workspace, with session counts distinct per agent so
+	// that a positional misalignment on insert shows up.
 	t2 := t1.Add(time.Second)
-	t.Log("inserting 1 stat")
-	b.Add(t2.Add(time.Millisecond), deps1.Agent.ID, deps1.User.ID, deps1.Template.ID, deps1.Workspace.ID, randStats(t), false)
+	t.Log("inserting 2 stats")
+	b.Add(t2.Add(time.Millisecond), deps1.Agent.ID, deps1.Template.ID, deps1.User.ID, deps1.Workspace.ID, randStats(t, func(s *agentproto.Stats) {
+		s.SessionCounts = map[string]int64{"VSCode": 3, "ssh": 1, "idle-ide": 0}
+	}), false)
+	b.Add(t2.Add(time.Millisecond), deps2.Agent.ID, deps2.Template.ID, deps2.User.ID, deps2.Workspace.ID, randStats(t, func(s *agentproto.Stats) {
+		s.SessionCounts = map[string]int64{"jetbrains": 4, "reconnecting-pty": 2}
+	}), false)
 
 	// When: it becomes time to report stats
 	// Signal a tick and wait for a flush to complete.
 	tick <- t2
 	f = <-flushed // Wait for a flush to complete.
-	require.Equal(t, 1, f, "expected one stat to be flushed")
+	require.Equal(t, 2, f, "expected two stats to be flushed")
 	t.Log("flush 2 completed")
 
-	// Then: it should report a single stat.
+	// Then: counts reach the right agent, normalized, without the zero entry.
 	stats, err = store.GetWorkspaceAgentStats(ctx, t2)
 	require.NoError(t, err, "should not error getting stats")
-	require.Len(t, stats, 1, "should have stats for workspace")
+	require.Len(t, stats, 2, "should have stats for both workspaces")
+	byAgent := make(map[uuid.UUID]database.GetWorkspaceAgentStatsRow)
+	for _, stat := range stats {
+		byAgent[stat.AgentID] = stat
+	}
+	require.EqualValues(t, 3, byAgent[deps1.Agent.ID].SessionCountVSCode)
+	require.EqualValues(t, 1, byAgent[deps1.Agent.ID].SessionCountSSH)
+	require.EqualValues(t, 0, byAgent[deps1.Agent.ID].SessionCountJetBrains)
+	require.EqualValues(t, 4, byAgent[deps2.Agent.ID].SessionCountJetBrains)
+	require.EqualValues(t, 2, byAgent[deps2.Agent.ID].SessionCountReconnectingPTY)
+	require.EqualValues(t, 0, byAgent[deps2.Agent.ID].SessionCountVSCode)
 
 	// Given: a lot of data points are added for both workspaces
 	// (equal to batch size)
@@ -86,9 +103,9 @@ func TestBatchStats(t *testing.T) {
 		t.Logf("inserting %d stats", defaultBufferSize)
 		for i := 0; i < defaultBufferSize; i++ {
 			if i%2 == 0 {
-				b.Add(t3.Add(time.Millisecond), deps1.Agent.ID, deps1.User.ID, deps1.Template.ID, deps1.Workspace.ID, randStats(t), false)
+				b.Add(t3.Add(time.Millisecond), deps1.Agent.ID, deps1.Template.ID, deps1.User.ID, deps1.Workspace.ID, randStats(t), false)
 			} else {
-				b.Add(t3.Add(time.Millisecond), deps2.Agent.ID, deps2.User.ID, deps2.Template.ID, deps2.Workspace.ID, randStats(t), false)
+				b.Add(t3.Add(time.Millisecond), deps2.Agent.ID, deps2.Template.ID, deps2.User.ID, deps2.Workspace.ID, randStats(t), false)
 			}
 		}
 	}()


### PR DESCRIPTION
Replaces the four `session_count_*` columns on `workspace_agent_stats` with a sparse `session_counts` JSONB object, so counting a new app needs no schema change.

- Only positive counts are stored, so an idle agent writes `{}` instead of four zeroes, and the template insights covering index drops four bigints from its `INCLUDE` list.
- The batcher normalizes and caps outside its lock, still ingests the deprecated fields from 2.10 agents, and marshals one object per row.
- Every reader and rollup moves to JSONB. Output column names and API shapes are unchanged.
- Resolves the `session_count_sftp` TODOs: a new session type is now a new key.

### Migration

Converts the window `DeleteOldWorkspaceAgentStats` retains, `MAX(template_usage_stats.start_time)` minus one day. Anything older is already rolled up. When nothing has ever rolled up there is no watermark to fall back on, so every row converts instead of letting old activity roll up as zero minutes later.

A backlog the rollup never consumed spanning more than 24 hours usually means the rollup is failing or blocked. The migration proceeds anyway and emits a warning naming the span, with a hint to check coderd logs and `pg_locks` after the upgrade:

> WARNING: migration 000590 found 30 days of workspace agent stats that template usage stats never rolled up

Measured on 10M rows: a healthy rollup converts ~330k rows in 11s on PG13 in Docker (4.44s on PG17 with tmpfs, 6.13s on durable storage). A rollup 30 days behind, or a deployment that never rolled up, converts all 10M rows in about 3.5 minutes, roughly 21 seconds per million backlogged rows.

### Trade-offs

- **The conversion is unbounded and holds `ACCESS EXCLUSIVE`**, so agent stat writes block for its duration; `DROP COLUMN` and the index rebuild need the lock regardless. A deployment whose rollup has failed for months converts its whole backlog at ~21s per million rows. The alternative, aborting until the rollup is fixed, blocked the upgrade with no way to trigger a rollup on demand.
- **jsonb parsing on a hot read path.** `UpsertTemplateUsageStats` extracts keys per row, every five minutes over the retained window, where it compared four integers. Neither form was indexed; the cost buys schema-free new apps.
- **Three queries change plan shape**, not just their column expressions, so a regression is harder to attribute. Family grouping in #28337 needs one pass per row, and doing it here avoids rewriting the same blocks twice.
- **One PR.** The migration drops the columns, so splitting it leaves either old code on the new schema or new queries on a missing column.
- **Rollback discards unknown keys.** The down migration restores the four known fields only; nothing else has a column to land in.

Depends on #28125. Phase 3 of #27410.

