### PR TITLE
docs: add Licensing & Usage page and reorder agents manifest

### DIFF
--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -9,7 +9,7 @@ Coder Agents is licensed differently depending on whether your deployment holds 
 Community licenses support up to five concurrently active agents deployment-wide.
 Coder doesn't limit how long those agents can run or how many tasks they complete over time.
 Agents will queue when more than five agents are active at a time.
-This enables individuals and small teams to experiment with Coder Agents at no cost.
+With this agent pool, individuals and small teams can experiment with Coder Agents at no cost.
 
 ## AI Premium licenses and Agent Time
 

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -39,6 +39,8 @@ Agent Time is measured with millisecond precision and is rounded down to the nea
 
 ## Concurrency and usage limits
 
+Coder handles concurrency and usage limits differently, depending on the license you use for Coder.
+
 ### Community concurrency limit
 
 When a Community license deployment reaches its limit of five concurrently active agents, any additional agents are placed in a queue.

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -44,7 +44,7 @@ Coder handles concurrency and usage limits differently, depending on the license
 ### Community concurrency limit
 
 When a Community license deployment reaches its limit of five concurrently active agents, any additional agents are placed in a queue.
-Queued agents are picked up automatically as soon as capacity frees up, so no work is lost and no action is required from the user.
+As soon as an active agent completes its task, the next queued agent begins its work, so no work is lost and no action is required from the user.
 
 ### AI Premium Agent Time exhaustion
 

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -1,0 +1,49 @@
+# Licensing & Usage
+
+Coder Agents is licensed differently depending on whether your deployment holds a Community license or a Premium license with a purchased Agent Time allocation.
+
+## Community licenses
+
+Community licenses support up to five concurrently active agents.
+There is no limit on how long those agents can run or how many tasks they complete over time; they simply queue when more than five agents are active.
+This enables individuals and small teams to experiment with Coder Agents at no cost.
+
+## Premium licenses and Agent Time
+
+Premium deployments can purchase Agent Time with their Premium license.
+Agent Time is shared across the deployment, allowing unlimited agents to run concurrently while consuming from a shared pool of purchased working hours.
+This usage-based model is designed for enterprise workloads, where large development teams, background automation, and API-triggered tasks can create highly variable bursts of agent activity without being constrained by a concurrency limit.
+
+## How Agent Time is measured
+
+Agent Time is the cumulative duration during which an AI agent is actively processing a task on behalf of the user.
+It is measured per interaction step and summed across the duration of a conversation.
+
+**Includes:**
+
+- Large language model inference time
+- Tool execution (such as file operations, terminal commands, and workspace provisioning)
+- Automated error recovery attempts
+
+**Excludes:**
+
+- Time the customer spends composing or reviewing messages
+- Time between conversation turns when the agent is not processing
+- Tool execution delegated to external systems outside the agent's direct control
+
+Agent Time does not accrue when a conversation is inactive or awaiting user input.
+Agent Time is measured with millisecond precision and is rounded down to the nearest minute for billing purposes.
+
+## Reaching concurrency and usage limits
+
+### Community concurrency limit
+
+When a Community license deployment reaches its limit of five concurrently active agents, any additional agents are placed in a queue.
+Queued agents are picked up automatically as soon as capacity frees up, so no work is lost and no action is required from the user.
+
+### Premium Agent Time exhaustion
+
+When a Premium deployment exhausts its purchased Agent Time, the deployment may be provisioned to fall back to the Community concurrency model until more Agent Time is purchased.
+In this state, agents are limited to five concurrent active agents, and any additional agents are queued until capacity is available.
+
+Deployment administrators see an in-app soft warning message as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -7,7 +7,8 @@ Coder Agents is licensed differently depending on whether your deployment holds 
 ## Community licenses
 
 Community licenses support up to five concurrently active agents deployment-wide.
