### PR TITLE
fix(docs): remove invalid `--yes` flag from `coder template version promote` (backport to release/2.34)

### DIFF
--- a/docs/tutorials/testing-templates.md
+++ b/docs/tutorials/testing-templates.md
@@ -131,5 +131,5 @@ jobs:
       - name: Promote template version
         if: success()
         run: |
-          coder template version promote --template=$TEMPLATE_NAME --template-version=${{ steps.name.outputs.version_name }} --yes
+          coder template version promote --template=$TEMPLATE_NAME --template-version=${{ steps.name.outputs.version_name }}
 ```


### PR DESCRIPTION
Backport of #28084 to `release/2.34` (ESR).

Cherry-picked `f3fd4c4a77f2` from `main` via `git cherry-pick -x`. Docs-only change; applied cleanly with no conflicts.

The `backport` label on the original merged PR did not produce a 2.34 backport, so this is created by hand. 2.34 is listed in `scripts/release_channels/esr_versions.txt`, so it is a valid backport target.

- Original PR: #28084
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).