### PR TITLE
fix(site): auto-select MCP server after successful OAuth

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -840,6 +840,46 @@ export const MCPAutoEnablesAfterOAuthCompletes: Story = {
 	},
 };
 
+// The coderd callback page posts the completion message and then closes
+// the popup, so the close poll can observe the closed popup before the
+// queued message is dispatched. An iframe contentWindow stands in for
+// the popup: it is a real Window whose closed becomes true on removal.
+export const MCPAutoEnablesWhenPopupClosesBeforeMessage: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [githubMCP],
+		selectedMCPServerIds: [],
+	},
+	play: async ({ args, canvasElement }) => {
+		const doc = canvasElement.ownerDocument;
+		const iframe = doc.createElement("iframe");
+		doc.body.appendChild(iframe);
+		const popup = iframe.contentWindow;
+		if (!popup) {
+			throw new Error("iframe contentWindow unavailable");
+		}
+		spyOn(window, "open").mockReturnValue(popup);
+
+		await startMCPOAuthFlow(canvasElement);
+		iframe.remove();
+		expect(popup.closed).toBe(true);
+		// Wait for the close poll to clear the connecting state before
+		// delivering the completion message.
+		const body = within(doc.body);
+		await waitFor(
+			() => {
+				expect(body.getByRole("button", { name: "Auth" })).toBeEnabled();
+			},
+			{ timeout: 2_000 },
+		);
+		dispatchMCPOAuthComplete(githubMCP.id, popup);
+
+		await waitFor(() => {
+			expect(args.onMCPSelectionChange).toHaveBeenCalledWith([githubMCP.id]);
+		});
+	},
+};
+
 export const MCPDoesNotDuplicateSelectionAfterOAuthCompletes: Story = {
 	args: {
 		...mcpDefaults,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -769,8 +769,8 @@ const dispatchMCPOAuthComplete = (
 	);
 };
 
-// Requires window.open mocked to return `window` so the completion
-// message can carry the popup as its source.
+// Requires window.open mocked to return a Window; the completion
+// message's source must be that same mocked popup to correlate.
 const startMCPOAuthFlow = async (canvasElement: HTMLElement) => {
 	const canvas = within(canvasElement);
 	const body = within(canvasElement.ownerDocument.body);

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -756,13 +756,26 @@ const mcpDefaults = {
 	onMCPAuthComplete: fn(),
 };
 
-const dispatchMCPOAuthComplete = (serverID: string) => {
+const dispatchMCPOAuthComplete = (
+	serverID: string,
+	source: MessageEventSource | null = null,
+) => {
 	window.dispatchEvent(
 		new MessageEvent("message", {
 			data: { type: "mcp-oauth2-complete", serverID },
 			origin: location.origin,
+			source,
 		}),
 	);
+};
+
+// Requires window.open mocked to return `window` so the completion
+// message can carry the popup as its source.
+const startMCPOAuthFlow = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	const body = within(canvasElement.ownerDocument.body);
+	await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+	await userEvent.click(await body.findByRole("button", { name: "Auth" }));
 };
 
 // ── MCP stories ────────────────────────────────────────────────
@@ -805,8 +818,17 @@ export const MCPAutoEnablesAfterOAuthCompletes: Story = {
 		mcpServers: [linearMCP, githubMCP],
 		selectedMCPServerIds: [linearMCP.id],
 	},
-	play: async ({ args }) => {
-		dispatchMCPOAuthComplete(githubMCP.id);
+	beforeEach: () => {
+		spyOn(window, "open").mockReturnValue(window);
+	},
+	play: async ({ args, canvasElement }) => {
+		await startMCPOAuthFlow(canvasElement);
+		expect(window.open).toHaveBeenCalledWith(
+			`/api/experimental/mcp/servers/${githubMCP.id}/oauth2/connect`,
+			"_blank",
+			"width=900,height=600",
+		);
+		dispatchMCPOAuthComplete(githubMCP.id, window);
 
 		await waitFor(() => {
 			expect(args.onMCPSelectionChange).toHaveBeenCalledWith([
@@ -824,8 +846,12 @@ export const MCPDoesNotDuplicateSelectionAfterOAuthCompletes: Story = {
 		mcpServers: [githubMCP],
 		selectedMCPServerIds: [githubMCP.id],
 	},
-	play: async ({ args }) => {
-		dispatchMCPOAuthComplete(githubMCP.id);
+	beforeEach: () => {
+		spyOn(window, "open").mockReturnValue(window);
+	},
+	play: async ({ args, canvasElement }) => {
+		await startMCPOAuthFlow(canvasElement);
+		dispatchMCPOAuthComplete(githubMCP.id, window);
 
 		await waitFor(() => {
 			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(githubMCP.id);
@@ -834,34 +860,37 @@ export const MCPDoesNotDuplicateSelectionAfterOAuthCompletes: Story = {
 	},
 };
 
-export const MCPIgnoresDisabledServerAfterOAuthCompletes: Story = {
+export const MCPIgnoresUnsolicitedOAuthComplete: Story = {
 	args: {
 		...mcpDefaults,
-		mcpServers: [{ ...githubMCP, enabled: false }],
-		selectedMCPServerIds: [],
-	},
-	play: async ({ args }) => {
-		dispatchMCPOAuthComplete(githubMCP.id);
-
-		await waitFor(() => {
-			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(githubMCP.id);
-		});
-		expect(args.onMCPSelectionChange).not.toHaveBeenCalled();
-	},
-};
-
-export const MCPIgnoresUnknownServerAfterOAuthCompletes: Story = {
-	args: {
-		...mcpDefaults,
-		mcpServers: [linearMCP],
+		mcpServers: [linearMCP, githubMCP],
 		selectedMCPServerIds: [linearMCP.id],
 	},
 	play: async ({ args }) => {
-		const unknownServerID = "mcp-unknown";
-		dispatchMCPOAuthComplete(unknownServerID);
+		dispatchMCPOAuthComplete(githubMCP.id, window);
 
 		await waitFor(() => {
-			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(unknownServerID);
+			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(githubMCP.id);
+		});
+		expect(args.onMCPSelectionChange).not.toHaveBeenCalled();
+	},
+};
+
+export const MCPIgnoresMismatchedServerAfterOAuthCompletes: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [linearMCP, githubMCP],
+		selectedMCPServerIds: [],
+	},
+	beforeEach: () => {
+		spyOn(window, "open").mockReturnValue(window);
+	},
+	play: async ({ args, canvasElement }) => {
+		await startMCPOAuthFlow(canvasElement);
+		dispatchMCPOAuthComplete(linearMCP.id, window);
+
+		await waitFor(() => {
+			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(linearMCP.id);
 		});
 		expect(args.onMCPSelectionChange).not.toHaveBeenCalled();
 	},

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -809,6 +809,9 @@ export const WithMCPNeedingAuth: Story = {
 			"_blank",
 			"width=900,height=600",
 		);
+		// The popup was blocked (window.open returned null), so the flow
+		// must not enter the connecting state that disables Auth buttons.
+		expect(body.getByRole("button", { name: "Auth" })).toBeEnabled();
 	},
 };
 
@@ -824,7 +827,7 @@ export const MCPAutoEnablesAfterOAuthCompletes: Story = {
 	play: async ({ args, canvasElement }) => {
 		await startMCPOAuthFlow(canvasElement);
 		expect(window.open).toHaveBeenCalledWith(
-			`/api/experimental/mcp/servers/${githubMCP.id}/oauth2/connect`,
+			`/api/experimental/organizations/org-1/mcp-servers/${githubMCP.id}/oauth2/connect`,
 			"_blank",
 			"width=900,height=600",
 		);

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -756,6 +756,15 @@ const mcpDefaults = {
 	onMCPAuthComplete: fn(),
 };
 
+const dispatchMCPOAuthComplete = (serverID: string) => {
+	window.dispatchEvent(
+		new MessageEvent("message", {
+			data: { type: "mcp-oauth2-complete", serverID },
+			origin: location.origin,
+		}),
+	);
+};
+
 // ── MCP stories ────────────────────────────────────────────────
 
 /** Input with multiple MCP servers selected — shows icon stack in toolbar. */
@@ -787,6 +796,74 @@ export const WithMCPNeedingAuth: Story = {
 			"_blank",
 			"width=900,height=600",
 		);
+	},
+};
+
+export const MCPAutoEnablesAfterOAuthCompletes: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [linearMCP, githubMCP],
+		selectedMCPServerIds: [linearMCP.id],
+	},
+	play: async ({ args }) => {
+		dispatchMCPOAuthComplete(githubMCP.id);
+
+		await waitFor(() => {
+			expect(args.onMCPSelectionChange).toHaveBeenCalledWith([
+				linearMCP.id,
+				githubMCP.id,
+			]);
+			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(githubMCP.id);
+		});
+	},
+};
+
+export const MCPDoesNotDuplicateSelectionAfterOAuthCompletes: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [githubMCP],
+		selectedMCPServerIds: [githubMCP.id],
+	},
+	play: async ({ args }) => {
+		dispatchMCPOAuthComplete(githubMCP.id);
+
+		await waitFor(() => {
+			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(githubMCP.id);
+		});
+		expect(args.onMCPSelectionChange).not.toHaveBeenCalled();
+	},
+};
+
+export const MCPIgnoresDisabledServerAfterOAuthCompletes: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [{ ...githubMCP, enabled: false }],
+		selectedMCPServerIds: [],
+	},
+	play: async ({ args }) => {
+		dispatchMCPOAuthComplete(githubMCP.id);
+
+		await waitFor(() => {
+			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(githubMCP.id);
+		});
+		expect(args.onMCPSelectionChange).not.toHaveBeenCalled();
+	},
+};
+
+export const MCPIgnoresUnknownServerAfterOAuthCompletes: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [linearMCP],
+		selectedMCPServerIds: [linearMCP.id],
+	},
+	play: async ({ args }) => {
+		const unknownServerID = "mcp-unknown";
+		dispatchMCPOAuthComplete(unknownServerID);
+
+		await waitFor(() => {
+			expect(args.onMCPAuthComplete).toHaveBeenCalledWith(unknownServerID);
+		});
+		expect(args.onMCPSelectionChange).not.toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -17,6 +17,7 @@ import type React from "react";
 import {
 	type FC,
 	useEffect,
+	useEffectEvent,
 	useImperativeHandle,
 	useRef,
 	useState,
@@ -507,6 +508,20 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		[],
 	);
 
+	const handleMCPAuthComplete = useEffectEvent((serverID: string) => {
+		setMcpConnectingId(null);
+		onMCPAuthComplete?.(serverID);
+		if (
+			onMCPSelectionChange &&
+			selectedMCPServerIds &&
+			mcpServers?.some((server) => server.id === serverID && server.enabled) &&
+			!selectedMCPServerIds.includes(serverID)
+		) {
+			onMCPSelectionChange([...selectedMCPServerIds, serverID]);
+		}
+		mcpPopupRef.current = null;
+	});
+
 	// Listen for OAuth2 completion postMessage from popup.
 	useEffect(() => {
 		const handler = (event: MessageEvent) => {
@@ -515,14 +530,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				event.data?.type === "mcp-oauth2-complete" &&
 				typeof event.data.serverID === "string"
 			) {
-				setMcpConnectingId(null);
-				onMCPAuthComplete?.(event.data.serverID);
-				mcpPopupRef.current = null;
+				handleMCPAuthComplete(event.data.serverID);
 			}
 		};
 		window.addEventListener("message", handler);
 		return () => window.removeEventListener("message", handler);
-	}, [onMCPAuthComplete]);
+	}, []);
 
 	// Poll for popup close and clean up on unmount.
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -508,19 +508,31 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		[],
 	);
 
