### PR TITLE
feat(site): move PR icon to diff line, add subagent status icons, persist kebab on active chat

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -1860,6 +1860,116 @@ export const WithPRStateIcons: Story = {
 			routing: agentsRouting,
 		}),
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByLabelText("Pull request open")).toBeInTheDocument();
+			expect(canvas.getByLabelText("Draft pull request")).toBeInTheDocument();
+			expect(canvas.getByLabelText("Pull request merged")).toBeInTheDocument();
+			expect(canvas.getByLabelText("Pull request closed")).toBeInTheDocument();
+		});
+	},
+};
+
+export const WithSubagentStatusIcons: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "solo-idle",
+				title: "Solo idle agent",
+				updated_at: recentTimestamp,
+			}),
+			buildChat({
+				id: "solo-working",
+				title: "Solo working agent",
+				status: "running",
+				updated_at: recentTimestamp,
+			}),
+			buildChat({
+				id: "parent-idle",
+				title: "Idle parent with subagents",
+				updated_at: recentTimestamp,
+				children: [
+					buildChat({
+						id: "sub-idle-1",
+						title: "Idle subagent",
+						parent_chat_id: "parent-idle",
+						root_chat_id: "parent-idle",
+					}),
+				],
+			}),
+			buildChat({
+				id: "parent-working",
+				title: "Working parent with subagents",
+				status: "running",
+				updated_at: recentTimestamp,
+				children: [
+					buildChat({
+						id: "sub-working-1",
+						title: "Working subagent",
+						status: "running",
+						parent_chat_id: "parent-working",
+						root_chat_id: "parent-working",
+					}),
+				],
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByLabelText("Idle, has subagents")).toBeInTheDocument();
+			expect(
+				canvas.getByLabelText("Working, has subagents"),
+			).toBeInTheDocument();
+		});
+		expect(canvas.getByLabelText("Idle")).toBeInTheDocument();
+		expect(canvas.getByLabelText("Working")).toBeInTheDocument();
+	},
+};
+
+export const ActiveChatKebabPersistent: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "active-chat",
+				title: "Active chat",
+				updated_at: recentTimestamp,
+			}),
+			buildChat({
+				id: "other-chat",
+				title: "Other chat",
+				updated_at: recentTimestamp,
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents/active-chat",
+				pathParams: { agentId: "active-chat" },
+			},
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const activeTrigger = await canvas.findByLabelText(
+			"Open actions for Active chat",
+		);
+		// The active chat keeps its actions trigger visible without hover.
+		await waitFor(() => {
+			expect(window.getComputedStyle(activeTrigger).opacity).toBe("1");
+		});
+		const otherTrigger = canvas.getByLabelText("Open actions for Other chat");
+		expect(window.getComputedStyle(otherTrigger).opacity).toBe("0");
+	},
 };
 
 export const WithUnreadChats: Story = {

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -255,8 +255,11 @@ const ChatSearchResultRow: FC<ChatSearchResultRowProps> = ({
 	const {
 		icon: StatusIcon,
 		className: statusClassName,
+		label: statusLabel,
+		prIcon,
 		diffStatus,
 	} = getChatDisplayConfig(chat);
+	const PRIcon = prIcon?.icon;
 	const additions = diffStatus?.additions ?? 0;
 	const deletions = diffStatus?.deletions ?? 0;
 	const changedFiles = diffStatus?.changed_files ?? 0;
@@ -285,12 +288,23 @@ const ChatSearchResultRow: FC<ChatSearchResultRowProps> = ({
 				isSelected && "bg-surface-tertiary/40 text-content-primary",
 			)}
 		>
-			<StatusIcon className={cn("mt-1 size-3.5 shrink-0", statusClassName)} />
+			<StatusIcon
+				role="img"
+				aria-label={statusLabel}
+				className={cn("mt-1 size-3.5 shrink-0", statusClassName)}
+			/>
 			<div className="min-w-0">
 				<div className="truncate text-sm text-content-primary">
 					{chat.title}
 				</div>
 				<div className="flex min-w-0 items-center gap-1.5 text-xs">
+					{PRIcon && prIcon && (
+						<PRIcon
+							role="img"
+							aria-label={prIcon.label}
+							className={cn("size-3.5 shrink-0", prIcon.className)}
+						/>
+					)}
 					{hasLineStats && (
 						<span className="inline-flex shrink-0 items-center gap-0.5 tabular-nums">
 							<span className="text-git-added-bright">+{additions}</span>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -127,8 +127,11 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 	const {
 		icon: StatusIcon,
 		className: statusClassName,
+		label: statusLabel,
+		prIcon,
 		diffStatus,
-	} = getChatDisplayConfig(chat);
+	} = getChatDisplayConfig(chat, hasChildren);
+	const PRIcon = prIcon?.icon;
 	const hasLinkedDiffStatus = Boolean(diffStatus?.url);
 	const changedFiles = diffStatus?.changed_files ?? 0;
 	const additions = diffStatus?.additions ?? 0;
@@ -199,6 +202,8 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											? `agents-tree-executing-${chat.id}`
 											: undefined
 									}
+									role="img"
+									aria-label={statusLabel}
 									className={cn("size-3.5 shrink-0", statusClassName)}
 								/>
 							</div>
@@ -253,6 +258,13 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												<BotIcon className="size-3.5" aria-hidden="true" />
 											</span>
 										)}
+										{PRIcon && prIcon && (
+											<PRIcon
+												role="img"
+												aria-label={prIcon.label}
+												className={cn("size-3.5 shrink-0", prIcon.className)}
+											/>
+										)}
 										{hasLinkedDiffStatus && hasLineStats && (
 											<span
 												className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 tabular-nums"
@@ -297,6 +309,9 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											// keep the timestamp visible.
 											hasMenuActions &&
 												"[@media(hover:hover)]:group-hover:hidden group-has-[[data-state=open]]:hidden",
+											// The active chat keeps the actions trigger visible, so
+											// the timestamp stays hidden there.
+											hasMenuActions && isActiveChat && "hidden",
 										)}
 									>
 										{chat.has_unread && !isActiveChat ? (
@@ -331,7 +346,12 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 										<Button
 											size="icon"
 											variant="subtle"
-											className="absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 data-[state=open]:opacity-100"
+											className={cn(
+												"absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 data-[state=open]:opacity-100",
+												// Keep the trigger visible on the active chat so it is
+												// reachable without hovering.
+												isActiveChat && "opacity-100",
+											)}
 											aria-label={`Open actions for ${chat.title}`}
 										>
 											<EllipsisVerticalIcon className="size-3.5" />

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -315,11 +315,15 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 										)}
 									>
 										{chat.has_unread && !isActiveChat ? (
-											<span
-												className="size-2 shrink-0 rounded-full bg-content-link pr-1"
-												data-testid={`unread-indicator-${chat.id}`}
-												aria-hidden="true"
-											/>
+											// The w-3.5 box matches the kebab icon's width so the
+											// dot centers on the same axis as the ellipsis glyph.
+											<span className="flex w-3.5 shrink-0 justify-center">
+												<span
+													className="size-2 rounded-full bg-content-link"
+													data-testid={`unread-indicator-${chat.id}`}
+													aria-hidden="true"
+												/>
+											</span>
 										) : (
 											<>
 												{/* Pin the ignored mask width so Pixel does not diff bounding rect changes. */}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SubagentsLoaderIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SubagentsLoaderIcon.tsx
@@ -3,8 +3,10 @@ import type { ComponentProps, JSX } from "react";
 /**
  * Spinner variant used when a chat has subagents: lucide's LoaderCircle
  * arc plus a second, inner arc so the icon reads as multiple agents
- * working at once. Drawn on the same 24x24 grid and stroke settings as
- * lucide icons so it can substitute for one.
+ * working at once. The arcs rotate independently (the inner one
+ * counter-rotates at a slower speed) so the motion conveys concurrent
+ * work rather than a single rigid spinner. Drawn on the same 24x24 grid
+ * and stroke settings as lucide icons so it can substitute for one.
  */
 export const SubagentsLoaderIcon = (
 	props: ComponentProps<"svg">,
@@ -21,7 +23,13 @@ export const SubagentsLoaderIcon = (
 		strokeLinejoin="round"
 		{...props}
 	>
-		<path d="M21 12a9 9 0 1 1-6.219-8.56" />
-		<path d="M16.5 12a4.5 4.5 0 1 1-3.11-4.28" />
+		<path
+			className="origin-center [transform-box:view-box] animate-spin"
+			d="M21 12a9 9 0 1 1-6.219-8.56"
+		/>
+		<path
+			className="origin-center [transform-box:view-box] animate-[spin_1.5s_linear_infinite_reverse]"
+			d="M16.5 12a4.5 4.5 0 1 1-3.11-4.28"
+		/>
 	</svg>
 );

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SubagentsLoaderIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SubagentsLoaderIcon.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps, JSX } from "react";
+
+/**
+ * Spinner variant used when a chat has subagents: lucide's LoaderCircle
+ * arc plus a second, inner arc so the icon reads as multiple agents
+ * working at once. Drawn on the same 24x24 grid and stroke settings as
+ * lucide icons so it can substitute for one.
+ */
+export const SubagentsLoaderIcon = (
+	props: ComponentProps<"svg">,
+): JSX.Element => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		{...props}
+	>
+		<path d="M21 12a9 9 0 1 1-6.219-8.56" />
+		<path d="M16.5 12a4.5 4.5 0 1 1-3.11-4.28" />
+	</svg>
+);

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/statusConfig.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/statusConfig.ts
@@ -59,8 +59,10 @@ const subagentsStatusConfig: Partial<Record<ChatStatus, ChatIconConfig>> = {
 		label: "Idle, has subagents",
 	},
 	running: {
+		// The icon animates its own arcs (independent rotation), so no
+		// animate-spin on the svg element here.
 		icon: SubagentsLoaderIcon,
-		className: "text-content-link animate-spin",
+		className: "text-content-link",
 		label: "Working, has subagents",
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/statusConfig.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/statusConfig.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import {
 	AlertTriangleIcon,
+	CheckCheckIcon,
 	CheckIcon,
 	GitMergeIcon,
 	GitPullRequestArrowIcon,
@@ -9,23 +10,67 @@ import {
 	Loader2Icon,
 	PauseIcon,
 } from "lucide-react";
+import type { ComponentProps, ComponentType } from "react";
 import type { Chat, ChatDiffStatus, ChatStatus } from "#/api/typesGenerated";
+import { SubagentsLoaderIcon } from "./SubagentsLoaderIcon";
+
+type StatusIconComponent = LucideIcon | ComponentType<ComponentProps<"svg">>;
 
 type ChatIconConfig = {
-	icon: LucideIcon;
+	icon: StatusIconComponent;
 	className: string;
+	label: string;
 };
 
 const statusConfig = {
-	waiting: { icon: CheckIcon, className: "text-content-secondary" },
-	running: { icon: Loader2Icon, className: "text-content-link animate-spin" },
-	interrupting: { icon: PauseIcon, className: "text-content-warning" },
-	requires_action: { icon: PauseIcon, className: "text-content-warning" },
-	error: { icon: AlertTriangleIcon, className: "text-content-destructive" },
-} as const;
+	waiting: {
+		icon: CheckIcon,
+		className: "text-content-secondary",
+		label: "Idle",
+	},
+	running: {
+		icon: Loader2Icon,
+		className: "text-content-link animate-spin",
+		label: "Working",
+	},
+	interrupting: {
+		icon: PauseIcon,
+		className: "text-content-warning",
+		label: "Interrupting",
+	},
+	requires_action: {
+		icon: PauseIcon,
+		className: "text-content-warning",
+		label: "Requires action",
+	},
+	error: {
+		icon: AlertTriangleIcon,
+		className: "text-content-destructive",
+		label: "Error",
+	},
+} as const satisfies Record<ChatStatus, ChatIconConfig>;
 
-const getStatusConfig = (status: ChatStatus): ChatIconConfig => {
-	return statusConfig[status] ?? statusConfig.waiting;
+// Icon variants shown when a chat has subagents: doubled check and
+// doubled spinner so the row reads as "this agent plus its subagents".
+const subagentsStatusConfig: Partial<Record<ChatStatus, ChatIconConfig>> = {
+	waiting: {
+		icon: CheckCheckIcon,
+		className: "text-content-secondary",
+		label: "Idle, has subagents",
+	},
+	running: {
+		icon: SubagentsLoaderIcon,
+		className: "text-content-link animate-spin",
+		label: "Working, has subagents",
+	},
+};
+
+const getStatusConfig = (
+	status: ChatStatus,
+	hasSubagents: boolean,
+): ChatIconConfig => {
+	const base = statusConfig[status] ?? statusConfig.waiting;
+	return (hasSubagents ? subagentsStatusConfig[status] : undefined) ?? base;
 };
 
 const getPRIconConfig = (
@@ -36,21 +81,31 @@ const getPRIconConfig = (
 		return undefined;
 	}
 	if (state === "merged") {
-		return { icon: GitMergeIcon, className: "text-git-merged-bright" };
+		return {
+			icon: GitMergeIcon,
+			className: "text-git-merged-bright",
+			label: "Pull request merged",
+		};
 	}
 	if (state === "closed") {
 		return {
 			icon: GitPullRequestClosedIcon,
 			className: "text-git-deleted-bright",
+			label: "Pull request closed",
 		};
 	}
 	if (diffStatus?.pull_request_draft) {
 		return {
 			icon: GitPullRequestDraftIcon,
 			className: "text-content-secondary",
+			label: "Draft pull request",
 		};
 	}
-	return { icon: GitPullRequestArrowIcon, className: "text-git-added-bright" };
+	return {
+		icon: GitPullRequestArrowIcon,
+		className: "text-git-added-bright",
+		label: "Pull request open",
+	};
 };
 
 const getChatDiffStatus = (chat: Chat): ChatDiffStatus | undefined => {
@@ -58,28 +113,29 @@ const getChatDiffStatus = (chat: Chat): ChatDiffStatus | undefined => {
 };
 
 /**
- * Returns the icon and styling that represents a chat's current state.
+ * Returns the icons and styling that represent a chat's current state.
  *
- * Combines `getStatusConfig` and `getPRIconConfig`: when the chat is in the
- * settled `waiting` state and has a linked PR, the PR icon takes precedence
- * so list rows surface the merge / closed / draft state instead of the
- * generic status icon.
+ * The status icon always reflects the chat status (with doubled variants
+ * when the chat has subagents). Any linked pull request is surfaced
+ * separately via `prIcon` so rows can render it next to the diff stats.
  */
 export const getChatDisplayConfig = (
 	chat: Chat,
+	hasSubagents = false,
 ): {
-	icon: LucideIcon;
+	icon: StatusIconComponent;
 	className: string;
+	label: string;
+	prIcon: ChatIconConfig | undefined;
 	diffStatus: ChatDiffStatus | undefined;
 } => {
 	const diffStatus = getChatDiffStatus(chat);
-	const baseConfig = getStatusConfig(chat.status);
-	const prConfig =
-		chat.status === "waiting" ? getPRIconConfig(diffStatus) : undefined;
-	const config = prConfig ?? baseConfig;
+	const config = getStatusConfig(chat.status, hasSubagents);
 	return {
 		icon: config.icon,
 		className: config.className,
+		label: config.label,
+		prIcon: getPRIconConfig(diffStatus),
 		diffStatus,
 	};
 };


### PR DESCRIPTION
Updates the agents chat sidebar rows in three ways, per design mocks:

- **PR icon moved to the diff line.** The linked pull request icon (open / draft / merged / closed) no longer replaces the status icon on the first line. It now renders on the second line next to the `+additions -deletions` stats, in both the sidebar tree and the chat search results. It also shows regardless of chat status instead of only when idle.
- **Subagent variants for status icons.** When a chat has subagents, the idle check becomes a double check (`CheckCheck`) and the working spinner becomes a new double-arc `SubagentsLoaderIcon` drawn on the lucide 24x24 grid, whose inner arc counter-rotates at a slower speed so the motion reads as concurrent work. The unread blue dot is unchanged. Status and PR icons now carry `role="img"` with accessible labels ("Idle", "Working, has subagents", "Pull request merged", ...).
- **Persistent kebab on the active chat.** The row actions trigger stays visible on the selected chat instead of only appearing on hover (which also makes it reachable on touch devices); the timestamp stays hidden there. Other rows keep the hover swap.

Storybook: updated `WithPRStateIcons` to assert the PR icon labels, and added `WithSubagentStatusIcons` and `ActiveChatKebabPersistent` stories with play assertions.

<details>
<summary>Implementation notes and decisions</summary>

**Approach**

- `statusConfig.ts`: `getChatDisplayConfig(chat, hasSubagents)` now returns the pure status icon plus a separate `prIcon` config (icon, className, accessible label) instead of letting the PR icon take precedence over the waiting state. Subagent icon variants live in a `subagentsStatusConfig` overlay for the `waiting` and `running` states.
- `SubagentsLoaderIcon.tsx`: feature-local SVG (lucide `LoaderCircle` arc plus a scaled inner arc; each arc animates independently via `origin-center [transform-box:view-box]`) rather than a shared `site/src/components` primitive, per the guideline to keep feature-specific variants local until a shared design lands.
- `ChatTreeNode.tsx` / `ChatSearchResults.tsx`: render `prIcon` on the second line before the line stats; pass `hasChildren` (same condition as the subagent count badge) for the icon variants. Search results always use the single-agent variants since subagent relationships are not available there.
- Kebab persistence uses the existing `isActiveChat` value: `opacity-100` on the trigger and `hidden` on the timestamp for the active row.

**Decisions**

- "Subagents present" means the chat has child chats in the tree, not specifically running ones, matching the subagent count badge condition.
- `ActiveChatKebabPersistent` asserts `getComputedStyle(...).opacity` because the reveal is opacity-based; `toBeVisible()` ignores opacity and there is no semantic query for it.

**Validation**

- `pnpm lint` (biome, tsc, circular deps, knip, compiler): pass
- Unit suite: 3348 passed
- Story tests: 54 sidebar + 31 search dialog, all pass
- `make pre-commit`: pass

</details>

---

🤖 Generated by Coder Agents on behalf of @tracyjohnsonux
