### PR TITLE
fix(docs): fix Helm TLS/ingress value keys in admin/setup (backport to release/2.34)

### DIFF
--- a/docs/admin/setup/index.md
+++ b/docs/admin/setup/index.md
@@ -94,12 +94,14 @@ working directory prior to step 1.
    ```yaml
    coder:
      tls:
-         secretName:
+       secretNames:
          - coder-tls
 
      # Alternatively, if you use an Ingress controller to terminate TLS,
      # set the following values:
      ingress:
+       enable: true
+       tls:
          enable: true
          secretName: coder-tls
          wildcardSecretName: coder-tls


### PR DESCRIPTION
Backport of #28087 to `release/2.34` (ESR).

Cherry-picked `5b97d99a4867` from `main` via `git cherry-pick -x`. Docs-only change; applied cleanly with no conflicts.

The `backport` label on the original merged PR did not produce a 2.34 backport, so this is created by hand. 2.34 is listed in `scripts/release_channels/esr_versions.txt`, so it is a valid backport target.

- Original PR: #28087
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).