### PR TITLE
feat: add turn-scoped chat environment variables

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -19207,6 +19207,13 @@ const docTemplate = `{
                         "$ref": "#/definitions/codersdk.ChatInputPart"
                     }
                 },
+                "environment_variables": {
+                    "description": "EnvironmentVariables apply only to the turn started by this message.\nValues are not included in model prompts or API responses, but are\nstored unencrypted in the Coder database.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "mcp_server_ids": {
                     "type": "array",
                     "items": {
@@ -19268,6 +19275,13 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.ChatInputPart"
+                    }
+                },
+                "environment_variables": {
+                    "description": "EnvironmentVariables are persisted with the initial user turn and\nprovided only to workspace command execution. Values are not included\nin model prompts or API responses, but are stored unencrypted in the\nCoder database.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
                     }
                 },
                 "labels": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -17372,6 +17372,13 @@
 						"$ref": "#/definitions/codersdk.ChatInputPart"
 					}
 				},
+				"environment_variables": {
+					"description": "EnvironmentVariables apply only to the turn started by this message.\nValues are not included in model prompts or API responses, but are\nstored unencrypted in the Coder database.",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"mcp_server_ids": {
 					"type": "array",
 					"items": {
@@ -17433,6 +17440,13 @@
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.ChatInputPart"
+					}
+				},
+				"environment_variables": {
+					"description": "EnvironmentVariables are persisted with the initial user turn and\nprovided only to workspace command execution. Values are not included\nin model prompts or API responses, but are stored unencrypted in the\nCoder database.",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
 					}
 				},
 				"labels": {

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -654,6 +654,31 @@ func TestChatMessage_PreservesProviderExecutedOnToolResults(t *testing.T) {
 	require.True(t, result.Content[1].ProviderExecuted, "tool result should preserve ProviderExecuted")
 }
 
+func TestChatMessage_OmitsEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	environmentVariables := pqtype.NullRawMessage{
+		RawMessage: []byte(`{"SCANNER_TOKEN":"secret"}`),
+		Valid:      true,
+	}
+	message := db2sdk.ChatMessage(database.ChatMessage{
+		ID:                   1,
+		ChatID:               uuid.New(),
+		Role:                 database.ChatMessageRoleUser,
+		EnvironmentVariables: environmentVariables,
+	})
+	encoded, err := json.Marshal(message)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "SCANNER_TOKEN")
+	require.NotContains(t, string(encoded), "secret")
+
+	queued := db2sdk.ChatQueuedMessage(database.ChatQueuedMessage{EnvironmentVariables: environmentVariables})
+	encoded, err = json.Marshal(queued)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "SCANNER_TOKEN")
+	require.NotContains(t, string(encoded), "secret")
+}
+
 func TestChatQueuedMessage_ParsesUserContentParts(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -122,26 +122,31 @@ func ChatMessage(t testing.TB, db database.Store, seed database.ChatMessage) dat
 	if seed.Content.Valid {
 		content = string(seed.Content.RawMessage)
 	}
+	environmentVariables := ""
+	if seed.EnvironmentVariables.Valid {
+		environmentVariables = string(seed.EnvironmentVariables.RawMessage)
+	}
 	role := takeFirst(seed.Role, database.ChatMessageRoleUser)
 
 	msgs, err := db.InsertChatMessages(genCtx, database.InsertChatMessagesParams{
-		ChatID:              seed.ChatID,
-		CreatedBy:           []uuid.UUID{seed.CreatedBy.UUID},
-		ModelConfigID:       []uuid.UUID{seed.ModelConfigID.UUID},
-		ReasoningEffort:     []string{string(seed.ReasoningEffort.ChatReasoningEffort)},
-		Role:                []database.ChatMessageRole{role},
-		Content:             []string{content},
-		ContentVersion:      []int16{takeFirst(seed.ContentVersion, chatprompt.CurrentContentVersion)},
-		Visibility:          []database.ChatMessageVisibility{takeFirst(seed.Visibility, database.ChatMessageVisibilityBoth)},
-		InputTokens:         []int64{seed.InputTokens.Int64},
-		OutputTokens:        []int64{seed.OutputTokens.Int64},
-		TotalTokens:         []int64{seed.TotalTokens.Int64},
-		ReasoningTokens:     []int64{seed.ReasoningTokens.Int64},
-		CacheCreationTokens: []int64{seed.CacheCreationTokens.Int64},
-		CacheReadTokens:     []int64{seed.CacheReadTokens.Int64},
-		ContextLimit:        []int64{seed.ContextLimit.Int64},
-		Compressed:          []bool{seed.Compressed},
-		RuntimeMs:           []int64{seed.RuntimeMs.Int64},
+		ChatID:               seed.ChatID,
+		CreatedBy:            []uuid.UUID{seed.CreatedBy.UUID},
+		ModelConfigID:        []uuid.UUID{seed.ModelConfigID.UUID},
+		ReasoningEffort:      []string{string(seed.ReasoningEffort.ChatReasoningEffort)},
+		Role:                 []database.ChatMessageRole{role},
+		Content:              []string{content},
+		EnvironmentVariables: []string{environmentVariables},
+		ContentVersion:       []int16{takeFirst(seed.ContentVersion, chatprompt.CurrentContentVersion)},
+		Visibility:           []database.ChatMessageVisibility{takeFirst(seed.Visibility, database.ChatMessageVisibilityBoth)},
+		InputTokens:          []int64{seed.InputTokens.Int64},
+		OutputTokens:         []int64{seed.OutputTokens.Int64},
+		TotalTokens:          []int64{seed.TotalTokens.Int64},
+		ReasoningTokens:      []int64{seed.ReasoningTokens.Int64},
+		CacheCreationTokens:  []int64{seed.CacheCreationTokens.Int64},
+		CacheReadTokens:      []int64{seed.CacheReadTokens.Int64},
+		ContextLimit:         []int64{seed.ContextLimit.Int64},
+		Compressed:           []bool{seed.Compressed},
+		RuntimeMs:            []int64{seed.RuntimeMs.Int64},
 	})
 	require.NoError(t, err, "insert chat message")
 	require.Len(t, msgs, 1)

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -2045,12 +2045,15 @@ CREATE TABLE chat_messages (
     provider_response_id text,
     revision bigint NOT NULL,
     reasoning_effort chat_reasoning_effort,
-    search_tsv tsvector
+    search_tsv tsvector,
+    environment_variables jsonb
 );
 
 COMMENT ON COLUMN chat_messages.reasoning_effort IS 'Stores the selected effort for the turn triggered by this message.';
 
 COMMENT ON COLUMN chat_messages.search_tsv IS 'Used for full text search. NULL initially, populated async via background job.';
+
+COMMENT ON COLUMN chat_messages.environment_variables IS 'Turn-scoped environment variables for workspace command execution. Not included in model prompts or API responses.';
 
 CREATE SEQUENCE chat_messages_id_seq
     START WITH 1
@@ -2097,10 +2100,13 @@ CREATE TABLE chat_queued_messages (
     model_config_id uuid,
     "position" bigint DEFAULT nextval('chat_queued_messages_position_seq'::regclass) NOT NULL,
     created_by uuid NOT NULL,
-    reasoning_effort chat_reasoning_effort
+    reasoning_effort chat_reasoning_effort,
+    environment_variables jsonb
 );
 
 COMMENT ON COLUMN chat_queued_messages.reasoning_effort IS 'Stores the selected effort until the queued row is promoted.';
+
+COMMENT ON COLUMN chat_queued_messages.environment_variables IS 'Turn-scoped environment variables retained until the queued message is promoted.';
 
 CREATE SEQUENCE chat_queued_messages_id_seq
     START WITH 1

--- a/coderd/database/migrations/000580_chat_turn_environment_variables.down.sql
+++ b/coderd/database/migrations/000580_chat_turn_environment_variables.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chat_queued_messages
+	DROP COLUMN environment_variables;
+
+ALTER TABLE chat_messages
+	DROP COLUMN environment_variables;

--- a/coderd/database/migrations/000580_chat_turn_environment_variables.up.sql
+++ b/coderd/database/migrations/000580_chat_turn_environment_variables.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE chat_messages
+	ADD COLUMN environment_variables jsonb;
+
+COMMENT ON COLUMN chat_messages.environment_variables IS
+	'Turn-scoped environment variables for workspace command execution. Not included in model prompts or API responses.';
+
+ALTER TABLE chat_queued_messages
+	ADD COLUMN environment_variables jsonb;
+
+COMMENT ON COLUMN chat_queued_messages.environment_variables IS
+	'Turn-scoped environment variables retained until the queued message is promoted.';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -5220,6 +5220,8 @@ type ChatMessage struct {
 	ReasoningEffort NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
 	// Used for full text search. NULL initially, populated async via background job.
 	SearchTsv interface{} `db:"search_tsv" json:"search_tsv"`
+	// Turn-scoped environment variables for workspace command execution. Not included in model prompts or API responses.
+	EnvironmentVariables pqtype.NullRawMessage `db:"environment_variables" json:"environment_variables"`
 }
 
 type ChatModelConfig struct {
@@ -5250,6 +5252,8 @@ type ChatQueuedMessage struct {
 	CreatedBy     uuid.UUID       `db:"created_by" json:"created_by"`
 	// Stores the selected effort until the queued row is promoted.
 	ReasoningEffort NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
+	// Turn-scoped environment variables retained until the queued message is promoted.
+	EnvironmentVariables pqtype.NullRawMessage `db:"environment_variables" json:"environment_variables"`
 }
 
 type ChatTable struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -8042,7 +8042,7 @@ func (q *sqlQuerier) GetChatHeartbeat(ctx context.Context, arg GetChatHeartbeatP
 
 const getChatMessageByID = `-- name: GetChatMessageByID :one
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -8078,6 +8078,7 @@ func (q *sqlQuerier) GetChatMessageByID(ctx context.Context, id int64) (ChatMess
 		&i.Revision,
 		&i.ReasoningEffort,
 		&i.SearchTsv,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }
