### PR TITLE
feat: annotate AI Bridge interceptions with user capabilities

### DIFF
--- a/coderd/aibridged.go
+++ b/coderd/aibridged.go
@@ -14,9 +14,33 @@ import (
 	"github.com/coder/coder/v2/coderd/aibridged"
 	aibridgedproto "github.com/coder/coder/v2/coderd/aibridged/proto"
 	"github.com/coder/coder/v2/coderd/aibridgedserver"
+	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 )
+
+// aiBridgeCapabilityChecker builds the checker that resolves the capabilities
+// annotated onto each interception. It returns a nil checker when the
+// workspace-capable-licensing experiment is disabled, which leaves
+// interceptions unannotated.
+func (api *API) aiBridgeCapabilityChecker() (capabilities.Checker, error) {
+	var checker capabilities.Checker
+	if !api.Experiments.Enabled(codersdk.ExperimentWorkspaceCapableLicensing) {
+		return checker, nil
+	}
+	dbChecker, err := capabilities.NewDBChecker(capabilities.Options{
+		DB:         api.Database,
+		Authorizer: api.Authorizer,
+		Logger:     api.Logger.Named("capabilities"),
+		Clock:      api.Clock,
+	})
+	if err != nil {
+		return nil, err
+	}
+	checker = dbChecker
+	return checker, nil
+}
 
 // AIGatewayHandler returns the in-memory AI Gateway HTTP handler
 // set by [API.RegisterInMemoryAIBridgedHTTPHandler], or nil if the daemon
@@ -65,10 +89,15 @@ func (api *API) CreateInMemoryAIBridgeServer(dialCtx context.Context) (client ai
 	}()
 
 	mux := drpcmux.New()
