### PR TITLE
chore(site): allow devin: URI scheme for Devin Desktop deep links

### DIFF
--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -20,6 +20,7 @@ const ALLOWED_EXTERNAL_APP_PROTOCOLS = [
 	"vscode:",
 	"vscode-insiders:",
 	"windsurf:",
+	"devin:",
 	"cursor:",
 	"jetbrains-gateway:",
 	"jetbrains:",


### PR DESCRIPTION
## Summary

`coder/registry#1050` adds a new `devin-desktop` module that opens Devin Desktop via a `devin://` deep link (Devin Desktop is Cognition's June 2, 2026 rebrand of Windsurf). Coder's frontend gates which external app URI schemes it will open with a session token, `ALLOWED_EXTERNAL_APP_PROTOCOLS` in `site/src/modules/apps/apps.ts`. `devin:` isn't in that list yet, so without this change the "Open" button on that app would return the raw URL with the `$SESSION_TOKEN` placeholder unsubstituted, an unusable link.

## Change

Add `"devin:"` to `ALLOWED_EXTERNAL_APP_PROTOCOLS`, next to the existing `"windsurf:"` entry.

## Validation

- `pnpm exec biome check --error-on-warnings src/modules/apps/apps.ts`: clean.
- `pnpm exec vitest run src/modules/apps/apps.test.ts`: 21/21 pass.
- `make pre-commit`: passes.

## Sequencing

`coder/registry#1050` should not be merged until this lands in a released Coder version, otherwise the `devin-desktop` module's deep link would be broken on deployments running an older Coder version. Tracked together in REG-77 / DEVEX-777.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