### PR TITLE
fix(docs): correct nginx X-Forwarded-Proto and certbot instructions flavor (backport to release/2.34)

### DIFF
--- a/docs/tutorials/reverse-proxy-nginx.md
+++ b/docs/tutorials/reverse-proxy-nginx.md
@@ -54,7 +54,7 @@ you're using `coder.example.com` as your subdomain.
 ## Install and configure LetsEncrypt Certbot
 
 1. Install LetsEncrypt Certbot: Refer to the
-   [CertBot documentation](https://certbot.eff.org/instructions?ws=apache&os=ubuntufocal&tab=wildcard).
+   [CertBot documentation](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal&tab=wildcard).
    Be sure to pick the wildcard tab and select your DNS provider for
    instructions to install the necessary DNS plugin.
 
@@ -134,7 +134,7 @@ providers, refer to the
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-           proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+           proxy_set_header X-Forwarded-Proto $scheme;
            add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
        }
    }


### PR DESCRIPTION
Backport of #28086 to `release/2.34` (ESR).

Cherry-picked `b0e93b6e3b59` from `main` via `git cherry-pick -x`. Docs-only change; applied cleanly with no conflicts.

The `backport` label on the original merged PR did not produce a 2.34 backport, so this is created by hand. 2.34 is listed in `scripts/release_channels/esr_versions.txt`, so it is a valid backport target.

- Original PR: #28086
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).