### PR TITLE
perf(site): reduce spinner rendering frequency

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/statusConfig.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/statusConfig.ts
@@ -18,7 +18,10 @@ type ChatIconConfig = {
 
 const statusConfig = {
 	waiting: { icon: CheckIcon, className: "text-content-secondary" },
-	running: { icon: Loader2Icon, className: "text-content-link animate-spin" },
+	running: {
+		icon: Loader2Icon,
+		className: "text-content-link animate-spin motion-reduce:animate-none",
+	},
 	interrupting: { icon: PauseIcon, className: "text-content-warning" },
 	requires_action: { icon: PauseIcon, className: "text-content-warning" },
 	error: { icon: AlertTriangleIcon, className: "text-content-destructive" },

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -158,6 +158,7 @@ module.exports = {
 			animation: {
 				loading: "loading 2s ease-in-out infinite alternate",
 				"caret-scan": "caret-scan 3s ease-in-out infinite",
+				spin: "spin 1s steps(12, end) infinite",
 				"spin-once": "spin 1s cubic-bezier(0.4, 0, 0.2, 1)",
 				"zip-right": "zip-right 1s cubic-bezier(0.4, 0, 0.2, 1)",
 				"bar-indeterminate":


### PR DESCRIPTION
A continuously animated spinner keeps Chrome rendering at display refresh rate even when the Agents page has no JavaScript activity. Override indefinite `animate-spin` animations to use 12 discrete updates per second, and respect reduced-motion preferences for the persistent sidebar status.

An isolated spinner dropped from 59.4 to 12.1 rendered frames per second and from 4.6% to 1.9% of one Chrome core. In an active-chat fixture with five concurrent tool spinners, stepping reduced Chrome CPU from about 26.0% to 20.7%; pausing those spinners measured 19.2%, confirming they accounted for about 6.8 percentage points while the remaining active-chat work continued at 60 Hz.

<details>
<summary>Implementation and validation notes</summary>

- Override Tailwind's indefinite `spin` animation with `steps(12, end)` while preserving the smooth one-shot `spin-once` animation.
- Disable the persistent sidebar spinner when reduced motion is requested.
- Validated with TypeScript, Biome, production Vite build, focused Storybook interaction tests, and repository pre-commit hooks.
- The complete Tool story file has one unrelated existing failure in `MCP Tool Completed`; the three affected running-spinner stories pass when selected directly.

This pull request was generated by Coder Agents.
</details>
