### PR TITLE
docs: pin devin-desktop version constraint to ~> 0.1

### DIFF
--- a/docs/get-started/customize-your-template/add-a-language.md
+++ b/docs/get-started/customize-your-template/add-a-language.md
@@ -612,7 +612,7 @@ module "zed" {
 module "devin-desktop" {
   count    = data.coder_workspace.me.start_count * (contains(local.ides, "devin-desktop") ? 1 : 0)
   source   = "registry.coder.com/coder/devin-desktop/coder"
-  version  = "~> 1.0"
+  version  = "~> 0.1"
   agent_id = coder_agent.main.id
   folder   = "/home/coder"
   order    = 6

--- a/docs/get-started/customize-your-template/authenticate-to-github.md
+++ b/docs/get-started/customize-your-template/authenticate-to-github.md
@@ -461,7 +461,7 @@ module "zed" {
 module "devin-desktop" {
   count    = data.coder_workspace.me.start_count * (contains(local.ides, "devin-desktop") ? 1 : 0)
   source   = "registry.coder.com/coder/devin-desktop/coder"
-  version  = "~> 1.0"
+  version  = "~> 0.1"
   agent_id = coder_agent.main.id
   folder   = "/home/coder"
   order    = 6

--- a/docs/get-started/customize-your-template/install-command-line-tools.md
+++ b/docs/get-started/customize-your-template/install-command-line-tools.md
@@ -737,7 +737,7 @@ module "zed" {
 module "devin-desktop" {
   count    = data.coder_workspace.me.start_count * (contains(local.ides, "devin-desktop") ? 1 : 0)
   source   = "registry.coder.com/coder/devin-desktop/coder"
-  version  = "~> 1.0"
+  version  = "~> 0.1"
   agent_id = coder_agent.main.id
   folder   = "/home/coder"
   order    = 6


### PR DESCRIPTION
## Summary

[coder/registry#1050](https://github.com/coder/registry/pull/1050) starts the new `devin-desktop` module at `0.1.0`, not `1.0.0`. The three `get-started/customize-your-template/*.md` tutorials merged in #28205 used `version = "~> 1.0"` for it, copied from the sibling IDE module blocks, that constraint doesn't match `0.1.x` releases.

## Change

`version = "~> 1.0"` -> `version = "~> 0.1"` for the `devin-desktop` module block in `add-a-language.md`, `authenticate-to-github.md`, and `install-command-line-tools.md`.

## Validation

- `pnpm run lint-docs`: clean.
- `make pre-commit`: passes.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