### PR TITLE
feat: report arbitrary workspace agent session types

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -128,23 +128,14 @@ type Options struct {
 }
 
 type Client interface {
-	ConnectRPC29(ctx context.Context) (
-		proto.DRPCAgentClient29, tailnetproto.DRPCTailnetClient28, error,
+	ConnectRPC211(ctx context.Context) (
+		proto.DRPCAgentClient211, tailnetproto.DRPCTailnetClient28, error,
 	)
-	// ConnectRPC29WithRole is like ConnectRPC29 but sends an explicit
+	// ConnectRPC211WithRole is like ConnectRPC211 but sends an explicit
 	// role query parameter to the server. The workspace agent should
 	// use role "agent" to enable connection monitoring.
-	ConnectRPC29WithRole(ctx context.Context, role string) (
-		proto.DRPCAgentClient29, tailnetproto.DRPCTailnetClient28, error,
-	)
-	ConnectRPC210(ctx context.Context) (
-		proto.DRPCAgentClient210, tailnetproto.DRPCTailnetClient28, error,
-	)
-	// ConnectRPC210WithRole is like ConnectRPC210 but sends an explicit
-	// role query parameter to the server. The workspace agent should
-	// use role "agent" to enable connection monitoring.
-	ConnectRPC210WithRole(ctx context.Context, role string) (
-		proto.DRPCAgentClient210, tailnetproto.DRPCTailnetClient28, error,
+	ConnectRPC211WithRole(ctx context.Context, role string) (
+		proto.DRPCAgentClient211, tailnetproto.DRPCTailnetClient28, error,
 	)
 	tailnet.DERPMapRewriter
 	agentsdk.RefreshableSessionTokenProvider
@@ -1176,7 +1167,7 @@ func (a *agent) run() (retErr error) {
 	// ConnectRPC returns the dRPC connection we use for the Agent and Tailnet v2+ APIs.
 	// We pass role "agent" to enable connection monitoring on the server, which tracks
 	// the agent's connectivity state (first_connected_at, last_connected_at, disconnected_at).
-	aAPI, tAPI, err := a.client.ConnectRPC210WithRole(a.hardCtx, "agent")
+	aAPI, tAPI, err := a.client.ConnectRPC211WithRole(a.hardCtx, "agent")
 	if err != nil {
 		return err
 	}
@@ -2162,13 +2153,12 @@ func (a *agent) Collect(ctx context.Context, networkStats map[netlogtype.Connect
 		stats.TxPackets += int64(counts.TxPackets)
 	}
 
-	// The count of active sessions; types without a protocol field are dropped.
-	sessionCounts := a.sshServer.SessionCounts()
-	stats.SessionCountSsh = sessionCounts[idemetadata.AppNameSSH]
-	stats.SessionCountVscode = sessionCounts[idemetadata.AppNameVSCode]
-	stats.SessionCountJetbrains = sessionCounts[idemetadata.AppNameJetBrains]
-
-	stats.SessionCountReconnectingPty = a.reconnectingPTYServer.ConnCount()
+	// Active sessions per app; the deprecated fields stay zero. A client can
+	// label an ssh session "reconnecting_pty", so add rather than overwrite.
+	stats.SessionCounts = a.sshServer.SessionCounts()
+	if count := a.reconnectingPTYServer.ConnCount(); count > 0 {
+		stats.SessionCounts[idemetadata.AppNameReconnectingPTY] += count
+	}
 
 	// Compute the median connection latency!
 	a.logger.Debug(ctx, "starting peer latency measurement for stats")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -229,7 +229,7 @@ func assertSSHStats(t *testing.T, stats <-chan *proto.Stats) {
 			return false
 		}
 		t.Logf("got stats: ConnectionCount=%d, RxBytes=%d, TxBytes=%d, SessionCountSsh=%d",
-			s.ConnectionCount, s.RxBytes, s.TxBytes, s.SessionCountSsh)
+			s.ConnectionCount, s.RxBytes, s.TxBytes, s.SessionCounts["ssh"])
 		if s.ConnectionCount > 0 {
 			connectionCountSeen = true
 		}
@@ -239,7 +239,7 @@ func assertSSHStats(t *testing.T, stats <-chan *proto.Stats) {
 		if s.TxBytes > 0 {
 			txBytesSeen = true
 		}
-		if s.SessionCountSsh == 1 {
+		if s.SessionCounts["ssh"] == 1 {
 			sessionCountSSHSeen = true
 		}
 		return connectionCountSeen && rxBytesSeen && txBytesSeen && sessionCountSSHSeen
@@ -287,7 +287,7 @@ func TestAgent_Stats_ReconnectingPTY(t *testing.T) {
 		if s.TxBytes > 0 {
 			txBytesSeen = true
 		}
-		if s.SessionCountReconnectingPty == 1 {
+		if s.SessionCounts["reconnecting_pty"] == 1 {
 			sessionCountReconnectingPTYSeen = true
 		}
 		return connectionCountSeen && rxBytesSeen && txBytesSeen && sessionCountReconnectingPTYSeen
@@ -346,12 +346,12 @@ func TestAgent_Stats_Magic(t *testing.T) {
 		require.NoError(t, err)
 		require.Eventuallyf(t, func() bool {
 			s, ok := <-stats
-			t.Logf("got stats: ok=%t, ConnectionCount=%d, RxBytes=%d, TxBytes=%d, SessionCountVSCode=%d, ConnectionMedianLatencyMS=%f",
-				ok, s.ConnectionCount, s.RxBytes, s.TxBytes, s.SessionCountVscode, s.ConnectionMedianLatencyMs)
+			t.Logf("got stats: ok=%t, ConnectionCount=%d, RxBytes=%d, TxBytes=%d, SessionCounts[vscode]=%d, ConnectionMedianLatencyMS=%f",
+				ok, s.ConnectionCount, s.RxBytes, s.TxBytes, s.SessionCounts["vscode"], s.ConnectionMedianLatencyMs)
 			return ok &&
 				// Ensure that the connection didn't count as a "normal" SSH session.
 				// This was a special one, so it should be labeled specially in the stats!
-				s.SessionCountVscode == 1 &&
+				s.SessionCounts["vscode"] == 1 &&
 				// Ensure that connection latency is being counted!
 				// If it isn't, it's set to -1.
 				s.ConnectionMedianLatencyMs >= 0
@@ -417,8 +417,8 @@ func TestAgent_Stats_Magic(t *testing.T) {
 		require.Eventuallyf(t, func() bool {
 			s, ok := <-stats
 			t.Logf("got stats with conn open: ok=%t, ConnectionCount=%d, SessionCountJetBrains=%d",
-				ok, s.ConnectionCount, s.SessionCountJetbrains)
-			return ok && s.SessionCountJetbrains == 1
+				ok, s.ConnectionCount, s.SessionCounts["jetbrains"])
+			return ok && s.SessionCounts["jetbrains"] == 1
 		}, testutil.WaitLong, testutil.IntervalFast,
 			"never saw stats with conn open",
 		)
@@ -431,9 +431,9 @@ func TestAgent_Stats_Magic(t *testing.T) {
 		require.Eventuallyf(t, func() bool {
 			s, ok := <-stats
 			t.Logf("got stats after disconnect %t, %d",
-				ok, s.SessionCountJetbrains)
+				ok, s.SessionCounts["jetbrains"])
 			return ok &&
-				s.SessionCountJetbrains == 0
+				s.SessionCounts["jetbrains"] == 0
 		}, testutil.WaitLong, testutil.IntervalFast,
 			"never saw stats after conn closes",
 		)

--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -152,6 +152,7 @@ func (c *Client) Close() {
 	c.derpMapOnce.Do(func() { close(c.derpMapUpdates) })
 }
 
+// Required by the agentfake scaletest dialer.
 func (c *Client) ConnectRPC29WithRole(ctx context.Context, _ string) (
 	agentproto.DRPCAgentClient29, proto.DRPCTailnetClient28, error,
 ) {
@@ -176,10 +177,17 @@ func (c *Client) ConnectRPC210(ctx context.Context) (
 	return client, tAPI, nil
 }
 
-func (c *Client) ConnectRPC210WithRole(ctx context.Context, _ string) (
-	agentproto.DRPCAgentClient210, proto.DRPCTailnetClient28, error,
+// v2.11 adds no RPCs, so the v2.10 client satisfies it as-is.
+func (c *Client) ConnectRPC211(ctx context.Context) (
+	agentproto.DRPCAgentClient211, proto.DRPCTailnetClient28, error,
 ) {
 	return c.ConnectRPC210(ctx)
+}
+
+func (c *Client) ConnectRPC211WithRole(ctx context.Context, _ string) (
+	agentproto.DRPCAgentClient211, proto.DRPCTailnetClient28, error,
+) {
+	return c.ConnectRPC211(ctx)
 }
 
 func (c *Client) ConnectRPC29(ctx context.Context) (

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -1532,17 +1532,12 @@ func getUsageAppName(usageApp string) codersdk.UsageAppName {
 	if usageApp == disableUsageApp {
 		return ""
 	}
-
-	allowedUsageApps := []string{
-		string(codersdk.UsageAppNameSSH),
-		string(codersdk.UsageAppNameVscode),
-		string(codersdk.UsageAppNameJetbrains),
-	}
-	if slices.Contains(allowedUsageApps, usageApp) {
-		return codersdk.UsageAppName(usageApp)
+	if usageApp == "" {
+		return codersdk.UsageAppNameSSH
 	}
 
-	return codersdk.UsageAppNameSSH
+	// The server accepts arbitrary app names.
+	return codersdk.UsageAppName(usageApp)
 }
 
 func setStatsCallback(

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1630,51 +1630,51 @@ func TestSSH(t *testing.T) {
 		t.Parallel()
 
 		type testCase struct {
-			name                   string
-			experiment             bool
-			usageAppName           string
-			expectedCalls          int
-			expectedCountSSH       int
-			expectedCountJetbrains int
-			expectedCountVscode    int
+			name           string
+			experiment     bool
+			usageAppName   string
+			expectedCalls  int
+			expectedCounts map[string]int64
 		}
 		tcs := []testCase{
 			{
 				name: "NoExperiment",
 			},
 			{
-				name:             "Empty",
-				experiment:       true,
-				expectedCalls:    1,
-				expectedCountSSH: 1,
+				name:           "Empty",
+				experiment:     true,
+				expectedCalls:  1,
+				expectedCounts: map[string]int64{"ssh": 1},
 			},
 			{
-				name:             "SSH",
-				experiment:       true,
-				usageAppName:     "ssh",
-				expectedCalls:    1,
-				expectedCountSSH: 1,
+				name:           "SSH",
+				experiment:     true,
+				usageAppName:   "ssh",
+				expectedCalls:  1,
+				expectedCounts: map[string]int64{"ssh": 1},
 			},
 			{
-				name:                   "Jetbrains",
-				experiment:             true,
-				usageAppName:           "jetbrains",
-				expectedCalls:          1,
-				expectedCountJetbrains: 1,
+				name:           "Jetbrains",
+				experiment:     true,
+				usageAppName:   "jetbrains",
+				expectedCalls:  1,
+				expectedCounts: map[string]int64{"jetbrains": 1},
 			},
 			{
-				name:                "Vscode",
-				experiment:          true,
-				usageAppName:        "vscode",
-				expectedCalls:       1,
-				expectedCountVscode: 1,
+				name:           "Vscode",
+				experiment:     true,
+				usageAppName:   "vscode",
+				expectedCalls:  1,
+				expectedCounts: map[string]int64{"vscode": 1},
 			},
 			{
-				name:             "InvalidDefaultsToSSH",
-				experiment:       true,
-				usageAppName:     "invalid",
-				expectedCalls:    1,
-				expectedCountSSH: 1,
+				// Arbitrary app names pass through raw (normalized at
+				// ingestion), so new IDEs need no CLI changes.
+				name:           "ArbitraryNamePassthrough",
+				experiment:     true,
+				usageAppName:   "SomeFutureIDE",
+				expectedCalls:  1,
+				expectedCounts: map[string]int64{"SomeFutureIDE": 1},
 			},
 			{
 				name:         "Disable",
@@ -1730,9 +1730,11 @@ func TestSSH(t *testing.T) {
 				<-cmdDone
 
 				require.EqualValues(t, tc.expectedCalls, batcher.Called)
-				require.EqualValues(t, tc.expectedCountSSH, batcher.LastStats.SessionCountSsh)
-				require.EqualValues(t, tc.expectedCountJetbrains, batcher.LastStats.SessionCountJetbrains)
-				require.EqualValues(t, tc.expectedCountVscode, batcher.LastStats.SessionCountVscode)
+				if len(tc.expectedCounts) == 0 {
+					require.Empty(t, batcher.LastStats.GetSessionCounts())
+				} else {
+					require.EqualValues(t, tc.expectedCounts, batcher.LastStats.GetSessionCounts())
+				}
 			})
 		}
 	})

--- a/cli/vscodessh_test.go
+++ b/cli/vscodessh_test.go
@@ -87,5 +87,5 @@ func TestVSCodeSSH(t *testing.T) {
 	}
 
 	require.EqualValues(t, 1, batcher.Called)
-	require.EqualValues(t, 1, batcher.LastStats.SessionCountVscode)
+	require.EqualValues(t, 1, batcher.LastStats.GetSessionCounts()["vscode"])
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3787,11 +3787,11 @@ func (q *querier) GetDeploymentID(ctx context.Context) (string, error) {
 	return q.db.GetDeploymentID(ctx)
 }
 
-func (q *querier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAfter time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (q *querier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAfter database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	return q.db.GetDeploymentWorkspaceAgentStats(ctx, createdAfter)
 }
 
-func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	return q.db.GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt)
 }
 
@@ -5486,19 +5486,19 @@ func (q *querier) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []
 	return q.db.GetWorkspaceAgentScriptsByAgentIDs(ctx, ids)
 }
 
-func (q *querier) GetWorkspaceAgentStats(ctx context.Context, createdAfter time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (q *querier) GetWorkspaceAgentStats(ctx context.Context, createdAfter database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
 	return q.db.GetWorkspaceAgentStats(ctx, createdAfter)
 }
 
-func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAfter time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAfter database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	return q.db.GetWorkspaceAgentStatsAndLabels(ctx, createdAfter)
 }
 
-func (q *querier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (q *querier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	return q.db.GetWorkspaceAgentUsageStats(ctx, createdAt)
 }
 
-func (q *querier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (q *querier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	return q.db.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt)
 }
 
@@ -9186,11 +9186,11 @@ func (q *querier) UpsertTelemetryItem(ctx context.Context, arg database.UpsertTe
 	return q.db.UpsertTelemetryItem(ctx, arg)
 }
 
-func (q *querier) UpsertTemplateUsageStats(ctx context.Context) error {
+func (q *querier) UpsertTemplateUsageStats(ctx context.Context, arg database.UpsertTemplateUsageStatsParams) error {
 	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
-	return q.db.UpsertTemplateUsageStats(ctx)
+	return q.db.UpsertTemplateUsageStats(ctx, arg)
 }
 
 func (q *querier) UpsertUserAIBudgetOverride(ctx context.Context, arg database.UpsertUserAIBudgetOverrideParams) (database.UserAIBudgetOverride, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -2837,7 +2838,7 @@ func (s *MethodTestSuite) TestTemplate() {
 		check.Args(arg).Asserts(rbac.ResourceTemplate, policy.ActionViewInsights).Returns([]database.TemplateUsageStat{})
 	}))
 	s.Run("UpsertTemplateUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		dbm.EXPECT().UpsertTemplateUsageStats(gomock.Any()).Return(nil).AnyTimes()
+		dbm.EXPECT().UpsertTemplateUsageStats(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		check.Asserts(rbac.ResourceSystem, policy.ActionUpdate)
 	}))
 	s.Run("UpdatePresetsLastInvalidatedAt", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
@@ -5323,12 +5324,24 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 	}))
 	s.Run("GetDeploymentWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().GetDeploymentWorkspaceAgentStats(gomock.Any(), t).Return(database.GetDeploymentWorkspaceAgentStatsRow{}, nil).AnyTimes()
+		dbm.EXPECT().GetDeploymentWorkspaceAgentStats(gomock.Any(), database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:           t,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		}).Return(database.GetDeploymentWorkspaceAgentStatsRow{}, nil).AnyTimes()
 		check.Args(t).Asserts()
 	}))
 	s.Run("GetDeploymentWorkspaceAgentUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().GetDeploymentWorkspaceAgentUsageStats(gomock.Any(), t).Return(database.GetDeploymentWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
+		dbm.EXPECT().GetDeploymentWorkspaceAgentUsageStats(gomock.Any(), database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:           t,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		}).Return(database.GetDeploymentWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
 		check.Args(t).Asserts()
 	}))
 	s.Run("GetDeploymentWorkspaceStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
@@ -5358,22 +5371,46 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 	}))
 	s.Run("GetWorkspaceAgentStatsAndLabels", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentStatsAndLabels(gomock.Any(), t).Return([]database.GetWorkspaceAgentStatsAndLabelsRow{}, nil).AnyTimes()
+		dbm.EXPECT().GetWorkspaceAgentStatsAndLabels(gomock.Any(), database.GetWorkspaceAgentStatsAndLabelsParams{
+			CreatedAt:           t,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		}).Return([]database.GetWorkspaceAgentStatsAndLabelsRow{}, nil).AnyTimes()
 		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentUsageStatsAndLabels", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentUsageStatsAndLabels(gomock.Any(), t).Return([]database.GetWorkspaceAgentUsageStatsAndLabelsRow{}, nil).AnyTimes()
+		dbm.EXPECT().GetWorkspaceAgentUsageStatsAndLabels(gomock.Any(), database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+			CreatedAt:           t,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		}).Return([]database.GetWorkspaceAgentUsageStatsAndLabelsRow{}, nil).AnyTimes()
 		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentStats(gomock.Any(), t).Return([]database.GetWorkspaceAgentStatsRow{}, nil).AnyTimes()
+		dbm.EXPECT().GetWorkspaceAgentStats(gomock.Any(), database.GetWorkspaceAgentStatsParams{
+			CreatedAt:           t,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		}).Return([]database.GetWorkspaceAgentStatsRow{}, nil).AnyTimes()
 		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentUsageStats(gomock.Any(), t).Return([]database.GetWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
+		dbm.EXPECT().GetWorkspaceAgentUsageStats(gomock.Any(), database.GetWorkspaceAgentUsageStatsParams{
+			CreatedAt:           t,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		}).Return([]database.GetWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
 		check.Args(t).Asserts()
 	}))
 	s.Run("GetWorkspaceProxyByHostname", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1977,7 +1977,7 @@ func (m queryMetricsStore) GetDeploymentID(ctx context.Context) (string, error) 
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetDeploymentWorkspaceAgentStats(ctx, createdAt)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceAgentStats").Observe(time.Since(start).Seconds())
@@ -1985,7 +1985,7 @@ func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context,
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (m queryMetricsStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceAgentUsageStats").Observe(time.Since(start).Seconds())
@@ -3585,7 +3585,7 @@ func (m queryMetricsStore) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Contex
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, createdAt database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentStats(ctx, createdAt)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentStats").Observe(time.Since(start).Seconds())
@@ -3593,7 +3593,7 @@ func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, createdAt
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentStatsAndLabels(ctx, createdAt)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentStatsAndLabels").Observe(time.Since(start).Seconds())
@@ -3601,7 +3601,7 @@ func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, 
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentUsageStats(ctx, createdAt)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentUsageStats").Observe(time.Since(start).Seconds())
@@ -3609,7 +3609,7 @@ func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, crea
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentUsageStatsAndLabels").Observe(time.Since(start).Seconds())
@@ -6569,9 +6569,9 @@ func (m queryMetricsStore) UpsertTelemetryItem(ctx context.Context, arg database
 	return r0
 }
 
-func (m queryMetricsStore) UpsertTemplateUsageStats(ctx context.Context) error {
+func (m queryMetricsStore) UpsertTemplateUsageStats(ctx context.Context, arg database.UpsertTemplateUsageStatsParams) error {
 	start := time.Now()
-	r0 := m.s.UpsertTemplateUsageStats(ctx)
+	r0 := m.s.UpsertTemplateUsageStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("UpsertTemplateUsageStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertTemplateUsageStats").Inc()
 	return r0

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3690,33 +3690,33 @@ func (mr *MockStoreMockRecorder) GetDeploymentID(ctx any) *gomock.Call {
 }
 
 // GetDeploymentWorkspaceAgentStats mocks base method.
-func (m *MockStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (m *MockStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentStats", ctx, arg)
 	ret0, _ := ret[0].(database.GetDeploymentWorkspaceAgentStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeploymentWorkspaceAgentStats indicates an expected call of GetDeploymentWorkspaceAgentStats.
-func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentStats), ctx, arg)
 }
 
 // GetDeploymentWorkspaceAgentUsageStats mocks base method.
-func (m *MockStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (m *MockStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentUsageStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentUsageStats", ctx, arg)
 	ret0, _ := ret[0].(database.GetDeploymentWorkspaceAgentUsageStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeploymentWorkspaceAgentUsageStats indicates an expected call of GetDeploymentWorkspaceAgentUsageStats.
-func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentUsageStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentUsageStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentUsageStats), ctx, arg)
 }
 
 // GetDeploymentWorkspaceStats mocks base method.
@@ -6735,63 +6735,63 @@ func (mr *MockStoreMockRecorder) GetWorkspaceAgentScriptsByAgentIDs(ctx, ids any
 }
 
 // GetWorkspaceAgentStats mocks base method.
-func (m *MockStore) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (m *MockStore) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentStats", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentStats indicates an expected call of GetWorkspaceAgentStats.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStats), ctx, arg)
 }
 
 // GetWorkspaceAgentStatsAndLabels mocks base method.
-func (m *MockStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (m *MockStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentStatsAndLabels", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentStatsAndLabels", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentStatsAndLabelsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentStatsAndLabels indicates an expected call of GetWorkspaceAgentStatsAndLabels.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentStatsAndLabels(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentStatsAndLabels(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStatsAndLabels), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStatsAndLabels), ctx, arg)
 }
 
 // GetWorkspaceAgentUsageStats mocks base method.
-func (m *MockStore) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (m *MockStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStats", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentUsageStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentUsageStats indicates an expected call of GetWorkspaceAgentUsageStats.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStats), ctx, arg)
 }
 
 // GetWorkspaceAgentUsageStatsAndLabels mocks base method.
-func (m *MockStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (m *MockStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStatsAndLabels", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStatsAndLabels", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentUsageStatsAndLabelsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentUsageStatsAndLabels indicates an expected call of GetWorkspaceAgentUsageStatsAndLabels.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStatsAndLabels(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStatsAndLabels), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStatsAndLabels), ctx, arg)
 }
 
 // GetWorkspaceAgentsByInstanceID mocks base method.
@@ -12329,17 +12329,17 @@ func (mr *MockStoreMockRecorder) UpsertTelemetryItem(ctx, arg any) *gomock.Call 
 }
 
 // UpsertTemplateUsageStats mocks base method.
-func (m *MockStore) UpsertTemplateUsageStats(ctx context.Context) error {
+func (m *MockStore) UpsertTemplateUsageStats(ctx context.Context, arg database.UpsertTemplateUsageStatsParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertTemplateUsageStats", ctx)
+	ret := m.ctrl.Call(m, "UpsertTemplateUsageStats", ctx, arg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertTemplateUsageStats indicates an expected call of UpsertTemplateUsageStats.
-func (mr *MockStoreMockRecorder) UpsertTemplateUsageStats(ctx any) *gomock.Call {
+func (mr *MockStoreMockRecorder) UpsertTemplateUsageStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTemplateUsageStats", reflect.TypeOf((*MockStore)(nil).UpsertTemplateUsageStats), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTemplateUsageStats", reflect.TypeOf((*MockStore)(nil).UpsertTemplateUsageStats), ctx, arg)
 }
 
 // UpsertUserAIBudgetOverride mocks base method.

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionerd/proto"
@@ -355,7 +356,13 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 			buf := &bytes.Buffer{}
 			enc := json.NewEncoder(buf)
 			enc.SetIndent("", "\t")
-			wasRows, err := db.GetWorkspaceAgentStats(ctx, now.AddDate(0, -7, 0))
+			wasRows, err := db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+				CreatedAt:           now.AddDate(0, -7, 0),
+				VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+				SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+				JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+				ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+			})
 			if err == nil {
 				_, _ = fmt.Fprintf(buf, "workspace agent stats: ")
 				_ = enc.Encode(wasRows)
@@ -414,7 +421,13 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	var err error
 	require.Eventuallyf(t, func() bool {
 		// Query all stats created not earlier than ~7 months ago
-		stats, err = db.GetWorkspaceAgentStats(ctx, now.AddDate(0, 0, -210))
+		stats, err = db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+			CreatedAt:           now.AddDate(0, 0, -210),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		if err != nil {
 			return false
 		}
@@ -437,7 +450,13 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	// then
 	require.Eventuallyf(t, func() bool {
 		// Query all stats created not earlier than ~7 months ago
-		stats, err = db.GetWorkspaceAgentStats(ctx, now.AddDate(0, 0, -210))
+		stats, err = db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+			CreatedAt:           now.AddDate(0, 0, -210),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		if err != nil {
 			return false
 		}

--- a/coderd/database/dbrollup/dbrollup.go
+++ b/coderd/database/dbrollup/dbrollup.go
@@ -10,6 +10,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 )
 
 const (
@@ -106,7 +107,12 @@ func (r *Rolluper) start(ctx context.Context) {
 				}
 
 				ev.TemplateUsageStats = true
-				return tx.UpsertTemplateUsageStats(ctx)
+				return tx.UpsertTemplateUsageStats(ctx, database.UpsertTemplateUsageStatsParams{
+					VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+					SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+					JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+					ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+				})
 			}, database.DefaultTXOptions().WithID("db_rollup"))
 		})
 

--- a/coderd/database/dbrollup/dbrollup_test.go
+++ b/coderd/database/dbrollup/dbrollup_test.go
@@ -43,9 +43,9 @@ func (w *wrapUpsertDB) InTx(fn func(database.Store) error, opts *database.TxOpti
 	}, opts)
 }
 
-func (w *wrapUpsertDB) UpsertTemplateUsageStats(ctx context.Context) error {
+func (w *wrapUpsertDB) UpsertTemplateUsageStats(ctx context.Context, arg database.UpsertTemplateUsageStatsParams) error {
 	<-w.resume
-	return w.Store.UpsertTemplateUsageStats(ctx)
+	return w.Store.UpsertTemplateUsageStats(ctx, arg)
 }
 
 func TestRollup_TwoInstancesUseLocking(t *testing.T) {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -550,8 +550,8 @@ type sqlcQuerier interface {
 	GetDefaultOrganization(ctx context.Context) (Organization, error)
 	GetDefaultProxyConfig(ctx context.Context) (GetDefaultProxyConfigRow, error)
 	GetDeploymentID(ctx context.Context) (string, error)
-	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
-	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
+	GetDeploymentWorkspaceAgentStats(ctx context.Context, arg GetDeploymentWorkspaceAgentStatsParams) (GetDeploymentWorkspaceAgentStatsRow, error)
+	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg GetDeploymentWorkspaceAgentUsageStatsParams) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
 	GetDeploymentWorkspaceStats(ctx context.Context) (GetDeploymentWorkspaceStatsRow, error)
 	GetEligibleProvisionerDaemonsByProvisionerJobIDs(ctx context.Context, provisionerJobIds []uuid.UUID) ([]GetEligibleProvisionerDaemonsByProvisionerJobIDsRow, error)
 	// Providers can be disabled independently of their model configs.
@@ -990,10 +990,10 @@ type sqlcQuerier interface {
 	GetWorkspaceAgentPortShare(ctx context.Context, arg GetWorkspaceAgentPortShareParams) (WorkspaceAgentPortShare, error)
 	GetWorkspaceAgentScriptTimingsByBuildID(ctx context.Context, id uuid.UUID) ([]GetWorkspaceAgentScriptTimingsByBuildIDRow, error)
 	GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]GetWorkspaceAgentScriptsByAgentIDsRow, error)
-	GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error)
-	GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
-	GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error)
-	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
+	GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspaceAgentStatsParams) ([]GetWorkspaceAgentStatsRow, error)
+	GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentStatsAndLabelsParams) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
+	GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWorkspaceAgentUsageStatsParams) ([]GetWorkspaceAgentUsageStatsRow, error)
+	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentUsageStatsAndLabelsParams) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
 	GetWorkspaceAgentsByInstanceID(ctx context.Context, authInstanceID string) ([]WorkspaceAgent, error)
 	GetWorkspaceAgentsByParentID(ctx context.Context, parentID uuid.UUID) ([]WorkspaceAgent, error)
 	GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAgent, error)