-There is no limit on how long those agents can run or how many tasks they complete over time; they simply queue when more than five agents are active.
+Coder doesn't limit how long those agents can run or how many tasks they complete over time.
+Agents will queue when more than five agents are active at a time.
 This enables individuals and small teams to experiment with Coder Agents at no cost.
 
 ## AI Premium licenses and Agent Time

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -1,4 +1,6 @@
-# Licensing & Usage
+---
+title: Licensing & Usage
+---
 
 Coder Agents is licensed differently depending on whether your deployment holds a Community license or an AI Premium license with a purchased Agent Time allocation.
 

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -37,7 +37,7 @@ It is measured per interaction step and summed across the duration of a conversa
 Agent Time does not accrue when a conversation is inactive or awaiting user input.
 Agent Time is measured with millisecond precision and is rounded down to the nearest minute for billing purposes.
 
-## Reaching concurrency and usage limits
+## Concurrency and usage limits
 
 ### Community concurrency limit
 

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -1,16 +1,16 @@
 # Licensing & Usage
 
-Coder Agents is licensed differently depending on whether your deployment holds a Community license or a Premium license with a purchased Agent Time allocation.
+Coder Agents is licensed differently depending on whether your deployment holds a Community license or an AI Premium license with a purchased Agent Time allocation.
 
 ## Community licenses
 
-Community licenses support up to five concurrently active agents.
+Community licenses support up to five concurrently active agents deployment-wide.
 There is no limit on how long those agents can run or how many tasks they complete over time; they simply queue when more than five agents are active.
 This enables individuals and small teams to experiment with Coder Agents at no cost.
 
-## Premium licenses and Agent Time
+## AI Premium licenses and Agent Time
 
-Premium deployments can purchase Agent Time with their Premium license.
+AI Premium licenses include a customizable amount of Agent Time.
 Agent Time is shared across the deployment, allowing unlimited agents to run concurrently while consuming from a shared pool of purchased working hours.
 This usage-based model is designed for enterprise workloads, where large development teams, background automation, and API-triggered tasks can create highly variable bursts of agent activity without being constrained by a concurrency limit.
 
@@ -41,9 +41,9 @@ Agent Time is measured with millisecond precision and is rounded down to the nea
 When a Community license deployment reaches its limit of five concurrently active agents, any additional agents are placed in a queue.
 Queued agents are picked up automatically as soon as capacity frees up, so no work is lost and no action is required from the user.
 
-### Premium Agent Time exhaustion
+### AI Premium Agent Time exhaustion
 
-When a Premium deployment exhausts its purchased Agent Time, the deployment may be provisioned to fall back to the Community concurrency model until more Agent Time is purchased.
+When an AI Premium deployment exhausts its purchased Agent Time, the deployment may be provisioned to fall back to the Community concurrency model until more Agent Time is purchased.
 In this state, agents are limited to five concurrent active agents, and any additional agents are queued until capacity is available.
 
 Deployment administrators see an in-app soft warning message as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -51,4 +51,4 @@ As soon as an active agent completes its task, the next queued agent begins its 
 When an AI Premium deployment exhausts its purchased Agent Time, the deployment may be provisioned to fall back to the Community concurrency model until more Agent Time is purchased.
 In this state, your Coder deployment is limited to five concurrent active agents, and any additional agents are queued until capacity is available.
 
-Deployment administrators see an in-app soft warning message as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.
+Coder sends deployment administrators an in-app soft warning message as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -48,7 +48,4 @@ As soon as an active agent completes its task, the next queued agent begins its 
 
 ### AI Premium Agent Time exhaustion
 
-When an AI Premium deployment exhausts its purchased Agent Time, the deployment may be provisioned to fall back to the Community concurrency model until more Agent Time is purchased.
-In this state, your Coder deployment is limited to five concurrent active agents, and any additional agents are queued until capacity is available.
-
 Coder sends deployment administrators an in-app soft warning message as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -19,7 +19,7 @@ This usage-based model is designed for enterprise workloads, where large develop
 
 ## How Agent Time is measured
 
