### PR TITLE
fix: gate group settings page and fix unauthorized group patch

### DIFF
--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -285,9 +285,15 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// Unauthorized errors return a 404 to not leak information about the
+	// existence of resources.
+	if httpapi.IsUnauthorizedError(err) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
 	if httpapi.Is404Error(err) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Failed to add or remove non-existent group member",
+			Message: "Failed to update group.",
 			Detail:  err.Error(),
 		})
 		return

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -420,6 +420,52 @@ func TestPatchGroup(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, cerr.StatusCode())
 	})
 
+	// A group member can read the group but must not be able to update it.
+	// The update must be rejected as an authorization failure that returns a
+	// 404 to not leak resource existence.
+	t.Run("MemberWithoutUpdatePermission", func(t *testing.T) {
+		t.Parallel()
+
+		client, user := coderdenttest.New(t, &coderdenttest.Options{LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureTemplateRBAC: 1,
+			},
+		}})
+		userAdminClient, _ := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleUserAdmin())
+		memberClient, member := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		group, err := userAdminClient.CreateGroup(ctx, user.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "hi",
+		})
+		require.NoError(t, err)
+
+		// Make the actor a member of the group so it can read the group but
+		// still lacks group:update.
+		_, err = userAdminClient.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
+			AddUsers: []string{member.ID.String()},
+		})
+		require.NoError(t, err)
+
+		// Updating the group budget must fail as unauthorized (404).
+		_, err = memberClient.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
+			QuotaAllowance: ptr.Ref(20),
+		})
+		require.Error(t, err)
+		cerr, ok := codersdk.AsError(err)
+		require.True(t, ok)
+		require.Equal(t, http.StatusNotFound, cerr.StatusCode())
+
+		// Adding a member must also fail as unauthorized (404).
+		_, err = memberClient.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
+			AddUsers: []string{user.UserID.String()},
+		})
+		require.Error(t, err)
+		cerr, ok = codersdk.AsError(err)
+		require.True(t, ok)
+		require.Equal(t, http.StatusNotFound, cerr.StatusCode())
+	})
+
 	t.Run("MalformedUUID", func(t *testing.T) {
 		t.Parallel()
 

--- a/site/src/pages/GroupsPage/GroupPage.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.stories.tsx
@@ -43,6 +43,7 @@ import {
 } from "#/testHelpers/storybook";
 import GroupMembersPage from "./GroupMembersPage";
 import GroupPage from "./GroupPage";
+import GroupSettingsPage from "./GroupSettingsPage";
 
 const meta: Meta<typeof GroupPage> = {
 	title: "pages/OrganizationGroupsPage/GroupPage",
@@ -205,6 +206,47 @@ export const NoUpdatePermission: Story = {
 			}),
 			permissionsQuery({ canUpdateGroup: false }),
 		],
+	},
+};
+
+/**
+ * The settings page is reachable by direct URL even when the settings tab is
+ * hidden. Without group:update, it must render the permission dialog instead
+ * of the editable form.
+ */
+export const SettingsWithoutUpdatePermission: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				pathParams: {
+					organization: MockDefaultOrganization.name,
+					groupName: MockGroupWithoutMembers.name,
+				},
+			},
+			routing: reactRouterOutlet(
+				{ path: "/organizations/:organization/groups/:groupName/settings" },
+				<GroupSettingsPage />,
+			),
+		}),
+		queries: [
+			groupQuery(MockGroupWithoutMembers),
+			groupMembersQuery({
+				users: MockGroup.members,
+				count: MockGroup.members.length,
+			}),
+			permissionsQuery({ canUpdateGroup: false }),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(document.body);
+		await expect(
+			await body.findByText("You don't have permission to view this page"),
+		).toBeInTheDocument();
+		// The editable budget/name form is never rendered.
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByRole("button", { name: "Save" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/GroupsPage/GroupSettingsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
+import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { dollarsToMicros, microsToDollars } from "#/utils/currency";
 import type { GroupPageOutletContext } from "./GroupPage";
 import GroupSettingsPageView from "./GroupSettingsPageView";
@@ -23,19 +24,25 @@ const GroupSettingsPage: FC = () => {
 		organization?: string;
 		groupName: string;
 	};
-	const { group: groupData } = useOutletContext<GroupPageOutletContext>();
+	const { group: groupData, permissions } =
+		useOutletContext<GroupPageOutletContext>();
 	const queryClient = useQueryClient();
 	const patchGroupMutation = useMutation(patchGroup(queryClient, organization));
 	const navigate = useNavigate();
 
 	const aibridgeVisible = Boolean(useFeatureVisibility().aibridge);
+	const canUpdateGroup = permissions.canUpdateGroup;
 	const budgetQuery = useQuery({
 		...groupAIBudget(groupData.id),
-		enabled: aibridgeVisible,
+		enabled: aibridgeVisible && canUpdateGroup,
 	});
 	const saveBudgetMutation = useMutation(
 		saveGroupAIBudget(queryClient, groupData.id),
 	);
+
+	if (!canUpdateGroup) {
+		return <RequirePermission isFeatureVisible={false} />;
+	}
 
 	if (aibridgeVisible && budgetQuery.isLoading) {
 		return (


### PR DESCRIPTION
## Problem

A user without `group:update` (e.g. the `Coder Agents User` role) could open the group settings page by direct URL and edit the budget. Saving then failed with a misleading error:

> Failed to add or remove non-existent group member — execute transaction: update group by ID: unauthorized: rbac: forbidden.

The authorization failure was misclassified as a missing group member, and the settings page was not gated on the required permission.

## Changes

- Return the standard vague 404 for authorization failures in the group PATCH handler, so the response is accurate and does not leak resource existence.
- Use a generic message for the remaining 400 branch, since it covers various transaction failures rather than only member add/remove.
- Gate the group settings page on `group:update`. The settings tab is already hidden without the permission, but the page was reachable by direct URL and rendered an editable form that always failed on save. It now shows the standard permission dialog.

Fixes [AIGOV-603](https://linear.app/codercom/issue/AIGOV-603/hide-group-budget-controls-without-permission).

> [!NOTE]
> Generated by Coder Agents, reviewed by @ssncferreira.