@@ -1686,7 +1686,7 @@ type sqlcQuerier interface {
 	// into a single table for efficient storage and querying. Half-hour buckets are
 	// used to store the data, and the minutes are summed for each user and template
 	// combination. The result is stored in the template_usage_stats table.
-	UpsertTemplateUsageStats(ctx context.Context) error
+	UpsertTemplateUsageStats(ctx context.Context, arg UpsertTemplateUsageStatsParams) error
 	UpsertUserAIBudgetOverride(ctx context.Context, arg UpsertUserAIBudgetOverrideParams) (UserAIBudgetOverride, error)
 	// UpsertUserAIProviderKey preserves the original id and created_at when the
 	// user/provider pair already exists. On conflict, callers provide id and

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/migrations"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -65,7 +66,13 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 2,
 		}, map[string]int64{"vscode": 1})
-		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:           dbtime.Now().Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
@@ -100,7 +107,13 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			RxBytes:                   1,
 			ConnectionMedianLatencyMS: 2,
 		}, map[string]int64{"vscode": 1})
-		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:           dbtime.Now().Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
@@ -163,7 +176,13 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			Usage:     true,
 		}, map[string]int64{"ssh": 1})
 
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:           dbtime.Now().Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
@@ -198,7 +217,13 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			Usage:     true,
 		}, map[string]int64{"ssh": 1})
 
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, cutoff)
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:           cutoff,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 		require.Zero(t, stats.SessionCountVSCode)
 		require.Equal(t, int64(1), stats.SessionCountSSH)