+	capabilityChecker, err := api.aiBridgeCapabilityChecker()
+	if err != nil {
+		return nil, err
+	}
 	srv, err := aibridgedserver.NewServer(api.ctx, aibridgedserver.Options{
 		Store:               api.Database,
 		Pubsub:              api.Pubsub,
 		AISeatTracker:       api.AISeatTracker,
+		CapabilityChecker:   capabilityChecker,
 		Enqueuer:            api.NotificationsEnqueuer,
 		AccessURL:           api.AccessURL.String(),
 		GatewayCfg:          api.DeploymentValues.AI.BridgeConfig,

--- a/coderd/aibridged.go
+++ b/coderd/aibridged.go
@@ -20,25 +20,36 @@ import (
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 )
 
-// aiBridgeCapabilityChecker builds the checker that resolves the capabilities
-// annotated onto each interception. It returns a nil checker when the
-// workspace-capable-licensing experiment is disabled, which leaves
-// interceptions unannotated.
-func (api *API) aiBridgeCapabilityChecker() (capabilities.Checker, error) {
+// AIBridgeCapabilityChecker returns the checker that resolves the capabilities
+// annotated onto each interception, constructing it on first use. It returns a
+// nil checker when the workspace-capable-licensing experiment is disabled,
+// which leaves interceptions unannotated.
+//
+// The checker is shared by every AI Gateway connection so that its cache is not
+// discarded when a gateway reconnects.
+func (api *API) AIBridgeCapabilityChecker() (capabilities.Checker, error) {
+	api.aiBridgeCapabilitiesMu.Lock()
+	defer api.aiBridgeCapabilitiesMu.Unlock()
+	if api.aiBridgeCapabilitiesInit {
+		return api.aiBridgeCapabilities, nil
+	}
+
 	var checker capabilities.Checker
-	if !api.Experiments.Enabled(codersdk.ExperimentWorkspaceCapableLicensing) {
-		return checker, nil
+	if api.Experiments.Enabled(codersdk.ExperimentWorkspaceCapableLicensing) {
+		dbChecker, err := capabilities.NewDBChecker(capabilities.Options{
+			DB:         api.Database,
+			Authorizer: api.Authorizer,
+			Logger:     api.Logger.Named("capabilities"),
+			Clock:      api.Clock,
+		})
+		if err != nil {
+			return nil, err
+		}
+		checker = dbChecker
 	}
-	dbChecker, err := capabilities.NewDBChecker(capabilities.Options{
-		DB:         api.Database,
-		Authorizer: api.Authorizer,
-		Logger:     api.Logger.Named("capabilities"),
-		Clock:      api.Clock,
-	})
-	if err != nil {
-		return nil, err
-	}
-	checker = dbChecker
+
+	api.aiBridgeCapabilities = checker
+	api.aiBridgeCapabilitiesInit = true
 	return checker, nil
 }
 
@@ -89,7 +100,7 @@ func (api *API) CreateInMemoryAIBridgeServer(dialCtx context.Context) (client ai
 	}()
 
 	mux := drpcmux.New()
-	capabilityChecker, err := api.aiBridgeCapabilityChecker()
+	capabilityChecker, err := api.AIBridgeCapabilityChecker()
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/aibridgedserver/aibridgedserver.go
+++ b/coderd/aibridgedserver/aibridgedserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd/aibridged/proto"
 	"github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/apikey"
+	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -117,6 +118,9 @@ type Server struct {
 	structuredLogging bool
 	aiSeatTracker     aiseats.SeatTracker
 	experiments       codersdk.Experiments
+	// capabilityChecker resolves the initiator's capabilities when recording an
+	// interception. Nil disables capability annotation.
+	capabilityChecker capabilities.Checker
 	// budgetPolicy selects the effective group when a user belongs to multiple
 	// budgeted groups, used for cost attribution on token usage records.
 	budgetPolicy codersdk.AIBudgetPolicy
@@ -134,6 +138,10 @@ type Options struct {
 	Store         store
 	Pubsub        pubsub.Pubsub
 	AISeatTracker aiseats.SeatTracker
+	// CapabilityChecker resolves the capabilities annotated onto each
+	// interception. When nil, interceptions are recorded without capability
+	// annotations.
+	CapabilityChecker capabilities.Checker
 	// Enqueuer enqueues notifications. When nil, NewServer substitutes a no-op
 	// enqueuer.
 	Enqueuer notifications.Enqueuer
@@ -172,6 +180,7 @@ func NewServer(lifecycleCtx context.Context, opts Options) (*Server, error) {
 		externalAuthConfigs: eac,
 		structuredLogging:   opts.GatewayCfg.StructuredLogging.Value(),
 		aiSeatTracker:       opts.AISeatTracker,
+		capabilityChecker:   opts.CapabilityChecker,
 		experiments:         opts.Experiments,
 		budgetPolicy:        codersdk.NewAIBudgetPolicyFromString(opts.GatewayCfg.BudgetPolicy),
 		budgetPeriod:        codersdk.NewAIBudgetPeriodFromString(opts.GatewayCfg.BudgetPeriod),
@@ -264,6 +273,7 @@ func (s *Server) RecordInterception(ctx context.Context, in *proto.RecordInterce
 		ProviderName:                providerName,
 		Model:                       in.Model,
 		Metadata:                    out,
+		Annotations:                 s.interceptionAnnotations(ctx, initID),
 		StartedAt:                   in.StartedAt.AsTime(),
 		ThreadParentInterceptionID:  uuid.NullUUID{UUID: parentID, Valid: parentID != uuid.Nil},
 		ThreadRootInterceptionID:    uuid.NullUUID{UUID: rootID, Valid: rootID != uuid.Nil},
@@ -281,6 +291,23 @@ func (s *Server) RecordInterception(ctx context.Context, in *proto.RecordInterce
 		s.aiSeatTracker.RecordUsage(ctx, initID, reason)
 	}
 	return &proto.RecordInterceptionResponse{}, nil
+}
+
+// interceptionAnnotations resolves the annotations recorded alongside an
+// interception. Resolution failures are logged and yield empty annotations
+// rather than failing the interception, since annotations are informational and
+// this runs on the request path.
+func (s *Server) interceptionAnnotations(ctx context.Context, initiatorID uuid.UUID) database.AIBridgeInterceptionAnnotations {
+	if s.capabilityChecker == nil {
+		return database.AIBridgeInterceptionAnnotations{}
+	}
+	caps, err := s.capabilityChecker.Capabilities(ctx, initiatorID)
+	if err != nil {
+		s.logger.Warn(ctx, "failed to resolve initiator capabilities for interception",
+			slog.F("initiator_id", initiatorID), slog.Error(err))
+		return database.AIBridgeInterceptionAnnotations{}
+	}
+	return database.AIBridgeInterceptionCapabilities(capabilities.Strings(caps))
 }
 
 func (s *Server) RecordInterceptionEnded(ctx context.Context, in *proto.RecordInterceptionEndedRequest) (*proto.RecordInterceptionEndedResponse, error) {

--- a/coderd/aibridgedserver/aibridgedserver_test.go
+++ b/coderd/aibridgedserver/aibridgedserver_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/coder/coder/v2/coderd/aibridgedserver"
 	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/apikey"
+	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/promhelp"
 	"github.com/coder/coder/v2/coderd/database"
@@ -4659,6 +4660,92 @@ func TestRecordInterceptionAISeat(t *testing.T) {
 			_, err = srv.RecordInterception(ctx, newRequest())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedCalls, tracker.calls.Load())
+		})
+	}
+}
+
+// stubCapabilityChecker returns fixed capabilities or a fixed error.
+type stubCapabilityChecker struct {
+	caps []capabilities.Capability
+	err  error
+}
+
+func (s stubCapabilityChecker) Capabilities(context.Context, uuid.UUID) ([]capabilities.Capability, error) {
+	return s.caps, s.err
+}
+
+// TestRecordInterceptionCapabilityAnnotations verifies the capability
+// annotations written alongside an interception. A resolution failure is
+// recorded as no annotations and does not fail the interception.
+func TestRecordInterceptionCapabilityAnnotations(t *testing.T) {
+	t.Parallel()
+
+	workspace := []string{string(capabilities.Workspace)}
+	none := []string{}
+
+	cases := []struct {
+		name     string
+		checker  capabilities.Checker
+		expected database.AIBridgeInterceptionAnnotations
+	}{
+		{
+			name:     "no checker leaves annotations empty",
+			checker:  nil,
+			expected: database.AIBridgeInterceptionAnnotations{},
+		},
+		{
+			name:     "workspace capability",
+			checker:  stubCapabilityChecker{caps: []capabilities.Capability{capabilities.Workspace}},
+			expected: database.AIBridgeInterceptionAnnotations{Capabilities: &workspace},
+		},
+		{
+			name:     "no capabilities records an empty list",
+			checker:  stubCapabilityChecker{},
+			expected: database.AIBridgeInterceptionAnnotations{Capabilities: &none},
+		},
+		{
+			name:     "resolution error leaves annotations empty",
+			checker:  stubCapabilityChecker{err: xerrors.New("boom")},
+			expected: database.AIBridgeInterceptionAnnotations{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			db := dbmock.NewMockStore(ctrl)
+			var recorded database.AIBridgeInterceptionAnnotations
+			db.EXPECT().InsertAIBridgeInterception(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, params database.InsertAIBridgeInterceptionParams) (database.AIBridgeInterception, error) {
+					recorded = params.Annotations
+					return database.AIBridgeInterception{}, nil
+				})
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			srv, err := aibridgedserver.NewServer(ctx, aibridgedserver.Options{
+				Store:             db,
+				AISeatTracker:     &countingSeatTracker{},
+				CapabilityChecker: tc.checker,
+				AccessURL:         "/",
+				GatewayCfg:        codersdk.AIBridgeConfig{},
+				Experiments:       requiredExperiments,
+				Logger:            testutil.Logger(t),
+				Clock:             quartz.NewReal(),
+			})
+			require.NoError(t, err)
+
+			_, err = srv.RecordInterception(ctx, &proto.RecordInterceptionRequest{
+				Id:          uuid.NewString(),
+				ApiKeyId:    uuid.NewString(),
+				InitiatorId: uuid.NewString(),
+				Provider:    "anthropic",
+				Model:       "claude-4-opus",
+				StartedAt:   timestamppb.Now(),
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, recorded)
 		})
 	}
 }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5052,7 +5052,7 @@ const docTemplate = `{
         },
         "/api/v2/organizations/{organization}/ai/spend/export": {
             "get": {
-                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nRequires organization-level administrator permissions.",
+                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nThe capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.\nRequires organization-level administrator permissions.",
                 "produces": [
                     "text/csv"
                 ],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4463,7 +4463,7 @@
 		},
 		"/api/v2/organizations/{organization}/ai/spend/export": {
 			"get": {
-				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nRequires organization-level administrator permissions.",
+				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nThe capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.\nRequires organization-level administrator permissions.",
 				"produces": ["text/csv"],
 				"tags": ["Enterprise"],
 				"summary": "Export organization AI spend as CSV",

--- a/coderd/capabilities/capabilities.go
+++ b/coderd/capabilities/capabilities.go
@@ -1,0 +1,229 @@
+// Package capabilities resolves the coarse-grained capabilities a user holds,
+// derived from the RBAC engine's verdict on representative actions.
+package capabilities
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/rbac/rolestore"
+	"github.com/coder/quartz"
+)
+
+// Capability names a coarse-grained ability a user holds.
+type Capability string
+
+// Workspace is held by users the RBAC engine authorizes to create a workspace
+// they own, in any organization.
+const Workspace Capability = "workspace"
+
+// Strings returns the capabilities as a sorted, deduplicated string slice.
+func Strings(caps []Capability) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, string(c))
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+// Checker resolves the capabilities held by a user.
+type Checker interface {
+	// Capabilities returns the capabilities the user currently holds. The
+	// returned slice may be empty.
+	Capabilities(ctx context.Context, userID uuid.UUID) ([]Capability, error)
+}
+
+// Noop resolves no capabilities.
+type Noop struct{}
+
+var _ Checker = Noop{}
+
+func (Noop) Capabilities(context.Context, uuid.UUID) ([]Capability, error) {
+	return nil, nil
+}
+
+// DefaultCacheTTL bounds how long a resolved capability set is reused. Role and
+// group changes are not observed until the entry expires.
+const DefaultCacheTTL = 5 * time.Minute
+
+// defaultCacheMaxEntries bounds memory use. The cache is cleared wholesale once
+// it exceeds this size rather than evicting in access order.
+const defaultCacheMaxEntries = 4096
+
+type cacheEntry struct {
+	caps      []Capability
+	expiresAt time.Time
+}
+
+// DBChecker resolves capabilities by expanding a user's stored roles and asking
+// the RBAC engine. Results are cached per user for the configured TTL.
+type DBChecker struct {
+	db         database.Store
+	authorizer rbac.Authorizer
+	logger     slog.Logger
+	clock      quartz.Clock
+	ttl        time.Duration
+
+	mu    sync.Mutex
+	cache map[uuid.UUID]cacheEntry
+}
+
+var _ Checker = (*DBChecker)(nil)
+
+// Options configures a DBChecker. Clock and CacheTTL are optional.
+type Options struct {
+	DB         database.Store
+	Authorizer rbac.Authorizer
+	Logger     slog.Logger
+	Clock      quartz.Clock
+	CacheTTL   time.Duration
+}
+
+func NewDBChecker(opts Options) (*DBChecker, error) {
+	if opts.DB == nil {
+		return nil, xerrors.New("database is required")
+	}
+	if opts.Authorizer == nil {
+		return nil, xerrors.New("authorizer is required")
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = quartz.NewReal()
+	}
+	ttl := opts.CacheTTL
+	if ttl <= 0 {
+		ttl = DefaultCacheTTL
+	}
+	return &DBChecker{
+		db:         opts.DB,
+		authorizer: opts.Authorizer,
+		logger:     opts.Logger,
+		clock:      clock,
+		ttl:        ttl,
+		cache:      make(map[uuid.UUID]cacheEntry),
+	}, nil
+}
+
+func (c *DBChecker) Capabilities(ctx context.Context, userID uuid.UUID) ([]Capability, error) {
+	if caps, ok := c.cached(userID); ok {
+		return caps, nil
+	}
+
+	caps, err := c.resolve(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	c.store(userID, caps)
+	return caps, nil
+}
+
+func (c *DBChecker) cached(userID uuid.UUID) ([]Capability, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.cache[userID]
+	if !ok || !entry.expiresAt.After(c.clock.Now()) {
+		return nil, false
+	}
+	return slices.Clone(entry.caps), true
+}
+
+func (c *DBChecker) store(userID uuid.UUID, caps []Capability) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.cache) >= defaultCacheMaxEntries {
+		c.cache = make(map[uuid.UUID]cacheEntry)
+	}
+	c.cache[userID] = cacheEntry{
+		caps:      slices.Clone(caps),
+		expiresAt: c.clock.Now().Add(c.ttl),
+	}
+}
+
+func (c *DBChecker) resolve(ctx context.Context, userID uuid.UUID) ([]Capability, error) {
+	// Reading another user's roles and expanding custom roles are both system
+	// operations; the caller's own authorization context cannot perform them.
+	//nolint:gocritic // Resolving capabilities is a system function.
+	sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+	row, err := c.db.GetAuthorizationUserRoles(sysCtx, userID)
+	if err != nil {
+		return nil, xerrors.Errorf("get authorization user roles: %w", err)
+	}
+	// Roles are ignored during authorization for users who are not active, so
+	// they hold no capabilities.
+	if row.Status != database.UserStatusActive {
+		return nil, nil
+	}
+
+	roleNames, err := row.RoleNames()
+	if err != nil {
+		// Authorization fails closed on an unparsable role string, so the user
+		// holds no capabilities.
+		c.logger.Warn(ctx, "user has an unparsable role, resolving no capabilities",
+			slog.F("user_id", userID),
+			slog.Error(err),
+		)
+		return nil, nil
+	}
+
+	subject := subjectFor(userID, roleNames, row.Groups)
+	roles, err := rolestore.Expand(sysCtx, c.db, subject.SafeRoleNames())
+	if err != nil {
+		return nil, xerrors.Errorf("expand roles: %w", err)
+	}
+	subject.Roles = roles
+	subject = subject.WithCachedASTValue()
+
+	var caps []Capability
+	if c.canCreateWorkspace(ctx, subject) {
+		caps = append(caps, Workspace)
+	}
+	return caps, nil
+}
+
+// canCreateWorkspace reports whether the RBAC engine authorizes the subject to
+// create a workspace they own in any organization: via membership grants or via
+// a site-wide role that applies regardless of membership.
+//
+// The any-organization form allows exactly when some per-organization check
+// would, because the policy takes the maximum vote across the subject's
+// memberships, and it also covers users who belong to zero organizations.
+func (c *DBChecker) canCreateWorkspace(ctx context.Context, subject rbac.Subject) bool {
+	return c.authorizer.Authorize(ctx, subject, policy.ActionCreate,
+		rbac.ResourceWorkspace.AnyOrganization().WithOwner(subject.ID)) == nil
+}
+
+// subjectFor builds the evaluation subject for a user, with roles and groups
+// sorted and deduplicated.
+func subjectFor(userID uuid.UUID, roleNames []rbac.RoleIdentifier, groups []string) rbac.Subject {
+	roleNames = slices.Clone(roleNames)
+	slices.SortFunc(roleNames, func(a, b rbac.RoleIdentifier) int {
+		return strings.Compare(a.String(), b.String())
+	})
+	roleNames = slices.CompactFunc(roleNames, func(a, b rbac.RoleIdentifier) bool {
+		return a == b
+	})
+	groups = slices.Clone(groups)
+	slices.Sort(groups)
+	groups = slices.Compact(groups)
+	return rbac.Subject{
+		Type:   rbac.SubjectTypeUser,
+		ID:     userID.String(),
+		Roles:  rbac.RoleIdentifiers(roleNames),
+		Groups: groups,
+		Scope:  rbac.ScopeAll,
+	}
+}

--- a/coderd/capabilities/capabilities.go
+++ b/coderd/capabilities/capabilities.go
@@ -188,7 +188,11 @@ func (c *DBChecker) resolve(ctx context.Context, userID uuid.UUID) ([]Capability
 	subject = subject.WithCachedASTValue()
 
 	var caps []Capability
-	if c.canCreateWorkspace(ctx, subject) {
+	capable, err := c.canCreateWorkspace(ctx, subject)
+	if err != nil {
+		return nil, xerrors.Errorf("authorize workspace create: %w", err)
+	}
+	if capable {
 		caps = append(caps, Workspace)
 	}
 	return caps, nil
@@ -201,9 +205,21 @@ func (c *DBChecker) resolve(ctx context.Context, userID uuid.UUID) ([]Capability
 // The any-organization form allows exactly when some per-organization check
 // would, because the policy takes the maximum vote across the subject's
 // memberships, and it also covers users who belong to zero organizations.
-func (c *DBChecker) canCreateWorkspace(ctx context.Context, subject rbac.Subject) bool {
-	return c.authorizer.Authorize(ctx, subject, policy.ActionCreate,
-		rbac.ResourceWorkspace.AnyOrganization().WithOwner(subject.ID)) == nil
+//
+// Only an authorization denial reports false. Any other failure, such as a
+// canceled context or an evaluation error, is returned as an error so the
+// caller does not record it as a denial.
+func (c *DBChecker) canCreateWorkspace(ctx context.Context, subject rbac.Subject) (bool, error) {
+	err := c.authorizer.Authorize(ctx, subject, policy.ActionCreate,
+		rbac.ResourceWorkspace.AnyOrganization().WithOwner(subject.ID))
+	switch {
+	case err == nil:
+		return true, nil
+	case rbac.IsUnauthorizedError(err):
+		return false, nil
+	default:
+		return false, err
+	}
 }
 
 // subjectFor builds the evaluation subject for a user, with roles and groups

--- a/coderd/capabilities/capabilities_test.go
+++ b/coderd/capabilities/capabilities_test.go
@@ -2,12 +2,14 @@ package capabilities_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/database"
@@ -196,4 +198,47 @@ func TestStrings(t *testing.T) {
 	require.Equal(t, []string{"workspace"}, capabilities.Strings([]capabilities.Capability{
 		capabilities.Workspace, capabilities.Workspace,
 	}))
+}
+
+// erroringAuthorizer fails every authorization with a non-denial error.
+type erroringAuthorizer struct {
+	calls atomic.Int64
+	err   error
+}
+
+func (a *erroringAuthorizer) Authorize(context.Context, rbac.Subject, policy.Action, rbac.Object) error {
+	a.calls.Add(1)
+	return a.err
+}
+
+func (*erroringAuthorizer) Prepare(context.Context, rbac.Subject, policy.Action, string) (rbac.PreparedAuthorized, error) {
+	return nil, xerrors.New("not implemented")
+}
+
+// TestDBCheckerAuthorizerError covers the distinction between a denial and an
+// evaluation failure: a failure must surface as an error and must not be cached
+// as "holds no capabilities".
+func TestDBCheckerAuthorizerError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, _ := dbtestutil.NewDB(t)
+	user := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+
+	authorizer := &erroringAuthorizer{err: xerrors.New("evaluation exploded")}
+	checker, err := capabilities.NewDBChecker(capabilities.Options{
+		DB:         db,
+		Authorizer: authorizer,
+		Logger:     testutil.Logger(t),
+		Clock:      quartz.NewMock(t),
+	})
+	require.NoError(t, err)
+
+	_, err = checker.Capabilities(ctx, user.ID)
+	require.ErrorContains(t, err, "evaluation exploded")
+
+	// The failure is not cached, so the next call re-evaluates.
+	_, err = checker.Capabilities(ctx, user.ID)
+	require.Error(t, err)
+	require.Equal(t, int64(2), authorizer.calls.Load())
 }

--- a/coderd/capabilities/capabilities_test.go
+++ b/coderd/capabilities/capabilities_test.go
@@ -1,0 +1,199 @@
+package capabilities_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/capabilities"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestDBCheckerCapabilities(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	newChecker := func(t *testing.T, db database.Store, clock quartz.Clock) *capabilities.DBChecker {
+		checker, err := capabilities.NewDBChecker(capabilities.Options{
+			DB:         db,
+			Authorizer: rbac.NewCachingAuthorizer(prometheus.NewRegistry()),
+			Logger:     testutil.Logger(t),
+			Clock:      clock,
+		})
+		require.NoError(t, err)
+		return checker
+	}
+	member := func(t *testing.T, db database.Store, orgID uuid.UUID, user database.User, roles ...string) {
+		dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			OrganizationID: orgID,
+			UserID:         user.ID,
+			Roles:          roles,
+		})
+	}
+	emptyDefaultRoles := func(t *testing.T, db database.Store, org database.Organization) {
+		_, err := db.UpdateOrganization(ctx, database.UpdateOrganizationParams{
+			ID:                    org.ID,
+			UpdatedAt:             dbtime.Now(),
+			Name:                  org.Name,
+			DisplayName:           org.DisplayName,
+			Description:           org.Description,
+			Icon:                  org.Icon,
+			DefaultOrgMemberRoles: []string{},
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("WorkspaceCapability", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		emptyDefaultRoles(t, db, org)
+		checker := newChecker(t, db, quartz.NewMock(t))
+
+		// Explicit organization-workspace-access grant.
+		wsUser := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		member(t, db, org.ID, wsUser, rbac.RoleOrgWorkspaceAccess())
+
+		// Floor permissions only.
+		gateway := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		member(t, db, org.ID, gateway)
+
+		// The creation ban negates workspace-create.
+		banned := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		member(t, db, org.ID, banned, rbac.RoleOrgWorkspaceAccess(), rbac.RoleOrgWorkspaceCreationBan())
+
+		// Site-wide owner, no org membership.
+		owner := dbgen.User(t, db, database.User{
+			Status:    database.UserStatusActive,
+			RBACRoles: []string{rbac.RoleOwner().Name},
+		})
+
+		// Org admin.
+		orgAdmin := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		member(t, db, org.ID, orgAdmin, rbac.RoleOrgAdmin())
+
+		// Belongs to no organization.
+		orphan := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+
+		// Roles are ignored for users who are not active.
+		suspended := dbgen.User(t, db, database.User{Status: database.UserStatusSuspended})
+		member(t, db, org.ID, suspended, rbac.RoleOrgAdmin())
+
+		// Service accounts are not excluded: the RBAC engine authorizes them
+		// to create workspaces even though they do not consume license seats.
+		serviceAccount := dbgen.User(t, db, database.User{
+			Status:           database.UserStatusActive,
+			IsServiceAccount: true,
+		})
+		member(t, db, org.ID, serviceAccount, rbac.RoleOrgWorkspaceAccess())
+
+		for _, tc := range []struct {
+			name    string
+			userID  uuid.UUID
+			capable bool
+		}{
+			{"workspace-access", wsUser.ID, true},
+			{"gateway", gateway.ID, false},
+			{"creation-ban", banned.ID, false},
+			{"owner", owner.ID, true},
+			{"org-admin", orgAdmin.ID, true},
+			{"no-organization", orphan.ID, false},
+			{"suspended", suspended.ID, false},
+			{"service-account", serviceAccount.ID, true},
+		} {
+			caps, err := checker.Capabilities(ctx, tc.userID)
+			require.NoError(t, err, tc.name)
+			if tc.capable {
+				require.Equal(t, []capabilities.Capability{capabilities.Workspace}, caps, tc.name)
+			} else {
+				require.Empty(t, caps, tc.name)
+			}
+		}
+	})
+
+	t.Run("CustomOrgRole", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		emptyDefaultRoles(t, db, org)
+		checker := newChecker(t, db, quartz.NewMock(t))
+
+		creatorRole, err := db.InsertCustomRole(ctx, database.InsertCustomRoleParams{
+			Name:           "workspace-creator",
+			DisplayName:    "Workspace Creator",
+			OrganizationID: uuid.NullUUID{UUID: org.ID, Valid: true},
+			OrgPermissions: []database.CustomRolePermission{{
+				ResourceType: rbac.ResourceWorkspace.Type,
+				Action:       policy.ActionCreate,
+			}},
+		})
+		require.NoError(t, err)
+
+		creator := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		member(t, db, org.ID, creator, creatorRole.Name)
+
+		caps, err := checker.Capabilities(ctx, creator.ID)
+		require.NoError(t, err)
+		require.Equal(t, []capabilities.Capability{capabilities.Workspace}, caps)
+	})
+
+	t.Run("CachesUntilTTLExpires", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		org := dbgen.Organization(t, db, database.Organization{})
+		emptyDefaultRoles(t, db, org)
+		clock := quartz.NewMock(t)
+		checker := newChecker(t, db, clock)
+
+		user := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		member(t, db, org.ID, user)
+
+		caps, err := checker.Capabilities(ctx, user.ID)
+		require.NoError(t, err)
+		require.Empty(t, caps)
+
+		// Granting the role does not invalidate the cached verdict.
+		_, err = db.UpdateMemberRoles(ctx, database.UpdateMemberRolesParams{
+			GrantedRoles: []string{rbac.RoleOrgWorkspaceAccess()},
+			UserID:       user.ID,
+			OrgID:        org.ID,
+		})
+		require.NoError(t, err)
+
+		caps, err = checker.Capabilities(ctx, user.ID)
+		require.NoError(t, err)
+		require.Empty(t, caps, "cached verdict must be reused within the TTL")
+
+		clock.Advance(capabilities.DefaultCacheTTL + time.Second)
+
+		caps, err = checker.Capabilities(ctx, user.ID)
+		require.NoError(t, err)
+		require.Equal(t, []capabilities.Capability{capabilities.Workspace}, caps)
+	})
+}
+
+func TestNoop(t *testing.T) {
+	t.Parallel()
+	caps, err := capabilities.Noop{}.Capabilities(context.Background(), uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, caps)
+}
+
+func TestStrings(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{}, capabilities.Strings(nil))
+	require.Equal(t, []string{"workspace"}, capabilities.Strings([]capabilities.Capability{
+		capabilities.Workspace, capabilities.Workspace,
+	}))
+}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -56,6 +56,7 @@ import (
 	"github.com/coder/coder/v2/coderd/awsidentity"
 	"github.com/coder/coder/v2/coderd/azureidentity"
 	"github.com/coder/coder/v2/coderd/boundaryusage"
+	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/connectionlog"
 	"github.com/coder/coder/v2/coderd/cryptokeys"
 	"github.com/coder/coder/v2/coderd/database"
@@ -2371,6 +2372,13 @@ type API struct {
 	// routes (license-gated) which apply their own StripPrefix, and by
 	// the in-memory transport (used by chatd, license-exempt).
 	aiGatewayHandler http.Handler
+	// aiBridgeCapabilities resolves the capabilities annotated onto AI Bridge
+	// interceptions. It is built on first use by AIBridgeCapabilityChecker and
+	// shared across gateway connections so its cache survives reconnects. A nil
+	// checker after initialization means annotation is disabled.
+	aiBridgeCapabilitiesMu   sync.Mutex
+	aiBridgeCapabilities     capabilities.Checker
+	aiBridgeCapabilitiesInit bool
 	// AIGatewayServerMetrics records AI budget cost-control metrics. May be nil.
 	AIGatewayServerMetrics *aibridgedserver.Metrics
 

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -2014,6 +2014,7 @@ func AIBridgeInterception(t testing.TB, db database.Store, seed database.InsertA
 		ProviderName:                takeFirst(seed.ProviderName, "provider-name"),
 		Model:                       takeFirst(seed.Model, "model"),
 		Metadata:                    takeFirstSlice(seed.Metadata, json.RawMessage("{}")),
+		Annotations:                 seed.Annotations,
 		StartedAt:                   takeFirst(seed.StartedAt, dbtime.Now()),
 		Client:                      seed.Client,
 		ThreadParentInterceptionID:  seed.ThreadParentInterceptionID,

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1608,7 +1608,8 @@ CREATE TABLE aibridge_interceptions (
     agent_firewall_session_id uuid,
     agent_firewall_sequence_number integer,
     error_type aibridge_interception_error_type,
-    error_message character varying(1024)
+    error_message character varying(1024),
+    annotations jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 COMMENT ON TABLE aibridge_interceptions IS 'Audit log of requests intercepted by AI Bridge';
@@ -1636,6 +1637,8 @@ COMMENT ON COLUMN aibridge_interceptions.agent_firewall_sequence_number IS 'The 
 COMMENT ON COLUMN aibridge_interceptions.error_type IS 'Categorised terminal upstream error for a failed interception; NULL when the interception succeeded.';
 
 COMMENT ON COLUMN aibridge_interceptions.error_message IS 'Raw terminal upstream error message for a failed interception; NULL when the interception succeeded.';
+
+COMMENT ON COLUMN aibridge_interceptions.annotations IS 'Server-derived annotations captured when the interception was recorded, such as the capabilities the initiator held at that time. Distinct from metadata, which is supplied by the client or provider.';
 
 CREATE TABLE aibridge_model_thoughts (
     interception_id uuid NOT NULL,

--- a/coderd/database/gentest/modelqueries_test.go
+++ b/coderd/database/gentest/modelqueries_test.go
@@ -23,10 +23,11 @@ func TestCustomQueriesSyncedRowScan(t *testing.T) {
 	t.Parallel()
 
 	funcsToTrack := map[string]string{
-		"GetTemplatesWithFilter": "GetAuthorizedTemplates",
-		"GetWorkspaces":          "GetAuthorizedWorkspaces",
-		"GetUsers":               "GetAuthorizedUsers",
-		"GetChats":               "GetAuthorizedChats",
+		"GetTemplatesWithFilter":     "GetAuthorizedTemplates",
+		"GetWorkspaces":              "GetAuthorizedWorkspaces",
+		"GetUsers":                   "GetAuthorizedUsers",
+		"GetChats":                   "GetAuthorizedChats",
+		"ListAIBridgeSessionThreads": "ListAuthorizedAIBridgeSessionThreads",
 	}
 
 	// Scan custom

--- a/coderd/database/migrations/000574_aibridge_interception_annotations.down.sql
+++ b/coderd/database/migrations/000574_aibridge_interception_annotations.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE aibridge_interceptions DROP COLUMN annotations;

--- a/coderd/database/migrations/000574_aibridge_interception_annotations.up.sql
+++ b/coderd/database/migrations/000574_aibridge_interception_annotations.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE aibridge_interceptions ADD COLUMN annotations JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN aibridge_interceptions.annotations IS 'Server-derived annotations captured when the interception was recorded, such as the capabilities the initiator held at that time. Distinct from metadata, which is supplied by the client or provider.';

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -1172,6 +1172,7 @@ func (q *sqlQuerier) ListAuthorizedAIBridgeSessionThreads(ctx context.Context, a
 			&i.AIBridgeInterception.AgentFirewallSequenceNumber,
 			&i.AIBridgeInterception.ErrorType,
 			&i.AIBridgeInterception.ErrorMessage,
+			&i.AIBridgeInterception.Annotations,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4723,6 +4723,8 @@ type AIBridgeInterception struct {
 	ErrorType NullAIBridgeInterceptionErrorType `db:"error_type" json:"error_type"`
 	// Raw terminal upstream error message for a failed interception; NULL when the interception succeeded.
 	ErrorMessage sql.NullString `db:"error_message" json:"error_message"`
+	// Server-derived annotations captured when the interception was recorded, such as the capabilities the initiator held at that time. Distinct from metadata, which is supplied by the client or provider.
+	Annotations AIBridgeInterceptionAnnotations `db:"annotations" json:"annotations"`
 }
 
 // Audit log of model thinking in intercepted requests in AI Bridge

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -258,6 +258,11 @@ type sqlcQuerier interface {
 	// @organization_id over the [period_start, period_end) window. Spend is
 	// attributed through the token usage's effective group, and rows are bucketed
 	// by the token usage created_at, matching how ai_user_daily_spend is derived.
+	// Capabilities are annotated per interception, so the distinct values observed
+	// across the interceptions behind each row are collapsed into one
+	// semicolon-separated cell. The capability set is computed in a separate CTE
+	// because the lateral expansion of the annotations array would otherwise
+	// multiply the summed token and cost values.
 	ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error)
 	FavoriteWorkspace(ctx context.Context, id uuid.UUID) error
 	FetchMemoryResourceMonitorsByAgentID(ctx context.Context, agentID uuid.UUID) (WorkspaceAgentMemoryResourceMonitor, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -260,9 +260,9 @@ type sqlcQuerier interface {
 	// by the token usage created_at, matching how ai_user_daily_spend is derived.
 	// Capabilities are annotated per interception, so the distinct values observed
 	// across the interceptions behind each row are collapsed into one
-	// semicolon-separated cell. The capability set is computed in a separate CTE
-	// because the lateral expansion of the annotations array would otherwise
-	// multiply the summed token and cost values.
+	// semicolon-separated cell. The per-interception arrays are aggregated inside
+	// the same GROUP BY as the sums and expanded afterwards, because expanding them
+	// alongside the token usage rows would multiply the summed values.
 	ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error)
 	FavoriteWorkspace(ctx context.Context, id uuid.UUID) error
 	FetchMemoryResourceMonitorsByAgentID(ctx context.Context, agentID uuid.UUID) (WorkspaceAgentMemoryResourceMonitor, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2782,7 +2782,14 @@ WITH usage AS (
 		COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
 		COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
 		COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
-		COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
+		COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros,
+		-- jsonb_array_elements_text errors on a non-array value, so anything
+		-- that is not an array contributes no capabilities.
+		JSONB_AGG(DISTINCT CASE
+			WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
+			THEN ai.annotations -> 'capabilities'
+			ELSE '[]'::jsonb
+		END) AS capability_sets
 	FROM aibridge_token_usages tu
 	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
 	JOIN users ON users.id = ai.initiator_id
@@ -2798,34 +2805,6 @@ WITH usage AS (
 		groups.name,
 		groups.organization_id,
 		organizations.name,
-		ai.model,
-		ai.provider,
-		ai.provider_name
-), capabilities AS (
-	SELECT
-		ai.initiator_id AS user_id,
-		tu.effective_group_id AS group_id,
-		ai.model AS model,
-		ai.provider AS provider,
-		ai.provider_name AS provider_name,
-		STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value) AS capabilities
-	FROM aibridge_token_usages tu
-	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
-	JOIN groups ON groups.id = tu.effective_group_id
-	-- jsonb_array_elements_text errors on a non-array value, so anything that is
-	-- not an array is treated as no capabilities.
-	CROSS JOIN LATERAL jsonb_array_elements_text(
-		CASE WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
-			THEN ai.annotations -> 'capabilities'
-			ELSE '[]'::jsonb
-		END
-	) AS capability(value)
-	WHERE groups.organization_id = $1
-		AND tu.created_at >= $2::timestamptz
-		AND tu.created_at < $3::timestamptz
-	GROUP BY
-		ai.initiator_id,
-		tu.effective_group_id,
 		ai.model,
 		ai.provider,
 		ai.provider_name
@@ -2845,13 +2824,12 @@ SELECT
 	usage.cache_read_tokens,
 	usage.cache_write_tokens,
 	usage.cost_micros,
-	COALESCE(capabilities.capabilities, '')::text AS capabilities
+	COALESCE((
+		SELECT STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value)
+		FROM jsonb_array_elements(usage.capability_sets) AS capability_set(value),
+			jsonb_array_elements_text(capability_set.value) AS capability(value)
+	), '')::text AS capabilities
 FROM usage
-LEFT JOIN capabilities ON capabilities.user_id = usage.user_id
-	AND capabilities.group_id = usage.group_id
-	AND capabilities.model = usage.model
-	AND capabilities.provider = usage.provider
-	AND capabilities.provider_name = usage.provider_name
 ORDER BY usage.user_id, usage.group_id, usage.provider, usage.provider_name, usage.model
 `
 
@@ -2885,9 +2863,9 @@ type ExportOrganizationAISpendRow struct {
 // by the token usage created_at, matching how ai_user_daily_spend is derived.
 // Capabilities are annotated per interception, so the distinct values observed
 // across the interceptions behind each row are collapsed into one
-// semicolon-separated cell. The capability set is computed in a separate CTE
-// because the lateral expansion of the annotations array would otherwise
-// multiply the summed token and cost values.
+// semicolon-separated cell. The per-interception arrays are aggregated inside
+// the same GROUP BY as the sums and expanded afterwards, because expanding them
+// alongside the token usage rows would multiply the summed values.
 func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error) {
 	rows, err := q.db.QueryContext(ctx, exportOrganizationAISpend, arg.OrganizationID, arg.PeriodStart, arg.PeriodEnd)
 	if err != nil {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1211,7 +1211,7 @@ func (q *sqlQuerier) GetAIBridgeChatCost(ctx context.Context, rootChatID uuid.UU
 
 const getAIBridgeInterceptionByID = `-- name: GetAIBridgeInterceptionByID :one
 SELECT
-	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
 FROM
 	aibridge_interceptions
 WHERE
@@ -1242,6 +1242,7 @@ func (q *sqlQuerier) GetAIBridgeInterceptionByID(ctx context.Context, id uuid.UU
 		&i.AgentFirewallSequenceNumber,
 		&i.ErrorType,
 		&i.ErrorMessage,
+		&i.Annotations,
 	)
 	return i, err
 }
@@ -1276,7 +1277,7 @@ func (q *sqlQuerier) GetAIBridgeInterceptionLineageByToolCallID(ctx context.Cont
 
 const getAIBridgeInterceptions = `-- name: GetAIBridgeInterceptions :many
 SELECT
-	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
 FROM
 	aibridge_interceptions
 `
@@ -1311,6 +1312,7 @@ func (q *sqlQuerier) GetAIBridgeInterceptions(ctx context.Context) ([]AIBridgeIn
 			&i.AgentFirewallSequenceNumber,
 			&i.ErrorType,
 			&i.ErrorMessage,
+			&i.Annotations,
 		); err != nil {
 			return nil, err
 		}
@@ -1561,30 +1563,31 @@ func (q *sqlQuerier) GetAIBridgeUserPromptsByInterceptionID(ctx context.Context,
 
 const insertAIBridgeInterception = `-- name: InsertAIBridgeInterception :one
 INSERT INTO aibridge_interceptions (
-	id, api_key_id, initiator_id, provider, provider_name, model, metadata, started_at, client, client_session_id, thread_parent_id, thread_root_id, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number
+	id, api_key_id, initiator_id, provider, provider_name, model, metadata, annotations, started_at, client, client_session_id, thread_parent_id, thread_root_id, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number
 ) VALUES (
-	$1, $2, $3, $4, $5, $6, COALESCE($7::jsonb, '{}'::jsonb), $8, $9, $10, $11::uuid, $12::uuid, $13, $14, $15::uuid, $16
+	$1, $2, $3, $4, $5, $6, COALESCE($7::jsonb, '{}'::jsonb), $8, $9, $10, $11, $12::uuid, $13::uuid, $14, $15, $16::uuid, $17
 )
-RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
 `
 
 type InsertAIBridgeInterceptionParams struct {
-	ID                          uuid.UUID       `db:"id" json:"id"`
-	APIKeyID                    sql.NullString  `db:"api_key_id" json:"api_key_id"`
-	InitiatorID                 uuid.UUID       `db:"initiator_id" json:"initiator_id"`
-	Provider                    string          `db:"provider" json:"provider"`
-	ProviderName                string          `db:"provider_name" json:"provider_name"`
-	Model                       string          `db:"model" json:"model"`
-	Metadata                    json.RawMessage `db:"metadata" json:"metadata"`
-	StartedAt                   time.Time       `db:"started_at" json:"started_at"`
-	Client                      sql.NullString  `db:"client" json:"client"`
-	ClientSessionID             sql.NullString  `db:"client_session_id" json:"client_session_id"`
-	ThreadParentInterceptionID  uuid.NullUUID   `db:"thread_parent_interception_id" json:"thread_parent_interception_id"`
-	ThreadRootInterceptionID    uuid.NullUUID   `db:"thread_root_interception_id" json:"thread_root_interception_id"`
-	CredentialKind              CredentialKind  `db:"credential_kind" json:"credential_kind"`
-	CredentialHint              string          `db:"credential_hint" json:"credential_hint"`
-	AgentFirewallSessionID      uuid.NullUUID   `db:"agent_firewall_session_id" json:"agent_firewall_session_id"`
-	AgentFirewallSequenceNumber sql.NullInt32   `db:"agent_firewall_sequence_number" json:"agent_firewall_sequence_number"`
+	ID                          uuid.UUID                       `db:"id" json:"id"`
+	APIKeyID                    sql.NullString                  `db:"api_key_id" json:"api_key_id"`
+	InitiatorID                 uuid.UUID                       `db:"initiator_id" json:"initiator_id"`
+	Provider                    string                          `db:"provider" json:"provider"`
+	ProviderName                string                          `db:"provider_name" json:"provider_name"`
+	Model                       string                          `db:"model" json:"model"`
+	Metadata                    json.RawMessage                 `db:"metadata" json:"metadata"`
+	Annotations                 AIBridgeInterceptionAnnotations `db:"annotations" json:"annotations"`
+	StartedAt                   time.Time                       `db:"started_at" json:"started_at"`
+	Client                      sql.NullString                  `db:"client" json:"client"`
+	ClientSessionID             sql.NullString                  `db:"client_session_id" json:"client_session_id"`
+	ThreadParentInterceptionID  uuid.NullUUID                   `db:"thread_parent_interception_id" json:"thread_parent_interception_id"`
+	ThreadRootInterceptionID    uuid.NullUUID                   `db:"thread_root_interception_id" json:"thread_root_interception_id"`
+	CredentialKind              CredentialKind                  `db:"credential_kind" json:"credential_kind"`
+	CredentialHint              string                          `db:"credential_hint" json:"credential_hint"`
+	AgentFirewallSessionID      uuid.NullUUID                   `db:"agent_firewall_session_id" json:"agent_firewall_session_id"`
+	AgentFirewallSequenceNumber sql.NullInt32                   `db:"agent_firewall_sequence_number" json:"agent_firewall_sequence_number"`
 }
 
 func (q *sqlQuerier) InsertAIBridgeInterception(ctx context.Context, arg InsertAIBridgeInterceptionParams) (AIBridgeInterception, error) {
@@ -1596,6 +1599,7 @@ func (q *sqlQuerier) InsertAIBridgeInterception(ctx context.Context, arg InsertA
 		arg.ProviderName,
 		arg.Model,
 		arg.Metadata,
+		arg.Annotations,
 		arg.StartedAt,
 		arg.Client,
 		arg.ClientSessionID,
@@ -1628,6 +1632,7 @@ func (q *sqlQuerier) InsertAIBridgeInterception(ctx context.Context, arg InsertA
 		&i.AgentFirewallSequenceNumber,
 		&i.ErrorType,
 		&i.ErrorMessage,
+		&i.Annotations,
 	)
 	return i, err
 }
@@ -2137,7 +2142,7 @@ WITH paginated_threads AS (
 )
 SELECT
 	COALESCE(aibridge_interceptions.thread_root_id, aibridge_interceptions.id) AS thread_id,
-	aibridge_interceptions.id, aibridge_interceptions.initiator_id, aibridge_interceptions.provider, aibridge_interceptions.model, aibridge_interceptions.started_at, aibridge_interceptions.metadata, aibridge_interceptions.ended_at, aibridge_interceptions.api_key_id, aibridge_interceptions.client, aibridge_interceptions.thread_parent_id, aibridge_interceptions.thread_root_id, aibridge_interceptions.client_session_id, aibridge_interceptions.session_id, aibridge_interceptions.provider_name, aibridge_interceptions.credential_kind, aibridge_interceptions.credential_hint, aibridge_interceptions.agent_firewall_session_id, aibridge_interceptions.agent_firewall_sequence_number, aibridge_interceptions.error_type, aibridge_interceptions.error_message
+	aibridge_interceptions.id, aibridge_interceptions.initiator_id, aibridge_interceptions.provider, aibridge_interceptions.model, aibridge_interceptions.started_at, aibridge_interceptions.metadata, aibridge_interceptions.ended_at, aibridge_interceptions.api_key_id, aibridge_interceptions.client, aibridge_interceptions.thread_parent_id, aibridge_interceptions.thread_root_id, aibridge_interceptions.client_session_id, aibridge_interceptions.session_id, aibridge_interceptions.provider_name, aibridge_interceptions.credential_kind, aibridge_interceptions.credential_hint, aibridge_interceptions.agent_firewall_session_id, aibridge_interceptions.agent_firewall_sequence_number, aibridge_interceptions.error_type, aibridge_interceptions.error_message, aibridge_interceptions.annotations
 FROM
 	aibridge_interceptions
 JOIN
@@ -2205,6 +2210,7 @@ func (q *sqlQuerier) ListAIBridgeSessionThreads(ctx context.Context, arg ListAIB
 			&i.AIBridgeInterception.AgentFirewallSequenceNumber,
 			&i.AIBridgeInterception.ErrorType,
 			&i.AIBridgeInterception.ErrorMessage,
+			&i.AIBridgeInterception.Annotations,
 		); err != nil {
 			return nil, err
 		}
@@ -2681,7 +2687,7 @@ UPDATE aibridge_interceptions
 WHERE
 	id = $5::uuid
 	AND ended_at IS NULL
-RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message
+RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
 `
 
 type UpdateAIBridgeInterceptionEndedParams struct {
@@ -2722,6 +2728,7 @@ func (q *sqlQuerier) UpdateAIBridgeInterceptionEnded(ctx context.Context, arg Up
 		&i.AgentFirewallSequenceNumber,
 		&i.ErrorType,
 		&i.ErrorMessage,
+		&i.Annotations,
 	)
 	return i, err
 }
@@ -2760,40 +2767,92 @@ func (q *sqlQuerier) DeleteUserAIBudgetOverride(ctx context.Context, userID uuid
 }
 
 const exportOrganizationAISpend = `-- name: ExportOrganizationAISpend :many
+WITH usage AS (
+	SELECT
+		ai.initiator_id AS user_id,
+		users.username AS username,
+		tu.effective_group_id AS group_id,
+		groups.name AS group_name,
+		groups.organization_id AS organization_id,
+		organizations.name AS organization_name,
+		ai.model AS model,
+		ai.provider AS provider,
+		ai.provider_name AS provider_name,
+		COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
+		COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
+		COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
+		COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
+		COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
+	FROM aibridge_token_usages tu
+	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+	JOIN users ON users.id = ai.initiator_id
+	JOIN groups ON groups.id = tu.effective_group_id
+	JOIN organizations ON organizations.id = groups.organization_id
+	WHERE groups.organization_id = $1
+		AND tu.created_at >= $2::timestamptz
+		AND tu.created_at < $3::timestamptz
+	GROUP BY
+		ai.initiator_id,
+		users.username,
+		tu.effective_group_id,
+		groups.name,
+		groups.organization_id,
+		organizations.name,
+		ai.model,
+		ai.provider,
+		ai.provider_name
+), capabilities AS (
+	SELECT
+		ai.initiator_id AS user_id,
+		tu.effective_group_id AS group_id,
+		ai.model AS model,
+		ai.provider AS provider,
+		ai.provider_name AS provider_name,
+		STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value) AS capabilities
+	FROM aibridge_token_usages tu
+	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+	JOIN groups ON groups.id = tu.effective_group_id
+	-- jsonb_array_elements_text errors on a non-array value, so anything that is
+	-- not an array is treated as no capabilities.
+	CROSS JOIN LATERAL jsonb_array_elements_text(
+		CASE WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
+			THEN ai.annotations -> 'capabilities'
+			ELSE '[]'::jsonb
+		END
+	) AS capability(value)
+	WHERE groups.organization_id = $1
+		AND tu.created_at >= $2::timestamptz
+		AND tu.created_at < $3::timestamptz
+	GROUP BY
+		ai.initiator_id,
+		tu.effective_group_id,
+		ai.model,
+		ai.provider,
+		ai.provider_name
+)
 SELECT
-	ai.initiator_id AS user_id,
-	users.username AS username,
-	tu.effective_group_id AS group_id,
-	groups.name AS group_name,
-	groups.organization_id AS organization_id,
-	organizations.name AS organization_name,
-	ai.model AS model,
-	ai.provider AS provider,
-	ai.provider_name AS provider_name,
-	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
-	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
-	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
-	COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
-	COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
-FROM aibridge_token_usages tu
-JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
-JOIN users ON users.id = ai.initiator_id
-JOIN groups ON groups.id = tu.effective_group_id
-JOIN organizations ON organizations.id = groups.organization_id
-WHERE groups.organization_id = $1
-	AND tu.created_at >= $2::timestamptz
-	AND tu.created_at < $3::timestamptz
-GROUP BY
-	ai.initiator_id,
-	users.username,
-	tu.effective_group_id,
-	groups.name,
-	groups.organization_id,
-	organizations.name,
-	ai.model,
-	ai.provider,
-	ai.provider_name
-ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.provider_name, ai.model
+	usage.user_id,
+	usage.username,
+	usage.group_id,
+	usage.group_name,
+	usage.organization_id,
+	usage.organization_name,
+	usage.model,
+	usage.provider,
+	usage.provider_name,
+	usage.input_tokens,
+	usage.output_tokens,
+	usage.cache_read_tokens,
+	usage.cache_write_tokens,
+	usage.cost_micros,
+	COALESCE(capabilities.capabilities, '')::text AS capabilities
+FROM usage
+LEFT JOIN capabilities ON capabilities.user_id = usage.user_id
+	AND capabilities.group_id = usage.group_id
+	AND capabilities.model = usage.model
+	AND capabilities.provider = usage.provider
+	AND capabilities.provider_name = usage.provider_name
+ORDER BY usage.user_id, usage.group_id, usage.provider, usage.provider_name, usage.model
 `
 
 type ExportOrganizationAISpendParams struct {
@@ -2817,12 +2876,18 @@ type ExportOrganizationAISpendRow struct {
 	CacheReadTokens  int64         `db:"cache_read_tokens" json:"cache_read_tokens"`
 	CacheWriteTokens int64         `db:"cache_write_tokens" json:"cache_write_tokens"`
 	CostMicros       int64         `db:"cost_micros" json:"cost_micros"`
+	Capabilities     string        `db:"capabilities" json:"capabilities"`
 }
 
 // Returns per-user, per-group, per-model, per-provider aggregated AI spend for
 // @organization_id over the [period_start, period_end) window. Spend is
 // attributed through the token usage's effective group, and rows are bucketed
 // by the token usage created_at, matching how ai_user_daily_spend is derived.
+// Capabilities are annotated per interception, so the distinct values observed
+// across the interceptions behind each row are collapsed into one
+// semicolon-separated cell. The capability set is computed in a separate CTE
+// because the lateral expansion of the annotations array would otherwise
+// multiply the summed token and cost values.
 func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOrganizationAISpendParams) ([]ExportOrganizationAISpendRow, error) {
 	rows, err := q.db.QueryContext(ctx, exportOrganizationAISpend, arg.OrganizationID, arg.PeriodStart, arg.PeriodEnd)
 	if err != nil {
@@ -2847,6 +2912,7 @@ func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOr
 			&i.CacheReadTokens,
 			&i.CacheWriteTokens,
 			&i.CostMicros,
+			&i.Capabilities,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -1,8 +1,8 @@
 -- name: InsertAIBridgeInterception :one
 INSERT INTO aibridge_interceptions (
-	id, api_key_id, initiator_id, provider, provider_name, model, metadata, started_at, client, client_session_id, thread_parent_id, thread_root_id, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number
+	id, api_key_id, initiator_id, provider, provider_name, model, metadata, annotations, started_at, client, client_session_id, thread_parent_id, thread_root_id, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number
 ) VALUES (
-	@id, @api_key_id, @initiator_id, @provider, @provider_name, @model, COALESCE(@metadata::jsonb, '{}'::jsonb), @started_at, @client, sqlc.narg('client_session_id'), sqlc.narg('thread_parent_interception_id')::uuid, sqlc.narg('thread_root_interception_id')::uuid, @credential_kind, @credential_hint, sqlc.narg('agent_firewall_session_id')::uuid, sqlc.narg('agent_firewall_sequence_number')
+	@id, @api_key_id, @initiator_id, @provider, @provider_name, @model, COALESCE(@metadata::jsonb, '{}'::jsonb), @annotations, @started_at, @client, sqlc.narg('client_session_id'), sqlc.narg('thread_parent_interception_id')::uuid, sqlc.narg('thread_root_interception_id')::uuid, @credential_kind, @credential_hint, sqlc.narg('agent_firewall_session_id')::uuid, sqlc.narg('agent_firewall_sequence_number')
 )
 RETURNING *;
 

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -421,9 +421,9 @@ ORDER BY effective_group_id;
 -- by the token usage created_at, matching how ai_user_daily_spend is derived.
 -- Capabilities are annotated per interception, so the distinct values observed
 -- across the interceptions behind each row are collapsed into one
--- semicolon-separated cell. The capability set is computed in a separate CTE
--- because the lateral expansion of the annotations array would otherwise
--- multiply the summed token and cost values.
+-- semicolon-separated cell. The per-interception arrays are aggregated inside
+-- the same GROUP BY as the sums and expanded afterwards, because expanding them
+-- alongside the token usage rows would multiply the summed values.
 WITH usage AS (
 	SELECT
 		ai.initiator_id AS user_id,
@@ -439,7 +439,14 @@ WITH usage AS (
 		COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
 		COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
 		COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
-		COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
+		COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros,
+		-- jsonb_array_elements_text errors on a non-array value, so anything
+		-- that is not an array contributes no capabilities.
+		JSONB_AGG(DISTINCT CASE
+			WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
+			THEN ai.annotations -> 'capabilities'
+			ELSE '[]'::jsonb
+		END) AS capability_sets
 	FROM aibridge_token_usages tu
 	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
 	JOIN users ON users.id = ai.initiator_id
@@ -455,34 +462,6 @@ WITH usage AS (
 		groups.name,
 		groups.organization_id,
 		organizations.name,
-		ai.model,
-		ai.provider,
-		ai.provider_name
-), capabilities AS (
-	SELECT
-		ai.initiator_id AS user_id,
-		tu.effective_group_id AS group_id,
-		ai.model AS model,
-		ai.provider AS provider,
-		ai.provider_name AS provider_name,
-		STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value) AS capabilities
-	FROM aibridge_token_usages tu
-	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
-	JOIN groups ON groups.id = tu.effective_group_id
-	-- jsonb_array_elements_text errors on a non-array value, so anything that is
-	-- not an array is treated as no capabilities.
-	CROSS JOIN LATERAL jsonb_array_elements_text(
-		CASE WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
-			THEN ai.annotations -> 'capabilities'
-			ELSE '[]'::jsonb
-		END
-	) AS capability(value)
-	WHERE groups.organization_id = @organization_id
-		AND tu.created_at >= @period_start::timestamptz
-		AND tu.created_at < @period_end::timestamptz
-	GROUP BY
-		ai.initiator_id,
-		tu.effective_group_id,
 		ai.model,
 		ai.provider,
 		ai.provider_name
@@ -502,11 +481,10 @@ SELECT
 	usage.cache_read_tokens,
 	usage.cache_write_tokens,
 	usage.cost_micros,
-	COALESCE(capabilities.capabilities, '')::text AS capabilities
+	COALESCE((
+		SELECT STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value)
+		FROM jsonb_array_elements(usage.capability_sets) AS capability_set(value),
+			jsonb_array_elements_text(capability_set.value) AS capability(value)
+	), '')::text AS capabilities
 FROM usage
-LEFT JOIN capabilities ON capabilities.user_id = usage.user_id
-	AND capabilities.group_id = usage.group_id
-	AND capabilities.model = usage.model
-	AND capabilities.provider = usage.provider
-	AND capabilities.provider_name = usage.provider_name
 ORDER BY usage.user_id, usage.group_id, usage.provider, usage.provider_name, usage.model;

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -419,37 +419,94 @@ ORDER BY effective_group_id;
 -- @organization_id over the [period_start, period_end) window. Spend is
 -- attributed through the token usage's effective group, and rows are bucketed
 -- by the token usage created_at, matching how ai_user_daily_spend is derived.
+-- Capabilities are annotated per interception, so the distinct values observed
+-- across the interceptions behind each row are collapsed into one
+-- semicolon-separated cell. The capability set is computed in a separate CTE
+-- because the lateral expansion of the annotations array would otherwise
+-- multiply the summed token and cost values.
+WITH usage AS (
+	SELECT
+		ai.initiator_id AS user_id,
+		users.username AS username,
+		tu.effective_group_id AS group_id,
+		groups.name AS group_name,
+		groups.organization_id AS organization_id,
+		organizations.name AS organization_name,
+		ai.model AS model,
+		ai.provider AS provider,
+		ai.provider_name AS provider_name,
+		COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
+		COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
+		COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
+		COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
+		COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
+	FROM aibridge_token_usages tu
+	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+	JOIN users ON users.id = ai.initiator_id
+	JOIN groups ON groups.id = tu.effective_group_id
+	JOIN organizations ON organizations.id = groups.organization_id
+	WHERE groups.organization_id = @organization_id
+		AND tu.created_at >= @period_start::timestamptz
+		AND tu.created_at < @period_end::timestamptz
+	GROUP BY
+		ai.initiator_id,
+		users.username,
+		tu.effective_group_id,
+		groups.name,
+		groups.organization_id,
+		organizations.name,
+		ai.model,
+		ai.provider,
+		ai.provider_name
+), capabilities AS (
+	SELECT
+		ai.initiator_id AS user_id,
+		tu.effective_group_id AS group_id,
+		ai.model AS model,
+		ai.provider AS provider,
+		ai.provider_name AS provider_name,
+		STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value) AS capabilities
+	FROM aibridge_token_usages tu
+	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
+	JOIN groups ON groups.id = tu.effective_group_id
+	-- jsonb_array_elements_text errors on a non-array value, so anything that is
+	-- not an array is treated as no capabilities.
+	CROSS JOIN LATERAL jsonb_array_elements_text(
+		CASE WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
+			THEN ai.annotations -> 'capabilities'
+			ELSE '[]'::jsonb
+		END
+	) AS capability(value)
+	WHERE groups.organization_id = @organization_id
+		AND tu.created_at >= @period_start::timestamptz
+		AND tu.created_at < @period_end::timestamptz
+	GROUP BY
+		ai.initiator_id,
+		tu.effective_group_id,
+		ai.model,
+		ai.provider,
+		ai.provider_name
+)
 SELECT
-	ai.initiator_id AS user_id,
-	users.username AS username,
-	tu.effective_group_id AS group_id,
-	groups.name AS group_name,
-	groups.organization_id AS organization_id,
-	organizations.name AS organization_name,
-	ai.model AS model,
-	ai.provider AS provider,
-	ai.provider_name AS provider_name,
-	COALESCE(SUM(tu.input_tokens), 0)::BIGINT AS input_tokens,
-	COALESCE(SUM(tu.output_tokens), 0)::BIGINT AS output_tokens,
-	COALESCE(SUM(tu.cache_read_input_tokens), 0)::BIGINT AS cache_read_tokens,
-	COALESCE(SUM(tu.cache_write_input_tokens), 0)::BIGINT AS cache_write_tokens,
-	COALESCE(SUM(tu.cost_micros), 0)::BIGINT AS cost_micros
-FROM aibridge_token_usages tu
-JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
-JOIN users ON users.id = ai.initiator_id
-JOIN groups ON groups.id = tu.effective_group_id
-JOIN organizations ON organizations.id = groups.organization_id
-WHERE groups.organization_id = @organization_id
-	AND tu.created_at >= @period_start::timestamptz
-	AND tu.created_at < @period_end::timestamptz
-GROUP BY
-	ai.initiator_id,
-	users.username,
-	tu.effective_group_id,
-	groups.name,
-	groups.organization_id,
-	organizations.name,
-	ai.model,
-	ai.provider,
-	ai.provider_name
-ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.provider_name, ai.model;
+	usage.user_id,
+	usage.username,
+	usage.group_id,
+	usage.group_name,
+	usage.organization_id,
+	usage.organization_name,
+	usage.model,
+	usage.provider,
+	usage.provider_name,
+	usage.input_tokens,
+	usage.output_tokens,
+	usage.cache_read_tokens,
+	usage.cache_write_tokens,
+	usage.cost_micros,
+	COALESCE(capabilities.capabilities, '')::text AS capabilities
+FROM usage
+LEFT JOIN capabilities ON capabilities.user_id = usage.user_id
+	AND capabilities.group_id = usage.group_id
+	AND capabilities.model = usage.model
+	AND capabilities.provider = usage.provider
+	AND capabilities.provider_name = usage.provider_name
+ORDER BY usage.user_id, usage.group_id, usage.provider, usage.provider_name, usage.model;

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -62,6 +62,9 @@ sql:
           - column: "custom_roles.member_permissions"
             go_type:
               type: "CustomRolePermissions"
+          - column: "aibridge_interceptions.annotations"
+            go_type:
+              type: "AIBridgeInterceptionAnnotations"
           - column: "provisioner_daemons.tags"
             go_type:
               type: "StringMap"

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -430,6 +430,40 @@ func (a UserLinkClaims) Value() (driver.Value, error) {
 	return json.Marshal(a)
 }
 
+// AIBridgeInterceptionAnnotations holds server-derived annotations recorded on
+// an AI Bridge interception.
+type AIBridgeInterceptionAnnotations struct {
+	// Capabilities lists the capabilities the initiator held when the
+	// interception was recorded. A nil pointer omits the key and means
+	// capabilities were not resolved, which is distinct from a pointer to an
+	// empty slice meaning the initiator held none.
+	Capabilities *[]string `json:"capabilities,omitempty"`
+}
+
+// AIBridgeInterceptionCapabilities returns annotations recording the given
+// capabilities. A nil slice is stored as an empty list rather than an absent
+// key, so the annotations record that resolution ran.
+func AIBridgeInterceptionCapabilities(caps []string) AIBridgeInterceptionAnnotations {
+	if caps == nil {
+		caps = []string{}
+	}
+	return AIBridgeInterceptionAnnotations{Capabilities: &caps}
+}
+
+func (a *AIBridgeInterceptionAnnotations) Scan(src interface{}) error {
+	switch v := src.(type) {
+	case string:
+		return json.Unmarshal([]byte(v), &a)
+	case []byte:
+		return json.Unmarshal(v, &a)
+	}
+	return xerrors.Errorf("unexpected type %T", src)
+}
+
+func (a AIBridgeInterceptionAnnotations) Value() (driver.Value, error) {
+	return json.Marshal(a)
+}
+
 func ParseIP(ipStr string) pqtype.Inet {
 	ip := net.ParseIP(ipStr)
 	ipNet := net.IPNet{}

--- a/docs/ai-coder/agents/platform-controls/spend-management.md
+++ b/docs/ai-coder/agents/platform-controls/spend-management.md
@@ -69,7 +69,7 @@ curl -X GET "https://coder.example.com/api/v2/organizations/$ORGANIZATION/ai/spe
 A successful response has the `Content-Type` header `text/csv; charset=utf-8` and starts with this CSV header:
 
 ```csv
-user_id,username,group_id,group_name,organization_id,organization_name,model,provider,provider_name,input_tokens,output_tokens,cache_read_tokens,cache_write_tokens,cost_micros,period_start,period_end
+user_id,username,capabilities,group_id,group_name,organization_id,organization_name,model,provider,provider_name,input_tokens,output_tokens,cache_read_tokens,cache_write_tokens,cost_micros,period_start,period_end
 ```
 
 The AI Gateway [sessions views](../../ai-gateway/audit.md#navigating-the-ui) show per-request token usage, which is the input to those costs rather than the costs themselves.

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1862,6 +1862,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/ai/spen
 Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
 The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.
 An explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.
+The capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.
 Requires organization-level administrator permissions.
 
 ### Parameters

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1099,10 +1099,10 @@ func (api *API) organizationGroupsAISpend(rw http.ResponseWriter, r *http.Reques
 
 // AISpendExportCSVHeader is the CSV column order for the AI spend export.
 var AISpendExportCSVHeader = []string{
-	"user_id", "username", "group_id", "group_name", "organization_id", "organization_name",
+	"user_id", "username", "capabilities", "group_id", "group_name", "organization_id", "organization_name",
 	"model", "provider", "provider_name",
 	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-	"cost_micros", "period_start", "period_end", "capabilities",
+	"cost_micros", "period_start", "period_end",
 }
 
 // csvFormulaPrefixes are the leading characters a spreadsheet treats as the
@@ -1256,6 +1256,7 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 		if err := cw.Write([]string{
 			row.UserID.String(),
 			escapeCSVCell(row.Username),
+			escapeCSVCell(row.Capabilities),
 			row.GroupID.UUID.String(),
 			escapeCSVCell(row.GroupName),
 			row.OrganizationID.String(),
@@ -1270,7 +1271,6 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 			strconv.FormatInt(row.CostMicros, 10),
 			start,
 			end,
-			escapeCSVCell(row.Capabilities),
 		}); err != nil {
 			logger.Error(ctx, "failed to write AI spend export row", slog.Error(err))
 			httpapi.InternalServerError(rw, err)

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1102,7 +1102,7 @@ var AISpendExportCSVHeader = []string{
 	"user_id", "username", "group_id", "group_name", "organization_id", "organization_name",
 	"model", "provider", "provider_name",
 	"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-	"cost_micros", "period_start", "period_end",
+	"cost_micros", "period_start", "period_end", "capabilities",
 }
 
 // csvFormulaPrefixes are the leading characters a spreadsheet treats as the
@@ -1199,6 +1199,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 // @Description Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.
 // @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.
 // @Description An explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.
+// @Description The capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.
 // @Description Requires organization-level administrator permissions.
 // @ID export-organization-ai-spend-as-csv
 // @Security CoderSessionToken
@@ -1269,6 +1270,7 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 			strconv.FormatInt(row.CostMicros, 10),
 			start,
 			end,
+			escapeCSVCell(row.Capabilities),
 		}); err != nil {
 			logger.Error(ctx, "failed to write AI spend export row", slog.Error(err))
 			httpapi.InternalServerError(rw, err)

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -4296,11 +4296,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// The default window echoes the current UTC month.
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "300", "150", "30", "15", "3000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
-			"",
 		}, records[1])
 	})
 
@@ -4357,11 +4357,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Len(t, records, 2) // header + only the retained row
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2026-03-06T12:00:00Z", "2026-04-01T00:00:00Z",
-			"",
 		}, records[1])
 	})
 
@@ -4410,11 +4410,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Len(t, records, 2) // header + only the start-boundary row
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			start.Format(time.RFC3339), end.Format(time.RFC3339),
-			"",
 		}, records[1])
 	})
 
