### PR TITLE
fix(site/src/pages): use RotateCcwIcon for update actions

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
@@ -1,6 +1,5 @@
 import {
 	BanIcon,
-	CloudIcon,
 	PlayIcon,
 	PowerIcon,
 	RotateCcwIcon,
@@ -41,7 +40,7 @@ export const UpdateButton: FC<ActionButtonProps> = ({
 					disabled={loading}
 					onClick={() => handleAction()}
 				>
-					{requireActiveVersion ? <PlayIcon /> : <CloudIcon />}
+					{requireActiveVersion ? <PlayIcon /> : <RotateCcwIcon />}
 					{loading ? (
 						<>Updating&hellip;</>
 					) : isRunning ? (

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -1,4 +1,4 @@
-import { CloudIcon, PlayIcon, SquareIcon, TrashIcon } from "lucide-react";
+import { PlayIcon, RotateCcwIcon, SquareIcon, TrashIcon } from "lucide-react";
 import type { FC } from "react";
 import type { UseQueryResult } from "react-query";
 import { hasError, isApiValidationError } from "#/api/errors";
@@ -171,7 +171,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 								</DropdownMenuItem>
 								<DropdownMenuSeparator />
 								<DropdownMenuItem onClick={onBatchUpdateTransition}>
-									<CloudIcon
+									<RotateCcwIcon
 										className="size-icon-sm"
 										data-testid="bulk-action-update"
 									/>{" "}

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -1,12 +1,12 @@
 import {
 	BanIcon,
 	CircleAlertIcon,
-	CloudIcon,
 	EllipsisVerticalIcon,
 	ExternalLinkIcon,
 	FileIcon,
 	PlayIcon,
 	RefreshCcwIcon,
+	RotateCcwIcon,
 	SquareTerminalIcon,
 	StarIcon,
 } from "lucide-react";
@@ -513,7 +513,7 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 							isLoading={workspaceUpdate.isUpdating}
 							label="Update and start workspace"
 						>
-							<CloudIcon />
+							<RotateCcwIcon />
 						</PrimaryAction>
 						<WorkspaceUpdateDialogs {...workspaceUpdate.dialogProps} />
 					</>
@@ -539,7 +539,7 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 							isLoading={workspaceUpdate.isUpdating}
 							label="Update and restart workspace"
 						>
-							<CloudIcon />
+							<RotateCcwIcon />
 						</PrimaryAction>
 						<WorkspaceUpdateDialogs {...workspaceUpdate.dialogProps} />
 					</>


### PR DESCRIPTION
Closes [DES-22067](https://linear.app/codercom/issue/DES-22067/update-and-restart-action-uses-a-cloud-icon).

The "Update and restart" / "Update and start" actions used `CloudIcon`, which reads as a cloud/network concept instead of an update-and-restart build action.

Switch them to `RotateCcwIcon`, which the UI already uses for:

- the `Restart` button on the workspace page
- the `Update` action in `WorkspaceOutdatedTooltip`, `AgentOutdatedTooltip`, and `SubAgentOutdatedTooltip`

Call sites changed:

- `WorkspacePage/WorkspaceActions/Buttons.tsx` - `UpdateButton`
- `WorkspacesPage/WorkspacesTable.tsx` - "Update and start workspace" and "Update and restart workspace" primary actions
- `WorkspacesPage/WorkspacesPageView.tsx` - batch "Update" menu item

The `requireActiveVersion` variant still uses `PlayIcon`, since that path starts the workspace on the active version rather than offering a choice. Worth a separate design pass if that should change too.

<details>
<summary>Investigation notes</summary>

Verified against `origin/main` (`af90d8e2be`): no prior PR referenced DES-22067 and all three `CloudIcon` usages were still present. `grep` confirms no `CloudIcon` usages remain in `site/src` after this change.

Icon conventions found in the codebase:

- `RotateCcwIcon`: restart, update (outdated tooltips), retry (RetryButton, TasksTable, TaskPage, HealthLayout)
- `RefreshCwIcon` / `RefreshCcwIcon`: softer "reload data" flows (terminal, secrets, prebuilds invalidate, inbox, git panel)

`data-testid="bulk-action-update"` is preserved on the batch update item, so e2e coverage is unaffected.

</details>

---

Generated by Coder Agents on behalf of @designertyler.
