### PR TITLE
refactor: move chat prompt sanitization into codersdk

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -4583,7 +4583,7 @@ func (api *API) putChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	if !httpapi.ReadLimit(ctx, rw, r, int64(2*maxSystemPromptLenBytes), &req) {
 		return
 	}
-	sanitizedPrompt := chatd.SanitizePromptText(req.SystemPrompt)
+	sanitizedPrompt := codersdk.SanitizePromptText(req.SystemPrompt)
 	// 128 KiB is generous for a system prompt while still
 	// preventing abuse or accidental pastes of large content.
 	if len(sanitizedPrompt) > maxSystemPromptLenBytes {
@@ -4773,7 +4773,7 @@ func (api *API) putChatPlanModeInstructions(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	sanitizedInstructions := chatd.SanitizePromptText(req.PlanModeInstructions)
+	sanitizedInstructions := codersdk.SanitizePromptText(req.PlanModeInstructions)
 	if len(sanitizedInstructions) > maxSystemPromptLenBytes {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Plan mode instructions exceed maximum length.",
@@ -5832,7 +5832,7 @@ func (api *API) putUserChatCustomPrompt(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	sanitizedPrompt := chatd.SanitizePromptText(params.CustomPrompt)
+	sanitizedPrompt := codersdk.SanitizePromptText(params.CustomPrompt)
 	// Apply the same 128 KiB limit as the deployment system prompt.
 	if len(sanitizedPrompt) > maxSystemPromptLenBytes {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1318,7 +1318,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		}
 	}
 
-	userPrompt := SanitizePromptText(opts.SystemPrompt)
+	userPrompt := codersdk.SanitizePromptText(opts.SystemPrompt)
 	workspaceAwareness := workspaceDetachedAwareness
 	if opts.WorkspaceID.Valid {
 		workspaceAwareness = workspaceAttachedAwareness
@@ -4421,7 +4421,7 @@ func (p *Server) resolveDeploymentSystemPrompt(ctx context.Context) string {
 		return DefaultSystemPrompt
 	}
 
-	sanitizedCustom := SanitizePromptText(config.ChatSystemPrompt)
+	sanitizedCustom := codersdk.SanitizePromptText(config.ChatSystemPrompt)
 	if sanitizedCustom == "" && strings.TrimSpace(config.ChatSystemPrompt) != "" {
 		p.logger.Warn(ctx, "custom system prompt became empty after sanitization, omitting custom portion")
 	}

--- a/coderd/x/chatd/context_prompt.go
+++ b/coderd/x/chatd/context_prompt.go
@@ -154,7 +154,7 @@ func decodeInstructionContent(body json.RawMessage) (content string, decoded boo
 	if !ok {
 		return "", false
 	}
-	return SanitizePromptText(string(decodedBody.GetContent())), true
+	return codersdk.SanitizePromptText(string(decodedBody.GetContent())), true
 }
 
 // decodeSkillIdentity decodes a skill resource body and returns its name and

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -1284,7 +1284,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 	if err != nil {
 		return database.Chat{}, xerrors.Errorf("marshal labels: %w", err)
 	}
-	childSystemPrompt := SanitizePromptText(opts.systemPrompt)
+	childSystemPrompt := codersdk.SanitizePromptText(opts.systemPrompt)
 	// Resolve the deployment prompt before opening the transaction so
 	// child chat creation does not hold one DB connection while waiting
 	// for another pool checkout.

--- a/codersdk/promptsanitize.go
+++ b/codersdk/promptsanitize.go
@@ -1,4 +1,4 @@
-package chatd
+package codersdk
 
 import (
 	"strings"
@@ -9,6 +9,9 @@ import (
 // hide prompt-injection content from human reviewers, normalizes line
 // endings, collapses excessive blank lines, and trims surrounding
 // whitespace.
+//
+// It lives in codersdk so API consumers, such as terraform-provider-coderd,
+// can compare prompt values the same way the server stores them.
 //
 // The stripped codepoints are truly invisible and have no legitimate
 // use in prompt text. An explicit codepoint list is used rather than

--- a/codersdk/promptsanitize_test.go
+++ b/codersdk/promptsanitize_test.go
@@ -1,4 +1,4 @@
-package chatd_test
+package codersdk_test
 
 import (
 	"strings"
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/x/chatd"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 func TestSanitizePromptText(t *testing.T) {
@@ -265,11 +265,11 @@ func TestSanitizePromptText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := chatd.SanitizePromptText(tt.input)
+			got := codersdk.SanitizePromptText(tt.input)
 			require.Equal(t, tt.want, got)
 
 			// Verify idempotency: f(f(x)) == f(x).
-			again := chatd.SanitizePromptText(got)
+			again := codersdk.SanitizePromptText(got)
 			require.Equal(t, got, again,
 				"SanitizePromptText is not idempotent for case %q", tt.name)
 		})
@@ -304,7 +304,7 @@ func TestIsVisibleCanonicalList(t *testing.T) {
 
 	for _, r := range stripped {
 		input := "a" + string(r) + "b"
-		got := chatd.SanitizePromptText(input)
+		got := codersdk.SanitizePromptText(input)
 		require.Equalf(t, "ab", got, "U+%04X should be stripped", r)
 	}
 
@@ -321,7 +321,7 @@ func TestIsVisibleCanonicalList(t *testing.T) {
 	for _, r := range preserved {
 		input := "a" + string(r) + "b"
 		want := "a" + string(r) + "b"
-		got := chatd.SanitizePromptText(input)
+		got := codersdk.SanitizePromptText(input)
 		require.Equalf(t, want, got, "U+%04X should be preserved", r)
 	}
 }


### PR DESCRIPTION
Exports `SanitizePromptText` (and its helpers) from `codersdk` instead of `coderd/x/chatd`, so API consumers can sanitize prompt text exactly the way the server stores it.

## Why

coder/terraform-provider-coderd#412 adds a `coderd_chat_system_prompt` resource whose `system_prompt` attribute compares values by their sanitized forms (otherwise the trailing newline from `file("system-prompt.md")` is perpetual drift, since the server stores the sanitized value). That currently requires a mirrored copy of the sanitizer in the provider, which can silently rot. Per review there ([discussion](https://github.com/coder/terraform-provider-coderd/pull/412#discussion_r3801110795)), the sanitizer should be exported from `codersdk` and imported instead.

## What

- `coderd/x/chatd/sanitize.go` → `codersdk/promptsanitize.go` (pure move; package + doc-comment note about why it lives in codersdk)
- `coderd/x/chatd/sanitize_test.go` → `codersdk/promptsanitize_test.go`
- Callsites updated (`exp_chats.go`, `chatd.go`, `subagent.go`, `context_prompt.go`); no wrapper left behind, single source of truth
- No behavior change

> Generated by Coder Agents on behalf of @bpmct