@@ -4495,11 +4495,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Len(t, records, 2) // header + the retained row
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2024-03-10T07:00:00Z", "2024-03-10T09:00:00Z",
-			"",
 		}, records[1])
 	})
 
@@ -4555,8 +4555,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		periodStart := "2026-03-01T00:00:00Z"
 		periodEnd := "2026-04-01T00:00:00Z"
 		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd, ""}, records[1])
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd, ""}, records[2])
+		require.Equal(t, []string{userID, username, "", groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd}, records[1])
+		require.Equal(t, []string{userID, username, "", groupID, groupName, orgID, orgName, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd}, records[2])
 	})
 
 	t.Run("SeparateRowPerProviderName", func(t *testing.T) {
@@ -4616,8 +4616,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		periodStart := "2026-03-01T00:00:00Z"
 		periodEnd := "2026-04-01T00:00:00Z"
 		// Ordered by provider name: anthropic-dev, then anthropic-prod.
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-dev", "100", "50", "0", "0", "1000", periodStart, periodEnd, ""}, records[1])
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd, ""}, records[2])
+		require.Equal(t, []string{userID, username, "", groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-dev", "100", "50", "0", "0", "1000", periodStart, periodEnd}, records[1])
+		require.Equal(t, []string{userID, username, "", groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd}, records[2])
 	})
 
 	t.Run("UnionsCapabilitiesAcrossInterceptions", func(t *testing.T) {
@@ -4669,11 +4669,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// the capability expansion.
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"workspace",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "300", "150", "0", "0", "3000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
-			"workspace",
 		}, records[1])
 	})
 
