### PR TITLE
fix: prevent bridge shutdown race during provider reload

### DIFF
--- a/aibridge/bridge.go
+++ b/aibridge/bridge.go
@@ -86,6 +86,7 @@ type RequestBridge struct {
 
 	clock quartz.Clock
 
+	retireOnce   sync.Once
 	shutdownOnce sync.Once
 	closed       chan struct{}
 }
@@ -390,15 +391,14 @@ func writeRequestBodyTooLarge(w http.ResponseWriter) {
 	), http.StatusRequestEntityTooLarge)
 }
 
-// ServeHTTP exposes the internal http.Handler, which has all [Provider]s' routes registered.
-// It also tracks inflight requests.
-func (b *RequestBridge) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+// admit reserves an in-flight slot for one request. It returns false after the
+// bridge has been retired.
+func (b *RequestBridge) admit() (release func(), ok bool) {
 	b.inflightMu.RLock()
 	select {
 	case <-b.closed:
 		b.inflightMu.RUnlock()
-		http.Error(rw, "server closed", http.StatusInternalServerError)
-		return
+		return nil, false
 	default:
 	}
 
@@ -408,11 +408,27 @@ func (b *RequestBridge) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	b.inflightReqs.Add(1)
 	b.inflightWG.Add(1)
 	b.inflightMu.RUnlock()
-	defer func() {
+	return func() {
 		b.inflightReqs.Add(-1)
 		b.inflightWG.Done()
-	}()
+	}, true
+}
 
+// TryServe admits and serves one request. It returns false if the bridge has
+// been retired, in which case the caller must retry with another bridge.
+func (b *RequestBridge) TryServe(rw http.ResponseWriter, r *http.Request) bool {
+	release, ok := b.admit()
+	if !ok {
+		return false
+	}
+	defer release()
+
+	b.serveAdmitted(rw, r)
+	return true
+}
+
+// serveAdmitted serves a request which already holds an in-flight slot.
+func (b *RequestBridge) serveAdmitted(rw http.ResponseWriter, r *http.Request) {
 	// We want to abide by the context passed in without losing any of its
 	// functionality, but we still want to link our shutdown context to each
 	// request.
@@ -424,16 +440,31 @@ func (b *RequestBridge) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	b.mux.ServeHTTP(rw, r.WithContext(ctx))
 }
 
-// Shutdown will attempt to gracefully shutdown. This entails waiting for all requests to
-// complete, and shutting down the MCP server proxier.
-// TODO: add tests.
-func (b *RequestBridge) Shutdown(ctx context.Context) error {
-	var err error
-	b.shutdownOnce.Do(func() {
-		// Close under inflightMu so no ServeHTTP sits mid-admission (see inflightMu).
+// ServeHTTP exposes the internal http.Handler, which has all [Provider]s' routes registered.
+// It also tracks inflight requests.
+func (b *RequestBridge) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if !b.TryServe(rw, r) {
+		http.Error(rw, "server closed", http.StatusInternalServerError)
+	}
+}
+
+// Retire prevents new requests from being admitted. Already admitted requests
+// continue until they complete or a shutdown context cancels them.
+func (b *RequestBridge) Retire() {
+	b.retireOnce.Do(func() {
+		// Close under inflightMu so no request sits mid-admission.
 		b.inflightMu.Lock()
 		close(b.closed)
 		b.inflightMu.Unlock()
+	})
+}
+
+// Shutdown retires the bridge, waits for admitted requests to complete, and
+// shuts down the MCP server proxier.
+func (b *RequestBridge) Shutdown(ctx context.Context) error {
+	var err error
+	b.shutdownOnce.Do(func() {
+		b.Retire()
 
 		// Wait for inflight requests to complete or context cancellation.
 		done := make(chan struct{})

--- a/aibridge/bridge.go
+++ b/aibridge/bridge.go
@@ -77,8 +77,8 @@ type RequestBridge struct {
 	inflightReqs atomic.Int32
 	inflightWG   sync.WaitGroup // For graceful shutdown.
 
-	// inflightMu orders inflightWG.Add (ServeHTTP, read-held) before
-	// close(b.closed) (Shutdown, write-held), so Add never races Wait.
+	// inflightMu orders inflightWG.Add (admit, read-held) before
+	// close(b.closed) (Retire, write-held), so Add never races Wait.
 	inflightMu sync.RWMutex
 
 	inflightCtx    context.Context
@@ -448,8 +448,10 @@ func (b *RequestBridge) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Retire prevents new requests from being admitted. Already admitted requests
-// continue until they complete or a shutdown context cancels them.
+// Retire prevents new requests from being admitted. Requests already admitted
+// run to completion; Retire does not cancel them. Use Shutdown with a canceled
+// context to cut them short. Every Retire must be followed by a Shutdown so the
+// MCP proxy is released.
 func (b *RequestBridge) Retire() {
 	b.retireOnce.Do(func() {
 		// Close under inflightMu so no request sits mid-admission.

--- a/aibridge/bridge_test.go
+++ b/aibridge/bridge_test.go
@@ -13,18 +13,119 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.uber.org/mock/gomock"
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/aibridge/aibridgetest"
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
+	"github.com/coder/coder/v2/aibridge/mcpmock"
 	"github.com/coder/coder/v2/aibridge/provider"
 	codertestutil "github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
 var bridgeTestTracer = otel.Tracer("bridge_test")
+
+func TestRequestBridgeRetireDrainsAdmittedRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := codertestutil.Context(t, codertestutil.WaitLong)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	bridge, err := aibridge.NewRequestBridge(
+		ctx,
+		[]provider.Provider{aibridge.NewOpenAIProvider(config.OpenAI{BaseURL: upstream.URL})},
+		&testutil.MockRecorder{},
+		nil,
+		slogtest.Make(t, nil),
+		nil,
+		bridgeTestTracer,
+	)
+	require.NoError(t, err)
+
+	served := make(chan bool, 1)
+	go func() {
+		served <- bridge.TryServe(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/openai/v1/models", nil))
+	}()
+	_ = codertestutil.TryReceive(ctx, t, started)
+
+	bridge.Retire()
+	require.False(t, bridge.TryServe(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/openai/v1/models", nil)))
+
+	shutdown := make(chan error, 1)
+	go func() {
+		shutdown <- bridge.Shutdown(ctx)
+	}()
+	select {
+	case err := <-shutdown:
+		t.Fatalf("shutdown completed before the admitted request: %v", err)
+	default:
+	}
+
+	close(release)
+	require.True(t, codertestutil.RequireReceive(ctx, t, served))
+	require.NoError(t, codertestutil.RequireReceive(ctx, t, shutdown))
+}
+
+func TestRequestBridgeShutdownContextCancelsAdmittedRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := codertestutil.Context(t, codertestutil.WaitLong)
+	started := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	t.Cleanup(func() {
+		upstream.CloseClientConnections()
+		upstream.Close()
+	})
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).Times(1).Return(nil)
+	bridge, err := aibridge.NewRequestBridge(
+		ctx,
+		[]provider.Provider{aibridge.NewOpenAIProvider(config.OpenAI{BaseURL: upstream.URL})},
+		&testutil.MockRecorder{},
+		mcpProxy,
+		slogtest.Make(t, nil),
+		nil,
+		bridgeTestTracer,
+	)
+	require.NoError(t, err)
+
+	served := make(chan bool, 1)
+	go func() {
+		served <- bridge.TryServe(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/openai/v1/models", nil))
+	}()
+	_ = codertestutil.TryReceive(ctx, t, started)
+
+	shutdownCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err = bridge.Shutdown(shutdownCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	_ = codertestutil.TryReceive(ctx, t, requestCanceled)
+	require.True(t, codertestutil.RequireReceive(ctx, t, served))
+}
 
 // TestRequestBridgeShutdownAdmissionRace deterministically interleaves request
 // admission with Shutdown using the `serve_admission` quartz trap.

--- a/aibridge/metrics/metrics.go
+++ b/aibridge/metrics/metrics.go
@@ -43,6 +43,11 @@ type Metrics struct {
 	// Keys attempted before success or exhaustion, per interception for
 	// bridged requests and per request for passthrough requests.
 	KeyPoolFailoverAttempts *prometheus.HistogramVec
+
+	// Request bridge pool metrics.
+	BridgePoolUncachedServeAttempts prometheus.Counter
+	BridgePoolRetries               *prometheus.CounterVec
+	BridgePoolRetryExhausted        *prometheus.CounterVec
 }
 
 // NewMetrics creates AND registers metrics. It will panic if a collector has already been registered.
@@ -164,5 +169,22 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 				"passthrough requests.",
 			Buckets: []float64{1, 2, 3, 4, 5, 10, 25},
 		}, []string{"provider"}),
+
+		// Request bridge pool metrics.
+		BridgePoolUncachedServeAttempts: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Subsystem: "bridge_pool",
+			Name:      "uncached_serve_attempts_total",
+			Help:      "The number of attempts to serve through a bridge rejected by the request bridge cache.",
+		}),
+		BridgePoolRetries: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Subsystem: "bridge_pool",
+			Name:      "retries_total",
+			Help:      "The number of request bridge retries after admission or provider generation failure.",
+		}, []string{"reason"}),
+		BridgePoolRetryExhausted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Subsystem: "bridge_pool",
+			Name:      "retry_exhausted_total",
+			Help:      "The number of requests that exhausted the request bridge retry limit.",
+		}, []string{"reason"}),
 	}
 }

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -192,7 +192,7 @@ func (s *Server) Serve(ctx context.Context, req Request, rw http.ResponseWriter,
 
 	err := s.requestBridgePool.Serve(ctx, req, s.Client, NewMCPProxyFactory(s.logger, s.tracer, s.Client), rw, r)
 	if err != nil {
-		return xerrors.Errorf("acquire request bridge: %w", err)
+		return xerrors.Errorf("serve request bridge: %w", err)
 	}
 
 	return nil

--- a/coderd/aibridged/aibridged.go
+++ b/coderd/aibridged/aibridged.go
@@ -183,18 +183,19 @@ func (s *Server) Client(ctx context.Context) (DRPCClient, error) {
 	}
 }
 
-// GetRequestHandler retrieves a (possibly reused) [*aibridge.RequestBridge] from the pool, for the given user.
-func (s *Server) GetRequestHandler(ctx context.Context, req Request) (http.Handler, error) {
+// Serve retrieves a (possibly reused) [*aibridge.RequestBridge] from the pool
+// for the given user and serves the request through it.
+func (s *Server) Serve(ctx context.Context, req Request, rw http.ResponseWriter, r *http.Request) error {
 	if s.requestBridgePool == nil {
-		return nil, xerrors.New("nil requestBridgePool")
+		return xerrors.New("nil requestBridgePool")
 	}
 
-	reqBridge, err := s.requestBridgePool.Acquire(ctx, req, s.Client, NewMCPProxyFactory(s.logger, s.tracer, s.Client))
+	err := s.requestBridgePool.Serve(ctx, req, s.Client, NewMCPProxyFactory(s.logger, s.tracer, s.Client), rw, r)
 	if err != nil {
-		return nil, xerrors.Errorf("acquire request bridge: %w", err)
+		return xerrors.Errorf("acquire request bridge: %w", err)
 	}
 
-	return reqBridge, nil
+	return nil
 }
 
 // Ready reports whether the server currently has an active DRPC connection to coderd.

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -238,10 +238,10 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 				// Should pass authorization and budget check.
 				client.EXPECT().IsAuthorized(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsAuthorizedResponse{OwnerId: uuid.NewString()}, nil)
 				client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsBudgetExceededResponse{}, nil)
-				// But fail when acquiring a pool instance.
+				// But fail when serving a pool instance.
 				pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(xerrors.New("oops"))
 			},
-			expectedErr:    aibridged.ErrAcquireRequestHandler,
+			expectedErr:    aibridged.ErrServeRequestHandler,
 			expectedStatus: http.StatusInternalServerError,
 		},
 	}

--- a/coderd/aibridged/aibridged_test.go
+++ b/coderd/aibridged/aibridged_test.go
@@ -239,7 +239,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 				client.EXPECT().IsAuthorized(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsAuthorizedResponse{OwnerId: uuid.NewString()}, nil)
 				client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsBudgetExceededResponse{}, nil)
 				// But fail when acquiring a pool instance.
-				pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, xerrors.New("oops"))
+				pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(xerrors.New("oops"))
 			},
 			expectedErr:    aibridged.ErrAcquireRequestHandler,
 			expectedStatus: http.StatusInternalServerError,
@@ -332,11 +332,12 @@ func TestServeHTTP_DelegatedAPIKey(t *testing.T) {
 						}, nil
 					})
 				client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).Return(&proto.IsBudgetExceededResponse{}, nil)
-				pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, req aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder) (http.Handler, error) {
+				pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
 						assert.Empty(t, req.SessionKey,
 							"delegated centralized request carries no session token")
-						return mockH, nil
+						mockH.ServeHTTP(rw, r)
+						return nil
 					})
 			},
 			expectStatus:  http.StatusOK,
@@ -365,11 +366,12 @@ func TestServeHTTP_DelegatedAPIKey(t *testing.T) {
 					Username: "u",
 				}, nil)
 				client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).Return(&proto.IsBudgetExceededResponse{}, nil)
-				pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, req aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder) (http.Handler, error) {
+				pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
 						assert.Equal(t, "coder-token-byok", req.SessionKey,
 							"BYOK delegated request must still surface the extracted Coder token as SessionKey")
-						return mockH, nil
+						mockH.ServeHTTP(rw, r)
+						return nil
 					})
 			},
 			expectStatus:  http.StatusOK,
@@ -456,7 +458,11 @@ func TestServeHTTP_DelegatedAPIKey_BYOK_Integration(t *testing.T) {
 			}, nil
 		})
 	client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).Return(&proto.IsBudgetExceededResponse{}, nil)
-	pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockH, nil)
+	pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
+			mockH.ServeHTTP(rw, r)
+			return nil
+		})
 
 	factory := aibridged.NewTransportFactory(srv)
 	rt, err := factory.TransportFor("openai", agplaibridge.SourceAgents)
@@ -509,7 +515,11 @@ func TestServeHTTP_DelegatedAPIKey_Integration(t *testing.T) {
 			}, nil
 		})
 	client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).Return(&proto.IsBudgetExceededResponse{}, nil)
-	pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockH, nil)
+	pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
+			mockH.ServeHTTP(rw, r)
+			return nil
+		})
 
 	factory := aibridged.NewTransportFactory(srv)
 	rt, err := factory.TransportFor("openai", agplaibridge.SourceAgents)
@@ -596,7 +606,11 @@ func TestServeHTTP_StripCoderToken(t *testing.T) {
 			client.EXPECT().DRPCConn().AnyTimes().Return(conn)
 			client.EXPECT().IsAuthorized(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsAuthorizedResponse{OwnerId: uuid.NewString()}, nil)
 			client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsBudgetExceededResponse{}, nil)
-			pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(mockH, nil)
+			pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+				func(_ context.Context, _ aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
+					mockH.ServeHTTP(rw, r)
+					return nil
+				})
 
 			httpSrv := httptest.NewServer(srv)
 			t.Cleanup(httpSrv.Close)
