### PR TITLE
fix: scope workspace and template available-user lists to the organization

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -20157,6 +20157,12 @@ WHERE
 			-- The pagination cursor is the last ID of the previous page.
 			-- The query is ordered by the username field, so select all
 			-- rows after the cursor.
+			-- TODO: if @after_id belongs to a user who is a member of multiple
+			-- organizations, this subquery returns one row per membership and
+			-- Postgres errors on the multi-row scalar. The username is identical
+			-- across those rows, so a LIMIT 1 (or DISTINCT) would fix it. Left as
+			-- a known limitation for now; this is shared pagination SQL used by
+			-- other endpoints too.
 			(LOWER(users.username)) > (
 				SELECT
 					LOWER(users.username)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -20157,12 +20157,12 @@ WHERE
 			-- The pagination cursor is the last ID of the previous page.
 			-- The query is ordered by the username field, so select all
 			-- rows after the cursor.
-			-- TODO: if @after_id belongs to a user who is a member of multiple
-			-- organizations, this subquery returns one row per membership and
-			-- Postgres errors on the multi-row scalar. The username is identical
-			-- across those rows, so a LIMIT 1 (or DISTINCT) would fix it. Left as
-			-- a known limitation for now; this is shared pagination SQL used by
-			-- other endpoints too.
+			-- TODO(DEVEX-790): if @after_id belongs to a user who is a member of
+			-- multiple organizations, this subquery returns one row per membership
+			-- and Postgres errors on the multi-row scalar. The username is
+			-- identical across those rows, so a LIMIT 1 (or DISTINCT) would fix it.
+			-- Left as a known limitation for now; this is shared pagination SQL
+			-- used by other endpoints too.
 			(LOWER(users.username)) > (
 				SELECT
 					LOWER(users.username)

--- a/coderd/database/queries/organizationmembers.sql
+++ b/coderd/database/queries/organizationmembers.sql
@@ -101,12 +101,12 @@ WHERE
 			-- The pagination cursor is the last ID of the previous page.
 			-- The query is ordered by the username field, so select all
 			-- rows after the cursor.
-			-- TODO: if @after_id belongs to a user who is a member of multiple
-			-- organizations, this subquery returns one row per membership and
-			-- Postgres errors on the multi-row scalar. The username is identical
-			-- across those rows, so a LIMIT 1 (or DISTINCT) would fix it. Left as
-			-- a known limitation for now; this is shared pagination SQL used by
-			-- other endpoints too.
+			-- TODO(DEVEX-790): if @after_id belongs to a user who is a member of
+			-- multiple organizations, this subquery returns one row per membership
+			-- and Postgres errors on the multi-row scalar. The username is
+			-- identical across those rows, so a LIMIT 1 (or DISTINCT) would fix it.
+			-- Left as a known limitation for now; this is shared pagination SQL
+			-- used by other endpoints too.
 			(LOWER(users.username)) > (
 				SELECT
 					LOWER(users.username)

--- a/coderd/database/queries/organizationmembers.sql
+++ b/coderd/database/queries/organizationmembers.sql
@@ -101,6 +101,12 @@ WHERE
 			-- The pagination cursor is the last ID of the previous page.
 			-- The query is ordered by the username field, so select all
 			-- rows after the cursor.
+			-- TODO: if @after_id belongs to a user who is a member of multiple
+			-- organizations, this subquery returns one row per membership and
+			-- Postgres errors on the multi-row scalar. The username is identical
+			-- across those rows, so a LIMIT 1 (or DISTINCT) would fix it. Left as
+			-- a known limitation for now; this is shared pagination SQL used by
+			-- other endpoints too.
 			(LOWER(users.username)) > (
 				SELECT
 					LOWER(users.username)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -3180,9 +3180,8 @@ func (api *API) workspaceAvailableUsers(rw http.ResponseWriter, r *http.Request)
 	// candidate list is this organization's roster, not every user on the
 	// deployment. We look members up under the caller's own context via
 	// PaginatedOrganizationMembers, which enforces organization_member read, so
-	// member identity (including email, for disambiguation) is only returned to
-	// callers authorized to read this organization's members. This also keeps
-	// the listing scoped to a single organization in multi-org deployments.
+	// the listing is scoped to a single organization in multi-org deployments and
+	// is only returned to callers authorized to read this organization's members.
 	members, err := api.Database.PaginatedOrganizationMembers(ctx, database.PaginatedOrganizationMembersParams{
 		AfterID:          paginationParams.AfterID,
 		OrganizationID:   organization.ID,

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -3220,7 +3220,6 @@ func (api *API) workspaceAvailableUsers(rw http.ResponseWriter, r *http.Request)
 			ID:        member.OrganizationMember.UserID,
 			Username:  member.Username,
 			Name:      member.Name,
-			Email:     member.Email,
 			AvatarURL: member.AvatarURL,
 		}))
 	}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -3163,22 +3163,66 @@ func (api *API) workspaceAvailableUsers(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Use system context to list all users. The authorization check above
-	// ensures only users who can create workspaces for others can access this.
-	//nolint:gocritic // System context needed to list users for workspace owner selection.
-	users, _, ok := api.GetUsers(rw, r.WithContext(dbauthz.AsSystemRestricted(ctx)))
+	userFilterParams, filterErrs := searchquery.Users(r.URL.Query().Get("q"))
+	if len(filterErrs) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Invalid user search query.",
+			Validations: filterErrs,
+		})
+		return
+	}
+	paginationParams, ok := ParsePagination(rw, r)
 	if !ok {
 		return
 	}
 