@@ -4715,7 +4715,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 
 		records := readAISpendExportResponse(t, res)
 		require.Len(t, records, 2)
-		require.Equal(t, "future;workspace", records[1][len(records[1])-1])
+		require.Equal(t, "future;workspace", records[1][2])
 	})
 
 	t.Run("SeparateRowPerGroup", func(t *testing.T) {
@@ -4781,8 +4781,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// Rows are ordered by group ID, which is a random UUID, so compare
 		// without depending on which group sorts first.
 		require.ElementsMatch(t, [][]string{
-			{userID, username, group.ID.String(), group.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd, ""},
-			{userID, username, secondGroup.ID.String(), secondGroup.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd, ""},
+			{userID, username, "", group.ID.String(), group.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd},
+			{userID, username, "", secondGroup.ID.String(), secondGroup.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd},
 		}, records[1:])
 	})
 
@@ -4835,11 +4835,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Len(t, records, 2) // header + current-month row
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
-			"",
 		}, records[1])
 	})
 
@@ -4950,11 +4950,11 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Len(t, records, 2) // header + the requested organization's row
 		require.Equal(t, []string{
 			owner.UserID.String(), coderdtest.FirstUserParams.Username,
+			"",
 			group.ID.String(), group.Name,
 			owner.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
-			"",
 		}, records[1])
 	})
 
