### PR TITLE
feat(AgentsPage): move workspace status from hover into pill dropdown

### DIFF
--- a/site/src/pages/AgentsPage/components/StatusIcon.tsx
+++ b/site/src/pages/AgentsPage/components/StatusIcon.tsx
@@ -34,7 +34,11 @@ export const StatusIcon: FC<{
 export function getWorkspaceStatus(
 	workspace: Workspace,
 	agent?: WorkspaceAgent | null,
-): { effectiveType: DisplayWorkspaceStatusType; statusLabel: string } {
+): {
+	effectiveType: DisplayWorkspaceStatusType;
+	statusLabel: string;
+	statusText: string;
+} {
 	let { type, text } = getDisplayWorkspaceStatus(
 		workspace.latest_build.status,
 		workspace.latest_build.job,
@@ -57,8 +61,9 @@ export function getWorkspaceStatus(
 	}
 
 	const effectiveType = workspace.health.healthy ? type : "warning";
+	const statusText = workspace.health.healthy ? text : `${text} (unhealthy)`;
 	const statusLabel = workspace.health.healthy
 		? `Workspace ${text.toLowerCase()}`
 		: `Workspace ${text.toLowerCase()} (unhealthy)`;
-	return { effectiveType, statusLabel };
+	return { effectiveType, statusLabel, statusText };
 }

--- a/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
@@ -149,9 +149,9 @@ export const WithAllApps: Story = {
 			expect(body.getByText("JetBrains Gateway")).toBeInTheDocument();
 			expect(body.getByText("Cursor")).toBeInTheDocument();
 			expect(body.getByText("Terminal")).toBeInTheDocument();
-			// The workspace status now renders as a subtitle under View
+			// The workspace status now renders as a colored subtitle under View
 			// Workspace instead of a hover tooltip.
-			expect(body.getByText("Workspace running")).toBeInTheDocument();
+			expect(body.getByText("Running")).toBeInTheDocument();
 			expect(body.getByText("Copy SSH Command")).toBeInTheDocument();
 			expect(body.getByText("View Workspace")).toBeInTheDocument();
 
@@ -316,7 +316,7 @@ export const WithStoppedWorkspace: Story = {
 			const body = within(document.body);
 
 			// Status subtitle under View Workspace reflects the stopped state.
-			expect(body.getByText("Workspace stopped")).toBeInTheDocument();
+			expect(body.getByText("Stopped")).toBeInTheDocument();
 
 			// VS Code items should be present but disabled.
 			const vscodeItem = body.getByText("VS Code").closest("[role=menuitem]");

--- a/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
@@ -149,6 +149,9 @@ export const WithAllApps: Story = {
 			expect(body.getByText("JetBrains Gateway")).toBeInTheDocument();
 			expect(body.getByText("Cursor")).toBeInTheDocument();
 			expect(body.getByText("Terminal")).toBeInTheDocument();
+			// The workspace status now lives inside the dropdown instead of a
+			// hover tooltip.
+			expect(body.getByText("Workspace running")).toBeInTheDocument();
 			expect(body.getByText("Copy SSH Command")).toBeInTheDocument();
 			expect(body.getByText("View Workspace")).toBeInTheDocument();
 
@@ -311,6 +314,9 @@ export const WithStoppedWorkspace: Story = {
 
 		await waitFor(() => {
 			const body = within(document.body);
+
+			// Status row reflects the stopped workspace inside the dropdown.
+			expect(body.getByText("Workspace stopped")).toBeInTheDocument();
 
 			// VS Code items should be present but disabled.
 			const vscodeItem = body.getByText("VS Code").closest("[role=menuitem]");

--- a/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.stories.tsx
@@ -149,8 +149,8 @@ export const WithAllApps: Story = {
 			expect(body.getByText("JetBrains Gateway")).toBeInTheDocument();
 			expect(body.getByText("Cursor")).toBeInTheDocument();
 			expect(body.getByText("Terminal")).toBeInTheDocument();
-			// The workspace status now lives inside the dropdown instead of a
-			// hover tooltip.
+			// The workspace status now renders as a subtitle under View
+			// Workspace instead of a hover tooltip.
 			expect(body.getByText("Workspace running")).toBeInTheDocument();
 			expect(body.getByText("Copy SSH Command")).toBeInTheDocument();
 			expect(body.getByText("View Workspace")).toBeInTheDocument();
@@ -315,7 +315,7 @@ export const WithStoppedWorkspace: Story = {
 		await waitFor(() => {
 			const body = within(document.body);
 
-			// Status row reflects the stopped workspace inside the dropdown.
+			// Status subtitle under View Workspace reflects the stopped state.
 			expect(body.getByText("Workspace stopped")).toBeInTheDocument();
 
 			// VS Code items should be present but disabled.

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -1,6 +1,5 @@
 import {
 	ChevronDownIcon,
-	CircleDotIcon,
 	CopyIcon,
 	LayoutGridIcon,
 	MonitorIcon,
@@ -29,6 +28,11 @@ import {
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { VSCodeIcon } from "#/components/Icons/VSCodeIcon";
 import { VSCodeInsidersIcon } from "#/components/Icons/VSCodeInsidersIcon";
+import {
+	StatusIndicator,
+	StatusIndicatorDot,
+	type StatusIndicatorProps,
+} from "#/components/StatusIndicator/StatusIndicator";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useIsBelowMdViewport } from "#/hooks/useIsBelowMdViewport";
@@ -236,15 +240,14 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 								<MonitorIcon className="mt-px size-3.5 shrink-0" />
 								<span className="flex min-w-0 flex-col">
 									<span className="truncate">View Workspace</span>
-									<span
-										className={cn(
-											"flex min-w-0 items-center gap-1 font-normal",
-											statusColorMap[effectiveType],
-										)}
+									<StatusIndicator
+										size="sm"
+										variant={statusDotVariant[effectiveType]}
+										className="min-w-0 font-normal"
 									>
-										<CircleDotIcon className="size-3 shrink-0" />
+										<StatusIndicatorDot />
 										<span className="truncate">{statusText}</span>
-									</span>
+									</StatusIndicator>
 								</span>
 							</Link>
 						</DropdownMenuItem>
@@ -267,13 +270,16 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 	);
 };
 
-const statusColorMap: Record<DisplayWorkspaceStatusType, string> = {
-	success: "text-content-success",
-	active: "text-content-link",
-	inactive: "text-content-secondary",
-	error: "text-content-destructive",
-	danger: "text-content-destructive",
-	warning: "text-content-warning",
+const statusDotVariant: Record<
+	DisplayWorkspaceStatusType,
+	StatusIndicatorProps["variant"]
+> = {
+	success: "success",
+	active: "pending",
+	inactive: "inactive",
+	error: "failed",
+	danger: "failed",
+	warning: "warning",
 };
 
 const VSCodeMenuItem: FC<{

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -234,7 +234,7 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 								<MonitorIcon className="mt-px size-3.5 shrink-0" />
 								<span className="flex min-w-0 flex-col">
 									<span className="truncate">View Workspace</span>
-									<span className="truncate text-[0.7rem] font-normal text-content-secondary">
+									<span className="truncate text-[0.7rem] font-normal text-content-disabled">
 										{statusLabel}
 									</span>
 								</span>

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -28,11 +28,6 @@ import {
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { VSCodeIcon } from "#/components/Icons/VSCodeIcon";
 import { VSCodeInsidersIcon } from "#/components/Icons/VSCodeInsidersIcon";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useIsBelowMdViewport } from "#/hooks/useIsBelowMdViewport";
@@ -49,6 +44,7 @@ import {
 	usePortsData,
 } from "#/modules/resources/usePortsData";
 import { cn } from "#/utils/cn";
+import type { DisplayWorkspaceStatusType } from "#/utils/workspace";
 import { getWorkspaceStatus, StatusIcon } from "./StatusIcon";
 import { MobilePortsPanel, PortsMenuItem } from "./WorkspacePillPorts";
 
@@ -70,7 +66,6 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 	onRemoveWorkspace,
 }) => {
 	const [open, setOpen] = useState(false);
-	const [tooltipOpen, setTooltipOpen] = useState(false);
 	const isRunning = workspace.latest_build.status === "running";
 	const route = `/@${workspace.owner_name}/${workspace.name}`;
 
@@ -128,40 +123,30 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 			}}
 		>
 			<span className="inline-flex min-w-0 items-center overflow-hidden rounded-full bg-surface-secondary text-xs font-medium text-content-secondary md:min-w-[2.75rem]">
-				<Tooltip
-					open={tooltipOpen}
-					onOpenChange={(v) => setTooltipOpen(v && !open)}
-				>
-					<TooltipTrigger asChild>
-						<DropdownMenuTrigger asChild>
-							<button
-								type="button"
-								aria-label={`${workspace.name} workspace menu`}
-								className={cn(
-									"inline-flex min-w-0 cursor-pointer items-center justify-center gap-1 rounded-full border-0 bg-transparent p-0 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-tertiary hover:text-content-primary",
-									"size-7 md:size-auto md:max-w-[200px] md:justify-start md:px-2 md:py-0.5",
-								)}
-							>
-								<StatusIcon
-									type={effectiveType}
-									className="size-icon-sm shrink-0 md:size-3"
-								/>
-								<span className="hidden min-w-0 truncate md:inline">
-									{workspace.name}
-								</span>
-								<ChevronDownIcon
-									className={cn(
-										"hidden size-3 shrink-0 opacity-60 transition-transform md:block",
-										open && "rotate-180",
-									)}
-								/>
-							</button>
-						</DropdownMenuTrigger>
-					</TooltipTrigger>
-					<TooltipContent className="hidden md:block">
-						{statusLabel}
-					</TooltipContent>
-				</Tooltip>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						aria-label={`${workspace.name} workspace menu`}
+						className={cn(
+							"inline-flex min-w-0 cursor-pointer items-center justify-center gap-1 rounded-full border-0 bg-transparent p-0 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-tertiary hover:text-content-primary",
+							"size-7 md:size-auto md:max-w-[200px] md:justify-start md:px-2 md:py-0.5",
+						)}
+					>
+						<StatusIcon
+							type={effectiveType}
+							className="size-icon-sm shrink-0 md:size-3"
+						/>
+						<span className="hidden min-w-0 truncate md:inline">
+							{workspace.name}
+						</span>
+						<ChevronDownIcon
+							className={cn(
+								"hidden size-3 shrink-0 opacity-60 transition-transform md:block",
+								open && "rotate-180",
+							)}
+						/>
+					</button>
+				</DropdownMenuTrigger>
 			</span>
 
 			<DropdownMenuContent
@@ -244,6 +229,11 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 							<DropdownMenuSeparator className="my-1" />
 						)}
 
+						<WorkspaceStatusItem
+							effectiveType={effectiveType}
+							statusLabel={statusLabel}
+						/>
+
 						{sshCommand && <CopySSHMenuItem sshCommand={sshCommand} />}
 						<DropdownMenuItem asChild>
 							<Link to={route} target="_blank" rel="noreferrer">
@@ -267,6 +257,34 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 				)}
 			</DropdownMenuContent>
 		</DropdownMenu>
+	);
+};
+
+const statusColorMap: Record<DisplayWorkspaceStatusType, string> = {
+	success: "text-content-success",
+	active: "text-content-link",
+	inactive: "text-content-secondary",
+	error: "text-content-destructive",
+	danger: "text-content-destructive",
+	warning: "text-content-warning",
+};
+
+// Non-interactive row that surfaces the workspace status inside the dropdown.
+// This replaces the hover tooltip that previously wrapped the pill trigger.
+const WorkspaceStatusItem: FC<{
+	effectiveType: DisplayWorkspaceStatusType;
+	statusLabel: string;
+}> = ({ effectiveType, statusLabel }) => {
+	return (
+		<div
+			className={cn(
+				"flex items-center gap-2 px-2 py-1 text-xs font-medium",
+				statusColorMap[effectiveType],
+			)}
+		>
+			<StatusIcon type={effectiveType} className="size-3.5 shrink-0" />
+			<span className="min-w-0 truncate">{statusLabel}</span>
+		</div>
 	);
 };
 

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -229,9 +229,9 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 						)}
 
 						{sshCommand && <CopySSHMenuItem sshCommand={sshCommand} />}
-						<DropdownMenuItem asChild>
+						<DropdownMenuItem asChild className="items-start">
 							<Link to={route} target="_blank" rel="noreferrer">
-								<MonitorIcon className="size-3.5" />
+								<MonitorIcon className="mt-px size-3.5 shrink-0" />
 								<span className="flex min-w-0 flex-col">
 									<span className="truncate">View Workspace</span>
 									<span className="truncate text-[0.7rem] font-normal text-content-secondary">

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -44,7 +44,6 @@ import {
 	usePortsData,
 } from "#/modules/resources/usePortsData";
 import { cn } from "#/utils/cn";
-import type { DisplayWorkspaceStatusType } from "#/utils/workspace";
 import { getWorkspaceStatus, StatusIcon } from "./StatusIcon";
 import { MobilePortsPanel, PortsMenuItem } from "./WorkspacePillPorts";
 
@@ -229,16 +228,16 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 							<DropdownMenuSeparator className="my-1" />
 						)}
 
