### PR TITLE
fix(site/src/pages/AgentsPage): restore pre-MUI styles for sidebar, chat input, lists, and tables

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1156,7 +1156,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				ref={setComposerElement}
 				data-testid="chat-composer"
 				className={cn(
-					"relative z-10 rounded-2xl border border-border-default/80 bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
+					"relative z-10 rounded-2xl bg-surface-secondary sm:bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40",
 					showAgentSetupNotice && "sm:bg-surface-secondary",
 					isDragging && "ring-2 ring-content-link/40",
 					isEditingHistoryMessage &&

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
@@ -198,6 +198,17 @@ const createComponents = (
 		hr: () => (
 			<hr className="my-6 border-0 border-t border-solid border-border-default" />
 		),
+		// Markdown tables: streamdown's default table renderer nests two
+		// bordered boxes around the table. With Tailwind preflight enabled
+		// (since the MUI removal), both borders render, producing a double
+		// frame. Keep the row separators and use a single outer frame.
+		table: ({ children }: MarkdownComponentProps) => (
+			<div className="my-4 overflow-x-auto overflow-y-auto rounded-md border border-solid border-border-default bg-surface-primary">
+				<table className="w-full divide-y divide-border border-collapse">
+					{children}
+				</table>
+			</div>
+		),
 		// Table cells: streamdown defaults to text-sm (14px).
 		// Drop the explicit size so cells inherit the 13px base.
 		th: ({ children }: MarkdownComponentProps) => (
@@ -207,6 +218,23 @@ const createComponents = (
 		),
 		td: ({ children }: MarkdownComponentProps) => (
 			<td className="px-4 py-2">{children}</td>
+		),
+		// List indentation. Tailwind preflight now zeroes the browser's
+		// default list margin/padding (it was previously disabled), which left
+		// markdown lists flush-left. Restore the indentation and the vertical
+		// rhythm that existed before the MUI removal.
+		ul: ({ children }: MarkdownComponentProps) => (
+			<ul className="my-4 list-disc pl-10 first:mt-0 last:mb-0 [&_li]:pl-1">
+				{children}
+			</ul>
+		),
+		ol: ({ children }: MarkdownComponentProps) => (
+			<ol className="my-4 list-decimal pl-10 first:mt-0 last:mb-0 [&_li]:pl-1">
+				{children}
+			</ol>
+		),
+		li: ({ children }: MarkdownComponentProps) => (
+			<li className="py-0.5">{children}</li>
 		),
 		// Inline code only, fenced blocks are handled by the pre override.
 		code: ({ children }: MarkdownComponentProps) => (
@@ -227,7 +255,7 @@ const createComponents = (
 					return (
 						<ScrollArea
 							orientation="both"
-							className="my-4 rounded-md border border-solid border-border-default bg-surface-primary"
+							className="my-4 rounded-md bg-surface-primary"
 							scrollBarClassName="w-1.5"
 							horizontalScrollBarClassName="h-1.5"
 						>

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/FileReferenceChip.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/FileReferenceChip.tsx
@@ -6,16 +6,16 @@ import { cn } from "#/utils/cn";
 import { getFileReferenceDisplay } from "./fileReferenceDisplay";
 
 const fileReferenceChipVariants = cva(
-	"inline-flex min-h-5 max-w-[300px] select-none items-center gap-1 rounded-md border border-border-default bg-surface-primary py-0 pl-0.5 pr-1.5 align-middle font-sans text-[13px] font-normal leading-none text-inherit shadow-sm transition-colors",
+	"inline-flex min-h-5 max-w-[300px] select-none items-center gap-1 rounded-md border-0 bg-surface-primary py-0 pl-0.5 pr-1.5 align-middle font-sans text-[13px] font-normal leading-none text-inherit shadow-sm transition-colors",
 	{
 		variants: {
 			interactive: {
-				true: "cursor-pointer hover:border-border-secondary hover:bg-surface-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+				true: "cursor-pointer hover:bg-surface-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
 				false: "cursor-default",
 			},
 			selected: {
 				true: "border-content-link bg-content-link/10 text-content-primary ring-1 ring-content-link/40",
-				false: "",
+				false: "border-0",
 			},
 		},
 		defaultVariants: {

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -361,7 +361,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 		>
 			<nav
 				aria-label="Sidebar"
-				className="hidden border-b border-border-default px-2 py-1.5 sm:flex sm:flex-col sm:gap-0.5"
+				className="hidden px-2 py-1.5 sm:flex sm:flex-col sm:gap-0.5"
 			>
 				<div className="flex items-center justify-between mb-2.5 ml-2.5">
 					<div className="flex items-center gap-2">


### PR DESCRIPTION
# What

Restores several AgentsPage styles that regressed when MUI was removed and Tailwind preflight was enabled in #27821.

# Root cause

`#27821` enabled Tailwind preflight (`corePlugins.preflight: false` → removed) and removed the MUI `CssBaseline` + global reset that was previously forcing every `border`/`border-b`/`divide-y` width to `0px` and preserving browser list defaults. Several AgentsPage surfaces were relying on that suppression:

- The sidebar header separator now renders as a `1px` line under "Search".
- The chat composer input box shows a resting border.
- File-reference chips in chat show a resting border.
- Code blocks show a border.
- Markdown lists lost their indentation/margins (streamdown's `list-inside` + `pl-6` was overridden by preflight `pl: 0`).
- Markdown tables render two nested borders plus the row separators (double frame).

# Fixes

| Surface | Change | File |
|---|---|---|
| Left sidebar separator | Remove `border-b border-border-default` from the top nav (it never used to render). | `ChatsSidebar/chats/ChatsPanel.tsx` |
| Chat input composer | Remove resting `border border-border-default/80`. | `AgentChatInput.tsx` |
| File-reference chip badge | `border`/`hover:border-border-secondary` → `border-0`; keep the accent ring for the selected/interactive state. | `ChatMessageInput/FileReferenceChip.tsx` |
| Markdown lists | Override streamdown's `ul`/`ol`/`li` with `my-4 pl-10`, markers, and `li` padding. | `ChatElements/Response.tsx` |
| Markdown tables | Override streamdown's `table`/`tbody`/`th`/`td` to use a single outer border frame and keep the row separators. | `ChatElements/Response.tsx` |

# Verification

Verified via a deterministic three-worktree Storybook harness comparing computed styles and screenshots:

- **before** `521c383f6b` (pre-MUI-removal, MUI/Emotion + preflight OFF)
- **after-PR** `ea8ba0c678` (MUI/Emotion removed, preflight ON)
- **after-fix** `a724b5a85c` (this branch)

Confirmed computed styles:

| Surface | Before | After-PR | After-fix |
|---|---|---|---|
| Sidebar nav `border-bottom-width` | `0px` | `1px` | `0px` |
| Chat composer `border-width` | `0px` | `1px` | `0px` |
| File chip `border-width` | `0px` | `1px` | `0px` |
| Code block `border-width` | `0px` | `1px` | `0px` |
| Markdown `ul`/`ol` `padding-left` | `40px` | `0px` | `40px` |
| Table | single bordered frame + no row lines | two nested borders + row lines | **single** border + row lines restored |

Also ran `biome format`/`biome lint`/`tsc --noEmit` on the changed files (clean), and `pnpm check:types`.

<details>
<summary>Methodology (computed-style capture harness)</summary>

Set up two git worktrees at the before/after commits plus the fix branch, booted three Storybook instances (ports 6012/6013/6014), and used `agent-browser` (separate sessions) to capture recursive `getComputedStyle` snapshots for the AgentsPage surfaces plus screenshots, then diffed the JSON by DOM path. Stories were identical across worktrees, so the only differences are the styling changes.
</details>

> 🤖 This PR was created by Coder Agents on behalf of Danielle Maywood.
