### PR TITLE
docs: remove space in GitHub-style callout markers [DOCS-680]

### DIFF
--- a/docs/user-guides/workspace-access/jetbrains/gateway.md
+++ b/docs/user-guides/workspace-access/jetbrains/gateway.md
@@ -1,6 +1,6 @@
 ## JetBrains Gateway
 
-> [! WARNING]
+> [!WARNING]
 > Using Coder through JetBrains Gateway is not recommended at this time. Instead, we suggest using [JetBrains Toolbox](https://coder.com/docs/user-guides/workspace-access/jetbrains/toolbox) for stability and performance benefits. If you are currently using Gateway, we recommend [migration](https://www.jetbrains.com/help/toolbox-app/jetbrains-gateway-migrations-guide.html).
 
 JetBrains Gateway is a compact desktop app that allows you to work remotely with


### PR DESCRIPTION
## What

Normalize the one GitHub-style callout marker that had a space after `!` to the canonical tight form.

- `docs/user-guides/workspace-access/jetbrains/gateway.md`: `> [! WARNING]` -> `> [!WARNING]`

A full-corpus scan confirmed this was the only spaced marker.

## Why

GitHub alerts, the hosted docs (coder.com), and the offlinedocs Fumadocs renderer all require the tight `> [!WARNING]` form. The spaced form rendered as literal `[! WARNING]` text instead of a styled alert, so this is a genuine rendering fix on GitHub and coder.com, not an offline-pipeline accommodation.

Surfaced by the offlinedocs Fumadocs migration review (CRF-60 on #27390). Tracked separately from the mixed-case uppercasing fix (DOCS-681), per request.

Linear: [DOCS-680](https://linear.app/codercom/issue/DOCS-680/remove-the-space-after-in-github-style-callout-markers-across-docs)

> This PR was created with AI assistance (Coder Agents).