### PR TITLE
fix(site): reach bottom of virtualized logs on autoscroll

### DIFF
--- a/site/src/modules/resources/AgentLogs/useAutoScrollToBottom.test.tsx
+++ b/site/src/modules/resources/AgentLogs/useAutoScrollToBottom.test.tsx
@@ -1,0 +1,120 @@
+import { act, render } from "@testing-library/react";
+import { type FC, useRef } from "react";
+import type { Line } from "#/components/Logs/LogLine";
+import { AgentLogs } from "./AgentLogs";
+import { MockSources } from "./mocks";
+import { useAutoScrollToBottom } from "./useAutoScrollToBottom";
+
+const VIEWPORT_HEIGHT = 200;
+// Mirrors the vertical padding AgentLogs applies to its scroll container
+// (py-4 top plus pb-10 bottom when logs overflow). react-window sizes its
+// scroll area to itemCount * itemSize and is unaware of this padding, which is
+// what made scrollToItem stop short of the bottom (coder/coder#25692).
+const CONTAINER_PADDING = 56;
+
+const makeLogs = (count: number): Line[] =>
+	Array.from({ length: count }, (_, i) => ({
+		id: i + 1,
+		level: "info",
+		output: `log line ${i + 1}`,
+		sourceId: MockSources[0].id,
+		time: "2024-03-14T11:31:04.090715Z",
+	}));
+
+type HarnessProps = {
+	logs: Line[];
+	enabled: boolean;
+};
+
+// Wires up AgentLogs and the hook the same way the real callers do.
+const Harness: FC<HarnessProps> = ({ logs, enabled }) => {
+	const outerRef = useRef<HTMLDivElement>(null);
+	useAutoScrollToBottom(outerRef, enabled, [logs]);
+	return (
+		<AgentLogs
+			outerRef={outerRef}
+			logs={logs}
+			sources={MockSources}
+			overflowed={false}
+			showSourceIcons={false}
+			height={VIEWPORT_HEIGHT}
+			width={600}
+		/>
+	);
+};
+
+const getScrollContainer = (container: HTMLElement): HTMLElement => {
+	const el = container.querySelector<HTMLElement>(
+		'div[style*="overflow: auto"]',
+	);
+	if (!el) {
+		throw new Error("react-window scroll container not found");
+	}
+	return el;
+};
+
+// jsdom performs no layout, so emulate the browser's scroll metrics. The
+// scrollHeight is derived from the inner sizing element react-window renders
+// (itemCount * itemSize) plus the container padding, and scrollTop is clamped
+// to the real maximum, exactly like a browser.
+const mockScrollMetrics = (outer: HTMLElement): void => {
+	let scrollTop = 0;
+	Object.defineProperty(outer, "clientHeight", {
+		configurable: true,
+		get: () => VIEWPORT_HEIGHT,
+	});
+	Object.defineProperty(outer, "scrollHeight", {
+		configurable: true,
+		get: () => {
+			const inner = outer.firstElementChild as HTMLElement | null;
+			const innerHeight = inner
+				? Number.parseFloat(inner.style.height || "0")
+				: 0;
+			return innerHeight + CONTAINER_PADDING;
+		},
+	});
+	Object.defineProperty(outer, "scrollTop", {
+		configurable: true,
+		get: () => scrollTop,
+		set: (value: number) => {
+			const max = Math.max(0, outer.scrollHeight - outer.clientHeight);
+			scrollTop = Math.min(Math.max(0, value), max);
+		},
+	});
+};
+
+describe("useAutoScrollToBottom", () => {
+	it("reaches the true bottom when new logs stream in", () => {
+		const { container, rerender } = render(
+			<Harness logs={makeLogs(100)} enabled />,
+		);
+		const outer = getScrollContainer(container);
+		mockScrollMetrics(outer);
+
+		act(() => {
+			rerender(<Harness logs={makeLogs(101)} enabled />);
+		});
+
+		// The last line must be reachable: the visible window has to extend all
+		// the way to the bottom of the scroll area (padding included). react-
+		// window's scrollToItem would have stopped short by the padding amount.
+		expect(outer.scrollTop + outer.clientHeight).toBeGreaterThanOrEqual(
+			outer.scrollHeight,
+		);
+	});
+
+	it("does not scroll when the user has scrolled away", () => {
+		const { container, rerender } = render(
+			<Harness logs={makeLogs(100)} enabled={false} />,
+		);
+		const outer = getScrollContainer(container);
+		mockScrollMetrics(outer);
+		outer.scrollTop = 300;
+
+		act(() => {
+			rerender(<Harness logs={makeLogs(101)} enabled={false} />);
+		});
+
+		expect(outer.scrollTop).toBe(300);
+	});
+});

