### PR TITLE
docs: note JetBrains client attribution in AI Gateway

### DIFF
--- a/docs/ai-coder/ai-gateway/clients/jetbrains.md
+++ b/docs/ai-coder/ai-gateway/clients/jetbrains.md
@@ -34,7 +34,7 @@ You can now use the AI Assistant chat with the configured provider.
 > [!NOTE]
 >
 > * JetBrains AI Assistant currently only supports OpenAI-compatible endpoints. There is an open [issue](https://youtrack.jetbrains.com/issue/LLM-22740) tracking support for Anthropic.
-> * JetBrains AI Assistant may not support all models that support OPenAI's `/chat/completions` endpoint in Chat mode.
+> * JetBrains AI Assistant may not support all models that support OpenAI's `/chat/completions` endpoint in Chat mode.
 > * JetBrains AI Assistant does not send an identifying user agent, so AI Gateway records these sessions with the client `Unknown`. Usage, tokens, and audit data are still captured.
 
 ## BYOK (Personal API Key)

--- a/docs/ai-coder/ai-gateway/clients/jetbrains.md
+++ b/docs/ai-coder/ai-gateway/clients/jetbrains.md
@@ -35,6 +35,7 @@ You can now use the AI Assistant chat with the configured provider.
 >
 > * JetBrains AI Assistant currently only supports OpenAI-compatible endpoints. There is an open [issue](https://youtrack.jetbrains.com/issue/LLM-22740) tracking support for Anthropic.
 > * JetBrains AI Assistant may not support all models that support OPenAI's `/chat/completions` endpoint in Chat mode.
+> * JetBrains AI Assistant does not send an identifying user agent, so AI Gateway records these sessions with the client `Unknown`. Usage, tokens, and audit data are still captured.
 
 ## BYOK (Personal API Key)
 


### PR DESCRIPTION
Noticed while testing Junie that JetBrains AI Assistant sends `User-Agent: ktor-client`, the stock Ktor default, so AI Gateway records these sessions as `Unknown`. Admins who enable Gateway for governance won't see their JetBrains attributed in the sessions view or the `client` filter.

Documents the behavior on the JetBrains client page. Nothing to fix on our side, matching `ktor-client` would misattribute any other Ktor-based application.