### PR TITLE
feat(site): add Install Coder Desktop item to UserDropdown

### DIFF
--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.stories.tsx
@@ -52,6 +52,32 @@ const openDropdown = async (canvasElement: HTMLElement) => {
 	);
 };
 
+// Overrides platform detection so the Coder Desktop gating can be exercised in
+// a story. Returns a cleanup that restores the original descriptors.
+const mockPlatform = (platform: string, maxTouchPoints = 0) => {
+	const platformDesc = Object.getOwnPropertyDescriptor(navigator, "platform");
+	const touchDesc = Object.getOwnPropertyDescriptor(
+		navigator,
+		"maxTouchPoints",
+	);
+	Object.defineProperty(navigator, "platform", {
+		value: platform,
+		configurable: true,
+	});
+	Object.defineProperty(navigator, "maxTouchPoints", {
+		value: maxTouchPoints,
+		configurable: true,
+	});
+	return () => {
+		if (platformDesc) {
+			Object.defineProperty(navigator, "platform", platformDesc);
+		}
+		if (touchDesc) {
+			Object.defineProperty(navigator, "maxTouchPoints", touchDesc);
+		}
+	};
+};
+
 const Example: Story = {
 	parameters: {
 		queries: [{ key: meAISpendKey, data: mockAISpend }],
@@ -321,6 +347,79 @@ export const AISpendHiddenOnNegativeLimit: Story = {
 		await step("hides AI spend on a negative limit", async () => {
 			await openDropdown(canvasElement);
 			expect(document.body).not.toHaveTextContent(spendPeriodLabel);
+		});
+	},
+};
+
+export const InstallCoderDesktopMacOS: Story = {
+	parameters: {
+		queries: [{ key: meAISpendKey, data: mockAISpend }],
+	},
+	beforeEach: () => mockPlatform("MacIntel"),
+	play: async ({ canvasElement, step }) => {
+		await step(
+			"links Install Coder Desktop to the docs alongside Install CLI",
+			async () => {
+				const menu = await openDropdown(canvasElement);
+				expect(
+					menu.getByRole("menuitem", { name: "Install Coder Desktop" }),
+				).toHaveAttribute("href", "https://coder.com/docs/user-guides/desktop");
+				expect(
+					menu.getByRole("menuitem", { name: "Install CLI" }),
+				).toBeInTheDocument();
+			},
+		);
+	},
+};
+
+export const InstallCoderDesktopWindows: Story = {
+	parameters: {
+		queries: [{ key: meAISpendKey, data: mockAISpend }],
+	},
+	beforeEach: () => mockPlatform("Win32"),
+	play: async ({ canvasElement, step }) => {
+		await step("shows Install Coder Desktop on Windows", async () => {
+			const menu = await openDropdown(canvasElement);
+			expect(
+				menu.getByRole("menuitem", { name: "Install Coder Desktop" }),
+			).toBeInTheDocument();
+		});
+	},
+};
+
+export const InstallCoderDesktopHiddenOnLinux: Story = {
+	parameters: {
+		queries: [{ key: meAISpendKey, data: mockAISpend }],
+	},
+	beforeEach: () => mockPlatform("Linux x86_64"),
+	play: async ({ canvasElement, step }) => {
+		await step(
+			"hides Install Coder Desktop but keeps Install CLI",
+			async () => {
+				const menu = await openDropdown(canvasElement);
+				expect(
+					menu.queryByRole("menuitem", { name: "Install Coder Desktop" }),
+				).not.toBeInTheDocument();
+				expect(
+					menu.getByRole("menuitem", { name: "Install CLI" }),
+				).toBeInTheDocument();
+			},
+		);
+	},
+};
+
+export const InstallCoderDesktopHiddenOniPadOS: Story = {
+	parameters: {
+		queries: [{ key: meAISpendKey, data: mockAISpend }],
+	},
+	// iPadOS 13+ reports "MacIntel" but exposes a touchscreen.
+	beforeEach: () => mockPlatform("MacIntel", 5),
+	play: async ({ canvasElement, step }) => {
+		await step("hides Install Coder Desktop on iPadOS", async () => {
+			const menu = await openDropdown(canvasElement);
+			expect(
+				menu.queryByRole("menuitem", { name: "Install Coder Desktop" }),
+			).not.toBeInTheDocument();
 		});
 	},
 };

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+import {
+	expect,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 import { meAISpendKey } from "#/api/queries/users";
 import type { FeatureName, UserAISpendStatus } from "#/api/typesGenerated";
 import { MockBuildInfo, MockUserOwner } from "#/testHelpers/entities";
@@ -53,28 +60,15 @@ const openDropdown = async (canvasElement: HTMLElement) => {
 };
 
 // Overrides platform detection so the Coder Desktop gating can be exercised in
-// a story. Returns a cleanup that restores the original descriptors.
+// a story. Returns a cleanup that restores the spied getters.
 const mockPlatform = (platform: string, maxTouchPoints = 0) => {
-	const platformDesc = Object.getOwnPropertyDescriptor(navigator, "platform");
-	const touchDesc = Object.getOwnPropertyDescriptor(
-		navigator,
-		"maxTouchPoints",
-	);
-	Object.defineProperty(navigator, "platform", {
-		value: platform,
-		configurable: true,
-	});
-	Object.defineProperty(navigator, "maxTouchPoints", {
-		value: maxTouchPoints,
-		configurable: true,
-	});
+	const navigatorSpy = spyOn(window, "navigator", "get").mockReturnValue({
+		...window.navigator,
+		platform,
+		maxTouchPoints,
+	} as Navigator);
 	return () => {
-		if (platformDesc) {
-			Object.defineProperty(navigator, "platform", platformDesc);
-		}
-		if (touchDesc) {
-			Object.defineProperty(navigator, "maxTouchPoints", touchDesc);
-		}
+		navigatorSpy.mockRestore();
 	};
 };
 

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.stories.tsx
@@ -62,13 +62,15 @@ const openDropdown = async (canvasElement: HTMLElement) => {
 // Overrides platform detection so the Coder Desktop gating can be exercised in
 // a story. Returns a cleanup that restores the spied getters.
 const mockPlatform = (platform: string, maxTouchPoints = 0) => {
-	const navigatorSpy = spyOn(window, "navigator", "get").mockReturnValue({
-		...window.navigator,
+	const platformSpy = spyOn(navigator, "platform", "get").mockReturnValue(
 		platform,
+	);
+	const touchSpy = spyOn(navigator, "maxTouchPoints", "get").mockReturnValue(
 		maxTouchPoints,
-	} as Navigator);
+	);
 	return () => {
-		navigatorSpy.mockRestore();
+		platformSpy.mockRestore();
+		touchSpy.mockRestore();
 	};
 };
 

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.test.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.test.tsx
@@ -98,8 +98,6 @@ describe("UserDropdownContent", () => {
 		renderUserDropdownContent({ onSignOut: vi.fn() });
 		await waitForLoaderToBeRemoved();
 
-		expect(
-			screen.queryByText("Install Coder Desktop"),
-		).not.toBeInTheDocument();
+		expect(screen.queryByText("Install Coder Desktop")).not.toBeInTheDocument();
 	});
 });

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.test.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.test.tsx
@@ -9,13 +9,6 @@ import { MockUserOwner } from "#/testHelpers/entities";
 import { render, waitForLoaderToBeRemoved } from "#/testHelpers/renderHelpers";
 import { UserDropdownContent } from "./UserDropdownContent";
 
-const setPlatform = (value: string) => {
-	Object.defineProperty(window.navigator, "platform", {
-		value,
-		configurable: true,
-	});
-};
-
 const renderUserDropdownContent = (props: {
 	onSignOut: () => void;
 	profileExtra?: ReactNode;
@@ -36,12 +29,6 @@ const renderUserDropdownContent = (props: {
 };
 
 describe("UserDropdownContent", () => {
-	const originalPlatform = navigator.platform;
-
-	afterEach(() => {
-		setPlatform(originalPlatform);
-	});
-
 	it("has the correct link for the account item", async () => {
 		renderUserDropdownContent({ onSignOut: vi.fn() });
 		await waitForLoaderToBeRemoved();
@@ -72,32 +59,5 @@ describe("UserDropdownContent", () => {
 		expect(
 			screen.getByText("AI spend - $819 / $1,200 USD"),
 		).toBeInTheDocument();
-	});
-
-	it("shows Install Coder Desktop linking to the docs on macOS", async () => {
-		setPlatform("MacIntel");
-		renderUserDropdownContent({ onSignOut: vi.fn() });
-		await waitForLoaderToBeRemoved();
-
-		const link = screen.getByText("Install Coder Desktop").closest("a");
-		expect(link?.getAttribute("href")).toBe(
-			"https://coder.com/docs/user-guides/desktop",
-		);
-	});
-
-	it("shows Install Coder Desktop on Windows", async () => {
-		setPlatform("Win32");
-		renderUserDropdownContent({ onSignOut: vi.fn() });
-		await waitForLoaderToBeRemoved();
-
-		expect(screen.getByText("Install Coder Desktop")).toBeInTheDocument();
-	});
-
-	it("hides Install Coder Desktop on unsupported platforms", async () => {
-		setPlatform("Linux x86_64");
-		renderUserDropdownContent({ onSignOut: vi.fn() });
-		await waitForLoaderToBeRemoved();
-
-		expect(screen.queryByText("Install Coder Desktop")).not.toBeInTheDocument();
 	});
 });

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.test.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.test.tsx
@@ -9,6 +9,13 @@ import { MockUserOwner } from "#/testHelpers/entities";
 import { render, waitForLoaderToBeRemoved } from "#/testHelpers/renderHelpers";
 import { UserDropdownContent } from "./UserDropdownContent";
 
+const setPlatform = (value: string) => {
+	Object.defineProperty(window.navigator, "platform", {
+		value,
+		configurable: true,
+	});
+};
+
 const renderUserDropdownContent = (props: {
 	onSignOut: () => void;
 	profileExtra?: ReactNode;
@@ -29,6 +36,12 @@ const renderUserDropdownContent = (props: {
 };
 
 describe("UserDropdownContent", () => {
+	const originalPlatform = navigator.platform;
+
+	afterEach(() => {
+		setPlatform(originalPlatform);
+	});
+
 	it("has the correct link for the account item", async () => {
 		renderUserDropdownContent({ onSignOut: vi.fn() });
 		await waitForLoaderToBeRemoved();
@@ -59,5 +72,34 @@ describe("UserDropdownContent", () => {
 		expect(
 			screen.getByText("AI spend - $819 / $1,200 USD"),
 		).toBeInTheDocument();
+	});
+
+	it("shows Install Coder Desktop linking to the docs on macOS", async () => {
+		setPlatform("MacIntel");
+		renderUserDropdownContent({ onSignOut: vi.fn() });
+		await waitForLoaderToBeRemoved();
+
+		const link = screen.getByText("Install Coder Desktop").closest("a");
+		expect(link?.getAttribute("href")).toBe(
+			"https://coder.com/docs/user-guides/desktop",
+		);
+	});
+
+	it("shows Install Coder Desktop on Windows", async () => {
+		setPlatform("Win32");
+		renderUserDropdownContent({ onSignOut: vi.fn() });
+		await waitForLoaderToBeRemoved();
+
+		expect(screen.getByText("Install Coder Desktop")).toBeInTheDocument();
+	});
+
+	it("hides Install Coder Desktop on unsupported platforms", async () => {
+		setPlatform("Linux x86_64");
+		renderUserDropdownContent({ onSignOut: vi.fn() });
+		await waitForLoaderToBeRemoved();
+
+		expect(
+			screen.queryByText("Install Coder Desktop"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -3,6 +3,7 @@ import {
 	CopyIcon,
 	LogOutIcon,
 	MonitorDownIcon,
+	MonitorIcon,
 	SquareArrowOutUpRightIcon,
 } from "lucide-react";
 import type { FC, ReactNode } from "react";
@@ -19,7 +20,14 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useClipboard } from "#/hooks/useClipboard";
+import { supportsCoderDesktop } from "#/utils/platform";
 import { SupportIcon } from "../SupportIcon";
+
+// Coder Desktop only ships for macOS and Windows. Rather than deep-linking to a
+// single install method (brew, winget, releases, source, ...), point users at
+// the docs page, which is the canonical hub listing every install method and
+// stays current without frontend changes.
+const CODER_DESKTOP_DOCS_URL = "https://coder.com/docs/user-guides/desktop";
 
 interface UserDropdownContentProps {
 	user: TypesGen.User;
@@ -52,6 +60,18 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 			</DropdownMenuItem>
 			{profileExtra}
 			<DropdownMenuSeparator />
+			{supportsCoderDesktop() && (
+				<DropdownMenuItem asChild>
+					<a
+						href={CODER_DESKTOP_DOCS_URL}
+						target="_blank"
+						rel="noreferrer"
+					>
+						<MonitorIcon />
+						<span>Install Coder Desktop</span>
+					</a>
+				</DropdownMenuItem>
+			)}
 			<DropdownMenuItem asChild>
 				<Link to="/install">
 					<MonitorDownIcon />

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -1,10 +1,10 @@
 import {
-	AppWindowMacIcon,
 	CircleUserIcon,
 	CopyIcon,
-	DownloadIcon,
 	LogOutIcon,
+	MonitorIcon,
 	SquareArrowOutUpRightIcon,
+	TerminalIcon,
 } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import { Link } from "react-router";
@@ -59,14 +59,14 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 			{supportsCoderDesktop() && (
 				<DropdownMenuItem asChild>
 					<a href={CODER_DESKTOP_DOCS_URL} target="_blank" rel="noreferrer">
-						<AppWindowMacIcon />
+						<MonitorIcon />
 						<span>Install Coder Desktop</span>
 					</a>
 				</DropdownMenuItem>
 			)}
 			<DropdownMenuItem asChild>
 				<Link to="/install">
-					<DownloadIcon />
+					<TerminalIcon />
 					<span>Install CLI</span>
 				</Link>
 			</DropdownMenuItem>

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -23,10 +23,6 @@ import { useClipboard } from "#/hooks/useClipboard";
 import { supportsCoderDesktop } from "#/utils/platform";
 import { SupportIcon } from "../SupportIcon";
 
-// Coder Desktop only ships for macOS and Windows. Rather than deep-linking to a
-// single install method (brew, winget, releases, source, ...), point users at
-// the docs page, which is the canonical hub listing every install method and
-// stays current without frontend changes.
 const CODER_DESKTOP_DOCS_URL = "https://coder.com/docs/user-guides/desktop";
 
 interface UserDropdownContentProps {

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -62,11 +62,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 			<DropdownMenuSeparator />
 			{supportsCoderDesktop() && (
 				<DropdownMenuItem asChild>
-					<a
-						href={CODER_DESKTOP_DOCS_URL}
-						target="_blank"
-						rel="noreferrer"
-					>
+					<a href={CODER_DESKTOP_DOCS_URL} target="_blank" rel="noreferrer">
 						<MonitorIcon />
 						<span>Install Coder Desktop</span>
 					</a>

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -1,9 +1,9 @@
 import {
+	AppWindowMacIcon,
 	CircleUserIcon,
 	CopyIcon,
+	DownloadIcon,
 	LogOutIcon,
-	MonitorDownIcon,
-	MonitorIcon,
 	SquareArrowOutUpRightIcon,
 } from "lucide-react";
 import type { FC, ReactNode } from "react";
@@ -63,14 +63,14 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 			{supportsCoderDesktop() && (
 				<DropdownMenuItem asChild>
 					<a href={CODER_DESKTOP_DOCS_URL} target="_blank" rel="noreferrer">
-						<MonitorIcon />
+						<AppWindowMacIcon />
 						<span>Install Coder Desktop</span>
 					</a>
 				</DropdownMenuItem>
 			)}
 			<DropdownMenuItem asChild>
 				<Link to="/install">
-					<MonitorDownIcon />
+					<DownloadIcon />
 					<span>Install CLI</span>
 				</Link>
 			</DropdownMenuItem>

--- a/site/src/utils/platform.test.ts
+++ b/site/src/utils/platform.test.ts
@@ -1,0 +1,37 @@
+import { isMac, isWindows, supportsCoderDesktop } from "./platform";
+
+const setPlatform = (value: string) => {
+	Object.defineProperty(window.navigator, "platform", {
+		value,
+		configurable: true,
+	});
+};
+
+describe("platform", () => {
+	const originalPlatform = navigator.platform;
+
+	afterEach(() => {
+		setPlatform(originalPlatform);
+	});
+
+	it("detects macOS", () => {
+		setPlatform("MacIntel");
+		expect(isMac()).toBe(true);
+		expect(isWindows()).toBe(false);
+		expect(supportsCoderDesktop()).toBe(true);
+	});
+
+	it("detects Windows", () => {
+		setPlatform("Win32");
+		expect(isWindows()).toBe(true);
+		expect(isMac()).toBe(false);
+		expect(supportsCoderDesktop()).toBe(true);
+	});
+
+	it("treats Linux and other platforms as unsupported", () => {
+		setPlatform("Linux x86_64");
+		expect(isMac()).toBe(false);
+		expect(isWindows()).toBe(false);
+		expect(supportsCoderDesktop()).toBe(false);
+	});
+});

--- a/site/src/utils/platform.test.ts
+++ b/site/src/utils/platform.test.ts
@@ -1,45 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { isMac, isWindows, supportsCoderDesktop } from "./platform";
 
-const setPlatform = (value: string) => {
-	Object.defineProperty(window.navigator, "platform", {
-		value,
-		configurable: true,
-	});
-};
-
-const setMaxTouchPoints = (value: number) => {
-	Object.defineProperty(window.navigator, "maxTouchPoints", {
-		value,
-		configurable: true,
+const stubPlatform = (platform: string, maxTouchPoints = 0) => {
+	vi.stubGlobal("navigator", {
+		...navigator,
+		platform,
+		maxTouchPoints,
 	});
 };
 
 describe("platform", () => {
-	const originalPlatform = navigator.platform;
-	const originalMaxTouchPoints = navigator.maxTouchPoints;
-
 	afterEach(() => {
-		setPlatform(originalPlatform);
-		setMaxTouchPoints(originalMaxTouchPoints);
+		vi.unstubAllGlobals();
 	});
 
 	it("detects macOS", () => {
-		setPlatform("MacIntel");
-		setMaxTouchPoints(0);
+		stubPlatform("MacIntel");
 		expect(isMac()).toBe(true);
 		expect(isWindows()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
 	});
 
 	it("detects Windows", () => {
-		setPlatform("Win32");
+		stubPlatform("Win32");
 		expect(isWindows()).toBe(true);
 		expect(isMac()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
 	});
 
 	it("treats Linux and other platforms as unsupported", () => {
-		setPlatform("Linux x86_64");
+		stubPlatform("Linux x86_64");
 		expect(isMac()).toBe(false);
 		expect(isWindows()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(false);
@@ -47,8 +37,7 @@ describe("platform", () => {
 
 	it("excludes iPadOS masquerading as macOS", () => {
 		// iPadOS 13+ reports "MacIntel" but exposes a touchscreen.
-		setPlatform("MacIntel");
-		setMaxTouchPoints(5);
+		stubPlatform("MacIntel", 5);
 		expect(isMac()).toBe(true);
 		expect(supportsCoderDesktop()).toBe(false);
 	});

--- a/site/src/utils/platform.test.ts
+++ b/site/src/utils/platform.test.ts
@@ -1,4 +1,4 @@
-import { isLinux, isMac, isWindows, supportsCoderDesktop } from "./platform";
+import { isMac, isWindows, supportsCoderDesktop } from "./platform";
 
 const setPlatform = (value: string) => {
 	Object.defineProperty(window.navigator, "platform", {
@@ -28,7 +28,6 @@ describe("platform", () => {
 		setMaxTouchPoints(0);
 		expect(isMac()).toBe(true);
 		expect(isWindows()).toBe(false);
-		expect(isLinux()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
 	});
 
@@ -36,23 +35,13 @@ describe("platform", () => {
 		setPlatform("Win32");
 		expect(isWindows()).toBe(true);
 		expect(isMac()).toBe(false);
-		expect(isLinux()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
 	});
 
-	it("detects Linux", () => {
+	it("treats Linux and other platforms as unsupported", () => {
 		setPlatform("Linux x86_64");
-		expect(isLinux()).toBe(true);
 		expect(isMac()).toBe(false);
 		expect(isWindows()).toBe(false);
-		expect(supportsCoderDesktop()).toBe(true);
-	});
-
-	it("treats other platforms as unsupported", () => {
-		setPlatform("CrOS x86_64");
-		expect(isMac()).toBe(false);
-		expect(isWindows()).toBe(false);
-		expect(isLinux()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(false);
 	});
 

--- a/site/src/utils/platform.test.ts
+++ b/site/src/utils/platform.test.ts
@@ -7,15 +7,25 @@ const setPlatform = (value: string) => {
 	});
 };
 
+const setMaxTouchPoints = (value: number) => {
+	Object.defineProperty(window.navigator, "maxTouchPoints", {
+		value,
+		configurable: true,
+	});
+};
+
 describe("platform", () => {
 	const originalPlatform = navigator.platform;
+	const originalMaxTouchPoints = navigator.maxTouchPoints;
 
 	afterEach(() => {
 		setPlatform(originalPlatform);
+		setMaxTouchPoints(originalMaxTouchPoints);
 	});
 
 	it("detects macOS", () => {
 		setPlatform("MacIntel");
+		setMaxTouchPoints(0);
 		expect(isMac()).toBe(true);
 		expect(isWindows()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
@@ -32,6 +42,14 @@ describe("platform", () => {
 		setPlatform("Linux x86_64");
 		expect(isMac()).toBe(false);
 		expect(isWindows()).toBe(false);
+		expect(supportsCoderDesktop()).toBe(false);
+	});
+
+	it("excludes iPadOS masquerading as macOS", () => {
+		// iPadOS 13+ reports "MacIntel" but exposes a touchscreen.
+		setPlatform("MacIntel");
+		setMaxTouchPoints(5);
+		expect(isMac()).toBe(true);
 		expect(supportsCoderDesktop()).toBe(false);
 	});
 });

--- a/site/src/utils/platform.test.ts
+++ b/site/src/utils/platform.test.ts
@@ -1,4 +1,4 @@
-import { isMac, isWindows, supportsCoderDesktop } from "./platform";
+import { isLinux, isMac, isWindows, supportsCoderDesktop } from "./platform";
 
 const setPlatform = (value: string) => {
 	Object.defineProperty(window.navigator, "platform", {
@@ -28,6 +28,7 @@ describe("platform", () => {
 		setMaxTouchPoints(0);
 		expect(isMac()).toBe(true);
 		expect(isWindows()).toBe(false);
+		expect(isLinux()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
 	});
 
@@ -35,13 +36,23 @@ describe("platform", () => {
 		setPlatform("Win32");
 		expect(isWindows()).toBe(true);
 		expect(isMac()).toBe(false);
+		expect(isLinux()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(true);
 	});
 
-	it("treats Linux and other platforms as unsupported", () => {
+	it("detects Linux", () => {
 		setPlatform("Linux x86_64");
+		expect(isLinux()).toBe(true);
 		expect(isMac()).toBe(false);
 		expect(isWindows()).toBe(false);
+		expect(supportsCoderDesktop()).toBe(true);
+	});
+
+	it("treats other platforms as unsupported", () => {
+		setPlatform("CrOS x86_64");
+		expect(isMac()).toBe(false);
+		expect(isWindows()).toBe(false);
+		expect(isLinux()).toBe(false);
 		expect(supportsCoderDesktop()).toBe(false);
 	});
 

--- a/site/src/utils/platform.ts
+++ b/site/src/utils/platform.ts
@@ -17,14 +17,22 @@ export function isWindows(): boolean {
 }
 
 /**
+ * Returns true if the current platform is Linux.
+ */
+export function isLinux(): boolean {
+	return navigator.platform.startsWith("Linux");
+}
+
+/**
  * Returns true if Coder Desktop is available for the current platform.
- * Coder Desktop currently ships for macOS and Windows only, so we hide the
- * install affordance everywhere else (e.g. Linux). iPadOS masquerades as macOS
- * via `navigator.platform`, so it is excluded using the touchscreen tell.
+ * Coder Desktop ships for macOS, Windows, and Linux (the Linux client is
+ * experimental), so we only hide the install affordance on platforms it does
+ * not target (e.g. iPadOS, ChromeOS). iPadOS masquerades as macOS via
+ * `navigator.platform`, so it is excluded using the touchscreen tell.
  */
 export function supportsCoderDesktop(): boolean {
 	const isIpadOS = isMac() && navigator.maxTouchPoints > 1;
-	return (isMac() || isWindows()) && !isIpadOS;
+	return (isMac() || isWindows() || isLinux()) && !isIpadOS;
 }
 
 /**

--- a/site/src/utils/platform.ts
+++ b/site/src/utils/platform.ts
@@ -17,22 +17,14 @@ export function isWindows(): boolean {
 }
 
 /**
- * Returns true if the current platform is Linux.
- */
-export function isLinux(): boolean {
-	return navigator.platform.startsWith("Linux");
-}
-
-/**
  * Returns true if Coder Desktop is available for the current platform.
- * Coder Desktop ships for macOS, Windows, and Linux (the Linux client is
- * experimental), so we only hide the install affordance on platforms it does
- * not target (e.g. iPadOS, ChromeOS). iPadOS masquerades as macOS via
- * `navigator.platform`, so it is excluded using the touchscreen tell.
+ * Coder Desktop currently ships for macOS and Windows only, so we hide the
+ * install affordance everywhere else (e.g. Linux). iPadOS masquerades as macOS
+ * via `navigator.platform`, so it is excluded using the touchscreen tell.
  */
 export function supportsCoderDesktop(): boolean {
 	const isIpadOS = isMac() && navigator.maxTouchPoints > 1;
-	return (isMac() || isWindows() || isLinux()) && !isIpadOS;
+	return (isMac() || isWindows()) && !isIpadOS;
 }
 
 /**

--- a/site/src/utils/platform.ts
+++ b/site/src/utils/platform.ts
@@ -6,6 +6,22 @@ export function isMac(): boolean {
 }
 
 /**
+ * Returns true if the current platform is Windows.
+ */
+export function isWindows(): boolean {
+	return navigator.platform.startsWith("Win");
+}
+
+/**
+ * Returns true if Coder Desktop is available for the current platform.
+ * Coder Desktop currently ships for macOS and Windows only, so we hide the
+ * install affordance everywhere else (e.g. Linux).
+ */
+export function supportsCoderDesktop(): boolean {
+	return isMac() || isWindows();
+}
+
+/**
  * Returns the platform-appropriate modifier key label: ⌘ on macOS,
  * Ctrl on everything else.
  */

--- a/site/src/utils/platform.ts
+++ b/site/src/utils/platform.ts
@@ -1,5 +1,9 @@
 /**
  * Returns true if the current platform is macOS.
+ *
+ * Note: iPadOS 13+ also reports `navigator.platform === "MacIntel"`. Callers
+ * that need to distinguish a real Mac from an iPad should additionally check
+ * `navigator.maxTouchPoints` (see `supportsCoderDesktop`).
  */
 export function isMac(): boolean {
 	return Boolean(navigator.platform.match("Mac"));
@@ -15,10 +19,12 @@ export function isWindows(): boolean {
 /**
  * Returns true if Coder Desktop is available for the current platform.
  * Coder Desktop currently ships for macOS and Windows only, so we hide the
- * install affordance everywhere else (e.g. Linux).
+ * install affordance everywhere else (e.g. Linux). iPadOS masquerades as macOS
+ * via `navigator.platform`, so it is excluded using the touchscreen tell.
  */
 export function supportsCoderDesktop(): boolean {
-	return isMac() || isWindows();
+	const isIpadOS = isMac() && navigator.maxTouchPoints > 1;
+	return (isMac() || isWindows()) && !isIpadOS;
 }
 
 /**


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

Resolves [DEVEX-722](https://linear.app/codercom/issue/DEVEX-722/add-install-coder-desktop-button-to-userdropdown).

Adds an **Install Coder Desktop** item to `UserDropdown`, sitting directly above the existing **Install CLI** option. Because `UserDropdownContent` is shared, it appears in both the navbar dropdown and the agents-page sidebar footer.

### Screenshots

macOS/Windows shots are captured with `navigator.platform` overridden accordingly; the Linux shot is the real workspace platform, where the Coder Desktop item is hidden. Install Coder Desktop uses a monitor glyph, and Install CLI now uses a terminal glyph (it was a monitor on `main`).

| `main` (before) | This PR · macOS/Windows | This PR · Linux / iPad OS |
| --- | --- | --- |
| ![UserDropdown on main](https://raw.githubusercontent.com/coder/coder/jakehwll/devex-722-assets/.github/assets/devex-722-userdropdown-main.png) | ![UserDropdown with Install Coder Desktop](https://raw.githubusercontent.com/coder/coder/jakehwll/devex-722-assets/.github/assets/devex-722-userdropdown-new.png) | ![UserDropdown on Linux without the Desktop item](https://raw.githubusercontent.com/coder/coder/jakehwll/devex-722-assets/.github/assets/devex-722-userdropdown-linux.png) |

### Behaviour
- **Platform-gated visibility:** shown only on macOS and Windows (the platforms Coder Desktop ships for), hidden on Linux/other. The Linux client ([coder/coder-desktop-linux](https://github.com/coder/coder-desktop-linux)) is experimental and not advertised yet, so it stays hidden there.
- **Links to the docs** (`https://coder.com/docs/user-guides/desktop`) rather than a single install method. The docs page is the canonical hub covering Homebrew, WinGet, manual release downloads, and source, and it stays current without frontend changes. The `coder-desktop-*` repo READMEs don't enumerate install methods; they defer to these same docs.
- **No installed-detection:** consistent with the Install CLI item, we don't try to detect whether Coder Desktop is already present.

### Changes
- `site/src/utils/platform.ts`: add `isWindows()` and `supportsCoderDesktop()`.
- `UserDropdownContent.tsx`: render the platform-gated item (`MonitorIcon`) and switch Install CLI to `TerminalIcon`.
- Unit tests for the platform helpers and Storybook coverage for the dropdown item (present + correct href on macOS/Windows, absent on Linux/iPadOS).


Implementation plan & decision log

**Ticket open questions and decisions**

1. *Shown to all users or only supported platforms?* Only supported platforms (macOS, Windows); hidden elsewhere. The Linux client is experimental and not advertised yet, so hiding it there is intentional.
2. *Where should it link?* The Coder Desktop docs page. Users install via many methods (brew, winget, releases, source); the docs are the single hub that lists them all and are maintained in-repo. The GitHub release pages / repo READMEs only cover downloads and defer back to the docs.
3. *Hide when already installed?* No. There is no reliable browser-side way to detect a native app install, and it mirrors how Install CLI behaves.

**Implementation**
- Extend `site/src/utils/platform.ts` with `isWindows()` and `supportsCoderDesktop()` (reusing the existing `isMac()`).
- In `UserDropdownContent.tsx`, conditionally render an `Install Coder Desktop` `DropdownMenuItem` (external link, `MonitorIcon`, opens in a new tab) above `Install CLI` when `supportsCoderDesktop()` is true.
- Tests: `platform.test.ts` (OS detection via `vi.stubGlobal`) and `UserDropdown.stories.tsx` (visibility + href per platform, mocking platform detection with `spyOn`).



Left as a **draft** pending review, let me know when you'd like it opened.