### PR TITLE
fix(site/src/pages/AgentsPage): stop gating chat stream parts on client status

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2399,6 +2399,67 @@ export const DurableUpdateFansOutToOlderPage: Story = {
 };
 
 /**
+ * A message_part arriving over the stream while the chat record still
+ * reads "waiting" (status lagging a new turn). The streamed thinking
+ * block must render. The play asserts on the disclosure header because
+ * smoothed body text never reveals in the test iframe
+ * (requestAnimationFrame is suspended).
+ */
+export const StreamedPartWhileStatusWaiting: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Stale status stream",
+				status: "waiting",
+			},
+			{
+				messages: [
+					{
+						id: 1,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:05:00.000Z",
+						role: "user",
+						content: [{ type: "text", text: "Start the next turn" }],
+					},
+				],
+				queued_messages: [],
+				has_more: false,
+			},
+			{ diffUrl: undefined },
+		),
+		webSocket: {
+			"/chats/": [
+				{
+					event: "message",
+					data: JSON.stringify([
+						{
+							type: "message_part",
+							chat_id: CHAT_ID,
+							message_part: {
+								part: {
+									type: "reasoning",
+									text: "Streaming while the chat still reads waiting",
+								},
+							},
+						},
+					] satisfies TypesGen.ChatStreamEvent[]),
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Start the next turn");
+		// The disclosure header is the only "Thinking" text in the DOM
+		// at this point: the generic indicator is suppressed at status
+		// "waiting".
+		expect(await canvas.findByText("Thinking")).toBeVisible();
+	},
+};
+
+/**
  * Live agent turn with streaming reasoning and a back-to-back flurry of
  * in-progress file tool calls. The persisted history establishes context
  * (an earlier completed read+write pair); the WebSocket then streams an

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -2399,10 +2399,8 @@ export const DurableUpdateFansOutToOlderPage: Story = {
 };
 
 /**
- * A message_part arriving over the stream while the chat record still
- * reads "waiting" (status lagging a new turn). The streamed thinking
- * block must render. The play asserts on the disclosure header because
- * smoothed body text never reveals in the test iframe
+ * The streamed thinking block is asserted via its disclosure header
+ * because smoothed body text never reveals in the test iframe
  * (requestAnimationFrame is suspended).
  */
 export const StreamedPartWhileStatusWaiting: Story = {

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1409,7 +1409,7 @@ describe("useChatStore", () => {
 		});
 	});
 
-	it("applies message_part updates while a stale chat status reads waiting", async () => {
+	it("applies message_part updates while a REST-hydrated chat status reads waiting", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-1";
@@ -1427,7 +1427,10 @@ describe("useChatStore", () => {
 				const { store } = useChatStore({
 					chatID,
 					chatMessages: [existingMessage],
-					chatRecord: buildChat(chatID),
+					// REST hydrates the store with a waiting status, but the
+					// stream has not delivered any status event, so the
+					// server's view may already be ahead.
+					chatRecord: { ...buildChat(chatID), status: "waiting" },
 					chatMessagesData: {
 						messages: [existingMessage],
 						queued_messages: [],
@@ -1456,8 +1459,74 @@ describe("useChatStore", () => {
 					role: "assistant",
 					part: {
 						type: "text",
-						text: "first",
+						text: "live output",
 					},
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "live output" },
+			]);
+		});
+	});
+
+	it("drops message_part updates after the stream reports waiting", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-1";
+		const existingMessage = buildMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: { ...buildChat(chatID), status: "waiting" },
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "first" },
 				},
 			});
 		});
@@ -1468,6 +1537,10 @@ describe("useChatStore", () => {
 			]);
 		});
 
+		// The stream reports waiting: the turn is over server-side.
+		// A part arriving now comes from the closed episode draining
+		// (the server keeps closed episodes subscribed for replay for
+		// up to 15s) and must not repopulate the stream.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
@@ -1477,34 +1550,54 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			// Stream state is preserved after status=waiting (the
-			// durable message event handles cleanup via
-			// needsStreamReset).
-			expect(result.current.streamState).not.toBeNull();
-			expect(result.current.streamState?.blocks).toEqual([
-				{ type: "response", text: "first" },
-			]);
+			expect(result.current.chatStatus).toBe("waiting");
 		});
 