@@ -5000,12 +5000,12 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		require.Len(t, records, 2) // header + the escaped row
 		require.Equal(t, []string{
 			targetUser.ID.String(), targetUser.Username,
+			"",
 			group.ID.String(), group.Name,
 			group.OrganizationID.String(), group.OrganizationName,
 			`'=HYPERLINK("http://insecure/","invoice")`, "'+openai", "'@prod",
 			"100", "50", "0", "0", "1000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
-			"",
 		}, records[1])
 	})
 
@@ -5044,10 +5044,10 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// column names are a published contract that a rename would break.
 		records := readAISpendExportResponse(t, res)
 		require.Equal(t, []string{
-			"user_id", "username", "group_id", "group_name", "organization_id", "organization_name",
+			"user_id", "username", "capabilities", "group_id", "group_name", "organization_id", "organization_name",
 			"model", "provider", "provider_name",
 			"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-			"cost_micros", "period_start", "period_end", "capabilities",
+			"cost_micros", "period_start", "period_end",
 		}, records[0])
 		require.Len(t, records, 1)
 	})

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -19,6 +19,7 @@ import (
 	aiblib "github.com/coder/coder/v2/aibridge"
 	agplaibridge "github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/coderd/audit"
+	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -4299,6 +4300,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "300", "150", "30", "15", "3000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+			"",
 		}, records[1])
 	})
 
