### PR TITLE
ci: skip oversized flake-check selections

### DIFF
--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -59,6 +59,7 @@ jobs:
             --repo-root . \
             --github-actions \
             --coalesce \
+            --max-selected-tests 100 \
             --out-matrix "$RUNNER_TEMP/flake-matrix.json"
 
       - name: Set up Terraform

--- a/mise.lock
+++ b/mise.lock
@@ -489,7 +489,7 @@ version = "337309bfb9524f38466a5090e310040fc7af0203"
 backend = "go:github.com/coder/sqlc/cmd/sqlc"
 
 [[tools."go:github.com/coder/whichtests"]]
-version = "ec33bab1ec04cd86beb7a61a069db4463dba63f5"
+version = "377b8dbf1cccae3b04b48bc8cfc2410813491414"
 backend = "go:github.com/coder/whichtests"
 
 [[tools."go:github.com/golang-migrate/migrate/v4/cmd/migrate"]]

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,7 @@ protoc-gen-go = "1.30.0"
 
 # Go development tools.
 "go:github.com/coder/paralleltestctx/cmd/paralleltestctx" = "v0.0.2"
-"go:github.com/coder/whichtests" = "ec33bab1ec04cd86beb7a61a069db4463dba63f5"
+"go:github.com/coder/whichtests" = "377b8dbf1cccae3b04b48bc8cfc2410813491414"
 # Keep golangci-lint on the Go backend while pinned to v1. The upstream
 # precompiled v1 binary is built with an older Go toolchain and cannot lint
 # this module's Go version. Upgrading to v2 should let us use the native


### PR DESCRIPTION
Skip the targeted Go flake check when a change selects more than 100 tests, and update `whichtests` to the version that supports this limit.

Large selections usually come from broad or mechanical changes rather than a narrowly introduced flaky behavior. Repeating hundreds of tests substantially increases runtime and runner resource usage while providing less focused signal; regular CI still exercises the affected test suite across its normal jobs and repetitions.