-	const handleMCPAuthComplete = useEffectEvent((serverID: string) => {
-		setMcpConnectingId(null);
-		onMCPAuthComplete?.(serverID);
-		if (
-			onMCPSelectionChange &&
-			selectedMCPServerIds &&
-			mcpServers?.some((server) => server.id === serverID && server.enabled) &&
-			!selectedMCPServerIds.includes(serverID)
-		) {
-			onMCPSelectionChange([...selectedMCPServerIds, serverID]);
-		}
-		mcpPopupRef.current = null;
-	});
+	const handleMCPAuthComplete = useEffectEvent(
+		(serverID: string, source: MessageEventSource | null) => {
+			onMCPAuthComplete?.(serverID);
+			// Only the popup this input opened expresses intent to use the
+			// server; a stray same-origin message must not clear an in-flight
+			// connect or change the selection.
+			if (source === null || source !== mcpPopupRef.current) {
+				return;
+			}
+			const isInitiatedServer = mcpConnectingId === serverID;
+			setMcpConnectingId(null);
+			mcpPopupRef.current = null;
+			if (
+				isInitiatedServer &&
+				onMCPSelectionChange &&
+				selectedMCPServerIds &&
+				mcpServers?.some(
+					(server) => server.id === serverID && server.enabled,
+				) &&
+				!selectedMCPServerIds.includes(serverID)
+			) {
+				onMCPSelectionChange([...selectedMCPServerIds, serverID]);
+			}
+		},
+	);
 
 	// Listen for OAuth2 completion postMessage from popup.
 	useEffect(() => {
@@ -530,7 +542,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				event.data?.type === "mcp-oauth2-complete" &&
 				typeof event.data.serverID === "string"
 			) {
-				handleMCPAuthComplete(event.data.serverID);
+				handleMCPAuthComplete(event.data.serverID, event.source);
 			}
 		};
 		window.addEventListener("message", handler);

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -431,7 +431,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	);
 	const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
 	const [mcpConnectingId, setMcpConnectingId] = useState<string | null>(null);
