### PR TITLE
fix(coderd): remove per-chat system prompt limit

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1310,15 +1310,6 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate per-chat system prompt length.
-	const maxSystemPromptLen = 10000
-	if len(req.SystemPrompt) > maxSystemPromptLen {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "System prompt exceeds maximum length.",
-			Detail:  fmt.Sprintf("System prompt must be at most %d characters, got %d.", maxSystemPromptLen, len(req.SystemPrompt)),
-		})
-		return
-	}
 	contentBlocks, titleSource, inputError := createChatInputFromRequest(ctx, api.Database, req)
 	if inputError != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, *inputError)

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -843,27 +843,6 @@ func TestPostChats(t *testing.T) {
 		}
 	})
 
-	t.Run("PerChatSystemPromptTooLong", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitLong)
-		client := newChatClient(t)
-		user := coderdtest.CreateFirstUser(t, client.Client)
-		_ = createChatModelConfig(t, client)
-
-		longPrompt := strings.Repeat("a", 10001)
-		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
-			OrganizationID: user.OrganizationID, Content: []codersdk.ChatInputPart{
-				{
-					Type: codersdk.ChatInputPartTypeText,
-					Text: "hello",
-				},
-			},
-			SystemPrompt: longPrompt,
-		})
-		requireSDKError(t, err, http.StatusBadRequest)
-	})
-
 	t.Run("WorkspaceNotAccessible", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Per-chat system prompts longer than 10,000 characters are rejected during chat creation.

Remove that validation so chat creation accepts longer system prompts within the existing request-body limit.