@@ -4359,6 +4361,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2026-03-06T12:00:00Z", "2026-04-01T00:00:00Z",
+			"",
 		}, records[1])
 	})
 
@@ -4411,6 +4414,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			start.Format(time.RFC3339), end.Format(time.RFC3339),
+			"",
 		}, records[1])
 	})
 
@@ -4495,6 +4499,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2024-03-10T07:00:00Z", "2024-03-10T09:00:00Z",
+			"",
 		}, records[1])
 	})
 
@@ -4550,8 +4555,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		periodStart := "2026-03-01T00:00:00Z"
 		periodEnd := "2026-04-01T00:00:00Z"
 		// Ordered by provider then model: anthropic/claude-4, then openai/gpt-4.
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd}, records[1])
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd}, records[2])
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd, ""}, records[1])
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "gpt-4", "openai", "openai-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd, ""}, records[2])
 	})
 
 	t.Run("SeparateRowPerProviderName", func(t *testing.T) {
@@ -4611,8 +4616,106 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		periodStart := "2026-03-01T00:00:00Z"
 		periodEnd := "2026-04-01T00:00:00Z"
 		// Ordered by provider name: anthropic-dev, then anthropic-prod.
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-dev", "100", "50", "0", "0", "1000", periodStart, periodEnd}, records[1])
-		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd}, records[2])
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-dev", "100", "50", "0", "0", "1000", periodStart, periodEnd, ""}, records[1])
+		require.Equal(t, []string{userID, username, groupID, groupName, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd, ""}, records[2])
+	})
+
+	t.Run("UnionsCapabilitiesAcrossInterceptions", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-capabilities-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		// Three interceptions collapse into one row: one recorded before
+		// capabilities were annotated, one with no capabilities, and one with
+		// the workspace capability.
+		for _, annotations := range []database.AIBridgeInterceptionAnnotations{
+			{},
+			database.AIBridgeInterceptionCapabilities(nil),
+			database.AIBridgeInterceptionCapabilities([]string{string(capabilities.Workspace)}),
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod",
+				Model: "claude-4", StartedAt: inMonth, Annotations: annotations,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: effectiveGroupID,
+				InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+			})
+		}
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2) // header + one aggregated row
+
+		// Capabilities are unioned into one cell, and the sums are unaffected by
+		// the capability expansion.
+		require.Equal(t, []string{
+			targetUser.ID.String(), targetUser.Username,
+			group.ID.String(), group.Name,
+			group.OrganizationID.String(), group.OrganizationName,
+			"claude-4", "anthropic", "anthropic-prod", "300", "150", "0", "0", "3000",
+			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+			"workspace",
+		}, records[1])
+	})
+
+	t.Run("MultipleCapabilitiesAreSemicolonSeparated", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-multi-capabilities-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod",
+			Model: "claude-4", StartedAt: inMonth,
+			// A capability that does not exist yet is still exported verbatim,
+			// and values are emitted in sorted order.
+			Annotations: database.AIBridgeInterceptionCapabilities([]string{"workspace", "future"}),
+		}, nil)
+		dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+			InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: effectiveGroupID,
+			InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+		})
+
+		// Now: 15 March 2026 12:00 UTC.
+		res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		records := readAISpendExportResponse(t, res)
+		require.Len(t, records, 2)
+		require.Equal(t, "future;workspace", records[1][len(records[1])-1])
 	})
 
 	t.Run("SeparateRowPerGroup", func(t *testing.T) {
@@ -4678,8 +4781,8 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		// Rows are ordered by group ID, which is a random UUID, so compare
 		// without depending on which group sorts first.
 		require.ElementsMatch(t, [][]string{
-			{userID, username, group.ID.String(), group.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd},
-			{userID, username, secondGroup.ID.String(), secondGroup.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd},
+			{userID, username, group.ID.String(), group.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000", periodStart, periodEnd, ""},
+			{userID, username, secondGroup.ID.String(), secondGroup.Name, orgID, orgName, "claude-4", "anthropic", "anthropic-prod", "500", "250", "0", "0", "5000", periodStart, periodEnd, ""},
 		}, records[1:])
 	})
 
@@ -4736,6 +4839,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			group.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+			"",
 		}, records[1])
 	})
 
