### PR TITLE
fix: repair stale chat agent bindings after workspace rebuild

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -34028,6 +34028,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx context.Co
 const getWorkspaceAgentsInLatestBuildByWorkspaceIDs = `-- name: GetWorkspaceAgentsInLatestBuildByWorkspaceIDs :many
 SELECT
 	workspace_builds.workspace_id,
+	workspace_builds.id AS build_id,
 	workspace_agents.id, workspace_agents.created_at, workspace_agents.updated_at, workspace_agents.name, workspace_agents.first_connected_at, workspace_agents.last_connected_at, workspace_agents.disconnected_at, workspace_agents.resource_id, workspace_agents.auth_token, workspace_agents.auth_instance_id, workspace_agents.architecture, workspace_agents.environment_variables, workspace_agents.operating_system, workspace_agents.instance_metadata, workspace_agents.resource_metadata, workspace_agents.directory, workspace_agents.version, workspace_agents.last_connected_replica_id, workspace_agents.connection_timeout_seconds, workspace_agents.troubleshooting_url, workspace_agents.motd_file, workspace_agents.lifecycle_state, workspace_agents.expanded_directory, workspace_agents.logs_length, workspace_agents.logs_overflowed, workspace_agents.started_at, workspace_agents.ready_at, workspace_agents.subsystems, workspace_agents.display_apps, workspace_agents.api_version, workspace_agents.display_order, workspace_agents.parent_id, workspace_agents.api_key_scope, workspace_agents.deleted
 FROM
 	workspace_agents
@@ -34054,6 +34055,7 @@ WHERE
 
 type GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow struct {
 	WorkspaceID    uuid.UUID      `db:"workspace_id" json:"workspace_id"`
+	BuildID        uuid.UUID      `db:"build_id" json:"build_id"`
 	WorkspaceAgent WorkspaceAgent `db:"workspace_agent" json:"workspace_agent"`
 }
 
@@ -34068,6 +34070,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(ctx context.C
 		var i GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow
 		if err := rows.Scan(
 			&i.WorkspaceID,
+			&i.BuildID,
 			&i.WorkspaceAgent.ID,
 			&i.WorkspaceAgent.CreatedAt,
 			&i.WorkspaceAgent.UpdatedAt,

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -340,6 +340,7 @@ WHERE
 -- name: GetWorkspaceAgentsInLatestBuildByWorkspaceIDs :many
 SELECT
 	workspace_builds.workspace_id,
+	workspace_builds.id AS build_id,
 	sqlc.embed(workspace_agents)
 FROM
 	workspace_agents

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -502,27 +502,23 @@ func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, sdkChats)
 }
 
-// enrichChatsWithMissingAgentIDs fills nil AgentIDs from each workspace's
-// latest build. List reads use it because validating existing bindings
-// costs a per-workspace authorization lookup per listed chat.
+// enrichChatsWithMissingAgentIDs skips existing bindings on list reads to avoid
+// one authorization check per bound workspace.
 func (api *API) enrichChatsWithMissingAgentIDs(ctx context.Context, chats []codersdk.Chat) {
 	api.enrichChatAgentIDs(ctx, chats, func(chat *codersdk.Chat) bool {
 		return chat.AgentID == nil
 	})
 }
 
-// repairChatAgentIDs fills missing AgentIDs and repairs ones that no
-// longer resolve in the workspace's latest build (chatd persists bindings
-// lazily and a rebuild replaces agents). Reserved for single-chat reads
-// because of the per-workspace authorization cost.
+// repairChatAgentIDs handles stale bindings left by workspace rebuilds. List
+// reads skip this work to avoid authorization checks for bound workspaces.
 func (api *API) repairChatAgentIDs(ctx context.Context, chats []codersdk.Chat) {
 	api.enrichChatAgentIDs(ctx, chats, func(*codersdk.Chat) bool {
 		return true
 	})
 }
 
-// enrichChatAgentIDs is best-effort and response-only; on error each
-// AgentID keeps its persisted value. shouldEnrich selects candidates.
+// enrichChatAgentIDs performs best-effort response-only updates.
 func (api *API) enrichChatAgentIDs(ctx context.Context, chats []codersdk.Chat, shouldEnrich func(*codersdk.Chat) bool) {
 	candidateChats := make([]*codersdk.Chat, 0, len(chats))
 	var workspaceIDs []uuid.UUID

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -502,11 +502,10 @@ func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, sdkChats)
 }
 
-// enrichChatWithWorkspaceAgentIDs fills missing AgentIDs and repairs stale
-// ones for chats with a bound workspace: chatd persists the binding lazily and
-// only rebinds on the next turn, so after a workspace rebuild the persisted
-// agent can reference a previous build. Best-effort and response-only; on
-// error the field keeps its persisted value.
+// enrichChatWithWorkspaceAgentIDs fills missing AgentIDs and repairs ones
+// that no longer resolve in the workspace's latest build (chatd persists
+// bindings lazily and a rebuild replaces agents). Best-effort and
+// response-only; on error the field keeps its persisted value.
 func (api *API) enrichChatWithWorkspaceAgentIDs(ctx context.Context, chats []codersdk.Chat) {
 	candidateChats := make([]*codersdk.Chat, 0, len(chats))
 	var workspaceIDs []uuid.UUID
@@ -550,8 +549,8 @@ func (api *API) enrichChatWithWorkspaceAgentIDs(ctx context.Context, chats []cod
 	}
 
 	for _, chat := range candidateChats {
-		// A binding that still exists in the latest build is authoritative:
-		// chatd bound it, so do not second-guess the selection.
+		// Preserve bindings that still resolve in the latest build instead
+		// of replacing them with the selected agent.
 		if chat.AgentID != nil && slices.ContainsFunc(
 			agentsByWorkspace[*chat.WorkspaceID],
 			func(agent database.WorkspaceAgent) bool { return agent.ID == *chat.AgentID },

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -549,8 +549,10 @@ func (api *API) enrichChatAgentIDs(ctx context.Context, chats []codersdk.Chat, s
 	}
 
 	agentsByWorkspace := make(map[uuid.UUID][]database.WorkspaceAgent)
+	latestBuildIDs := make(map[uuid.UUID]uuid.UUID)
 	for _, row := range rows {
 		agentsByWorkspace[row.WorkspaceID] = append(agentsByWorkspace[row.WorkspaceID], row.WorkspaceAgent)
+		latestBuildIDs[row.WorkspaceID] = row.BuildID
 	}
 	agentIDs := make(map[uuid.UUID]uuid.UUID, len(agentsByWorkspace))
 	for workspaceID, agents := range agentsByWorkspace {
@@ -574,6 +576,10 @@ func (api *API) enrichChatAgentIDs(ctx context.Context, chats []codersdk.Chat, s
 		if agentID, ok := agentIDs[*chat.WorkspaceID]; ok {
 			id := agentID
 			chat.AgentID = &id
+			// Pair the agent with its build so the response never mixes
+			// the latest build's agent with a previous build's ID.
+			buildID := latestBuildIDs[*chat.WorkspaceID]
+			chat.BuildID = &buildID
 		}
 	}
 }

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -502,23 +502,28 @@ func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, sdkChats)
 }
 
-// enrichChatWithWorkspaceAgentIDs fills missing AgentIDs for chats with a bound
-// workspace, since chatd persists the binding lazily. Best-effort and
-// response-only; on error the field stays null.
+// enrichChatWithWorkspaceAgentIDs fills missing AgentIDs and repairs stale
+// ones for chats with a bound workspace: chatd persists the binding lazily and
+// only rebinds on the next turn, so after a workspace rebuild the persisted
+// agent can reference a previous build. Best-effort and response-only; on
+// error the field keeps its persisted value.
 func (api *API) enrichChatWithWorkspaceAgentIDs(ctx context.Context, chats []codersdk.Chat) {
-	missingChats := make([]*codersdk.Chat, 0, len(chats))
+	candidateChats := make([]*codersdk.Chat, 0, len(chats))
 	var workspaceIDs []uuid.UUID
-	addMissing := func(chat *codersdk.Chat) {
-		if chat.AgentID == nil && chat.WorkspaceID != nil {
-			missingChats = append(missingChats, chat)
+	addCandidate := func(chat *codersdk.Chat) {
+		if chat.WorkspaceID != nil {
+			candidateChats = append(candidateChats, chat)
 			workspaceIDs = append(workspaceIDs, *chat.WorkspaceID)
 		}
 	}
 	for i := range chats {
-		addMissing(&chats[i])
+		addCandidate(&chats[i])
 		for j := range chats[i].Children {
-			addMissing(&chats[i].Children[j])
+			addCandidate(&chats[i].Children[j])
 		}
+	}
+	if len(candidateChats) == 0 {
+		return
 	}
 
 	slices.SortFunc(workspaceIDs, func(a, b uuid.UUID) int {
@@ -544,7 +549,15 @@ func (api *API) enrichChatWithWorkspaceAgentIDs(ctx context.Context, chats []cod
 		agentIDs[workspaceID] = agent.ID
 	}
 
-	for _, chat := range missingChats {
+	for _, chat := range candidateChats {
+		// A binding that still exists in the latest build is authoritative:
+		// chatd bound it, so do not second-guess the selection.
+		if chat.AgentID != nil && slices.ContainsFunc(
+			agentsByWorkspace[*chat.WorkspaceID],
+			func(agent database.WorkspaceAgent) bool { return agent.ID == *chat.AgentID },
+		) {
+			continue
+		}
 		if agentID, ok := agentIDs[*chat.WorkspaceID]; ok {
 			id := agentID
 			chat.AgentID = &id

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -498,22 +498,40 @@ func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	sdkChats := db2sdk.ChatRowsWithChildren(chatRows, childRows, diffStatusesByChatID)
-	api.enrichChatWithWorkspaceAgentIDs(ctx, sdkChats)
+	api.enrichChatsWithMissingAgentIDs(ctx, sdkChats)
 	httpapi.Write(ctx, rw, http.StatusOK, sdkChats)
 }
 
-// enrichChatWithWorkspaceAgentIDs fills missing AgentIDs and repairs ones
-// that no longer resolve in the workspace's latest build (chatd persists
-// bindings lazily and a rebuild replaces agents). Best-effort and
-// response-only; on error the field keeps its persisted value.
-func (api *API) enrichChatWithWorkspaceAgentIDs(ctx context.Context, chats []codersdk.Chat) {
+// enrichChatsWithMissingAgentIDs fills nil AgentIDs from each workspace's
+// latest build. List reads use it because validating existing bindings
+// costs a per-workspace authorization lookup per listed chat.
+func (api *API) enrichChatsWithMissingAgentIDs(ctx context.Context, chats []codersdk.Chat) {
+	api.enrichChatAgentIDs(ctx, chats, func(chat *codersdk.Chat) bool {
+		return chat.AgentID == nil
+	})
+}
+
+// repairChatAgentIDs fills missing AgentIDs and repairs ones that no
+// longer resolve in the workspace's latest build (chatd persists bindings
+// lazily and a rebuild replaces agents). Reserved for single-chat reads
+// because of the per-workspace authorization cost.
+func (api *API) repairChatAgentIDs(ctx context.Context, chats []codersdk.Chat) {
+	api.enrichChatAgentIDs(ctx, chats, func(*codersdk.Chat) bool {
+		return true
+	})
+}
+
+// enrichChatAgentIDs is best-effort and response-only; on error each
+// AgentID keeps its persisted value. shouldEnrich selects candidates.
+func (api *API) enrichChatAgentIDs(ctx context.Context, chats []codersdk.Chat, shouldEnrich func(*codersdk.Chat) bool) {
 	candidateChats := make([]*codersdk.Chat, 0, len(chats))
 	var workspaceIDs []uuid.UUID
 	addCandidate := func(chat *codersdk.Chat) {
-		if chat.WorkspaceID != nil {
-			candidateChats = append(candidateChats, chat)
-			workspaceIDs = append(workspaceIDs, *chat.WorkspaceID)
+		if chat.WorkspaceID == nil || !shouldEnrich(chat) {
+			return
 		}
+		candidateChats = append(candidateChats, chat)
+		workspaceIDs = append(workspaceIDs, *chat.WorkspaceID)
 	}
 	for i := range chats {
 		addCandidate(&chats[i])
@@ -1651,7 +1669,7 @@ func (api *API) getChat(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	enriched := []codersdk.Chat{sdkChat}
-	api.enrichChatWithWorkspaceAgentIDs(ctx, enriched)
+	api.repairChatAgentIDs(ctx, enriched)
 	sdkChat = enriched[0]
 
 	httpapi.Write(ctx, rw, http.StatusOK, sdkChat)

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -169,7 +169,7 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 			}, nil
 		}).Times(1)
 		chats := []codersdk.Chat{{WorkspaceID: &workspaceID, Children: []codersdk.Chat{{WorkspaceID: &workspaceID}}}, {WorkspaceID: &otherWorkspaceID}}
-		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		api.enrichChatsWithMissingAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Equal(t, rootAgentID, *chats[0].AgentID)
 		require.Equal(t, rootAgentID, *chats[0].Children[0].AgentID)
 		require.Equal(t, otherAgentID, *chats[1].AgentID)
@@ -179,7 +179,7 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 		api, mDB := newAPI(t)
 		mDB.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(gomock.Any(), gomock.Any()).Return(nil, xerrors.New("boom"))
 		chats := []codersdk.Chat{{WorkspaceID: &workspaceID}, {WorkspaceID: &otherWorkspaceID}}
-		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		api.enrichChatsWithMissingAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Nil(t, chats[0].AgentID)
 		require.Nil(t, chats[1].AgentID)
 	})
@@ -189,7 +189,7 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 		mDB.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(gomock.Any(), []uuid.UUID{workspaceID}).Return([]database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow{row(workspaceID, uuid.New(), uuid.NullUUID{UUID: rootAgentID, Valid: true}, "sub")}, nil)
 		bound := otherAgentID
 		chats := []codersdk.Chat{{}, {WorkspaceID: &workspaceID}, {WorkspaceID: &workspaceID, AgentID: &bound}}
-		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		api.repairChatAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Nil(t, chats[1].AgentID)
 		require.Equal(t, bound, *chats[2].AgentID)
 	})
@@ -206,15 +206,30 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 			{WorkspaceID: &workspaceID, AgentID: &stale},
 			{WorkspaceID: &workspaceID, AgentID: &valid},
 		}
-		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		api.repairChatAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Equal(t, rootAgentID, *chats[0].AgentID)
 		require.Equal(t, secondRootAgentID, *chats[1].AgentID)
+	})
+	t.Run("list mode skips bound chats entirely", func(t *testing.T) {
+		t.Parallel()
+		api, mDB := newAPI(t)
+		mDB.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(gomock.Any(), []uuid.UUID{workspaceID}).Return([]database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow{
+			row(workspaceID, rootAgentID, uuid.NullUUID{}, "root"),
+		}, nil).Times(1)
+		stale := uuid.New()
+		chats := []codersdk.Chat{
+			{WorkspaceID: &workspaceID},
+			{WorkspaceID: &otherWorkspaceID, AgentID: &stale},
+		}
+		api.enrichChatsWithMissingAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		require.Equal(t, rootAgentID, *chats[0].AgentID)
+		require.Equal(t, stale, *chats[1].AgentID)
 	})
 	t.Run("no bound workspaces skips the query", func(t *testing.T) {
 		t.Parallel()
 		api, _ := newAPI(t)
 		chats := []codersdk.Chat{{AgentID: &rootAgentID}, {}}
-		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		api.repairChatAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Equal(t, rootAgentID, *chats[0].AgentID)
 		require.Nil(t, chats[1].AgentID)
 	})

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -139,7 +139,7 @@ func TestGetChatCostFallsBackToParentChat(t *testing.T) {
 	require.Equal(t, int64(125), cost.TotalCostMicros)
 }
 
-func TestEnrichMissingChatAgentIDs(t *testing.T) {
+func TestEnrichChatAgentIDs(t *testing.T) {
 	t.Parallel()
 	newAPI := func(t *testing.T) (*API, *dbmock.MockStore) {
 		t.Helper()
@@ -183,7 +183,7 @@ func TestEnrichMissingChatAgentIDs(t *testing.T) {
 		require.Nil(t, chats[0].AgentID)
 		require.Nil(t, chats[1].AgentID)
 	})
-	t.Run("selection error and skips bound or unbound", func(t *testing.T) {
+	t.Run("selection error keeps persisted values", func(t *testing.T) {
 		t.Parallel()
 		api, mDB := newAPI(t)
 		mDB.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(gomock.Any(), []uuid.UUID{workspaceID}).Return([]database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow{row(workspaceID, uuid.New(), uuid.NullUUID{UUID: rootAgentID, Valid: true}, "sub")}, nil)
@@ -192,6 +192,34 @@ func TestEnrichMissingChatAgentIDs(t *testing.T) {
 		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Nil(t, chats[1].AgentID)
 		require.Equal(t, bound, *chats[2].AgentID)
+	})
+	t.Run("repairs stale and keeps valid bindings", func(t *testing.T) {
+		t.Parallel()
+		api, mDB := newAPI(t)
+		secondRootAgentID := uuid.New()
+		mDB.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(gomock.Any(), []uuid.UUID{workspaceID}).Return([]database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow{
+			row(workspaceID, rootAgentID, uuid.NullUUID{}, "a"),
+			row(workspaceID, secondRootAgentID, uuid.NullUUID{}, "b"),
+		}, nil)
+		stale, valid := uuid.New(), secondRootAgentID
+		chats := []codersdk.Chat{
+			{WorkspaceID: &workspaceID, AgentID: &stale},
+			{WorkspaceID: &workspaceID, AgentID: &valid},
+		}
+		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		// The stale binding is repaired to the selected agent, while a
+		// binding still present in the latest build is kept even though
+		// selection would prefer another agent.
+		require.Equal(t, rootAgentID, *chats[0].AgentID)
+		require.Equal(t, secondRootAgentID, *chats[1].AgentID)
+	})
+	t.Run("no bound workspaces skips the query", func(t *testing.T) {
+		t.Parallel()
+		api, _ := newAPI(t)
+		chats := []codersdk.Chat{{AgentID: &rootAgentID}, {}}
+		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
+		require.Equal(t, rootAgentID, *chats[0].AgentID)
+		require.Nil(t, chats[1].AgentID)
 	})
 }
 

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -149,9 +149,12 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 	}
 	workspaceID, otherWorkspaceID := uuid.New(), uuid.New()
 	rootAgentID, otherAgentID := uuid.New(), uuid.New()
+	latestBuildID, otherLatestBuildID := uuid.New(), uuid.New()
+	latestBuildIDs := map[uuid.UUID]uuid.UUID{workspaceID: latestBuildID, otherWorkspaceID: otherLatestBuildID}
 	row := func(workspaceID, id uuid.UUID, parentID uuid.NullUUID, name string) database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow {
 		return database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow{
 			WorkspaceID: workspaceID,
+			BuildID:     latestBuildIDs[workspaceID],
 			WorkspaceAgent: database.WorkspaceAgent{
 				ID:       id,
 				ParentID: parentID,
@@ -173,6 +176,9 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 		require.Equal(t, rootAgentID, *chats[0].AgentID)
 		require.Equal(t, rootAgentID, *chats[0].Children[0].AgentID)
 		require.Equal(t, otherAgentID, *chats[1].AgentID)
+		require.Equal(t, latestBuildID, *chats[0].BuildID)
+		require.Equal(t, latestBuildID, *chats[0].Children[0].BuildID)
+		require.Equal(t, otherLatestBuildID, *chats[1].BuildID)
 	})
 	t.Run("query error", func(t *testing.T) {
 		t.Parallel()
@@ -188,10 +194,13 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 		api, mDB := newAPI(t)
 		mDB.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceIDs(gomock.Any(), []uuid.UUID{workspaceID}).Return([]database.GetWorkspaceAgentsInLatestBuildByWorkspaceIDsRow{row(workspaceID, uuid.New(), uuid.NullUUID{UUID: rootAgentID, Valid: true}, "sub")}, nil)
 		bound := otherAgentID
-		chats := []codersdk.Chat{{}, {WorkspaceID: &workspaceID}, {WorkspaceID: &workspaceID, AgentID: &bound}}
+		boundBuildID := uuid.New()
+		chats := []codersdk.Chat{{}, {WorkspaceID: &workspaceID}, {WorkspaceID: &workspaceID, AgentID: &bound, BuildID: &boundBuildID}}
 		api.repairChatAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Nil(t, chats[1].AgentID)
+		require.Nil(t, chats[1].BuildID)
 		require.Equal(t, bound, *chats[2].AgentID)
+		require.Equal(t, boundBuildID, *chats[2].BuildID)
 	})
 	t.Run("repairs stale and keeps valid bindings", func(t *testing.T) {
 		t.Parallel()
@@ -202,13 +211,16 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 			row(workspaceID, secondRootAgentID, uuid.NullUUID{}, "b"),
 		}, nil)
 		stale, valid := uuid.New(), secondRootAgentID
+		staleBuildID, validBuildID := uuid.New(), uuid.New()
 		chats := []codersdk.Chat{
-			{WorkspaceID: &workspaceID, AgentID: &stale},
-			{WorkspaceID: &workspaceID, AgentID: &valid},
+			{WorkspaceID: &workspaceID, AgentID: &stale, BuildID: &staleBuildID},
+			{WorkspaceID: &workspaceID, AgentID: &valid, BuildID: &validBuildID},
 		}
 		api.repairChatAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
 		require.Equal(t, rootAgentID, *chats[0].AgentID)
 		require.Equal(t, secondRootAgentID, *chats[1].AgentID)
+		require.Equal(t, latestBuildID, *chats[0].BuildID)
+		require.Equal(t, validBuildID, *chats[1].BuildID)
 	})
 	t.Run("list mode skips bound chats entirely", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -207,9 +207,6 @@ func TestEnrichChatAgentIDs(t *testing.T) {
 			{WorkspaceID: &workspaceID, AgentID: &valid},
 		}
 		api.enrichChatWithWorkspaceAgentIDs(testutil.Context(t, testutil.WaitShort), chats)
-		// The stale binding is repaired to the selected agent, while a
-		// binding still present in the latest build is kept even though
-		// selection would prefer another agent.
 		require.Equal(t, rootAgentID, *chats[0].AgentID)
 		require.Equal(t, secondRootAgentID, *chats[1].AgentID)
 	})

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -2486,6 +2486,48 @@ describe("mergeWatchedChatSummary", () => {
 		).toBe(context);
 	});
 
+	it("keeps the repaired build_id when the event snapshot carries a stale binding", () => {
+		const cachedChat = makeChat("chat-1", {
+			workspace_id: "workspace-1",
+			agent_id: "agent-new",
+			build_id: "build-new",
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			workspace_id: "workspace-1",
+			agent_id: "agent-old",
+			build_id: "build-old",
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		const merged = mergeWatchedChatSummary(cachedChat, watchedChat, {
+			eventKind: "diff_status_change",
+		});
+		expect(merged.build_id).toBe("build-new");
+		expect(merged.agent_id).toBe("agent-new");
+	});
+
+	it("adopts a fresh build_id when the event snapshot agrees on the agent", () => {
+		const cachedChat = makeChat("chat-1", {
+			workspace_id: "workspace-1",
+			agent_id: "agent-1",
+			build_id: "build-old",
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			workspace_id: "workspace-1",
+			agent_id: "agent-1",
+			build_id: "build-new",
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "status_change",
+			}).build_id,
+		).toBe("build-new");
+	});
+
 	it("merges fresh status updates without clobbering a newer title snapshot", () => {
 		const cachedChat = makeChat("chat-1", {
 			status: "waiting",

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -551,9 +551,13 @@ export const mergeWatchedChatSummary = (
 	const nextWorkspaceId = isFreshEnough
 		? (watchedChat.workspace_id ?? cachedChat.workspace_id)
 		: cachedChat.workspace_id;
-	const nextBuildId = isFreshEnough
-		? (watchedChat.build_id ?? cachedChat.build_id)
-		: cachedChat.build_id;
+	// Single-chat reads repair agent/build bindings response-only, so watch
+	// events can replay stale DB pairs. Adopting build_id with a mismatched
+	// agent would split the repaired pair because merge never adopts agent_id.
+	const nextBuildId =
+		isFreshEnough && watchedChat.agent_id === cachedChat.agent_id
+			? (watchedChat.build_id ?? cachedChat.build_id)
+			: cachedChat.build_id;
 	// All event types carry the current model config from the DB.
 	const nextLastModelConfigId = isFreshEnough
 		? watchedChat.last_model_config_id

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2235,12 +2235,6 @@ const rebuildRecoveryChat: TypesGen.Chat = {
 	status: "waiting",
 };
 
-/**
- * A rebuild replaces workspace agents, leaving the chat's persisted agent ID
- * stale. The workspace watch stream delivers the rebuilt workspace, the page
- * refetches the chat, and the repaired binding restores agent-backed controls
- * such as the Terminal tab.
- */
 export const RecoversSidebarAfterWorkspaceRebuild: Story = {
 	beforeEach: () => {
 		localStorage.setItem(RIGHT_PANEL_OPEN_KEY, "true");

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -35,6 +35,7 @@ import {
 	MockOrganizationMember2,
 	MockUserOwner,
 	MockWorkspace,
+	MockWorkspaceAgent,
 	mockApiError,
 } from "#/testHelpers/entities";
 import {
@@ -2208,6 +2209,82 @@ export const SidebarWithSingleRepo: Story = {
 		},
 	},
 };
+
+const rebuiltWorkspaceAgent: TypesGen.WorkspaceAgent = {
+	...MockWorkspaceAgent,
+	id: "rebuilt-agent-1",
+};
+const rebuiltWorkspace: TypesGen.Workspace = {
+	...mockWorkspace,
+	latest_build: {
+		...mockWorkspace.latest_build,
+		id: "rebuilt-build-1",
+		resources: [
+			{
+				...mockWorkspace.latest_build.resources[0],
+				agents: [rebuiltWorkspaceAgent],
+			},
+		],
+	},
+};
+const rebuildRecoveryChat: TypesGen.Chat = {
+	id: CHAT_ID,
+	...baseChatFields,
+	agent_id: "stale-agent-1",
+	title: "Rebuild recovery",
+	status: "waiting",
+};
+
+/**
+ * A rebuild replaces workspace agents, leaving the chat's persisted agent ID
+ * stale. The workspace watch stream delivers the rebuilt workspace, the page
+ * refetches the chat, and the repaired binding restores agent-backed controls
+ * such as the Terminal tab.
+ */
+export const RecoversSidebarAfterWorkspaceRebuild: Story = {
+	beforeEach: () => {
+		localStorage.setItem(RIGHT_PANEL_OPEN_KEY, "true");
+		spyOn(API.experimental, "getChat").mockResolvedValue({
+			...rebuildRecoveryChat,
+			agent_id: rebuiltWorkspaceAgent.id,
+		});
+		return () => localStorage.removeItem(RIGHT_PANEL_OPEN_KEY);
+	},
+	parameters: {
+		queries: [
+			...withoutQuery(
+				buildQueries(
+					rebuildRecoveryChat,
+					{ messages: [], queued_messages: [], has_more: false },
+					{ diffUrl: undefined },
+				),
+				workspaceByIdKey(mockWorkspace.id),
+			),
+			{ key: workspaceByIdKey(mockWorkspace.id), data: rebuiltWorkspace },
+		],
+		webSocket: {
+			"watch-ws": [
+				{
+					event: "message",
+					data: JSON.stringify({
+						type: "data",
+						data: rebuiltWorkspace,
+					} satisfies TypesGen.ServerSentEvent),
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const terminalTab = await canvas.findByRole(
+			"tab",
+			{ name: "Terminal" },
+			{ timeout: 5000 },
+		);
+		expect(terminalTab).toBeVisible();
+	},
+};
+
 /**
  * Streaming reasoning part via WebSocket, renders inline text.
  */

--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -23,6 +23,7 @@ import {
 	draftInputStorageKeyPrefix,
 	getPersistedDraftInputValue,
 	getWorkspaceOptionsWithLinkedWorkspace,
+	isChatAgentBindingUnresolved,
 	isWatchedWorkspaceViewUnchanged,
 	reconcilePromotedQueueHead,
 	restoreOptimisticRequestSnapshot,
@@ -1459,5 +1460,70 @@ describe("isWatchedWorkspaceViewUnchanged", () => {
 				MockWorkspaceAgent.id,
 			),
 		).toBe(false);
+	});
+
+	it("is false when the latest build changes", () => {
+		const next: Workspace = {
+			...MockWorkspace,
+			latest_build: { ...MockWorkspace.latest_build, id: "new-build-id" },
+		};
+
+		expect(
+			isWatchedWorkspaceViewUnchanged(
+				MockWorkspace,
+				next,
+				MockWorkspaceAgent.id,
+			),
+		).toBe(false);
+	});
+});
+
+describe("isChatAgentBindingUnresolved", () => {
+	it("is true when the bound agent is missing from the running build", () => {
+		expect(isChatAgentBindingUnresolved(MockWorkspace, "stale-agent-id")).toBe(
+			true,
+		);
+	});
+
+	it("is true when the chat has no binding yet", () => {
+		expect(isChatAgentBindingUnresolved(MockWorkspace, undefined)).toBe(true);
+	});
+
+	it("is false when the bound agent resolves", () => {
+		expect(
+			isChatAgentBindingUnresolved(MockWorkspace, MockWorkspaceAgent.id),
+		).toBe(false);
+	});
+
+	it("is false when the workspace is not running", () => {
+		const stopped: Workspace = {
+			...MockWorkspace,
+			latest_build: { ...MockWorkspace.latest_build, status: "stopped" },
+		};
+
+		expect(isChatAgentBindingUnresolved(stopped, "stale-agent-id")).toBe(false);
+	});
+
+	it("is false when the running build has no agents", () => {
+		const noAgents: Workspace = {
+			...MockWorkspace,
+			latest_build: {
+				...MockWorkspace.latest_build,
+				resources: MockWorkspace.latest_build.resources.map((resource) => ({
+					...resource,
+					agents: [],
+				})),
+			},
+		};
+
+		expect(isChatAgentBindingUnresolved(noAgents, "stale-agent-id")).toBe(
+			false,
+		);
+	});
+
+	it("is false while the workspace is loading", () => {
+		expect(isChatAgentBindingUnresolved(undefined, "stale-agent-id")).toBe(
+			false,
+		);
 	});
 });

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1048,12 +1048,9 @@ const AgentChatPage: FC = () => {
 					return next;
 				},
 			);
-			// Cool down refetches per chat/build/binding key: repair can fail
-			// with no query error (server enrichment is best-effort and can
-			// return the stale binding), so a bare latch would block retries
-			// while an unconditional refetch would fire on every watch event.
-			// Workspace watches send current state after reconnecting, so
-			// rebuilds missed while disconnected still trigger a refetch.
+			// Cool down each chat/build/binding key because best-effort repair can return
+			// a stale binding without a query error, while unconditional refetches would run
+			// on every event. Reconnects replay state, so missed rebuilds still refetch.
 			if (!agentId || !isChatAgentBindingUnresolved(next, chatAgentId)) {
 				return;
 			}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -69,6 +69,7 @@ import { isMobileViewport } from "#/utils/mobile";
 import { pageTitle } from "#/utils/page";
 import { rewriteLocalhostURL } from "#/utils/portForward";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
+import { getWorkspaceAgents } from "#/utils/workspace";
 import { AgentChatPageErrorView } from "./AgentChatPageErrorView";
 import {
 	AgentChatPageLoadingView,
@@ -450,6 +451,7 @@ export const isWatchedWorkspaceViewUnchanged = (
 	const prevApps = prevAgent?.apps ?? [];
 	const nextApps = nextAgent?.apps ?? [];
 	return (
+		prev.latest_build.id === next.latest_build.id &&
 		prev.latest_build.status === next.latest_build.status &&
 		prev.health.healthy === next.health.healthy &&
 		prev.name === next.name &&
@@ -467,6 +469,29 @@ export const isWatchedWorkspaceViewUnchanged = (
 			);
 		})
 	);
+};
+
+/**
+ * True when the chat's persisted agent binding does not resolve in the
+ * running workspace, which happens between a workspace rebuild and the next
+ * chat turn (or before the first binding is persisted). Chat reads repair the
+ * binding server-side, so the chat should be refetched. Requires agents in
+ * the latest build so a refetch is only requested when the server can
+ * actually re-resolve the binding.
+ *
+ * @internal Exported for testing.
+ */
+export const isChatAgentBindingUnresolved = (
+	workspace: TypesGen.Workspace | undefined,
+	chatAgentId: string | undefined,
+): boolean => {
+	if (!workspace || workspace.latest_build.status !== "running") {
+		return false;
+	}
+	if (getWorkspaceAgents(workspace).length === 0) {
+		return false;
+	}
+	return getWorkspaceAgent(workspace, chatAgentId) === undefined;
 };
 
 const buildAttachmentMediaTypes = (
@@ -1058,6 +1083,34 @@ const AgentChatPage: FC = () => {
 	const sshConfigQuery = useQuery(deploymentSSHConfig());
 	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 	const { proxy } = useProxy();
+
+	// After a workspace rebuild the chat's persisted agent binding can
+	// reference an agent from a previous build until the next turn rebinds
+	// it. Chat reads repair the binding, so refetch the chat, once per
+	// build/binding pair to stay loop-safe when repair is impossible.
+	const workspaceBuildId = workspace?.latest_build.id;
+	const agentBindingUnresolved = isChatAgentBindingUnresolved(
+		workspace,
+		chatAgentId,
+	);
+	const agentBindingRefetchKeyRef = useRef<string | undefined>(undefined);
+	useEffect(() => {
+		if (!agentId || !workspaceBuildId || !agentBindingUnresolved) {
+			return;
+		}
+		const refetchKey = `${agentId}:${workspaceBuildId}:${chatAgentId ?? ""}`;
+		if (agentBindingRefetchKeyRef.current === refetchKey) {
+			return;
+		}
+		agentBindingRefetchKeyRef.current = refetchKey;
+		void invalidateChatEntity(queryClient, agentId);
+	}, [
+		agentId,
+		workspaceBuildId,
+		chatAgentId,
+		agentBindingUnresolved,
+		queryClient,
+	]);
 
 	const chatRecord = chatQuery.data;
 	const isArchived = chatRecord?.archived ?? false;

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -28,7 +28,6 @@ import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chat,
-	chatEntityKey,
 	chatMessagesForInfiniteScroll,
 	chatModelConfigs,
 	chatModels,
@@ -128,6 +127,9 @@ import {
 export const RIGHT_PANEL_OPEN_KEY = "agents.right-panel-open";
 
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
+
+const AGENT_BINDING_REFETCH_COOLDOWN_MS = 30_000;
+
 class CompactCommandPendingError extends Error {}
 
 /** @internal Exported for testing. */
@@ -1023,7 +1025,9 @@ const AgentChatPage: FC = () => {
 		chatModelsQuery.data,
 	);
 
-	const agentBindingRefetchKeyRef = useRef<string | undefined>(undefined);
+	const agentBindingRefetchRef = useRef<
+		{ key: string; at: number } | undefined
+	>(undefined);
 	// Subscribe to live workspace updates so that agent status changes
 	// (e.g. connected/disconnected) are reflected without a page refresh.
 	const applyWatchedWorkspaceUpdate = useEffectEvent(
@@ -1044,27 +1048,26 @@ const AgentChatPage: FC = () => {
 					return next;
 				},
 			);
-			// Key refetches by chat, build, and binding so a failed repair cannot loop.
-			// Workspace watches send current state after reconnecting, so rebuilds missed
-			// while disconnected still trigger a refetch.
+			// Cool down refetches per chat/build/binding key: repair can fail
+			// with no query error (server enrichment is best-effort and can
+			// return the stale binding), so a bare latch would block retries
+			// while an unconditional refetch would fire on every watch event.
+			// Workspace watches send current state after reconnecting, so
+			// rebuilds missed while disconnected still trigger a refetch.
 			if (!agentId || !isChatAgentBindingUnresolved(next, chatAgentId)) {
 				return;
 			}
 			const refetchKey = `${agentId}:${next.latest_build.id}:${chatAgentId ?? ""}`;
-			if (agentBindingRefetchKeyRef.current === refetchKey) {
+			const lastRefetch = agentBindingRefetchRef.current;
+			const now = Date.now();
+			if (
+				lastRefetch?.key === refetchKey &&
+				now - lastRefetch.at < AGENT_BINDING_REFETCH_COOLDOWN_MS
+			) {
 				return;
 			}
-			agentBindingRefetchKeyRef.current = refetchKey;
-			void invalidateChatEntity(queryClient, agentId).then(() => {
-				// The query client does not retry, so clear the key after a
-				// failed refetch to let the next watch event try again.
-				if (
-					agentBindingRefetchKeyRef.current === refetchKey &&
-					queryClient.getQueryState(chatEntityKey(agentId))?.error
-				) {
-					agentBindingRefetchKeyRef.current = undefined;
-				}
-			});
+			agentBindingRefetchRef.current = { key: refetchKey, at: now };
+			void invalidateChatEntity(queryClient, agentId);
 		},
 	);
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -28,6 +28,7 @@ import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chat,
+	chatEntityKey,
 	chatMessagesForInfiniteScroll,
 	chatModelConfigs,
 	chatModels,
@@ -1054,7 +1055,16 @@ const AgentChatPage: FC = () => {
 				return;
 			}
 			agentBindingRefetchKeyRef.current = refetchKey;
-			void invalidateChatEntity(queryClient, agentId);
+			void invalidateChatEntity(queryClient, agentId).then(() => {
+				// The query client does not retry, so clear the key after a
+				// failed refetch to let the next watch event try again.
+				if (
+					agentBindingRefetchKeyRef.current === refetchKey &&
+					queryClient.getQueryState(chatEntityKey(agentId))?.error
+				) {
+					agentBindingRefetchKeyRef.current = undefined;
+				}
+			});
 		},
 	);
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -472,12 +472,9 @@ export const isWatchedWorkspaceViewUnchanged = (
 };
 
 /**
- * True when the chat's persisted agent binding does not resolve in the
- * running workspace, which happens between a workspace rebuild and the next
- * chat turn (or before the first binding is persisted). Chat reads repair the
- * binding server-side, so the chat should be refetched. Requires agents in
- * the latest build so a refetch is only requested when the server can
- * actually re-resolve the binding.
+ * True when a running workspace has agents but the chat's agent ID is absent
+ * from the latest build (stale after a rebuild, or not yet persisted). Chat
+ * reads can return a repaired ID, so callers should refetch the chat.
  *
  * @internal Exported for testing.
  */
@@ -488,10 +485,8 @@ export const isChatAgentBindingUnresolved = (
 	if (!workspace || workspace.latest_build.status !== "running") {
 		return false;
 	}
-	if (getWorkspaceAgents(workspace).length === 0) {
-		return false;
-	}
-	return getWorkspaceAgent(workspace, chatAgentId) === undefined;
+	const agents = getWorkspaceAgents(workspace);
+	return agents.length > 0 && !agents.some((agent) => agent.id === chatAgentId);
 };
 
 const buildAttachmentMediaTypes = (
@@ -1084,10 +1079,9 @@ const AgentChatPage: FC = () => {
 	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 	const { proxy } = useProxy();
 
-	// After a workspace rebuild the chat's persisted agent binding can
-	// reference an agent from a previous build until the next turn rebinds
-	// it. Chat reads repair the binding, so refetch the chat, once per
-	// build/binding pair to stay loop-safe when repair is impossible.
+	// A rebuild can leave the chat's persisted agent ID absent from the
+	// latest build. Chat reads can return a repaired ID, so refetch, once
+	// per chat/build/binding key to stay loop-safe when repair fails.
 	const workspaceBuildId = workspace?.latest_build.id;
 	const agentBindingUnresolved = isChatAgentBindingUnresolved(
 		workspace,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -128,7 +128,7 @@ export const RIGHT_PANEL_OPEN_KEY = "agents.right-panel-open";
 
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
 
-const AGENT_BINDING_REFETCH_COOLDOWN_MS = 30_000;
+const AGENT_BINDING_REPAIR_POLL_MS = 30_000;
 
 class CompactCommandPendingError extends Error {}
 
@@ -943,6 +943,21 @@ const AgentChatPage: FC = () => {
 	const chatQuery = useQuery({
 		...chat(agentId ?? ""),
 		enabled: Boolean(agentId),
+		// Poll while the binding is unresolved: repair happens on chat reads
+		// and watch events cannot be relied on for retries because an idle
+		// workspace publishes none.
+		refetchInterval: ({ state }) => {
+			const workspaceId = state.data?.workspace_id;
+			const workspace = workspaceId
+				? queryClient.getQueryData<TypesGen.Workspace>(
+						workspaceByIdKey(workspaceId),
+					)
+				: undefined;
+			return isChatAgentBindingUnresolved(workspace, state.data?.agent_id)
+				? AGENT_BINDING_REPAIR_POLL_MS
+				: false;
+		},
+		refetchIntervalInBackground: false,
 	});
 	const chatMessagesQuery = useInfiniteQuery({
 		...chatMessagesForInfiniteScroll(agentId ?? ""),
@@ -1025,9 +1040,7 @@ const AgentChatPage: FC = () => {
 		chatModelsQuery.data,
 	);
 
-	const agentBindingRefetchRef = useRef<
-		{ key: string; at: number } | undefined
-	>(undefined);
+	const agentBindingRefetchKeyRef = useRef<string | undefined>(undefined);
 	// Subscribe to live workspace updates so that agent status changes
 	// (e.g. connected/disconnected) are reflected without a page refresh.
 	const applyWatchedWorkspaceUpdate = useEffectEvent(
@@ -1048,22 +1061,17 @@ const AgentChatPage: FC = () => {
 					return next;
 				},
 			);
-			// Cool down each chat/build/binding key because best-effort repair can return
-			// a stale binding without a query error, while unconditional refetches would run
-			// on every event. Reconnects replay state, so missed rebuilds still refetch.
+			// Refetch once per chat/build/binding key for immediate repair
+			// after a rebuild; the chat query's refetchInterval owns retries
+			// when repair fails, so the latch never blocks recovery.
 			if (!agentId || !isChatAgentBindingUnresolved(next, chatAgentId)) {
 				return;
 			}
 			const refetchKey = `${agentId}:${next.latest_build.id}:${chatAgentId ?? ""}`;
-			const lastRefetch = agentBindingRefetchRef.current;
-			const now = Date.now();
-			if (
-				lastRefetch?.key === refetchKey &&
-				now - lastRefetch.at < AGENT_BINDING_REFETCH_COOLDOWN_MS
-			) {
+			if (agentBindingRefetchKeyRef.current === refetchKey) {
 				return;
 			}
-			agentBindingRefetchRef.current = { key: refetchKey, at: now };
+			agentBindingRefetchKeyRef.current = refetchKey;
 			void invalidateChatEntity(queryClient, agentId);
 		},
 	);

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1043,12 +1043,9 @@ const AgentChatPage: FC = () => {
 					return next;
 				},
 			);
-			// A rebuild can leave the chat's persisted agent ID absent from
-			// the latest build. Chat reads return a repaired ID, so refetch,
-			// once per chat/build/binding key to stay loop-safe when repair
-			// fails. The watch stream replays the current workspace on every
-			// (re)connect, so this also covers rebuilds missed while
-			// disconnected.
+			// Key refetches by chat, build, and binding so a failed repair cannot loop.
+			// Workspace watches send current state after reconnecting, so rebuilds missed
+			// while disconnected still trigger a refetch.
 			if (!agentId || !isChatAgentBindingUnresolved(next, chatAgentId)) {
 				return;
 			}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1022,6 +1022,7 @@ const AgentChatPage: FC = () => {
 		chatModelsQuery.data,
 	);
 
+	const agentBindingRefetchKeyRef = useRef<string | undefined>(undefined);
 	// Subscribe to live workspace updates so that agent status changes
 	// (e.g. connected/disconnected) are reflected without a page refresh.
 	const applyWatchedWorkspaceUpdate = useEffectEvent(
@@ -1042,6 +1043,21 @@ const AgentChatPage: FC = () => {
 					return next;
 				},
 			);
+			// A rebuild can leave the chat's persisted agent ID absent from
+			// the latest build. Chat reads return a repaired ID, so refetch,
+			// once per chat/build/binding key to stay loop-safe when repair
+			// fails. The watch stream replays the current workspace on every
+			// (re)connect, so this also covers rebuilds missed while
+			// disconnected.
+			if (!agentId || !isChatAgentBindingUnresolved(next, chatAgentId)) {
+				return;
+			}
+			const refetchKey = `${agentId}:${next.latest_build.id}:${chatAgentId ?? ""}`;
+			if (agentBindingRefetchKeyRef.current === refetchKey) {
+				return;
+			}
+			agentBindingRefetchKeyRef.current = refetchKey;
+			void invalidateChatEntity(queryClient, agentId);
 		},
 	);
 	useEffect(() => {
@@ -1078,33 +1094,6 @@ const AgentChatPage: FC = () => {
 	const sshConfigQuery = useQuery(deploymentSSHConfig());
 	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 	const { proxy } = useProxy();
-
-	// A rebuild can leave the chat's persisted agent ID absent from the
-	// latest build. Chat reads can return a repaired ID, so refetch, once
-	// per chat/build/binding key to stay loop-safe when repair fails.
-	const workspaceBuildId = workspace?.latest_build.id;
-	const agentBindingUnresolved = isChatAgentBindingUnresolved(
-		workspace,
-		chatAgentId,
-	);
-	const agentBindingRefetchKeyRef = useRef<string | undefined>(undefined);
-	useEffect(() => {
-		if (!agentId || !workspaceBuildId || !agentBindingUnresolved) {
-			return;
-		}
-		const refetchKey = `${agentId}:${workspaceBuildId}:${chatAgentId ?? ""}`;
-		if (agentBindingRefetchKeyRef.current === refetchKey) {
-			return;
-		}
-		agentBindingRefetchKeyRef.current = refetchKey;
-		void invalidateChatEntity(queryClient, agentId);
-	}, [
-		agentId,
-		workspaceBuildId,
-		chatAgentId,
-		agentBindingUnresolved,
-		queryClient,
-	]);
 
 	const chatRecord = chatQuery.data;
 	const isArchived = chatRecord?.archived ?? false;


### PR DESCRIPTION
## Problem

When a chat is bound to a workspace, chatd persists `chats.agent_id` pointing at a specific workspace agent, and it only rebinds on the next chat turn. A workspace stop/start creates a new agent with a new ID in the latest build, so the chat page resolves the stale agent ID to `undefined` and the right sidebar silently drops Terminal, Desktop, Browser, apps, and ports even though the workspace is running. The existing read-time enrichment only filled nil agent IDs and skipped stale non-nil ones, so refreshing did not help until the user sent another message.

## Fix

- `coderd/exp_chats.go`: single-chat reads now repair agent IDs that no longer resolve in the workspace's latest build, using the same `agentselect.FindChatAgent` selection chatd uses. A repaired binding also carries the latest build's ID so the response never pairs the new agent with the previous build. Bindings that still resolve are preserved, and repair stays best-effort and response-only (no write-on-read). List reads keep the previous nil-fill-only behavior because validating existing bindings would cost a per-workspace authorization lookup per listed chat.
- `site/src/pages/AgentsPage/AgentChatPage.tsx`: the workspace watch update handler detects when a running workspace's latest build no longer contains the chat's bound agent and invalidates the chat query once per chat/build/binding key for immediate recovery, and the chat query polls every 30 seconds while the binding remains unresolved so a transiently failed repair retries even when an idle workspace publishes no further watch events. The watch stream replays the current workspace on every (re)connect, so this covers rebuilds that happen while the page is open or disconnected; page loads are covered by the server-side repair. The workspace-watcher bailout now also keys on `latest_build.id` so a rebuild propagates while the page is open.
- `site/src/api/queries/chats.ts`: chat watch events replay the persisted (pre-repair) binding, so the summary merge adopts a snapshot's `build_id` only when the snapshot agrees on `agent_id`, keeping the repaired agent/build pair atomic in the caches.

## Testing

- `go test ./coderd -run TestEnrichChatAgentIDs` covering repair, keep-valid, selection-error, list-mode-skips-bound, and no-workspaces cases.
- Storybook interaction story `RecoversSidebarAfterWorkspaceRebuild` exercising the watch-event to chat-refetch to sidebar-recovery flow (verified red without the invalidation, green with it).
- `pnpm test AgentChatPage.test.ts` covering the binding-resolution predicate.

> Mux created this PR on Mike's behalf.




