### PR TITLE
ci: cache chromium

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1007,7 +1007,7 @@ jobs:
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-        working-directory: site
+        working-directory: site/
 
       # Cache the browser to avoid relying on azure.archive.ubuntu.com, which
       # can be flakey. Only the default branch is trusted to write the cache,
@@ -1021,7 +1021,7 @@ jobs:
 
       - run: pnpm exec playwright install chromium
         timeout-minutes: 5
-        working-directory: site
+        working-directory: site/
 
       - name: Save Chromium cache
         if: github.ref == 'refs/heads/main' && steps.playwright-chromium-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1010,9 +1010,11 @@ jobs:
         working-directory: site
 
       # Cache the browser to avoid relying on azure.archive.ubuntu.com, which
-      # can be flakey.
-      - name: Cache Chromium
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # can be flakey. Only the default branch is trusted to write the cache,
+      # so PR runs cannot poison it.
+      - name: Restore Chromium cache
+        id: playwright-chromium-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -1020,6 +1022,13 @@ jobs:
       - run: pnpm exec playwright install chromium
         timeout-minutes: 5
         working-directory: site
+
+      - name: Save Chromium cache
+        if: github.ref == 'refs/heads/main' && steps.playwright-chromium-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-chromium-cache.outputs.cache-primary-key }}
 
       # Cache the Coder release binaries downloaded by the outdatedCLI /
       # outdatedAgent e2e tests so most runs skip the flaky GitHub release
@@ -1120,9 +1129,11 @@ jobs:
         id: playwright-version
 
       # Cache the browser to avoid relying on azure.archive.ubuntu.com, which
-      # can be flakey.
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        name: Cache Chromium
+      # can be flakey. Only the default branch is trusted to write the cache,
+      # so PR runs cannot poison it.
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        name: Restore Chromium cache
+        id: playwright-chromium-cache
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -1131,6 +1142,13 @@ jobs:
         working-directory: site/
         name: Install Chromium
         timeout-minutes: 5
+
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        name: Save Chromium cache
+        if: github.ref == 'refs/heads/main' && steps.playwright-chromium-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-chromium-cache.outputs.cache-primary-key }}
 
       - run: pnpm pixel-storybook
         working-directory: site/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1004,7 +1004,21 @@ jobs:
       - run: make site/e2e/bin/coder
         name: make coder
 
-      - run: pnpm playwright:install
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        working-directory: site
+
+      # Cache the browser to avoid relying on azure.archive.ubuntu.com, which
+      # can be flakey.
+      - name: Cache Chromium
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - run: pnpm exec playwright install chromium
+        timeout-minutes: 5
         working-directory: site
 
       # Cache the Coder release binaries downloaded by the outdatedCLI /
@@ -1100,9 +1114,23 @@ jobs:
         working-directory: site/
         name: Build Storybook
 
-      - run: pnpm playwright:install
+      - run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        working-directory: site/
+        name: Get Playwright version
+        id: playwright-version
+
+      # Cache the browser to avoid relying on azure.archive.ubuntu.com, which
+      # can be flakey.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        name: Cache Chromium
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - run: pnpm exec playwright install chromium
         working-directory: site/
         name: Install Chromium
+        timeout-minutes: 5
 
       - run: pnpm pixel-storybook
         working-directory: site/


### PR DESCRIPTION
`playwright install --with-deps chromium` has been hanging in CI until the job times out, due to the well-known instability of the `azure.archive.ubuntu.com` apt mirror (actions/runner-images#11347).

Same treatment as coder/pixel-storybook#67, applied to the `test-e2e` and `storybook` jobs, which removes apt from the critical path:

- Install Chromium directly instead of via `playwright:install`, dropping `--with-deps`; the Ubuntu runner images already ship the shared libraries Chromium needs. The `playwright:install` script is left as-is for local use.
- Cache the browser download keyed on the resolved Playwright version.
- Add a step timeout on the install so any future hang fails in minutes instead of hours.

---

🤖 Generated by Coder Agents on behalf of @aslilac