@@ -4850,6 +4954,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			owner.OrganizationID.String(), group.OrganizationName,
 			"claude-4", "anthropic", "anthropic-prod", "100", "50", "0", "0", "1000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+			"",
 		}, records[1])
 	})
 
@@ -4900,6 +5005,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			`'=HYPERLINK("http://insecure/","invoice")`, "'+openai", "'@prod",
 			"100", "50", "0", "0", "1000",
 			"2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z",
+			"",
 		}, records[1])
 	})
 
@@ -4941,7 +5047,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			"user_id", "username", "group_id", "group_name", "organization_id", "organization_name",
 			"model", "provider", "provider_name",
 			"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-			"cost_micros", "period_start", "period_end",
+			"cost_micros", "period_start", "period_end", "capabilities",
 		}, records[0])
 		require.Len(t, records, 1)
 	})

--- a/enterprise/coderd/aibridgeserve.go
+++ b/enterprise/coderd/aibridgeserve.go
@@ -134,10 +134,17 @@ func (api *API) aiGatewayServe(rw http.ResponseWriter, r *http.Request) {
 	go aiGatewayCheckEntitlementAndTrackKeyUsage(connCtx, keyCtxCancel, api, gatewayKey.ID, logger)
 
 	mux := drpcmux.New()
+	capabilityChecker, err := api.AGPL.AIBridgeCapabilityChecker()
+	if err != nil {
+		logger.Error(connCtx, "build capability checker failed", slog.Error(err))
+		_ = conn.Close(websocket.StatusInternalError, httpapi.WebsocketCloseSprintf("build capability checker: %s", err))
+		return
+	}
 	srv, err := aibridgedserver.NewServer(connCtx, aibridgedserver.Options{
 		Store:               api.Database,
 		Pubsub:              api.AGPL.Pubsub,
 		AISeatTracker:       api.AGPL.AISeatTracker,
+		CapabilityChecker:   capabilityChecker,
 		Enqueuer:            api.AGPL.NotificationsEnqueuer,
 		AccessURL:           api.AccessURL.String(),
 		GatewayCfg:          api.DeploymentValues.AI.BridgeConfig,

--- a/enterprise/coderd/license/usercount_test.go
+++ b/enterprise/coderd/license/usercount_test.go
@@ -2,6 +2,7 @@ package license_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/capabilities"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -610,6 +612,89 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			require.ErrorIs(t, err, context.Canceled)
 		})
 	})
+}
+
+// TestWorkspaceCapabilityMatchesSeatCount pins the workspace capability
+// resolved per user to the workspace-create check that counts license seats.
+// The two evaluate the same permission through separate code paths, so they can
+// drift independently.
+func TestWorkspaceCapabilityMatchesSeatCount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	authorizer := rbac.NewCachingAuthorizer(prometheus.NewRegistry())
+	db, _ := dbtestutil.NewDB(t)
+
+	checker, err := capabilities.NewDBChecker(capabilities.Options{
+		DB:         db,
+		Authorizer: authorizer,
+		Logger:     testutil.Logger(t),
+	})
+	require.NoError(t, err)
+
+	orgA := dbgen.Organization(t, db, database.Organization{})
+	orgB := dbgen.Organization(t, db, database.Organization{})
+	for _, org := range []database.Organization{orgA, orgB} {
+		_, err := db.UpdateOrganization(ctx, database.UpdateOrganizationParams{
+			ID:                    org.ID,
+			UpdatedAt:             dbtime.Now(),
+			Name:                  org.Name,
+			DisplayName:           org.DisplayName,
+			Description:           org.Description,
+			Icon:                  org.Icon,
+			DefaultOrgMemberRoles: []string{},
+		})
+		require.NoError(t, err)
+	}
+
+	member := func(orgID uuid.UUID, user database.User, roles ...string) {
+		dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			OrganizationID: orgID,
+			UserID:         user.ID,
+			Roles:          roles,
+		})
+	}
+
+	// Every seeded user is active and not a service account, so seat counting
+	// and capability resolution consider the same population.
+	var users []database.User
+	newUser := func(seed database.User) database.User {
+		seed.Status = database.UserStatusActive
+		user := dbgen.User(t, db, seed)
+		users = append(users, user)
+		return user
+	}
+
+	member(orgA.ID, newUser(database.User{}))
+	member(orgA.ID, newUser(database.User{}), rbac.RoleOrgWorkspaceAccess())
+	member(orgA.ID, newUser(database.User{}), rbac.RoleOrgWorkspaceAccess(), rbac.RoleOrgWorkspaceCreationBan())
+	member(orgA.ID, newUser(database.User{}), rbac.RoleOrgAdmin())
+	member(orgA.ID, newUser(database.User{}), rbac.RoleOrgAuditor())
+	member(orgA.ID, newUser(database.User{RBACRoles: []string{rbac.RoleOwner().Name}}))
+	member(orgA.ID, newUser(database.User{RBACRoles: []string{rbac.RoleTemplateAdmin().Name}}))
+	member(orgA.ID, newUser(database.User{RBACRoles: []string{rbac.RoleAuditor().Name}}))
+	newUser(database.User{})
+	newUser(database.User{RBACRoles: []string{rbac.RoleOwner().Name}})
+
+	split := newUser(database.User{})
+	member(orgA.ID, split)
+	member(orgB.ID, split, rbac.RoleOrgWorkspaceAccess())
+
+	bannedSplit := newUser(database.User{})
+	member(orgA.ID, bannedSplit, rbac.RoleOrgWorkspaceAccess(), rbac.RoleOrgWorkspaceCreationBan())
+	member(orgB.ID, bannedSplit, rbac.RoleOrgWorkspaceAccess())
+
+	var capable int64
+	for _, user := range users {
+		caps, err := checker.Capabilities(ctx, user.ID)
+		require.NoError(t, err)
+		if slices.Contains(caps, capabilities.Workspace) {
+			capable++
+		}
+	}
+
+	count, err := license.CountWorkspaceCapableUsers(ctx, testutil.Logger(t), db, authorizer)
+	require.NoError(t, err)
+	require.Equal(t, count, capable)
 }
 
 // TestCountWorkspaceCapableUsersErrors covers the count's database


### PR DESCRIPTION
Annotates AI Bridge interceptions with the capabilities the initiating user held at the time, and surfaces them in the organization AI spend CSV export. The only capability today is `workspace`.

## What changed

- **`coderd/capabilities`** (new): `DBChecker` resolves a user's capabilities by expanding their stored roles and authorizing `ActionCreate` on `ResourceWorkspace.AnyOrganization().WithOwner(userID)`, the same permission that counts license seats. Results are cached per user for 5 minutes. Non-active users resolve to no capabilities; service accounts are not excluded, since RBAC genuinely authorizes them even though they never consume a seat.
- **Schema**: migration `000574` adds `aibridge_interceptions.annotations jsonb NOT NULL DEFAULT '{}'`, typed as `database.AIBridgeInterceptionAnnotations`. `capabilities` is a pointer slice, so an absent key means "not resolved" and `[]` means "resolved, held none". `annotations` is server-derived, unlike the client-supplied `metadata` column.
- **Write path**: `aibridgedserver.RecordInterception` resolves capabilities before insert. Resolution failures log and record `{}` rather than failing the user's request.
- **Export**: `ExportOrganizationAISpend` computes the capability set in a separate CTE and left-joins it onto the existing aggregate, so the lateral expansion of the annotations array cannot multiply the summed tokens and cost. The new trailing `capabilities` CSV column holds the distinct union across the interceptions behind each row, semicolon-separated.

