### PR TITLE
fix: emit provisioner tags query param as string in swagger

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6123,7 +6123,7 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "object",
+                        "type": "string",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
                         "in": "query"
@@ -6234,7 +6234,7 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "object",
+                        "type": "string",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
                         "in": "query"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5438,7 +5438,7 @@
 						"in": "query"
 					},
 					{
-						"type": "object",
+						"type": "string",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
 						"in": "query"
@@ -5543,7 +5543,7 @@
 						"in": "query"
 					},
 					{
-						"type": "object",
+						"type": "string",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
 						"in": "query"

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -26,7 +26,7 @@ import (
 // @Param limit query int false "Page limit"
 // @Param ids query []string false "Filter results by job IDs" format(uuid)
 // @Param status query codersdk.ProvisionerJobStatus false "Filter results by status" enums(pending,running,succeeded,canceling,canceled,failed)
-// @Param tags query object false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
+// @Param tags query string false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
 // @Success 200 {array} codersdk.ProvisionerDaemon
 // @Router /api/v2/organizations/{organization}/provisionerdaemons [get]
 func (api *API) provisionerDaemons(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -75,7 +75,7 @@ func (api *API) provisionerJob(rw http.ResponseWriter, r *http.Request) {
 // @Param limit query int false "Page limit"
 // @Param ids query []string false "Filter results by job IDs" format(uuid)
 // @Param status query codersdk.ProvisionerJobStatus false "Filter results by status" enums(pending,running,succeeded,canceling,canceled,failed)
-// @Param tags query object false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
+// @Param tags query string false "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)"
 // @Param initiator query string false "Filter results by initiator" format(uuid)
 // @Success 200 {array} codersdk.ProvisionerJob
 // @Router /api/v2/organizations/{organization}/provisionerjobs [get]

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -299,7 +299,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 | `limit`        | query | integer      | false    | Page limit                                                                           |
 | `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                            |
 | `status`       | query | string       | false    | Filter results by status                                                             |
-| `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
+| `tags`         | query | string       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
 | `initiator`    | query | string(uuid) | false    | Filter results by initiator                                                          |
 
 #### Enumerated Values

--- a/docs/reference/api/provisioning.md
+++ b/docs/reference/api/provisioning.md
@@ -26,7 +26,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 | `limit`        | query | integer      | false    | Page limit                                                                           |
 | `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                            |
 | `status`       | query | string       | false    | Filter results by status                                                             |
-| `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
+| `tags`         | query | string       | false    | Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`) |
 
 #### Enumerated Values
 


### PR DESCRIPTION
## Summary

The `tags` query parameter on the "Get provisioner daemons" and "Get provisioner jobs" endpoints was annotated as `@Param tags query object`, which caused Swagger to emit `"type": "object"` for a query parameter. Query parameters cannot be of type `object` in the OpenAPI 2.0 spec, so this produced an invalid schema that breaks spec validators and client generators.

As noted in the doc, the value is actually a single JSON-encoded string (parsed via `QueryParamParser.JSONStringMap`), so the correct type is `string`. This is a doc only concern as generators do not use this file.

## Changes

- Change the `tags` query param annotation from `object` to `string` in:
  - `coderd/provisionerdaemons.go` (`GET /api/v2/organizations/{organization}/provisionerdaemons`)
  - `coderd/provisionerjobs.go` (`GET /api/v2/organizations/{organization}/provisionerjobs`)
- Regenerate API docs (`make coderd/apidoc/.gen`): `coderd/apidoc/swagger.json`, `coderd/apidoc/docs.go`, and the reference markdown.

The description still documents the expected JSON form (`{'tag1':'value1','tag2':'value2'}`), so no behavior changes for callers.

> [!NOTE]
> This PR was generated by Coder Agents on behalf of @snagles.