-		// A late part arriving while the status still reads "waiting"
-		// is current content (the status has not caught up yet).
 		act(() => {
 			mockSocket.emitData({
 				type: "message_part",
 				chat_id: chatID,
 				message_part: {
 					role: "assistant",
-					part: {
-						type: "text",
-						text: "late",
-					},
+					part: { type: "text", text: "late drain" },
+				},
+			});
+		});
+
+		// Wait past the coalesced flush window so the drop is
+		// observable rather than "not yet flushed".
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		});
+
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "first" },
+		]);
+
+		// The stream reporting running reopens the window: the next
+		// turn's parts must flow again.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "next turn" },
 				},
 			});
 		});
 
 		await waitFor(() => {
 			expect(result.current.streamState?.blocks).toEqual([
-				{ type: "response", text: "firstlate" },
+				{ type: "response", text: "firstnext turn" },
 			]);
 		});
 	});

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1409,7 +1409,7 @@ describe("useChatStore", () => {
 		});
 	});
 
-	it("ignores message_part updates while chat is waiting", async () => {
+	it("applies message_part updates while a stale chat status reads waiting", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-1";
@@ -1479,14 +1479,15 @@ describe("useChatStore", () => {
 		await waitFor(() => {
 			// Stream state is preserved after status=waiting (the
 			// durable message event handles cleanup via
-			// needsStreamReset). Only new message_parts should be
-			// blocked by the shouldApplyMessagePart gate.
+			// needsStreamReset).
 			expect(result.current.streamState).not.toBeNull();
 			expect(result.current.streamState?.blocks).toEqual([
 				{ type: "response", text: "first" },
 			]);
 		});
 
+		// A late part arriving while the status still reads "waiting"
+		// is current content (the status has not caught up yet).
 		act(() => {
 			mockSocket.emitData({
 				type: "message_part",
@@ -1502,11 +1503,8 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			// The late message_part should not be applied because
-			// shouldApplyMessagePart gates on waiting.
-			// Stream state still shows the original "first".
 			expect(result.current.streamState?.blocks).toEqual([
-				{ type: "response", text: "first" },
+				{ type: "response", text: "firstlate" },
 			]);
 		});
 	});
@@ -4384,7 +4382,7 @@ describe("thinking indicator event ordering", () => {
 		});
 	});
 
-	it("discards buffered parts when status transitions to pending", async () => {
+	it("discards buffered parts when status transitions to waiting", async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		immediateAnimationFrame();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1503,6 +1503,7 @@ describe("useChatStore", () => {
 				return {
 					streamState: useChatSelector(store, selectStreamState),
 					chatStatus: useChatSelector(store, selectChatStatus),
+					store,
 				};
 			},
 			{ wrapper },
@@ -1566,6 +1567,31 @@ describe("useChatStore", () => {
 
 		// Wait past the coalesced flush window so the drop is
 		// observable rather than "not yet flushed".
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		});
+
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "first" },
+		]);
+
+		// An optimistic send status must not reopen the window; drain
+		// parts from the closed episode are still dropped.
+		act(() => {
+			result.current.store.setChatStatus("running");
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "drain after send" },
+				},
+			});
+		});
+
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 10));
 		});

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -143,8 +143,8 @@ export const useChatStore = (
 	// source for chatStatus and the REST-fetched chatRecord.status
 	// must not overwrite it. Without this guard, a React Query
 	// refetch (e.g. on window focus) can regress chatStatus to a
-	// stale value like "waiting", causing shouldApplyMessagePart()
-	// to drop all incoming parts.
+	// stale value like "waiting", hiding live status from the user
+	// until the next server event arrives.
 	const wsStatusReceivedRef = useRef(false);
 	const [pendingStatusResync, setPendingStatusResync] = useState(false);
 	const pendingStatusResyncUpdatedAtRef = useRef<number | null>(null);
@@ -423,10 +423,6 @@ export const useChatStore = (
 		let historyResetPending = false;
 		const historyReplacementBuf: TypesGen.ChatMessage[] = [];
 
-		const shouldApplyMessagePart = (): boolean => {
-			return store.getSnapshot().chatStatus !== "waiting";
-		};
-
 		const schedulePartsFlush = () => {
 			if (partsFlushTimer !== null || partsBuf.length === 0) {
 				return;
@@ -436,11 +432,7 @@ export const useChatStore = (
 				if (disposed || activeChatIDRef.current !== chatID) {
 					return;
 				}
-				const parts = partsBuf.splice(0);
-				if (parts.length === 0 || !shouldApplyMessagePart()) {
-					return;
-				}
-				store.applyMessageParts(parts);
+				store.applyMessageParts(partsBuf.splice(0));
 			}, 0);
 		};
 
@@ -455,11 +447,10 @@ export const useChatStore = (
 				clearTimeout(partsFlushTimer);
 				partsFlushTimer = null;
 			}
-			const parts = partsBuf.splice(0);
-			if (activeChatIDRef.current !== chatID || !shouldApplyMessagePart()) {
+			if (activeChatIDRef.current !== chatID) {
 				return;
 			}
-			store.applyMessageParts(parts);
+			store.applyMessageParts(partsBuf.splice(0));
 		};
 
 		// Discard buffered parts without applying them. Used when
@@ -521,9 +512,6 @@ export const useChatStore = (
 							continue;
 						}
 						commitHistoryReplacement();
-						if (!shouldApplyMessagePart()) {
-							continue;
-						}
 						const part = streamEvent.message_part?.part;
 						if (part) {
 							store.clearRetryState();
@@ -698,10 +686,7 @@ export const useChatStore = (
 							clearTimeout(partsFlushTimer);
 							partsFlushTimer = null;
 						}
-						const nextParts = partsBuf.splice(0);
-						if (shouldApplyMessagePart()) {
-							store.applyMessageParts(nextParts);
-						}
+						store.applyMessageParts(partsBuf.splice(0));
 					}
 				}
 			});

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -423,14 +423,10 @@ export const useChatStore = (
 		let historyResetPending = false;
 		const historyReplacementBuf: TypesGen.ChatMessage[] = [];
 
-		// Latch set when the stream delivers an authoritative "waiting"
-		// status, cleared on any other stream status. A part arriving
-		// while the latch is set belongs to an episode the server already
-		// closed (closed episodes drain for up to 15s server-side) and is
-		// dropped; a REST-hydrated "waiting" never sets the latch, so
-		// parts still flow when the REST status lags a live turn. An
-		// optimistic status write carries no liveness signal; only a
-		// stream status event clears the latch.
+		// Set when the stream reports "waiting", cleared by any other
+		// stream status. While set, parts are dropped: they are late
+		// leftovers from the finished turn. REST and optimistic
+		// statuses never set it, because they can lag a live turn.
 		let streamReportedWaiting = false;
 
 		const shouldKeepMessagePart = (): boolean => !streamReportedWaiting;

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -428,11 +428,12 @@ export const useChatStore = (
 		// while the latch is set belongs to an episode the server already
 		// closed (closed episodes drain for up to 15s server-side) and is
 		// dropped; a REST-hydrated "waiting" never sets the latch, so
-		// parts still flow when the REST status lags a live turn.
+		// parts still flow when the REST status lags a live turn. An
+		// optimistic status write carries no liveness signal; only a
+		// stream status event clears the latch.
 		let streamReportedWaiting = false;
 
-		const shouldKeepMessagePart = (): boolean =>
-			store.getSnapshot().chatStatus !== "waiting" || !streamReportedWaiting;
+		const shouldKeepMessagePart = (): boolean => !streamReportedWaiting;
 
 		const schedulePartsFlush = () => {
 			if (partsFlushTimer !== null || partsBuf.length === 0) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -423,6 +423,17 @@ export const useChatStore = (
 		let historyResetPending = false;
 		const historyReplacementBuf: TypesGen.ChatMessage[] = [];
 
+		// Latch set when the stream delivers an authoritative "waiting"
+		// status, cleared on any other stream status. A part arriving
+		// while the latch is set belongs to an episode the server already
+		// closed (closed episodes drain for up to 15s server-side) and is
+		// dropped; a REST-hydrated "waiting" never sets the latch, so
+		// parts still flow when the REST status lags a live turn.
+		let streamReportedWaiting = false;
+
+		const shouldKeepMessagePart = (): boolean =>
+			store.getSnapshot().chatStatus !== "waiting" || !streamReportedWaiting;
+
 		const schedulePartsFlush = () => {
 			if (partsFlushTimer !== null || partsBuf.length === 0) {
 				return;
@@ -430,6 +441,10 @@ export const useChatStore = (
 			partsFlushTimer = setTimeout(() => {
 				partsFlushTimer = null;
 				if (disposed || activeChatIDRef.current !== chatID) {
+					return;
+				}
+				if (!shouldKeepMessagePart()) {
+					partsBuf.length = 0;
 					return;
 				}
 				store.applyMessageParts(partsBuf.splice(0));
@@ -447,7 +462,8 @@ export const useChatStore = (
 				clearTimeout(partsFlushTimer);
 				partsFlushTimer = null;
 			}
-			if (activeChatIDRef.current !== chatID) {
+			if (activeChatIDRef.current !== chatID || !shouldKeepMessagePart()) {
+				partsBuf.length = 0;
 				return;
 			}
 			store.applyMessageParts(partsBuf.splice(0));
@@ -512,6 +528,9 @@ export const useChatStore = (
 							continue;
 						}
 						commitHistoryReplacement();
+						if (!shouldKeepMessagePart()) {
+							continue;
+						}
 						const part = streamEvent.message_part?.part;
 						if (part) {
 							store.clearRetryState();
@@ -610,6 +629,7 @@ export const useChatStore = (
 								continue;
 							}
 
+							streamReportedWaiting = nextStatus === "waiting";
 							wsStatusReceivedRef.current = true;
 							store.clearRetryState();
 							store.applyServerChatStatus(nextStatus);
@@ -631,6 +651,7 @@ export const useChatStore = (
 								kind: "generic",
 								message: "Chat processing failed.",
 							};
+							streamReportedWaiting = false;
 							wsStatusReceivedRef.current = true;
 							store.applyServerChatStatus("error");
 							store.setStreamError(reason);
@@ -686,7 +707,9 @@ export const useChatStore = (
 							clearTimeout(partsFlushTimer);
 							partsFlushTimer = null;
 						}
-						store.applyMessageParts(partsBuf.splice(0));
+						if (shouldKeepMessagePart()) {
+							store.applyMessageParts(partsBuf.splice(0));
+						}
 					}
 				}
 			});


### PR DESCRIPTION
## Problem

When messaging an agent, the "Thinking" indicator would sometimes appear and never progress to a visible thinking block, even though the agent was working. Reloading the page fixed it.

The chat stream handler dropped `message_part` events whenever the client-side chat status read `waiting`. The server only forwards parts for the chat's current episode (filtered by history version and generation attempt in `streamLoop.part`), so the gate was redundant. Its only effect was to convert client/server status skew into permanent output loss: dropped parts are never re-sent. Once the status caught up to `running` with no stream state accumulated, the UI showed the "Thinking" indicator indefinitely.

A typical trigger: the WebSocket reconnects and replays a stale `waiting` status from a just-completed turn, the user re-sends, and the new turn's first parts arrive before the new `running` status event.

## Fix

Apply parts whenever they arrive, and let the server's episode filtering stand as the single source of truth for staleness. Interrupt semantics are preserved: `status:waiting` still discards parts buffered before it in the same ordered stream, and the durable message commit still clears applied stream state.

The existing test asserting the gate's behavior is inverted to assert parts are now applied under a stale `waiting` status, so it fails if the gate is ever reintroduced.

---

Generated with Coder Agents