Gated on the existing `workspace-capable-licensing` experiment: with it disabled, interceptions are unannotated and the column is empty. The column is always present in the header, since the header is an exported contract.

Also fixes `ListAuthorizedAIBridgeSessionThreads`, whose hand-written scan in `modelqueries.go` enumerates interception columns and needed the new field.

## Known gaps

- A cell reading `workspace` means the capability was held at some point in the period, not throughout it.
- Rows recorded before the experiment was enabled are indistinguishable from rows where the user held nothing, once unioned.
- The workspace-create expression is duplicated rather than shared with `enterprise/coderd/license/usercount.go`, since AGPL cannot import enterprise. `TestWorkspaceCapabilityMatchesSeatCount` pins the two together.

<details>
<summary>Implementation plan</summary>

# Plan: annotate AI Bridge interceptions with user capabilities

## Goal

Record, on each `aibridge_interceptions` row, a snapshot of the capabilities the
initiating user held at interception time. The only capability to start is
`workspace`, derived from the same RBAC check that the permission-based
licensing experiment uses to count seats. Surface the capability set as a new
column in the organization AI spend CSV export.

## Confirmed decisions

| Decision | Choice |
|---|---|
| CSV aggregation | Distinct union across the grouped interceptions, sorted, `;`-joined into one cell |
| Computation point | Synchronously in `aibridgedserver.RecordInterception`, before the insert |
| Shared permission logic | Duplicate the authorize expression in AGPL, with a parity test against licensing |
| Experiment gating | Gated on `workspace-capable-licensing` (`ExperimentWorkspaceCapableLicensing`) |

## Current state (verified)

- Table `aibridge_interceptions` (`coderd/database/dump.sql:1591-1612`). Latest
  migration is `000573_audit_chat_instruction_settings`, so the next number is
  `000574`. Existing jsonb precedent on this table: `metadata jsonb DEFAULT NULL`
  (`migrations/000372_aibridge_interception_metadata.up.sql`), which is
  client/provider-supplied. `annotations` is server-derived, so a separate column
  is the right call.
- Insert: `InsertAIBridgeInterception`
  (`coderd/database/queries/aibridge.sql:1-7`), sole production caller
  `coderd/aibridgedserver/aibridgedserver.go:257-275` inside
  `RecordInterception` (line 195). Auth context there is
  `dbauthz.AsAIBridged(ctx)`; the insert is **not** in a transaction, and the
  call is synchronous, so an error fails the user's request
  (`aibridge/bridge.go:325-331`).
- At that point only `initiator_id` and `api_key_id` are available. No
  organization ID; org attribution happens later via
  `aibridge_token_usages.effective_group_id`.
- Export: `AISpendExportCSVHeader`
  (`enterprise/coderd/aibridge.go:1100-1106`, 16 columns),
  `exportOrganizationAISpend` (L1212-1298), SQL
  `ExportOrganizationAISpend` (`coderd/database/queries/aicostcontrol.sql:417-455`).
  Grain: (user x effective group x model x provider x provider_name).
  Only consumer is `codersdk.Client.ExportOrganizationAISpend`; nothing in
  `site/src` reads the CSV.
- Licensing check: `canCreateWorkspace`
  (`enterprise/coderd/license/usercount.go:140-154`):
  `authorizer.Authorize(ctx, subject, policy.ActionCreate,
  rbac.ResourceWorkspace.AnyOrganization().WithOwner(subject.ID))` with roles
  expanded via `rolestore.Expand` under `dbauthz.AsSystemRestricted`. Nothing is
  persisted or materialized; the seat count only lives in the entitlements
  snapshot, refreshed at most every 10 minutes.
- `aibridgedserver.Server` has **no** `rbac.Authorizer` and its `store` is a
  narrow interface, not `database.Store`. `rolestore.Expand` and
  `PrefetchCustomRoles` require the full `database.Store`.

## Implementation steps

### 1. AGPL capability checker package

New package `capabilities` at `coderd/capabilities`, holding:

- `type Capability string`, `const Workspace Capability = "workspace"` (referenced
  as `capabilities.Workspace`, avoiding the `capabilities.CapabilityWorkspace`
  stutter).
- `type Checker interface { Capabilities(ctx context.Context, userID uuid.UUID) ([]Capability, error) }`.
- `Noop` implementation returning nil, used when the experiment is off or in
  tests.
- `DBChecker` holding `database.Store`, `rbac.Authorizer`, `slog.Logger`,
  `quartz.Clock`. It:
  1. reads the user's roles/groups via `GetAuthorizationUserRoles` under
     `dbauthz.AsSystemRestricted` (`//nolint:gocritic`),
  2. builds an `rbac.Subject` with `ScopeAll` and `WithCachedASTValue()`,
     expanding roles with `rolestore.Expand`,
  3. returns `CapabilityWorkspace` when
     `Authorize(ctx, subject, policy.ActionCreate,
     rbac.ResourceWorkspace.AnyOrganization().WithOwner(userID.String()))`
     returns nil.
- A TTL cache keyed by user ID (proposed TTL 5 minutes, `quartz.Clock` for
  tests, bounded map with eviction) so the hot path does not run a roles query
  and an authorize call on every interception.

This is the deliberately duplicated expression. Guard it with a parity test
(step 6).

### 2. Wire the checker into aibridged

- Add `Capabilities capabilities.Checker` to `aibridgedserver.Options` and a
  field on `Server`. Nil means "do not annotate", so the ~10 existing
  `NewServer` call sites in tests keep compiling.
- Construct the real checker in `coderd/aibridged.go:68` (that scope has
  `database.Store` and `api.HTTPAuth.Authorizer`), only when
  `api.Experiments.Enabled(codersdk.ExperimentWorkspaceCapableLicensing)`;
  otherwise pass nil.

### 3. Schema and generated code

- Migration `000574_aibridge_interception_annotations.{up,down}.sql`:
  `ALTER TABLE aibridge_interceptions ADD COLUMN annotations jsonb NOT NULL
  DEFAULT '{}'::jsonb;` plus a `COMMENT ON COLUMN` describing it as
  server-derived annotations. Down drops the column. No `BEGIN`/`COMMIT`.
- `coderd/database/types.go`: `AIBridgeInterceptionAnnotations struct {
  Capabilities []string \`json:"capabilities,omitempty"\` }` with `Scan`/`Value`
  following the `UserLinkClaims` pattern, and a `sqlc.yaml` column override for
  `aibridge_interceptions.annotations`.
- Add `annotations` to the `InsertAIBridgeInterception` column list and params.
- `make gen`, then re-check `enterprise/audit/table.go` (currently no aibridge
  entries, so expected to be a no-op) and update
  `coderd/database/dbgen/dbgen.go:2008` if the helper needs the new field.

### 4. Populate on insert

In `RecordInterception`, before the insert: if the checker is non-nil, resolve
capabilities for `initiator_id` and set `Annotations`. On error, log at warn and
insert `{}` rather than failing the request, since this is metadata, not
enforcement.

Semantics to lock in: when the experiment is on, always write the
`capabilities` key (empty array when the user has none), so an absent key means
"not computed". This is the only way to distinguish "no capabilities" from
"annotation disabled".

### 5. CSV export column

- Append `capabilities` to `AISpendExportCSVHeader` and the matching cell in the
  `cw.Write` slice, wrapped in `escapeCSVCell`.
- Rewrite `ExportOrganizationAISpend` as two CTEs joined on the grain, so the
  capability fan-out cannot multiply the `SUM`s:
  - `usage`: the current aggregate, unchanged.
  - `caps`: same joins and filters, plus
    `CROSS JOIN LATERAL jsonb_array_elements_text(CASE WHEN
    jsonb_typeof(ai.annotations -> 'capabilities') = 'array' THEN
    ai.annotations -> 'capabilities' ELSE '[]'::jsonb END) AS cap(value)`,
    aggregated with `STRING_AGG(DISTINCT cap.value, ';' ORDER BY cap.value)`,
    grouped by the same keys.
  - `SELECT usage.*, COALESCE(caps.capabilities, '')` with a `LEFT JOIN`.
  The `jsonb_typeof` guard matters: `jsonb_array_elements_text` errors on a
  non-array value, which would break the whole export.
- Keep `organization_id` in the select list; `modelmethods.go:477` RBAC object
  depends on it.
- Update the swagger `@Description` on the handler to document the new column.
- Column is always present in the header regardless of the experiment; it is
  simply empty when nothing was annotated. A conditional header would break the
  exported-constant contract and its equality assertions.

### 6. Tests

- `coderd/capabilities`: unit tests for member vs auditor vs owner vs
  template-admin subjects, users with no org, and cache expiry via `quartz`.
- Parity test in `enterprise/coderd/license` (enterprise may import AGPL):
  seed a matrix of role/group combinations, assert
  `CountWorkspaceCapableUsers` equals the number of users the AGPL checker
  reports as workspace-capable. This is the guard for the duplicated
  expression.
- `coderd/aibridgedserver/aibridgedserver_test.go`: interception rows get
  `{"capabilities":["workspace"]}` for a capable user, `{"capabilities":[]}` for
  an incapable one, `{}` when the checker is nil, and the request still succeeds
  when the checker errors.
- `enterprise/coderd/aibridge_test.go` (`TestExportOrganizationAISpend`,
  L4128): new subtests for union across interceptions with differing
  capabilities, empty cell for legacy rows, unchanged `SUM`s when the lateral
  join is present, and formula escaping. Update the header assertions at L4292
  and L4776, and check `coderd/database/dbauthz/dbauthz_test.go:6917`.
- `make lint`, `make gen` clean, `make test RUN=...` on the touched packages.

## Gaps and risks to resolve

1. **Hot-path cost.** Every first interception per user per TTL adds one query
   plus role expansion and an authorize call to a synchronous, user-facing path.
   Need agreement on the TTL (5 minutes proposed) and on cache eviction bounds.
   Staleness is arguably fine given entitlements are already up to 10 minutes
   stale, but it means a user who just gained the role can be annotated
   incorrectly for up to the TTL.
2. **Duplicated expression drift.** The parity test reduces but does not
   eliminate this. If licensing changes its subject construction (for example
   the synthetic `countingSubjectID` canonicalization), the two paths can
   diverge in ways the seeded matrix does not cover.
3. **Service accounts and system users.** Seat counting excludes
   `is_system` and `is_service_account` users at the SQL level. The per-user
   checker has no such filter, so a service account initiating an interception
   could be annotated `workspace` while never counting as a seat. Decide:
   mirror the exclusion in the checker, or accept the difference.
4. **Mixed data when the experiment flips.** Rows recorded while the experiment
   was off have `{}`, so a period spanning the flip yields a partial union. The
   CSV cannot express "unknown" versus "none" per row. Acceptable for an
   experiment, worth documenting.
5. **Union semantics are lossy for reporting.** A cell reading `workspace`
   means "held at some point during the period", not "held throughout". If the
   consumer wants seat-accurate reporting, `GROUP BY` on capabilities is the
   more faithful shape and can be revisited.
6. **No API surface yet.** `annotations` will not be exposed through the
   sessions API or `codersdk`/`db2sdk`. Confirm that CSV-only is sufficient for
   now.
7. **Naming.** `annotations` versus reusing `metadata`, and `capabilities`
   values as a flat string list versus an object. A flat list is
   forward-compatible for adding capabilities, but cannot carry per-capability
   detail later without a shape change.
8. **Retention interaction.** `DeleteOldAIBridgeRecords` purges interceptions,
   so exports past the retention window lose capability data alongside spend
   data. Consistent with existing behavior; no action expected.
9. **Backfill.** None planned. Confirm that historical rows staying empty is
   acceptable.

## Out of scope

- Additional capabilities beyond `workspace`.
- Frontend display; there is no frontend consumer of this CSV.
- Changing how licensing counts seats.

</details>

---

Created by Coder Agents on behalf of @jscottmiller.
