### PR TITLE
fix(site/src/pages/AgentsPage): clear streamed message when a chat errors

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3310,6 +3310,78 @@ describe("useChatStore", () => {
 		expect(result.current.chatStatus).toBe("running");
 	});
 
+	// A status from a turn that was already running must not clear a stored
+	// request failure, because the failed prompt was never retried.
+	it("keeps streamError when a running turn emits a non-error status", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+
+		const chatID = "chat-keeps-request-error";
+		const existingMessage = buildMessage(
+			chatID,
+			1,
+			"user",
+			"create a workspace",
+		);
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: { ...buildChat(chatID), status: "running" },
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					store,
+					chatStatus: useChatSelector(store, selectChatStatus),
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// A queued send fails while the prior turn is still running.
+		act(() => {
+			result.current.store.setStreamError({
+				kind: "generic",
+				message: "Prompt could not be sent.",
+			});
+		});
+		expect(result.current.streamError).not.toBeNull();
+
+		// The still-running turn completes and emits a non-error status.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "waiting" },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("waiting");
+		});
+		expect(result.current.streamError).not.toBeNull();
+	});
+
 	it("uses fallback message when error event has no message", async () => {
 		immediateAnimationFrame();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3039,8 +3039,11 @@ describe("useChatStore", () => {
 		expect(liveStatus.hasAccumulatedOutput).toBe(false);
 	});
 
-	// Parts that arrive during or after the error must not restore the stream.
-	it("does not re-populate the stream from late parts after a terminal error", async () => {
+	// A part already queued from the errored turn can still arrive after the
+	// error and repopulate the stream. This is accepted because the gate that
+	// would drop it cannot tell it apart from a part belonging to the next
+	// turn. The error status and callout are preserved either way.
+	it("keeps the error status when a late part arrives after a terminal error", async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 
 		const chatID = "chat-error-late-parts";
@@ -3076,6 +3079,7 @@ describe("useChatStore", () => {
 				return {
 					chatStatus: useChatSelector(store, selectChatStatus),
 					streamState: useChatSelector(store, selectStreamState),
+					streamError: useChatSelector(store, selectStreamError),
 				};
 			},
 			{ wrapper },
@@ -3085,38 +3089,24 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 		});
 
-		// Send an error and a part in the same frame. The part must be dropped.
 		act(() => {
-			mockSocket.emitDataBatch([
-				{
-					type: "error",
-					chat_id: chatID,
-					error: {
-						message: "The chat session ended unexpectedly.",
-						kind: "generic",
-						retryable: false,
-					},
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: {
+					message: "The chat session ended unexpectedly.",
+					kind: "generic",
+					retryable: false,
 				},
-				{
-					type: "message_part",
-					chat_id: chatID,
-					message_part: {
-						part: {
-							type: "tool-call",
-							tool_call_id: "create-workspace-1",
-							tool_name: "create_workspace",
-							args: { name: "dev" },
-						},
-					},
-				},
-			]);
+			});
 		});
 
-		await act(async () => {
-			vi.advanceTimersByTime(1);
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("error");
+			expect(result.current.streamState).toBeNull();
 		});
 
-		// A part in a later frame must also be dropped.
+		// A late part from the errored turn arrives in a later frame.
 		act(() => {
 			mockSocket.emitData({
 				type: "message_part",
@@ -3131,14 +3121,22 @@ describe("useChatStore", () => {
 			vi.advanceTimersByTime(1);
 		});
 
+		// The part is kept and the error status and callout are preserved.
 		await waitFor(() => {
-			expect(result.current.chatStatus).toBe("error");
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "late partial output" },
+			]);
 		});
-		expect(result.current.streamState).toBeNull();
+		expect(result.current.chatStatus).toBe("error");
+		expect(result.current.streamError).toMatchObject({
+			kind: "generic",
+			message: "The chat session ended unexpectedly.",
+		});
 	});
 
-	// The error drops late parts. The next turn must stream again once a new
-	// status event arrives.
+	// The next turn must stream again after an error. Its first part can
+	// arrive before its running status because the server sends parts and
+	// status on separate paths, so the part must be kept either way.
 	it("re-enables streaming parts on the next turn after a terminal error", async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 
@@ -3201,22 +3199,26 @@ describe("useChatStore", () => {
 			expect(result.current.streamState).toBeNull();
 		});
 
-		act(() => {
-			mockSocket.emitData({
-				type: "status",
-				chat_id: chatID,
-				status: { status: "running" },
-			});
-		});
-
+		// The next turn's first part arrives before its running status.
 		act(() => {
 			mockSocket.emitData({
 				type: "message_part",
 				chat_id: chatID,
 				message_part: {
-					role: "assistant",
 					part: { type: "text", text: "retry output" },
 				},
+			});
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
 			});
 		});
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3233,6 +3233,83 @@ describe("useChatStore", () => {
 		});
 	});
 