-	minimalUsers := make([]codersdk.MinimalUser, 0, len(users))
-	for _, user := range users {
-		minimalUsers = append(minimalUsers, codersdk.MinimalUser{
-			ID:        user.ID,
-			Username:  user.Username,
-			Name:      user.Name,
-			AvatarURL: user.AvatarURL,
-		})
+	// A workspace owner must be a member of the workspace's organization, so the
+	// candidate list is this organization's roster, not every user on the
+	// deployment. We look members up under the caller's own context via
+	// PaginatedOrganizationMembers, which enforces organization_member read, so
+	// member identity (including email, for disambiguation) is only returned to
+	// callers authorized to read this organization's members. This also keeps
+	// the listing scoped to a single organization in multi-org deployments.
+	members, err := api.Database.PaginatedOrganizationMembers(ctx, database.PaginatedOrganizationMembersParams{
+		AfterID:          paginationParams.AfterID,
+		OrganizationID:   organization.ID,
+		IncludeSystem:    false,
+		Search:           userFilterParams.Search,
+		Name:             userFilterParams.Name,
+		ExactUsername:    userFilterParams.ExactUsername,
+		ExactEmail:       userFilterParams.ExactEmail,
+		Status:           userFilterParams.Status,
+		IsServiceAccount: userFilterParams.IsServiceAccount,
+		RbacRole:         userFilterParams.RbacRole,
+		LastSeenBefore:   userFilterParams.LastSeenBefore,
+		LastSeenAfter:    userFilterParams.LastSeenAfter,
+		CreatedAfter:     userFilterParams.CreatedAfter,
+		CreatedBefore:    userFilterParams.CreatedBefore,
+		GithubComUserID:  userFilterParams.GithubComUserID,
+		LoginType:        userFilterParams.LoginType,
+		// #nosec G115 - Pagination offsets are small and fit in int32
+		OffsetOpt: int32(paginationParams.Offset),
+		// #nosec G115 - Pagination limits are small and fit in int32
+		LimitOpt: int32(paginationParams.Limit),
+	})
+	if dbauthz.IsNotAuthorizedError(err) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	minimalUsers := make([]codersdk.MinimalUser, 0, len(members))
+	for _, member := range members {
+		minimalUsers = append(minimalUsers, db2sdk.MinimalUser(database.User{
+			ID:        member.OrganizationMember.UserID,
+			Username:  member.Username,
+			Name:      member.Name,
+			Email:     member.Email,
+			AvatarURL: member.AvatarURL,
+		}))
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, minimalUsers)

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -97,6 +97,8 @@ func (api *API) templateAvailablePermissions(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// This returns ReducedUser rather than MinimalUser because the frontend
+	// requires the email field. Switching to MinimalUser needs a UI change first.
 	reducedUsers := make([]codersdk.ReducedUser, 0, len(members))
 	for _, member := range members {
 		reducedUsers = append(reducedUsers, db2sdk.ReducedUser(database.User{

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -44,17 +44,9 @@ func (api *API) templateAvailablePermissions(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// We have to use the system restricted context here because the caller
-	// might not have permission to read all users.
-	// nolint:gocritic
-	users, _, ok := api.AGPL.GetUsers(rw, r.WithContext(dbauthz.AsSystemRestricted(ctx)))
-	if !ok {
-		return
-	}
-
-	// Apply the same q/limit semantics to groups as the users half of this response.
-	// The query semantics are defined for the users, which is awkward. But we can
-	// just reuse the search part of the query which is a fuzzy match.
+	// Apply the same q/limit semantics to users and groups. The query semantics
+	// are defined for the users, which is awkward. But we can just reuse the
+	// search part of the query which is a fuzzy match.
 	userFilter, verr := searchquery.Users(r.URL.Query().Get("q"))
 	if len(verr) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -66,6 +58,60 @@ func (api *API) templateAvailablePermissions(rw http.ResponseWriter, r *http.Req
 	groupPagination, ok := agpl.ParsePagination(rw, r)
 	if !ok {
 		return
+	}
+
+	// Only members of the template's organization can be granted access to it,
+	// so the candidate list is that organization's roster, not every user on the
+	// deployment. We look members up under the caller's own context via
+	// PaginatedOrganizationMembers, which enforces organization_member read. This
+	// keeps the listing scoped to the template's organization and avoids exposing
+	// users (and their email) from other organizations in multi-org deployments.
+	members, err := api.Database.PaginatedOrganizationMembers(ctx, database.PaginatedOrganizationMembersParams{
+		AfterID:          groupPagination.AfterID,
+		OrganizationID:   template.OrganizationID,
+		IncludeSystem:    false,
+		Search:           userFilter.Search,
+		Name:             userFilter.Name,
+		ExactUsername:    userFilter.ExactUsername,
+		ExactEmail:       userFilter.ExactEmail,
+		Status:           userFilter.Status,
+		IsServiceAccount: userFilter.IsServiceAccount,
+		RbacRole:         userFilter.RbacRole,
+		LastSeenBefore:   userFilter.LastSeenBefore,
+		LastSeenAfter:    userFilter.LastSeenAfter,
+		CreatedAfter:     userFilter.CreatedAfter,
+		CreatedBefore:    userFilter.CreatedBefore,
+		GithubComUserID:  userFilter.GithubComUserID,
+		LoginType:        userFilter.LoginType,
+		// #nosec G115 - Pagination offsets are small and fit in int32
+		OffsetOpt: int32(groupPagination.Offset),
+		// #nosec G115 - Pagination limits are small and fit in int32
+		LimitOpt: int32(groupPagination.Limit),
+	})
+	if dbauthz.IsNotAuthorizedError(err) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	reducedUsers := make([]codersdk.ReducedUser, 0, len(members))
+	for _, member := range members {
+		reducedUsers = append(reducedUsers, db2sdk.ReducedUser(database.User{
+			ID:               member.OrganizationMember.UserID,
+			Username:         member.Username,
+			Name:             member.Name,
+			Email:            member.Email,
+			AvatarURL:        member.AvatarURL,
+			CreatedAt:        member.UserCreatedAt,
+			UpdatedAt:        member.UserUpdatedAt,
+			LastSeenAt:       member.LastSeenAt,
+			Status:           member.Status,
+			LoginType:        member.LoginType,
+			IsServiceAccount: member.IsServiceAccount,
+		}))
 	}
 
 	// Perm check is the template update check.
@@ -112,10 +158,7 @@ func (api *API) templateAvailablePermissions(rw http.ResponseWriter, r *http.Req
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ACLAvailable{
-		// TODO: @emyrk we should return a MinimalUser here instead of a full user.
-		// The FE requires the `email` field, so this cannot be done without
-		// a UI change.
-		Users:  db2sdk.ReducedUsers(users),
+		Users:  reducedUsers,
 		Groups: sdkGroups,
 	})
 }

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -2445,3 +2445,47 @@ func TestInvalidateTemplatePrebuilds_LicenseFeatureDisabled(t *testing.T) {
 	require.ErrorAs(t, err, &sdkError)
 	require.Equal(t, http.StatusForbidden, sdkError.StatusCode())
 }
+
+// TestTemplateACLAvailableMultiOrg verifies that the template ACL
+// available-users list is scoped to the template's organization and does not
+// leak members of other organizations in a multi-org deployment.
+func TestTemplateACLAvailableMultiOrg(t *testing.T) {
+	t.Parallel()
+
+	client, first := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+				codersdk.FeatureTemplateRBAC:          1,
+			},
+		},
+	})
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// A second organization with a member who does not belong to the first org.
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+	_, otherOrgUser := coderdtest.CreateAnotherUser(t, client, secondOrg.ID)
+
+	// A member of the first organization, to confirm same-org users are listed.
+	_, firstOrgUser := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
+
+	// A template that lives in the first organization.
+	version := coderdtest.CreateTemplateVersion(t, client, first.OrganizationID, nil)
+	template := coderdtest.CreateTemplate(t, client, first.OrganizationID, version.ID)
+
+	// The owner listing available ACL users for the first organization's
+	// template must only see members of that organization, never the second
+	// organization's member.
+	//nolint:gocritic // The test verifies the owner's org-scoped available-users view.
+	available, err := client.TemplateACLAvailable(ctx, template.ID, codersdk.UsersRequest{})
+	require.NoError(t, err)
+
+	usernames := make([]string, 0, len(available.Users))
+	for _, u := range available.Users {
+		usernames = append(usernames, u.Username)
+	}
+	require.Contains(t, usernames, firstOrgUser.Username)
+	require.NotContains(t, usernames, otherOrgUser.Username,
+		"template ACL available-users must not leak members of another organization")
+}

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -5077,10 +5077,7 @@ func TestWorkspaceAvailableUsersMultiOrg(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	// A second organization with a member who does not belong to the first org.
-	secondOrg, err := client.CreateOrganization(ctx, codersdk.CreateOrganizationRequest{
-		Name: "second",
-	})
-	require.NoError(t, err)
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
 	_, otherOrgUser := coderdtest.CreateAnotherUser(t, client, secondOrg.ID)
 
 	// A member of the first organization, to confirm same-org users are listed.
@@ -5088,6 +5085,7 @@ func TestWorkspaceAvailableUsersMultiOrg(t *testing.T) {
 
 	// The owner listing available users for the first organization must only see
 	// members of that organization, never the second organization's member.
+	//nolint:gocritic // The test verifies the owner's org-scoped available-users view.
 	users, err := client.WorkspaceAvailableUsers(ctx, first.OrganizationID, "me")
 	require.NoError(t, err)
 

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -5059,3 +5059,43 @@ func TestWorkspaceAITask(t *testing.T) {
 		require.Len(t, usage.GetDiscreteEvents(), 1)
 	})
 }
+
+// TestWorkspaceAvailableUsersMultiOrg verifies that the available-users
+// people-picker is scoped to the organization in the request path and does not
+// leak members of other organizations in a multi-org deployment.
+func TestWorkspaceAvailableUsersMultiOrg(t *testing.T) {
+	t.Parallel()
+
+	client, first := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// A second organization with a member who does not belong to the first org.
+	secondOrg, err := client.CreateOrganization(ctx, codersdk.CreateOrganizationRequest{
+		Name: "second",
+	})
+	require.NoError(t, err)
+	_, otherOrgUser := coderdtest.CreateAnotherUser(t, client, secondOrg.ID)
+
+	// A member of the first organization, to confirm same-org users are listed.
+	_, firstOrgUser := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
+
+	// The owner listing available users for the first organization must only see
+	// members of that organization, never the second organization's member.
+	users, err := client.WorkspaceAvailableUsers(ctx, first.OrganizationID, "me")
+	require.NoError(t, err)
+
+	usernames := make([]string, 0, len(users))
+	for _, u := range users {
+		usernames = append(usernames, u.Username)
+	}
+	require.Contains(t, usernames, firstOrgUser.Username)
+	require.NotContains(t, usernames, otherOrgUser.Username,
+		"available-users must not leak members of another organization")
+}


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

Part of [DEVEX-448](https://linear.app/codercom/issue/DEVEX-448/normalize-user-identity-display-across-coder). Independent security fix; merges after #28240.

## Why

The workspace `available-users` and template `available` ACL people-pickers listed every user on the deployment. Both called `GetUsers` under the System context with no organization filter, using the `{organization}` / `{template}` path param only for the authorization gate. In a multi-org deployment this exposed users from other organizations to an org-scoped admin, and the template endpoint (which returns `ReducedUser`) leaked those users' email across organizations.

## What

Rebuild both endpoints on caller-context `PaginatedOrganizationMembers`, scoped to the request's organization:

- `coderd/workspaces.go` `workspaceAvailableUsers` -> members of the path organization.
- `enterprise/coderd/templates.go` `templateAvailablePermissions` -> members of the template's organization (its groups half was already org-scoped).

`PaginatedOrganizationMembers` runs under the caller's own context and enforces `organization_member` read, so the listing is confined to members of that organization and only returned to callers authorized to read them. Search (`q`) and pagination are preserved. A workspace owner and a template grantee must belong to the relevant organization, so the org roster is the correct candidate set.

## Testing

- `TestWorkspaceAvailableUsersMultiOrg` and `TestTemplateACLAvailableMultiOrg`: an owner listing available users for org A does not receive a member who only belongs to org B. Both fail against pre-fix code and pass against the fix.
- Existing `TestWorkspaceAvailableUsers` still holds; `go build` / `go vet` clean. Postgres-backed tests run in CI.

<details>
<summary>Design notes</summary>

- The alternative (keep System context, add a manual `OrganizationID` filter to `GetUsers`) still bypasses authz. Using `PaginatedOrganizationMembers` under the caller's context lets the org-scoped RBAC resource resolve visibility per request, including the "admin in org A, member in org B" case.
- The template endpoint keeps returning `ReducedUser` to avoid a frontend regression (`MultiUserSelect` reads `email`); switching it to `MinimalUser` is a follow-up once `MinimalUser` carries email.
- Known limitation: `PaginatedOrganizationMembers`'s `after_id` cursor subquery 500s when the cursor user belongs to multiple organizations (pre-existing in the shared SQL, also used by `coderd/members.go`). Tracked and marked with a root-cause `TODO(DEVEX-790)`; the `LIMIT 1`/`DISTINCT` fix is deferred to DEVEX-790 to keep this PR out of shared pagination SQL.
</details>