-	const mcpPopupRef = useRef<Window | null>(null);
+	// Correlates a completion message with the initiating OAuth flow.
+	// Retained after popup close: the callback page posts before closing,
+	// and the close poll can run before the queued message is dispatched.
+	const mcpAuthFlowRef = useRef<{ popup: Window; serverID: string } | null>(
+		null,
+	);
 	const [mcpDisconnectTarget, setMcpDisconnectTarget] =
 		useState<TypesGen.MCPServerConfig | null>(null);
 	const queryClient = useQueryClient();
@@ -511,17 +516,15 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleMCPAuthComplete = useEffectEvent(
 		(serverID: string, source: MessageEventSource | null) => {
 			onMCPAuthComplete?.(serverID);
-			// Only the popup this input opened expresses intent to use the
-			// server; a stray same-origin message must not clear an in-flight
-			// connect or change the selection.
-			if (source === null || source !== mcpPopupRef.current) {
+			// Only a message from the initiating popup for the initiating
+			// server may change the selection.
+			const flow = mcpAuthFlowRef.current;
+			if (!flow || source !== flow.popup || serverID !== flow.serverID) {
 				return;
 			}
-			const isInitiatedServer = mcpConnectingId === serverID;
+			mcpAuthFlowRef.current = null;
 			setMcpConnectingId(null);
-			mcpPopupRef.current = null;
 			if (
-				isInitiatedServer &&
 				onMCPSelectionChange &&
 				selectedMCPServerIds &&
 				mcpServers?.some(
@@ -549,20 +552,22 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		return () => window.removeEventListener("message", handler);
 	}, []);
 
-	// Poll for popup close and clean up on unmount.
+	// Clear only the connecting indicator when the popup closes; the flow
+	// ref stays so a completion message posted before close still
+	// correlates.
 	useEffect(() => {
-		if (!mcpConnectingId || !mcpPopupRef.current) return;
+		if (!mcpConnectingId || !mcpAuthFlowRef.current) return;
 		const interval = setInterval(() => {
-			if (mcpPopupRef.current?.closed) {
+			if (mcpAuthFlowRef.current?.popup.closed) {
 				setMcpConnectingId(null);
-				mcpPopupRef.current = null;
 			}
 		}, 500);
 		return () => {
 			clearInterval(interval);
-			if (mcpPopupRef.current && !mcpPopupRef.current.closed) {
-				mcpPopupRef.current.close();
-				mcpPopupRef.current = null;
+			const popup = mcpAuthFlowRef.current?.popup;
+			if (popup && !popup.closed) {
+				popup.close();
+				mcpAuthFlowRef.current = null;
 			}
 		};
 	}, [mcpConnectingId]);
@@ -587,11 +592,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			chatOrganizationId,
 			server.id,
 		);
-		mcpPopupRef.current = window.open(
-			connectUrl,
-			"_blank",
-			"width=900,height=600",
-		);
+		const popup = window.open(connectUrl, "_blank", "width=900,height=600");
+		mcpAuthFlowRef.current = popup ? { popup, serverID: server.id } : null;
 	};
 
 	const handleMcpDisconnectConfirm = () => {

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -429,7 +429,6 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		"main",
 	);
 	const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
-	// Auto-select the server once its OAuth flow succeeds.
 	const { connectingServerId: mcpConnectingId, connect: connectMCPServer } =
 		useMCPOAuthFlow({
 			organizationId: chatOrganizationId,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -17,7 +17,6 @@ import type React from "react";
 import {
 	type FC,
 	useEffect,
-	useEffectEvent,
 	useImperativeHandle,
 	useRef,
 	useState,
@@ -25,7 +24,6 @@ import {
 import { useMutation, useQueryClient } from "react-query";
 import { Link } from "react-router";
 import { toast } from "sonner";
-import { mcpServerOAuth2ConnectPath } from "#/api/api";
 import { getErrorMessage } from "#/api/errors";
 import { disconnectMCPServerOAuth2 } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -63,6 +61,7 @@ import { cn } from "#/utils/cn";
 import { countInvisibleCharacters } from "#/utils/invisibleUnicode";
 import { isBelowMdViewport, isMobileViewport } from "#/utils/mobile";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
+import { useMCPOAuthFlow } from "../hooks/useMCPOAuthFlow";
 import { useOverflowCount } from "../hooks/useOverflowCount";
 import { useSpeechRecognition } from "../hooks/useSpeechRecognition";
 import {
@@ -430,13 +429,24 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		"main",
 	);
 	const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
-	const [mcpConnectingId, setMcpConnectingId] = useState<string | null>(null);
-	// Correlates a completion message with the initiating OAuth flow.
-	// Retained after popup close: the callback page posts before closing,
-	// and the close poll can run before the queued message is dispatched.
-	const mcpAuthFlowRef = useRef<{ popup: Window; serverID: string } | null>(
-		null,
-	);
+	// Auto-select the server once its OAuth flow succeeds.
+	const { connectingServerId: mcpConnectingId, connect: connectMCPServer } =
+		useMCPOAuthFlow({
+			organizationId: chatOrganizationId,
+			onAuthComplete: onMCPAuthComplete,
+			onFlowSuccess: (serverID) => {
+				if (
+					onMCPSelectionChange &&
+					selectedMCPServerIds &&
+					mcpServers?.some(
+						(server) => server.id === serverID && server.enabled,
+					) &&
+					!selectedMCPServerIds.includes(serverID)
+				) {
+					onMCPSelectionChange([...selectedMCPServerIds, serverID]);
+				}
+			},
+		});
 	const [mcpDisconnectTarget, setMcpDisconnectTarget] =
 		useState<TypesGen.MCPServerConfig | null>(null);
 	const queryClient = useQueryClient();
@@ -513,65 +523,6 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		[],
 	);
 
-	const handleMCPAuthComplete = useEffectEvent(
-		(serverID: string, source: MessageEventSource | null) => {
-			onMCPAuthComplete?.(serverID);
-			// Only a message from the initiating popup for the initiating
-			// server may change the selection.
-			const flow = mcpAuthFlowRef.current;
-			if (!flow || source !== flow.popup || serverID !== flow.serverID) {
-				return;
-			}
-			mcpAuthFlowRef.current = null;
-			setMcpConnectingId(null);
-			if (
-				onMCPSelectionChange &&
-				selectedMCPServerIds &&
-				mcpServers?.some(
-					(server) => server.id === serverID && server.enabled,
-				) &&
-				!selectedMCPServerIds.includes(serverID)
-			) {
-				onMCPSelectionChange([...selectedMCPServerIds, serverID]);
-			}
-		},
-	);
-
-	// Listen for OAuth2 completion postMessage from popup.
-	useEffect(() => {
-		const handler = (event: MessageEvent) => {
-			if (event.origin !== location.origin) return;
-			if (
-				event.data?.type === "mcp-oauth2-complete" &&
-				typeof event.data.serverID === "string"
-			) {
-				handleMCPAuthComplete(event.data.serverID, event.source);
-			}
-		};
-		window.addEventListener("message", handler);
-		return () => window.removeEventListener("message", handler);
-	}, []);
-
-	// Clear only the connecting indicator when the popup closes; the flow
-	// ref stays so a completion message posted before close still
-	// correlates.
-	useEffect(() => {
-		if (!mcpConnectingId || !mcpAuthFlowRef.current) return;
-		const interval = setInterval(() => {
-			if (mcpAuthFlowRef.current?.popup.closed) {
-				setMcpConnectingId(null);
-			}
-		}, 500);
-		return () => {
-			clearInterval(interval);
-			const popup = mcpAuthFlowRef.current?.popup;
-			if (popup && !popup.closed) {
-				popup.close();
-				mcpAuthFlowRef.current = null;
-			}
-		};
-	}, [mcpConnectingId]);
-
 	const handleMcpToggle = (serverId: string, checked: boolean) => {
 		if (!onMCPSelectionChange || !selectedMCPServerIds) return;
 		if (checked) {
@@ -581,19 +532,6 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				selectedMCPServerIds.filter((id) => id !== serverId),
 			);
 		}
-	};
-
-	const handleMcpConnect = (server: TypesGen.MCPServerConfig) => {
-		if (!chatOrganizationId) {
-			return;
-		}
-		setMcpConnectingId(server.id);
-		const connectUrl = mcpServerOAuth2ConnectPath(
-			chatOrganizationId,
-			server.id,
-		);
-		const popup = window.open(connectUrl, "_blank", "width=900,height=600");
-		mcpAuthFlowRef.current = popup ? { popup, serverID: server.id } : null;
 	};
 
 	const handleMcpDisconnectConfirm = () => {
@@ -1424,7 +1362,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 																	variant="outline"
 																	size="sm"
 																	className="h-6 shrink-0 px-2 text-[10px] leading-none"
-																	onClick={() => handleMcpConnect(server)}
+																	onClick={() => connectMCPServer(server.id)}
 																	disabled={
 																		isDisabled || mcpConnectingId !== null
 																	}

--- a/site/src/pages/AgentsPage/hooks/useMCPOAuthFlow.ts
+++ b/site/src/pages/AgentsPage/hooks/useMCPOAuthFlow.ts
@@ -17,10 +17,12 @@ type MCPOAuthFlow = {
 	connect: (serverId: string) => void;
 };
 
-// Runs the MCP server OAuth2 popup flow: opens the consent popup,
-// listens for the completion message coderd's callback page posts to
-// the opener, and reports success only for the initiating popup and
-// server.
+/**
+ * Runs the MCP server OAuth2 popup flow: opens the consent popup,
+ * listens for the completion message coderd's callback page posts to
+ * the opener, and reports success only for the initiating popup and
+ * server.
+ */
 export const useMCPOAuthFlow = ({
 	organizationId,
 	onAuthComplete,

--- a/site/src/pages/AgentsPage/hooks/useMCPOAuthFlow.ts
+++ b/site/src/pages/AgentsPage/hooks/useMCPOAuthFlow.ts
@@ -13,7 +13,6 @@ type UseMCPOAuthFlowOptions = {
 };
 
 type MCPOAuthFlow = {
-	// Server whose OAuth consent popup is open.
 	connectingServerId: string | null;
 	connect: (serverId: string) => void;
 };
@@ -51,7 +50,6 @@ export const useMCPOAuthFlow = ({
 		},
 	);
 
-	// Listen for OAuth2 completion postMessage from popup.
 	useEffect(() => {
 		const handler = (event: MessageEvent) => {
 			if (event.origin !== location.origin) return;

--- a/site/src/pages/AgentsPage/hooks/useMCPOAuthFlow.ts
+++ b/site/src/pages/AgentsPage/hooks/useMCPOAuthFlow.ts
@@ -1,0 +1,102 @@
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { mcpServerOAuth2ConnectPath } from "#/api/api";
+
+type UseMCPOAuthFlowOptions = {
+	organizationId?: string;
+	// Called for every same-origin completion message, regardless of
+	// which flow (if any) produced it, so callers can refresh server
+	// state.
+	onAuthComplete?: (serverId: string) => void;
+	// Called only for a completion posted by the initiating popup for
+	// the initiating server.
+	onFlowSuccess: (serverId: string) => void;
+};
+
+type MCPOAuthFlow = {
+	// Server whose OAuth consent popup is open.
+	connectingServerId: string | null;
+	connect: (serverId: string) => void;
+};
+
+// Runs the MCP server OAuth2 popup flow: opens the consent popup,
+// listens for the completion message coderd's callback page posts to
+// the opener, and reports success only for the initiating popup and
+// server.
+export const useMCPOAuthFlow = ({
+	organizationId,
+	onAuthComplete,
+	onFlowSuccess,
+}: UseMCPOAuthFlowOptions): MCPOAuthFlow => {
+	const [connectingServerId, setConnectingServerId] = useState<string | null>(
+		null,
+	);
+	// Correlates a completion message with the initiating flow.
+	// Retained after popup close: the callback page posts before
+	// closing, and the close poll can run before the queued message is
+	// dispatched.
+	const flowRef = useRef<{ popup: Window; serverID: string } | null>(null);
+
+	const handleAuthComplete = useEffectEvent(
+		(serverID: string, source: MessageEventSource | null) => {
+			onAuthComplete?.(serverID);
+			// Only a message from the initiating popup for the initiating
+			// server counts as flow success.
+			const flow = flowRef.current;
+			if (!flow || source !== flow.popup || serverID !== flow.serverID) {
+				return;
+			}
+			flowRef.current = null;
+			setConnectingServerId(null);
+			onFlowSuccess(serverID);
+		},
+	);
+
+	// Listen for OAuth2 completion postMessage from popup.
+	useEffect(() => {
+		const handler = (event: MessageEvent) => {
+			if (event.origin !== location.origin) return;
+			if (
+				event.data?.type === "mcp-oauth2-complete" &&
+				typeof event.data.serverID === "string"
+			) {
+				handleAuthComplete(event.data.serverID, event.source);
+			}
+		};
+		window.addEventListener("message", handler);
+		return () => window.removeEventListener("message", handler);
+	}, []);
+
+	// Clear only the connecting indicator when the popup closes; the
+	// flow ref stays so a completion message posted before close still
+	// correlates.
+	useEffect(() => {
+		if (!connectingServerId || !flowRef.current) return;
+		const interval = setInterval(() => {
+			if (flowRef.current?.popup.closed) {
+				setConnectingServerId(null);
+			}
+		}, 500);
+		return () => {
+			clearInterval(interval);
+			const popup = flowRef.current?.popup;
+			if (popup && !popup.closed) {
+				popup.close();
+				flowRef.current = null;
+			}
+		};
+	}, [connectingServerId]);
+
+	const connect = (serverId: string) => {
+		if (!organizationId) {
+			return;
+		}
+		const connectUrl = mcpServerOAuth2ConnectPath(organizationId, serverId);
+		const popup = window.open(connectUrl, "_blank", "width=900,height=600");
+		// A blocked popup (window.open returns null) must not enter the
+		// connecting state; nothing would ever clear it.
+		flowRef.current = popup ? { popup, serverID: serverId } : null;
+		setConnectingServerId(popup ? serverId : null);
+	};
+
+	return { connectingServerId, connect };
+};


### PR DESCRIPTION
When an MCP server requires OAuth, the chat MCP picker showed an "Auth" button, and after completing the popup flow the user still had to reopen the picker and flip the enable switch manually. Clicking Auth already expresses the intent to use the server, so the extra step was unnecessary.

This change auto-selects the server when its OAuth popup reports success. The flow lives in a `useMCPOAuthFlow` hook (extracted from `AgentChatInput` after review feedback, following the React docs guidance on wrapping Effects in custom hooks): it tracks the flow it started as `{popup, serverID}`, and a `mcp-oauth2-complete` postMessage reports success only when it comes from that popup and names that server. `AgentChatInput` then adds the server to the selection only if it exists in the fetched list, is enabled, and is not already selected. The correlation deliberately survives popup close: coderd's callback page posts the message and then closes itself, so the close poll can observe the closed popup before the queued message is dispatched. Selection persistence is unchanged (parent callbacks on the chat page and create form store it as before), and failed or aborted auth flows post no message, so they cannot select anything. Moving the code also fixed a pre-existing stuck state: a blocked popup (`window.open` returning null) no longer enters the connecting state that permanently disabled every Auth button.

Covered by Storybook interaction stories: successful auto-enable through a real menu-open and Auth click with a mocked popup, auto-enable when the popup closes before the message is dispatched, no duplicate selection, unsolicited-message rejection (no Auth click), mismatched-server rejection (completion names a different server than the one authenticated), and no stuck connecting state when the popup is blocked. Each behavior story was verified red-green against the code it guards.

Dogfood UAT ran two rounds with a full OAuth round trip (real authorize, consent, callback, and PKCE token exchange against a local OAuth2 provider) on both the chat page and the create form, plus aborted-popup, forged-message, two-server isolation, manual toggle, force_on, and disconnect regression checks; all passed.

> Shux acted on Mike's behalf to create this PR.
