### PR TITLE
fix(docs): fix P2/P3 typos and syntax errors from drift sweep (backport to release/2.34)

### DIFF
--- a/docs/about/contributing/modules.md
+++ b/docs/about/contributing/modules.md
@@ -342,7 +342,7 @@ Use the version bump script to update versions:
 
    ```bash
    git add .
-   git commit -m "feat(git-clone):add git-clone module"
+   git commit -m "feat(git-clone): add git-clone module"
    ```
 
 4. **Open a pull request**:

--- a/docs/admin/networking/port-forwarding.md
+++ b/docs/admin/networking/port-forwarding.md
@@ -78,7 +78,7 @@ where each segment of hostnames must not exceed 63 characters. If your app
 name, agent name, workspace name and username exceed 63 characters in the
 hostname, port forwarding via the dashboard will not work.
 
-### From an coder_app resource
+### From a coder_app resource
 
 One way to port forward is to configure a `coder_app` resource in the
 workspace's template. This approach shows a visual application icon in the

--- a/docs/admin/templates/extending-templates/variables.md
+++ b/docs/admin/templates/extending-templates/variables.md
@@ -51,7 +51,7 @@ and predictability.
 If you encounter a situation where you need to override template settings for
 variables, you can employ a straightforward solution:
 
-1. Create a `terraform.tfvars` file in in the template directory:
+1. Create a `terraform.tfvars` file in the template directory:
 
    ```tf
    coder_image = newimage:tag

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -241,7 +241,7 @@ role sync at the organization level.
 1. Confirm you have the [Coder CLI](../../install/index.md) installed and are
    logged in with a user who is an Owner or has an Organization Admin role.
 
-1. To fetch the current group sync settings for an organization, run the
+1. To fetch the current role sync settings for an organization, run the
    following:
 
    ```sh
@@ -388,7 +388,7 @@ settings, a user's memberships will update when they log out and log back in.
             "cbdcf774-4123-4118-8cd9-b3f502c84dfb"
          ],
          "sales": [
-            "d79144d9-b30a-555a-9af8-7dac83b2q4ec",
+            "d79144d9-b30a-555a-9af8-7dac83b2q4ec"
          ]
       },
       "organization_assign_default": true

--- a/docs/ai-coder/tasks-migration.md
+++ b/docs/ai-coder/tasks-migration.md
@@ -76,7 +76,7 @@ Below is a minimal illustrative example of a Coder Tasks template pre-2.28.0.
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder
+      source = "coder/coder"
     }
   }
 }
@@ -132,8 +132,8 @@ Example (**not** a full template):
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder
-      version = ">= 2.13.0
+      source = "coder/coder"
+      version = ">= 2.13.0"
     }
   }
 }

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -26,7 +26,7 @@ customization options, keyboard shortcuts, and troubleshooting guides.
 
 ## SSH
 
-### Through with the CLI
+### Through the CLI
 
 Coder will use the optimal path for an SSH connection (determined by your
 deployment's [networking configuration](../../admin/infrastructure/index.md))


### PR DESCRIPTION
Backport of #28101 to `release/2.34` (ESR).

Cherry-picked `1d189cc204f9` from `main` via `git cherry-pick -x`. Docs-only change; applied cleanly with no conflicts.

The `backport` label on the original merged PR did not produce a 2.34 backport, so this is created by hand. 2.34 is listed in `scripts/release_channels/esr_versions.txt`, so it is a valid backport target.

- Original PR: #28101
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).