+	// A non-error status means a new turn began, so the prior error must be
+	// cleared for the new stream to render.
+	it("clears streamError when a non-error status arrives after an error", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+
+		const chatID = "chat-error-clears-on-running";
+		const existingMessage = buildMessage(
+			chatID,
+			1,
+			"user",
+			"create a workspace",
+		);
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					chatStatus: useChatSelector(store, selectChatStatus),
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: {
+					message: "The chat session ended unexpectedly.",
+					kind: "generic",
+					retryable: false,
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).not.toBeNull();
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toBeNull();
+		});
+		expect(result.current.chatStatus).toBe("running");
+	});
+
 	it("uses fallback message when error event has no message", async () => {
 		immediateAnimationFrame();
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -2997,7 +2997,6 @@ describe("useChatStore", () => {
 			),
 		).toMatchObject([{ id: "create-workspace-1", status: "running" }]);
 
-		// The session ends unexpectedly so the server emits an error.
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
@@ -3018,7 +3017,6 @@ describe("useChatStore", () => {
 			});
 		});
 
-		// The partial stream is cleared so the tool stops spinning.
 		expect(result.current.streamState).toBeNull();
 		expect(result.current.hasStreamState).toBe(false);
 		expect(
@@ -3186,7 +3184,6 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 		});
 
