### PR TITLE
docs: add markdown_url front matter so the About page links to /docs.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+---
+markdown_url: /docs.md
+---
+
 # About
 
 <!-- Warning for docs contributors: The first route in manifest.json must be titled "About" for the static landing page to work correctly. -->


### PR DESCRIPTION
The docs About page renders at `/docs/about`, but its Markdown source is the docs root `README.md`, whose Markdown twin is `/docs.md`. The path-derived mapping (`/docs/about` -> `/docs/about.md`) points the "Copy page / view as Markdown" affordance and the sitewide `rel="alternate"` link at a URL that 404s for this page.

Add a `markdown_url: /docs.md` front-matter override to `docs/README.md`. It is inert for rendering and for `/docs.md` itself (the body still begins at `# About`); it only populates the front matter the docs site reads to advertise the correct Markdown alternate.

Reader side: coder/coder.com#1013 (DOCS-638). Neither change breaks without the other, so they can merge in either order.

Refs DOCS-678

> This PR was created with AI assistance (Coder Agents).