### PR TITLE
test(site/src/modules/workspaces): cover version picker stacking

### DIFF
--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { templateVersionsQueryKey } from "#/api/queries/templates";
 import {
 	MockTemplateVersion,
@@ -75,3 +76,52 @@ export const MarkdownMessage: Story = {
 		},
 	},
 };
+
+export const SelectVersion: Story = {
+	args: {
+		onClose: fn(),
+		onConfirm: fn(),
+	},
+	play: async ({ args }) => {
+		const body = within(document.body);
+
+		const trigger = body.getByRole("button", { name: "Template version" });
+		await userEvent.click(trigger);
+
+		const option = await body.findByRole("option", {
+			name: new RegExp(MockTemplateVersionWithMarkdownMessage.name),
+		});
+		await waitFor(() => expect(isTopmostAtCenter(option)).toBe(true));
+
+		await userEvent.click(option);
+		await waitFor(() =>
+			expect(trigger).toHaveTextContent(
+				MockTemplateVersionWithMarkdownMessage.name,
+			),
+		);
+
+		await userEvent.click(body.getByRole("button", { name: "Change" }));
+		await waitFor(() =>
+			expect(args.onConfirm).toHaveBeenCalledWith(
+				MockTemplateVersionWithMarkdownMessage,
+			),
+		);
+	},
+};
+
+/**
+ * Reports whether a click at the element's center would land on it.
+ *
+ * The version picker is a popover that portals to the document body, outside
+ * the dialog it belongs to. Queries and visibility assertions still pass when
+ * that popover paints underneath the dialog surface, so only a hit test proves
+ * the options are reachable.
+ */
+function isTopmostAtCenter(element: Element): boolean {
+	const { left, top, width, height } = element.getBoundingClientRect();
+	const hit = document.elementFromPoint(
+		Math.round(left + width / 2),
+		Math.round(top + height / 2),
+	);
+	return hit !== null && element.contains(hit);
+}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of @david-fraley.

Closes [DEVEX-780](https://linear.app/codercom/issue/DEVEX-780/change-version-dialog-picker-is-inaccessible) on `main`.

## Context

[DEVEX-780](https://linear.app/codercom/issue/DEVEX-780/change-version-dialog-picker-is-inaccessible) reports that the Change version dialog's picker is unusable, hidden behind the dialog backdrop. The report is accurate for **2.36.0**, but `main` is already fixed. This PR adds the regression guard that was missing, rather than a redundant fix.

**What happened:** the picker is a Radix popover that portals to `document.body` with `z-50`. coder/coder#24276 swapped this dialog's MUI `Autocomplete` for that popover on 2026-07-14, while the surrounding dialog was still `@mui/material/Dialog` at `z-index: 1300`. Two body-level portals, `50` loses to `1300`, so the options painted under the dialog surface. coder/coder#27506 moved all dialogs onto Radix on 2026-07-31, which fixed the stacking incidentally, but it landed after the 2.36 branch cut. So 2.36.0 shipped broken and `main` did not.

**Why nothing caught it:** the dialog has four stories, and none of them open the picker. Even if they did, a plain `userEvent.click` on an option succeeds while the popover is layered behind the dialog, because testing-library does not hit test.

## Change

Adds a `SelectVersion` story that opens the picker, hit tests an option against `document.elementFromPoint`, then selects it and confirms. Storybook stories run in real Chromium via the `storybook` vitest project, so the hit test is meaningful in CI.

## Validation

Both trees rendered in headless Chromium, immediately after clicking the picker trigger.

`v2.36.0`**, picker open.** The dialog is unchanged: the option list is behind it.

![Change version dialog on v2.36.0 with the picker open, showing no visible option list](https://raw.githubusercontent.com/coder/coder/dfraley/eng-3175-assets/eng-3175-v2.36.0-picker-open.png)

`main`**, picker open.** The option list paints above the dialog.

![Change version dialog on main with the picker open, showing the option list above the dialog](https://raw.githubusercontent.com/coder/coder/dfraley/eng-3175-assets/eng-3175-main-picker-open.png)

`v2.36.0`**, after clicking where an option should be.** Pixel-identical to the previous 2.36.0 shot; the click hits the dialog instead.

![Change version dialog on v2.36.0 after clicking an option, unchanged from before the click](https://raw.githubusercontent.com/coder/coder/dfraley/eng-3175-assets/eng-3175-v2.36.0-after-click.png)

Measured from the DOM in the same runs:

<!-- linear:table-colwidths:266,266,266 -->
|  | `v2.36.0` | `main` |
| -- | -- | -- |
| dialog container `z-index` | `1300` (MUI) | `50` (Radix) |
| popover `z-index` | `50` | `50` |
| element at popover center | `div.css-az7ti9` (the dialog) | the popover contents |
| click an option | timed out, intercepted | selected |

The guard itself was run against both trees, to confirm it detects the reported bug rather than just passing:

<!-- linear:table-colwidths:400,400 -->
| Tree | `vitest run --project=storybook ChangeWorkspaceVersionDialog.stories.tsx` |
| -- | -- |
| `main` (this branch) | 5 passed |
| `v2.36.0` (story cherry-picked in) | 4 passed, 1 failed at the hit test |

Also ran `biome check` and `tsc` clean on the changed file.

Screenshots are hosted on the `dfraley/eng-3175-assets` branch of this repo, which carries no code and is not part of this PR.

## Note on 2.36.x

This PR does not fix released 2.36. Customers on 2.36.0 still hit this. A backport would be a one-line z-index bump on `ComboboxContent` in that dialog. Backporting coder/coder#27506 itself is not advisable, it touches \~30 dialogs.