--- a/site/src/modules/resources/AgentLogs/useAutoScrollToBottom.ts
+++ b/site/src/modules/resources/AgentLogs/useAutoScrollToBottom.ts
@@ -1,0 +1,27 @@
+import { type DependencyList, type RefObject, useLayoutEffect } from "react";
+
+/**
+ * Keeps a scroll container pinned to the bottom whenever `deps` change and
+ * `enabled` is true.
+ *
+ * It sets `scrollTop` to the full `scrollHeight`, so the container reaches its
+ * true bottom regardless of any padding applied to it. react-window's
+ * `scrollToItem(..., "end")` only accounts for `itemCount * itemSize` and is
+ * unaware of container padding, so it stops short by the padding amount and the
+ * last lines can never come into view (coder/coder#25692).
+ */
+export function useAutoScrollToBottom(
+	outerRef: RefObject<HTMLElement | null>,
+	enabled: boolean,
+	deps: DependencyList,
+): void {
+	useLayoutEffect(() => {
+		if (!enabled) {
+			return;
+		}
+		const el = outerRef.current;
+		if (el) {
+			el.scrollTop = el.scrollHeight;
+		}
+	}, [enabled, outerRef, ...deps]);
+}

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -7,17 +7,10 @@ import {
 	SquareCheckBigIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
-import {
-	type FC,
-	type ReactNode,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import AutoSizer from "react-virtualized-auto-sizer";
-import type { FixedSizeList as List, ListOnScrollProps } from "react-window";
+import type { ListOnScrollProps } from "react-window";
 import type {
 	AgentScriptTiming,
 	Template,
@@ -75,6 +68,7 @@ import { AgentExternal } from "./AgentExternal";
 import { AgentLatency } from "./AgentLatency";
 import { AGENT_LOG_LINE_HEIGHT } from "./AgentLogs/AgentLogLine";
 import { AgentLogs } from "./AgentLogs/AgentLogs";
+import { useAutoScrollToBottom } from "./AgentLogs/useAutoScrollToBottom";
 import { AgentMetadata } from "./AgentMetadata";
 import { AgentStatus } from "./AgentStatus";
 import { AgentVersion } from "./AgentVersion";
@@ -189,8 +183,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 			hasStartupFeatures,
 	);
 	const agentLogs = useAgentLogs({ agentId: agent.id, enabled: showLogs });
-	const logListRef = useRef<List>(null);
-	const logListDivRef = useRef<HTMLDivElement>(null);
+	const logListOuterRef = useRef<HTMLDivElement>(null);
 	const [bottomOfLogs, setBottomOfLogs] = useState(true);
 
 	useEffect(() => {
@@ -207,36 +200,23 @@ export const AgentRow: FC<AgentRowProps> = ({
 		hasStartupFeatures,
 	]);
 
-	// This is a layout effect to remove flicker when we're scrolling to the bottom.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: consider refactoring
-	useLayoutEffect(() => {
-		// If we're currently watching the bottom, we always want to stay at the bottom.
-		if (bottomOfLogs && logListRef.current) {
-			logListRef.current.scrollToItem(agentLogs.length - 1, "end");
-		}
-	}, [showLogs, agentLogs, bottomOfLogs]);
+	// While the user is watching the bottom, keep the list pinned there as new
+	// logs stream in. Scrolling the container itself (rather than react-window's
+	// scrollToItem) reaches the true bottom even with padding on the container.
+	useAutoScrollToBottom(logListOuterRef, bottomOfLogs, [showLogs, agentLogs]);
 
 	// This is a bit of a hack on the react-window API to get the scroll position.
 	// If we're scrolled to the bottom, we want to keep the list scrolled to the bottom.
 	// This makes it feel similar to a terminal that auto-scrolls downwards!
 	const handleLogScroll = (props: ListOnScrollProps) => {
-		if (
-			props.scrollOffset === 0 ||
-			props.scrollUpdateWasRequested ||
-			!logListDivRef.current
-		) {
+		const outer = logListOuterRef.current;
+		if (props.scrollOffset === 0 || props.scrollUpdateWasRequested || !outer) {
 			return;
 		}
-		// The parent holds the height of the list!
-		const parent = logListDivRef.current.parentElement;
-		if (!parent) {
-			return;
-		}
-		// Use the parent's scrollHeight (not the inner div's) so that
-		// any padding on the scroll container is included in the
-		// calculation and doesn't inflate the "at bottom" zone.
+		// Read scrollHeight from the scroll container so any padding on it is
+		// included in the calculation and doesn't inflate the "at bottom" zone.
 		const distanceFromBottom =
-			parent.scrollHeight - (props.scrollOffset + parent.clientHeight);
+			outer.scrollHeight - (props.scrollOffset + outer.clientHeight);
 		setBottomOfLogs(distanceFromBottom < AGENT_LOG_LINE_HEIGHT);
 	};
 
@@ -763,8 +743,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 											<AutoSizer disableHeight>
 												{({ width }) => (
 													<AgentLogs
-														ref={logListRef}
-														innerRef={logListDivRef}
+														outerRef={logListOuterRef}
 														height={256}
 														width={width}
 														onScroll={handleLogScroll}

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -11,14 +11,12 @@ import {
 	type ReactNode,
 	useCallback,
 	useEffect,
-	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Link as RouterLink, useParams } from "react-router";
-import type { FixedSizeList } from "react-window";
 import { toast } from "sonner";
 import { API } from "#/api/api";
 import { getErrorDetail, getErrorMessage, isApiError } from "#/api/errors";
@@ -46,6 +44,7 @@ import { useWorkspaceBuildLogs } from "#/hooks/useWorkspaceBuildLogs";
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
 import { getAllAppsWithAgent } from "#/modules/apps/workspaceApps";
 import { AgentLogs } from "#/modules/resources/AgentLogs/AgentLogs";
+import { useAutoScrollToBottom } from "#/modules/resources/AgentLogs/useAutoScrollToBottom";
 import { useAgentLogs } from "#/modules/resources/useAgentLogs";
 import { TasksSidebar } from "#/modules/tasks/TasksSidebar/TasksSidebar";
 import { isPauseDisabled } from "#/modules/tasks/taskActions";
@@ -830,7 +829,7 @@ type TaskStartingAgentProps = {
 
 const TaskStartingAgent: FC<TaskStartingAgentProps> = ({ task, agent }) => {
 	const logs = useAgentLogs({ agentId: agent.id });
-	const listRef = useRef<FixedSizeList>(null);
+	const logsOuterRef = useRef<HTMLDivElement>(null);
 	const queryClient = useQueryClient();
 	const pauseMutation = useMutation({
 		...pauseTask(task, queryClient),
@@ -842,11 +841,8 @@ const TaskStartingAgent: FC<TaskStartingAgentProps> = ({ task, agent }) => {
 	});
 	const pauseDisabled = isPauseDisabled(task.status);
 
-	useLayoutEffect(() => {
-		if (listRef.current) {
-			listRef.current.scrollToItem(logs.length - 1, "end");
-		}
-	}, [logs]);
+	// Keep the startup logs pinned to the bottom as new lines stream in.
+	useAutoScrollToBottom(logsOuterRef, true, [logs]);
 
 	return (
 		<section className="p-16 overflow-y-auto">
@@ -877,7 +873,7 @@ const TaskStartingAgent: FC<TaskStartingAgentProps> = ({ task, agent }) => {
 					<div className="w-full max-w-screen-lg flex flex-col gap-4 overflow-hidden">
 						<div className="h-96 border border-solid border-border rounded-lg">
 							<AgentLogs
-								ref={listRef}
+								outerRef={logsOuterRef}
 								sources={agent.log_sources}
 								height={96 * 4}
 								width="100%"


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Fixes [DEVEX-407](https://linear.app/codercom/issue/DEVEX-407). Closes #25692.

## Problem

Auto-scrolling the virtualized agent/build logs stuttered and never quite reached the bottom once there were enough rows to virtualize.

## Root cause

The log list (`AgentLogs`, react-window `FixedSizeList`) auto-scrolled with `scrollToItem(last, "end")`. react-window computes that offset from `itemCount * itemSize` only and is unaware of the vertical padding on the scroll container (`py-4`, plus `pb-10` when logs overflow). So `"end"` landed ~16px short of the real bottom, leaving the last line clipped, and every new log line re-fired the same short scroll, which read as stuttering.

## Fix

Scroll the container itself to its full `scrollHeight` instead. That reaches the true bottom regardless of any padding and is idempotent, so the re-fire stutter goes away. The behaviour is shared through a small `useAutoScrollToBottom` hook consumed by both callers (`AgentRow` and the task startup logs in `TaskPage`).

## Testing

- New `useAutoScrollToBottom.test.tsx` regression test: with the list padded and virtualized, appending a log while pinned must leave `scrollTop + clientHeight >= scrollHeight` (bottom reached), and it must not scroll when the user has scrolled away.
- `biome check`, `tsc -p .`, and the AgentLogs unit tests pass.

<details>
<summary>Decision log</summary>

- Considered baking the padding into react-window via `innerElementType`. Rejected: it still requires changing the autoscroll call (`scrollToItem` stays short by the top offset), adds per-row `top` offsetting, and has to handle the conditional `pb-10`. More surface area, no benefit here.
- Chose `el.scrollTop = el.scrollHeight` over `el.scrollTo(...)`: padding-agnostic, idempotent, and test-friendly (jsdom does not implement `scrollTo`). Direct assignment still emits a scroll event, so react-window keeps its virtualization window in sync and follow-mode detection stays intact.
- `AgentRow`'s at-bottom detection already read the container's `scrollHeight`; it now reads the same `outerRef` the hook scrolls, keeping one source of truth.
- Regression test asserts the behavioural invariant (`scrollTop + clientHeight >= scrollHeight`) rather than an exact `scrollTop`, so a correct `scrollHeight - clientHeight` implementation would not be considered a false failure.

</details>