### PR TITLE
fix(docs): fix prometheus metric name and slack webhook backtick (backport to release/2.34)

### DIFF
--- a/docs/admin/integrations/prometheus.md
+++ b/docs/admin/integrations/prometheus.md
@@ -329,7 +329,7 @@ The following metrics support native histograms:
 
 * `coderd_workspace_creation_duration_seconds`
 * `coderd_prebuilt_workspace_claim_duration_seconds`
-* `coderd_template_coderd_template_workspace_build_duration_seconds`
+* `coderd_template_workspace_build_duration_seconds`
 
 Native histograms are an **experimental** Prometheus feature that removes the need to predefine bucket boundaries and allows higher-resolution buckets that adapt to deployment characteristics.
 Whether a metric is exposed as classic or native depends entirely on the Prometheus server configuration (see [Prometheus docs](https://prometheus.io/docs/specs/native_histograms/) for details):

--- a/docs/admin/monitoring/notifications/slack.md
+++ b/docs/admin/monitoring/notifications/slack.md
@@ -196,7 +196,7 @@ To enable webhook integration in Coder, define the POST webhook endpoint
 matching the deployed Slack bot:
 
 ```bash
-export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook`
+export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook
 ```
 
 Finally, go to the **Notification Settings** in Coder and switch the notifier to


### PR DESCRIPTION
Backport of #28085 to `release/2.34` (ESR).

Cherry-picked `3145cc8386f9` from `main` via `git cherry-pick -x`. `prometheus.md` applied cleanly.

**Conflict resolved manually:** `docs/admin/monitoring/notifications/slack.md`. On `release/2.34` the fence is ` ```bash ` where `main` uses ` ```sh `; that fence difference is an unrelated cross-branch divergence. This backport keeps 2.34's existing `bash` fence and applies only #28085's intended change: removing the stray trailing backtick from the `CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT` export.

The `backport` label on the original merged PR did not produce a 2.34 backport, so this is created by hand. 2.34 is listed in `scripts/release_channels/esr_versions.txt`, so it is a valid backport target.

- Original PR: #28085
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).