### PR TITLE
fix: link workspaces empty state to template builder

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
@@ -54,7 +54,7 @@ export const WorkspacesEmpty: FC<WorkspacesEmptyProps> = ({
 				description={`${defaultMessage} To create a workspace, you first need to create a template.`}
 				cta={
 					<Button asChild>
-						<Link to="/templates">Go to templates</Link>
+						<Link to="/templates/new/builder">Create a template</Link>
 					</Button>
 				}
 				className="pb-0"

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.stories.tsx
@@ -253,6 +253,10 @@ export const EmptyWithoutTemplates: Story = {
 				key: getTemplatesQueryKey(),
 				data: [],
 			},
+			{
+				key: workspacesKey({ q: "owner:me", limit: 25, offset: 0 }),
+				data: { workspaces: [], count: 0 },
+			},
 		],
 		reactRouter: reactRouterParameters({
 			location: { path: "/workspaces" },
@@ -264,9 +268,6 @@ export const EmptyWithoutTemplates: Story = {
 				},
 			],
 		}),
-	},
-	beforeEach: () => {
-		spyOn(API, "getWorkspaces").mockResolvedValue({ workspaces: [], count: 0 });
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.stories.tsx
@@ -7,6 +7,7 @@ import {
 	waitFor,
 	within,
 } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
 import { getAuthorizationKey } from "#/api/queries/authCheck";
 import { workspacePermissionsByOrganization } from "#/api/queries/organizations";
@@ -238,6 +239,42 @@ export const Empty: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await canvas.findByRole("heading", { name: /Create a workspace/ });
+	},
+};
+
+export const EmptyWithoutTemplates: Story = {
+	parameters: {
+		permissions: {
+			createTemplates: true,
+			createWorkspace: true,
+		},
+		queries: [
+			{
+				key: getTemplatesQueryKey(),
+				data: [],
+			},
+		],
+		reactRouter: reactRouterParameters({
+			location: { path: "/workspaces" },
+			routing: [
+				{ path: "/workspaces", useStoryElement: true },
+				{
+					path: "/templates/new/builder",
+					element: <div>Template builder</div>,
+				},
+			],
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API, "getWorkspaces").mockResolvedValue({ workspaces: [], count: 0 });
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+		await user.click(
+			await canvas.findByRole("link", { name: "Create a template" }),
+		);
+		await canvas.findByText("Template builder");
 	},
 };
 


### PR DESCRIPTION
Links the empty workspaces state directly to the template builder when the user can create templates.

Includes Storybook coverage for the navigation.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents.
</details>