-						<WorkspaceStatusItem
-							effectiveType={effectiveType}
-							statusLabel={statusLabel}
-						/>
-
 						{sshCommand && <CopySSHMenuItem sshCommand={sshCommand} />}
 						<DropdownMenuItem asChild>
 							<Link to={route} target="_blank" rel="noreferrer">
 								<MonitorIcon className="size-3.5" />
-								View Workspace
+								<span className="flex min-w-0 flex-col">
+									<span className="truncate">View Workspace</span>
+									<span className="truncate text-[0.7rem] font-normal text-content-secondary">
+										{statusLabel}
+									</span>
+								</span>
 							</Link>
 						</DropdownMenuItem>
 						{onRemoveWorkspace && (
@@ -257,34 +256,6 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 				)}
 			</DropdownMenuContent>
 		</DropdownMenu>
-	);
-};
-
-const statusColorMap: Record<DisplayWorkspaceStatusType, string> = {
-	success: "text-content-success",
-	active: "text-content-link",
-	inactive: "text-content-secondary",
-	error: "text-content-destructive",
-	danger: "text-content-destructive",
-	warning: "text-content-warning",
-};
-
-// Non-interactive row that surfaces the workspace status inside the dropdown.
-// This replaces the hover tooltip that previously wrapped the pill trigger.
-const WorkspaceStatusItem: FC<{
-	effectiveType: DisplayWorkspaceStatusType;
-	statusLabel: string;
-}> = ({ effectiveType, statusLabel }) => {
-	return (
-		<div
-			className={cn(
-				"flex items-center gap-2 px-2 py-1 text-xs font-medium",
-				statusColorMap[effectiveType],
-			)}
-		>
-			<StatusIcon type={effectiveType} className="size-3.5 shrink-0" />
-			<span className="min-w-0 truncate">{statusLabel}</span>
-		</div>
 	);
 };
 

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -234,7 +234,7 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 								<MonitorIcon className="mt-px size-3.5 shrink-0" />
 								<span className="flex min-w-0 flex-col">
 									<span className="truncate">View Workspace</span>