-		// The first turn errors out.
 		act(() => {
 			mockSocket.emitData({
 				type: "error",
@@ -3204,7 +3201,6 @@ describe("useChatStore", () => {
 			expect(result.current.streamState).toBeNull();
 		});
 
-		// The user sends again and the server starts a new turn.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
@@ -3213,7 +3209,6 @@ describe("useChatStore", () => {
 			});
 		});
 
-		// Parts from the new turn must flow again.
 		act(() => {
 			mockSocket.emitData({
 				type: "message_part",

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -41,6 +41,7 @@ import { createTestQueryClient } from "#/testHelpers/renderHelpers";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import {
 	selectChatStatus,
+	selectHasStreamState,
 	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
@@ -53,6 +54,8 @@ import {
 	useChatSelector,
 	useChatStore,
 } from "./chatStore";
+import { deriveLiveStatus } from "./liveStatusModel";
+import { buildStreamTools } from "./streamState";
 
 vi.mock("#/api/api", () => ({
 	watchChat: vi.fn(),
@@ -2908,6 +2911,328 @@ describe("useChatStore", () => {
 			provider: "anthropic",
 			retryable: true,
 			statusCode: 429,
+		});
+	});
+
+	// Regression coverage for a chat that stopped with an error but kept the
+	// streamed tool spinning. The error event must clear the partial stream.
+	it("clears the in-flight streamed tool after a terminal error event", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+
+		const chatID = "chat-error-clears-running-tool";
+		const existingMessage = buildMessage(
+			chatID,
+			1,
+			"user",
+			"create a workspace",
+		);
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					store,
+					hasStreamState: useChatSelector(store, selectHasStreamState),
+					chatStatus: useChatSelector(store, selectChatStatus),
+					streamState: useChatSelector(store, selectStreamState),
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// A create_workspace tool call begins but never gets a result.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					part: {
+						type: "tool-call",
+						tool_call_id: "create-workspace-1",
+						tool_name: "create_workspace",
+						args: { name: "dev" },
+					},
+				},
+			});
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1);
+		});
+
+		// A tool call with no result renders as running.
+		await waitFor(() => {
+			expect(
+				result.current.streamState?.toolCalls["create-workspace-1"]?.name,
+			).toBe("create_workspace");
+		});
+		expect(
+			buildStreamTools(
+				result.current.streamState?.toolCalls,
+				result.current.streamState?.toolResults,
+			),
+		).toMatchObject([{ id: "create-workspace-1", status: "running" }]);
+
+		// The session ends unexpectedly so the server emits an error.
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: {
+					message: "The chat session ended unexpectedly.",
+					kind: "generic",
+					retryable: false,
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("error");
+			expect(result.current.streamError).toMatchObject({
+				kind: "generic",
+				message: "The chat session ended unexpectedly.",
+			});
+		});
+
+		// The partial stream is cleared so the tool stops spinning.
+		expect(result.current.streamState).toBeNull();
+		expect(result.current.hasStreamState).toBe(false);
+		expect(
+			buildStreamTools(
+				result.current.streamState?.toolCalls,
+				result.current.streamState?.toolResults,
+			),
+		).toEqual([]);
+
+		const liveStatus = deriveLiveStatus({
+			streamState: result.current.streamState,
+			retryState: null,
+			reconnectState: null,
+			streamError: result.current.streamError,
+			persistedError: null,
+			isAwaitingFirstStreamChunk: false,
+			chatStatus: result.current.chatStatus,
+		});
+		expect(liveStatus.phase).toBe("failed");
+		expect(liveStatus.hasAccumulatedOutput).toBe(false);
+	});
+
+	// Parts that arrive during or after the error must not restore the stream.
+	it("does not re-populate the stream from late parts after a terminal error", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+
+		const chatID = "chat-error-late-parts";
+		const existingMessage = buildMessage(
+			chatID,
+			1,
+			"user",
+			"create a workspace",
+		);
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					chatStatus: useChatSelector(store, selectChatStatus),
+					streamState: useChatSelector(store, selectStreamState),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Send an error and a part in the same frame. The part must be dropped.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "error",
+					chat_id: chatID,
+					error: {
+						message: "The chat session ended unexpectedly.",
+						kind: "generic",
+						retryable: false,
+					},
+				},
+				{
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						part: {
+							type: "tool-call",
+							tool_call_id: "create-workspace-1",
+							tool_name: "create_workspace",
+							args: { name: "dev" },
+						},
+					},
+				},
+			]);
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1);
+		});
+
+		// A part in a later frame must also be dropped.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					part: { type: "text", text: "late partial output" },
+				},
+			});
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1);
+		});
+
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("error");
+		});
+		expect(result.current.streamState).toBeNull();
+	});
+
+	// The error drops late parts. The next turn must stream again once a new
+	// status event arrives.
+	it("re-enables streaming parts on the next turn after a terminal error", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+
+		const chatID = "chat-error-next-turn";
+		const existingMessage = buildMessage(
+			chatID,
+			1,
+			"user",
+			"create a workspace",
+		);
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = createWrapper(queryClient);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: buildChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					chatStatus: useChatSelector(store, selectChatStatus),
+					streamState: useChatSelector(store, selectStreamState),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// The first turn errors out.
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: {
+					message: "The chat session ended unexpectedly.",
+					kind: "generic",
+					retryable: false,
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.chatStatus).toBe("error");
+			expect(result.current.streamState).toBeNull();
+		});
+
+		// The user sends again and the server starts a new turn.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+
+		// Parts from the new turn must flow again.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "retry output" },
+				},
+			});
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1);
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "retry output" },
+			]);
 		});
 	});
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
@@ -159,6 +159,17 @@ describe("deriveLiveStatus", () => {
 		});
 	});
 
