### PR TITLE
feat(site): native picker, [now] shortcut, and Now label in DateTimeRangeFilter

### DIFF
--- a/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.stories.tsx
+++ b/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.stories.tsx
@@ -62,6 +62,22 @@ export const RangeEndingTodayLabel: Story = {
 	},
 };
 
+export const RangeEndingNowLabel: Story = {
+	args: {
+		// A live To bound (at fixedNow) reads as "Now", not "Today".
+		value: {
+			startedAfter: new Date(2026, 7, 11, 23, 59, 59),
+			startedBefore: fixedNow,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("button", { name: "Filter by time range" }),
+		).toHaveTextContent("Aug 11 - Now");
+	},
+};
+
 export const SameMonthLabel: Story = {
 	args: {
 		value: {
@@ -87,12 +103,6 @@ export const OpenPrefillsExpressions: Story = {
 		const toInput = body.getByLabelText("End of time range");
 		expect(fromInput).toHaveValue("2026-04-10 07:23:00");
 		expect(toInput).toHaveValue("2026-04-10 09:30:00");
-
-		// The examples footer explains the accepted grammar.
-		expect(body.getByText("Examples:")).toBeInTheDocument();
-		expect(
-			body.getByText("Defaults to midnight if no time is provided."),
-		).toBeInTheDocument();
 
 		// Apply stays disabled until the selection changes.
 		expect(body.getByRole("button", { name: "Apply" })).toBeDisabled();
@@ -291,8 +301,10 @@ export const PartialRangeShowsCustom: Story = {
 	},
 };
 
-export const ClickableExamplesFillFields: Story = {
+export const NowButtonFillsTo: Story = {
 	args: {
+		// A frozen To bound so the [now] button has something to change.
+		value: singleDayValue,
 		onChange: fn(),
 	},
 	play: async ({ canvasElement }) => {
@@ -302,19 +314,12 @@ export const ClickableExamplesFillFields: Story = {
 			canvas.getByRole("button", { name: "Filter by time range" }),
 		);
 
-		// The datetime example evaluates to 24 hours before now and fills From.
-		const datetimeExample = formatDateTime(
-			new Date(fixedNow.getTime() - 24 * 60 * 60 * 1000),
-		);
-		await userEvent.click(body.getByRole("button", { name: datetimeExample }));
-		const fromInput = body.getByLabelText("Start of time range");
-		expect(fromInput).toHaveValue(datetimeExample);
+		const toInput = await body.findByLabelText("End of time range");
+		expect(toInput).toHaveValue("2026-04-10 09:30:00");
 
-		// The Now example fills To with the literal expression.
-		await userEvent.click(body.getByRole("button", { name: "Now" }));
-		expect(body.getByLabelText("End of time range")).toHaveValue("now");
-
-		// Both fields touched and valid, so Apply is enabled.
+		// The [now] shortcut fills To with the literal live expression.
+		await userEvent.click(body.getByRole("button", { name: "[now]" }));
+		expect(toInput).toHaveValue("now");
 		expect(body.getByRole("button", { name: "Apply" })).toBeEnabled();
 	},
 };

--- a/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.stories.tsx
+++ b/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.stories.tsx
@@ -9,16 +9,16 @@ import {
 } from "storybook/test";
 import { formatDateTime } from "#/utils/time";
 import { DateTimeRangeFilter } from "./DateTimeRangeFilter";
-import type { TimeRange } from "./timeRange";
+import type { FullTimeRange } from "./timeRange";
 
 const fixedNow = new Date(2026, 7, 13, 15, 0, 0);
 
-const defaultValue: TimeRange = {
+const defaultValue: FullTimeRange = {
 	startedAfter: new Date(2026, 7, 12, 15, 0, 0),
 	startedBefore: fixedNow,
 };
 
-const singleDayValue: TimeRange = {
+const singleDayValue: FullTimeRange = {
 	startedAfter: new Date(2026, 3, 10, 7, 23, 0),
 	startedBefore: new Date(2026, 3, 10, 9, 30, 0),
 };
@@ -264,5 +264,57 @@ export const EscapeClosesWithoutApplying: Story = {
 			expect(body.queryByRole("button", { name: "Apply" })).toBeNull();
 		});
 		expect(args.onChange).not.toHaveBeenCalled();
+	},
+};
+
+export const PartialRangeShowsCustom: Story = {
+	args: {
+		value: { startedAfter: new Date(2026, 7, 11, 23, 59, 59) },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		expect(
+			canvas.getByRole("button", { name: "Filter by time range" }),
+		).toHaveTextContent("Custom");
+
+		// The popover shows the present bound and an empty field for the
+		// missing one; Apply stays disabled until both are filled.
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Filter by time range" }),
+		);
+		const fromInput = await body.findByLabelText("Start of time range");
+		const toInput = body.getByLabelText("End of time range");
+		expect(fromInput).toHaveValue("2026-08-11 23:59:59");
+		expect(toInput).toHaveValue("");
+		expect(body.getByRole("button", { name: "Apply" })).toBeDisabled();
+	},
+};
+
+export const ClickableExamplesFillFields: Story = {
+	args: {
+		onChange: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Filter by time range" }),
+		);
+
+		// The datetime example evaluates to 24 hours before now and fills From.
+		const datetimeExample = formatDateTime(
+			new Date(fixedNow.getTime() - 24 * 60 * 60 * 1000),
+		);
+		await userEvent.click(body.getByRole("button", { name: datetimeExample }));
+		const fromInput = body.getByLabelText("Start of time range");
+		expect(fromInput).toHaveValue(datetimeExample);
+
+		// The Now example fills To with the literal expression.
+		await userEvent.click(body.getByRole("button", { name: "Now" }));
+		expect(body.getByLabelText("End of time range")).toHaveValue("now");
+
+		// Both fields touched and valid, so Apply is enabled.
+		expect(body.getByRole("button", { name: "Apply" })).toBeEnabled();
 	},
 };

--- a/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.stories.tsx
+++ b/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.stories.tsx
@@ -303,7 +303,7 @@ export const PartialRangeShowsCustom: Story = {
 
 export const NowButtonFillsTo: Story = {
 	args: {
-		// A frozen To bound so the [now] button has something to change.
+		// A frozen To bound gives the [now] button something to change.
 		value: singleDayValue,
 		onChange: fn(),
 	},

--- a/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.tsx
+++ b/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.tsx
@@ -9,8 +9,9 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import { cn } from "#/utils/cn";
-import { formatDateTime } from "#/utils/time";
+import { DATE_FORMAT, formatDateTime } from "#/utils/time";
 import {
+	type FullTimeRange,
 	formatTriggerLabel,
 	isNowExpression,
 	parseTimeExpression,
@@ -23,8 +24,8 @@ interface DateTimeRangeFilterProps {
 	 * The range the page falls back to when no explicit filter is set.
 	 * The trigger labels it as "Last 24 hours" while the value equals it.
 	 */
-	defaultValue: TimeRange;
-	onChange: (value: TimeRange) => void;
+	defaultValue: FullTimeRange;
+	onChange: (value: FullTimeRange) => void;
 	now?: Date;
 	/** Matches the SelectFilter trigger metrics in the filter row. */
 	width?: number;
@@ -34,8 +35,6 @@ interface FieldState {
 	text: string;
 	touched: boolean;
 }
-
-const EXAMPLES = ["Now", "15:43", "2026-08-13 11:43"];
 
 const INVALID_TIME_MESSAGE = "Enter a valid time, e.g. 2026-08-13 11:43";
 
@@ -51,8 +50,10 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 	const [open, setOpen] = useState(false);
 	const currentTime = now ?? new Date();
 	const isDefault =
-		value.startedAfter.getTime() === defaultValue.startedAfter.getTime() &&
-		value.startedBefore.getTime() === defaultValue.startedBefore.getTime();
+		value.startedAfter !== undefined &&
+		value.startedBefore !== undefined &&
+		value.startedAfter.getTime() === defaultValue.startedAfter?.getTime() &&
+		value.startedBefore.getTime() === defaultValue.startedBefore?.getTime();
 
 	// Text state is kept separate from the committed value so the user can
 	// adjust the expressions freely before applying; invalid text never
@@ -71,10 +72,16 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 		if (next) {
 			// Boundaries at (or very near) the current moment read better
 			// as "now" than as a frozen timestamp when the popover reopens.
-			const toFieldText = (date: Date): string =>
-				Math.abs(date.getTime() - currentTime.getTime()) < NOW_TOLERANCE_MS
+			// A missing bound stays empty so the popover reflects the query.
+			const toFieldText = (date: Date | undefined): string => {
+				if (!date) {
+					return "";
+				}
+				return Math.abs(date.getTime() - currentTime.getTime()) <
+					NOW_TOLERANCE_MS
 					? "now"
 					: formatDateTime(date);
+			};
 			setFromField({
 				text: toFieldText(value.startedAfter),
 				touched: false,
@@ -135,9 +142,13 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 			: null;
 
 	// Apply is only useful when something actually changed; untouched
-	// fields resolve back to the committed range.
+	// fields resolve back to the committed range. Both bounds are required
+	// so the popover always commits a full range; a one-sided range is a
+	// deliberate free-text-only escape hatch.
 	const applyDisabled =
 		!(fromField.touched || toField.touched) ||
+		fromField.text === "" ||
+		toField.text === "" ||
 		fromError !== null ||
 		toError !== null ||
 		rangeError !== null;
@@ -230,7 +241,46 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 				</div>
 				<div className="flex flex-col gap-2 border-t border-border-default p-4 text-sm text-content-secondary">
 					<span className="font-semibold text-content-primary">Examples:</span>
-					<span>{EXAMPLES.join(" | ")}</span>
+					<div className="flex gap-1">
+						<button
+							type="button"
+							className="cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-content-secondary hover:bg-surface-secondary hover:text-content-primary"
+							onClick={() => setToField({ text: "now", touched: true })}
+						>
+							Now
+						</button>
+						<button
+							type="button"
+							className="cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-content-secondary hover:bg-surface-secondary hover:text-content-primary"
+							onClick={() =>
+								setFromField({
+									text: formatDateTime(
+										currentTime,
+										DATE_FORMAT.TIME_24H_MINUTE,
+									),
+									touched: true,
+								})
+							}
+						>
+							{formatDateTime(currentTime, DATE_FORMAT.TIME_24H_MINUTE)}
+						</button>
+						<button
+							type="button"
+							className="cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-content-secondary hover:bg-surface-secondary hover:text-content-primary"
+							onClick={() =>
+								setFromField({
+									text: formatDateTime(
+										new Date(currentTime.getTime() - 24 * 60 * 60 * 1000),
+									),
+									touched: true,
+								})
+							}
+						>
+							{formatDateTime(
+								new Date(currentTime.getTime() - 24 * 60 * 60 * 1000),
+							)}
+						</button>
+					</div>
 					<span>Defaults to midnight if no time is provided.</span>
 					<span>Defaults to current day if no date is provided.</span>
 				</div>

--- a/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.tsx
+++ b/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.tsx
@@ -1,5 +1,6 @@
+import dayjs from "dayjs";
 import { CalendarIcon } from "lucide-react";
-import { type FC, useEffectEvent, useState } from "react";
+import { type FC, useEffectEvent, useRef, useState } from "react";
 import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
@@ -9,10 +10,11 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import { cn } from "#/utils/cn";
-import { DATE_FORMAT, formatDateTime } from "#/utils/time";
+import { formatDateTime } from "#/utils/time";
 import {
 	type FullTimeRange,
 	formatTriggerLabel,
+	isLiveNow,
 	isNowExpression,
 	parseTimeExpression,
 	type TimeRange,
@@ -37,8 +39,6 @@ interface FieldState {
 }
 
 const INVALID_TIME_MESSAGE = "Enter a valid time, e.g. 2026-08-13 11:43";
-
-const NOW_TOLERANCE_MS = 60 * 1000;
 
 export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 	value,
@@ -68,6 +68,37 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 		touched: false,
 	});
 
+	// Hidden datetime-local inputs back the calendar buttons, so the free
+	// text grammar ("now", clock-only, ISO) and the native picker coexist.
+	const fromPickerRef = useRef<HTMLInputElement>(null);
+	const toPickerRef = useRef<HTMLInputElement>(null);
+
+	const openPicker = (input: HTMLInputElement | null, seed: string) => {
+		if (!input) {
+			return;
+		}
+		// Seed the picker from the current text so it opens on the right
+		// moment; fall back to now for empty or non-absolute expressions. The
+		// native picker speaks "YYYY-MM-DDTHH:mm" in browser-local time.
+		const parsed = parseTimeExpression(seed, currentTime);
+		input.value = dayjs(parsed ?? currentTime).format("YYYY-MM-DDTHH:mm");
+		input.showPicker();
+	};
+
+	const pickFrom = useEffectEvent((value: string) => {
+		const parsed = parseTimeExpression(value, currentTime);
+		if (parsed !== null) {
+			setFromField({ text: formatDateTime(parsed), touched: true });
+		}
+	});
+
+	const pickTo = useEffectEvent((value: string) => {
+		const parsed = parseTimeExpression(value, currentTime);
+		if (parsed !== null) {
+			setToField({ text: formatDateTime(parsed), touched: true });
+		}
+	});
+
 	const handleOpenChange = useEffectEvent((next: boolean) => {
 		if (next) {
 			// Boundaries at (or very near) the current moment read better
@@ -77,10 +108,7 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 				if (!date) {
 					return "";
 				}
-				return Math.abs(date.getTime() - currentTime.getTime()) <
-					NOW_TOLERANCE_MS
-					? "now"
-					: formatDateTime(date);
+				return isLiveNow(date, currentTime) ? "now" : formatDateTime(date);
 			};
 			setFromField({
 				text: toFieldText(value.startedAfter),
@@ -176,18 +204,44 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 						<Label htmlFor="time-range-from" className="text-content-primary">
 							From
 						</Label>
-						<Input
-							id="time-range-from"
-							aria-label="Start of time range"
-							aria-invalid={fromError !== null}
-							placeholder="now"
-							className={cn(fromError !== null && "border-border-destructive")}
-							value={fromField.text}
-							onChange={(event) => {
-								setFromField({ text: event.target.value, touched: true });
-							}}
-							onBlur={normalizeFrom}
-						/>
+						<div className="relative">
+							<Input
+								id="time-range-from"
+								aria-label="Start of time range"
+								aria-invalid={fromError !== null}
+								placeholder="now"
+								className={cn(
+									"pr-9",
+									fromError !== null && "border-border-destructive",
+								)}
+								value={fromField.text}
+								onChange={(event) => {
+									setFromField({ text: event.target.value, touched: true });
+								}}
+								onBlur={normalizeFrom}
+							/>
+							<button
+								type="button"
+								tabIndex={-1}
+								aria-label="Pick start date and time"
+								className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-content-secondary hover:text-content-primary"
+								onClick={() =>
+									openPicker(fromPickerRef.current, fromField.text)
+								}
+							>
+								<CalendarIcon className="size-4" />
+							</button>
+							<input
+								ref={fromPickerRef}
+								type="datetime-local"
+								tabIndex={-1}
+								aria-hidden="true"
+								className="pointer-events-none absolute h-0 w-0 opacity-0"
+								// Chrome and WebKit both fire input per pick; change only
+								// fires on dismissal, which is too late for live feedback.
+								onInput={(event) => pickFrom(event.currentTarget.value)}
+							/>
+						</div>
 						{fromError !== null && (
 							<span className="text-sm text-content-destructive">
 								{fromError}
@@ -195,21 +249,53 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 						)}
 					</div>
 					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="time-range-to" className="text-content-primary">
-							To
-						</Label>
-						<Input
-							id="time-range-to"
-							aria-label="End of time range"
-							aria-invalid={toError !== null}
-							placeholder="now"
-							className={cn(toError !== null && "border-border-destructive")}
-							value={toField.text}
-							onChange={(event) => {
-								setToField({ text: event.target.value, touched: true });
-							}}
-							onBlur={normalizeTo}
-						/>
+						<div className="flex items-center justify-between">
+							<Label htmlFor="time-range-to" className="text-content-primary">
+								To
+							</Label>
+							<button
+								type="button"
+								tabIndex={-1}
+								className="cursor-pointer border-none bg-transparent p-0 text-xs font-normal text-content-secondary hover:text-content-primary"
+								onClick={() => setToField({ text: "now", touched: true })}
+							>
+								[now]
+							</button>
+						</div>
+						<div className="relative">
+							<Input
+								id="time-range-to"
+								aria-label="End of time range"
+								aria-invalid={toError !== null}
+								placeholder="now"
+								className={cn(
+									"pr-9",
+									toError !== null && "border-border-destructive",
+								)}
+								value={toField.text}
+								onChange={(event) => {
+									setToField({ text: event.target.value, touched: true });
+								}}
+								onBlur={normalizeTo}
+							/>
+							<button
+								type="button"
+								tabIndex={-1}
+								aria-label="Pick end date and time"
+								className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-content-secondary hover:text-content-primary"
+								onClick={() => openPicker(toPickerRef.current, toField.text)}
+							>
+								<CalendarIcon className="size-4" />
+							</button>
+							<input
+								ref={toPickerRef}
+								type="datetime-local"
+								tabIndex={-1}
+								aria-hidden="true"
+								className="pointer-events-none absolute h-0 w-0 opacity-0"
+								onInput={(event) => pickTo(event.currentTarget.value)}
+							/>
+						</div>
 						{toError !== null && (
 							<span className="text-sm text-content-destructive">
 								{toError}
@@ -238,51 +324,6 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 							Apply
 						</Button>
 					</div>
-				</div>
-				<div className="flex flex-col gap-2 border-t border-border-default p-4 text-sm text-content-secondary">
-					<span className="font-semibold text-content-primary">Examples:</span>
-					<div className="flex gap-1">
-						<button
-							type="button"
-							className="cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-content-secondary hover:bg-surface-secondary hover:text-content-primary"
-							onClick={() => setToField({ text: "now", touched: true })}
-						>
-							Now
-						</button>
-						<button
-							type="button"
-							className="cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-content-secondary hover:bg-surface-secondary hover:text-content-primary"
-							onClick={() =>
-								setFromField({
-									text: formatDateTime(
-										currentTime,
-										DATE_FORMAT.TIME_24H_MINUTE,
-									),
-									touched: true,
-								})
-							}
-						>
-							{formatDateTime(currentTime, DATE_FORMAT.TIME_24H_MINUTE)}
-						</button>
-						<button
-							type="button"
-							className="cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-content-secondary hover:bg-surface-secondary hover:text-content-primary"
-							onClick={() =>
-								setFromField({
-									text: formatDateTime(
-										new Date(currentTime.getTime() - 24 * 60 * 60 * 1000),
-									),
-									touched: true,
-								})
-							}
-						>
-							{formatDateTime(
-								new Date(currentTime.getTime() - 24 * 60 * 60 * 1000),
-							)}
-						</button>
-					</div>
-					<span>Defaults to midnight if no time is provided.</span>
-					<span>Defaults to current day if no date is provided.</span>
 				</div>
 			</PopoverContent>
 		</Popover>

--- a/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.tsx
+++ b/site/src/components/DateTimeRangeFilter/DateTimeRangeFilter.tsx
@@ -55,10 +55,10 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 		value.startedAfter.getTime() === defaultValue.startedAfter?.getTime() &&
 		value.startedBefore.getTime() === defaultValue.startedBefore?.getTime();
 
-	// Text state is kept separate from the committed value so the user can
-	// adjust the expressions freely before applying; invalid text never
-	// leaks out. If this control grows more fields or validation rules,
-	// consider moving to formik and yup instead of hand-rolling state.
+	// Keep text state separate from the committed value so the user can edit
+	// freely before applying; invalid text never leaks out. If this control
+	// grows more fields or validation rules, consider formik and yup instead
+	// of hand-rolling state.
 	const [fromField, setFromField] = useState<FieldState>({
 		text: "",
 		touched: false,
@@ -68,8 +68,8 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 		touched: false,
 	});
 
-	// Hidden datetime-local inputs back the calendar buttons, so the free
-	// text grammar ("now", clock-only, ISO) and the native picker coexist.
+	// Hidden datetime-local inputs back the calendar buttons so the free-text
+	// grammar and the native picker coexist.
 	const fromPickerRef = useRef<HTMLInputElement>(null);
 	const toPickerRef = useRef<HTMLInputElement>(null);
 
@@ -77,9 +77,9 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 		if (!input) {
 			return;
 		}
-		// Seed the picker from the current text so it opens on the right
-		// moment; fall back to now for empty or non-absolute expressions. The
-		// native picker speaks "YYYY-MM-DDTHH:mm" in browser-local time.
+		// Seed the picker from the current text so it opens on the right moment;
+		// fall back to now for empty or non-absolute expressions. The picker
+		// uses "YYYY-MM-DDTHH:mm" in browser-local time.
 		const parsed = parseTimeExpression(seed, currentTime);
 		input.value = dayjs(parsed ?? currentTime).format("YYYY-MM-DDTHH:mm");
 		input.showPicker();
@@ -101,9 +101,8 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 
 	const handleOpenChange = useEffectEvent((next: boolean) => {
 		if (next) {
-			// Boundaries at (or very near) the current moment read better
-			// as "now" than as a frozen timestamp when the popover reopens.
-			// A missing bound stays empty so the popover reflects the query.
+			// Show a bound at (or near) the current moment as "now" rather than a
+			// frozen timestamp. A missing bound stays empty to reflect the query.
 			const toFieldText = (date: Date | undefined): string => {
 				if (!date) {
 					return "";
@@ -125,11 +124,10 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 	const parsedFrom = parseTimeExpression(fromField.text, currentTime);
 	const parsedTo = parseTimeExpression(toField.text, currentTime);
 
-	// Underspecified expressions resolve to absolute local timestamps when
-	// the input loses focus, so the user sees exactly what will be applied.
-	// "now" is left as-is because it is already unambiguous. Out-of-range
-	// values clamp against the other boundary so the committed range is
-	// always valid.
+	// On blur, resolve underspecified expressions to absolute local timestamps
+	// so the user sees exactly what will apply. Leave "now" as-is; it is
+	// already unambiguous. Clamp out-of-range values against the other bound
+	// so the committed range stays valid.
 	const normalizeFrom = useEffectEvent(() => {
 		setFromField((current) => {
 			if (isNowExpression(current.text) || parsedFrom === null) {
@@ -169,9 +167,8 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 			? "From must be before To"
 			: null;
 
-	// Apply is only useful when something actually changed; untouched
-	// fields resolve back to the committed range. Both bounds are required
-	// so the popover always commits a full range; a one-sided range is a
+	// Enable Apply only when something changed and both bounds are valid, so
+	// the popover always commits a full range. A one-sided range stays a
 	// deliberate free-text-only escape hatch.
 	const applyDisabled =
 		!(fromField.touched || toField.touched) ||
@@ -237,8 +234,8 @@ export const DateTimeRangeFilter: FC<DateTimeRangeFilterProps> = ({
 								tabIndex={-1}
 								aria-hidden="true"
 								className="pointer-events-none absolute h-0 w-0 opacity-0"
-								// Chrome and WebKit both fire input per pick; change only
-								// fires on dismissal, which is too late for live feedback.
+								// Chrome and WebKit fire input per pick; change fires only
+								// on dismissal, which is too late for live feedback.
 								onInput={(event) => pickFrom(event.currentTarget.value)}
 							/>
 						</div>

--- a/site/src/components/DateTimeRangeFilter/timeRange.test.ts
+++ b/site/src/components/DateTimeRangeFilter/timeRange.test.ts
@@ -123,7 +123,7 @@ describe("formatTriggerLabel", () => {
 				now,
 			),
 		).toBe("Aug 11 - Now");
-		// Within the one-minute tolerance still reads as Now.
+		// Within the one-minute tolerance it still reads as Now.
 		expect(
 			formatTriggerLabel(
 				{

--- a/site/src/components/DateTimeRangeFilter/timeRange.test.ts
+++ b/site/src/components/DateTimeRangeFilter/timeRange.test.ts
@@ -53,6 +53,12 @@ describe("parseTimeExpression", () => {
 		);
 	});
 
+	it("parses T-separated datetimes from the native picker and ISO paste", () => {
+		expect(parseTimeExpression("2026-08-13T11:43", now)).toEqual(
+			new Date(2026, 7, 13, 11, 43, 0),
+		);
+	});
+
 	it("rejects single-digit hours", () => {
 		expect(parseTimeExpression("9:05", now)).toBeNull();
 		expect(parseTimeExpression("2026-08-13 7:23:00", now)).toBeNull();
@@ -70,7 +76,6 @@ describe("parseTimeExpression", () => {
 		expect(parseTimeExpression("", now)).toBeNull();
 		expect(parseTimeExpression("30d", now)).toBeNull();
 		expect(parseTimeExpression("13/08/2026", now)).toBeNull();
-		expect(parseTimeExpression("2026-08-13T11:43", now)).toBeNull();
 	});
 });
 
@@ -106,6 +111,28 @@ describe("formatTriggerLabel", () => {
 				now,
 			),
 		).toBe("Aug 11 - Today");
+	});
+
+	it("labels a live now end bound as Now", () => {
+		expect(
+			formatTriggerLabel(
+				{
+					startedAfter: new Date(2026, 7, 11, 23, 59, 59),
+					startedBefore: new Date(now.getTime()),
+				},
+				now,
+			),
+		).toBe("Aug 11 - Now");
+		// Within the one-minute tolerance still reads as Now.
+		expect(
+			formatTriggerLabel(
+				{
+					startedAfter: new Date(2026, 7, 11, 23, 59, 59),
+					startedBefore: new Date(now.getTime() - 30 * 1000),
+				},
+				now,
+			),
+		).toBe("Aug 11 - Now");
 	});
 
 	it("shortens ranges within one month", () => {

--- a/site/src/components/DateTimeRangeFilter/timeRange.test.ts
+++ b/site/src/components/DateTimeRangeFilter/timeRange.test.ts
@@ -75,6 +75,15 @@ describe("parseTimeExpression", () => {
 });
 
 describe("formatTriggerLabel", () => {
+	it("labels a partial range as Custom", () => {
+		expect(
+			formatTriggerLabel({ startedAfter: new Date(2026, 7, 11) }, now),
+		).toBe("Custom");
+		expect(
+			formatTriggerLabel({ startedBefore: new Date(2026, 7, 13) }, now),
+		).toBe("Custom");
+	});
+
 	it("collapses a single day", () => {
 		expect(
 			formatTriggerLabel(

--- a/site/src/components/DateTimeRangeFilter/timeRange.ts
+++ b/site/src/components/DateTimeRangeFilter/timeRange.ts
@@ -21,6 +21,8 @@ const DATE_FORMATS = [
 	DATE_FORMAT.ISO_DATE,
 	DATE_FORMAT.ISO_DATETIME,
 	DATE_FORMAT.ISO_DATETIME_MINUTE,
+	// T-separated datetime, as produced by the native picker and ISO paste.
+	"YYYY-MM-DDTHH:mm",
 ];
 const TIME_FORMATS = [DATE_FORMAT.TIME_24H, DATE_FORMAT.TIME_24H_MINUTE];
 
@@ -68,19 +70,22 @@ export const parseTimeExpression = (
 	return null;
 };
 
-const sameDay = (a: Date, b: Date): boolean =>
-	a.getFullYear() === b.getFullYear() &&
-	a.getMonth() === b.getMonth() &&
-	a.getDate() === b.getDate();
+// Bounds within a minute of the current moment read better as "now" than
+// as a frozen timestamp.
+const NOW_TOLERANCE_MS = 60 * 1000;
+
+/** Whether a bound is at (or very near) the current moment. */
+export const isLiveNow = (date: Date, now: Date): boolean =>
+	Math.abs(date.getTime() - now.getTime()) < NOW_TOLERANCE_MS;
 
 const MONTH_DAY = "MMM D";
 
 /**
  * Summarizes a resolved range the way the filter trigger displays it:
  * a single day, a range ending today, a range within one month, or a
- * full from-to range. A partial range (only one bound) reads as
- * "Custom". Callers render "Last 24 hours" for the default range
- * before falling back to this.
+ * full from-to range. A live "now" end bound reads as "Now" rather than
+ * "Today". A partial range (only one bound) reads as "Custom". Callers
+ * render "Last 24 hours" for the default range before falling back to this.
  */
 export const formatTriggerLabel = (range: TimeRange, now: Date): string => {
 	if (!range.startedAfter || !range.startedBefore) {
@@ -88,10 +93,13 @@ export const formatTriggerLabel = (range: TimeRange, now: Date): string => {
 	}
 	const from = dayjs(range.startedAfter);
 	const to = range.startedBefore;
-	if (sameDay(range.startedAfter, to)) {
+	if (dayjs(range.startedAfter).isSame(to, "day")) {
 		return from.format(MONTH_DAY);
 	}
-	if (sameDay(to, now)) {
+	if (isLiveNow(to, now)) {
+		return `${from.format(MONTH_DAY)} - Now`;
+	}
+	if (dayjs(to).isSame(now, "day")) {
 		return `${from.format(MONTH_DAY)} - Today`;
 	}
 	if (

--- a/site/src/components/DateTimeRangeFilter/timeRange.ts
+++ b/site/src/components/DateTimeRangeFilter/timeRange.ts
@@ -74,18 +74,18 @@ export const parseTimeExpression = (
 // as a frozen timestamp.
 const NOW_TOLERANCE_MS = 60 * 1000;
 
-/** Whether a bound is at (or very near) the current moment. */
+/** Whether a bound is at or near the current moment. */
 export const isLiveNow = (date: Date, now: Date): boolean =>
 	Math.abs(date.getTime() - now.getTime()) < NOW_TOLERANCE_MS;
 
 const MONTH_DAY = "MMM D";
 
 /**
- * Summarizes a resolved range the way the filter trigger displays it:
- * a single day, a range ending today, a range within one month, or a
- * full from-to range. A live "now" end bound reads as "Now" rather than
- * "Today". A partial range (only one bound) reads as "Custom". Callers
- * render "Last 24 hours" for the default range before falling back to this.
+ * Summarizes a resolved range the way the filter trigger displays it: a
+ * single day, a range ending today, a range within one month, or a full
+ * from-to range. A live "now" end bound reads as "Now" rather than "Today".
+ * A partial range (one bound) reads as "Custom". Callers render "Last 24
+ * hours" for the default range before falling back to this.
  */
 export const formatTriggerLabel = (range: TimeRange, now: Date): string => {
 	if (!range.startedAfter || !range.startedBefore) {

--- a/site/src/components/DateTimeRangeFilter/timeRange.ts
+++ b/site/src/components/DateTimeRangeFilter/timeRange.ts
@@ -5,6 +5,12 @@ import { DATE_FORMAT } from "#/utils/time";
 dayjs.extend(customParseFormat);
 
 export type TimeRange = {
+	startedAfter?: Date;
+	startedBefore?: Date;
+};
+
+/** A range with both bounds present, as committed by the popover. */
+export type FullTimeRange = {
 	startedAfter: Date;
 	startedBefore: Date;
 };
@@ -72,22 +78,27 @@ const MONTH_DAY = "MMM D";
 /**
  * Summarizes a resolved range the way the filter trigger displays it:
  * a single day, a range ending today, a range within one month, or a
- * full from-to range. Callers render "Last 24 hours" for the default
- * range before falling back to this.
+ * full from-to range. A partial range (only one bound) reads as
+ * "Custom". Callers render "Last 24 hours" for the default range
+ * before falling back to this.
  */
 export const formatTriggerLabel = (range: TimeRange, now: Date): string => {
+	if (!range.startedAfter || !range.startedBefore) {
+		return "Custom";
+	}
 	const from = dayjs(range.startedAfter);
-	if (sameDay(range.startedAfter, range.startedBefore)) {
+	const to = range.startedBefore;
+	if (sameDay(range.startedAfter, to)) {
 		return from.format(MONTH_DAY);
 	}
-	if (sameDay(range.startedBefore, now)) {
+	if (sameDay(to, now)) {
 		return `${from.format(MONTH_DAY)} - Today`;
 	}
 	if (
-		range.startedAfter.getFullYear() === range.startedBefore.getFullYear() &&
-		range.startedAfter.getMonth() === range.startedBefore.getMonth()
+		range.startedAfter.getFullYear() === to.getFullYear() &&
+		range.startedAfter.getMonth() === to.getMonth()
 	) {
-		return `${from.format(MONTH_DAY)} - ${range.startedBefore.getDate()}`;
+		return `${from.format(MONTH_DAY)} - ${to.getDate()}`;
 	}
-	return `${from.format(MONTH_DAY)} - ${dayjs(range.startedBefore).format(MONTH_DAY)}`;
+	return `${from.format(MONTH_DAY)} - ${dayjs(to).format(MONTH_DAY)}`;
 };

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
 import { fn } from "storybook/test";
-import type { TimeRange } from "#/components/DateTimeRangeFilter/timeRange";
+import type { FullTimeRange } from "#/components/DateTimeRangeFilter/timeRange";
 import {
 	getDefaultFilterProps,
 	MockMenu,
@@ -12,7 +12,7 @@ type FilterProps = ComponentProps<typeof ListSessionsFilter>;
 
 type FilterAndMenus = Pick<FilterProps, "filter" | "menus">;
 
-const timeRange: TimeRange = {
+const timeRange: FullTimeRange = {
 	startedAfter: new Date("2026-08-12T15:00:00Z"),
 	startedBefore: new Date("2026-08-13T15:00:00Z"),
 };

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.tsx
@@ -1,6 +1,9 @@
 import type { FC } from "react";
 import { DateTimeRangeFilter } from "#/components/DateTimeRangeFilter/DateTimeRangeFilter";
-import type { TimeRange } from "#/components/DateTimeRangeFilter/timeRange";
+import type {
+	FullTimeRange,
+	TimeRange,
+} from "#/components/DateTimeRangeFilter/timeRange";
 import {
 	Filter,
 	MenuSkeleton,
@@ -28,8 +31,8 @@ interface ListSessionsFilterProps {
 		model: ModelFilterMenu;
 	};
 	timeRange: TimeRange;
-	defaultTimeRange: TimeRange;
-	onTimeRangeChange: (range: TimeRange) => void;
+	defaultTimeRange: FullTimeRange;
+	onTimeRangeChange: (range: FullTimeRange) => void;
 }
 
 export const ListSessionsFilter: FC<ListSessionsFilterProps> = ({

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
 import { fn } from "storybook/test";
-import type { TimeRange } from "#/components/DateTimeRangeFilter/timeRange";
+import type { FullTimeRange } from "#/components/DateTimeRangeFilter/timeRange";
 import {
 	getDefaultFilterProps,
 	MockMenu,
@@ -15,7 +15,7 @@ import { ListSessionsPageView } from "./ListSessionsPageView";
 
 type FilterProps = ComponentProps<typeof ListSessionsPageView>["filterProps"];
 
-const timeRange: TimeRange = {
+const timeRange: FullTimeRange = {
 	startedAfter: new Date("2026-08-12T15:00:00Z"),
 	startedBefore: new Date("2026-08-13T15:00:00Z"),
 };

--- a/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.test.ts
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { TimeRange } from "#/components/DateTimeRangeFilter/timeRange";
+import type { FullTimeRange } from "#/components/DateTimeRangeFilter/timeRange";
 import {
 	defaultTimeRange,
 	parseTimeRange,
@@ -29,7 +29,7 @@ describe("defaultTimeRange", () => {
 });
 
 describe("withDefaultTimeRange", () => {
-	const range: TimeRange = {
+	const range: FullTimeRange = {
 		startedAfter: new Date(Date.UTC(2026, 7, 12, 15, 0, 0)),
 		startedBefore: new Date(Date.UTC(2026, 7, 13, 15, 0, 0)),
 	};
@@ -64,7 +64,7 @@ describe("withDefaultTimeRange", () => {
 });
 
 describe("queryWithTimeRange", () => {
-	const range: TimeRange = {
+	const range: FullTimeRange = {
 		startedAfter: new Date(Date.UTC(2026, 7, 12, 15, 0, 0)),
 		startedBefore: new Date(Date.UTC(2026, 7, 13, 15, 0, 0)),
 	};
@@ -98,22 +98,31 @@ describe("parseTimeRange", () => {
 		});
 	});
 
-	it("returns null when either bound is missing", () => {
+	it("returns null when neither bound is set", () => {
 		expect(parseTimeRange({})).toBeNull();
-		expect(
-			parseTimeRange({ started_after: "2026-08-12T15:00:00Z" }),
-		).toBeNull();
-		expect(
-			parseTimeRange({ started_before: "2026-08-13T15:00:00Z" }),
-		).toBeNull();
 	});
 
-	it("returns null for malformed bounds", () => {
+	it("returns a partial range when only one bound is set", () => {
+		expect(parseTimeRange({ started_after: "2026-08-12T15:00:00Z" })).toEqual({
+			startedAfter: new Date(Date.UTC(2026, 7, 12, 15, 0, 0)),
+			startedBefore: undefined,
+		});
+		expect(parseTimeRange({ started_before: "2026-08-13T15:00:00Z" })).toEqual({
+			startedAfter: undefined,
+			startedBefore: new Date(Date.UTC(2026, 7, 13, 15, 0, 0)),
+		});
+	});
+
+	it("drops malformed bounds", () => {
 		expect(
 			parseTimeRange({
 				started_after: "bogus",
 				started_before: "2026-08-13T15:00:00Z",
 			}),
-		).toBeNull();
+		).toEqual({
+			startedAfter: undefined,
+			startedBefore: new Date(Date.UTC(2026, 7, 13, 15, 0, 0)),
+		});
+		expect(parseTimeRange({ started_after: "bogus" })).toBeNull();
 	});
 });

--- a/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.ts
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.ts
@@ -1,6 +1,9 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import type { TimeRange } from "#/components/DateTimeRangeFilter/timeRange";
+import type {
+	FullTimeRange,
+	TimeRange,
+} from "#/components/DateTimeRangeFilter/timeRange";
 import {
 	parseFilterQuery,
 	stringifyFilter,
@@ -14,7 +17,7 @@ export const toRFC3339 = (date: Date): string => {
 };
 
 /** The default sessions window: the 24 hours ending at now. */
-export const defaultTimeRange = (now: Date): TimeRange => ({
+export const defaultTimeRange = (now: Date): FullTimeRange => ({
 	startedAfter: new Date(now.getTime() - 24 * 60 * 60 * 1000),
 	startedBefore: now,
 });
@@ -27,7 +30,7 @@ export const defaultTimeRange = (now: Date): TimeRange => ({
  */
 export const withDefaultTimeRange = (
 	query: string,
-	range: TimeRange,
+	range: FullTimeRange,
 ): string => {
 	const values = parseFilterQuery(query);
 	if (
@@ -52,7 +55,7 @@ export const withDefaultTimeRange = (
  */
 export const queryWithTimeRange = (
 	values: Record<string, string | undefined>,
-	range: TimeRange,
+	range: FullTimeRange,
 ): string => {
 	return stringifyFilter({
 		...values,
@@ -61,22 +64,22 @@ export const queryWithTimeRange = (
 	});
 };
 
-/** Extracts an explicit time range from filter values, or null if absent. */
+/** Extracts a time range from filter values, or null if neither bound is set. */
 export const parseTimeRange = (
 	values: Record<string, string | undefined>,
 ): TimeRange | null => {
-	const after = values.started_after;
-	const before = values.started_before;
-	if (!after || !before) {
+	const startedAfter = values.started_after
+		? new Date(values.started_after)
+		: undefined;
+	const startedBefore = values.started_before
+		? new Date(values.started_before)
+		: undefined;
+	const valid = (d: Date | undefined) =>
+		d !== undefined && !Number.isNaN(d.getTime());
+	const after = valid(startedAfter) ? startedAfter : undefined;
+	const before = valid(startedBefore) ? startedBefore : undefined;
+	if (after === undefined && before === undefined) {
 		return null;
 	}
-	const startedAfter = new Date(after);
-	const startedBefore = new Date(before);
-	if (
-		Number.isNaN(startedAfter.getTime()) ||
-		Number.isNaN(startedBefore.getTime())
-	) {
-		return null;
-	}
-	return { startedAfter, startedBefore };
+	return { startedAfter: after, startedBefore: before };
 };


### PR DESCRIPTION
Follow-ups to #28255

**Native picker alongside free text.** Each From/To field keeps its free-text grammar (`now`, `HH:mm`, ISO date/datetime) and gains a calendar icon that opens the native `datetime-local` picker via `showPicker()` on a hidden input seeded from the current text. The picker commits to the text field on the `input` event and marks the field touched so Apply enables. The calendar icons are `tabIndex={-1}` so Tab still moves From to To directly. The grammar also accepts `YYYY-MM-DDTHH:mm`, the picker's machine format and a pasteable ISO form.

**[now] shortcut.** A right-aligned `[now]` button on the To label fills the field with the literal `now` expression, the live bound the picker cannot express. The clickable datetime examples are gone; the picker covers them, and blur auto-fill made the explanatory footer text redundant.

**Trigger reads "- Now" for a live bound.** A shared `isLiveNow` (one-minute tolerance) drives both the popover prefill and the trigger label, so a To bound at the current moment reads `MMM D - Now` instead of `MMM D - Today`. A frozen earlier-today bound still reads `Today`.

**Partial ranges.** `TimeRange` bounds are now optional. Before, a hand-written one-sided query (only `started_after` in the search box) showed "Last 24 hours" on the trigger while the query stayed one-sided. Now the trigger shows `Custom` and the popover shows the present bound with an empty field for the missing one. Apply requires both bounds, so the popover always commits a full range; one-sided queries stay a deliberate free-text-only escape hatch. The page's `parseTimeRange` returns partial ranges so the trigger reflects the query. A `FullTimeRange` type (both bounds present) covers the committed value and query builders while `TimeRange` stays partial for the display value.

Open questions: how best to style the native picker?

## Screenshots

<img width="272" height="201" alt="image" src="https://github.com/user-attachments/assets/d08dfed6-bc5c-45eb-9bf0-28636274a1b4" />


<img width="393" height="315" alt="image" src="https://github.com/user-attachments/assets/f3ee8a13-71cd-4099-add5-3a8b41ef7b23" />


---
_Generated by Coder Agents on behalf of @johnstcn._