@@ -966,7 +980,11 @@ func TestServeHTTP_StripInternalHeaders(t *testing.T) {
 			client.EXPECT().DRPCConn().AnyTimes().Return(conn)
 			client.EXPECT().IsAuthorized(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsAuthorizedResponse{OwnerId: uuid.NewString()}, nil)
 			client.EXPECT().IsBudgetExceeded(gomock.Any(), gomock.Any()).AnyTimes().Return(&proto.IsBudgetExceededResponse{}, nil)
-			pool.EXPECT().Acquire(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(mockH, nil)
+			pool.EXPECT().Serve(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+				func(_ context.Context, _ aibridged.Request, _ aibridged.ClientFunc, _ aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
+					mockH.ServeHTTP(rw, r)
+					return nil
+				})
 
 			httpSrv := httptest.NewServer(srv)
 			t.Cleanup(httpSrv.Close)

--- a/coderd/aibridged/aibridgedmock/poolmock.go
+++ b/coderd/aibridged/aibridgedmock/poolmock.go
@@ -43,21 +43,6 @@ func (m *MockPooler) EXPECT() *MockPoolerMockRecorder {
 	return m.recorder
 }
 
-// Acquire mocks base method.
-func (m *MockPooler) Acquire(ctx context.Context, req aibridged.Request, clientFn aibridged.ClientFunc, mcpBootstrapper aibridged.MCPProxyBuilder) (http.Handler, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Acquire", ctx, req, clientFn, mcpBootstrapper)
-	ret0, _ := ret[0].(http.Handler)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Acquire indicates an expected call of Acquire.
-func (mr *MockPoolerMockRecorder) Acquire(ctx, req, clientFn, mcpBootstrapper any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockPooler)(nil).Acquire), ctx, req, clientFn, mcpBootstrapper)
-}
-
 // ReplaceProviders mocks base method.
 func (m *MockPooler) ReplaceProviders(providers []aibridge.Provider) {
 	m.ctrl.T.Helper()
@@ -68,6 +53,20 @@ func (m *MockPooler) ReplaceProviders(providers []aibridge.Provider) {
 func (mr *MockPoolerMockRecorder) ReplaceProviders(providers any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceProviders", reflect.TypeOf((*MockPooler)(nil).ReplaceProviders), providers)
+}
+
+// Serve mocks base method.
+func (m *MockPooler) Serve(ctx context.Context, req aibridged.Request, clientFn aibridged.ClientFunc, mcpBootstrapper aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Serve", ctx, req, clientFn, mcpBootstrapper, rw, r)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Serve indicates an expected call of Serve.
+func (mr *MockPoolerMockRecorder) Serve(ctx, req, clientFn, mcpBootstrapper, rw, r any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Serve", reflect.TypeOf((*MockPooler)(nil).Serve), ctx, req, clientFn, mcpBootstrapper, rw, r)
 }
 
 // Shutdown mocks base method.

--- a/coderd/aibridged/aibridgedmock/poolmock.go
+++ b/coderd/aibridged/aibridgedmock/poolmock.go
@@ -56,17 +56,17 @@ func (mr *MockPoolerMockRecorder) ReplaceProviders(providers any) *gomock.Call {
 }
 
 // Serve mocks base method.
-func (m *MockPooler) Serve(ctx context.Context, req aibridged.Request, clientFn aibridged.ClientFunc, mcpBootstrapper aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
+func (m *MockPooler) Serve(ctx context.Context, req aibridged.Request, clientFn aibridged.ClientFunc, mcpProxyFactory aibridged.MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Serve", ctx, req, clientFn, mcpBootstrapper, rw, r)
+	ret := m.ctrl.Call(m, "Serve", ctx, req, clientFn, mcpProxyFactory, rw, r)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Serve indicates an expected call of Serve.
-func (mr *MockPoolerMockRecorder) Serve(ctx, req, clientFn, mcpBootstrapper, rw, r any) *gomock.Call {
+func (mr *MockPoolerMockRecorder) Serve(ctx, req, clientFn, mcpProxyFactory, rw, r any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Serve", reflect.TypeOf((*MockPooler)(nil).Serve), ctx, req, clientFn, mcpBootstrapper, rw, r)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Serve", reflect.TypeOf((*MockPooler)(nil).Serve), ctx, req, clientFn, mcpProxyFactory, rw, r)
 }
 
 // Shutdown mocks base method.

--- a/coderd/aibridged/http.go
+++ b/coderd/aibridged/http.go
@@ -170,16 +170,14 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		"Username": resp.GetUsername(),
 	}))
 
-	handler, err := s.GetRequestHandler(ctx, Request{
+	err = s.Serve(ctx, Request{
 		SessionKey:  key,
 		APIKeyID:    resp.ApiKeyId,
 		InitiatorID: id,
-	})
+	}, rw, r)
 	if err != nil {
 		logger.Warn(ctx, "failed to acquire request handler", slog.Error(err))
 		http.Error(rw, ErrAcquireRequestHandler.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	handler.ServeHTTP(rw, r)
 }

--- a/coderd/aibridged/http.go
+++ b/coderd/aibridged/http.go
@@ -18,17 +18,21 @@ import (
 var _ http.Handler = &Server{}
 
 var (
-	ErrNoAuthKey             = xerrors.New("no authentication key provided")
-	ErrConnect               = xerrors.New("could not connect to coderd")
-	ErrUnauthorized          = xerrors.New("unauthorized")
-	ErrAcquireRequestHandler = xerrors.New("failed to acquire request handler")
-	ErrBudgetCheck           = xerrors.New("internal server error checking user AI budget")
+	ErrNoAuthKey           = xerrors.New("no authentication key provided")
+	ErrConnect             = xerrors.New("could not connect to coderd")
+	ErrUnauthorized        = xerrors.New("unauthorized")
+	ErrServeRequestHandler = xerrors.New("failed to serve request handler")
+	ErrBudgetCheck         = xerrors.New("internal server error checking user AI budget")
 )
+
+// ErrAcquireRequestHandler is retained for compatibility.
+// Deprecated: use ErrServeRequestHandler.
+var ErrAcquireRequestHandler = ErrServeRequestHandler
 
 // ServeHTTP is the entrypoint for requests which will be intercepted by AI Bridge.
 // This function will validate that the given API key may be used to perform the request.
 //
-// An [aibridge.RequestBridge] instance is acquired from a pool based on the API key's
+// An [aibridge.RequestBridge] instance is served from a pool based on the API key's
 // owner (referred to as the "initiator"); this instance is responsible for the
 // AI Bridge-specific handling of the request.
 //
@@ -176,8 +180,8 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		InitiatorID: id,
 	}, rw, r)
 	if err != nil {
-		logger.Warn(ctx, "failed to acquire request handler", slog.Error(err))
-		http.Error(rw, ErrAcquireRequestHandler.Error(), http.StatusInternalServerError)
+		logger.Warn(ctx, "failed to serve request handler", slog.Error(err))
+		http.Error(rw, ErrServeRequestHandler.Error(), http.StatusInternalServerError)
 		return
 	}
 }

--- a/coderd/aibridged/pool.go
+++ b/coderd/aibridged/pool.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/xerrors"
-	"tailscale.com/util/singleflight"
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/aibridge"
@@ -23,20 +22,34 @@ import (
 	"github.com/coder/quartz"
 )
 
-const cacheCost = 1
+const (
+	// Each bridge has the same cache cost, so MaxCost is an item limit rather
+	// than an estimate of bridge memory use.
+	cacheCost = 1
+
+	maxBridgeServeAttempts     = 3
+	uncachedServeWarningPeriod = time.Minute
+	bridgeRetirementTimeout    = 5 * time.Second
+)
 
 var (
-	errGenerationRetired = xerrors.New("provider generation retired")
-	errCacheRejected     = xerrors.New("request bridge rejected by cache")
+	errGenerationRetired           = xerrors.New("provider generation retired")
+	errBridgeBuildExited           = xerrors.New("request bridge build exited")
+	errBridgeServeRetriesExhausted = xerrors.New("request bridge retry limit exceeded")
 )
 
 // Pooler describes a pool of [*aibridge.RequestBridge] instances.
 type Pooler interface {
-	Serve(ctx context.Context, req Request, clientFn ClientFunc, mcpBootstrapper MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error
+	// Serve retrieves or creates a request bridge for the current provider
+	// generation, admits the request, and serves it. It returns after the
+	// response has been written or the failure surfaced.
+	Serve(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error
 	// ReplaceProviders swaps the providers used to construct future
 	// RequestBridge instances. Disabled providers must be included; the bridge
 	// serves a 503 sentinel on their routes.
 	ReplaceProviders(providers []aibridge.Provider)
+	// Shutdown prevents new operations and drains inflight ones. Context
+	// cancellation accelerates cleanup by canceling admitted requests.
 	Shutdown(ctx context.Context) error
 }
 
@@ -61,20 +74,124 @@ type providerGeneration struct {
 	id        uint64
 	providers []aibridge.Provider
 
-	mu        sync.Mutex
-	retired   bool
-	entries   map[*bridgeEntry]struct{}
+	mu      sync.Mutex
+	retired bool
+	entries map[*bridgeEntry]struct{}
+	// publishWG brackets cache publication so generation retirement cannot
+	// finish until every in-flight publish attempt completes. retired is
+	// mu-guarded (rather than atomic) because publish must fence publishWG.Add
+	// behind the same mutex that retirement uses to observe retired.
 	publishWG sync.WaitGroup
 }
 
 type bridgeEntry struct {
-	key        string
-	generation *providerGeneration
-	bridge     *aibridge.RequestBridge
-	retired    atomic.Bool
-	retireOnce sync.Once
+	key           string
+	generation    *providerGeneration
+	bridge        *aibridge.RequestBridge
+	cacheRejected atomic.Bool
+	uncached      bool
+	retired       atomic.Bool
+	retireOnce    sync.Once
 }
 
+type bridgeBuildCall struct {
+	ready      chan struct{}
+	entry      *bridgeEntry
+	err        error
+	panicValue any
+	cleanup    func()
+	users      int
+}
+
+// bridgeBuildGroup coalesces bridge construction and keeps an uncached result
+// alive until every caller that joined the build has finished serving or trying
+// to admit its request. Unlike singleflight, this gives rejected cache entries
+// a defined shared lifetime instead of making each waiter build a fallback.
+type bridgeBuildGroup struct {
+	mu    sync.Mutex
+	calls map[string]*bridgeBuildCall
+}
+
+func (g *bridgeBuildGroup) Do(key string, fn func() (*bridgeEntry, func(), error)) (*bridgeEntry, func(), error) {
+	g.mu.Lock()
+	if call := g.calls[key]; call != nil {
+		call.users++
+		g.mu.Unlock()
+		<-call.ready
+		return g.result(call)
+	}
+	if g.calls == nil {
+		g.calls = make(map[string]*bridgeBuildCall)
+	}
+	call := &bridgeBuildCall{ready: make(chan struct{}), users: 1}
+	g.calls[key] = call
+	g.mu.Unlock()
+
+	g.build(key, call, fn)
+	return g.result(call)
+}
+
+func (g *bridgeBuildGroup) build(key string, call *bridgeBuildCall, fn func() (*bridgeEntry, func(), error)) {
+	completed := false
+	defer func() {
+		panicValue := recover()
+		switch {
+		case panicValue != nil:
+			call.panicValue = panicValue
+		case !completed:
+			// runtime.Goexit runs deferred functions without a recoverable panic.
+			call.err = errBridgeBuildExited
+		}
+
+		g.mu.Lock()
+		delete(g.calls, key)
+		close(call.ready)
+		g.mu.Unlock()
+
+		if panicValue != nil {
+			panic(panicValue)
+		}
+	}()
+
+	call.entry, call.cleanup, call.err = fn()
+	completed = true
+}
+
+func (g *bridgeBuildGroup) result(call *bridgeBuildCall) (*bridgeEntry, func(), error) {
+	if call.panicValue != nil {
+		panic(call.panicValue)
+	}
+	return call.entry, g.releaseFunc(call), call.err
+}
+
+func (g *bridgeBuildGroup) releaseFunc(call *bridgeBuildCall) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			var cleanup func()
+			g.mu.Lock()
+			call.users--
+			if call.users == 0 {
+				cleanup = call.cleanup
+				call.cleanup = nil
+			}
+			g.mu.Unlock()
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+	}
+}
+
+// CachedBridgePool coordinates caching and retirement across three layers, in
+// lock order: cacheMu/cacheWG order operations against Shutdown; replaceMu
+// serializes ReplaceProviders against Shutdown; each providerGeneration guards
+// retired/entries with mu and brackets publication with publishWG. Each
+// bridgeEntry pairs retired with retireOnce so cache callbacks and generation
+// retirement converge. bridgeBuildGroup keeps a rejected cache entry alive
+// until every caller that joined its build releases it. retirementCtx and
+// retirementWG bound bridge cleanup and cancel admitted requests during
+// Shutdown.
 type CachedBridgePool struct {
 	cache *ristretto.Cache[string, *bridgeEntry]
 	clock quartz.Clock
@@ -85,10 +202,12 @@ type CachedBridgePool struct {
 	logger  slog.Logger
 	options PoolOptions
 
-	singleflight *singleflight.Group[string, *bridgeEntry]
+	builds bridgeBuildGroup
 
 	metrics *aibridge.Metrics
 	tracer  trace.Tracer
+
+	uncachedServeWarningAt atomic.Int64
 
 	shutDownOnce   sync.Once
 	shuttingDownCh chan struct{}
@@ -98,6 +217,10 @@ type CachedBridgePool struct {
 	cacheMu sync.RWMutex
 	cacheWG sync.WaitGroup
 
+	// retirementCtx is canceled only by Shutdown. It has two cancellation
+	// paths: Serve links its operation context to it via AfterFunc so Shutdown
+	// can cut an active Serve short, and trackShutdown passes it to
+	// bridge.Shutdown so Shutdown cancels admitted requests on timeout.
 	retirementCtx    context.Context
 	retirementCancel context.CancelFunc
 	retirementWG     sync.WaitGroup
@@ -117,8 +240,6 @@ func NewCachedBridgePool(options PoolOptions, providers []aibridge.Provider, log
 		tracer:  tracer,
 		logger:  logger,
 
-		singleflight: &singleflight.Group[string, *bridgeEntry]{},
-
 		shuttingDownCh: make(chan struct{}),
 
 		retirementCtx:    retirementCtx,
@@ -126,13 +247,23 @@ func NewCachedBridgePool(options PoolOptions, providers []aibridge.Provider, log
 	}
 
 	cache, err := ristretto.NewCache(&ristretto.Config[string, *bridgeEntry]{
-		NumCounters:        options.MaxItems * 10,
-		MaxCost:            options.MaxItems * cacheCost,
+		// Ristretto recommends 10 counters per expected item to keep its
+		// admission-frequency estimates accurate.
+		NumCounters: options.MaxItems * 10,
+		// Cache costs count bridge instances, not bytes.
+		MaxCost: options.MaxItems * cacheCost,
+		// Internal byte estimates do not match the memory retained by a bridge.
 		IgnoreInternalCost: true,
-		BufferItems:        64,
-		Metrics:            true,
+		// Ristretto recommends 64 for normal Get contention.
+		BufferItems: 64,
+		Metrics:     true,
+		OnReject: func(item *ristretto.Item[*bridgeEntry]) {
+			if item != nil && item.Value != nil {
+				item.Value.cacheRejected.Store(true)
+			}
+		},
 		OnExit: func(entry *bridgeEntry) {
-			if entry != nil {
+			if entry != nil && !entry.cacheRejected.Load() {
 				entry.retire(pool)
 			}
 		},
@@ -154,6 +285,9 @@ func NewCachedBridgePool(options PoolOptions, providers []aibridge.Provider, log
 
 // ReplaceProviders publishes a new provider generation and retires the old one.
 // Already admitted requests continue to drain against their original generation.
+// The old generation is retired eagerly rather than left to TTL expiry so its
+// bridges, and their MCP sessions, are released promptly after a provider
+// change such as a key rotation.
 func (p *CachedBridgePool) ReplaceProviders(providers []aibridge.Provider) {
 	if !p.beginOperation() {
 		return
@@ -213,12 +347,12 @@ func (p *CachedBridgePool) Serve(ctx context.Context, req Request, clientFn Clie
 		attribute.String(tracing.InitiatorID, req.InitiatorID.String()),
 		attribute.String(tracing.APIKeyID, req.APIKeyID),
 	}
-	ctx, span := p.tracer.Start(ctx, "CachedBridgePool.Acquire", trace.WithAttributes(spanAttrs...))
+	ctx, span := p.tracer.Start(ctx, "CachedBridgePool.Serve", trace.WithAttributes(spanAttrs...))
 	defer tracing.EndSpanErr(span, &outErr)
 	ctx = tracing.WithRequestBridgeAttributesInContext(ctx, spanAttrs)
 
 	if err := ctx.Err(); err != nil {
-		return xerrors.Errorf("acquire: %w", err)
+		return xerrors.Errorf("serve: %w", err)
 	}
 	if !p.beginOperation() {
 		return xerrors.New("pool shutting down")
@@ -226,6 +360,8 @@ func (p *CachedBridgePool) Serve(ctx context.Context, req Request, clientFn Clie
 	defer p.cacheWG.Done()
 
 	operationCtx, cancelOperation := context.WithCancel(ctx)
+	// Tie this Serve call's cancellation to pool retirement so Shutdown can
+	// cut it short.
 	stopRetirementCancel := context.AfterFunc(p.retirementCtx, cancelOperation)
 	defer func() {
 		stopRetirementCancel()
@@ -233,9 +369,9 @@ func (p *CachedBridgePool) Serve(ctx context.Context, req Request, clientFn Clie
 	}()
 	ctx = operationCtx
 
-	for {
+	for attempt := 1; attempt <= maxBridgeServeAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
-			return xerrors.Errorf("acquire: %w", err)
+			return xerrors.Errorf("serve: %w", err)
 		}
 		if p.isShuttingDown() {
 			return xerrors.New("pool shutting down")
@@ -243,45 +379,60 @@ func (p *CachedBridgePool) Serve(ctx context.Context, req Request, clientFn Clie
 
 		generation := p.generation.Load()
 		if generation == nil {
-			return xerrors.New("no provider generation")
+			return xerrors.New("aibridged pool used before initialization completed")
 		}
 
-		entry, err := p.getOrBuild(ctx, req, clientFn, mcpProxyFactory, generation, span)
-		switch {
-		case err == nil:
-			if entry.bridge.TryServe(rw, r) {
-				return nil
-			}
-			span.AddEvent("admission_retry")
-			continue
-		case errors.Is(err, errGenerationRetired):
-			span.AddEvent("generation_retry")
-			continue
-		case errors.Is(err, errCacheRejected):
-			err = p.serveUncached(ctx, req, clientFn, mcpProxyFactory, generation, rw, r)
+		entry, release, err := p.getOrBuild(ctx, req, clientFn, mcpProxyFactory, generation, span)
+		if err != nil {
+			release()
 			if errors.Is(err, errGenerationRetired) {
-				span.AddEvent("generation_retry")
+				if attempt == maxBridgeServeAttempts {
+					return p.retryExhausted(span, "generation")
+				}
+				p.recordRetry(span, "generation", attempt)
 				continue
 			}
 			return err
-		default:
-			return err
 		}
+
+		served := func() bool {
+			// A cache-rejected entry is leased from bridgeBuildGroup. Release it
+			// even if request handling panics or exits its goroutine.
+			defer release()
+			if entry.uncached {
+				p.recordUncachedServe(ctx, span, generation.id)
+			}
+
+			// Trap point for deterministic tests of the retirement window between
+			// bridge selection and request admission.
+			_ = p.clock.Now("bridge_serve_admission")
+			return entry.bridge.TryServe(rw, r)
+		}()
+		if served {
+			return nil
+		}
+		if attempt == maxBridgeServeAttempts {
+			return p.retryExhausted(span, "admission")
+		}
+		p.recordRetry(span, "admission", attempt)
 	}
+	return errBridgeServeRetriesExhausted
 }
 
-func (p *CachedBridgePool) getOrBuild(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, generation *providerGeneration, span trace.Span) (*bridgeEntry, error) {
+func (p *CachedBridgePool) getOrBuild(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, generation *providerGeneration, span trace.Span) (*bridgeEntry, func(), error) {
 	cacheKey := bridgeCacheKey(generation.id, req)
 	if entry, ok := p.cache.Get(cacheKey); ok && entry != nil && !entry.retired.Load() {
+		// Cache entries expire even when they remain active. This periodically
+		// refreshes MCP connections until token expiry can be detected directly.
 		span.AddEvent("cache_hit")
-		return entry, nil
+		return entry, func() {}, nil
 	}
 	span.AddEvent("cache_miss")
 
-	entry, err, _ := p.singleflight.Do(cacheKey, func() (*bridgeEntry, error) {
+	return p.builds.Do(cacheKey, func() (*bridgeEntry, func(), error) {
 		bridge, err := p.buildBridge(ctx, req, clientFn, mcpProxyFactory, generation.providers)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		entry := &bridgeEntry{key: cacheKey, generation: generation, bridge: bridge}
 
@@ -289,44 +440,76 @@ func (p *CachedBridgePool) getOrBuild(ctx context.Context, req Request, clientFn
 		_ = p.clock.Now("bridge_cache_publish")
 
 		if !generation.publish(p.cache, entry, p.options.TTL) {
-			entry.retire(p)
-			if generation.isRetired() {
-				return nil, errGenerationRetired
+			// A dropped SetWithTTL does not invoke OnReject. Register the entry
+			// explicitly so provider replacement can retire it while the callers
+			// that joined this build are serving through it.
+			entry.uncached = true
+			if !generation.register(entry) {
+				entry.retire(p)
+				return nil, nil, errGenerationRetired
 			}
-			return nil, errCacheRejected
+			return entry, func() { entry.retire(p) }, nil
 		}
 
-		// Make publication visible before singleflight releases its waiters.
-		// Policy rejection invokes OnExit, which marks the entry retired.
+		// Make publication visible before releasing callers that joined the
+		// build. Policy rejection invokes OnReject followed by OnExit. OnExit
+		// leaves rejected entries alive so those callers can share the bridge.
 		p.cache.Wait()
-		if entry.retired.Load() {
-			return nil, errCacheRejected
+		if entry.cacheRejected.Load() {
+			entry.uncached = true
+			if generation.isRetired() {
+				entry.retire(p)
+				return nil, nil, errGenerationRetired
+			}
+			return entry, func() { entry.retire(p) }, nil
 		}
-		return entry, nil
+		if entry.retired.Load() && generation.isRetired() {
+			return nil, nil, errGenerationRetired
+		}
+		return entry, nil, nil
 	})
-	return entry, err
 }
 
-func (p *CachedBridgePool) serveUncached(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, generation *providerGeneration, rw http.ResponseWriter, r *http.Request) error {
-	bridge, err := p.buildBridge(ctx, req, clientFn, mcpProxyFactory, generation.providers)
-	if err != nil {
-		return err
+func (p *CachedBridgePool) recordRetry(span trace.Span, reason string, attempt int) {
+	span.AddEvent(reason+"_retry", trace.WithAttributes(attribute.Int("attempt", attempt)))
+	if p.metrics != nil {
+		p.metrics.BridgePoolRetries.WithLabelValues(reason).Inc()
 	}
-	entry := &bridgeEntry{generation: generation, bridge: bridge}
-	if !generation.register(entry) {
-		entry.retire(p)
-		return errGenerationRetired
-	}
-	defer entry.retire(p)
+}
 
-	if !bridge.TryServe(rw, r) {
-		return errGenerationRetired
+func (p *CachedBridgePool) retryExhausted(span trace.Span, reason string) error {
+	span.AddEvent("retry_exhausted", trace.WithAttributes(attribute.String("reason", reason)))
+	if p.metrics != nil {
+		p.metrics.BridgePoolRetryExhausted.WithLabelValues(reason).Inc()
 	}
-	return nil
+	return xerrors.Errorf("%w: %s", errBridgeServeRetriesExhausted, reason)
+}
+
+func (p *CachedBridgePool) recordUncachedServe(ctx context.Context, span trace.Span, generation uint64) {
+	span.AddEvent("uncached_serve")
+	if p.metrics != nil {
+		p.metrics.BridgePoolUncachedServeAttempts.Inc()
+	}
+
+	now := p.clock.Now("uncached_serve_warning").UnixNano()
+	for {
+		previous := p.uncachedServeWarningAt.Load()
+		if previous != 0 && time.Duration(now-previous) < uncachedServeWarningPeriod {
+			return
+		}
+		if p.uncachedServeWarningAt.CompareAndSwap(previous, now) {
+			p.logger.Warn(ctx, "request bridge cache rejected entry; serving uncached",
+				slog.F("provider_generation", generation),
+			)
+			return
+		}
+	}
 }
 
 func (p *CachedBridgePool) buildBridge(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, providers []aibridge.Provider) (*aibridge.RequestBridge, error) {
 	recorder := aibridge.NewRecorder(p.logger.Named("recorder"), p.tracer, func(clientCtx context.Context) (aibridge.Recorder, error) {
+		// The recorder outlives this Serve call, so the client is acquired
+		// against the context of the record call being served.
 		client, err := clientFn(clientCtx)
 		if err != nil {
 			return nil, xerrors.Errorf("acquire client: %w", err)
@@ -336,9 +519,13 @@ func (p *CachedBridgePool) buildBridge(ctx context.Context, req Request, clientF
 
 	mcpServers, err := mcpProxyFactory.Build(ctx, req, p.tracer)
 	if err != nil {
+		// Don't fail here; MCP server injection can gracefully degrade.
 		p.logger.Warn(ctx, "failed to create MCP server proxiers", slog.Error(err))
 	}
 	if mcpServers != nil {
+		// This blocks while connections are established with upstream MCP
+		// server(s) and tools are listed. A canceled leader still publishes
+		// the bridge so callers that joined its build are not stranded.
 		if err := mcpServers.Init(ctx); err != nil {
 			p.logger.Warn(ctx, "failed to initialize MCP server proxier(s)", slog.Error(err))
 		}
@@ -376,7 +563,7 @@ func (g *providerGeneration) publish(cache *ristretto.Cache[string, *bridgeEntry
 	if ok {
 		return true
 	}
-	g.remove(entry)
+	g.deregister(entry)
 	return false
 }
 
@@ -390,7 +577,7 @@ func (g *providerGeneration) register(entry *bridgeEntry) bool {
 	return true
 }
 
-func (g *providerGeneration) remove(entry *bridgeEntry) {
+func (g *providerGeneration) deregister(entry *bridgeEntry) {
 	g.mu.Lock()
 	delete(g.entries, entry)
 	g.mu.Unlock()
@@ -439,18 +626,21 @@ func (entry *bridgeEntry) retire(pool *CachedBridgePool) {
 		entry.retired.Store(true)
 		// Removal matters for eviction and rejection paths. Generation retirement
 		// clears the registry before reaching here, so this is then a no-op.
-		entry.generation.remove(entry)
+		entry.generation.deregister(entry)
 		pool.trackShutdown(entry.bridge)
 	})
 }
 
 func (p *CachedBridgePool) trackShutdown(bridge *aibridge.RequestBridge) {
 	bridge.Retire()
-	p.retirementWG.Add(1)
-	go func() {
-		defer p.retirementWG.Done()
-		_ = bridge.Shutdown(p.retirementCtx)
-	}()
+	p.retirementWG.Go(func() {
+		// Bound the drain so a retired bridge with a long-lived streaming
+		// response cannot hold its MCP session indefinitely. Pool Shutdown
+		// still cancels immediately via retirementCtx.
+		ctx, cancel := context.WithTimeout(p.retirementCtx, bridgeRetirementTimeout)
+		defer cancel()
+		_ = bridge.Shutdown(ctx)
+	})
 }
 
 func (p *CachedBridgePool) isShuttingDown() bool {

--- a/coderd/aibridged/pool.go
+++ b/coderd/aibridged/pool.go
@@ -2,6 +2,7 @@ package aibridged
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"slices"
 	"strconv"
@@ -18,23 +19,23 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/aibridge/keypool"
-	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/tracing"
 	"github.com/coder/quartz"
 )
 
-const (
-	cacheCost = 1 // We can't know the actual size in bytes of the value (it'll change over time).
+const cacheCost = 1
+
+var (
+	errGenerationRetired = xerrors.New("provider generation retired")
+	errCacheRejected     = xerrors.New("request bridge rejected by cache")
 )
 
-// Pooler describes a pool of [*aibridge.RequestBridge] instances from which instances can be retrieved.
-// One [*aibridge.RequestBridge] instance is created per given key.
+// Pooler describes a pool of [*aibridge.RequestBridge] instances.
 type Pooler interface {
-	Acquire(ctx context.Context, req Request, clientFn ClientFunc, mcpBootstrapper MCPProxyBuilder) (http.Handler, error)
+	Serve(ctx context.Context, req Request, clientFn ClientFunc, mcpBootstrapper MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) error
 	// ReplaceProviders swaps the providers used to construct future
-	// RequestBridge instances and clears the cache. Disabled providers
-	// must be included; the bridge serves a 503 sentinel on their
-	// routes.
+	// RequestBridge instances. Disabled providers must be included; the bridge
+	// serves a 503 sentinel on their routes.
 	ReplaceProviders(providers []aibridge.Provider)
 	Shutdown(ctx context.Context) error
 }
@@ -56,17 +57,35 @@ var DefaultPoolOptions = PoolOptions{MaxItems: 5000, TTL: time.Minute * 15}
 
 var _ Pooler = &CachedBridgePool{}
 
-type CachedBridgePool struct {
-	cache *ristretto.Cache[string, *aibridge.RequestBridge]
-	clock quartz.Clock
-	// providers is the live provider set used by new RequestBridge
-	// instances. Includes disabled providers.
-	providers       atomic.Pointer[[]aibridge.Provider]
-	providerVersion atomic.Int64
-	logger          slog.Logger
-	options         PoolOptions
+type providerGeneration struct {
+	id        uint64
+	providers []aibridge.Provider
 
-	singleflight *singleflight.Group[string, *aibridge.RequestBridge]
+	mu        sync.Mutex
+	retired   bool
+	entries   map[*bridgeEntry]struct{}
+	publishWG sync.WaitGroup
+}
+
+type bridgeEntry struct {
+	key        string
+	generation *providerGeneration
+	bridge     *aibridge.RequestBridge
+	retired    atomic.Bool
+	retireOnce sync.Once
+}
+
+type CachedBridgePool struct {
+	cache *ristretto.Cache[string, *bridgeEntry]
+	clock quartz.Clock
+
+	generation atomic.Pointer[providerGeneration]
+	replaceMu  sync.Mutex
+
+	logger  slog.Logger
+	options PoolOptions
+
+	singleflight *singleflight.Group[string, *bridgeEntry]
 
 	metrics *aibridge.Metrics
 	tracer  trace.Tracer
@@ -74,106 +93,112 @@ type CachedBridgePool struct {
 	shutDownOnce   sync.Once
 	shuttingDownCh chan struct{}
 
-	// cacheMu + cacheWG order cache use against Shutdown. Without it,
-	// (*ristretto.Cache).Close may race against cache usage.
+	// cacheMu and cacheWG order complete pool operations against Shutdown.
+	// This prevents cache use and retirement registration after cache.Close.
 	cacheMu sync.RWMutex
 	cacheWG sync.WaitGroup
+
+	retirementCtx    context.Context
+	retirementCancel context.CancelFunc
+	retirementWG     sync.WaitGroup
 }
 
 func NewCachedBridgePool(options PoolOptions, providers []aibridge.Provider, logger slog.Logger, metrics *aibridge.Metrics, tracer trace.Tracer) (*CachedBridgePool, error) {
-	cache, err := ristretto.NewCache(&ristretto.Config[string, *aibridge.RequestBridge]{
-		NumCounters:        options.MaxItems * 10,        // Docs suggest setting this 10x number of keys.
-		MaxCost:            options.MaxItems * cacheCost, // Up to n instances.
-		IgnoreInternalCost: true,                         // Don't try estimate cost using bytes (ristretto does this naïvely anyway, just using the size of the value struct not the REAL memory usage).
-		BufferItems:        64,                           // Sticking with recommendation from docs.
-		Metrics:            true,                         // Collect metrics (only used in tests, for now).
-		OnEvict: func(item *ristretto.Item[*aibridge.RequestBridge]) {
-			if item == nil || item.Value == nil {
-				return
-			}
-			// Capture the value synchronously: ristretto reuses the
-			// item slot after OnEvict returns, so reading item.Value
-			// from the goroutine below races with the caller of
-			// Clear/Set. The shutdown still runs in the background to
-			// avoid blocking ristretto's eviction loop.
-			bridge := item.Value
-			go func() {
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-				defer cancel()
-				_ = bridge.Shutdown(shutdownCtx)
-			}()
-		},
-	})
-	if err != nil {
-		return nil, xerrors.Errorf("create cache: %w", err)
-	}
-
 	clk := options.Clock
 	if clk == nil {
 		clk = quartz.NewReal()
 	}
 
+	retirementCtx, retirementCancel := context.WithCancel(context.Background())
 	pool := &CachedBridgePool{
-		cache:   cache,
 		clock:   clk,
 		options: options,
 		metrics: metrics,
 		tracer:  tracer,
 		logger:  logger,
 
-		singleflight: &singleflight.Group[string, *aibridge.RequestBridge]{},
+		singleflight: &singleflight.Group[string, *bridgeEntry]{},
 
 		shuttingDownCh: make(chan struct{}),
+
+		retirementCtx:    retirementCtx,
+		retirementCancel: retirementCancel,
 	}
-	initial := slices.Clone(providers)
-	pool.providers.Store(&initial)
+
+	cache, err := ristretto.NewCache(&ristretto.Config[string, *bridgeEntry]{
+		NumCounters:        options.MaxItems * 10,
+		MaxCost:            options.MaxItems * cacheCost,
+		IgnoreInternalCost: true,
+		BufferItems:        64,
+		Metrics:            true,
+		OnExit: func(entry *bridgeEntry) {
+			if entry != nil {
+				entry.retire(pool)
+			}
+		},
+	})
+	if err != nil {
+		retirementCancel()
+		return nil, xerrors.Errorf("create cache: %w", err)
+	}
+	pool.cache = cache
+
+	initial := &providerGeneration{
+		id:        1,
+		providers: slices.Clone(providers),
+		entries:   make(map[*bridgeEntry]struct{}),
+	}
+	pool.generation.Store(initial)
 	return pool, nil
 }
 
-// ReplaceProviders swaps the provider snapshot used by future Acquires.
-// It is safe to call concurrently with Acquire and is a no-op after
-// Shutdown.
+// ReplaceProviders publishes a new provider generation and retires the old one.
+// Already admitted requests continue to drain against their original generation.
 func (p *CachedBridgePool) ReplaceProviders(providers []aibridge.Provider) {
-	p.cacheMu.RLock()
-	select {
-	case <-p.shuttingDownCh:
-		p.cacheMu.RUnlock()
+	if !p.beginOperation() {
 		return
-	default:
 	}
-	p.cacheWG.Add(1)
-	p.cacheMu.RUnlock()
 	defer p.cacheWG.Done()
 
-	snapshot := slices.Clone(providers)
-	p.providers.Store(&snapshot)
-	version := p.clock.Now("provider_reload_version").UnixNano()
-	p.providerVersion.Store(version)
-	// Clear evicts every cached bridge; OnEvict shuts each one down in
-	// the background. Wait for buffered writes to drain so a replacement
-	// immediately followed by an Acquire always sees the cleared cache.
-	p.cache.Clear()
-	p.cache.Wait()
-	p.logger.Info(context.Background(), "request bridge pool reloaded",
-		slog.F("provider_count", len(snapshot)),
-		slog.F("provider_version", version),
-	)
-}
-
-// loadProviders returns the current providers snapshot. The returned
-// slice must not be mutated.
-func (p *CachedBridgePool) loadProviders() []aibridge.Provider {
-	if ptr := p.providers.Load(); ptr != nil {
-		return *ptr
+	p.replaceMu.Lock()
+	defer p.replaceMu.Unlock()
+	if p.isShuttingDown() {
+		return
 	}
-	return nil
+
+	old := p.generation.Load()
+	nextID := uint64(1)
+	if old != nil {
+		nextID = old.id + 1
+	}
+	next := &providerGeneration{
+		id:        nextID,
+		providers: slices.Clone(providers),
+		entries:   make(map[*bridgeEntry]struct{}),
+	}
+	// Trap point for deterministic replacement and shutdown tests.
+	_ = p.clock.Now("provider_generation_publish")
+	p.generation.Store(next)
+
+	if old != nil {
+		old.retire(p)
+	}
+
+	p.logger.Info(context.Background(), "request bridge pool reloaded",
+		slog.F("provider_count", len(next.providers)),
+		slog.F("provider_generation", next.id),
+	)
 }
 
 // KeyPools returns the key pools of the current live providers.
 func (p *CachedBridgePool) KeyPools() []*keypool.Pool {
-	providers := p.loadProviders()
-	pools := make([]*keypool.Pool, 0, len(providers))
-	for _, prov := range providers {
+	generation := p.generation.Load()
+	if generation == nil {
+		return nil
+	}
+
+	pools := make([]*keypool.Pool, 0, len(generation.providers))
+	for _, prov := range generation.providers {
 		if pool := prov.KeyPool(); pool != nil {
 			pools = append(pools, pool)
 		}
@@ -181,11 +206,9 @@ func (p *CachedBridgePool) KeyPools() []*keypool.Pool {
 	return pools
 }
 
-// Acquire retrieves or creates a [*aibridge.RequestBridge] instance per given key.
-//
-// Each returned [*aibridge.RequestBridge] is safe for concurrent use.
-// Each [*aibridge.RequestBridge] is stateful because it has MCP clients which maintain sessions to the configured MCP server.
-func (p *CachedBridgePool) Acquire(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder) (_ http.Handler, outErr error) {
+// Serve retrieves or creates a request bridge for the current provider
+// generation, admits the request, and serves it.
+func (p *CachedBridgePool) Serve(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, rw http.ResponseWriter, r *http.Request) (outErr error) {
 	spanAttrs := []attribute.KeyValue{
 		attribute.String(tracing.InitiatorID, req.InitiatorID.String()),
 		attribute.String(tracing.APIKeyID, req.APIKeyID),
@@ -195,108 +218,318 @@ func (p *CachedBridgePool) Acquire(ctx context.Context, req Request, clientFn Cl
 	ctx = tracing.WithRequestBridgeAttributesInContext(ctx, spanAttrs)
 
 	if err := ctx.Err(); err != nil {
-		return nil, xerrors.Errorf("acquire: %w", err)
+		return xerrors.Errorf("acquire: %w", err)
 	}
-
-	p.cacheMu.RLock()
-	select {
-	case <-p.shuttingDownCh:
-		p.cacheMu.RUnlock()
-		return nil, xerrors.New("pool shutting down")
-	default:
+	if !p.beginOperation() {
+		return xerrors.New("pool shutting down")
 	}
-	p.cacheWG.Add(1)
-	p.cacheMu.RUnlock()
 	defer p.cacheWG.Done()
 
-	// Wait for all buffered writes to be applied, otherwise multiple calls in quick succession
-	// may visit the slow path unnecessarily.
-	defer p.cache.Wait()
+	operationCtx, cancelOperation := context.WithCancel(ctx)
+	stopRetirementCancel := context.AfterFunc(p.retirementCtx, cancelOperation)
+	defer func() {
+		stopRetirementCancel()
+		cancelOperation()
+	}()
+	ctx = operationCtx
 
-	// Fast path.
-	cacheKey := req.InitiatorID.String() + "|" + req.APIKeyID
-	bridge, ok := p.cache.Get(cacheKey)
-	if ok && bridge != nil {
-		// TODO: future improvement:
-		// Once we can detect token expiry against an MCP server, we no longer need to let these instances
-		// expire after the original TTL; we can extend the TTL on each Acquire() call.
-		// For now, we need to let the instance expiry to keep the MCP connections fresh.
+	for {
+		if err := ctx.Err(); err != nil {
+			return xerrors.Errorf("acquire: %w", err)
+		}
+		if p.isShuttingDown() {
+			return xerrors.New("pool shutting down")
+		}
 
-		span.AddEvent("cache_hit")
-		return bridge, nil
+		generation := p.generation.Load()
+		if generation == nil {
+			return xerrors.New("no provider generation")
+		}
+
+		entry, err := p.getOrBuild(ctx, req, clientFn, mcpProxyFactory, generation, span)
+		switch {
+		case err == nil:
+			if entry.bridge.TryServe(rw, r) {
+				return nil
+			}
+			span.AddEvent("admission_retry")
+			continue
+		case errors.Is(err, errGenerationRetired):
+			span.AddEvent("generation_retry")
+			continue
+		case errors.Is(err, errCacheRejected):
+			err = p.serveUncached(ctx, req, clientFn, mcpProxyFactory, generation, rw, r)
+			if errors.Is(err, errGenerationRetired) {
+				span.AddEvent("generation_retry")
+				continue
+			}
+			return err
+		default:
+			return err
+		}
 	}
+}
 
+func (p *CachedBridgePool) getOrBuild(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, generation *providerGeneration, span trace.Span) (*bridgeEntry, error) {
+	cacheKey := bridgeCacheKey(generation.id, req)
+	if entry, ok := p.cache.Get(cacheKey); ok && entry != nil && !entry.retired.Load() {
+		span.AddEvent("cache_hit")
+		return entry, nil
+	}
 	span.AddEvent("cache_miss")
-	providerVersion := p.providerVersion.Load()
+
+	entry, err, _ := p.singleflight.Do(cacheKey, func() (*bridgeEntry, error) {
+		bridge, err := p.buildBridge(ctx, req, clientFn, mcpProxyFactory, generation.providers)
+		if err != nil {
+			return nil, err
+		}
+		entry := &bridgeEntry{key: cacheKey, generation: generation, bridge: bridge}
+
+		// Trap point for deterministic generation publication tests.
+		_ = p.clock.Now("bridge_cache_publish")
+
+		if !generation.publish(p.cache, entry, p.options.TTL) {
+			entry.retire(p)
+			if generation.isRetired() {
+				return nil, errGenerationRetired
+			}
+			return nil, errCacheRejected
+		}
+
+		// Make publication visible before singleflight releases its waiters.
+		// Policy rejection invokes OnExit, which marks the entry retired.
+		p.cache.Wait()
+		if entry.retired.Load() {
+			return nil, errCacheRejected
+		}
+		return entry, nil
+	})
+	return entry, err
+}
+
+func (p *CachedBridgePool) serveUncached(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, generation *providerGeneration, rw http.ResponseWriter, r *http.Request) error {
+	bridge, err := p.buildBridge(ctx, req, clientFn, mcpProxyFactory, generation.providers)
+	if err != nil {
+		return err
+	}
+	entry := &bridgeEntry{generation: generation, bridge: bridge}
+	if !generation.register(entry) {
+		entry.retire(p)
+		return errGenerationRetired
+	}
+	defer entry.retire(p)
+
+	if !bridge.TryServe(rw, r) {
+		return errGenerationRetired
+	}
+	return nil
+}
+
+func (p *CachedBridgePool) buildBridge(ctx context.Context, req Request, clientFn ClientFunc, mcpProxyFactory MCPProxyBuilder, providers []aibridge.Provider) (*aibridge.RequestBridge, error) {
 	recorder := aibridge.NewRecorder(p.logger.Named("recorder"), p.tracer, func(clientCtx context.Context) (aibridge.Recorder, error) {
-		// The recorder outlives this Acquire call, so the client is acquired
-		// against the context of the record call being served.
 		client, err := clientFn(clientCtx)
 		if err != nil {
 			return nil, xerrors.Errorf("acquire client: %w", err)
 		}
-
 		return &recorderTranslation{apiKeyID: req.APIKeyID, client: client}, nil
 	})
 
-	// Slow path.
-	// Creating an *aibridge.RequestBridge may take some time, so gate all subsequent callers behind the initial request and return the resulting value.
-	// TODO: track startup time since it adds latency to first request (histogram count will also help us see how often this occurs).
-	singleflightKey := cacheKey + "|" + strconv.FormatInt(providerVersion, 10)
-	instance, err, _ := p.singleflight.Do(singleflightKey, func() (*aibridge.RequestBridge, error) {
-		var (
-			mcpServers mcp.ServerProxier
-			err        error
-		)
-
-		mcpServers, err = mcpProxyFactory.Build(ctx, req, p.tracer)
-		if err != nil {
-			p.logger.Warn(ctx, "failed to create MCP server proxiers", slog.Error(err))
-			// Don't fail here; MCP server injection can gracefully degrade.
+	mcpServers, err := mcpProxyFactory.Build(ctx, req, p.tracer)
+	if err != nil {
+		p.logger.Warn(ctx, "failed to create MCP server proxiers", slog.Error(err))
+	}
+	if mcpServers != nil {
+		if err := mcpServers.Init(ctx); err != nil {
+			p.logger.Warn(ctx, "failed to initialize MCP server proxier(s)", slog.Error(err))
 		}
+	}
 
+	bridge, err := aibridge.NewRequestBridge(ctx, providers, recorder, mcpServers, p.logger, p.metrics, p.tracer, aibridge.WithClock(p.clock))
+	if err != nil {
 		if mcpServers != nil {
-			// This will block while connections are established with upstream MCP server(s), and tools are listed.
-			if err := mcpServers.Init(ctx); err != nil {
-				p.logger.Warn(ctx, "failed to initialize MCP server proxier(s)", slog.Error(err))
-			}
+			_ = mcpServers.Shutdown(ctx)
 		}
+		return nil, xerrors.Errorf("create new request bridge: %w", err)
+	}
+	return bridge, nil
+}
 
-		bridge, err := aibridge.NewRequestBridge(ctx, p.loadProviders(), recorder, mcpServers, p.logger, p.metrics, p.tracer, aibridge.WithClock(p.clock))
-		if err != nil {
-			return nil, xerrors.Errorf("create new request bridge: %w", err)
+func bridgeCacheKey(generation uint64, req Request) string {
+	return strconv.FormatUint(generation, 10) + "|" + req.InitiatorID.String() + "|" + req.APIKeyID
+}
+
+func (g *providerGeneration) publish(cache *ristretto.Cache[string, *bridgeEntry], entry *bridgeEntry, ttl time.Duration) bool {
+	g.mu.Lock()
+	if g.retired {
+		g.mu.Unlock()
+		return false
+	}
+	g.entries[entry] = struct{}{}
+	g.publishWG.Add(1)
+	g.mu.Unlock()
+
+	// SetWithTTL can synchronously invoke OnExit when replacing an existing
+	// value. Do not hold g.mu while calling it. publishWG prevents generation
+	// retirement from finishing until this publication attempt completes.
+	ok := cache.SetWithTTL(entry.key, entry, cacheCost, ttl)
+	g.publishWG.Done()
+	if ok {
+		return true
+	}
+	g.remove(entry)
+	return false
+}
+
+func (g *providerGeneration) register(entry *bridgeEntry) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.retired {
+		return false
+	}
+	g.entries[entry] = struct{}{}
+	return true
+}
+
+func (g *providerGeneration) remove(entry *bridgeEntry) {
+	g.mu.Lock()
+	delete(g.entries, entry)
+	g.mu.Unlock()
+}
+
+func (g *providerGeneration) isRetired() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.retired
+}
+
+func (g *providerGeneration) retire(pool *CachedBridgePool) {
+	g.mu.Lock()
+	if g.retired {
+		g.mu.Unlock()
+		return
+	}
+	g.retired = true
+	g.mu.Unlock()
+
+	// publish registers with publishWG before releasing g.mu. Once retired is
+	// set, no new publication can start, so this Wait cannot race an Add.
+	g.publishWG.Wait()
+
+	g.mu.Lock()
+	entries := make([]*bridgeEntry, 0, len(g.entries))
+	for entry := range g.entries {
+		entries = append(entries, entry)
+	}
+	clear(g.entries)
+	g.mu.Unlock()
+
+	for _, entry := range entries {
+		entry.retire(pool)
+		if entry.key != "" {
+			// Del invokes OnExit synchronously. entry.retireOnce makes the
+			// converging callback a no-op.
+			pool.cache.Del(entry.key)
 		}
+	}
+	pool.cache.Wait()
+}
 
-		if p.providerVersion.Load() == providerVersion {
-			p.cache.SetWithTTL(cacheKey, bridge, cacheCost, p.options.TTL)
-		}
-
-		return bridge, nil
+func (entry *bridgeEntry) retire(pool *CachedBridgePool) {
+	entry.retireOnce.Do(func() {
+		entry.retired.Store(true)
+		// Removal matters for eviction and rejection paths. Generation retirement
+		// clears the registry before reaching here, so this is then a no-op.
+		entry.generation.remove(entry)
+		pool.trackShutdown(entry.bridge)
 	})
+}
 
-	return instance, err
+func (p *CachedBridgePool) trackShutdown(bridge *aibridge.RequestBridge) {
+	bridge.Retire()
+	p.retirementWG.Add(1)
+	go func() {
+		defer p.retirementWG.Done()
+		_ = bridge.Shutdown(p.retirementCtx)
+	}()
+}
+
+func (p *CachedBridgePool) isShuttingDown() bool {
+	select {
+	case <-p.shuttingDownCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *CachedBridgePool) beginOperation() bool {
+	p.cacheMu.RLock()
+	defer p.cacheMu.RUnlock()
+	select {
+	case <-p.shuttingDownCh:
+		return false
+	default:
+		p.cacheWG.Add(1)
+		return true
+	}
 }
 
 func (p *CachedBridgePool) CacheMetrics() PoolMetrics {
 	if p.cache == nil {
 		return nil
 	}
-
 	return p.cache.Metrics
 }
 
-// Shutdown will close the cache which will trigger eviction of all the Bridge entries.
-func (p *CachedBridgePool) Shutdown(_ context.Context) error {
+// Shutdown prevents new pool operations, retires the current generation, and
+// waits for operations and bridge cleanup. Context cancellation accelerates
+// retirement by canceling admitted requests.
+func (p *CachedBridgePool) Shutdown(ctx context.Context) error {
+	var outErr error
 	p.shutDownOnce.Do(func() {
-		// Block new cache use, drain in-flight ops, then close (see cacheMu).
 		p.cacheMu.Lock()
 		close(p.shuttingDownCh)
 		p.cacheMu.Unlock()
 
-		p.cacheWG.Wait()
+		// Serialize with replacement so the generation observed here is the last
+		// one that can be published. Retire before waiting for Serve operations to
+		// close admission and let context cancellation unblock active handlers.
+		p.replaceMu.Lock()
+		if generation := p.generation.Load(); generation != nil {
+			generation.retire(p)
+		}
+		p.replaceMu.Unlock()
+
+		operationsDone := make(chan struct{})
+		go func() {
+			p.cacheWG.Wait()
+			close(operationsDone)
+		}()
+
+		select {
+		case <-operationsDone:
+		case <-ctx.Done():
+			p.retirementCancel()
+			<-operationsDone
+			outErr = ctx.Err()
+		}
 
 		p.cache.Close()
-	})
 
-	return nil
+		retirementDone := make(chan struct{})
+		go func() {
+			p.retirementWG.Wait()
+			close(retirementDone)
+		}()
+
+		select {
+		case <-retirementDone:
+			p.retirementCancel()
+		case <-ctx.Done():
+			p.retirementCancel()
+			<-retirementDone
+			outErr = ctx.Err()
+		}
+	})
+	return outErr
 }

--- a/coderd/aibridged/pool_internal_test.go
+++ b/coderd/aibridged/pool_internal_test.go
@@ -5,10 +5,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -21,12 +25,13 @@ import (
 	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/mcpmock"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
-// TestPoolServeRebuildsShutdownCachedBridge covers a request which finds a
-// cached bridge that a provider reload has already shut down. The pool must
-// rebuild instead of serving through the closed bridge, which responds 500.
-func TestPoolServeRebuildsShutdownCachedBridge(t *testing.T) {
+// TestPoolServeRetriesRetiredCachedBridgeAdmission covers the retirement
+// window after a cached bridge is selected but before TryServe admits the
+// request. The pool must retry instead of serving through the closed bridge.
+func TestPoolServeRetriesRetiredCachedBridgeAdmission(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -40,9 +45,11 @@ func TestPoolServeRebuildsShutdownCachedBridge(t *testing.T) {
 	mcpProxy.EXPECT().Init(gomock.Any()).AnyTimes().Return(nil)
 	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
 
-	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute}, []aibridge.Provider{
+	clk := quartz.NewMock(t)
+	metrics := aibridge.NewMetrics(prometheus.NewRegistry())
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute, Clock: clk}, []aibridge.Provider{
 		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
-	}, slogtest.Make(t, nil), nil, otel.Tracer("pool_internal_test"))
+	}, slogtest.Make(t, nil), metrics, otel.Tracer("pool_internal_test"))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
 
@@ -55,35 +62,407 @@ func TestPoolServeRebuildsShutdownCachedBridge(t *testing.T) {
 	clientFn := func(context.Context) (DRPCClient, error) {
 		return nil, xerrors.New("no DRPC client")
 	}
-	factory := &poolTestMCPFactory{proxy: mcpProxy}
-
-	serve := func() *httptest.ResponseRecorder {
-		t.Helper()
-
-		rw := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
-		require.NoError(t, pool.Serve(ctx, req, clientFn, factory, rw, r))
-		return rw
-	}
+	factory := &countingMCPFactory{proxy: mcpProxy}
 
 	// Given: a cached bridge which served a request.
-	require.Equal(t, http.StatusOK, serve().Code)
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+	require.NoError(t, pool.Serve(ctx, req, clientFn, factory, rw, r))
+	require.Equal(t, http.StatusOK, rw.Code)
 
-	// When: that bridge is retired while it is still cached, as a cache exit
-	// does before the buffered deletion becomes visible.
+	trap := clk.Trap().Now("bridge_serve_admission")
+	defer trap.Close()
+
+	// When: a second request selects that bridge and provider replacement or
+	// eviction retires it before TryServe admission.
+	serveDone := make(chan poolServeResult, 1)
+	go func() {
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+		err := pool.Serve(ctx, req, clientFn, factory, rw, r)
+		serveDone <- poolServeResult{err: err, code: rw.Code, body: rw.Body.String()}
+	}()
+
+	firstAdmission := trap.MustWait(ctx)
 	cacheKey := bridgeCacheKey(pool.generation.Load().id, req)
 	cached, ok := pool.cache.Get(cacheKey)
 	require.True(t, ok)
 	cached.retire(pool)
+	firstAdmission.MustRelease(ctx)
 
-	// Then: the request is served by a rebuilt bridge.
-	rw := serve()
-	require.Equal(t, http.StatusOK, rw.Code)
-	require.Equal(t, "served", rw.Body.String())
+	// The retry selects a rebuilt bridge. Let that admission proceed.
+	trap.MustWait(ctx).MustRelease(ctx)
+
+	result := testutil.RequireReceive(ctx, t, serveDone)
+	require.NoError(t, result.err)
+	require.Equal(t, http.StatusOK, result.code)
+	require.Equal(t, "served", result.body)
+	require.EqualValues(t, 2, factory.builds.Load())
+	require.Equal(t, 1.0, promtest.ToFloat64(metrics.BridgePoolRetries.WithLabelValues("admission")))
+	require.Equal(t, 0.0, promtest.ToFloat64(metrics.BridgePoolRetryExhausted.WithLabelValues("admission")))
 
 	rebuilt, ok := pool.cache.Get(cacheKey)
 	require.True(t, ok)
 	require.NotSame(t, cached.bridge, rebuilt.bridge)
+}
+
+func TestPoolServeUncachedFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "served")
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Init(gomock.Any()).AnyTimes().Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
+
+	// A negative TTL makes Ristretto's SetWithTTL a deterministic no-op that
+	// returns false. The rejected build itself must serve the request without a
+	// second MCP build.
+	metrics := aibridge.NewMetrics(prometheus.NewRegistry())
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: -time.Second}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), metrics, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	req := Request{
+		SessionKey:  "key",
+		InitiatorID: uuid.New(),
+		APIKeyID:    uuid.New().String(),
+	}
+	clientFn := func(context.Context) (DRPCClient, error) {
+		return nil, xerrors.New("no DRPC client")
+	}
+	factory := &countingMCPFactory{proxy: mcpProxy}
+
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+	require.NoError(t, pool.Serve(ctx, req, clientFn, factory, rw, r))
+
+	require.Equal(t, http.StatusOK, rw.Code)
+	require.Equal(t, "served", rw.Body.String())
+	require.EqualValues(t, 1, factory.builds.Load())
+	require.EqualValues(t, 0, pool.CacheMetrics().KeysAdded())
+	require.Equal(t, 1.0, promtest.ToFloat64(metrics.BridgePoolUncachedServeAttempts))
+}
+
+func TestPoolServeUncachedFallbackCoalescesConcurrentBuilds(t *testing.T) {
+	t.Parallel()
+
+	const requestCount = 16
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "served")
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	shutdown := make(chan struct{})
+	mcpProxy.EXPECT().Init(gomock.Any()).Times(1).Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).DoAndReturn(func(context.Context) error {
+		close(shutdown)
+		return nil
+	}).Times(1)
+
+	metrics := aibridge.NewMetrics(prometheus.NewRegistry())
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: -time.Second}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), metrics, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	req := Request{
+		SessionKey:  "key",
+		InitiatorID: uuid.New(),
+		APIKeyID:    uuid.New().String(),
+	}
+	clientFn := func(context.Context) (DRPCClient, error) {
+		return nil, xerrors.New("no DRPC client")
+	}
+	factory := newBlockingCountingMCPFactory(mcpProxy)
+	results := make(chan poolServeResult, requestCount)
+	serve := func() {
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+		err := pool.Serve(ctx, req, clientFn, factory, rw, r)
+		results <- poolServeResult{err: err, code: rw.Code, body: rw.Body.String()}
+	}
+
+	go serve()
+	_ = testutil.TryReceive(ctx, t, factory.started)
+
+	cacheKey := bridgeCacheKey(pool.generation.Load().id, req)
+	for users := 2; users <= requestCount; users++ {
+		go serve()
+		require.Eventually(t, func() bool {
+			pool.builds.mu.Lock()
+			defer pool.builds.mu.Unlock()
+			call := pool.builds.calls[cacheKey]
+			return call != nil && call.users == users
+		}, testutil.WaitShort, testutil.IntervalFast)
+	}
+	close(factory.release)
+
+	for range requestCount {
+		result := testutil.RequireReceive(ctx, t, results)
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusOK, result.code)
+		require.Equal(t, "served", result.body)
+	}
+
+	require.EqualValues(t, 1, factory.builds.Load())
+	require.EqualValues(t, 0, pool.CacheMetrics().KeysAdded())
+	require.Equal(t, float64(requestCount), promtest.ToFloat64(metrics.BridgePoolUncachedServeAttempts))
+	_ = testutil.TryReceive(ctx, t, shutdown)
+}
+
+func TestPoolPolicyRejectedEntryRemainsUsableUntilRetired(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "served")
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Init(gomock.Any()).Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
+
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), nil, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	req := Request{SessionKey: "key", InitiatorID: uuid.New(), APIKeyID: uuid.New().String()}
+	generation := pool.generation.Load()
+	bridge, err := pool.buildBridge(ctx, req, func(context.Context) (DRPCClient, error) {
+		return nil, xerrors.New("no DRPC client")
+	}, &poolTestMCPFactory{proxy: mcpProxy}, generation.providers)
+	require.NoError(t, err)
+
+	entry := &bridgeEntry{key: "policy-rejected", generation: generation, bridge: bridge}
+	require.True(t, generation.register(entry))
+
+	// A cost above MaxCost is accepted into the set buffer, then rejected by
+	// policy. OnReject marks the entry before OnExit runs, preserving it for
+	// callers that already joined the build.
+	require.True(t, pool.cache.SetWithTTL(entry.key, entry, cacheCost+1, time.Minute))
+	pool.cache.Wait()
+	require.True(t, entry.cacheRejected.Load())
+	require.False(t, entry.retired.Load())
+	require.EqualValues(t, 0, pool.cache.Metrics.KeysAdded())
+
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+	require.True(t, entry.bridge.TryServe(rw, r))
+	require.Equal(t, http.StatusOK, rw.Code)
+	require.Equal(t, "served", rw.Body.String())
+
+	entry.retire(pool)
+	require.True(t, entry.retired.Load())
+}
+
+func TestPoolServeAdmissionRetriesAreBounded(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "unexpected")
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Init(gomock.Any()).AnyTimes().Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
+
+	clk := quartz.NewMock(t)
+	metrics := aibridge.NewMetrics(prometheus.NewRegistry())
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute, Clock: clk}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), metrics, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	req := Request{SessionKey: "key", InitiatorID: uuid.New(), APIKeyID: uuid.New().String()}
+	clientFn := func(context.Context) (DRPCClient, error) {
+		return nil, xerrors.New("no DRPC client")
+	}
+	factory := &countingMCPFactory{proxy: mcpProxy}
+
+	// Populate the cache before trapping admission for the request under test.
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+	require.NoError(t, pool.Serve(ctx, req, clientFn, factory, rw, r))
+
+	trap := clk.Trap().Now("bridge_serve_admission")
+	defer trap.Close()
+	serveDone := make(chan error, 1)
+	go func() {
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+		serveDone <- pool.Serve(ctx, req, clientFn, factory, rw, r)
+	}()
+
+	cacheKey := bridgeCacheKey(pool.generation.Load().id, req)
+	for range maxBridgeServeAttempts {
+		admission := trap.MustWait(ctx)
+		entry, ok := pool.cache.Get(cacheKey)
+		require.True(t, ok)
+		require.False(t, entry.retired.Load())
+		entry.retire(pool)
+		admission.MustRelease(ctx)
+	}
+
+	err = testutil.RequireReceive(ctx, t, serveDone)
+	require.ErrorIs(t, err, errBridgeServeRetriesExhausted)
+	require.EqualValues(t, maxBridgeServeAttempts, factory.builds.Load())
+	require.Equal(t, float64(maxBridgeServeAttempts-1), promtest.ToFloat64(metrics.BridgePoolRetries.WithLabelValues("admission")))
+	require.Equal(t, 1.0, promtest.ToFloat64(metrics.BridgePoolRetryExhausted.WithLabelValues("admission")))
+}
+
+func TestBridgeBuildGroupReleasesWaitersAfterPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	var group bridgeBuildGroup
+	started := make(chan struct{})
+	panicBuild := make(chan struct{})
+	panics := make(chan any, 2)
+
+	call := func(fn func() (*bridgeEntry, func(), error)) {
+		defer func() { panics <- recover() }()
+		_, release, _ := group.Do("key", fn)
+		release()
+	}
+
+	go call(func() (*bridgeEntry, func(), error) {
+		close(started)
+		<-panicBuild
+		panic("build panic")
+	})
+	_ = testutil.TryReceive(ctx, t, started)
+
+	go call(func() (*bridgeEntry, func(), error) {
+		t.Error("duplicate caller unexpectedly built a bridge")
+		return nil, nil, nil
+	})
+	require.Eventually(t, func() bool {
+		group.mu.Lock()
+		defer group.mu.Unlock()
+		call := group.calls["key"]
+		return call != nil && call.users == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	close(panicBuild)
+
+	require.Equal(t, "build panic", testutil.RequireReceive(ctx, t, panics))
+	require.Equal(t, "build panic", testutil.RequireReceive(ctx, t, panics))
+
+	entry := &bridgeEntry{}
+	got, release, err := group.Do("key", func() (*bridgeEntry, func(), error) {
+		return entry, nil, nil
+	})
+	require.NoError(t, err)
+	require.Same(t, entry, got)
+	release()
+}
+
+func TestBridgeBuildGroupReleasesWaitersAfterGoexit(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	var group bridgeBuildGroup
+	started := make(chan struct{})
+	exitBuild := make(chan struct{})
+	leaderDone := make(chan struct{})
+	waiterDone := make(chan error, 1)
+
+	go func() {
+		defer close(leaderDone)
+		_, release, _ := group.Do("key", func() (*bridgeEntry, func(), error) {
+			close(started)
+			<-exitBuild
+			runtime.Goexit()
+			return nil, nil, nil
+		})
+		release()
+	}()
+	_ = testutil.TryReceive(ctx, t, started)
+
+	go func() {
+		_, release, err := group.Do("key", func() (*bridgeEntry, func(), error) {
+			t.Error("duplicate caller unexpectedly built a bridge")
+			return nil, nil, nil
+		})
+		release()
+		waiterDone <- err
+	}()
+	require.Eventually(t, func() bool {
+		group.mu.Lock()
+		defer group.mu.Unlock()
+		call := group.calls["key"]
+		return call != nil && call.users == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	close(exitBuild)
+
+	_ = testutil.TryReceive(ctx, t, leaderDone)
+	require.ErrorIs(t, testutil.RequireReceive(ctx, t, waiterDone), errBridgeBuildExited)
+
+	entry := &bridgeEntry{}
+	got, release, err := group.Do("key", func() (*bridgeEntry, func(), error) {
+		return entry, nil, nil
+	})
+	require.NoError(t, err)
+	require.Same(t, entry, got)
+	release()
+}
+
+func TestPoolServeUncachedFallbackReleasesAfterPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "served")
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	shutdown := make(chan struct{})
+	mcpProxy.EXPECT().Init(gomock.Any()).Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).DoAndReturn(func(context.Context) error {
+		close(shutdown)
+		return nil
+	}).Times(1)
+
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: -time.Second}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), nil, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	req := Request{SessionKey: "key", InitiatorID: uuid.New(), APIKeyID: uuid.New().String()}
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+		_ = pool.Serve(ctx, req, func(context.Context) (DRPCClient, error) {
+			return nil, xerrors.New("no DRPC client")
+		}, &poolTestMCPFactory{proxy: mcpProxy}, panicResponseWriter{}, r)
+	}()
+
+	require.Equal(t, "response writer panic", panicValue)
+	_ = testutil.TryReceive(ctx, t, shutdown)
 }
 
 func TestPoolShutdownCancelsBridgeBuild(t *testing.T) {
@@ -171,6 +550,53 @@ func TestPoolShutdownCancelsAdmittedRequest(t *testing.T) {
 	require.NoError(t, testutil.RequireReceive(ctx, t, serveDone))
 }
 
+type panicResponseWriter struct{}
+
+func (panicResponseWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (panicResponseWriter) Write([]byte) (int, error) {
+	panic("response writer panic")
+}
+
+func (panicResponseWriter) WriteHeader(int) {
+	panic("response writer panic")
+}
+
+type poolServeResult struct {
+	err  error
+	code int
+	body string
+}
+
+type blockingCountingMCPFactory struct {
+	proxy   *mcpmock.MockServerProxier
+	builds  atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func newBlockingCountingMCPFactory(proxy *mcpmock.MockServerProxier) *blockingCountingMCPFactory {
+	return &blockingCountingMCPFactory{
+		proxy:   proxy,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (f *blockingCountingMCPFactory) Build(ctx context.Context, _ Request, _ trace.Tracer) (mcp.ServerProxier, error) {
+	if f.builds.Add(1) == 1 {
+		close(f.started)
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return f.proxy, nil
+}
+
 type MCPProxyBuilderFunc func(context.Context, Request, trace.Tracer) (mcp.ServerProxier, error)
 
 func (f MCPProxyBuilderFunc) Build(ctx context.Context, req Request, tracer trace.Tracer) (mcp.ServerProxier, error) {
@@ -182,5 +608,15 @@ type poolTestMCPFactory struct {
 }
 
 func (f *poolTestMCPFactory) Build(context.Context, Request, trace.Tracer) (mcp.ServerProxier, error) {
+	return f.proxy, nil
+}
+
+type countingMCPFactory struct {
+	proxy  *mcpmock.MockServerProxier
+	builds atomic.Int32
+}
+
+func (f *countingMCPFactory) Build(context.Context, Request, trace.Tracer) (mcp.ServerProxier, error) {
+	f.builds.Add(1)
 	return f.proxy, nil
 }

--- a/coderd/aibridged/pool_internal_test.go
+++ b/coderd/aibridged/pool_internal_test.go
@@ -1,0 +1,186 @@
+package aibridged
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/aibridge"
+	"github.com/coder/coder/v2/aibridge/config"
+	"github.com/coder/coder/v2/aibridge/mcp"
+	"github.com/coder/coder/v2/aibridge/mcpmock"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestPoolServeRebuildsShutdownCachedBridge covers a request which finds a
+// cached bridge that a provider reload has already shut down. The pool must
+// rebuild instead of serving through the closed bridge, which responds 500.
+func TestPoolServeRebuildsShutdownCachedBridge(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "served")
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Init(gomock.Any()).AnyTimes().Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
+
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), nil, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	req := Request{
+		SessionKey:  "key",
+		InitiatorID: uuid.New(),
+		APIKeyID:    uuid.New().String(),
+	}
+	// The passthrough below is not recorded, so no DRPC client is needed.
+	clientFn := func(context.Context) (DRPCClient, error) {
+		return nil, xerrors.New("no DRPC client")
+	}
+	factory := &poolTestMCPFactory{proxy: mcpProxy}
+
+	serve := func() *httptest.ResponseRecorder {
+		t.Helper()
+
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+		require.NoError(t, pool.Serve(ctx, req, clientFn, factory, rw, r))
+		return rw
+	}
+
+	// Given: a cached bridge which served a request.
+	require.Equal(t, http.StatusOK, serve().Code)
+
+	// When: that bridge is retired while it is still cached, as a cache exit
+	// does before the buffered deletion becomes visible.
+	cacheKey := bridgeCacheKey(pool.generation.Load().id, req)
+	cached, ok := pool.cache.Get(cacheKey)
+	require.True(t, ok)
+	cached.retire(pool)
+
+	// Then: the request is served by a rebuilt bridge.
+	rw := serve()
+	require.Equal(t, http.StatusOK, rw.Code)
+	require.Equal(t, "served", rw.Body.String())
+
+	rebuilt, ok := pool.cache.Get(cacheKey)
+	require.True(t, ok)
+	require.NotSame(t, cached.bridge, rebuilt.bridge)
+}
+
+func TestPoolShutdownCancelsBridgeBuild(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	buildStarted := make(chan struct{})
+	buildCanceled := make(chan struct{})
+	factory := MCPProxyBuilderFunc(func(ctx context.Context, _ Request, _ trace.Tracer) (mcp.ServerProxier, error) {
+		close(buildStarted)
+		<-ctx.Done()
+		close(buildCanceled)
+		return nil, ctx.Err()
+	})
+
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute}, nil, slogtest.Make(t, nil), nil, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+
+	serveDone := make(chan error, 1)
+	go func() {
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+		serveDone <- pool.Serve(ctx, Request{
+			SessionKey:  "key",
+			InitiatorID: uuid.New(),
+			APIKeyID:    uuid.New().String(),
+		}, func(context.Context) (DRPCClient, error) {
+			return nil, xerrors.New("no DRPC client")
+		}, factory, rw, r)
+	}()
+	_ = testutil.TryReceive(ctx, t, buildStarted)
+
+	shutdownCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, pool.Shutdown(shutdownCtx), context.Canceled)
+	_ = testutil.TryReceive(ctx, t, buildCanceled)
+	require.ErrorIs(t, testutil.RequireReceive(ctx, t, serveDone), context.Canceled)
+}
+
+func TestPoolShutdownCancelsAdmittedRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(canceled)
+	}))
+	t.Cleanup(func() {
+		upstream.CloseClientConnections()
+		upstream.Close()
+	})
+
+	ctrl := gomock.NewController(t)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Init(gomock.Any()).Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).Return(nil)
+
+	pool, err := NewCachedBridgePool(PoolOptions{MaxItems: 1, TTL: time.Minute}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "p", BaseURL: upstream.URL}),
+	}, slogtest.Make(t, nil), nil, otel.Tracer("pool_internal_test"))
+	require.NoError(t, err)
+
+	req := Request{
+		SessionKey:  "key",
+		InitiatorID: uuid.New(),
+		APIKeyID:    uuid.New().String(),
+	}
+	serveDone := make(chan error, 1)
+	go func() {
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/p/v1/models", nil).WithContext(ctx)
+		serveDone <- pool.Serve(ctx, req, func(context.Context) (DRPCClient, error) {
+			return nil, xerrors.New("no DRPC client")
+		}, &poolTestMCPFactory{proxy: mcpProxy}, rw, r)
+	}()
+	_ = testutil.TryReceive(ctx, t, started)
+
+	shutdownCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, pool.Shutdown(shutdownCtx), context.Canceled)
+	_ = testutil.TryReceive(ctx, t, canceled)
+	require.NoError(t, testutil.RequireReceive(ctx, t, serveDone))
+}
+
+type MCPProxyBuilderFunc func(context.Context, Request, trace.Tracer) (mcp.ServerProxier, error)
+
+func (f MCPProxyBuilderFunc) Build(ctx context.Context, req Request, tracer trace.Tracer) (mcp.ServerProxier, error) {
+	return f(ctx, req, tracer)
+}
+
+type poolTestMCPFactory struct {
+	proxy *mcpmock.MockServerProxier
+}
+
+func (f *poolTestMCPFactory) Build(context.Context, Request, trace.Tracer) (mcp.ServerProxier, error) {
+	return f.proxy, nil
+}

--- a/coderd/aibridged/pool_test.go
+++ b/coderd/aibridged/pool_test.go
@@ -57,19 +57,19 @@ func TestPool(t *testing.T) {
 	// This is part of the lifecycle.
 	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
 
-	// Acquiring a pool instance will create one the first time it sees an
-	// initiator ID...
+	// Serving a request for an initiator ID will create a bridge the first time
+	// it is seen...
 	req1 := aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: id,
 		APIKeyID:    apiKeyID1.String(),
 	}
 	err = servePool(t.Context(), pool, req1, clientFn, newMockMCPFactory(mcpProxy))
-	require.NoError(t, err, "acquire pool instance")
+	require.NoError(t, err, "serve pool instance")
 
-	// ...and it will reuse it when acquired again.
+	// ...and it will reuse it when served again.
 	err = servePool(t.Context(), pool, req1, clientFn, newMockMCPFactory(mcpProxy))
-	require.NoError(t, err, "acquire pool instance")
+	require.NoError(t, err, "serve pool instance")
 
 	cacheMetrics := pool.CacheMetrics()
 	require.EqualValues(t, 1, cacheMetrics.KeysAdded())
@@ -87,7 +87,7 @@ func TestPool(t *testing.T) {
 		APIKeyID:    apiKeyID1.String(),
 	}
 	err = servePool(t.Context(), pool, req2, clientFn, newMockMCPFactory(mcpProxy))
-	require.NoError(t, err, "acquire pool instance")
+	require.NoError(t, err, "serve pool instance")
 
 	cacheMetrics = pool.CacheMetrics()
 	require.EqualValues(t, 2, cacheMetrics.KeysAdded())
@@ -105,7 +105,7 @@ func TestPool(t *testing.T) {
 		APIKeyID:    apiKeyID2.String(),
 	}
 	err = servePool(t.Context(), pool, req2B, clientFn, newMockMCPFactory(mcpProxy))
-	require.NoError(t, err, "acquire pool instance 2B")
+	require.NoError(t, err, "serve pool instance 2B")
 
 	cacheMetrics = pool.CacheMetrics()
 	require.EqualValues(t, 3, cacheMetrics.KeysAdded())
@@ -114,7 +114,7 @@ func TestPool(t *testing.T) {
 	require.EqualValues(t, 3, cacheMetrics.Misses())
 }
 
-func TestPoolReplaceProvidersClearsCacheAndUsesNewProviders(t *testing.T) {
+func TestPoolReplaceProvidersUsesNewProviders(t *testing.T) {
 	t.Parallel()
 
 	oldUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -232,7 +232,7 @@ func TestPoolReplaceProvidersDuringCachePublication(t *testing.T) {
 	require.Equal(t, "new", result.body)
 }
 
-func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
+func TestPoolReplaceProvidersDoesNotJoinStaleBuild(t *testing.T) {
 	t.Parallel()
 
 	oldUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -265,10 +265,10 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 	}
 
 	factory := newBlockingMCPFactory()
-	firstDone := make(chan acquireResult, 1)
+	firstDone := make(chan serveResult, 1)
 	go func() {
 		err := servePool(t.Context(), pool, req, clientFn, factory)
-		firstDone <- acquireResult{err: err}
+		firstDone <- serveResult{err: err}
 	}()
 
 	require.Eventually(t, factory.firstBuildStarted, testutil.WaitShort, testutil.IntervalFast)
@@ -277,13 +277,18 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 		aibridge.NewOpenAIProvider(config.OpenAI{Name: "new", BaseURL: newUpstream.URL}),
 	})
 
-	secondDone := make(chan acquireResult, 1)
+	// The second serve is concurrent with ReplaceProviders. It must be routed
+	// through the new provider, not the stale bridge being built by the first
+	// serve. Capture its recorder body and assert on it directly.
+	secondDone := make(chan serveResult, 1)
 	go func() {
-		err := servePool(t.Context(), pool, req, clientFn, factory)
-		secondDone <- acquireResult{err: err}
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/new/v1/models", nil).WithContext(t.Context())
+		err := pool.Serve(t.Context(), req, clientFn, factory, rw, r)
+		secondDone <- serveResult{err: err, code: rw.Code, body: rw.Body.String()}
 	}()
 
-	var second acquireResult
+	var second serveResult
 	require.Eventually(t, func() bool {
 		select {
 		case second = <-secondDone:
@@ -293,10 +298,11 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 		}
 	}, testutil.WaitShort, testutil.IntervalFast)
 	require.NoError(t, second.err)
-	assertPoolBody(t, pool, req, clientFn, factory, "/new/v1/models", "new")
+	require.Equal(t, http.StatusOK, second.code)
+	require.Equal(t, "new", second.body)
 
 	close(factory.releaseFirst)
-	var first acquireResult
+	var first serveResult
 	require.Eventually(t, func() bool {
 		select {
 		case first = <-firstDone:
@@ -364,11 +370,11 @@ func TestPool_Expiry(t *testing.T) {
 
 		ctx := t.Context()
 
-		// First acquire is a cache miss.
+		// First serve is a cache miss.
 		err = servePool(ctx, pool, req, clientFn, newMockMCPFactory(mcpProxy))
 		require.NoError(t, err)
 
-		// Second acquire is a cache hit.
+		// Second serve is a cache hit.
 		err = servePool(ctx, pool, req, clientFn, newMockMCPFactory(mcpProxy))
 		require.NoError(t, err)
 
@@ -379,7 +385,7 @@ func TestPool_Expiry(t *testing.T) {
 		// TTL expires
 		time.Sleep(ttl + time.Millisecond)
 
-		// Third acquire is a cache miss because the entry expired.
+		// Third serve is a cache miss because the entry expired.
 		err = servePool(ctx, pool, req, clientFn, newMockMCPFactory(mcpProxy))
 		require.NoError(t, err)
 
@@ -456,7 +462,8 @@ func TestPoolShutdownReplaceProviders(t *testing.T) {
 
 	clientFn := func(context.Context) (aibridged.DRPCClient, error) { return client, nil }
 
-	// Populate the cache so ReplaceProviders' Clear has an entry to evict.
+	// Populate the cache so ReplaceProviders' generation retirement has an
+	// entry to retire.
 	err = servePool(ctx, pool, aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: uuid.New(),
@@ -494,8 +501,10 @@ func (m *mockMCPFactory) Build(ctx context.Context, req aibridged.Request, trace
 	return m.proxy, nil
 }
 
-type acquireResult struct {
-	err error
+type serveResult struct {
+	err  error
+	code int
+	body string
 }
 
 type blockingMCPFactory struct {

--- a/coderd/aibridged/pool_test.go
+++ b/coderd/aibridged/pool_test.go
@@ -59,21 +59,17 @@ func TestPool(t *testing.T) {
 
 	// Acquiring a pool instance will create one the first time it sees an
 	// initiator ID...
-	inst, err := pool.Acquire(t.Context(), aibridged.Request{
+	req1 := aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: id,
 		APIKeyID:    apiKeyID1.String(),
-	}, clientFn, newMockMCPFactory(mcpProxy))
+	}
+	err = servePool(t.Context(), pool, req1, clientFn, newMockMCPFactory(mcpProxy))
 	require.NoError(t, err, "acquire pool instance")
 
-	// ...and it will return it when acquired again.
-	instB, err := pool.Acquire(t.Context(), aibridged.Request{
-		SessionKey:  "key",
-		InitiatorID: id,
-		APIKeyID:    apiKeyID1.String(),
-	}, clientFn, newMockMCPFactory(mcpProxy))
+	// ...and it will reuse it when acquired again.
+	err = servePool(t.Context(), pool, req1, clientFn, newMockMCPFactory(mcpProxy))
 	require.NoError(t, err, "acquire pool instance")
-	require.Same(t, inst, instB)
 
 	cacheMetrics := pool.CacheMetrics()
 	require.EqualValues(t, 1, cacheMetrics.KeysAdded())
@@ -85,13 +81,13 @@ func TestPool(t *testing.T) {
 	mcpProxy.EXPECT().Init(gomock.Any()).Times(1).Return(nil)
 
 	// But that key will be evicted when a new initiator is seen (maxItems=1):
-	inst2, err := pool.Acquire(t.Context(), aibridged.Request{
+	req2 := aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: id2,
 		APIKeyID:    apiKeyID1.String(),
-	}, clientFn, newMockMCPFactory(mcpProxy))
+	}
+	err = servePool(t.Context(), pool, req2, clientFn, newMockMCPFactory(mcpProxy))
 	require.NoError(t, err, "acquire pool instance")
-	require.NotSame(t, inst, inst2)
 
 	cacheMetrics = pool.CacheMetrics()
 	require.EqualValues(t, 2, cacheMetrics.KeysAdded())
@@ -103,13 +99,13 @@ func TestPool(t *testing.T) {
 	mcpProxy.EXPECT().Init(gomock.Any()).Times(1).Return(nil)
 
 	// New instance is created for different api key id
-	inst2B, err := pool.Acquire(t.Context(), aibridged.Request{
+	req2B := aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: id2,
 		APIKeyID:    apiKeyID2.String(),
-	}, clientFn, newMockMCPFactory(mcpProxy))
+	}
+	err = servePool(t.Context(), pool, req2B, clientFn, newMockMCPFactory(mcpProxy))
 	require.NoError(t, err, "acquire pool instance 2B")
-	require.NotSame(t, inst2, inst2B)
 
 	cacheMetrics = pool.CacheMetrics()
 	require.EqualValues(t, 3, cacheMetrics.KeysAdded())
@@ -153,18 +149,87 @@ func TestPoolReplaceProvidersClearsCacheAndUsesNewProviders(t *testing.T) {
 		return client, nil
 	}
 
-	inst, err := pool.Acquire(t.Context(), req, clientFn, newMockMCPFactory(mcpProxy))
-	require.NoError(t, err)
-	assertHandlerBody(t, inst, "/old/v1/models", "old")
+	assertPoolBody(t, pool, req, clientFn, newMockMCPFactory(mcpProxy), "/old/v1/models", "old")
 
 	pool.ReplaceProviders([]aibridge.Provider{
 		aibridge.NewOpenAIProvider(config.OpenAI{Name: "new", BaseURL: newUpstream.URL}),
 	})
 
-	instAfterReload, err := pool.Acquire(t.Context(), req, clientFn, newMockMCPFactory(mcpProxy))
+	assertPoolBody(t, pool, req, clientFn, newMockMCPFactory(mcpProxy), "/new/v1/models", "new")
+}
+
+func TestPoolReplaceProvidersDuringCachePublication(t *testing.T) {
+	t.Parallel()
+
+	oldUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "old")
+	}))
+	t.Cleanup(oldUpstream.Close)
+	newUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "new")
+	}))
+	t.Cleanup(newUpstream.Close)
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clk := quartz.NewMock(t)
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockDRPCClient(ctrl)
+	mcpProxy := mcpmock.NewMockServerProxier(ctrl)
+	mcpProxy.EXPECT().Init(gomock.Any()).AnyTimes().Return(nil)
+	mcpProxy.EXPECT().Shutdown(gomock.Any()).AnyTimes().Return(nil)
+
+	pool, err := aibridged.NewCachedBridgePool(aibridged.PoolOptions{
+		MaxItems: 1,
+		TTL:      time.Minute,
+		Clock:    clk,
+	}, []aibridge.Provider{
+		aibridge.NewOpenAIProvider(config.OpenAI{Name: "old", BaseURL: oldUpstream.URL}),
+	}, slogtest.Make(t, nil), nil, testTracer)
 	require.NoError(t, err)
-	require.NotSame(t, inst, instAfterReload)
-	assertHandlerBody(t, instAfterReload, "/new/v1/models", "new")
+	t.Cleanup(func() { _ = pool.Shutdown(context.Background()) })
+
+	publishTrap := clk.Trap().Now("bridge_cache_publish")
+	replaceTrap := clk.Trap().Now("provider_generation_publish")
+	defer replaceTrap.Close()
+
+	req := aibridged.Request{
+		SessionKey:  "key",
+		InitiatorID: uuid.New(),
+		APIKeyID:    uuid.New().String(),
+	}
+	type serveResult struct {
+		code int
+		body string
+		err  error
+	}
+	serveDone := make(chan serveResult, 1)
+	go func() {
+		rw := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/new/v1/models", nil).WithContext(ctx)
+		err := pool.Serve(ctx, req, func(context.Context) (aibridged.DRPCClient, error) {
+			return client, nil
+		}, newMockMCPFactory(mcpProxy), rw, r)
+		serveDone <- serveResult{code: rw.Code, body: rw.Body.String(), err: err}
+	}()
+
+	publish := publishTrap.MustWait(ctx)
+	replaceDone := make(chan struct{})
+	go func() {
+		defer close(replaceDone)
+		pool.ReplaceProviders([]aibridge.Provider{
+			aibridge.NewOpenAIProvider(config.OpenAI{Name: "new", BaseURL: newUpstream.URL}),
+		})
+	}()
+	replace := replaceTrap.MustWait(ctx)
+	replace.MustRelease(ctx)
+	publish.MustRelease(ctx)
+	publishTrap.Close()
+
+	_ = testutil.TryReceive(ctx, t, replaceDone)
+	result := testutil.RequireReceive(ctx, t, serveDone)
+	require.NoError(t, result.err)
+	require.Equal(t, http.StatusOK, result.code)
+	require.Equal(t, "new", result.body)
 }
 
 func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
@@ -202,8 +267,8 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 	factory := newBlockingMCPFactory()
 	firstDone := make(chan acquireResult, 1)
 	go func() {
-		handler, err := pool.Acquire(t.Context(), req, clientFn, factory)
-		firstDone <- acquireResult{handler: handler, err: err}
+		err := servePool(t.Context(), pool, req, clientFn, factory)
+		firstDone <- acquireResult{err: err}
 	}()
 
 	require.Eventually(t, factory.firstBuildStarted, testutil.WaitShort, testutil.IntervalFast)
@@ -214,8 +279,8 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 
 	secondDone := make(chan acquireResult, 1)
 	go func() {
-		handler, err := pool.Acquire(t.Context(), req, clientFn, factory)
-		secondDone <- acquireResult{handler: handler, err: err}
+		err := servePool(t.Context(), pool, req, clientFn, factory)
+		secondDone <- acquireResult{err: err}
 	}()
 
 	var second acquireResult
@@ -228,7 +293,7 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 		}
 	}, testutil.WaitShort, testutil.IntervalFast)
 	require.NoError(t, second.err)
-	assertHandlerBody(t, second.handler, "/new/v1/models", "new")
+	assertPoolBody(t, pool, req, clientFn, factory, "/new/v1/models", "new")
 
 	close(factory.releaseFirst)
 	var first acquireResult
@@ -242,9 +307,8 @@ func TestPoolReplaceProvidersDoesNotJoinStaleSingleflight(t *testing.T) {
 	}, testutil.WaitShort, testutil.IntervalFast)
 	require.NoError(t, first.err)
 
-	third, err := pool.Acquire(t.Context(), req, clientFn, factory)
+	err = servePool(t.Context(), pool, req, clientFn, factory)
 	require.NoError(t, err)
-	require.Same(t, second.handler, third)
 }
 
 func TestPoolReplaceProvidersAfterShutdownIsNoop(t *testing.T) {
@@ -262,7 +326,7 @@ func TestPoolReplaceProvidersAfterShutdownIsNoop(t *testing.T) {
 		})
 	})
 
-	_, err = pool.Acquire(t.Context(), aibridged.Request{
+	err = servePool(t.Context(), pool, aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: uuid.New(),
 		APIKeyID:    uuid.New().String(),
@@ -301,11 +365,11 @@ func TestPool_Expiry(t *testing.T) {
 		ctx := t.Context()
 
 		// First acquire is a cache miss.
-		_, err = pool.Acquire(ctx, req, clientFn, newMockMCPFactory(mcpProxy))
+		err = servePool(ctx, pool, req, clientFn, newMockMCPFactory(mcpProxy))
 		require.NoError(t, err)
 
 		// Second acquire is a cache hit.
-		_, err = pool.Acquire(ctx, req, clientFn, newMockMCPFactory(mcpProxy))
+		err = servePool(ctx, pool, req, clientFn, newMockMCPFactory(mcpProxy))
 		require.NoError(t, err)
 
 		metrics := pool.CacheMetrics()
@@ -316,7 +380,7 @@ func TestPool_Expiry(t *testing.T) {
 		time.Sleep(ttl + time.Millisecond)
 
 		// Third acquire is a cache miss because the entry expired.
-		_, err = pool.Acquire(ctx, req, clientFn, newMockMCPFactory(mcpProxy))
+		err = servePool(ctx, pool, req, clientFn, newMockMCPFactory(mcpProxy))
 		require.NoError(t, err)
 
 		metrics = pool.CacheMetrics()
@@ -331,12 +395,20 @@ func TestPool_Expiry(t *testing.T) {
 	})
 }
 
-func assertHandlerBody(t *testing.T, handler http.Handler, path string, body string) {
+func servePool(ctx context.Context, pool aibridged.Pooler, req aibridged.Request, clientFn aibridged.ClientFunc, factory aibridged.MCPProxyBuilder) error {
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	return pool.Serve(ctx, req, clientFn, factory, rw, r)
+}
+
+func assertPoolBody(t *testing.T, pool aibridged.Pooler, req aibridged.Request, clientFn aibridged.ClientFunc, factory aibridged.MCPProxyBuilder, path string, body string) {
 	t.Helper()
 
-	req := httptest.NewRequest(http.MethodGet, path, nil)
+	ctx := t.Context()
 	rw := httptest.NewRecorder()
-	handler.ServeHTTP(rw, req)
+	r := httptest.NewRequest(http.MethodGet, path, nil).WithContext(ctx)
+	err := pool.Serve(ctx, req, clientFn, factory, rw, r)
+	require.NoError(t, err)
 	resp := rw.Result()
 	defer resp.Body.Close()
 
@@ -375,8 +447,6 @@ func TestPoolShutdownReplaceProviders(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	clk := quartz.NewMock(t)
-	trap := clk.Trap().Now("provider_reload_version")
-	defer trap.Close()
 
 	opts := aibridged.PoolOptions{MaxItems: 16, TTL: time.Minute, Clock: clk}
 	pool, err := aibridged.NewCachedBridgePool(opts, []aibridge.Provider{
@@ -387,12 +457,15 @@ func TestPoolShutdownReplaceProviders(t *testing.T) {
 	clientFn := func(context.Context) (aibridged.DRPCClient, error) { return client, nil }
 
 	// Populate the cache so ReplaceProviders' Clear has an entry to evict.
-	_, err = pool.Acquire(ctx, aibridged.Request{
+	err = servePool(ctx, pool, aibridged.Request{
 		SessionKey:  "key",
 		InitiatorID: uuid.New(),
 		APIKeyID:    uuid.New().String(),
 	}, clientFn, newMockMCPFactory(mcpProxy))
 	require.NoError(t, err)
+
+	trap := clk.Trap().Now("provider_generation_publish")
+	defer trap.Close()
 
 	replaceDone := make(chan struct{})
 	go func() {
@@ -402,8 +475,8 @@ func TestPoolShutdownReplaceProviders(t *testing.T) {
 		})
 	}()
 
-	// ReplaceProviders is now parked at clock.Now, i.e. immediately before
-	// cache.Clear/cache.Wait. Deterministic readiness, no require.Eventually.
+	// ReplaceProviders is parked immediately before publishing the new
+	// generation. Deterministic readiness, no require.Eventually.
 	call := trap.MustWait(ctx)
 
 	shutdownDone := make(chan struct{})
@@ -422,8 +495,7 @@ func (m *mockMCPFactory) Build(ctx context.Context, req aibridged.Request, trace
 }
 
 type acquireResult struct {
-	handler http.Handler
-	err     error
+	err error
 }
 
 type blockingMCPFactory struct {

--- a/docs/ai-coder/ai-gateway/monitoring.md
+++ b/docs/ai-coder/ai-gateway/monitoring.md
@@ -45,6 +45,9 @@ Some metrics use the explicit `provider_name` or `provider_type` labels for clar
 | `coder_ai_gateway_key_pool_state_transitions_total`                | counter   | `provider`, `reason`                                                       | Provider key state transitions during failover.                                                                                                    |
 | `coder_ai_gateway_key_pool_exhaustions_total`                      | counter   | `outcome`, `provider`                                                      | Times a provider key pool had no usable key.                                                                                                       |
 | `coder_ai_gateway_key_pool_failover_attempts`                      | histogram | `provider`                                                                 | Keys attempted before a request succeeded or exhausted the provider key pool.                                                                      |
+| `coder_ai_gateway_bridge_pool_uncached_serve_attempts_total`       | counter   |                                                                            | Attempts to serve through a request bridge that the cache rejected.                                                                                |
+| `coder_ai_gateway_bridge_pool_retries_total`                       | counter   | `reason`                                                                   | Request bridge retries after an `admission` or provider `generation` failure.                                                                      |
+| `coder_ai_gateway_bridge_pool_retry_exhausted_total`               | counter   | `reason`                                                                   | Requests that exhausted the request bridge retry limit after an `admission` or provider `generation` failure.                                      |
 | `coder_ai_gateway_provider_info`                                   | gauge     | `provider_name`, `provider_type`, `status`                                 | Build status of each configured provider, including disabled and errored ones. Value is always `1`; `status` is `enabled`, `disabled`, or `error`. |
 | `coder_ai_gateway_providers_last_reload_timestamp_seconds`         | gauge     |                                                                            | Unix timestamp of the last attempt to rebuild the Gateway provider pool.                                                                           |
 | `coder_ai_gateway_providers_last_reload_success_timestamp_seconds` | gauge     |                                                                            | Unix timestamp of the last successful rebuild of the Gateway provider pool.                                                                        |
@@ -267,7 +270,7 @@ AI Gateway creates spans for the following operations:
 
 | Span name                                   | Description                                          |
 |---------------------------------------------|------------------------------------------------------|
-| `CachedBridgePool.Acquire`                  | Acquiring a request bridge instance from the pool    |
+| `CachedBridgePool.Serve`                    | Serving a request through a pooled request bridge    |
 | `Intercept`                                 | Top-level span for processing an intercepted request |
 | `Intercept.CreateInterceptor`               | Creating the request interceptor                     |
 | `Intercept.ProcessRequest`                  | Processing the request through the bridge            |

--- a/enterprise/aibridged_integration_test.go
+++ b/enterprise/aibridged_integration_test.go
@@ -287,8 +287,8 @@ func TestIntegration(t *testing.T) {
 	// Then: verify tracing spans were recorded.
 	spans := sr.Ended()
 	require.NotEmpty(t, spans)
-	i := slices.IndexFunc(spans, func(s sdktrace.ReadOnlySpan) bool { return s.Name() == "CachedBridgePool.Acquire" })
-	require.NotEqual(t, -1, i, "span named 'CachedBridgePool.Acquire' not found")
+	i := slices.IndexFunc(spans, func(s sdktrace.ReadOnlySpan) bool { return s.Name() == "CachedBridgePool.Serve" })
+	require.NotEqual(t, -1, i, "span named 'CachedBridgePool.Serve' not found")
 
 	expectAttrs := []attribute.KeyValue{
 		attribute.String(aibtracing.InitiatorID, user.ID.String()),
@@ -303,7 +303,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	expectedAibridgeSpans := []string{
-		"CachedBridgePool.Acquire",
+		"CachedBridgePool.Serve",
 		"ServerProxyManager.Init",
 		"StreamableHTTPServerProxy.Init",
 		"StreamableHTTPServerProxy.Init.fetchTools",

--- a/enterprise/cli/aigatewaystart_test.go
+++ b/enterprise/cli/aigatewaystart_test.go
@@ -495,11 +495,16 @@ func requireAIGatewaySessions(ctx context.Context, t *testing.T, dep *aiGatewayD
 	return sessions
 }
 
-// TestAIGatewayStartE2E_ReconnectAfterDisconnect covers a coderd outage: the
-// gateway serves LLM traffic again once coderd returns, without any operator
-// intervention, which requires the provider cache and the recorder to recover
-// alongside the DRPC connection.
-func TestAIGatewayStartE2E_ReconnectAfterDisconnect(t *testing.T) {
+// TestAIGatewayStartE2E_CoderdOutage covers a coderd outage end to end: traffic
+// is served before it, a request arriving during it is parked rather than
+// failed, readiness withdraws and recovers, and afterwards both the parked
+// request and a new one are served. Serving again requires the provider cache
+// and the recorder to recover alongside the DRPC connection.
+//
+// Readiness transitions appear here as steps. The full matrix, including
+// /healthz staying up throughout, is asserted by
+// TestStandaloneGatewayHealthAndReadiness.
+func TestAIGatewayStartE2E_CoderdOutage(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -514,7 +519,8 @@ func TestAIGatewayStartE2E_ReconnectAfterDisconnect(t *testing.T) {
 	before := postChatCompletionAndRead(ctx, baseURL+aiGatewayChatCompletionPath,
 		dep.userClient.SessionToken(), aiGatewayChatCompletionRequest)
 
-	// Then: it is served and recorded.
+	// Then: it is served and recorded. Waiting for the record here keeps the
+	// outage below from cutting the recording RPCs of this request.
 	require.NoError(t, before.err)
 	require.Equal(t, http.StatusOK, before.status, "body: %s", before.body)
 	requireAIGatewaySessions(ctx, t, dep, 1)
@@ -522,8 +528,25 @@ func TestAIGatewayStartE2E_ReconnectAfterDisconnect(t *testing.T) {
 	// When: coderd becomes unreachable.
 	proxy.disconnect()
 
-	// Then: readiness withdraws.
+	// Then: readiness withdraws, so a load balancer stops sending traffic.
 	requireEventualAIGatewayStatus(ctx, t, baseURL+aiGatewayReadyzPath, http.StatusServiceUnavailable)
+
+	// When: a request arrives during the outage.
+	responses := make(chan aiGatewayResponse, 1)
+	go func() {
+		responses <- postChatCompletionAndRead(ctx, baseURL+aiGatewayChatCompletionPath,
+			dep.userClient.SessionToken(), aiGatewayChatCompletionRequest)
+	}()
+
+	// Then: it is parked rather than failed, and does not reach the upstream
+	// before it is authorized. The proxy is still unhealthy, so there is no path
+	// for it to complete; the window only has to cover it reaching the handler.
+	select {
+	case result := <-responses:
+		t.Fatalf("request completed while disconnected: status=%d, err=%v", result.status, result.err)
+	case <-time.After(testutil.IntervalMedium):
+	}
+	require.Equal(t, int32(1), dep.upstreamHits.Load(), "a request must not reach the upstream while it cannot be authorized")
 
 	// When: coderd is reachable again.
 	proxy.setHealthy(true)
@@ -531,58 +554,21 @@ func TestAIGatewayStartE2E_ReconnectAfterDisconnect(t *testing.T) {
 	// Then: readiness recovers with no intervention.
 	requireEventualAIGatewayStatus(ctx, t, baseURL+aiGatewayReadyzPath, http.StatusOK)
 
-	// Then: a new request is served and both interceptions are recorded, so the
-	// provider cache and the recorder recovered with the connection.
+	// Then: the parked request is served.
+	parked := testutil.RequireReceive(ctx, t, responses)
+	require.NoError(t, parked.err)
+	require.Equal(t, http.StatusOK, parked.status, "body: %s", parked.body)
+	require.Contains(t, string(parked.body), "standalone gateway e2e response")
+
+	// Then: a request arriving after the outage is served too, and every
+	// interception is recorded.
 	after := postChatCompletionAndRead(ctx, baseURL+aiGatewayChatCompletionPath,
 		dep.userClient.SessionToken(), aiGatewayChatCompletionRequest)
 	require.NoError(t, after.err)
 	require.Equal(t, http.StatusOK, after.status, "body: %s", after.body)
 	require.Contains(t, string(after.body), "standalone gateway e2e response")
-	require.Equal(t, int32(2), dep.upstreamHits.Load())
-	requireAIGatewaySessions(ctx, t, dep, 2)
-}
-
-// TestAIGatewayStartE2E_RequestWhileDisconnected pins the behavior of an LLM
-// request that arrives while the gateway has no DRPC connection to coderd. The
-// request is parked until the connection returns rather than failing fast,
-// because the pre-flight calls block in [aibridged.Server.Client] with the
-// caller's context as the only bound.
-func TestAIGatewayStartE2E_RequestWhileDisconnected(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitLong)
-	dep := setupAIGatewayDeployment(ctx, t)
-
-	// Given: a ready gateway that then loses its connection to coderd.
-	proxy := newChaosProxy(t, dep.client.URL)
-	baseURL, _ := startAIGatewayCommand(ctx, t, proxy.srv.URL, dep.key)
-	requireEventualAIGatewayStatus(ctx, t, baseURL+aiGatewayReadyzPath, http.StatusOK)
-	proxy.disconnect()
-	requireEventualAIGatewayStatus(ctx, t, baseURL+aiGatewayReadyzPath, http.StatusServiceUnavailable)
-
-	// When: a request arrives while the gateway has no connection to coderd.
-	responses := make(chan aiGatewayResponse, 1)
-	go func() {
-		responses <- postChatCompletionAndRead(ctx, baseURL+aiGatewayChatCompletionPath,
-			dep.userClient.SessionToken(), aiGatewayChatCompletionRequest)
-	}()
-
-	// Then: it does not fail fast, and it does not reach the upstream before it
-	// is authorized which requires a connection to coderd.
-	select {
-	case result := <-responses:
-		t.Fatalf("request completed while disconnected: status=%d, err=%v", result.status, result.err)
-	case <-time.After(testutil.IntervalMedium):
-	}
-	require.Equal(t, int32(0), dep.upstreamHits.Load(), "a request must not reach the upstream before it is authorized")
-
-	// When: coderd returns. Then: the parked request is served.
-	proxy.setHealthy(true)
-	result := testutil.RequireReceive(ctx, t, responses)
-	require.NoError(t, result.err)
-	require.Equal(t, http.StatusOK, result.status, "body: %s", result.body)
-	require.Contains(t, string(result.body), "standalone gateway e2e response")
-	require.Equal(t, int32(1), dep.upstreamHits.Load(), "the parked request reaches the upstream once it is authorized")
+	require.Equal(t, int32(3), dep.upstreamHits.Load())
+	requireAIGatewaySessions(ctx, t, dep, 3)
 }
 
 // readAIGatewayStreamEvent returns the payload of the next server-sent event,


### PR DESCRIPTION
> This PR was generated with Coder Agents.

Fixes following race:

1. [Acquire returns a cached bridge](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/coderd/aibridged/pool.go#L216-L226).

2. Before [ServeHTTP is called on it](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/coderd/aibridged/http.go#L173-L184), [ReplaceProviders clears the cache](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/coderd/aibridged/pool.go#L148-L156) and [shuts down the evicted bridge](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/coderd/aibridged/pool.go#L90-L104).
3. The request reaches the bridge after it has closed, before it can [register as inflight](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/aibridge/bridge.go#L403-L418), and fails with HTTP 500.

This is likely to happen when standalone Gateway reconnects. Requests made while the connection between Gateway and `coderd` is unavailable are parked in [Server.Client](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/coderd/aibridged/aibridged.go#L170-L183). When connection recovers they resume processing and provider cache reloads at the same time. The reconnect scenario is covered by [TestAIGatewayStartE2E_ReconnectAfterDisconnect](https://github.com/coder/coder/blob/1fbd0297544054c11e9eb6070e1e18c64646ae55/enterprise/cli/aigatewaystart_test.go#L498-L542) which was flaky before the fix.

The pool API changes from `Acquire` to `Serve` making bridge selection, request admission, and serving stay inside the pool.
Cache and `singleflight` keys now include the provider generation. `ReplaceProviders` retires the previous generation. This prevents new requests from using bridges created with stale configuration, while requests already admitted through TryServe can finish normally.