+	it("does not stream stale output while a retry is in flight after an error", () => {
+		expect(
+			derive({
+				streamState: buildStreamState({
+					blocks: [{ type: "response", text: "Partial response" }],
+				}),
+				chatStatus: "error",
+			}),
+		).toEqual({ phase: "idle", hasAccumulatedOutput: false });
+	});
+
 	it("passes provider detail through failed status", () => {
 		expect(
 			derive({

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
@@ -132,17 +132,30 @@ describe("deriveLiveStatus", () => {
 		).toEqual({ phase: "streaming", hasAccumulatedOutput: false });
 	});
 
-	it("suppresses accumulated output on failed streams", () => {
+	it("suppresses accumulated output after a terminal stream error", () => {
 		expect(
 			derive({
 				streamState: buildStreamState({
 					blocks: [{ type: "response", text: "Partial response" }],
 				}),
 				streamError: buildStreamError(),
+				chatStatus: "error",
+			}),
+		).toEqual(failedStatus);
+	});
+
+	it("keeps accumulated output when a non-terminal error leaves the stream live", () => {
+		expect(
+			derive({
+				streamState: buildStreamState({
+					blocks: [{ type: "response", text: "Partial response" }],
+				}),
+				streamError: buildStreamError(),
+				chatStatus: "running",
 			}),
 		).toEqual({
 			...failedStatus,
-			hasAccumulatedOutput: false,
+			hasAccumulatedOutput: true,
 		});
 	});
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
@@ -197,6 +197,21 @@ describe("deriveLiveStatus", () => {
 		});
 	});
 
+	it("suppresses accumulated output while reconnecting after a terminal error", () => {
+		expect(
+			derive({
+				streamState: buildStreamState({
+					blocks: [{ type: "response", text: "Partial response" }],
+				}),
+				reconnectState: buildReconnectState(),
+				chatStatus: "error",
+			}),
+		).toEqual({
+			...reconnectingStatus,
+			hasAccumulatedOutput: false,
+		});
+	});
+
 	it("prioritizes retrying over failed and reconnecting", () => {
 		expect(
 			derive({

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.test.ts
@@ -132,7 +132,7 @@ describe("deriveLiveStatus", () => {
 		).toEqual({ phase: "streaming", hasAccumulatedOutput: false });
 	});
 
-	it("tracks accumulated output on failed streams", () => {
+	it("suppresses accumulated output on failed streams", () => {
 		expect(
 			derive({
 				streamState: buildStreamState({
@@ -142,7 +142,7 @@ describe("deriveLiveStatus", () => {
 			}),
 		).toEqual({
 			...failedStatus,
-			hasAccumulatedOutput: true,
+			hasAccumulatedOutput: false,
 		});
 	});
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
@@ -120,7 +120,11 @@ export const deriveLiveStatus = ({
 	}
 
 	if (streamError) {
-		return toFailedLiveStatus(streamError, { hasAccumulatedOutput });
+		// The error handler clears the stream, so output and an error
+		// only coexist when a stale part repopulates the stream after
+		// the clear. Suppress that leftover so it does not render as a
+		// live row under the callout.
+		return toFailedLiveStatus(streamError, { hasAccumulatedOutput: false });
 	}
 
 	if (reconnectState) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
@@ -114,11 +114,13 @@ export const deriveLiveStatus = ({
 	chatStatus,
 }: DeriveLiveStatusParams): LiveStatusModel => {
 	const hasAccumulatedOutput = getHasAccumulatedOutput(streamState);
-	// Suppress stale stream output whenever the status is terminal (error).
+	// The stream is cleared on error, so leftover blocks are stale.
 	const showOutput = chatStatus === "error" ? false : hasAccumulatedOutput;
 
 	if (retryState) {
-		return toRetryingLiveStatus(retryState, { hasAccumulatedOutput });
+		return toRetryingLiveStatus(retryState, {
+			hasAccumulatedOutput: showOutput,
+		});
 	}
 
 	if (streamError) {
@@ -128,7 +130,9 @@ export const deriveLiveStatus = ({
 	}
 
 	if (reconnectState) {
-		return toReconnectingLiveStatus(reconnectState, { hasAccumulatedOutput });
+		return toReconnectingLiveStatus(reconnectState, {
+			hasAccumulatedOutput: showOutput,
+		});
 	}
 
 	// The interrupt outranks stream leftovers: while the worker drains and

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
@@ -114,18 +114,16 @@ export const deriveLiveStatus = ({
 	chatStatus,
 }: DeriveLiveStatusParams): LiveStatusModel => {
 	const hasAccumulatedOutput = getHasAccumulatedOutput(streamState);
+	// Suppress stale stream output whenever the status is terminal (error).
+	const showOutput = chatStatus === "error" ? false : hasAccumulatedOutput;
 
 	if (retryState) {
 		return toRetryingLiveStatus(retryState, { hasAccumulatedOutput });
 	}
 
 	if (streamError) {
-		// Terminal stream errors clear the stream, so any output left is
-		// a stale leftover. Request and parse errors leave the stream
-		// live, so keep their output visible.
 		return toFailedLiveStatus(streamError, {
-			hasAccumulatedOutput:
-				chatStatus === "error" ? false : hasAccumulatedOutput,
+			hasAccumulatedOutput: showOutput,
 		});
 	}
 
@@ -144,13 +142,15 @@ export const deriveLiveStatus = ({
 		return { phase: "starting", hasAccumulatedOutput };
 	}
 
-	if (streamState !== null) {
+	if (streamState !== null && chatStatus !== "error") {
 		return { phase: "streaming", hasAccumulatedOutput };
 	}
 
 	if (persistedError) {
-		return toFailedLiveStatus(persistedError, { hasAccumulatedOutput });
+		return toFailedLiveStatus(persistedError, {
+			hasAccumulatedOutput: showOutput,
+		});
 	}
 
-	return { phase: "idle", hasAccumulatedOutput };
+	return { phase: "idle", hasAccumulatedOutput: showOutput };
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
@@ -120,11 +120,13 @@ export const deriveLiveStatus = ({
 	}
 
 	if (streamError) {
-		// The error handler clears the stream, so output and an error
-		// only coexist when a stale part repopulates the stream after
-		// the clear. Suppress that leftover so it does not render as a
-		// live row under the callout.
-		return toFailedLiveStatus(streamError, { hasAccumulatedOutput: false });
+		// Terminal stream errors clear the stream, so any output left is
+		// a stale leftover. Request and parse errors leave the stream
+		// live, so keep their output visible.
+		return toFailedLiveStatus(streamError, {
+			hasAccumulatedOutput:
+				chatStatus === "error" ? false : hasAccumulatedOutput,
+		});
 	}
 
 	if (reconnectState) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -569,17 +569,10 @@ export const useChatStore = (
 						continue;
 					}
 
-					// Only flush buffered parts before events that
-					// need them applied first. `message` events
-					// commit durable state that must include all
-					// stream parts. `error` events should surface
-					// partial output. Other events (status, retry,
-					// queue_update) must not flush. Status changes
-					// need to be visible before parts so the
-					// Thinking indicator can render, and retry
-					// clears stream state which a flush would
-					// re-populate.
-					if (streamEvent.type === "message" || streamEvent.type === "error") {
+					// Flush buffered parts before a durable message
+					// commits them. Other events must not flush because
+					// some clear the stream and a flush would restore it.
+					if (streamEvent.type === "message") {
 						flushMessageParts();
 					}
 
@@ -648,10 +641,14 @@ export const useChatStore = (
 								kind: "generic",
 								message: "Chat processing failed.",
 							};
-							streamReportedWaiting = false;
+							// An error ends the turn. Clear the partial
+							// stream so no tool keeps spinning.
+							discardBufferedParts();
+							streamReportedWaiting = true;
 							wsStatusReceivedRef.current = true;
 							store.applyServerChatStatus("error");
 							store.setStreamError(reason);
+							store.clearStreamState();
 							store.clearRetryState();
 							setChatErrorReasonEvent(chatID, reason);
 							updateSidebarChat((chat) =>

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -642,9 +642,10 @@ export const useChatStore = (
 								message: "Chat processing failed.",
 							};
 							// An error ends the turn. Clear the partial
-							// stream so no tool keeps spinning.
+							// stream so no tool keeps spinning. Parts stay
+							// ungated because the next turn can send a part
+							// before its running status.
 							discardBufferedParts();
-							streamReportedWaiting = true;
 							wsStatusReceivedRef.current = true;
 							store.applyServerChatStatus("error");
 							store.setStreamError(reason);

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -622,13 +622,20 @@ export const useChatStore = (
 							streamReportedWaiting = nextStatus === "waiting";
 							wsStatusReceivedRef.current = true;
 							store.clearRetryState();
+							const prevStatus = store.getSnapshot().chatStatus;
 							store.applyServerChatStatus(nextStatus);
 							if (nextStatus === "waiting") {
 								discardBufferedParts();
 							}
 							if (nextStatus !== "error") {
 								clearChatErrorReasonEvent(chatID);
-								store.clearStreamError();
+								// Only an errored chat starting a new turn
+								// supersedes the stored error. A status from a
+								// turn that was already running must not clear
+								// an unrelated request failure.
+								if (prevStatus === "error") {
+									store.clearStreamError();
+								}
 							}
 							updateSidebarChat((chat) =>
 								chat.status === nextStatus

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -628,6 +628,7 @@ export const useChatStore = (
 							}
 							if (nextStatus !== "error") {
 								clearChatErrorReasonEvent(chatID);
+								store.clearStreamError();
 							}
 							updateSidebarChat((chat) =>
 								chat.status === nextStatus

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -175,6 +175,45 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 	},
 };
 
+// Matches the fixed terminal error path. A tool call streams without a
+// result, then the error clears the stream so the running row goes away
+// and the failure callout stays.
+export const ErrorClearsStreamingTool: Story = {
+	render: () => {
+		const store = createChatStore();
+		store.replaceMessages([
+			buildMessage(1, "user", [{ type: "text", text: "Create a workspace" }]),
+		]);
+		store.setChatStatus("running");
+		store.applyMessagePart({
+			type: "tool-call",
+			tool_call_id: "create-workspace-call",
+			tool_name: "create_workspace",
+			args: { name: "dev" },
+		});
+		store.applyServerChatStatus("error");
+		store.setStreamError({
+			kind: "generic",
+			message: "The chat session ended unexpectedly.",
+		});
+		store.clearStreamState();
+
+		return (
+			<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>
+				<StoryChatPageTimeline store={store} />
+			</ChatWorkspaceContext>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByText("Creating workspace…")).toBeNull();
+		expect(canvas.getByText("Request failed")).toBeInTheDocument();
+		expect(
+			canvas.getByText("The chat session ended unexpectedly."),
+		).toBeInTheDocument();
+	},
+};
+
 export const HiddenAssistantPlaceholderDoesNotRender: Story = {
 	render: () => {
 		const store = createChatStore();

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -1,7 +1,7 @@
 import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChatQueuedMessage } from "#/testHelpers/chatEntities";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
@@ -175,38 +175,43 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 	},
 };
 
-// Matches the fixed terminal error path. A tool call streams without a
-// result, then the error clears the stream so the running row goes away
-// and the failure callout stays.
+// Matches the fixed terminal error path.
+const errorClearsStreamStore = createChatStore();
 export const ErrorClearsStreamingTool: Story = {
 	render: () => {
-		const store = createChatStore();
-		store.replaceMessages([
+		errorClearsStreamStore.replaceMessages([
 			buildMessage(1, "user", [{ type: "text", text: "Create a workspace" }]),
 		]);
-		store.setChatStatus("running");
-		store.applyMessagePart({
+		errorClearsStreamStore.setChatStatus("running");
+		errorClearsStreamStore.applyMessagePart({
 			type: "tool-call",
 			tool_call_id: "create-workspace-call",
 			tool_name: "create_workspace",
 			args: { name: "dev" },
 		});
-		store.applyServerChatStatus("error");
-		store.setStreamError({
-			kind: "generic",
-			message: "The chat session ended unexpectedly.",
-		});
-		store.clearStreamState();
 
 		return (
 			<ChatWorkspaceContext value={{ workspaceId: "workspace-1" }}>
-				<StoryChatPageTimeline store={store} />
+				<StoryChatPageTimeline store={errorClearsStreamStore} />
 			</ChatWorkspaceContext>
 		);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.queryByText("Creating workspace…")).toBeNull();
+		expect(canvas.getByText("Creating workspace…")).toBeInTheDocument();
+
+		errorClearsStreamStore.batch(() => {
+			errorClearsStreamStore.applyServerChatStatus("error");
+			errorClearsStreamStore.setStreamError({
+				kind: "generic",
+				message: "The chat session ended unexpectedly.",
+			});
+			errorClearsStreamStore.clearStreamState();
+		});
+
+		await waitFor(() => {
+			expect(canvas.queryByText("Creating workspace…")).toBeNull();
+		});
 		expect(canvas.getByText("Request failed")).toBeInTheDocument();
 		expect(
 			canvas.getByText("The chat session ended unexpectedly."),

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -179,6 +179,7 @@ export const DurableUnresolvedWorkspaceToolRuns: Story = {
 const errorClearsStreamStore = createChatStore();
 export const ErrorClearsStreamingTool: Story = {
 	render: () => {
+		errorClearsStreamStore.resetTransientState();
 		errorClearsStreamStore.replaceMessages([
 			buildMessage(1, "user", [{ type: "text", text: "Create a workspace" }]),
 		]);


### PR DESCRIPTION
Fixes CODAGT-622

When a chat stopped with an error, the streamed message and its running status stayed on screen instead of clearing. A chat that hit "Response failed: The chat session ended unexpectedly" while "Creating workspace..." kept showing a spinner. Refreshing showed the correct status because the stream state is transient, confirming it was frontend-only.

The WebSocket `error` handler set the chat status and stored the error but never cleared the in-flight `streamState`. A tool call with no result yet keeps a derived `running` status, so the leftover row kept spinning. Treat the `error` event as a terminal turn boundary: discard buffered parts, gate late parts from the finished turn, and clear the stream state. The error callout still surfaces the failure.

On this error path the partial output is not committed durably server-side (partial persistence only runs on the interrupt path), so clearing the preview converges the live UI with what a refresh already shows.

<details>
<summary>Implementation plan and fix evaluation</summary>

Root cause was confirmed with a store-level test that fails the moment `clearStreamState()` runs on the error path. Four independent fix designs were evaluated (clear `streamState`; finalize orphaned tools to `error`; render-layer-only; combinations). All rejected the render-layer-only fix because `isStreaming`/`isChatCompleted` in `ChatPageContent` derive from `streamState !== null` and would stay wrong. Chosen approach clears `streamState` and adds hardening against a pending flush timer or same-frame `message_part` re-populating the stream after the clear.

Backend verification: `flushActiveState` partial persistence in `coderd/x/chatd/chatloop/chatloop.go` runs only on `ErrInterrupted`, not on the "stream closed unexpectedly" provider-error path (`chaterror/classify.go`), so the partial output is not recoverable server-side here and discarding the transient preview matches the refreshed view.

</details>

Generated by Coder Agents.