@@ -8164,7 +8165,7 @@ func (q *sqlQuerier) GetChatMessageSummariesPerChat(ctx context.Context, created
 
 const getChatMessagesByChatID = `-- name: GetChatMessagesByChatID :many
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -8218,6 +8219,7 @@ func (q *sqlQuerier) GetChatMessagesByChatID(ctx context.Context, arg GetChatMes
 			&i.Revision,
 			&i.ReasoningEffort,
 			&i.SearchTsv,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -8234,7 +8236,7 @@ func (q *sqlQuerier) GetChatMessagesByChatID(ctx context.Context, arg GetChatMes
 
 const getChatMessagesByChatIDAscPaginated = `-- name: GetChatMessagesByChatIDAscPaginated :many
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -8288,6 +8290,7 @@ func (q *sqlQuerier) GetChatMessagesByChatIDAscPaginated(ctx context.Context, ar
 			&i.Revision,
 			&i.ReasoningEffort,
 			&i.SearchTsv,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -8304,7 +8307,7 @@ func (q *sqlQuerier) GetChatMessagesByChatIDAscPaginated(ctx context.Context, ar
 
 const getChatMessagesByChatIDDescPaginated = `-- name: GetChatMessagesByChatIDDescPaginated :many
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -8371,6 +8374,7 @@ func (q *sqlQuerier) GetChatMessagesByChatIDDescPaginated(ctx context.Context, a
 			&i.Revision,
 			&i.ReasoningEffort,
 			&i.SearchTsv,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -8387,7 +8391,7 @@ func (q *sqlQuerier) GetChatMessagesByChatIDDescPaginated(ctx context.Context, a
 
 const getChatMessagesByRevisionForStream = `-- name: GetChatMessagesByRevisionForStream :many
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -8438,6 +8442,7 @@ func (q *sqlQuerier) GetChatMessagesByRevisionForStream(ctx context.Context, arg
 			&i.Revision,
 			&i.ReasoningEffort,
 			&i.SearchTsv,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -8469,7 +8474,7 @@ WITH latest_compressed_summary AS (
         1
 )
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -8545,6 +8550,7 @@ func (q *sqlQuerier) GetChatMessagesForPromptByChatID(ctx context.Context, chatI
 			&i.Revision,
 			&i.ReasoningEffort,
 			&i.SearchTsv,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -8664,7 +8670,7 @@ func (q *sqlQuerier) GetChatQueuedForCapacity(ctx context.Context, arg GetChatQu
 }
 
 const getChatQueuedMessageByID = `-- name: GetChatQueuedMessageByID :one
-SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort FROM chat_queued_messages
+SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables FROM chat_queued_messages
 WHERE id = $1::bigint AND chat_id = $2::uuid
 `
 
@@ -8685,12 +8691,13 @@ func (q *sqlQuerier) GetChatQueuedMessageByID(ctx context.Context, arg GetChatQu
 		&i.Position,
 		&i.CreatedBy,
 		&i.ReasoningEffort,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }
 
 const getChatQueuedMessageHead = `-- name: GetChatQueuedMessageHead :one
-SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort FROM chat_queued_messages
+SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables FROM chat_queued_messages
 WHERE chat_id = $1::uuid
 ORDER BY position ASC, id ASC
 LIMIT 1
@@ -8709,12 +8716,13 @@ func (q *sqlQuerier) GetChatQueuedMessageHead(ctx context.Context, chatID uuid.U
 		&i.Position,
 		&i.CreatedBy,
 		&i.ReasoningEffort,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }
 
 const getChatQueuedMessages = `-- name: GetChatQueuedMessages :many
-SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort FROM chat_queued_messages
+SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables FROM chat_queued_messages
 WHERE chat_id = $1
 ORDER BY created_at ASC, id ASC
 `
@@ -8737,6 +8745,7 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 			&i.Position,
 			&i.CreatedBy,
 			&i.ReasoningEffort,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -8752,7 +8761,7 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 }
 
 const getChatQueuedMessagesByPosition = `-- name: GetChatQueuedMessagesByPosition :many
-SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort FROM chat_queued_messages
+SELECT id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables FROM chat_queued_messages
 WHERE chat_id = $1::uuid
 ORDER BY position ASC, id ASC
 `
@@ -8776,6 +8785,7 @@ func (q *sqlQuerier) GetChatQueuedMessagesByPosition(ctx context.Context, chatID
 			&i.Position,
 			&i.CreatedBy,
 			&i.ReasoningEffort,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -9772,7 +9782,7 @@ func (q *sqlQuerier) GetDatabaseNow(ctx context.Context) (time.Time, error) {
 
 const getLastChatMessageByRole = `-- name: GetLastChatMessageByRole :one
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM
     chat_messages
 WHERE
@@ -9820,6 +9830,7 @@ func (q *sqlQuerier) GetLastChatMessageByRole(ctx context.Context, arg GetLastCh
 		&i.Revision,
 		&i.ReasoningEffort,
 		&i.SearchTsv,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }
@@ -10304,6 +10315,7 @@ inserted AS (
         reasoning_effort,
         role,
         content,
+        environment_variables,
         content_version,
         visibility,
         input_tokens,
@@ -10324,70 +10336,73 @@ inserted AS (
         NULLIF(($2::text[])[allocated.ord], '')::chat_reasoning_effort,
         ($4::chat_message_role[])[allocated.ord],
         ($6::text[])[allocated.ord]::jsonb,
-        ($7::smallint[])[allocated.ord],
-        ($8::chat_message_visibility[])[allocated.ord],
-        NULLIF(($9::bigint[])[allocated.ord], 0),
+        NULLIF(($7::text[])[allocated.ord], '')::jsonb,
+        ($8::smallint[])[allocated.ord],
+        ($9::chat_message_visibility[])[allocated.ord],
         NULLIF(($10::bigint[])[allocated.ord], 0),
         NULLIF(($11::bigint[])[allocated.ord], 0),
         NULLIF(($12::bigint[])[allocated.ord], 0),
         NULLIF(($13::bigint[])[allocated.ord], 0),
         NULLIF(($14::bigint[])[allocated.ord], 0),
         NULLIF(($15::bigint[])[allocated.ord], 0),
-        ($16::boolean[])[allocated.ord],
-        NULLIF(($17::bigint[])[allocated.ord], 0)
+        NULLIF(($16::bigint[])[allocated.ord], 0),
+        ($17::boolean[])[allocated.ord],
+        NULLIF(($18::bigint[])[allocated.ord], 0)
     FROM allocated
-    RETURNING id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+    RETURNING id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 )
-SELECT id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv
+SELECT id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, environment_variables
 FROM inserted
 ORDER BY id
 `
 
 type InsertChatMessagesParams struct {
-	ModelConfigID       []uuid.UUID             `db:"model_config_id" json:"model_config_id"`
-	ReasoningEffort     []string                `db:"reasoning_effort" json:"reasoning_effort"`
-	ChatID              uuid.UUID               `db:"chat_id" json:"chat_id"`
-	Role                []ChatMessageRole       `db:"role" json:"role"`
-	CreatedBy           []uuid.UUID             `db:"created_by" json:"created_by"`
-	Content             []string                `db:"content" json:"content"`
-	ContentVersion      []int16                 `db:"content_version" json:"content_version"`
-	Visibility          []ChatMessageVisibility `db:"visibility" json:"visibility"`
-	InputTokens         []int64                 `db:"input_tokens" json:"input_tokens"`
-	OutputTokens        []int64                 `db:"output_tokens" json:"output_tokens"`
-	TotalTokens         []int64                 `db:"total_tokens" json:"total_tokens"`
-	ReasoningTokens     []int64                 `db:"reasoning_tokens" json:"reasoning_tokens"`
-	CacheCreationTokens []int64                 `db:"cache_creation_tokens" json:"cache_creation_tokens"`
-	CacheReadTokens     []int64                 `db:"cache_read_tokens" json:"cache_read_tokens"`
-	ContextLimit        []int64                 `db:"context_limit" json:"context_limit"`
-	Compressed          []bool                  `db:"compressed" json:"compressed"`
-	RuntimeMs           []int64                 `db:"runtime_ms" json:"runtime_ms"`
+	ModelConfigID        []uuid.UUID             `db:"model_config_id" json:"model_config_id"`
+	ReasoningEffort      []string                `db:"reasoning_effort" json:"reasoning_effort"`
+	ChatID               uuid.UUID               `db:"chat_id" json:"chat_id"`
+	Role                 []ChatMessageRole       `db:"role" json:"role"`
+	CreatedBy            []uuid.UUID             `db:"created_by" json:"created_by"`
+	Content              []string                `db:"content" json:"content"`
+	EnvironmentVariables []string                `db:"environment_variables" json:"environment_variables"`
+	ContentVersion       []int16                 `db:"content_version" json:"content_version"`
+	Visibility           []ChatMessageVisibility `db:"visibility" json:"visibility"`
+	InputTokens          []int64                 `db:"input_tokens" json:"input_tokens"`
+	OutputTokens         []int64                 `db:"output_tokens" json:"output_tokens"`
+	TotalTokens          []int64                 `db:"total_tokens" json:"total_tokens"`
+	ReasoningTokens      []int64                 `db:"reasoning_tokens" json:"reasoning_tokens"`
+	CacheCreationTokens  []int64                 `db:"cache_creation_tokens" json:"cache_creation_tokens"`
+	CacheReadTokens      []int64                 `db:"cache_read_tokens" json:"cache_read_tokens"`
+	ContextLimit         []int64                 `db:"context_limit" json:"context_limit"`
+	Compressed           []bool                  `db:"compressed" json:"compressed"`
+	RuntimeMs            []int64                 `db:"runtime_ms" json:"runtime_ms"`
 }
 
 type InsertChatMessagesRow struct {
-	ID                  int64                   `db:"id" json:"id"`
-	ChatID              uuid.UUID               `db:"chat_id" json:"chat_id"`
-	ModelConfigID       uuid.NullUUID           `db:"model_config_id" json:"model_config_id"`
-	CreatedAt           time.Time               `db:"created_at" json:"created_at"`
-	Role                ChatMessageRole         `db:"role" json:"role"`
-	Content             pqtype.NullRawMessage   `db:"content" json:"content"`
-	Visibility          ChatMessageVisibility   `db:"visibility" json:"visibility"`
-	InputTokens         sql.NullInt64           `db:"input_tokens" json:"input_tokens"`
-	OutputTokens        sql.NullInt64           `db:"output_tokens" json:"output_tokens"`
-	TotalTokens         sql.NullInt64           `db:"total_tokens" json:"total_tokens"`
-	ReasoningTokens     sql.NullInt64           `db:"reasoning_tokens" json:"reasoning_tokens"`
-	CacheCreationTokens sql.NullInt64           `db:"cache_creation_tokens" json:"cache_creation_tokens"`
-	CacheReadTokens     sql.NullInt64           `db:"cache_read_tokens" json:"cache_read_tokens"`
-	ContextLimit        sql.NullInt64           `db:"context_limit" json:"context_limit"`
-	Compressed          bool                    `db:"compressed" json:"compressed"`
-	CreatedBy           uuid.NullUUID           `db:"created_by" json:"created_by"`
-	ContentVersion      int16                   `db:"content_version" json:"content_version"`
-	TotalCostMicros     sql.NullInt64           `db:"total_cost_micros" json:"total_cost_micros"`
-	RuntimeMs           sql.NullInt64           `db:"runtime_ms" json:"runtime_ms"`
-	Deleted             bool                    `db:"deleted" json:"deleted"`
-	ProviderResponseID  sql.NullString          `db:"provider_response_id" json:"provider_response_id"`
-	Revision            int64                   `db:"revision" json:"revision"`
-	ReasoningEffort     NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
-	SearchTsv           interface{}             `db:"search_tsv" json:"search_tsv"`
+	ID                   int64                   `db:"id" json:"id"`
+	ChatID               uuid.UUID               `db:"chat_id" json:"chat_id"`
+	ModelConfigID        uuid.NullUUID           `db:"model_config_id" json:"model_config_id"`
+	CreatedAt            time.Time               `db:"created_at" json:"created_at"`
+	Role                 ChatMessageRole         `db:"role" json:"role"`
+	Content              pqtype.NullRawMessage   `db:"content" json:"content"`
+	Visibility           ChatMessageVisibility   `db:"visibility" json:"visibility"`
+	InputTokens          sql.NullInt64           `db:"input_tokens" json:"input_tokens"`
+	OutputTokens         sql.NullInt64           `db:"output_tokens" json:"output_tokens"`
+	TotalTokens          sql.NullInt64           `db:"total_tokens" json:"total_tokens"`
+	ReasoningTokens      sql.NullInt64           `db:"reasoning_tokens" json:"reasoning_tokens"`
+	CacheCreationTokens  sql.NullInt64           `db:"cache_creation_tokens" json:"cache_creation_tokens"`
+	CacheReadTokens      sql.NullInt64           `db:"cache_read_tokens" json:"cache_read_tokens"`
+	ContextLimit         sql.NullInt64           `db:"context_limit" json:"context_limit"`
+	Compressed           bool                    `db:"compressed" json:"compressed"`
+	CreatedBy            uuid.NullUUID           `db:"created_by" json:"created_by"`
+	ContentVersion       int16                   `db:"content_version" json:"content_version"`
+	TotalCostMicros      sql.NullInt64           `db:"total_cost_micros" json:"total_cost_micros"`
+	RuntimeMs            sql.NullInt64           `db:"runtime_ms" json:"runtime_ms"`
+	Deleted              bool                    `db:"deleted" json:"deleted"`
+	ProviderResponseID   sql.NullString          `db:"provider_response_id" json:"provider_response_id"`
+	Revision             int64                   `db:"revision" json:"revision"`
+	ReasoningEffort      NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
+	SearchTsv            interface{}             `db:"search_tsv" json:"search_tsv"`
+	EnvironmentVariables pqtype.NullRawMessage   `db:"environment_variables" json:"environment_variables"`
 }
 
 // Returns the inserted rows in input array order. Ids are allocated before the
@@ -10401,6 +10416,7 @@ func (q *sqlQuerier) InsertChatMessages(ctx context.Context, arg InsertChatMessa
 		pq.Array(arg.Role),
 		pq.Array(arg.CreatedBy),
 		pq.Array(arg.Content),
+		pq.Array(arg.EnvironmentVariables),
 		pq.Array(arg.ContentVersion),
 		pq.Array(arg.Visibility),
 		pq.Array(arg.InputTokens),
@@ -10445,6 +10461,7 @@ func (q *sqlQuerier) InsertChatMessages(ctx context.Context, arg InsertChatMessa
 			&i.Revision,
 			&i.ReasoningEffort,
 			&i.SearchTsv,
+			&i.EnvironmentVariables,
 		); err != nil {
 			return nil, err
 		}
@@ -10460,23 +10477,25 @@ func (q *sqlQuerier) InsertChatMessages(ctx context.Context, arg InsertChatMessa
 }
 
 const insertChatQueuedMessage = `-- name: InsertChatQueuedMessage :one
-INSERT INTO chat_queued_messages (chat_id, content, model_config_id, reasoning_effort, created_by)
+INSERT INTO chat_queued_messages (chat_id, content, environment_variables, model_config_id, reasoning_effort, created_by)
 SELECT
     $1::uuid,
     $2::jsonb,
-    $3::uuid,
-    $4::chat_reasoning_effort,
+    $3::jsonb,
+    $4::uuid,
+    $5::chat_reasoning_effort,
     chats.owner_id
 FROM chats
 WHERE chats.id = $1::uuid
-RETURNING id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort
+RETURNING id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables
 `
 
 type InsertChatQueuedMessageParams struct {
-	ChatID          uuid.UUID               `db:"chat_id" json:"chat_id"`
-	Content         json.RawMessage         `db:"content" json:"content"`
-	ModelConfigID   uuid.NullUUID           `db:"model_config_id" json:"model_config_id"`
-	ReasoningEffort NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
+	ChatID               uuid.UUID               `db:"chat_id" json:"chat_id"`
+	Content              json.RawMessage         `db:"content" json:"content"`
+	EnvironmentVariables pqtype.NullRawMessage   `db:"environment_variables" json:"environment_variables"`
+	ModelConfigID        uuid.NullUUID           `db:"model_config_id" json:"model_config_id"`
+	ReasoningEffort      NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
 }
 
 // Legacy queue insertion path. When no caller-supplied creator exists,
@@ -10486,6 +10505,7 @@ func (q *sqlQuerier) InsertChatQueuedMessage(ctx context.Context, arg InsertChat
 	row := q.db.QueryRowContext(ctx, insertChatQueuedMessage,
 		arg.ChatID,
 		arg.Content,
+		arg.EnvironmentVariables,
 		arg.ModelConfigID,
 		arg.ReasoningEffort,
 	)
@@ -10499,28 +10519,31 @@ func (q *sqlQuerier) InsertChatQueuedMessage(ctx context.Context, arg InsertChat
 		&i.Position,
 		&i.CreatedBy,
 		&i.ReasoningEffort,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }
 
 const insertChatQueuedMessageWithCreator = `-- name: InsertChatQueuedMessageWithCreator :one
-INSERT INTO chat_queued_messages (chat_id, content, model_config_id, reasoning_effort, created_by)
+INSERT INTO chat_queued_messages (chat_id, content, environment_variables, model_config_id, reasoning_effort, created_by)
 VALUES (
     $1::uuid,
     $2::jsonb,
-    $3::uuid,
-    $4::chat_reasoning_effort,
-    $5::uuid
+    $3::jsonb,
+    $4::uuid,
+    $5::chat_reasoning_effort,
+    $6::uuid
 )
-RETURNING id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort
+RETURNING id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables
 `
 
 type InsertChatQueuedMessageWithCreatorParams struct {
-	ChatID          uuid.UUID               `db:"chat_id" json:"chat_id"`
-	Content         json.RawMessage         `db:"content" json:"content"`
-	ModelConfigID   uuid.NullUUID           `db:"model_config_id" json:"model_config_id"`
-	ReasoningEffort NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
-	CreatedBy       uuid.UUID               `db:"created_by" json:"created_by"`
+	ChatID               uuid.UUID               `db:"chat_id" json:"chat_id"`
+	Content              json.RawMessage         `db:"content" json:"content"`
+	EnvironmentVariables pqtype.NullRawMessage   `db:"environment_variables" json:"environment_variables"`
+	ModelConfigID        uuid.NullUUID           `db:"model_config_id" json:"model_config_id"`
+	ReasoningEffort      NullChatReasoningEffort `db:"reasoning_effort" json:"reasoning_effort"`
+	CreatedBy            uuid.UUID               `db:"created_by" json:"created_by"`
 }
 
 // Inserts a queued message that carries a position (from the default
@@ -10530,6 +10553,7 @@ func (q *sqlQuerier) InsertChatQueuedMessageWithCreator(ctx context.Context, arg
 	row := q.db.QueryRowContext(ctx, insertChatQueuedMessageWithCreator,
 		arg.ChatID,
 		arg.Content,
+		arg.EnvironmentVariables,
 		arg.ModelConfigID,
 		arg.ReasoningEffort,
 		arg.CreatedBy,
@@ -10544,6 +10568,7 @@ func (q *sqlQuerier) InsertChatQueuedMessageWithCreator(ctx context.Context, arg
 		&i.Position,
 		&i.CreatedBy,
 		&i.ReasoningEffort,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }
@@ -10923,7 +10948,7 @@ WHERE id = (
     ORDER BY cqm.created_at ASC, cqm.id ASC
     LIMIT 1
 )
-RETURNING id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort
+RETURNING id, chat_id, content, created_at, model_config_id, position, created_by, reasoning_effort, environment_variables
 `
 
 func (q *sqlQuerier) PopNextQueuedMessage(ctx context.Context, chatID uuid.UUID) (ChatQueuedMessage, error) {
@@ -10938,6 +10963,7 @@ func (q *sqlQuerier) PopNextQueuedMessage(ctx context.Context, chatID uuid.UUID)
 		&i.Position,
 		&i.CreatedBy,
 		&i.ReasoningEffort,
+		&i.EnvironmentVariables,
 	)
 	return i, err
 }

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -922,6 +922,7 @@ inserted AS (
         reasoning_effort,
         role,
         content,
+        environment_variables,
         content_version,
         visibility,
         input_tokens,
@@ -942,6 +943,7 @@ inserted AS (
         NULLIF((@reasoning_effort::text[])[allocated.ord], '')::chat_reasoning_effort,
         (@role::chat_message_role[])[allocated.ord],
         (@content::text[])[allocated.ord]::jsonb,
+        NULLIF((@environment_variables::text[])[allocated.ord], '')::jsonb,
         (@content_version::smallint[])[allocated.ord],
         (@visibility::chat_message_visibility[])[allocated.ord],
         NULLIF((@input_tokens::bigint[])[allocated.ord], 0),
@@ -1915,10 +1917,11 @@ RETURNING
 -- Legacy queue insertion path. When no caller-supplied creator exists,
 -- preserve the created_by invariant by attributing the queued row to the
 -- chat owner.
-INSERT INTO chat_queued_messages (chat_id, content, model_config_id, reasoning_effort, created_by)
+INSERT INTO chat_queued_messages (chat_id, content, environment_variables, model_config_id, reasoning_effort, created_by)
 SELECT
     @chat_id::uuid,
     @content::jsonb,
+    sqlc.narg('environment_variables')::jsonb,
     sqlc.narg('model_config_id')::uuid,
     sqlc.narg('reasoning_effort')::chat_reasoning_effort,
     chats.owner_id
@@ -2650,10 +2653,11 @@ SELECT NOW()::timestamptz AS now;
 -- Inserts a queued message that carries a position (from the default
 -- sequence) and an explicit created_by reference. Use this when the
 -- queued-message creator differs from the chat owner.
-INSERT INTO chat_queued_messages (chat_id, content, model_config_id, reasoning_effort, created_by)
+INSERT INTO chat_queued_messages (chat_id, content, environment_variables, model_config_id, reasoning_effort, created_by)
 VALUES (
     @chat_id::uuid,
     @content::jsonb,
+    sqlc.narg('environment_variables')::jsonb,
     sqlc.narg('model_config_id')::uuid,
     sqlc.narg('reasoning_effort')::chat_reasoning_effort,
     @created_by::uuid

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -78,6 +79,46 @@ const (
 )
 
 var allowedReasoningEffortValues = strings.Join(codersdk.ChatModelReasoningEffortValues(), ", ")
+
+func validateChatEnvironmentVariables(environmentVariables map[string]string) []codersdk.ValidationError {
+	var validations []codersdk.ValidationError
+	if len(environmentVariables) > codersdk.MaxUserSecretsPerUserCount {
+		validations = append(validations, codersdk.ValidationError{
+			Field:  "environment_variables",
+			Detail: fmt.Sprintf("must not contain more than %d entries", codersdk.MaxUserSecretsPerUserCount),
+		})
+	}
+
+	totalBytes := 0
+	for _, name := range slices.Sorted(maps.Keys(environmentVariables)) {
+		value := environmentVariables[name]
+		totalBytes += len(name) + len(value)
+		if name == "" {
+			validations = append(validations, codersdk.ValidationError{
+				Field:  "environment_variables",
+				Detail: "environment variable names must not be empty",
+			})
+		} else if err := codersdk.UserSecretEnvNameValid(name); err != nil {
+			validations = append(validations, codersdk.ValidationError{
+				Field:  "environment_variables",
+				Detail: fmt.Sprintf("%q: %s", name, err),
+			})
+		}
+		if err := codersdk.UserSecretValueValid(value); err != nil {
+			validations = append(validations, codersdk.ValidationError{
+				Field:  "environment_variables",
+				Detail: fmt.Sprintf("%q: %s", name, err),
+			})
+		}
+	}
+	if totalBytes > codersdk.MaxUserSecretValueBytes {
+		validations = append(validations, codersdk.ValidationError{
+			Field:  "environment_variables",
+			Detail: fmt.Sprintf("names and values must not exceed %d bytes in total", codersdk.MaxUserSecretValueBytes),
+		})
+	}
+	return validations
+}
 
 // chatGitRef holds the branch, remote origin, and optional chat
 // ID reported by the workspace agent during a git operation.
@@ -1321,6 +1362,13 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 	if !httpapi.ReadLimit(ctx, rw, r, int64(2*maxSystemPromptLenBytes), &req) {
 		return
 	}
+	if validations := validateChatEnvironmentVariables(req.EnvironmentVariables); len(validations) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Invalid environment_variables.",
+			Validations: validations,
+		})
+		return
+	}
 
 	aReq, commitAudit := audit.InitRequest[database.Chat](rw, &audit.RequestParams{
 		Audit:          *api.Auditor.Load(),
@@ -1492,6 +1540,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		TitleDerivedFromContent: true,
 		ModelConfigID:           modelConfigID,
 		ReasoningEffort:         reasoningEffort,
+		EnvironmentVariables:    req.EnvironmentVariables,
 		PlanMode:                planModeToNullChatPlanMode(req.PlanMode),
 		ClientType:              clientType,
 		SystemPrompt:            req.SystemPrompt,
@@ -2760,6 +2809,13 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
 	}
+	if validations := validateChatEnvironmentVariables(req.EnvironmentVariables); len(validations) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Invalid environment_variables.",
+			Validations: validations,
+		})
+		return
+	}
 
 	contentBlocks, _, inputError := createChatInputFromParts(ctx, api.Database, req.Content, "content")
 	if inputError != nil {
@@ -2848,14 +2904,15 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	sendResult, sendErr := api.chatDaemon.SendMessage(
 		ctx,
 		chatd.SendMessageOptions{
-			ChatID:          chatID,
-			CreatedBy:       apiKey.UserID,
-			Content:         contentBlocks,
-			ModelConfigID:   modelConfigID,
-			ReasoningEffort: reasoningEffort,
-			BusyBehavior:    busyBehavior,
-			PlanMode:        sendPlanMode,
-			MCPServerIDs:    req.MCPServerIDs,
+			ChatID:               chatID,
+			CreatedBy:            apiKey.UserID,
+			Content:              contentBlocks,
+			ModelConfigID:        modelConfigID,
+			ReasoningEffort:      reasoningEffort,
+			EnvironmentVariables: req.EnvironmentVariables,
+			BusyBehavior:         busyBehavior,
+			PlanMode:             sendPlanMode,
+			MCPServerIDs:         req.MCPServerIDs,
 		},
 	)
 	if sendErr != nil {

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -25,6 +26,29 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
+
+func TestValidateChatEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		environmentVariables map[string]string
+		wantErrors           int
+	}{
+		{name: "Valid", environmentVariables: map[string]string{"SCANNER_TOKEN": "secret"}},
+		{name: "EmptyName", environmentVariables: map[string]string{"": "secret"}, wantErrors: 1},
+		{name: "InvalidName", environmentVariables: map[string]string{"NOT VALID": "secret"}, wantErrors: 1},
+		{name: "ReservedName", environmentVariables: map[string]string{"CODER_AGENT_TOKEN": "secret"}, wantErrors: 1},
+		{name: "NullValue", environmentVariables: map[string]string{"SCANNER_TOKEN": "bad\x00value"}, wantErrors: 1},
+		{name: "OverTotalBytes", environmentVariables: map[string]string{"SCANNER_TOKEN": strings.Repeat("x", codersdk.MaxUserSecretValueBytes)}, wantErrors: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Len(t, validateChatEnvironmentVariables(test.environmentVariables), test.wantErrors)
+		})
+	}
+}
 
 // ExtractChatParam authorizes the read, then GetAIBridgeChatCost authorizes it
 // again. A denial on the second check means the ACL changed in between (a

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -47,6 +47,8 @@ There is other data that is held in the database and is associated with a chat, 
 
 We call it **metadata**. The core state machine concerns itself with **execution state**. As a general guideline, a piece of data is execution state if the core state machine needs it to decide what the next state transition may be, or if it's directly modified by a state transition. For example, a queued message is part of the execution state because it impacts what the next action of the agent loop can be. If the agent loop finishes processing a user message and would otherwise stop, but there's a queued message, the agent loop will start processing the queued message instead. On the other hand, a chat's title does not impact the agent loop at all - it's just a label that helps the user identify the chat.
 
+> TODO(chatd): Document the turn-scoped environment variable flow before promoting the proof of concept. Cover persistence on active and queued user messages, queue promotion and message edits, automatic and manual compaction boundaries, and injection into the `execute` tool.
+
 File links are metadata, but one invariant is enforced at transition time: if a transition persists message content that references uploaded files (chat create, message send, queued send, or message edit), it records the file links in the same transaction. If linking would exceed the per-chat attachment cap, the whole transition is rejected. File retention skips files that are still linked to existing chats, so a persisted message must never reference a file without a link.
 
 If the distinction isn't completely clear to you at this point, don't worry. It should become clearer as you learn more about the core state machine.

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1091,6 +1091,7 @@ type CreateOptions struct {
 	TitleDerivedFromContent bool
 	ModelConfigID           uuid.UUID
 	ReasoningEffort         *string
+	EnvironmentVariables    map[string]string
 	ChatMode                database.NullChatMode
 	PlanMode                database.NullChatPlanMode
 	ClientType              database.ChatClientType
@@ -1116,14 +1117,15 @@ const (
 
 // SendMessageOptions controls user message insertion with busy-state behavior.
 type SendMessageOptions struct {
-	ChatID          uuid.UUID
-	CreatedBy       uuid.UUID
-	Content         []codersdk.ChatMessagePart
-	ModelConfigID   uuid.UUID
-	ReasoningEffort *string
-	BusyBehavior    SendMessageBusyBehavior
-	PlanMode        *database.NullChatPlanMode
-	MCPServerIDs    *[]uuid.UUID
+	ChatID               uuid.UUID
+	CreatedBy            uuid.UUID
+	Content              []codersdk.ChatMessagePart
+	ModelConfigID        uuid.UUID
+	ReasoningEffort      *string
+	EnvironmentVariables map[string]string
+	BusyBehavior         SendMessageBusyBehavior
+	PlanMode             *database.NullChatPlanMode
+	MCPServerIDs         *[]uuid.UUID
 }
 
 // SendMessageResult contains the outcome of user message processing.
@@ -1340,7 +1342,12 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		initialMessages = append(initialMessages, systemMessage(userPromptContent, opts.ModelConfigID))
 	}
 	initialMessages = append(initialMessages, systemMessage(workspaceAwarenessContent, opts.ModelConfigID))
-	initialMessages = append(initialMessages, userMessage(userContent, opts.ModelConfigID, opts.OwnerID, opts.ReasoningEffort))
+	initialUserMessage := userMessage(userContent, opts.ModelConfigID, opts.OwnerID, opts.ReasoningEffort)
+	initialUserMessage.EnvironmentVariables, err = marshalEnvironmentVariables(opts.EnvironmentVariables)
+	if err != nil {
+		return database.Chat{}, xerrors.Errorf("marshal environment variables: %w", err)
+	}
+	initialMessages = append(initialMessages, initialUserMessage)
 
 	result, err := chatstate.CreateChatWithID(ctx, p.db, p.pubsub, chatID, chatstate.CreateChatInput{
 		OrganizationID:    opts.OrganizationID,
@@ -1454,6 +1461,10 @@ func (p *Server) SendMessage(
 	if err != nil {
 		return SendMessageResult{}, xerrors.Errorf("marshal message content: %w", err)
 	}
+	environmentVariables, err := marshalEnvironmentVariables(opts.EnvironmentVariables)
+	if err != nil {
+		return SendMessageResult{}, xerrors.Errorf("marshal environment variables: %w", err)
+	}
 
 	requestedPlanMode := opts.PlanMode
 	requestedMCPServerIDs := opts.MCPServerIDs
@@ -1524,6 +1535,7 @@ func (p *Server) SendMessage(
 		// Queue capacity is enforced inside tx.SendMessage; this
 		// wrapper only propagates the typed error.
 		message := userMessage(content, modelConfigID, messageCreatedBy, opts.ReasoningEffort)
+		message.EnvironmentVariables = environmentVariables
 		sendResult, err := tx.SendMessage(chatstate.SendMessageInput{
 			Message:      message,
 			BusyBehavior: busyBehaviorToChatState(busyBehavior),

--- a/coderd/x/chatd/chatstate/messages.go
+++ b/coderd/x/chatd/chatstate/messages.go
@@ -18,22 +18,23 @@ import (
 // The state machine never reshapes a Message except to attach the
 // runtime `chat_id`.
 type Message struct {
-	Role                database.ChatMessageRole
-	Content             pqtype.NullRawMessage
-	Visibility          database.ChatMessageVisibility
-	ModelConfigID       uuid.NullUUID
-	ReasoningEffort     database.NullChatReasoningEffort
-	CreatedBy           uuid.NullUUID
-	ContentVersion      int16
-	Compressed          bool
-	InputTokens         sql.NullInt64
-	OutputTokens        sql.NullInt64
-	TotalTokens         sql.NullInt64
-	ReasoningTokens     sql.NullInt64
-	CacheCreationTokens sql.NullInt64
-	CacheReadTokens     sql.NullInt64
-	ContextLimit        sql.NullInt64
-	RuntimeMs           sql.NullInt64
+	Role                 database.ChatMessageRole
+	Content              pqtype.NullRawMessage
+	EnvironmentVariables pqtype.NullRawMessage
+	Visibility           database.ChatMessageVisibility
+	ModelConfigID        uuid.NullUUID
+	ReasoningEffort      database.NullChatReasoningEffort
+	CreatedBy            uuid.NullUUID
+	ContentVersion       int16
+	Compressed           bool
+	InputTokens          sql.NullInt64
+	OutputTokens         sql.NullInt64
+	TotalTokens          sql.NullInt64
+	ReasoningTokens      sql.NullInt64
+	CacheCreationTokens  sql.NullInt64
+	CacheReadTokens      sql.NullInt64
+	ContextLimit         sql.NullInt64
+	RuntimeMs            sql.NullInt64
 }
 
 // toInsertParams converts a batch of Messages into the parallel-array
@@ -45,23 +46,24 @@ type Message struct {
 func toInsertParams(chatID uuid.UUID, messages []Message) database.InsertChatMessagesParams {
 	n := len(messages)
 	params := database.InsertChatMessagesParams{
-		ChatID:              chatID,
-		CreatedBy:           make([]uuid.UUID, n),
-		ModelConfigID:       make([]uuid.UUID, n),
-		ReasoningEffort:     make([]string, n),
-		Role:                make([]database.ChatMessageRole, n),
-		Content:             make([]string, n),
-		ContentVersion:      make([]int16, n),
-		Visibility:          make([]database.ChatMessageVisibility, n),
-		InputTokens:         make([]int64, n),
-		OutputTokens:        make([]int64, n),
-		TotalTokens:         make([]int64, n),
-		ReasoningTokens:     make([]int64, n),
-		CacheCreationTokens: make([]int64, n),
-		CacheReadTokens:     make([]int64, n),
-		ContextLimit:        make([]int64, n),
-		Compressed:          make([]bool, n),
-		RuntimeMs:           make([]int64, n),
+		ChatID:               chatID,
+		CreatedBy:            make([]uuid.UUID, n),
+		ModelConfigID:        make([]uuid.UUID, n),
+		ReasoningEffort:      make([]string, n),
+		Role:                 make([]database.ChatMessageRole, n),
+		Content:              make([]string, n),
+		EnvironmentVariables: make([]string, n),
+		ContentVersion:       make([]int16, n),
+		Visibility:           make([]database.ChatMessageVisibility, n),
+		InputTokens:          make([]int64, n),
+		OutputTokens:         make([]int64, n),
+		TotalTokens:          make([]int64, n),
+		ReasoningTokens:      make([]int64, n),
+		CacheCreationTokens:  make([]int64, n),
+		CacheReadTokens:      make([]int64, n),
+		ContextLimit:         make([]int64, n),
+		Compressed:           make([]bool, n),
+		RuntimeMs:            make([]int64, n),
 	}
 	for i, m := range messages {
 		params.CreatedBy[i] = nullUUIDOrNil(m.CreatedBy)
@@ -70,6 +72,9 @@ func toInsertParams(chatID uuid.UUID, messages []Message) database.InsertChatMes
 			params.ReasoningEffort[i] = string(m.ReasoningEffort.ChatReasoningEffort)
 		}
 		params.Role[i] = m.Role
+		if m.EnvironmentVariables.Valid {
+			params.EnvironmentVariables[i] = string(m.EnvironmentVariables.RawMessage)
+		}
 		if m.Content.Valid {
 			params.Content[i] = string(m.Content.RawMessage)
 		} else {

--- a/coderd/x/chatd/chatstate/messages_internal_test.go
+++ b/coderd/x/chatd/chatstate/messages_internal_test.go
@@ -1,0 +1,32 @@
+package chatstate
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+func TestTurnEnvironmentVariablesPersistence(t *testing.T) {
+	t.Parallel()
+
+	environmentVariables := pqtype.NullRawMessage{
+		RawMessage: []byte(`{"SCANNER_TOKEN":"secret"}`),
+		Valid:      true,
+	}
+	params := toInsertParams(uuid.New(), []Message{{ //nolint:gosec // Test-only placeholder value.
+		Role:                 database.ChatMessageRoleUser,
+		Content:              pqtype.NullRawMessage{RawMessage: []byte(`[]`), Valid: true},
+		EnvironmentVariables: environmentVariables,
+	}})
+	require.Equal(t, string(environmentVariables.RawMessage), params.EnvironmentVariables[0])
+
+	promoted := messageFromQueuedRow(database.ChatQueuedMessage{
+		Content:              []byte(`[]`),
+		EnvironmentVariables: environmentVariables,
+	})
+	require.Equal(t, environmentVariables, promoted.EnvironmentVariables)
+}

--- a/coderd/x/chatd/chatstate/transitions.go
+++ b/coderd/x/chatd/chatstate/transitions.go
@@ -273,11 +273,12 @@ func (tx *Tx) insertQueuedMessage(ownerFallback uuid.UUID, m Message) (database.
 		return database.ChatQueuedMessage{}, err
 	}
 	return tx.store.InsertChatQueuedMessageWithCreator(tx.ctx, database.InsertChatQueuedMessageWithCreatorParams{
-		ChatID:          tx.chatID,
-		Content:         rawContent,
-		ModelConfigID:   m.ModelConfigID,
-		ReasoningEffort: m.ReasoningEffort,
-		CreatedBy:       createdBy,
+		ChatID:               tx.chatID,
+		Content:              rawContent,
+		EnvironmentVariables: m.EnvironmentVariables,
+		ModelConfigID:        m.ModelConfigID,
+		ReasoningEffort:      m.ReasoningEffort,
+		CreatedBy:            createdBy,
 	})
 }
 
@@ -285,13 +286,14 @@ func (tx *Tx) insertQueuedMessage(ownerFallback uuid.UUID, m Message) (database.
 // suitable for promoting into active history.
 func messageFromQueuedRow(q database.ChatQueuedMessage) Message {
 	return Message{
-		Role:            database.ChatMessageRoleUser,
-		Content:         pqtype.NullRawMessage{RawMessage: q.Content, Valid: q.Content != nil},
-		Visibility:      database.ChatMessageVisibilityBoth,
-		ModelConfigID:   q.ModelConfigID,
-		ReasoningEffort: q.ReasoningEffort,
-		CreatedBy:       uuid.NullUUID{UUID: q.CreatedBy, Valid: true},
-		ContentVersion:  chatprompt.CurrentContentVersion,
+		Role:                 database.ChatMessageRoleUser,
+		Content:              pqtype.NullRawMessage{RawMessage: q.Content, Valid: q.Content != nil},
+		EnvironmentVariables: q.EnvironmentVariables,
+		Visibility:           database.ChatMessageVisibilityBoth,
+		ModelConfigID:        q.ModelConfigID,
+		ReasoningEffort:      q.ReasoningEffort,
+		CreatedBy:            uuid.NullUUID{UUID: q.CreatedBy, Valid: true},
+		ContentVersion:       chatprompt.CurrentContentVersion,
 	}
 }
 
@@ -628,13 +630,14 @@ func (tx *Tx) EditMessage(input EditMessageInput) (EditMessageResult, error) {
 		reasoningEffort = input.ReasoningEffortOverride
 	}
 	replacement := Message{
-		Role:            database.ChatMessageRoleUser,
-		Content:         input.Content,
-		Visibility:      target.Visibility,
-		ModelConfigID:   modelConfig,
-		ReasoningEffort: reasoningEffort,
-		CreatedBy:       uuid.NullUUID{UUID: input.CreatedBy, Valid: true},
-		ContentVersion:  chatprompt.CurrentContentVersion,
+		Role:                 database.ChatMessageRoleUser,
+		Content:              input.Content,
+		EnvironmentVariables: target.EnvironmentVariables,
+		Visibility:           target.Visibility,
+		ModelConfigID:        modelConfig,
+		ReasoningEffort:      reasoningEffort,
+		CreatedBy:            uuid.NullUUID{UUID: input.CreatedBy, Valid: true},
+		ContentVersion:       chatprompt.CurrentContentVersion,
 	}
 	insertedReplacement, err := tx.insertMessages([]Message{replacement})
 	if err != nil {

--- a/coderd/x/chatd/chatstate_bridge.go
+++ b/coderd/x/chatd/chatstate_bridge.go
@@ -1,6 +1,8 @@
 package chatd
 
 import (
+	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 
@@ -41,6 +43,17 @@ func userMessage(rawContent pqtype.NullRawMessage, modelConfigID, createdBy uuid
 		CreatedBy:       uuid.NullUUID{UUID: createdBy, Valid: createdBy != uuid.Nil},
 		ContentVersion:  chatprompt.CurrentContentVersion,
 	}
+}
+
+func marshalEnvironmentVariables(environmentVariables map[string]string) (pqtype.NullRawMessage, error) {
+	if len(environmentVariables) == 0 {
+		return pqtype.NullRawMessage{}, nil
+	}
+	raw, err := json.Marshal(environmentVariables)
+	if err != nil {
+		return pqtype.NullRawMessage{}, err
+	}
+	return pqtype.NullRawMessage{RawMessage: raw, Valid: true}, nil
 }
 
 // busyBehaviorToChatState converts the public busy-behavior enum used

--- a/coderd/x/chatd/chattool/execute.go
+++ b/coderd/x/chatd/chattool/execute.go
@@ -97,7 +97,8 @@ type ExecuteOptions struct {
 	// AgentBrowserSession, when non-empty, is exported as
 	// AGENT_BROWSER_SESSION so agent-browser CLI invocations land in a
 	// browser session scoped to this chat instead of a shared default.
-	AgentBrowserSession string
+	AgentBrowserSession  string
+	EnvironmentVariables map[string]string
 }
 
 // ProcessToolOptions configures a process management tool
@@ -148,8 +149,12 @@ func executeTool(
 		return fantasy.NewTextErrorResponse("command is required")
 	}
 
-	// Build the environment map for the process request.
-	env := make(map[string]string, len(nonInteractiveEnvVars)+2)
+	// Build the environment map for the process request. Tool-owned
+	// variables are applied last so callers cannot override them.
+	env := make(map[string]string, len(nonInteractiveEnvVars)+len(options.EnvironmentVariables)+2)
+	for k, v := range options.EnvironmentVariables {
+		env[k] = v
+	}
 	env["CODER_CHAT_AGENT"] = "true"
 	if options.AgentBrowserSession != "" {
 		env["AGENT_BROWSER_SESSION"] = options.AgentBrowserSession

--- a/coderd/x/chatd/chattool/execute_test.go
+++ b/coderd/x/chatd/chattool/execute_test.go
@@ -268,6 +268,49 @@ func TestExecuteTool(t *testing.T) {
 		assert.Equal(t, "chat-123", capturedReq.Env["AGENT_BROWSER_SESSION"])
 	})
 
+	t.Run("TurnEnvironmentVariables", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		var capturedReq workspacesdk.StartProcessRequest
+		mockConn.EXPECT().
+			StartProcess(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req workspacesdk.StartProcessRequest) (workspacesdk.StartProcessResponse, error) {
+				capturedReq = req
+				return workspacesdk.StartProcessResponse{ID: "proc-1"}, nil
+			})
+		exitCode := 0
+		mockConn.EXPECT().
+			ProcessOutput(gomock.Any(), "proc-1", gomock.Any()).
+			Return(workspacesdk.ProcessOutputResponse{Running: false, ExitCode: &exitCode}, nil)
+
+		tool := chattool.Execute(chattool.ExecuteOptions{
+			GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			AgentBrowserSession: "chat-123",
+			EnvironmentVariables: map[string]string{
+				"SCANNER_TOKEN":         "secret",
+				"CODER_CHAT_AGENT":      "false",
+				"AGENT_BROWSER_SESSION": "other-chat",
+				"TERM":                  "interactive",
+			},
+		})
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "execute",
+			Input: `{"command":"scanner"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Equal(t, "secret", capturedReq.Env["SCANNER_TOKEN"])
+		assert.Equal(t, "true", capturedReq.Env["CODER_CHAT_AGENT"])
+		assert.Equal(t, "chat-123", capturedReq.Env["AGENT_BROWSER_SESSION"])
+		assert.Equal(t, "dumb", capturedReq.Env["TERM"])
+	})
+
 	t.Run("ModelIntentIgnoredByExecution", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -2,6 +2,7 @@ package chatd
 
 import (
 	"context"
+	"encoding/json"
 	"slices"
 	"strings"
 	"sync"
@@ -97,6 +98,10 @@ func (server *Server) prepareGeneration(
 		return err
 	})
 	if err := g.Wait(); err != nil {
+		return generationPrepared{}, err
+	}
+	turnEnvironmentVariables, err := currentTurnEnvironmentVariables(promptRows)
+	if err != nil {
 		return generationPrepared{}, err
 	}
 
@@ -437,8 +442,9 @@ func (server *Server) prepareGeneration(
 			StoreFile:        storeChatAttachment,
 		}),
 		chattool.Execute(chattool.ExecuteOptions{
-			GetWorkspaceConn:    workspaceCtx.getWorkspaceConn,
-			AgentBrowserSession: chat.ID.String(),
+			GetWorkspaceConn:     workspaceCtx.getWorkspaceConn,
+			AgentBrowserSession:  chat.ID.String(),
+			EnvironmentVariables: turnEnvironmentVariables,
 		}),
 		chattool.ProcessOutput(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
 		chattool.ProcessList(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
@@ -736,6 +742,21 @@ func (server *Server) prepareGeneration(
 		Cleanup: cleanup,
 		Debug:   debug,
 	}, nil
+}
+
+func currentTurnEnvironmentVariables(messages []database.ChatMessage) (map[string]string, error) {
+	index := lastUserPromptIndex(messages)
+	if index < 0 || !messages[index].EnvironmentVariables.Valid {
+		return map[string]string{}, nil
+	}
+	var environmentVariables map[string]string
+	if err := json.Unmarshal(messages[index].EnvironmentVariables.RawMessage, &environmentVariables); err != nil {
+		return nil, xerrors.Errorf("parse turn environment variables: %w", err)
+	}
+	if environmentVariables == nil {
+		return map[string]string{}, nil
+	}
+	return environmentVariables, nil
 }
 
 func latestPromptUsage(messages []database.ChatMessage) fantasy.Usage {

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -100,7 +100,7 @@ func (server *Server) prepareGeneration(
 	if err := g.Wait(); err != nil {
 		return generationPrepared{}, err
 	}
-	turnEnvironmentVariables, err := currentTurnEnvironmentVariables(promptRows)
+	turnEnvironmentVariables, err := currentTurnEnvironmentVariables(chat, input.Messages)
 	if err != nil {
 		return generationPrepared{}, err
 	}
@@ -744,7 +744,10 @@ func (server *Server) prepareGeneration(
 	}, nil
 }
 
-func currentTurnEnvironmentVariables(messages []database.ChatMessage) (map[string]string, error) {
+func currentTurnEnvironmentVariables(chat database.Chat, messages []database.ChatMessage) (map[string]string, error) {
+	if chat.CompactionRequestedAt.Valid {
+		return map[string]string{}, nil
+	}
 	index := lastUserPromptIndex(messages)
 	if index < 0 || !messages[index].EnvironmentVariables.Valid {
 		return map[string]string{}, nil

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -45,6 +45,39 @@ func textMessage(t *testing.T, id int64, role database.ChatMessageRole, parts ..
 	}
 }
 
+func TestCurrentTurnEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	marshalEnv := func(environmentVariables map[string]string) pqtype.NullRawMessage {
+		t.Helper()
+		raw, err := json.Marshal(environmentVariables)
+		require.NoError(t, err)
+		return pqtype.NullRawMessage{RawMessage: raw, Valid: true}
+	}
+	message := func(role database.ChatMessageRole, visibility database.ChatMessageVisibility, environmentVariables pqtype.NullRawMessage) database.ChatMessage {
+		return database.ChatMessage{
+			Role:                 role,
+			Visibility:           visibility,
+			EnvironmentVariables: environmentVariables,
+		}
+	}
+
+	messages := []database.ChatMessage{
+		message(database.ChatMessageRoleUser, database.ChatMessageVisibilityBoth, marshalEnv(map[string]string{"TOKEN": "old"})),
+		message(database.ChatMessageRoleAssistant, database.ChatMessageVisibilityBoth, pqtype.NullRawMessage{}),
+		message(database.ChatMessageRoleUser, database.ChatMessageVisibilityBoth, marshalEnv(map[string]string{"TOKEN": "current"})),
+		message(database.ChatMessageRoleUser, database.ChatMessageVisibilityModel, marshalEnv(map[string]string{"TOKEN": "hook"})),
+	}
+	environmentVariables, err := currentTurnEnvironmentVariables(messages)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"TOKEN": "current"}, environmentVariables)
+
+	messages = append(messages, message(database.ChatMessageRoleUser, database.ChatMessageVisibilityBoth, pqtype.NullRawMessage{}))
+	environmentVariables, err = currentTurnEnvironmentVariables(messages)
+	require.NoError(t, err)
+	require.Empty(t, environmentVariables, "a later turn without variables must not inherit an earlier turn")
+}
+
 func TestLatestAssistantText(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -1,6 +1,7 @@
 package chatd //nolint:testpackage // Exercises unexported re-derivation helpers.
 
 import (
+	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -68,14 +69,33 @@ func TestCurrentTurnEnvironmentVariables(t *testing.T) {
 		message(database.ChatMessageRoleUser, database.ChatMessageVisibilityBoth, marshalEnv(map[string]string{"TOKEN": "current"})),
 		message(database.ChatMessageRoleUser, database.ChatMessageVisibilityModel, marshalEnv(map[string]string{"TOKEN": "hook"})),
 	}
-	environmentVariables, err := currentTurnEnvironmentVariables(messages)
+	environmentVariables, err := currentTurnEnvironmentVariables(database.Chat{}, messages)
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"TOKEN": "current"}, environmentVariables)
 
 	messages = append(messages, message(database.ChatMessageRoleUser, database.ChatMessageVisibilityBoth, pqtype.NullRawMessage{}))
-	environmentVariables, err = currentTurnEnvironmentVariables(messages)
+	environmentVariables, err = currentTurnEnvironmentVariables(database.Chat{}, messages)
 	require.NoError(t, err)
 	require.Empty(t, environmentVariables, "a later turn without variables must not inherit an earlier turn")
+
+	compacted := []database.ChatMessage{
+		message(database.ChatMessageRoleUser, database.ChatMessageVisibilityBoth, marshalEnv(map[string]string{"TOKEN": "current"})),
+		{
+			Role:       database.ChatMessageRoleUser,
+			Visibility: database.ChatMessageVisibilityModel,
+			Compressed: true,
+		},
+	}
+	environmentVariables, err = currentTurnEnvironmentVariables(database.Chat{}, compacted)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"TOKEN": "current"}, environmentVariables,
+		"automatic compaction must preserve the active user turn variables")
+
+	environmentVariables, err = currentTurnEnvironmentVariables(database.Chat{
+		CompactionRequestedAt: sql.NullTime{Valid: true},
+	}, compacted)
+	require.NoError(t, err)
+	require.Empty(t, environmentVariables, "manual compaction must not reuse the previous completed turn variables")
 }
 
 func TestLatestAssistantText(t *testing.T) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -565,14 +565,19 @@ type ToolResult struct {
 
 // CreateChatRequest is the request to create a new chat.
 type CreateChatRequest struct {
-	OrganizationID  uuid.UUID         `json:"organization_id" format:"uuid"`
-	Content         []ChatInputPart   `json:"content"`
-	SystemPrompt    string            `json:"system_prompt,omitempty"`
-	WorkspaceID     *uuid.UUID        `json:"workspace_id,omitempty" format:"uuid"`
-	ModelConfigID   *uuid.UUID        `json:"model_config_id,omitempty" format:"uuid"`
-	ReasoningEffort *string           `json:"reasoning_effort,omitempty"`
-	MCPServerIDs    []uuid.UUID       `json:"mcp_server_ids,omitempty" format:"uuid"`
-	Labels          map[string]string `json:"labels,omitempty"`
+	OrganizationID  uuid.UUID       `json:"organization_id" format:"uuid"`
+	Content         []ChatInputPart `json:"content"`
+	SystemPrompt    string          `json:"system_prompt,omitempty"`
+	WorkspaceID     *uuid.UUID      `json:"workspace_id,omitempty" format:"uuid"`
+	ModelConfigID   *uuid.UUID      `json:"model_config_id,omitempty" format:"uuid"`
+	ReasoningEffort *string         `json:"reasoning_effort,omitempty"`
+	// EnvironmentVariables are persisted with the initial user turn and
+	// provided only to workspace command execution. Values are not included
+	// in model prompts or API responses, but are stored unencrypted in the
+	// Coder database.
+	EnvironmentVariables map[string]string `json:"environment_variables,omitempty"`
+	MCPServerIDs         []uuid.UUID       `json:"mcp_server_ids,omitempty" format:"uuid"`
+	Labels               map[string]string `json:"labels,omitempty"`
 	// UnsafeDynamicTools declares client-executed tools that the
 	// LLM can invoke. This API is highly experimental and highly
 	// subject to change.
@@ -635,6 +640,10 @@ type CreateChatMessageRequest struct {
 	// nil: no change, ptr to "plan": enable, ptr to "": clear.
 	PlanMode        *ChatPlanMode `json:"plan_mode,omitempty"`
 	ReasoningEffort *string       `json:"reasoning_effort,omitempty"`
+	// EnvironmentVariables apply only to the turn started by this message.
+	// Values are not included in model prompts or API responses, but are
+	// stored unencrypted in the Coder database.
+	EnvironmentVariables map[string]string `json:"environment_variables,omitempty"`
 }
 
 // EditChatMessageRequest is the request to edit a user message in a chat.

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -280,6 +280,10 @@ Experimental: this endpoint is subject to change.
       "type": "text"
     }
   ],
+  "environment_variables": {
+    "property1": "string",
+    "property2": "string"
+  },
   "labels": {
     "property1": "string",
     "property2": "string"
@@ -1873,6 +1877,10 @@ Experimental: this endpoint is subject to change.
       "type": "text"
     }
   ],
+  "environment_variables": {
+    "property1": "string",
+    "property2": "string"
+  },
   "mcp_server_ids": [
     "497f6eca-6276-4993-bfeb-53cbbbba6f08"
   ],

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -4649,6 +4649,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "type": "text"
     }
   ],
+  "environment_variables": {
+    "property1": "string",
+    "property2": "string"
+  },
   "mcp_server_ids": [
     "497f6eca-6276-4993-bfeb-53cbbbba6f08"
   ],
@@ -4660,14 +4664,16 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name               | Type                                                      | Required | Restrictions | Description                                                                                                  |
-|--------------------|-----------------------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------|
-| `busy_behavior`    | [codersdk.ChatBusyBehavior](#codersdkchatbusybehavior)    | false    |              |                                                                                                              |
-| `content`          | array of [codersdk.ChatInputPart](#codersdkchatinputpart) | false    |              |                                                                                                              |
-| `mcp_server_ids`   | array of string                                           | false    |              |                                                                                                              |
-| `model_config_id`  | string                                                    | false    |              |                                                                                                              |
-| `plan_mode`        | [codersdk.ChatPlanMode](#codersdkchatplanmode)            | false    |              | Plan mode switches the chat's persistent plan mode. nil: no change, ptr to "plan": enable, ptr to "": clear. |
-| `reasoning_effort` | string                                                    | false    |              |                                                                                                              |
+| Name                    | Type                                                      | Required | Restrictions | Description                                                                                                                                                                        |
+|-------------------------|-----------------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `busy_behavior`         | [codersdk.ChatBusyBehavior](#codersdkchatbusybehavior)    | false    |              |                                                                                                                                                                                    |
+| `content`               | array of [codersdk.ChatInputPart](#codersdkchatinputpart) | false    |              |                                                                                                                                                                                    |
+| `environment_variables` | object                                                    | false    |              | Environment variables apply only to the turn started by this message. Values are not included in model prompts or API responses, but are stored unencrypted in the Coder database. |
+| » `[any property]`      | string                                                    | false    |              |                                                                                                                                                                                    |
+| `mcp_server_ids`        | array of string                                           | false    |              |                                                                                                                                                                                    |
+| `model_config_id`       | string                                                    | false    |              |                                                                                                                                                                                    |
+| `plan_mode`             | [codersdk.ChatPlanMode](#codersdkchatplanmode)            | false    |              | Plan mode switches the chat's persistent plan mode. nil: no change, ptr to "plan": enable, ptr to "": clear.                                                                       |
+| `reasoning_effort`      | string                                                    | false    |              |                                                                                                                                                                                    |
 
 #### Enumerated Values
 
@@ -4946,6 +4952,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "type": "text"
     }
   ],
+  "environment_variables": {
+    "property1": "string",
+    "property2": "string"
+  },
   "labels": {
     "property1": "string",
     "property2": "string"
@@ -4973,20 +4983,22 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name                   | Type                                                      | Required | Restrictions | Description                                                                                                                                |
-|------------------------|-----------------------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `client_type`          | [codersdk.ChatClientType](#codersdkchatclienttype)        | false    |              |                                                                                                                                            |
-| `content`              | array of [codersdk.ChatInputPart](#codersdkchatinputpart) | false    |              |                                                                                                                                            |
-| `labels`               | object                                                    | false    |              |                                                                                                                                            |
-| » `[any property]`     | string                                                    | false    |              |                                                                                                                                            |
-| `mcp_server_ids`       | array of string                                           | false    |              |                                                                                                                                            |
-| `model_config_id`      | string                                                    | false    |              |                                                                                                                                            |
-| `organization_id`      | string                                                    | false    |              |                                                                                                                                            |
-| `plan_mode`            | [codersdk.ChatPlanMode](#codersdkchatplanmode)            | false    |              |                                                                                                                                            |
-| `reasoning_effort`     | string                                                    | false    |              |                                                                                                                                            |
-| `system_prompt`        | string                                                    | false    |              |                                                                                                                                            |
-| `unsafe_dynamic_tools` | array of [codersdk.DynamicTool](#codersdkdynamictool)     | false    |              | Unsafe dynamic tools declares client-executed tools that the LLM can invoke. This API is highly experimental and highly subject to change. |
-| `workspace_id`         | string                                                    | false    |              |                                                                                                                                            |
+| Name                    | Type                                                      | Required | Restrictions | Description                                                                                                                                                                                                                   |
+|-------------------------|-----------------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `client_type`           | [codersdk.ChatClientType](#codersdkchatclienttype)        | false    |              |                                                                                                                                                                                                                               |
+| `content`               | array of [codersdk.ChatInputPart](#codersdkchatinputpart) | false    |              |                                                                                                                                                                                                                               |
+| `environment_variables` | object                                                    | false    |              | Environment variables are persisted with the initial user turn and provided only to workspace command execution. Values are not included in model prompts or API responses, but are stored unencrypted in the Coder database. |
+| » `[any property]`      | string                                                    | false    |              |                                                                                                                                                                                                                               |
+| `labels`                | object                                                    | false    |              |                                                                                                                                                                                                                               |
+| » `[any property]`      | string                                                    | false    |              |                                                                                                                                                                                                                               |
+| `mcp_server_ids`        | array of string                                           | false    |              |                                                                                                                                                                                                                               |
+| `model_config_id`       | string                                                    | false    |              |                                                                                                                                                                                                                               |
+| `organization_id`       | string                                                    | false    |              |                                                                                                                                                                                                                               |
+| `plan_mode`             | [codersdk.ChatPlanMode](#codersdkchatplanmode)            | false    |              |                                                                                                                                                                                                                               |
+| `reasoning_effort`      | string                                                    | false    |              |                                                                                                                                                                                                                               |
+| `system_prompt`         | string                                                    | false    |              |                                                                                                                                                                                                                               |
+| `unsafe_dynamic_tools`  | array of [codersdk.DynamicTool](#codersdkdynamictool)     | false    |              | Unsafe dynamic tools declares client-executed tools that the LLM can invoke. This API is highly experimental and highly subject to change.                                                                                    |
+| `workspace_id`          | string                                                    | false    |              |                                                                                                                                                                                                                               |
 
 ## codersdk.CreateFirstUserOnboardingInfo
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3856,6 +3856,12 @@ export interface CreateChatMessageRequest {
 	 */
 	readonly plan_mode?: ChatPlanMode;
 	readonly reasoning_effort?: string;
+	/**
+	 * EnvironmentVariables apply only to the turn started by this message.
+	 * Values are not included in model prompts or API responses, but are
+	 * stored unencrypted in the Coder database.
+	 */
+	readonly environment_variables?: Record<string, string>;
 }
 
 // From codersdk/chats.go
@@ -3917,6 +3923,13 @@ export interface CreateChatRequest {
 	readonly workspace_id?: string;
 	readonly model_config_id?: string;
 	readonly reasoning_effort?: string;
+	/**
+	 * EnvironmentVariables are persisted with the initial user turn and
+	 * provided only to workspace command execution. Values are not included
+	 * in model prompts or API responses, but are stored unencrypted in the
+	 * Coder database.
+	 */
+	readonly environment_variables?: Record<string, string>;
 	readonly mcp_server_ids?: readonly string[];
 	readonly labels?: Record<string, string>;
 	/**


### PR DESCRIPTION
## Summary

Add experimental, turn-scoped environment variables to the Coder Agents chat API so API clients can provide credentials to workspace command execution without placing their values in model-visible chat content.

Environment variables are persisted with the triggering user message, survive queued-message promotion and message edits, and apply only to the `execute` tool for that turn. Coder-owned process variables retain precedence, and the values are omitted from model prompts and chat API responses.

> [!WARNING]
> This proof of concept stores the values unencrypted in PostgreSQL `jsonb` columns. The API documentation calls out this limitation explicitly.

## Dogfood

Validated against a local Coder deployment with a real Docker workspace and model provider:

- The initial chat turn returned `ENV_OK` when its environment variable was present.
- A message-specific turn returned `TURN_SCOPED_OK`, confirming the initial variable was not inherited.
- A follow-up without environment variables returned `CLEAN_TURN_OK`, confirming earlier turn variables did not leak.
- Secret values were absent from the chat messages API responses.


---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh`_
