### PR TITLE
ci: ignore flaky codeium.com and marketplace.visualstudio.com links

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -20,6 +20,8 @@ ignorePatterns:
   # These real sites were blocking the linkspector action / GitHub runner IPs(?)
   - pattern: "i.imgur.com"
   - pattern: "code.visualstudio.com"
+  - pattern: "marketplace.visualstudio.com"
+  - pattern: "codeium.com"
   - pattern: "www.emacswiki.org"
   - pattern: "linux.die.net/man"
   - pattern: "www.gnu.org"


### PR DESCRIPTION
## Problem

The docs link-check job (linkspector) started failing on two external links that aren't actually broken, they're being rate-limited/blocked by the target sites when hit from GitHub runner IPs:

- `https://codeium.com/windsurf` -> 429
- `https://marketplace.visualstudio.com/vscode` -> 503

## Fix

Add both domains to `ignorePatterns` in `.github/.linkspector.yml`, matching the existing pattern already used for other real sites that block the linkspector action / GitHub runner IPs (`code.visualstudio.com`, `npmjs.com`, `merriam-webster.com`, etc.).

## Validation

Validated the updated YAML parses correctly and ran `make lint` locally (docs lint, markdownlint, and repo checks all pass).

Follow-up: a separate PR will rebrand the Windsurf docs to Devin Desktop (Codeium -> Windsurf -> Devin Desktop), since codeium.com is stale branding, not just a flaky link.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