### PR TITLE
fix(aibridge): bound the passthrough route metric label

### DIFF
--- a/aibridge/internal/integrationtest/metrics_internal_test.go
+++ b/aibridge/internal/integrationtest/metrics_internal_test.go
@@ -249,6 +249,37 @@ func TestMetrics_PassthroughCount(t *testing.T) {
 	require.Equal(t, 1.0, count)
 }
 
+// "/models/" is registered as a ServeMux subtree pattern, so every path beneath
+// it reaches the passthrough handler. The route label must be the matched
+// pattern, not the request path, or each distinct URL gets its own series.
+func TestMetrics_PassthroughCountBoundedBySubtreeRoute(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(upstream.Close)
+
+	m := aibridge.NewMetrics(prometheus.NewRegistry())
+	bridgeServer := newBridgeTestServer(t.Context(), t, upstream.URL,
+		withMetrics(m),
+	)
+
+	for _, path := range []string{
+		"/openai/v1/models/gpt-4.1",
+		"/openai/v1/models/gpt-4o",
+		"/openai/v1/models/anything-a-client-asks-for",
+	} {
+		resp, err := bridgeServer.makeRequest(t, http.MethodGet, path, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	require.Equal(t, 1, promtest.CollectAndCount(m.PassthroughCount),
+		"three paths under one subtree route must share a single series")
+	require.Equal(t, 3.0, promtest.ToFloat64(m.PassthroughCount.WithLabelValues(
+		config.ProviderOpenAI, "/models/", "GET")))
+}
+
 func TestMetrics_PromptCount(t *testing.T) {
 	t.Parallel()
 

--- a/aibridge/metrics/metrics.go
+++ b/aibridge/metrics/metrics.go
@@ -77,7 +77,8 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		}, baseLabels),
 
 		// Pessimistic cardinality: 3 providers, 10 routes, 3 methods = up to 90.
-		// NOTE: route is not unbounded because PassthroughRoutes (see provider.go) is a static list.
+		// NOTE: route is the matched ServeMux pattern, not the request path, so it is
+		// bounded by the static PassthroughRoutes list (see passthroughRoute).
 		PassthroughCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Subsystem: "passthrough",
 			Name:      "total",

--- a/aibridge/passthrough.go
+++ b/aibridge/passthrough.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -66,7 +67,7 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if m != nil {
-			m.PassthroughCount.WithLabelValues(prov.Name(), r.URL.Path, r.Method).Add(1)
+			m.PassthroughCount.WithLabelValues(prov.Name(), passthroughRoute(prov, r), r.Method).Add(1)
 		}
 
 		ctx, span := startSpan(r, tracer)
@@ -74,6 +75,16 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 
 		proxy.ServeHTTP(w, r.WithContext(ctx))
 	}
+}
+
+// passthroughRoute returns the registered route the request matched, for the
+// "route" metric label. Most PassthroughRoutes are ServeMux subtree patterns
+// (e.g. "/models/"), so r.URL.Path is unbounded but the pattern is not.
+func passthroughRoute(prov provider.Provider, r *http.Request) string {
+	if r.Pattern == "" {
+		return "unknown"
+	}
+	return strings.TrimPrefix(r.Pattern, prov.RoutePrefix())
 }
 
 // rewritePassthroughRequest configures the outbound request for the upstream and
@@ -107,7 +118,7 @@ func newInvalidBaseURLHandler(prov provider.Provider, logger slog.Logger, m *met
 		defer span.End()
 
 		if m != nil {
-			m.PassthroughCount.WithLabelValues(prov.Name(), r.URL.Path, r.Method).Add(1)
+			m.PassthroughCount.WithLabelValues(prov.Name(), passthroughRoute(prov, r), r.Method).Add(1)
 		}
 
 		logger.Warn(ctx, "invalid provider base URL", slog.Error(baseURLErr))


### PR DESCRIPTION
## Problem

`PassthroughCount` labels its `route` dimension with `r.URL.Path`:

```go
m.PassthroughCount.WithLabelValues(prov.Name(), r.URL.Path, r.Method).Add(1)
```

The declaration reasons that this is safe:

```go
// Pessimistic cardinality: 3 providers, 10 routes, 3 methods = up to 90.
// NOTE: route is not unbounded because PassthroughRoutes (see provider.go) is a static list.
```

The list is static, but most of its entries are `ServeMux` **subtree** patterns ending in a slash, so any path beneath them reaches the handler. 9 of the 14 passthrough routes are subtree patterns today:

- Anthropic: `/v1/models/`, `/api/event_logging/`
- OpenAI: `/conversations/`, `/models/`, `/responses/`
- Copilot: `/models/`, `/agents/`, `/mcp/`, `/.well-known/`

So `GET /openai/v1/models/<anything>` is matched by `/models/` and produces one series per distinct URL. A client enumerating models, a retry loop with a changing suffix, or anything scanning the endpoint drives that without a ceiling. Copilot's `/agents/` and `/mcp/` are the widest.

## Fix

Label with the route that was actually matched rather than the path. `http.Request.Pattern` is the registered pattern, which is exactly the static list the comment assumed, and it survives the `http.StripPrefix` wrapper. The provider prefix is trimmed so values are unchanged for routes that were already bounded.

Label values for already-bounded routes are identical, so the existing `TestMetrics_PassthroughCount` passes untouched. Requests under a subtree route now report the pattern (`/models/`) instead of the full path.

## Verification

Added `TestMetrics_PassthroughCountBoundedBySubtreeRoute`, which sends three distinct paths under one subtree route and asserts a single series results.

Without the fix (reproduces the bug):

```
    Error:      	Not equal:
                	expected: 1
                	actual  : 3
    Test:       	TestMetrics_PassthroughCountBoundedBySubtreeRoute
    Messages:   	three paths under one subtree route must share a single series
FAIL	github.com/coder/coder/v2/aibridge/internal/integrationtest	0.779s
```

With the fix:

```
--- PASS: TestMetrics_PassthroughCount (0.00s)
--- PASS: TestMetrics_PassthroughCountBoundedBySubtreeRoute (0.00s)
ok  	github.com/coder/coder/v2/aibridge/internal/integrationtest	1.092s
```

Full `go test ./aibridge/...` passes, all 15 packages.

## AI disclosure

Per the [AI contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING): this change was written with AI assistance. I found it while testing a static analyser I am building for observability instrumentation defects, which flagged the `r.URL.Path` label. The `ServeMux` subtree behaviour was then confirmed manually with a standalone reproduction before any code was changed, and the fix was verified by the failing/passing test output above rather than by assuming the tooling was right.

Happy to adjust the label format if you would rather keep the leading provider prefix, or to drop the `metrics.go` comment change.