@@ -223,7 +248,13 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			ConnectionMedianLatencyMS: 2,
 		}, map[string]int64{"ssh": 3, "vscode": 1}) // Should be ignored.
 
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:           dbtime.Now().Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(3), stats.WorkspaceTxBytes)
@@ -886,7 +917,13 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 		}, map[string]int64{"jetbrains": 1})
 
 		reqTime := dbtime.Now().Add(-time.Hour)
-		stats, err := db.GetWorkspaceAgentUsageStats(ctx, reqTime)
+		stats, err := db.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
+			CreatedAt:           reqTime,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		ws1Stats, ws2Stats := stats[0], stats[1]
@@ -928,7 +965,13 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			ConnectionMedianLatencyMS: 2,
 		}, map[string]int64{"ssh": 3, "vscode": 1}) // Should be ignored.
 
-		stats, err := db.GetWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
+		stats, err := db.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
+			CreatedAt:           dbtime.Now().Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Len(t, stats, 1)
@@ -1156,7 +1199,13 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			Usage:       true,
 		}, map[string]int64{"ssh": 1})
 
-		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
+		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+			CreatedAt:           insertTime.Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Len(t, stats, 2)
@@ -1222,7 +1271,13 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			ConnectionMedianLatencyMS: 1,
 		}, map[string]int64{"vscode": 3, "ssh": 1}) // Should be ignored.
 
