### PR TITLE
fix(docs): correct broken CLI commands and flags from drift sweep (backport to release/2.34)

### DIFF
--- a/docs/admin/infrastructure/scale-utility.md
+++ b/docs/admin/infrastructure/scale-utility.md
@@ -130,7 +130,7 @@ wish to clean up all workspaces, you can run the following command:
 ```shell
 coder exp scaletest cleanup \
     --cleanup-job-timeout 2h \
-    --cleanup-timeout 15min
+    --cleanup-timeout 15m
 ```
 
 This will delete all workspaces and users with the prefix `scaletest-`.

--- a/docs/admin/integrations/dx-data-cloud.md
+++ b/docs/admin/integrations/dx-data-cloud.md
@@ -30,10 +30,11 @@ If your organization already uses the Coder-DX integration, you can find a list 
 
 ### CLI
 
-Use `users list` to export the list of users to a CSV file:
+Use `users list` with `jq` to export the list of users to a CSV file:
 
 ```shell
-coder users list > users.csv
+coder users list --output json | \
+  jq -r '["username","email","created_at","status"], (.[] | [.username, .email, .created_at, .status]) | @csv' > users.csv
 ```
 
 Visit the [users list](../../reference/cli/users_list.md) documentation for more options.

--- a/docs/admin/users/index.md
+++ b/docs/admin/users/index.md
@@ -230,10 +230,11 @@ You can use the Coder CLI or API to retrieve your list of users.
 
 ### CLI
 
-Use `users list` to export the list of users to a CSV file:
+Use `users list` with `jq` to export the list of users to a CSV file:
 
 ```shell
-coder users list > users.csv
+coder users list --output json | \
+  jq -r '["username","email","created_at","status"], (.[] | [.username, .email, .created_at, .status]) | @csv' > users.csv
 ```
 
 Visit the [users list](../../reference/cli/users_list.md) documentation for more options.

--- a/docs/ai-coder/github-to-tasks.md
+++ b/docs/ai-coder/github-to-tasks.md
@@ -99,9 +99,6 @@ You must also set `coder-template-name` as part of this. The GHA example has thi
 ```bash
 # List all templates in your organization
 coder templates list
-
-# List templates in a specific organization
-coder templates list --org your-org-name
 ```
 
 You can also choose to modify the other [input parameters](https://github.com/coder/create-task-action?tab=readme-ov-file#inputs) to better fit your desired workflow.
@@ -229,7 +226,7 @@ Generate a new token with these permissions at `https://<your-coder-url>/deploym
 
 **Solution:**
 
-1. Verify the template name using: `coder templates list --org your-org-name`
+1. Verify the template name using: `coder templates list`
 1. Update the `coder-template-name` input in your workflow file to match exactly, or input secret or variable saved in GitHub
 1. Ensure the template exists in the organization specified by `coder-organization`
 

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -176,7 +176,7 @@ services or preview environments.
 
 You can also [share ports](./port-forwarding.md#sharing-ports) with other users,
 or [port-forward](./port-forwarding.md#the-coder-port-forward-command) through
-the CLI with `coder port forward`. Read more in the
+the CLI with `coder port-forward`. Read more in the
 [docs on workspace ports](./port-forwarding.md).
 
 ![Open Ports window](../../images/networking/listeningports.png)


### PR DESCRIPTION
Backport of #28098 to `release/2.34` (ESR).

Cherry-picked `58de9ab8f87e` from `main` via `git cherry-pick -x`. Three of the five files applied cleanly.

**Conflicts resolved manually:** `docs/admin/integrations/dx-data-cloud.md` and `docs/admin/users/index.md`. On `release/2.34` both blocks use a ` ```shell ` fence where `main` uses ` ```sh `; that fence difference is an unrelated cross-branch divergence. This backport keeps 2.34's existing `shell` fence (which also matches the neighboring code blocks in those files) and applies #28098's intended change: replacing the broken `coder users list > users.csv` with the `coder users list --output json | jq ... | @csv > users.csv` pipeline. The resulting commit touches the same five files with the same insertion/deletion counts as the original squash.

The `backport` label on the original merged PR did not produce a 2.34 backport, so this is created by hand. 2.34 is listed in `scripts/release_channels/esr_versions.txt`, so it is a valid backport target.

- Original PR: #28098
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).