### PR TITLE
feat(site/src/pages/AgentsPage/components/ChatsSidebar): add a persistent bot-icon expand toggle for subagents

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatActionsMenuItems.tsx
+++ b/site/src/pages/AgentsPage/components/ChatActionsMenuItems.tsx
@@ -1,7 +1,7 @@
 import {
 	ArchiveIcon,
 	ArchiveRestoreIcon,
-	GitForkIcon,
+	BotIcon,
 	PinIcon,
 	PinOffIcon,
 	SquarePenIcon,
@@ -81,7 +81,7 @@ export const ChatActionsMenuItems: FC<ChatActionsMenuItemsProps> = ({
 
 	const subagentToggle = showSubagentsToggle ? (
 		<Item onSelect={onToggleSubagents}>
-			<GitForkIcon className="size-3.5 rotate-180" />
+			<BotIcon className="size-3.5" />
 			{isSubagentsExpanded
 				? "Hide subagents"
 				: `Show subagents (${subagentCount})`}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -475,17 +475,16 @@ export const RunningChatPreservesSpinner: Story = {
 		const spinner = node.querySelector(".animate-spin");
 		await expect(spinner).toBeInTheDocument();
 
-		// The toggle button should exist (the node has children) but
-		// must be invisible by default. It only appears on hover of
-		// the icon area itself, not the whole row.
+		// The subagent count doubles as a persistent expand toggle, so it
+		// is always visible when the node has children (no hover required).
 		const toggle = canvas.getByTestId("agents-tree-toggle-root-running");
 		await expect(toggle).toBeInTheDocument();
-		await expect(toggle.className).toMatch(/\binvisible\b/);
+		await expect(toggle.className).not.toMatch(/\binvisible\b/);
 	},
 };
 
-// When a root chat is idle but has a running child, the chevron
-// should still be scoped to the icon area hover, not the full row.
+// When a root chat is idle but has a running child, the persistent
+// expand toggle next to the subagent count is still shown.
 export const IdleParentWithRunningChild: Story = {
 	args: {
 		chats: [
@@ -517,12 +516,12 @@ export const IdleParentWithRunningChild: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 
-		// The parent's toggle should use icon-only hover scope because
-		// its child is actively running.
+		// The parent exposes a persistent expand toggle next to its
+		// subagent count, regardless of the running child.
 		const toggle = canvas.getByTestId("agents-tree-toggle-idle-parent");
 		await expect(toggle).toBeInTheDocument();
-		await expect(toggle.className).toMatch(/\binvisible\b/);
-		await expect(toggle.className).toContain("group-hover/icon:visible");
+		await expect(toggle.className).not.toMatch(/\binvisible\b/);
+		await expect(toggle).toHaveAttribute("aria-expanded", "true");
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -2087,6 +2087,68 @@ export const SubagentsMenuToggle: Story = {
 	},
 };
 
+// The on-row subagent count (`N` + bot icon) is a button: clicking it expands
+// the collapsed parent without navigating away, and its accessible label flips
+// from "Show N subagents" to "Hide N subagents".
+export const SubagentsCountToggle: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "root-subagents",
+				title: "Parent with subagents",
+				workspace_id: "workspace-1",
+				updated_at: recentTimestamp,
+				children: [
+					buildChat({
+						id: "subagent-1",
+						title: "Subagent one",
+						parent_chat_id: "root-subagents",
+						root_chat_id: "root-subagents",
+					}),
+					buildChat({
+						id: "subagent-2",
+						title: "Subagent two",
+						parent_chat_id: "root-subagents",
+						root_chat_id: "root-subagents",
+					}),
+				],
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			// Route to the parent so the tree starts collapsed and the count reads
+			// "Show 2 subagents".
+			location: {
+				path: "/agents/root-subagents",
+				pathParams: { agentId: "root-subagents" },
+			},
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("Parent with subagents")).toBeInTheDocument();
+		});
+		// Collapsed by default: children are not rendered yet.
+		expect(canvas.queryByText("Subagent one")).not.toBeInTheDocument();
+
+		const countToggle = canvas.getByRole("button", {
+			name: "Show 2 subagents",
+		});
+		await userEvent.click(countToggle);
+
+		// Clicking the count expands the children without navigating away.
+		await waitFor(() => {
+			expect(canvas.getByText("Subagent one")).toBeInTheDocument();
+		});
+		expect(
+			canvas.getByRole("button", { name: "Hide 2 subagents" }),
+		).toBeInTheDocument();
+	},
+};
+
 export const ArchivedChildChatRowHasNoActionsMenu: Story = {
 	args: {
 		chats: [

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -225,7 +225,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												role="button"
 												tabIndex={0}
 												data-testid={`agents-tree-toggle-${chat.id}`}
-												className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 rounded-sm text-[13px] leading-4 tabular-nums text-content-secondary hover:text-content-primary"
+												className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 rounded-sm text-content-secondary hover:text-content-primary"
 												aria-expanded={isExpanded}
 												aria-label={`${
 													isExpanded ? "Hide" : "Show"
@@ -233,7 +233,6 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 													childIDs.length === 1 ? "subagent" : "subagents"
 												}`}
 											>
-												{childIDs.length}
 												<BotIcon className="size-3.5" aria-hidden="true" />
 												<ChevronDownIcon
 													aria-hidden="true"

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -187,44 +187,15 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 							"has-[[aria-current=page]]:bg-surface-quaternary/25 has-[[aria-current=page]]:text-content-primary [@media(hover:hover)]:has-[[aria-current=page]]:hover:bg-surface-quaternary/50",
 						)}
 					>
-						<div
-							className={cn(
-								"group/icon relative mt-1.5 size-5 shrink-0",
-								hasChildren && "cursor-pointer",
-							)}
-						>
-							<div
-								className={cn(
-									"flex size-5 items-center justify-center rounded-md",
-									hasChildren &&
-										"[@media(hover:hover)]:group-hover/icon:invisible",
-								)}
-							>
-								<StatusIcon
-									data-testid={
-										isDelegatedExecuting
-											? `agents-tree-executing-${chat.id}`
-											: undefined
-									}
-									className={cn("size-3.5 shrink-0", statusClassName)}
-								/>
-							</div>
-							{hasChildren && (
-								<Button
-									variant="subtle"
-									size="icon"
-									onClick={() => toggleExpanded(chatID)}
-									className={cn(
-										"absolute inset-0 invisible flex size-5 min-w-0 items-center justify-center rounded-md p-0 text-content-secondary/60 hover:text-content-primary [&>svg]:size-3.5",
-										"[@media(hover:hover)]:group-hover/icon:visible",
-									)}
-									data-testid={`agents-tree-toggle-${chat.id}`}
-									aria-label={isExpanded ? "Collapse" : "Expand"}
-									aria-expanded={isExpanded}
-								>
-									{isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
-								</Button>
-							)}
+						<div className="mt-1.5 flex size-5 shrink-0 items-center justify-center rounded-md">
+							<StatusIcon
+								data-testid={
+									isDelegatedExecuting
+										? `agents-tree-executing-${chat.id}`
+										: undefined
+								}
+								className={cn("size-3.5 shrink-0", statusClassName)}
+							/>
 						</div>
 						<NavLink
 							to={{
@@ -254,6 +225,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												{...subagentToggleProps}
 												role="button"
 												tabIndex={0}
+												data-testid={`agents-tree-toggle-${chat.id}`}
 												className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 rounded-sm text-[13px] leading-4 tabular-nums text-content-secondary hover:text-content-primary"
 												aria-expanded={isExpanded}
 												aria-label={`${
@@ -264,6 +236,17 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											>
 												{childIDs.length}
 												<BotIcon className="size-3.5" aria-hidden="true" />
+												{isExpanded ? (
+													<ChevronDownIcon
+														className="size-3.5"
+														aria-hidden="true"
+													/>
+												) : (
+													<ChevronRightIcon
+														className="size-3.5"
+														aria-hidden="true"
+													/>
+												)}
 											</span>
 										)}
 										{hasLinkedDiffStatus && hasLineStats && (

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -249,19 +249,6 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 										)}
 									</div>
 									<div className="flex min-w-0 items-center gap-1.5">
-										{hasLinkedDiffStatus && hasLineStats && (
-											<span
-												className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 tabular-nums"
-												title={`${filesChangedLabel}, +${additions} -${deletions}`}
-											>
-												<span className="text-git-added-bright">
-													+{additions}
-												</span>
-												<span className="text-git-deleted-bright">
-													&minus;{deletions}
-												</span>
-											</span>
-										)}
 										{hasChildren && (
 											<span
 												{...subagentToggleProps}
@@ -277,6 +264,19 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											>
 												{childIDs.length}
 												<BotIcon className="size-3.5" aria-hidden="true" />
+											</span>
+										)}
+										{hasLinkedDiffStatus && hasLineStats && (
+											<span
+												className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 tabular-nums"
+												title={`${filesChangedLabel}, +${additions} -${deletions}`}
+											>
+												<span className="text-git-added-bright">
+													+{additions}
+												</span>
+												<span className="text-git-deleted-bright">
+													&minus;{deletions}
+												</span>
 											</span>
 										)}
 										<div

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -24,6 +24,7 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import { Spinner } from "#/components/Spinner/Spinner";
+import { useClickable } from "#/hooks/useClickable";
 import { cn } from "#/utils/cn";
 import { shortRelativeTime } from "#/utils/time";
 import {
@@ -140,6 +141,12 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 	const workspaceId = chat.workspace_id;
 	const isArchivingThisChat = isArchiving && archivingChatId === chat.id;
 	const isExpanded = normalizedSearch ? true : (expandedById[chatID] ?? false);
+	const subagentToggleProps = useClickable<HTMLSpanElement>((event) => {
+		// Prevent the surrounding NavLink from navigating; just toggle the row.
+		event.preventDefault();
+		event.stopPropagation();
+		toggleExpanded(chatID);
+	});
 
 	const hasMenuActions = chatHasMenuActions({
 		isArchived: chat.archived,
@@ -242,17 +249,6 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 										)}
 									</div>
 									<div className="flex min-w-0 items-center gap-1.5">
-										{hasChildren && (
-											<span
-												className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 tabular-nums text-content-secondary"
-												title={`${childIDs.length} ${
-													childIDs.length === 1 ? "subagent" : "subagents"
-												}`}
-											>
-												{childIDs.length}
-												<BotIcon className="size-3.5" aria-hidden="true" />
-											</span>
-										)}
 										{hasLinkedDiffStatus && hasLineStats && (
 											<span
 												className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 tabular-nums"
@@ -264,6 +260,23 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												<span className="text-git-deleted-bright">
 													&minus;{deletions}
 												</span>
+											</span>
+										)}
+										{hasChildren && (
+											<span
+												{...subagentToggleProps}
+												role="button"
+												tabIndex={0}
+												className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 rounded-sm text-[13px] leading-4 tabular-nums text-content-secondary hover:text-content-primary"
+												aria-expanded={isExpanded}
+												aria-label={`${
+													isExpanded ? "Hide" : "Show"
+												} ${childIDs.length} ${
+													childIDs.length === 1 ? "subagent" : "subagents"
+												}`}
+											>
+												{childIDs.length}
+												<BotIcon className="size-3.5" aria-hidden="true" />
 											</span>
 										)}
 										<div

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -1,7 +1,6 @@
 import {
 	BotIcon,
 	ChevronDownIcon,
-	ChevronRightIcon,
 	EllipsisVerticalIcon,
 	UsersIcon,
 } from "lucide-react";
@@ -236,17 +235,13 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											>
 												{childIDs.length}
 												<BotIcon className="size-3.5" aria-hidden="true" />
-												{isExpanded ? (
-													<ChevronDownIcon
-														className="size-3.5"
-														aria-hidden="true"
-													/>
-												) : (
-													<ChevronRightIcon
-														className="size-3.5"
-														aria-hidden="true"
-													/>
-												)}
+												<ChevronDownIcon
+													aria-hidden="true"
+													className={cn(
+														"size-3.5 transition-transform",
+														isExpanded && "rotate-180",
+													)}
+												/>
 											</span>
 										)}
 										{hasLinkedDiffStatus && hasLineStats && (


### PR DESCRIPTION
## What

Follow-up UI polish to the subagent sidebar indicator from #28234.

- **Removed the hover-only chevron** that overlaid the status icon on the left. The status icon is now always shown.
- **Added a persistent expand control** next to the bot icon: `🤖 ⌄`. The chevron hugs the bot icon (small gap) with more breathing room before the content to its right, and rotates 180° down/up to match the section-header (category) chevrons.
- **Dropped the numeric subagent count.** The bot icon plus chevron reads as an expand affordance on its own; the exact count is still available to screen readers via the control's `aria-label` (`Show N subagents` / `Hide N subagents`).
- The control is keyboard-accessible (`role="button"`, `tabIndex`, Enter/Space via the shared `useClickable` hook) and calls `preventDefault`/`stopPropagation` so it toggles in place without triggering the surrounding `NavLink` navigation.

Expansion still flows through the existing sidebar expand state, so the actions-menu toggle (from #28234) and the on-row control stay in sync.

## Notes / decisions

- Used the existing `useClickable` hook and a `<span role="button">` rather than a native `<button>`, because the control lives inside the row's `NavLink` (`<a>`) and nesting a `<button>` in an `<a>` is invalid HTML. `role`/`tabIndex` are also set explicitly so Biome's static a11y checks pass.
- Moved the `agents-tree-toggle-<id>` test id from the old hover chevron onto the new persistent control, so existing expand/collapse stories keep exercising the same behavior.

## Testing

- `pnpm exec tsc --noEmit` and `biome check` pass with 0 errors.
- Updated `RunningChatPreservesSpinner` and `IdleParentWithRunningChild` stories, which previously asserted the chevron was hidden until icon hover, to assert the persistent toggle is visible instead.
- Added a `SubagentsCountToggle` story asserting click-to-expand without navigation and the accessible-label swap.
- Ran the full `ChatsSidebar` storybook interaction suite: 96/96 pass.

---

*This PR was generated by Coder Agents on behalf of @tracyjohnsonux.*