-		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
+		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+			CreatedAt:           insertTime.Add(-time.Hour),
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		require.NoError(t, err)
 
 		require.Len(t, stats, 1)
@@ -19164,4 +19219,81 @@ func TestGetAIModelPrices(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSessionCountsAttributeByFamily(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	err := migrations.Up(sqlDB)
+	require.NoError(t, err)
+	db := database.New(sqlDB)
+	ctx := context.Background()
+
+	cursorTemplate := uuid.New()
+	zedTemplate := uuid.New()
+	unknownTemplate := uuid.New()
+	for _, tc := range []struct {
+		templateID uuid.UUID
+		counts     map[string]int64
+	}{
+		{cursorTemplate, map[string]int64{"cursor": 2}},
+		{zedTemplate, map[string]int64{idemetadata.AppNameZed: 1}},
+		{unknownTemplate, map[string]int64{"some_new_ide": 5}},
+	} {
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			TemplateID:                tc.templateID,
+			UserID:                    uuid.New(),
+			AgentID:                   uuid.New(),
+			ConnectionCount:           1,
+			ConnectionMedianLatencyMS: 1,
+			Usage:                     true,
+		}, tc.counts)
+	}
+
+	vscodeApps := idemetadata.FamilyAliases(idemetadata.AppNameVSCode)
+	sshApps := idemetadata.FamilyAliases(idemetadata.AppNameSSH)
+	jetbrainsApps := idemetadata.FamilyAliases(idemetadata.AppNameJetBrains)
+	rptyApps := idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY)
+
+	// A VS Code fork counts as VS Code, and Zed counts as SSH.
+	stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+		CreatedAt:           dbtime.Now().Add(-time.Hour),
+		VscodeApps:          vscodeApps,
+		SshApps:             sshApps,
+		JetbrainsApps:       jetbrainsApps,
+		ReconnectingPtyApps: rptyApps,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), stats.SessionCountVSCode)
+	require.Equal(t, int64(1), stats.SessionCountSSH)
+	require.Zero(t, stats.SessionCountJetBrains)
+	require.Zero(t, stats.SessionCountReconnectingPTY)
+
+	insights, err := db.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{
+		StartTime:           dbtime.Now().Add(-time.Hour),
+		EndTime:             dbtime.Now().Add(time.Hour),
+		VscodeApps:          vscodeApps,
+		SshApps:             sshApps,
+		JetbrainsApps:       jetbrainsApps,
+		ReconnectingPtyApps: rptyApps,
+	})
+	require.NoError(t, err)
+
+	byTemplate := make(map[uuid.UUID]database.GetTemplateInsightsByTemplateRow, len(insights))
+	for _, row := range insights {
+		byTemplate[row.TemplateID] = row
+	}
+	require.Equal(t, int64(60), byTemplate[cursorTemplate].UsageVscodeSeconds)
+	require.Equal(t, int64(60), byTemplate[zedTemplate].UsageSshSeconds)
+
+	// An app with no family is still activity, so the user is not counted idle.
+	unknown, ok := byTemplate[unknownTemplate]
+	require.True(t, ok, "a session with no family must still appear as usage")
+	require.Equal(t, int64(1), unknown.ActiveUsers)
+	require.Zero(t, unknown.UsageVscodeSeconds)
+	require.Zero(t, unknown.UsageSshSeconds)
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -16096,17 +16096,17 @@ WITH
 			template_id,
 			user_id,
 			date_trunc('minute', created_at) AS minute,