-Agent Time is the cumulative duration during which an AI agent is actively processing a task on behalf of the user.
+Agent Time is the cumulative duration during which an AI agent is actively processing a task for the user.
 It is measured per interaction step and summed across the duration of a conversation.
 
 **Includes:**

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -49,6 +49,6 @@ As soon as an active agent completes its task, the next queued agent begins its 
 ### AI Premium Agent Time exhaustion
 
 When an AI Premium deployment exhausts its purchased Agent Time, the deployment may be provisioned to fall back to the Community concurrency model until more Agent Time is purchased.
-In this state, agents are limited to five concurrent active agents, and any additional agents are queued until capacity is available.
+In this state, your Coder deployment is limited to five concurrent active agents, and any additional agents are queued until capacity is available.
 
 Deployment administrators see an in-app soft warning message as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1125,7 +1125,7 @@
 							"path": "./ai-coder/agents/chat-search-syntax.md"
 						},
 						{
-							"title": "Licensing & Usage",
+							"title": "Licensing \u0026 Usage",
 							"description": "Licensing and usage details for Coder Agents.",
 							"path": "./ai-coder/agents/licensing-usage.md"
 						},

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1034,29 +1034,9 @@
 							"path": "./ai-coder/agents/getting-started.md"
 						},
 						{
-							"title": "Search Syntax",
-							"description": "Filter Coder Agents conversations by title, status, and linked pull requests with search syntax.",
-							"path": "./ai-coder/agents/chat-search-syntax.md"
-						},
-						{
 							"title": "Architecture",
 							"description": "Learn how the Coder Agents control-plane agent communicates with your workspaces.",
 							"path": "./ai-coder/agents/architecture.md"
-						},
-						{
-							"title": "Chat Sharing",
-							"description": "Give other users and groups read-only access to a Coder Agents conversation with chat sharing.",
-							"path": "./ai-coder/agents/chat-sharing.md"
-						},
-						{
-							"title": "Models",
-							"description": "Configure the LLM providers and models that power Coder Agents from Admin settings.",
-							"path": "./ai-coder/agents/models.md"
-						},
-						{
-							"title": "Tools",
-							"description": "How Coder Agents uses tool calls to select templates and create workspaces",
-							"path": "./ai-coder/agents/tools/index.md"
 						},
 						{
 							"title": "Platform Controls",
@@ -1123,6 +1103,31 @@
 							"title": "Extending Agents",
 							"description": "Extend Coder Agents with custom skills and MCP tools defined in your workspace templates.",
 							"path": "./ai-coder/agents/extending-agents.md"
+						},
+						{
+							"title": "Models",
+							"description": "Configure the LLM providers and models that power Coder Agents from Admin settings.",
+							"path": "./ai-coder/agents/models.md"
+						},
+						{
+							"title": "Tools",
+							"description": "How Coder Agents uses tool calls to select templates and create workspaces",
+							"path": "./ai-coder/agents/tools/index.md"
+						},
+						{
+							"title": "Chat Sharing",
+							"description": "Give other users and groups read-only access to a Coder Agents conversation with chat sharing.",
+							"path": "./ai-coder/agents/chat-sharing.md"
+						},
+						{
+							"title": "Search Syntax",
+							"description": "Filter Coder Agents conversations by title, status, and linked pull requests with search syntax.",
+							"path": "./ai-coder/agents/chat-search-syntax.md"
+						},
+						{
+							"title": "Licensing & Usage",
+							"description": "Licensing and usage details for Coder Agents.",
+							"path": "./ai-coder/agents/licensing-usage.md"
 						},
 						{
 							"title": "Tasks to Chats API Migration",


### PR DESCRIPTION
Adds a new Licensing & Usage page under `docs/ai-coder/agents/` covering the difference between Community and AI Premium licenses, how Agent Time is measured, and what happens when concurrency or usage limits are reached.

Reorders the Coder Agents section in `docs/manifest.json` to the following sequence: Getting Started, Architecture, Platform Controls, Extending Agents, Models, Tools, Chat Sharing, Search Syntax, Licensing & Usage, Tasks to Chats API Migration.

---

PR generated with Coder Agents