### PR TITLE
fix(site/src/pages/AgentsPage/components): use neutral divider for history-edit header

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1184,7 +1184,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 					</div>
 				)}
 				{isEditingHistoryMessage && editingQueuedMessageID === null && (
-					<div className="flex items-center justify-between border-b border-border-warning/50 px-3 py-1.5">
+					<div className="flex items-center justify-between border-b border-border-default/70 px-3 py-1.5">
 						<span className="flex items-center gap-1.5 text-xs font-medium text-content-warning">
 							<PencilIcon className="size-3.5" />
 							Editing will delete all subsequent messages and restart the


### PR DESCRIPTION
In the history-edit state of the Agents chat composer, the divider under the "Editing will delete all subsequent messages..." warning header used `border-border-warning/50`, which renders as a harsh, overly light gold line in dark mode.

This switches that divider to the neutral `border-border-default/70` token, matching the sibling "editing queued message" header divider. The warning text and pencil icon keep their `content-warning` color, so the state still reads as a warning.

Story: `pages-agentspage-agentchatinput--prompt-history-suppressed-while-editing-history-message`.

---

> This PR was generated by Coder Agents on behalf of @tracyjohnsonux.