-			BOOL_OR(session_counts ? 'ssh') AS ssh,
-			BOOL_OR(session_counts ? 'reconnecting_pty') AS reconnecting_pty,
-			BOOL_OR(session_counts ? 'vscode') AS vscode,
-			BOOL_OR(session_counts ? 'jetbrains') AS jetbrains,
+			BOOL_OR(session_counts ?| $1::text[]) AS ssh,
+			BOOL_OR(session_counts ?| $2::text[]) AS reconnecting_pty,
+			BOOL_OR(session_counts ?| $3::text[]) AS vscode,
+			BOOL_OR(session_counts ?| $4::text[]) AS jetbrains,
 			BOOL_OR(connection_count > 0) AS has_connection
 		FROM
 			workspace_agent_stats
 		WHERE
-			created_at >= $1::timestamptz
-			AND created_at < $2::timestamptz
-			AND session_counts ?| ARRAY['ssh', 'reconnecting_pty', 'vscode', 'jetbrains']
+			created_at >= $5::timestamptz
+			AND created_at < $6::timestamptz
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			template_id, user_id, minute
 	),
@@ -16145,8 +16145,12 @@ GROUP BY
 `
 
 type GetTemplateInsightsByTemplateParams struct {
-	StartTime time.Time `db:"start_time" json:"start_time"`
-	EndTime   time.Time `db:"end_time" json:"end_time"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	StartTime           time.Time `db:"start_time" json:"start_time"`
+	EndTime             time.Time `db:"end_time" json:"end_time"`
 }
 
 type GetTemplateInsightsByTemplateRow struct {
@@ -16161,7 +16165,14 @@ type GetTemplateInsightsByTemplateRow struct {
 // GetTemplateInsightsByTemplate is used for Prometheus metrics. Keep
 // in sync with GetTemplateInsights and UpsertTemplateUsageStats.
 func (q *sqlQuerier) GetTemplateInsightsByTemplate(ctx context.Context, arg GetTemplateInsightsByTemplateParams) ([]GetTemplateInsightsByTemplateRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTemplateInsightsByTemplate, arg.StartTime, arg.EndTime)
+	rows, err := q.db.QueryContext(ctx, getTemplateInsightsByTemplate,
+		pq.Array(arg.SshApps),
+		pq.Array(arg.ReconnectingPtyApps),
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.JetbrainsApps),
+		arg.StartTime,
+		arg.EndTime,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -16735,10 +16746,10 @@ WITH
 			user_id,
 			-- Store each unique minute bucket for later merge between datasets.
 			array_agg(DISTINCT date_trunc('minute', created_at)) AS minute_buckets,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'ssh' THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'reconnecting_pty' THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'vscode' THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'jetbrains' THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| $1::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| $2::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| $3::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| $4::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
 			-- NOTE(mafredri): The agent stats are currently very unreliable, and
 			-- sometimes the connections are missing, even during active sessions.
 			-- Since we can't fully rely on this, we check for "any connection
@@ -16751,7 +16762,7 @@ WITH
 			-- AND created_at < @end_time::timestamptz
 			created_at >= (SELECT t FROM latest_start)
 			AND created_at < NOW()
-			AND session_counts ?| ARRAY['ssh', 'reconnecting_pty', 'vscode', 'jetbrains']
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			time_bucket, template_id, user_id
 	),
@@ -16900,12 +16911,24 @@ WHERE
 	(tus.*) IS DISTINCT FROM (EXCLUDED.*)
 `
 
+type UpsertTemplateUsageStatsParams struct {
+	SshApps             []string `db:"ssh_apps" json:"ssh_apps"`
+	ReconnectingPtyApps []string `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+	VscodeApps          []string `db:"vscode_apps" json:"vscode_apps"`
+	JetbrainsApps       []string `db:"jetbrains_apps" json:"jetbrains_apps"`
+}
+
 // This query aggregates the workspace_agent_stats and workspace_app_stats data
 // into a single table for efficient storage and querying. Half-hour buckets are
 // used to store the data, and the minutes are summed for each user and template
 // combination. The result is stored in the template_usage_stats table.
-func (q *sqlQuerier) UpsertTemplateUsageStats(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, upsertTemplateUsageStats)
+func (q *sqlQuerier) UpsertTemplateUsageStats(ctx context.Context, arg UpsertTemplateUsageStatsParams) error {
+	_, err := q.db.ExecContext(ctx, upsertTemplateUsageStats,
+		pq.Array(arg.SshApps),
+		pq.Array(arg.ReconnectingPtyApps),
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.JetbrainsApps),
+	)
 	return err
 }
 
