### PR TITLE
docs: remove inaccurate Agent Firewall filesystem protection claim

### DIFF
--- a/docs/ai-coder/ai-governance.md
+++ b/docs/ai-coder/ai-governance.md
@@ -53,7 +53,7 @@ adoption patterns and potential issues.
 
 AI agents can make arbitrary network requests, potentially accessing unauthorized services or exfiltrating data.
 Agent Firewall enforces process-level policies that restrict which domains agents can reach and what actions they can perform,
-preventing unintended data exposure and destructive operations like `rm -rf`.
+preventing unintended data exposure.
 
 ### Centralizing API key management
 


### PR DESCRIPTION
Removes the claim that Agent Firewall prevents "destructive operations like `rm -rf`" from the AI Governance doc.

Agent Firewall enforces **network-only** policy (domains, HTTP methods, URL paths). It has no filesystem protection capability.

**Change:** Removed the `rm -rf` / "destructive operations" phrase from the "Restricting agent network access" section in `docs/ai-coder/ai-governance.md`.

---

*PR generated with Coder Agents*