### PR TITLE
docs: remove internal Slack link from CONTRIBUTING.md [DOCS-684]

### DIFF
--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -156,9 +156,6 @@ this:
 > PR deployment will be re-deployed automatically when the PR is updated.
 > It will use the last values automatically for redeployment.
 
-Once the deployment is finished, a unique link and credentials will be posted
-in the internal `#pr-deployments` Slack channel.
-
 ## Styling
 
 - [Documentation style guide](./documentation.md)

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -21,9 +21,9 @@ Learn more [how Nix works](https://nixos.org/guides/how-nix-works).
    nix-shell
 
    ...
-   copying path '/nix/store/3ms6cs5210n8vfb5a7jkdvzrzdagqzbp-iana-etc-20210225' from 'https://   cache.nixos.org'...
-   copying path '/nix/store/dxg5aijpyy36clz05wjsyk90gqcdzbam-iana-etc-20220520' from 'https://   cache.nixos.org'...
-   copying path '/nix/store/v2gvj8whv241nj4lzha3flq8pnllcmvv-ignore-5.2.0.tgz' from 'https://cache.   nixos.org'...
+   copying path '/nix/store/3ms6cs5210n8vfb5a7jkdvzrzdagqzbp-iana-etc-20210225' from 'https://cache.nixos.org'...
+   copying path '/nix/store/dxg5aijpyy36clz05wjsyk90gqcdzbam-iana-etc-20220520' from 'https://cache.nixos.org'...
+   copying path '/nix/store/v2gvj8whv241nj4lzha3flq8pnllcmvv-ignore-5.2.0.tgz' from 'https://cache.nixos.org'...
    ...
    ```
 
@@ -101,8 +101,8 @@ the Makefile trigger the full targets as before.
 
    This will start two processes:
 
-   - http://localhost:3000 — the backend API server. Primarily used for backend development and also serves the *static* frontend build.
-   - http://localhost:8080 — the Node.js frontend development server. Supports *hot reloading* and is useful if you're working on the frontend as well.
+   - http://localhost:3000: the backend API server. Primarily used for backend development and also serves the *static* frontend build.
+   - http://localhost:8080: the Node.js frontend development server. Supports *hot reloading* and is useful if you're working on the frontend as well.
 
    Additionally, it starts a local PostgreSQL instance, creates both an admin and a member user account, and installs a default Docker-based template.
 
@@ -112,7 +112,7 @@ the Makefile trigger the full targets as before.
 
    ```sh
    ./scripts/coder-dev.sh list
-      ```
+   ```
 
    This should return an empty list of workspaces. If you encounter an error, review the output from the [develop.sh](../../../scripts/develop.sh) script for issues.
 
@@ -156,9 +156,8 @@ this:
 > PR deployment will be re-deployed automatically when the PR is updated.
 > It will use the last values automatically for redeployment.
 
-Once the deployment is finished, a unique link and credentials will be posted in
-the [#pr-deployments](https://codercom.slack.com/archives/C05DNE982E8) Slack
-channel.
+Once the deployment is finished, a unique link and credentials will be posted
+in the internal `#pr-deployments` Slack channel.
 
 ## Styling
 
@@ -315,7 +314,7 @@ PR reuses the original title (e.g.
 meaningful in release notes.
 
 If the cherry-pick encounters conflicts, the backport PR is still created
-with instructions for manual resolution — no conflict markers are committed.
+with instructions for manual resolution; no conflict markers are committed.
 
 ### Breaking changes
 


### PR DESCRIPTION
The `codercom.slack.com` link in CONTRIBUTING.md returns a 403 for the docs link checker (Slack archive URLs require authentication, so it can never pass) and advertises an internal Slack channel in a public contributor doc. The `pr-deploy.yaml` workflow already treats the channel URL as a secret, so the doc now refers to the channel by name only.

While in the file, this also fixes a few formatting issues: emdashes used as punctuation in the dev server list and the backport conflict note, sample `nix-shell` output where hard-wrapping had garbled the `cache.nixos.org` URLs, and a misindented closing code fence in the "Verify Your Session" step.

Refs [DOCS-684](https://linear.app/codercom/issue/DOCS-684/remove-internal-slack-link-from-contributingmd-and-fix-minor)

---
🤖 Built with AI assistance.