### PR TITLE
docs: uppercase mixed-case GitHub-style callout markers [DOCS-681]

### DIFF
--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -83,7 +83,7 @@ kubectl create secret generic coder-db-url -n coder \
   --from-literal=url="postgres://coder:coder@coder-db-postgresql.coder.svc.cluster.local:5432/coder?sslmode=disable"
 ```
 
-> [!Important]
+> [!IMPORTANT]
 > If you're using a managed PostgreSQL service, replace the connection URL with your specific database credentials.
 
 ## Install Coder through the Rancher UI

--- a/docs/user-guides/shared-workspaces.md
+++ b/docs/user-guides/shared-workspaces.md
@@ -40,7 +40,7 @@ To remove sharing from a workspace:
 - `coder sharing remove <workspace> --group contractor`
   - Workspace is no longer shared with the group `contractor`.
 
-> [!Important]
+> [!IMPORTANT]
 > The workspace must be restarted for the user or group removal to take effect.
 
 To show who a workspace is shared with:

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -38,7 +38,7 @@ coder ssh my-workspace
 
 Or, you can configure plain SSH on your client below.
 
-> [!Note]
+> [!NOTE]
 > The `coder ssh` command does not have full parity with the standard
 > SSH command. For users who need the full functionality of SSH, use the
 > configuration method below.


### PR DESCRIPTION
## What

Uppercase the mixed-case GitHub-style callout markers in the docs corpus to the canonical all-caps form.

- `docs/install/rancher.md`: `> [!Important]` -> `> [!IMPORTANT]`
- `docs/user-guides/shared-workspaces.md`: `> [!Important]` -> `> [!IMPORTANT]`
- `docs/user-guides/workspace-access/index.md`: `> [!Note]` -> `> [!NOTE]`

A full-corpus scan confirmed these were the only mixed-case markers.

## Why

GitHub alerts, the hosted docs (coder.com), and the offlinedocs Fumadocs renderer all require all-caps alert types (`[!NOTE]`, `[!IMPORTANT]`, and so on). The mixed-case form rendered as literal text instead of a styled alert (on some pages directly next to a correctly-rendered all-caps alert), so this is a genuine rendering fix on GitHub and coder.com, not an offline-pipeline accommodation.

Surfaced by the offlinedocs Fumadocs migration review (CRF-60 on #27390). Tracked separately from the space-after-`!` fix (DOCS-680), per request.

Linear: [DOCS-681](https://linear.app/codercom/issue/DOCS-681/uppercase-mixed-case-github-style-callout-markers-across-docs)

> This PR was created with AI assistance (Coder Agents).