### PR TITLE
fix(docs): correct broken CLI commands and flags from drift sweep (backport to release/2.29)

### DIFF
--- a/docs/admin/infrastructure/scale-utility.md
+++ b/docs/admin/infrastructure/scale-utility.md
@@ -130,7 +130,7 @@ wish to clean up all workspaces, you can run the following command:
 ```shell
 coder exp scaletest cleanup \
     --cleanup-job-timeout 2h \
-    --cleanup-timeout 15min
+    --cleanup-timeout 15m
 ```
 
 This will delete all workspaces and users with the prefix `scaletest-`.

--- a/docs/admin/integrations/dx-data-cloud.md
+++ b/docs/admin/integrations/dx-data-cloud.md
@@ -30,10 +30,11 @@ If your organization already uses the Coder-DX integration, you can find a list 
 
 ### CLI
 
-Use `users list` to export the list of users to a CSV file:
+Use `users list` with `jq` to export the list of users to a CSV file:
 
 ```shell
-coder users list > users.csv
+coder users list --output json | \
+  jq -r '["username","email","created_at","status"], (.[] | [.username, .email, .created_at, .status]) | @csv' > users.csv
 ```
 
 Visit the [users list](../../reference/cli/users_list.md) documentation for more options.

--- a/docs/admin/users/index.md
+++ b/docs/admin/users/index.md
@@ -215,10 +215,11 @@ You can use the Coder CLI or API to retrieve your list of users.
 
 ### CLI
 
-Use `users list` to export the list of users to a CSV file:
+Use `users list` with `jq` to export the list of users to a CSV file:
 
 ```shell
-coder users list > users.csv
+coder users list --output json | \
+  jq -r '["username","email","created_at","status"], (.[] | [.username, .email, .created_at, .status]) | @csv' > users.csv
 ```
 
 Visit the [users list](../../reference/cli/users_list.md) documentation for more options.

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -156,7 +156,7 @@ services or preview environments.
 
 You can also [share ports](./port-forwarding.md#sharing-ports) with other users,
 or [port-forward](./port-forwarding.md#the-coder-port-forward-command) through
-the CLI with `coder port forward`. Read more in the
+the CLI with `coder port-forward`. Read more in the
 [docs on workspace ports](./port-forwarding.md).
 
 ![Open Ports window](../../images/networking/listeningports.png)


### PR DESCRIPTION
Backport of #28098 to `release/2.29` (ESR).

Replaces the stale automated backport #28163, whose branch was an empty placeholder based on an older `release/2.29` (the branch predates four docs backports that have since merged: #28159, #28160, #28162, #28157). This branch is cut from the current `release/2.29` tip and cherry-picks `58de9ab8f87e` with `git cherry-pick -x`.

**Conflicts resolved manually:**
- `dx-data-cloud.md`, `users/index.md`: kept 2.29's `shell` fence and applied the `coder users list --output json | jq ... | @csv > users.csv` pipeline (same fence divergence as on `main`).
- `docs/ai-coder/github-to-tasks.md`: that page does not exist on `release/2.29`, so its hunk is dropped. The backport touches `scale-utility.md`, `dx-data-cloud.md`, `users/index.md`, and `workspace-access/index.md`.

Once reviewed, #28163 can be closed in favor of this PR.

- Original PR: #28098
- Replaces: #28163
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).