@@ -35158,9 +35181,21 @@ WITH stats AS (
 		rx_bytes,
 		tx_bytes,
 		connection_median_latency_ms,
-		session_counts,
+		family.vscode,
+		family.ssh,
+		family.jetbrains,
+		family.reconnecting_pty,
 		ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 	FROM workspace_agent_stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($2::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($3::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($4::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($5::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(workspace_agent_stats.session_counts) AS entry
+	) AS family ON true
 	WHERE created_at > $1
 )
 SELECT
@@ -35169,12 +35204,20 @@ SELECT
 	-- Positive latency values exclude legacy agents that do not report latency.
 	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
 	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+	coalesce(SUM(vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
+	coalesce(SUM(ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
+	coalesce(SUM(jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM(reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
 `
+
+type GetDeploymentWorkspaceAgentStatsParams struct {
+	CreatedAt           time.Time `db:"created_at" json:"created_at"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+}
 
 type GetDeploymentWorkspaceAgentStatsRow struct {
 	WorkspaceRxBytes             int64   `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
@@ -35187,8 +35230,14 @@ type GetDeploymentWorkspaceAgentStatsRow struct {
 	SessionCountReconnectingPTY  int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentStats, createdAt)
+func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg GetDeploymentWorkspaceAgentStatsParams) (GetDeploymentWorkspaceAgentStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentStats,
+		arg.CreatedAt,
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.SshApps),
+		pq.Array(arg.JetbrainsApps),
+		pq.Array(arg.ReconnectingPtyApps),
+	)
 	var i GetDeploymentWorkspaceAgentStatsRow
 	err := row.Scan(
 		&i.WorkspaceRxBytes,
@@ -35230,14 +35279,23 @@ latest_minutes AS (
 ),
 latest_agent_stats AS (
 	SELECT
-		coalesce(SUM((stats.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((stats.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((stats.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((stats.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	FROM
 		latest_minutes
 	JOIN
 		workspace_agent_stats AS stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($2::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($3::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($4::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($5::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(stats.session_counts) AS entry
+	) AS family ON true
 	ON
 		stats.agent_id = latest_minutes.agent_id
 		AND stats.created_at >= $1
@@ -35247,6 +35305,14 @@ latest_agent_stats AS (
 )
 SELECT workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats, latest_agent_stats
 `
+
+type GetDeploymentWorkspaceAgentUsageStatsParams struct {
+	CreatedAt           time.Time `db:"created_at" json:"created_at"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+}
 
 type GetDeploymentWorkspaceAgentUsageStatsRow struct {
 	WorkspaceRxBytes             int64   `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
@@ -35259,8 +35325,14 @@ type GetDeploymentWorkspaceAgentUsageStatsRow struct {
 	SessionCountReconnectingPTY  int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentUsageStats, createdAt)
+func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg GetDeploymentWorkspaceAgentUsageStatsParams) (GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentUsageStats,
+		arg.CreatedAt,
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.SshApps),
+		pq.Array(arg.JetbrainsApps),
+		pq.Array(arg.ReconnectingPtyApps),
+	)
 	var i GetDeploymentWorkspaceAgentUsageStatsRow
 	err := row.Scan(
 		&i.WorkspaceRxBytes,
@@ -35294,19 +35366,36 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
 		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
 	) AS a
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($2::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($3::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($4::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($5::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(a.session_counts) AS entry
+	) AS family ON true
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
 SELECT user_id, agent_stats.agent_id, workspace_id, template_id, aggregated_from, workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, latest_agent_stats.agent_id, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id
 `
+
+type GetWorkspaceAgentStatsParams struct {
+	CreatedAt           time.Time `db:"created_at" json:"created_at"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+}
 
 type GetWorkspaceAgentStatsRow struct {
 	UserID                       uuid.UUID `db:"user_id" json:"user_id"`
@@ -35325,8 +35414,14 @@ type GetWorkspaceAgentStatsRow struct {
 	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStats, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspaceAgentStatsParams) ([]GetWorkspaceAgentStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStats,
+		arg.CreatedAt,
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.SshApps),
+		pq.Array(arg.JetbrainsApps),
+		pq.Array(arg.ReconnectingPtyApps),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -35377,10 +35472,10 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
@@ -35389,6 +35484,15 @@ WITH agent_stats AS (
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
 	) AS a
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($2::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($3::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($4::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($5::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(a.session_counts) AS entry
+	) AS family ON true
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id
 )
@@ -35416,6 +35520,14 @@ ON
 	workspaces.id = agent_stats.workspace_id
 `
 
+type GetWorkspaceAgentStatsAndLabelsParams struct {
+	CreatedAt           time.Time `db:"created_at" json:"created_at"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+}
+
 type GetWorkspaceAgentStatsAndLabelsRow struct {
 	Username                    string  `db:"username" json:"username"`
 	AgentName                   string  `db:"agent_name" json:"agent_name"`
@@ -35430,8 +35542,14 @@ type GetWorkspaceAgentStatsAndLabelsRow struct {
 	ConnectionMedianLatencyMS   float64 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStatsAndLabels, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentStatsAndLabelsParams) ([]GetWorkspaceAgentStatsAndLabelsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStatsAndLabels,
+		arg.CreatedAt,
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.SshApps),
+		pq.Array(arg.JetbrainsApps),
+		pq.Array(arg.ReconnectingPtyApps),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -35477,11 +35595,23 @@ WITH stats AS (
 		tx_bytes,
 		connection_median_latency_ms,
 		usage,
-		session_counts,
+		family.vscode,
+		family.ssh,
+		family.jetbrains,
+		family.reconnecting_pty,
 		MAX(date_trunc('minute', created_at)) FILTER (
 			WHERE usage AND created_at < date_trunc('minute', now())
 		) OVER (PARTITION BY agent_id) AS latest_usage_minute
 	FROM workspace_agent_stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($2::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($3::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($4::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($5::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(workspace_agent_stats.session_counts) AS entry
+	) AS family ON true
 	WHERE created_at >= $1
 )
 SELECT
@@ -35505,22 +35635,30 @@ SELECT
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
 	)), -1)::FLOAT AS workspace_connection_latency_95,
 	agent_id,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (
+	coalesce(SUM(vscode) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (
+	coalesce(SUM(ssh) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (
+	coalesce(SUM(jetbrains) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (
+	coalesce(SUM(reconnecting_pty) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
 GROUP BY user_id, agent_id, workspace_id, template_id
 HAVING BOOL_OR(created_at > $1 AND connection_median_latency_ms > 0)
 `
+
+type GetWorkspaceAgentUsageStatsParams struct {
+	CreatedAt           time.Time `db:"created_at" json:"created_at"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+}
 
 type GetWorkspaceAgentUsageStatsRow struct {
 	UserID                       uuid.UUID `db:"user_id" json:"user_id"`
@@ -35539,8 +35677,14 @@ type GetWorkspaceAgentUsageStatsRow struct {
 	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWorkspaceAgentUsageStatsParams) ([]GetWorkspaceAgentUsageStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats,
+		arg.CreatedAt,
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.SshApps),
+		pq.Array(arg.JetbrainsApps),
+		pq.Array(arg.ReconnectingPtyApps),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -35593,12 +35737,21 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		agent_id,
-		coalesce(SUM((session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count
 	FROM workspace_agent_stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($2::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($3::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($4::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY($5::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(workspace_agent_stats.session_counts) AS entry
+	) AS family ON true
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
 	WHERE usage AND created_at > now() - '1 minute'::interval
@@ -35632,6 +35785,14 @@ ON
 	workspaces.id = agent_stats.workspace_id
 `
 
+type GetWorkspaceAgentUsageStatsAndLabelsParams struct {
+	CreatedAt           time.Time `db:"created_at" json:"created_at"`
+	VscodeApps          []string  `db:"vscode_apps" json:"vscode_apps"`
+	SshApps             []string  `db:"ssh_apps" json:"ssh_apps"`
+	JetbrainsApps       []string  `db:"jetbrains_apps" json:"jetbrains_apps"`
+	ReconnectingPtyApps []string  `db:"reconnecting_pty_apps" json:"reconnecting_pty_apps"`
+}
+
 type GetWorkspaceAgentUsageStatsAndLabelsRow struct {
 	Username                    string  `db:"username" json:"username"`
 	AgentName                   string  `db:"agent_name" json:"agent_name"`
@@ -35646,8 +35807,14 @@ type GetWorkspaceAgentUsageStatsAndLabelsRow struct {
 	ConnectionMedianLatencyMS   float64 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStatsAndLabels, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentUsageStatsAndLabelsParams) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStatsAndLabels,
+		arg.CreatedAt,
+		pq.Array(arg.VscodeApps),
+		pq.Array(arg.SshApps),
+		pq.Array(arg.JetbrainsApps),
+		pq.Array(arg.ReconnectingPtyApps),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -154,17 +154,17 @@ WITH
 			template_id,
 			user_id,
 			date_trunc('minute', created_at) AS minute,
-			BOOL_OR(session_counts ? 'ssh') AS ssh,
-			BOOL_OR(session_counts ? 'reconnecting_pty') AS reconnecting_pty,
-			BOOL_OR(session_counts ? 'vscode') AS vscode,
-			BOOL_OR(session_counts ? 'jetbrains') AS jetbrains,
+			BOOL_OR(session_counts ?| @ssh_apps::text[]) AS ssh,
+			BOOL_OR(session_counts ?| @reconnecting_pty_apps::text[]) AS reconnecting_pty,
+			BOOL_OR(session_counts ?| @vscode_apps::text[]) AS vscode,
+			BOOL_OR(session_counts ?| @jetbrains_apps::text[]) AS jetbrains,
 			BOOL_OR(connection_count > 0) AS has_connection
 		FROM
 			workspace_agent_stats
 		WHERE
 			created_at >= @start_time::timestamptz
 			AND created_at < @end_time::timestamptz
-			AND session_counts ?| ARRAY['ssh', 'reconnecting_pty', 'vscode', 'jetbrains']
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			template_id, user_id, minute
 	),
@@ -562,10 +562,10 @@ WITH
 			user_id,
 			-- Store each unique minute bucket for later merge between datasets.
 			array_agg(DISTINCT date_trunc('minute', created_at)) AS minute_buckets,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'ssh' THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'reconnecting_pty' THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'vscode' THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN session_counts ? 'jetbrains' THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| @ssh_apps::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| @reconnecting_pty_apps::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| @vscode_apps::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| @jetbrains_apps::text[] THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
 			-- NOTE(mafredri): The agent stats are currently very unreliable, and
 			-- sometimes the connections are missing, even during active sessions.
 			-- Since we can't fully rely on this, we check for "any connection
@@ -578,7 +578,7 @@ WITH
 			-- AND created_at < @end_time::timestamptz
 			created_at >= (SELECT t FROM latest_start)
 			AND created_at < NOW()
-			AND session_counts ?| ARRAY['ssh', 'reconnecting_pty', 'vscode', 'jetbrains']
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			time_bucket, template_id, user_id
 	),

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -73,9 +73,21 @@ WITH stats AS (
 		rx_bytes,
 		tx_bytes,
 		connection_median_latency_ms,
-		session_counts,
+		family.vscode,
+		family.ssh,
+		family.jetbrains,
+		family.reconnecting_pty,
 		ROW_NUMBER() OVER (PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 	FROM workspace_agent_stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@vscode_apps::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@ssh_apps::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@jetbrains_apps::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@reconnecting_pty_apps::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(workspace_agent_stats.session_counts) AS entry
+	) AS family ON true
 	WHERE created_at > $1
 )
 SELECT
@@ -84,10 +96,10 @@ SELECT
 	-- Positive latency values exclude legacy agents that do not report latency.
 	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
 	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+	coalesce(SUM(vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
+	coalesce(SUM(ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
+	coalesce(SUM(jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM(reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
 FROM stats;
 
 -- name: GetDeploymentWorkspaceAgentUsageStats :one
@@ -117,14 +129,23 @@ latest_minutes AS (
 ),
 latest_agent_stats AS (
 	SELECT
-		coalesce(SUM((stats.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((stats.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((stats.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((stats.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	FROM
 		latest_minutes
 	JOIN
 		workspace_agent_stats AS stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@vscode_apps::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@ssh_apps::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@jetbrains_apps::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@reconnecting_pty_apps::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(stats.session_counts) AS entry
+	) AS family ON true
 	ON
 		stats.agent_id = latest_minutes.agent_id
 		AND stats.created_at >= $1
@@ -153,14 +174,23 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
 		SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
 	) AS a
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@vscode_apps::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@ssh_apps::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@jetbrains_apps::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@reconnecting_pty_apps::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(a.session_counts) AS entry
+	) AS family ON true
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
@@ -178,11 +208,23 @@ WITH stats AS (
 		tx_bytes,
 		connection_median_latency_ms,
 		usage,
-		session_counts,
+		family.vscode,
+		family.ssh,
+		family.jetbrains,
+		family.reconnecting_pty,
 		MAX(date_trunc('minute', created_at)) FILTER (
 			WHERE usage AND created_at < date_trunc('minute', now())
 		) OVER (PARTITION BY agent_id) AS latest_usage_minute
 	FROM workspace_agent_stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@vscode_apps::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@ssh_apps::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@jetbrains_apps::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@reconnecting_pty_apps::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(workspace_agent_stats.session_counts) AS entry
+	) AS family ON true
 	WHERE created_at >= $1
 )
 SELECT
@@ -206,16 +248,16 @@ SELECT
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
 	)), -1)::FLOAT AS workspace_connection_latency_95,
 	agent_id,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (
+	coalesce(SUM(vscode) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (
+	coalesce(SUM(ssh) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (
+	coalesce(SUM(jetbrains) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (
+	coalesce(SUM(reconnecting_pty) FILTER (
 		WHERE usage AND date_trunc('minute', created_at) = latest_usage_minute
 	), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
@@ -236,10 +278,10 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
@@ -248,6 +290,15 @@ WITH agent_stats AS (
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
 	) AS a
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@vscode_apps::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@ssh_apps::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@jetbrains_apps::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@reconnecting_pty_apps::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(a.session_counts) AS entry
+	) AS family ON true
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id
 )
@@ -290,12 +341,21 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		agent_id,
-		coalesce(SUM((session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(family.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(family.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(family.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(family.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count
 	FROM workspace_agent_stats
+	-- One pass per row folds app names into the families reporting can hold.
+	LEFT JOIN LATERAL (
+		SELECT
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@vscode_apps::text[])), 0)::bigint AS vscode,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@ssh_apps::text[])), 0)::bigint AS ssh,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@jetbrains_apps::text[])), 0)::bigint AS jetbrains,
+			coalesce(SUM(entry.value::bigint) FILTER (WHERE entry.key = ANY(@reconnecting_pty_apps::text[])), 0)::bigint AS reconnecting_pty
+		FROM jsonb_each_text(workspace_agent_stats.session_counts) AS entry
+	) AS family ON true
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
 	WHERE usage AND created_at > now() - '1 minute'::interval

--- a/coderd/idemetadata/idemetadata.go
+++ b/coderd/idemetadata/idemetadata.go
@@ -4,6 +4,7 @@
 package idemetadata
 
 import (
+	"slices"
 	"strings"
 
 	utilstrings "github.com/coder/coder/v2/coderd/util/strings"
@@ -50,6 +51,29 @@ var families = map[string]string{
 	AppNameZed:             AppNameSSH,
 	AppNameSSH:             AppNameSSH,
 	AppNameReconnectingPTY: AppNameReconnectingPTY,
+}
+
+// AttributedFamilies are the families usage reporting has somewhere to put.
+// Every value in families must appear here or its sessions go uncounted, which
+// TestEveryFamilyIsAttributed enforces.
+var AttributedFamilies = []string{
+	AppNameVSCode,
+	AppNameJetBrains,
+	AppNameSSH,
+	AppNameReconnectingPTY,
+}
+
+// FamilyAliases returns the app names belonging to a family, sorted so query
+// parameters stay stable across calls.
+func FamilyAliases(family string) []string {
+	var aliases []string
+	for appName, appFamily := range families {
+		if appFamily == family {
+			aliases = append(aliases, appName)
+		}
+	}
+	slices.Sort(aliases)
+	return aliases
 }
 
 // Family returns the family for an app name, or AppNameUnknown. Matching is

--- a/coderd/idemetadata/idemetadata_internal_test.go
+++ b/coderd/idemetadata/idemetadata_internal_test.go
@@ -14,3 +14,13 @@ func TestFamilyKeysAreCanonical(t *testing.T) {
 		require.Equal(t, canonicalKey(name), name)
 	}
 }
+
+// A family with no destination in AttributedFamilies silently drops its
+// sessions from usage reporting, so adding one must fail here first.
+func TestEveryFamilyIsAttributed(t *testing.T) {
+	t.Parallel()
+	for appName, family := range families {
+		require.Contains(t, AttributedFamilies, family,
+			"app %q maps to family %q, which usage reporting cannot report", appName, family)
+	}
+}

--- a/coderd/idemetadata/idemetadata_test.go
+++ b/coderd/idemetadata/idemetadata_test.go
@@ -1,6 +1,7 @@
 package idemetadata_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -80,4 +81,20 @@ func TestFamily(t *testing.T) {
 			require.Equal(t, tc.want, idemetadata.Family(tc.input))
 		})
 	}
+}
+
+func TestFamilyAliases(t *testing.T) {
+	t.Parallel()
+
+	// Forks share the VS Code family, and the list is sorted.
+	vscode := idemetadata.FamilyAliases(idemetadata.AppNameVSCode)
+	require.Contains(t, vscode, "cursor")
+	require.Contains(t, vscode, idemetadata.AppNameVSCode)
+	require.True(t, slices.IsSorted(vscode))
+
+	// Zed speaks SSH, so it reports under the SSH family.
+	require.Equal(t, []string{idemetadata.AppNameSSH, idemetadata.AppNameZed},
+		idemetadata.FamilyAliases(idemetadata.AppNameSSH))
+
+	require.Empty(t, idemetadata.FamilyAliases("no_such_family"))
 }

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 	"github.com/coder/retry"
@@ -138,13 +139,25 @@ func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 	)
 
 	if c.usage {
-		agentUsageStats, err := c.database.GetDeploymentWorkspaceAgentUsageStats(ctx, from)
+		agentUsageStats, err := c.database.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:           from,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		if err != nil {
 			return err
 		}
 		agentStats = database.GetDeploymentWorkspaceAgentStatsRow(agentUsageStats)
 	} else {
-		agentStats, err = c.database.GetDeploymentWorkspaceAgentStats(ctx, from)
+		agentStats, err = c.database.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:           from,
+			VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+			SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+			JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+			ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+		})
 		if err != nil {
 			return err
 		}

--- a/coderd/prometheusmetrics/insights/metricscollector.go
+++ b/coderd/prometheusmetrics/insights/metricscollector.go
@@ -13,6 +13,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/coderd/pproflabel"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
@@ -98,8 +99,12 @@ func (mc *MetricsCollector) Run(ctx context.Context) (func(), error) {
 		eg.Go(func() error {
 			var err error
 			templateInsights, err = mc.database.GetTemplateInsightsByTemplate(egCtx, database.GetTemplateInsightsByTemplateParams{
-				StartTime: startTime,
-				EndTime:   endTime,
+				StartTime:           startTime,
+				EndTime:             endTime,
+				VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+				SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+				JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+				ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
 			})
 			if err != nil {
 				mc.logger.Error(ctx, "unable to fetch template insights from database", slog.Error(err))

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/quartz"
@@ -567,13 +568,25 @@ func AgentStats(ctx context.Context, logger slog.Logger, registerer prometheus.R
 			)
 			if usage {
 				var agentUsageStats []database.GetWorkspaceAgentUsageStatsAndLabelsRow
-				agentUsageStats, err = db.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAfter)
+				agentUsageStats, err = db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+					CreatedAt:           createdAfter,
+					VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+					SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+					JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+					ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+				})
 				stats = make([]database.GetWorkspaceAgentStatsAndLabelsRow, 0, len(agentUsageStats))
 				for _, agentUsageStat := range agentUsageStats {
 					stats = append(stats, database.GetWorkspaceAgentStatsAndLabelsRow(agentUsageStat))
 				}
 			} else {
-				stats, err = db.GetWorkspaceAgentStatsAndLabels(ctx, createdAfter)
+				stats, err = db.GetWorkspaceAgentStatsAndLabels(ctx, database.GetWorkspaceAgentStatsAndLabelsParams{
+					CreatedAt:           createdAfter,
+					VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+					SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+					JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+					ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+				})
 			}
 			if err != nil {
 				logger.Error(ctx, "can't get agent stats", slog.Error(err))

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	tailnetproto "github.com/coder/coder/v2/tailnet/proto"
@@ -647,7 +648,13 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 	})
 	eg.Go(func() error {
 		if r.options.DeploymentConfig != nil && slices.Contains(r.options.DeploymentConfig.Experiments, string(codersdk.ExperimentWorkspaceUsage)) {
-			agentStats, err := r.options.Database.GetWorkspaceAgentUsageStats(ctx, createdAfter)
+			agentStats, err := r.options.Database.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
+				CreatedAt:           createdAfter,
+				VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+				SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+				JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+				ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+			})
 			if err != nil {
 				return xerrors.Errorf("get workspace agent stats: %w", err)
 			}
@@ -656,7 +663,13 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 				snapshot.WorkspaceAgentStats = append(snapshot.WorkspaceAgentStats, ConvertWorkspaceAgentStat(database.GetWorkspaceAgentStatsRow(stat)))
 			}
 		} else {
-			agentStats, err := r.options.Database.GetWorkspaceAgentStats(ctx, createdAfter)
+			agentStats, err := r.options.Database.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+				CreatedAt:           createdAfter,
+				VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+				SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+				JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+				ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+			})
 			if err != nil {
 				return xerrors.Errorf("get workspace agent stats: %w", err)
 			}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1776,34 +1776,11 @@ func (api *API) postWorkspaceUsage(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if !slices.Contains(codersdk.AllowedAppNames, req.AppName) {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Invalid request",
-			Validations: []codersdk.ValidationError{{
-				Field:  "app_name",
-				Detail: fmt.Sprintf("must be one of %v", codersdk.AllowedAppNames),
-			}},
-		})
-		return
-	}
 
+	// Any app name is accepted, normalized at ingestion.
 	stat := &proto.Stats{
 		ConnectionCount: 1,
-	}
-	switch req.AppName {
-	case codersdk.UsageAppNameVscode:
-		stat.SessionCountVscode = 1
-	case codersdk.UsageAppNameJetbrains:
-		stat.SessionCountJetbrains = 1
-	case codersdk.UsageAppNameReconnectingPty:
-		stat.SessionCountReconnectingPty = 1
-	case codersdk.UsageAppNameSSH:
-		stat.SessionCountSsh = 1
-	default:
-		// This means the app_name is in the codersdk.AllowedAppNames but not being
-		// handled by this switch statement.
-		httpapi.InternalServerError(rw, xerrors.Errorf("unknown app_name %q", req.AppName))
-		return
+		SessionCounts:   map[string]int64{string(req.AppName): 1},
 	}
 
 	agent, err := api.Database.GetWorkspaceAgentByID(ctx, req.AgentID)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -5242,12 +5242,12 @@ func TestWorkspaceUsageTracking(t *testing.T) {
 			AppName: "ssh",
 		})
 		require.ErrorContains(t, err, "app_name")
-		// unknown app name fails
+		// unknown app names are accepted
 		err = client.PostWorkspaceUsageWithBody(ctx, r.Workspace.ID, codersdk.PostWorkspaceUsageRequest{
 			AgentID: workspace.LatestBuild.Resources[0].Agents[0].ID,
-			AppName: "unknown",
+			AppName: "SomeFutureIDE",
 		})
-		require.ErrorContains(t, err, "app_name")
+		require.NoError(t, err)
 
 		// vscode works
 		err = client.PostWorkspaceUsageWithBody(ctx, r.Workspace.ID, codersdk.PostWorkspaceUsageRequest{

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/idemetadata"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
 )
@@ -57,7 +58,13 @@ func TestBatchStats(t *testing.T) {
 	t.Log("flush 1 completed")
 
 	// Then: it should report no stats.
-	stats, err := store.GetWorkspaceAgentStats(ctx, t1)
+	stats, err := store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:           t1,
+		VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+		SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+		JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+		ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Empty(t, stats, "should have no stats for workspace")
 
@@ -80,7 +87,13 @@ func TestBatchStats(t *testing.T) {
 	t.Log("flush 2 completed")
 
 	// Then: counts reach the right agent, normalized, without the zero entry.
-	stats, err = store.GetWorkspaceAgentStats(ctx, t2)
+	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:           t2,
+		VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+		SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+		JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+		ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 2, "should have stats for both workspaces")
 	byAgent := make(map[uuid.UUID]database.GetWorkspaceAgentStatsRow)
@@ -135,7 +148,13 @@ func TestBatchStats(t *testing.T) {
 	// And we should finish inserting the stats
 	<-done
 
-	stats, err = store.GetWorkspaceAgentStats(ctx, t3)
+	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:           t3,
+		VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+		SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+		JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+		ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 2, "should have stats for both workspaces")
 
@@ -154,7 +173,13 @@ func TestBatchStats(t *testing.T) {
 	require.Zero(t, f, "expected zero stats to have been flushed")
 	t.Log("flush 5 completed")
 
-	stats, err = store.GetWorkspaceAgentStats(ctx, t5)
+	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:           t5,
+		VscodeApps:          idemetadata.FamilyAliases(idemetadata.AppNameVSCode),
+		SshApps:             idemetadata.FamilyAliases(idemetadata.AppNameSSH),
+		JetbrainsApps:       idemetadata.FamilyAliases(idemetadata.AppNameJetBrains),
+		ReconnectingPtyApps: idemetadata.FamilyAliases(idemetadata.AppNameReconnectingPTY),
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 0, "should have no stats for workspace")
 

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -349,19 +349,6 @@ func (c *Client) ConnectRPC210(ctx context.Context) (
 	return proto.NewDRPCAgentClient(conn), tailnetproto.NewDRPCTailnetClient(conn), nil
 }
 
-// ConnectRPC210WithRole is like ConnectRPC210 but sends an explicit role
-// query parameter to the server. Use "agent" for workspace agents to
-// enable connection monitoring.
-func (c *Client) ConnectRPC210WithRole(ctx context.Context, role string) (
-	proto.DRPCAgentClient210, tailnetproto.DRPCTailnetClient28, error,
-) {
-	conn, err := c.connectRPCVersion(ctx, apiversion.New(2, 10), role)
-	if err != nil {
-		return nil, nil, err
-	}
-	return proto.NewDRPCAgentClient(conn), tailnetproto.NewDRPCTailnetClient(conn), nil
-}
-
 // ConnectRPC211 returns a dRPC client to the Agent API v2.11. It is useful
 // when you want to report per-app session counts on Stats.
 func (c *Client) ConnectRPC211(ctx context.Context) (

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -383,6 +383,9 @@ type PostWorkspaceUsageRequest struct {
 
 type UsageAppName string
 
+// Well-known usage app names. The API accepts any name, normalized at
+// ingestion. These are wire format and cannot change: the hyphen in
+// reconnecting-pty folds to the canonical reconnecting_pty.
 const (
 	UsageAppNameVscode          UsageAppName = "vscode"
 	UsageAppNameJetbrains       UsageAppName = "jetbrains"
@@ -390,6 +393,8 @@ const (
 	UsageAppNameSSH             UsageAppName = "ssh"
 )
 
+// Deprecated: the workspace usage API no longer restricts app_name to this
+// list. Use it only to recognize the well-known names.
 var AllowedAppNames = []UsageAppName{
 	UsageAppNameVscode,
 	UsageAppNameJetbrains,


### PR DESCRIPTION
Turns the producers on now that the schema and the write path are in place.

- The agent connects on Agent API 2.11 and reports `Stats.session_counts` from its normalized map.
- Reconnecting PTY activity is merged into that map rather than overwriting it, since a client is free to label an ssh session `reconnecting_pty`.
- `coder ssh --usage-app` passes any app name through instead of rewriting unrecognized ones to `ssh`.
- The workspace usage API accepts any `app_name`, normalized at ingestion, so a new IDE needs no Coder change to show up in usage reporting.
- `codersdk.AllowedAppNames` stays as the deprecated well-known-name list, and the 2.9 and 2.10 client constructors stay for compatibility.

Depends on #28337, which adds the family grouping these names are counted under. Phase 1 of #27410.

Ships with #27412, which makes `connection_logs.type` TEXT. Without it, a Cursor connection is recorded as `vscode` in the connection log.


