### PR TITLE
fix(docs): fix slack webhook backtick (backport of #28085 to release/2.29)

### DIFF
--- a/docs/admin/monitoring/notifications/slack.md
+++ b/docs/admin/monitoring/notifications/slack.md
@@ -196,7 +196,7 @@ To enable webhook integration in Coder, define the POST webhook endpoint
 matching the deployed Slack bot:
 
 ```bash
-export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook`
+export CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT=http://localhost:6000/v1/webhook
 ```
 
 Finally, go to the **Notification Settings** in Coder and switch the notifier to


### PR DESCRIPTION
Backport of #28085 to `release/2.29` (ESR).

Replaces the stale automated backport #28164, whose branch was an empty placeholder based on an older `release/2.29`. This branch is cut from the current `release/2.29` tip and cherry-picks `3145cc8386f9` with `git cherry-pick -x`.

**Scope note:** only the `slack.md` fix (removing the stray trailing backtick from the `CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT` export) applies to 2.29. #28085 also fixed a doubled-prefix metric name in `prometheus.md`, but `release/2.29`'s native-histograms list does not include `coderd_template_workspace_build_duration_seconds` at all, so that hunk is intentionally dropped rather than adding a metric 2.29 does not document. The `slack.md` conflict kept 2.29's `bash` fence.

Once reviewed, #28164 can be closed in favor of this PR.

- Original PR: #28085
- Replaces: #28164
- Tracking: DOCS-651

> This PR was created with AI assistance (Coder Agents).