### PR TITLE
docs: fix broken callout on the AI Gateway Monitoring page

### DIFF
--- a/docs/ai-coder/ai-gateway/monitoring.md
+++ b/docs/ai-coder/ai-gateway/monitoring.md
@@ -198,12 +198,13 @@ curl -X GET "https://coder.example.com/api/v2/ai-gateway/sessions" \
 Available query filters:
 
 - `client` - Filter by client name.
-  <details>
-  <summary>Possible <code>client</code> values</summary>
 
   > [!NOTE]
   > Client classification is done on best effort basis using the `User-Agent` header;
-  not all clients send these headers in an easily-identifiable manner.
+  > not all clients send these headers in an easily-identifiable manner.
+
+  <br /><details>
+  <summary>Possible <code>client</code> values</summary>
 
   - `Claude Code`
   - `Codex`
@@ -217,7 +218,8 @@ Available query filters:
   - `OpenCode`
   - `Unknown`
 
-  </details><br>
+  </details>
+
 - `initiator` - Filter by user ID or username
 - `provider` - Filter by AI provider (e.g., `openai`, `anthropic`)
 - `model` - Filter by model name


### PR DESCRIPTION
The callout on this page is broken, as flagged by Atif. This PR moves the callout out of the `<details>` block to avoid the broken formatting.

Fixes DOCS-679

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