-									<span className="truncate text-[0.7rem] font-normal text-content-disabled">
+									<span className="truncate font-normal text-content-disabled">
 										{statusLabel}
 									</span>
 								</span>

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -1,5 +1,6 @@
 import {
 	ChevronDownIcon,
+	CircleDotIcon,
 	CopyIcon,
 	LayoutGridIcon,
 	MonitorIcon,
@@ -44,6 +45,7 @@ import {
 	usePortsData,
 } from "#/modules/resources/usePortsData";
 import { cn } from "#/utils/cn";
+import type { DisplayWorkspaceStatusType } from "#/utils/workspace";
 import { getWorkspaceStatus, StatusIcon } from "./StatusIcon";
 import { MobilePortsPanel, PortsMenuItem } from "./WorkspacePillPorts";
 
@@ -68,7 +70,7 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 	const isRunning = workspace.latest_build.status === "running";
 	const route = `/@${workspace.owner_name}/${workspace.name}`;
 
-	const { effectiveType, statusLabel } = getWorkspaceStatus(workspace, agent);
+	const { effectiveType, statusText } = getWorkspaceStatus(workspace, agent);
 
 	const { mutate: generateKey, isPending: isGeneratingKey } = useMutation({
 		mutationFn: () => API.getApiKey(),
@@ -234,8 +236,14 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 								<MonitorIcon className="mt-px size-3.5 shrink-0" />
 								<span className="flex min-w-0 flex-col">
 									<span className="truncate">View Workspace</span>
-									<span className="truncate font-normal text-content-disabled">
-										{statusLabel}
+									<span
+										className={cn(
+											"flex min-w-0 items-center gap-1 font-normal",
+											statusColorMap[effectiveType],
+										)}
+									>
+										<CircleDotIcon className="size-3 shrink-0" />
+										<span className="truncate">{statusText}</span>
 									</span>
 								</span>
 							</Link>
@@ -257,6 +265,15 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);
+};
+
+const statusColorMap: Record<DisplayWorkspaceStatusType, string> = {
+	success: "text-content-success",
+	active: "text-content-link",
+	inactive: "text-content-secondary",
+	error: "text-content-destructive",
+	danger: "text-content-destructive",
+	warning: "text-content-warning",
 };
 
 const VSCodeMenuItem: FC<{


### PR DESCRIPTION
## Summary

The workspace pill in Coder Agents currently shows its status two ways: a hover tooltip on the pill trigger **and** the dropdown menu. That double affordance is confusing.

This PR drops the hover tooltip and surfaces the status as a non-interactive row inside the dropdown, right above `Copy SSH Command` / `View Workspace` (matching the target design).

## Changes

- Remove the `Tooltip`/`TooltipContent`/`TooltipTrigger` wrapper (and the `tooltipOpen` state) around the pill trigger.
- Add a `WorkspaceStatusItem` row in the dropdown that renders the `StatusIcon` + `statusLabel`, colored by status type (e.g. green for a healthy running workspace).
- Update stories to assert the status now renders inside the dropdown.

The pill trigger itself still shows the status icon + workspace name, so the at-a-glance status is preserved without a hover.

## Testing

- Storybook interaction tests updated (`WorkspacePill.stories.tsx`). I was not able to run the frontend test suite in this environment; please confirm CI (`pnpm test`/storybook) is green.

<details>
<summary>Decision notes</summary>

- The status row is intentionally non-interactive (a plain `div`, not a `DropdownMenuItem`) so it does not receive keyboard focus or look clickable.
- Status color mapping mirrors the existing `DisplayWorkspaceStatusType` conventions used elsewhere in the app (`success`/`active`/`inactive`/`error`/`danger`/`warning`).
- The existing apps/actions separator already divides apps from the status/actions section, so no extra separator was added.

</details>

---

*This PR was generated by Coder Agents on behalf of @tracyjohnsonux.*