### PR TITLE
feat: annotate AI Gateway interceptions with work context

### DIFF
--- a/coderd/aibridge/annotations/annotations.go
+++ b/coderd/aibridge/annotations/annotations.go
@@ -1,0 +1,127 @@
+// Package annotations validates client-asserted work context before it is
+// written to the annotations column of an AI Bridge interception.
+package annotations
+
+import (
+	"database/sql"
+	"regexp"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// MaxValueLength bounds each annotation value. The values are model generated
+// and are stored verbatim in a JSONB column that is also read back into CSV
+// exports.
+const MaxValueLength = 256
+
+// MaxLinearIssueIDs bounds how many issues a single call may add. The stored
+// set can still grow across calls.
+const MaxLinearIssueIDs = 16
+
+// MaxGitHubPRURLs bounds how many pull request URLs a single call may add. The
+// stored set can still grow across calls.
+const MaxGitHubPRURLs = 16
+
+// githubPRURLPattern matches the canonical GitHub pull request URL. The stored
+// value is rendered as a link target, so anything else, including other
+// schemes and hosts, is rejected before it reaches the database.
+var githubPRURLPattern = regexp.MustCompile(`^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+$`)
+
+// Input is the untrusted work context supplied by a caller.
+type Input struct {
+	LinearIssueIDs []string
+	GitHubPRURLs   []string
+	Repo           string
+	Branch         string
+}
+
+// Params trims the input and maps empty values to NULL, which the update query
+// treats as "leave unchanged". It returns an error when every field is empty,
+// because such a call would write nothing. The returned params carry no
+// interception ID; the caller sets it.
+func Params(input Input) (database.UpdateAIBridgeInterceptionAnnotationsParams, error) {
+	var params database.UpdateAIBridgeInterceptionAnnotationsParams
+	for _, field := range []struct {
+		name  string
+		value string
+		dest  *sql.NullString
+	}{
+		{"repo", input.Repo, &params.Repo},
+		{"branch", input.Branch, &params.Branch},
+	} {
+		value, err := trimValue(field.name, field.value)
+		if err != nil {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
+		}
+		if value == "" {
+			continue
+		}
+		*field.dest = sql.NullString{String: value, Valid: true}
+	}
+
+	if len(input.LinearIssueIDs) > MaxLinearIssueIDs {
+		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+			"linear_issue_ids accepts at most %d issues per call", MaxLinearIssueIDs,
+		)
+	}
+	var issues []string
+	for _, issue := range input.LinearIssueIDs {
+		value, err := trimValue("linear_issue_ids", issue)
+		if err != nil {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
+		}
+		if value == "" {
+			continue
+		}
+		issues = append(issues, value)
+	}
+	if len(issues) > 0 {
+		params.LinearIssueIds = issues
+	}
+
+	if len(input.GitHubPRURLs) > MaxGitHubPRURLs {
+		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+			"github_pr_urls accepts at most %d URLs per call", MaxGitHubPRURLs,
+		)
+	}
+	var prs []string
+	for _, pr := range input.GitHubPRURLs {
+		value, err := trimValue("github_pr_urls", pr)
+		if err != nil {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
+		}
+		if value == "" {
+			continue
+		}
+		if !githubPRURLPattern.MatchString(value) {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+				"github_pr_urls entry %q must look like https://github.com/{owner}/{repo}/pull/{number}", value,
+			)
+		}
+		prs = append(prs, value)
+	}
+	if len(prs) > 0 {
+		params.GithubPrUrls = prs
+	}
+
+	if len(params.LinearIssueIds) == 0 && len(params.GithubPrUrls) == 0 &&
+		!params.Repo.Valid && !params.Branch.Valid {
+		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.New(
+			"provide at least one of linear_issue_ids, github_pr_urls, repo, or branch",
+		)
+	}
+	return params, nil
+}
+
+func trimValue(name string, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) > MaxValueLength {
+		return "", xerrors.Errorf(
+			"%s must be %d characters or fewer", name, MaxValueLength,
+		)
+	}
+	return value, nil
+}

--- a/coderd/aibridge/annotations/annotations.go
+++ b/coderd/aibridge/annotations/annotations.go
@@ -3,7 +3,6 @@
 package annotations
 
 import (
-	"database/sql"
 	"regexp"
 	"strings"
 
@@ -17,111 +16,93 @@ import (
 // exports.
 const MaxValueLength = 256
 
-// MaxLinearIssueIDs bounds how many issues a single call may add. The stored
-// set can still grow across calls.
-const MaxLinearIssueIDs = 16
-
-// MaxGitHubPRURLs bounds how many pull request URLs a single call may add. The
+// MaxValuesPerKey bounds how many values a single call may add to one key. The
 // stored set can still grow across calls.
-const MaxGitHubPRURLs = 16
+const MaxValuesPerKey = 16
 
 // githubPRURLPattern matches the canonical GitHub pull request URL. The stored
 // value is rendered as a link target, so anything else, including other
 // schemes and hosts, is rejected before it reaches the database.
 var githubPRURLPattern = regexp.MustCompile(`^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+$`)
 
-// Input is the untrusted work context supplied by a caller.
+// Input is the untrusted work context supplied by a caller. Every key holds a
+// set of values, which the update query unions with the values already stored.
 type Input struct {
 	LinearIssueIDs []string
 	GitHubPRURLs   []string
-	Repo           string
-	Branch         string
+	Repos          []string
+	Branches       []string
 }
 
-// Params trims the input and maps empty values to NULL, which the update query
-// treats as "leave unchanged". It returns an error when every field is empty,
+// Params trims the input and leaves an empty key NULL, which the update query
+// treats as "leave unchanged". It returns an error when every key is empty,
 // because such a call would write nothing. The returned params carry no
 // interception ID; the caller sets it.
 func Params(input Input) (database.UpdateAIBridgeInterceptionAnnotationsParams, error) {
 	var params database.UpdateAIBridgeInterceptionAnnotationsParams
-	for _, field := range []struct {
-		name  string
-		value string
-		dest  *sql.NullString
+	for _, key := range []struct {
+		name     string
+		values   []string
+		validate func(string) error
+		dest     *[]string
 	}{
-		{"repo", input.Repo, &params.Repo},
-		{"branch", input.Branch, &params.Branch},
+		{"linear_issue_ids", input.LinearIssueIDs, nil, &params.LinearIssueIds},
+		{"github_pr_urls", input.GitHubPRURLs, validateGitHubPRURL, &params.GithubPrUrls},
+		{"repos", input.Repos, nil, &params.Repos},
+		{"branches", input.Branches, nil, &params.Branches},
 	} {
-		value, err := trimValue(field.name, field.value)
+		values, err := cleanValues(key.name, key.values, key.validate)
 		if err != nil {
 			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
 		}
-		if value == "" {
-			continue
-		}
-		*field.dest = sql.NullString{String: value, Valid: true}
-	}
-
-	if len(input.LinearIssueIDs) > MaxLinearIssueIDs {
-		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-			"linear_issue_ids accepts at most %d issues per call", MaxLinearIssueIDs,
-		)
-	}
-	var issues []string
-	for _, issue := range input.LinearIssueIDs {
-		value, err := trimValue("linear_issue_ids", issue)
-		if err != nil {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
-		}
-		if value == "" {
-			continue
-		}
-		issues = append(issues, value)
-	}
-	if len(issues) > 0 {
-		params.LinearIssueIds = issues
-	}
-
-	if len(input.GitHubPRURLs) > MaxGitHubPRURLs {
-		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-			"github_pr_urls accepts at most %d URLs per call", MaxGitHubPRURLs,
-		)
-	}
-	var prs []string
-	for _, pr := range input.GitHubPRURLs {
-		value, err := trimValue("github_pr_urls", pr)
-		if err != nil {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
-		}
-		if value == "" {
-			continue
-		}
-		if !githubPRURLPattern.MatchString(value) {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-				"github_pr_urls entry %q must look like https://github.com/{owner}/{repo}/pull/{number}", value,
-			)
-		}
-		prs = append(prs, value)
-	}
-	if len(prs) > 0 {
-		params.GithubPrUrls = prs
+		*key.dest = values
 	}
 
 	if len(params.LinearIssueIds) == 0 && len(params.GithubPrUrls) == 0 &&
-		!params.Repo.Valid && !params.Branch.Valid {
+		len(params.Repos) == 0 && len(params.Branches) == 0 {
 		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.New(
-			"provide at least one of linear_issue_ids, github_pr_urls, repo, or branch",
+			"provide at least one of linear_issue_ids, github_pr_urls, repos, or branches",
 		)
 	}
 	return params, nil
 }
 
-func trimValue(name string, value string) (string, error) {
-	value = strings.TrimSpace(value)
-	if len(value) > MaxValueLength {
-		return "", xerrors.Errorf(
-			"%s must be %d characters or fewer", name, MaxValueLength,
+// cleanValues trims each value, drops the empty ones, and applies validate to
+// what remains. It returns nil when nothing survives, so the key is left
+// unchanged rather than written as an empty set.
+func cleanValues(name string, values []string, validate func(string) error) ([]string, error) {
+	if len(values) > MaxValuesPerKey {
+		return nil, xerrors.Errorf(
+			"%s accepts at most %d values per call", name, MaxValuesPerKey,
 		)
 	}
-	return value, nil
+
+	var cleaned []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if len(value) > MaxValueLength {
+			return nil, xerrors.Errorf(
+				"%s must be %d characters or fewer", name, MaxValueLength,
+			)
+		}
+		if validate != nil {
+			if err := validate(value); err != nil {
+				return nil, err
+			}
+		}
+		cleaned = append(cleaned, value)
+	}
+	return cleaned, nil
+}
+
+func validateGitHubPRURL(value string) error {
+	if !githubPRURLPattern.MatchString(value) {
+		return xerrors.Errorf(
+			"github_pr_urls entry %q must look like https://github.com/{owner}/{repo}/pull/{number}", value,
+		)
+	}
+	return nil
 }

--- a/coderd/aibridge/annotations/annotations_test.go
+++ b/coderd/aibridge/annotations/annotations_test.go
@@ -17,20 +17,19 @@ func TestParams(t *testing.T) {
 
 		params, err := annotations.Params(annotations.Input{
 			LinearIssueIDs: []string{" ENG-1234 ", "  "},
-			Repo:           " coder/coder ",
+			Repos:          []string{" coder/coder "},
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"ENG-1234"}, params.LinearIssueIds)
-		require.Equal(t, "coder/coder", params.Repo.String)
-		require.True(t, params.Repo.Valid)
-		require.False(t, params.Branch.Valid)
+		require.Equal(t, []string{"coder/coder"}, params.Repos)
+		require.Empty(t, params.Branches)
 		require.Empty(t, params.GithubPrUrls)
 	})
 
 	t.Run("NoFields", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := annotations.Params(annotations.Input{Repo: "   ", LinearIssueIDs: []string{}})
+		_, err := annotations.Params(annotations.Input{Repos: []string{"   "}, LinearIssueIDs: []string{}})
 		require.ErrorContains(t, err, "provide at least one of")
 	})
 
@@ -38,8 +37,8 @@ func TestParams(t *testing.T) {
 		t.Parallel()
 
 		for name, input := range map[string]annotations.Input{
-			"repo":             {Repo: strings.Repeat("a", annotations.MaxValueLength+1)},
-			"branch":           {Branch: strings.Repeat("a", annotations.MaxValueLength+1)},
+			"repos":            {Repos: []string{strings.Repeat("a", annotations.MaxValueLength+1)}},
+			"branches":         {Branches: []string{strings.Repeat("a", annotations.MaxValueLength+1)}},
 			"linear_issue_ids": {LinearIssueIDs: []string{strings.Repeat("a", annotations.MaxValueLength+1)}},
 			"github_pr_urls":   {GitHubPRURLs: []string{strings.Repeat("a", annotations.MaxValueLength+1)}},
 		} {
@@ -51,19 +50,26 @@ func TestParams(t *testing.T) {
 	t.Run("TooManyItems", func(t *testing.T) {
 		t.Parallel()
 
-		issues := make([]string, annotations.MaxLinearIssueIDs+1)
+		issues := make([]string, annotations.MaxValuesPerKey+1)
 		for i := range issues {
 			issues[i] = "ENG-1"
 		}
 		_, err := annotations.Params(annotations.Input{LinearIssueIDs: issues})
-		require.ErrorContains(t, err, "at most 16 issues per call")
+		require.ErrorContains(t, err, "linear_issue_ids accepts at most 16 values per call")
 
-		prs := make([]string, annotations.MaxGitHubPRURLs+1)
+		branches := make([]string, annotations.MaxValuesPerKey+1)
+		for i := range branches {
+			branches[i] = "main"
+		}
+		_, err = annotations.Params(annotations.Input{Branches: branches})
+		require.ErrorContains(t, err, "branches accepts at most 16 values per call")
+
+		prs := make([]string, annotations.MaxValuesPerKey+1)
 		for i := range prs {
 			prs[i] = "https://github.com/coder/coder/pull/1"
 		}
 		_, err = annotations.Params(annotations.Input{GitHubPRURLs: prs})
-		require.ErrorContains(t, err, "at most 16 URLs per call")
+		require.ErrorContains(t, err, "github_pr_urls accepts at most 16 values per call")
 	})
 
 	t.Run("AcceptsCanonicalPullRequestURLs", func(t *testing.T) {

--- a/coderd/aibridge/annotations/annotations_test.go
+++ b/coderd/aibridge/annotations/annotations_test.go
@@ -1,0 +1,99 @@
+package annotations_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/aibridge/annotations"
+)
+
+func TestParams(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TrimsAndKeepsOnlySetFields", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := annotations.Params(annotations.Input{
+			LinearIssueIDs: []string{" ENG-1234 ", "  "},
+			Repo:           " coder/coder ",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"ENG-1234"}, params.LinearIssueIds)
+		require.Equal(t, "coder/coder", params.Repo.String)
+		require.True(t, params.Repo.Valid)
+		require.False(t, params.Branch.Valid)
+		require.Empty(t, params.GithubPrUrls)
+	})
+
+	t.Run("NoFields", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := annotations.Params(annotations.Input{Repo: "   ", LinearIssueIDs: []string{}})
+		require.ErrorContains(t, err, "provide at least one of")
+	})
+
+	t.Run("ValueTooLong", func(t *testing.T) {
+		t.Parallel()
+
+		for name, input := range map[string]annotations.Input{
+			"repo":             {Repo: strings.Repeat("a", annotations.MaxValueLength+1)},
+			"branch":           {Branch: strings.Repeat("a", annotations.MaxValueLength+1)},
+			"linear_issue_ids": {LinearIssueIDs: []string{strings.Repeat("a", annotations.MaxValueLength+1)}},
+			"github_pr_urls":   {GitHubPRURLs: []string{strings.Repeat("a", annotations.MaxValueLength+1)}},
+		} {
+			_, err := annotations.Params(input)
+			require.ErrorContains(t, err, "256 characters or fewer", "field %q", name)
+		}
+	})
+
+	t.Run("TooManyItems", func(t *testing.T) {
+		t.Parallel()
+
+		issues := make([]string, annotations.MaxLinearIssueIDs+1)
+		for i := range issues {
+			issues[i] = "ENG-1"
+		}
+		_, err := annotations.Params(annotations.Input{LinearIssueIDs: issues})
+		require.ErrorContains(t, err, "at most 16 issues per call")
+
+		prs := make([]string, annotations.MaxGitHubPRURLs+1)
+		for i := range prs {
+			prs[i] = "https://github.com/coder/coder/pull/1"
+		}
+		_, err = annotations.Params(annotations.Input{GitHubPRURLs: prs})
+		require.ErrorContains(t, err, "at most 16 URLs per call")
+	})
+
+	t.Run("AcceptsCanonicalPullRequestURLs", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := annotations.Params(annotations.Input{GitHubPRURLs: []string{
+			"https://github.com/coder/coder/pull/28300",
+			"https://github.com/some-org/some.repo_name/pull/1",
+		}})
+		require.NoError(t, err)
+		require.Len(t, params.GithubPrUrls, 2)
+	})
+
+	t.Run("RejectsNonPullRequestURLs", func(t *testing.T) {
+		t.Parallel()
+
+		for _, url := range []string{
+			"javascript:alert(1)",
+			"http://github.com/coder/coder/pull/1",
+			"https://github.example.com/coder/coder/pull/1",
+			"https://github.com.evil.example/coder/coder/pull/1",
+			"https://github.com/coder/coder/issues/1",
+			"https://github.com/coder/coder/pull/1?x=y",
+			"https://github.com/coder/coder/pull/1#files",
+			"https://github.com/coder/coder/pull/1/files",
+			"https://github.com/coder/coder/pull/abc",
+			"https://github.com/coder/pull/1",
+		} {
+			_, err := annotations.Params(annotations.Input{GitHubPRURLs: []string{url}})
+			require.ErrorContains(t, err, "must look like https://github.com/", "url %q", url)
+		}
+	})
+}

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15835,6 +15835,12 @@ const docTemplate = `{
         "codersdk.AIBridgeSessionThreadsResponse": {
             "type": "object",
             "properties": {
+                "branches": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "client": {
                     "type": "string"
                 },
@@ -15842,11 +15848,24 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time"
                 },
+                "github_pr_urls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
                 "initiator": {
                     "$ref": "#/definitions/codersdk.MinimalUser"
+                },
+                "linear_issue_ids": {
+                    "description": "LinearIssueIDs lists the distinct Linear issue identifiers annotated on\nthe session's interceptions, sorted ascending. Empty when no interception\nin the session was annotated with one. GitHubPRURLs, Repos, and Branches\nare the same for their respective annotations.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "metadata": {
                     "type": "object",
@@ -15892,6 +15911,12 @@ const docTemplate = `{
                     "format": "date-time"
                 },
                 "providers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "repos": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5052,7 +5052,7 @@ const docTemplate = `{
         },
         "/api/v2/organizations/{organization}/ai/spend/export": {
             "get": {
-                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nThe capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.\nRequires organization-level administrator permissions.",
+                "description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nThe capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.\nThe optional columns query parameter appends annotation-derived columns after the fixed ones, in the order requested. Each cell lists the distinct values the annotation held across the interceptions behind the row, semicolon-separated.\nRequires organization-level administrator permissions.",
                 "produces": [
                     "text/csv"
                 ],
@@ -5082,6 +5082,18 @@ const docTemplate = `{
                         "format": "date-time",
                         "description": "Exclusive upper bound (RFC3339)",
                         "name": "period_end",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "linear_issue_ids",
+                            "github_pr_urls",
+                            "repo",
+                            "branch"
+                        ],
+                        "type": "string",
+                        "description": "Comma-separated optional annotation columns",
+                        "name": "columns",
                         "in": "query"
                     }
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5088,8 +5088,8 @@ const docTemplate = `{
                         "enum": [
                             "linear_issue_ids",
                             "github_pr_urls",
-                            "repo",
-                            "branch"
+                            "repos",
+                            "branches"
                         ],
                         "type": "string",
                         "description": "Comma-separated optional annotation columns",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4492,7 +4492,7 @@
 						"in": "query"
 					},
 					{
-						"enum": ["linear_issue_ids", "github_pr_urls", "repo", "branch"],
+						"enum": ["linear_issue_ids", "github_pr_urls", "repos", "branches"],
 						"type": "string",
 						"description": "Comma-separated optional annotation columns",
 						"name": "columns",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14111,6 +14111,12 @@
 		"codersdk.AIBridgeSessionThreadsResponse": {
 			"type": "object",
 			"properties": {
+				"branches": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"client": {
 					"type": "string"
 				},
@@ -14118,11 +14124,24 @@
 					"type": "string",
 					"format": "date-time"
 				},
+				"github_pr_urls": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"id": {
 					"type": "string"
 				},
 				"initiator": {
 					"$ref": "#/definitions/codersdk.MinimalUser"
+				},
+				"linear_issue_ids": {
+					"description": "LinearIssueIDs lists the distinct Linear issue identifiers annotated on\nthe session's interceptions, sorted ascending. Empty when no interception\nin the session was annotated with one. GitHubPRURLs, Repos, and Branches\nare the same for their respective annotations.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				},
 				"metadata": {
 					"type": "object",
@@ -14168,6 +14187,12 @@
 					"format": "date-time"
 				},
 				"providers": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"repos": {
 					"type": "array",
 					"items": {
 						"type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4463,7 +4463,7 @@
 		},
 		"/api/v2/organizations/{organization}/ai/spend/export": {
 			"get": {
-				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nThe capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.\nRequires organization-level administrator permissions.",
+				"description": "Returns per-user, per-group, per-model, per-provider aggregated AI spend for the organization as CSV, built from raw AI Gateway token usage.\nThe optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.\nAn explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.\nThe capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.\nThe optional columns query parameter appends annotation-derived columns after the fixed ones, in the order requested. Each cell lists the distinct values the annotation held across the interceptions behind the row, semicolon-separated.\nRequires organization-level administrator permissions.",
 				"produces": ["text/csv"],
 				"tags": ["Enterprise"],
 				"summary": "Export organization AI spend as CSV",
@@ -4489,6 +4489,13 @@
 						"format": "date-time",
 						"description": "Exclusive upper bound (RFC3339)",
 						"name": "period_end",
+						"in": "query"
+					},
+					{
+						"enum": ["linear_issue_ids", "github_pr_urls", "repo", "branch"],
+						"type": "string",
+						"description": "Comma-separated optional annotation columns",
+						"name": "columns",
 						"in": "query"
 					}
 				],

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1290,6 +1290,10 @@ func AIBridgeSessionThreads(p AIBridgeSessionThreadsParams) codersdk.AIBridgeSes
 		resp.NetworkDomainCount = d.TotalDomains
 	}
 	resp.NetworkCallLogs = AgentFirewallLogs(p.NetworkCalls)
+	resp.LinearIssueIDs = session.LinearIssueIds
+	resp.GitHubPRURLs = session.GithubPrUrls
+	resp.Repos = session.Repos
+	resp.Branches = session.Branches
 	return resp
 }
 

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3971,6 +3971,10 @@ func (q *querier) GetLastUpdateCheck(ctx context.Context) (string, error) {
 	return q.db.GetLastUpdateCheck(ctx)
 }
 
+func (q *querier) GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, initiatorID uuid.UUID) (database.AIBridgeInterception, error) {
+	return fetch(q.log, q.auth, q.db.GetLatestAIBridgeInterceptionByInitiator)(ctx, initiatorID)
+}
+
 func (q *querier) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceCryptoKey); err != nil {
 		return database.CryptoKey{}, err
@@ -7265,6 +7269,13 @@ func (q *querier) UnsetDefaultChatModelConfigs(ctx context.Context) error {
 		return err
 	}
 	return q.db.UnsetDefaultChatModelConfigs(ctx)
+}
+
+func (q *querier) UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg database.UpdateAIBridgeInterceptionAnnotationsParams) (database.AIBridgeInterception, error) {
+	if err := q.authorizeAIBridgeInterceptionAction(ctx, policy.ActionUpdate, arg.ID); err != nil {
+		return database.AIBridgeInterception{}, err
+	}
+	return q.db.UpdateAIBridgeInterceptionAnnotations(ctx, arg)
 }
 
 func (q *querier) UpdateAIBridgeInterceptionEnded(ctx context.Context, params database.UpdateAIBridgeInterceptionEndedParams) (database.AIBridgeInterception, error) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3975,6 +3975,16 @@ func (q *querier) GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, 
 	return fetch(q.log, q.auth, q.db.GetLatestAIBridgeInterceptionByInitiator)(ctx, initiatorID)
 }
 
+// GetLatestAIBridgeInterceptionIDByInitiator returns an identifier rather than
+// interception content, so it is authorized as a system read. Callers must
+// scope the lookup to the initiator they are acting for.
+func (q *querier) GetLatestAIBridgeInterceptionIDByInitiator(ctx context.Context, arg database.GetLatestAIBridgeInterceptionIDByInitiatorParams) (uuid.UUID, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
+		return uuid.Nil, err
+	}
+	return q.db.GetLatestAIBridgeInterceptionIDByInitiator(ctx, arg)
+}
+
 func (q *querier) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceCryptoKey); err != nil {
 		return database.CryptoKey{}, err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6723,6 +6723,13 @@ func (s *MethodTestSuite) TestAIBridge() {
 		check.Args(initID).Asserts(intc, policy.ActionRead).Returns(intc)
 	}))
 
+	s.Run("GetLatestAIBridgeInterceptionIDByInitiator", s.Mocked(func(db *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.GetLatestAIBridgeInterceptionIDByInitiatorParams{InitiatorID: uuid.UUID{3}}
+		intcID := uuid.UUID{2}
+		db.EXPECT().GetLatestAIBridgeInterceptionIDByInitiator(gomock.Any(), arg).Return(intcID, nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceSystem, policy.ActionRead).Returns(intcID)
+	}))
+
 	s.Run("GetAIBridgeTokenUsagesByInterceptionID", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		intID := uuid.UUID{2}
 		intc := testutil.Fake(s.T(), faker, database.AIBridgeInterception{ID: intID})

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6716,6 +6716,13 @@ func (s *MethodTestSuite) TestAIBridge() {
 		check.Args().Asserts(a, policy.ActionRead, b, policy.ActionRead).Returns([]database.AIBridgeInterception{a, b})
 	}))
 
+	s.Run("GetLatestAIBridgeInterceptionByInitiator", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		initID := uuid.UUID{3}
+		intc := testutil.Fake(s.T(), faker, database.AIBridgeInterception{ID: uuid.UUID{2}, InitiatorID: initID})
+		db.EXPECT().GetLatestAIBridgeInterceptionByInitiator(gomock.Any(), initID).Return(intc, nil).AnyTimes()
+		check.Args(initID).Asserts(intc, policy.ActionRead).Returns(intc)
+	}))
+
 	s.Run("GetAIBridgeTokenUsagesByInterceptionID", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		intID := uuid.UUID{2}
 		intc := testutil.Fake(s.T(), faker, database.AIBridgeInterception{ID: intID})
@@ -6858,6 +6865,15 @@ func (s *MethodTestSuite) TestAIBridge() {
 		intc := testutil.Fake(s.T(), faker, database.AIBridgeInterception{ID: intcID})
 		db.EXPECT().GetAIBridgeInterceptionByID(gomock.Any(), intcID).Return(intc, nil).AnyTimes() // Validation.
 		db.EXPECT().UpdateAIBridgeInterceptionEnded(gomock.Any(), params).Return(intc, nil).AnyTimes()
+		check.Args(params).Asserts(intc, policy.ActionUpdate).Returns(intc)
+	}))
+
+	s.Run("UpdateAIBridgeInterceptionAnnotations", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		intcID := uuid.UUID{1}
+		params := database.UpdateAIBridgeInterceptionAnnotationsParams{ID: intcID}
+		intc := testutil.Fake(s.T(), faker, database.AIBridgeInterception{ID: intcID})
+		db.EXPECT().GetAIBridgeInterceptionByID(gomock.Any(), intcID).Return(intc, nil).AnyTimes() // Validation.
+		db.EXPECT().UpdateAIBridgeInterceptionAnnotations(gomock.Any(), params).Return(intc, nil).AnyTimes()
 		check.Args(params).Asserts(intc, policy.ActionUpdate).Returns(intc)
 	}))
 

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2233,6 +2233,14 @@ func (m queryMetricsStore) GetLastUpdateCheck(ctx context.Context) (string, erro
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, initiatorID uuid.UUID) (database.AIBridgeInterception, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetLatestAIBridgeInterceptionByInitiator(ctx, initiatorID)
+	m.queryLatencies.WithLabelValues("GetLatestAIBridgeInterceptionByInitiator").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetLatestAIBridgeInterceptionByInitiator").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetLatestCryptoKeyByFeature(ctx, feature)
@@ -5143,6 +5151,14 @@ func (m queryMetricsStore) UnsetDefaultChatModelConfigs(ctx context.Context) err
 	m.queryLatencies.WithLabelValues("UnsetDefaultChatModelConfigs").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UnsetDefaultChatModelConfigs").Inc()
 	return r0
+}
+
+func (m queryMetricsStore) UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg database.UpdateAIBridgeInterceptionAnnotationsParams) (database.AIBridgeInterception, error) {
+	start := time.Now()
+	r0, r1 := m.s.UpdateAIBridgeInterceptionAnnotations(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateAIBridgeInterceptionAnnotations").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateAIBridgeInterceptionAnnotations").Inc()
+	return r0, r1
 }
 
 func (m queryMetricsStore) UpdateAIBridgeInterceptionEnded(ctx context.Context, arg database.UpdateAIBridgeInterceptionEndedParams) (database.AIBridgeInterception, error) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2241,6 +2241,14 @@ func (m queryMetricsStore) GetLatestAIBridgeInterceptionByInitiator(ctx context.
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetLatestAIBridgeInterceptionIDByInitiator(ctx context.Context, arg database.GetLatestAIBridgeInterceptionIDByInitiatorParams) (uuid.UUID, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetLatestAIBridgeInterceptionIDByInitiator(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetLatestAIBridgeInterceptionIDByInitiator").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetLatestAIBridgeInterceptionIDByInitiator").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetLatestCryptoKeyByFeature(ctx, feature)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -4155,6 +4155,21 @@ func (mr *MockStoreMockRecorder) GetLastUpdateCheck(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastUpdateCheck", reflect.TypeOf((*MockStore)(nil).GetLastUpdateCheck), ctx)
 }
 
+// GetLatestAIBridgeInterceptionByInitiator mocks base method.
+func (m *MockStore) GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, initiatorID uuid.UUID) (database.AIBridgeInterception, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestAIBridgeInterceptionByInitiator", ctx, initiatorID)
+	ret0, _ := ret[0].(database.AIBridgeInterception)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestAIBridgeInterceptionByInitiator indicates an expected call of GetLatestAIBridgeInterceptionByInitiator.
+func (mr *MockStoreMockRecorder) GetLatestAIBridgeInterceptionByInitiator(ctx, initiatorID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestAIBridgeInterceptionByInitiator", reflect.TypeOf((*MockStore)(nil).GetLatestAIBridgeInterceptionByInitiator), ctx, initiatorID)
+}
+
 // GetLatestCryptoKeyByFeature mocks base method.
 func (m *MockStore) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	m.ctrl.T.Helper()
@@ -9730,6 +9745,21 @@ func (m *MockStore) UnsetDefaultChatModelConfigs(ctx context.Context) error {
 func (mr *MockStoreMockRecorder) UnsetDefaultChatModelConfigs(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsetDefaultChatModelConfigs", reflect.TypeOf((*MockStore)(nil).UnsetDefaultChatModelConfigs), ctx)
+}
+
+// UpdateAIBridgeInterceptionAnnotations mocks base method.
+func (m *MockStore) UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg database.UpdateAIBridgeInterceptionAnnotationsParams) (database.AIBridgeInterception, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAIBridgeInterceptionAnnotations", ctx, arg)
+	ret0, _ := ret[0].(database.AIBridgeInterception)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAIBridgeInterceptionAnnotations indicates an expected call of UpdateAIBridgeInterceptionAnnotations.
+func (mr *MockStoreMockRecorder) UpdateAIBridgeInterceptionAnnotations(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAIBridgeInterceptionAnnotations", reflect.TypeOf((*MockStore)(nil).UpdateAIBridgeInterceptionAnnotations), ctx, arg)
 }
 
 // UpdateAIBridgeInterceptionEnded mocks base method.

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -4170,6 +4170,21 @@ func (mr *MockStoreMockRecorder) GetLatestAIBridgeInterceptionByInitiator(ctx, i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestAIBridgeInterceptionByInitiator", reflect.TypeOf((*MockStore)(nil).GetLatestAIBridgeInterceptionByInitiator), ctx, initiatorID)
 }
 
+// GetLatestAIBridgeInterceptionIDByInitiator mocks base method.
+func (m *MockStore) GetLatestAIBridgeInterceptionIDByInitiator(ctx context.Context, arg database.GetLatestAIBridgeInterceptionIDByInitiatorParams) (uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestAIBridgeInterceptionIDByInitiator", ctx, arg)
+	ret0, _ := ret[0].(uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestAIBridgeInterceptionIDByInitiator indicates an expected call of GetLatestAIBridgeInterceptionIDByInitiator.
+func (mr *MockStoreMockRecorder) GetLatestAIBridgeInterceptionIDByInitiator(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestAIBridgeInterceptionIDByInitiator", reflect.TypeOf((*MockStore)(nil).GetLatestAIBridgeInterceptionIDByInitiator), ctx, arg)
+}
+
 // GetLatestCryptoKeyByFeature mocks base method.
 func (m *MockStore) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -1068,6 +1068,10 @@ func (q *sqlQuerier) ListAuthorizedAIBridgeSessions(ctx context.Context, arg Lis
 			&i.NetworkCallsTotal,
 			&i.NetworkCallsBlocked,
 			&i.FirewallActive,
+			pq.Array(&i.LinearIssueIds),
+			pq.Array(&i.GithubPrUrls),
+			pq.Array(&i.Repos),
+			pq.Array(&i.Branches),
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -635,6 +635,7 @@ type sqlcQuerier interface {
 	// "last" must use id order.
 	GetLastChatMessageByRole(ctx context.Context, arg GetLastChatMessageByRoleParams) (ChatMessage, error)
 	GetLastUpdateCheck(ctx context.Context) (string, error)
+	GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, initiatorID uuid.UUID) (AIBridgeInterception, error)
 	GetLatestCryptoKeyByFeature(ctx context.Context, feature CryptoKeyFeature) (CryptoKey, error)
 	GetLatestWorkspaceAgentContextSnapshot(ctx context.Context, workspaceAgentID uuid.UUID) (WorkspaceAgentContextSnapshot, error)
 	GetLatestWorkspaceAppStatusByAppID(ctx context.Context, appID uuid.UUID) (WorkspaceAppStatus, error)
@@ -1412,6 +1413,11 @@ type sqlcQuerier interface {
 	UnlinkOIDCUsersByIssuerMismatch(ctx context.Context, expectedPrefix string) (int64, error)
 	UnpinChatByID(ctx context.Context, id uuid.UUID) error
 	UnsetDefaultChatModelConfigs(ctx context.Context) error
+	// Merges client-supplied work context into the annotations object. The keys
+	// are built explicitly so no other annotation key can be written through
+	// this query, and jsonb_strip_nulls drops the arguments left NULL so they
+	// keep whatever value the row already holds.
+	UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg UpdateAIBridgeInterceptionAnnotationsParams) (AIBridgeInterception, error)
 	UpdateAIBridgeInterceptionEnded(ctx context.Context, arg UpdateAIBridgeInterceptionEndedParams) (AIBridgeInterception, error)
 	// Records heartbeat liveness for an active Gateway DRPC session. The database sets the
 	// timestamp so it stays consistent regardless of clock drift between API

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1416,7 +1416,10 @@ type sqlcQuerier interface {
 	// Merges client-supplied work context into the annotations object. The keys
 	// are built explicitly so no other annotation key can be written through
 	// this query, and jsonb_strip_nulls drops the arguments left NULL so they
-	// keep whatever value the row already holds.
+	// keep whatever value the row already holds. Linear issues and pull request
+	// URLs accumulate as sorted sets: the supplied values are unioned with the
+	// ones already stored, discarding a non-array value left by an older
+	// annotation shape.
 	UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg UpdateAIBridgeInterceptionAnnotationsParams) (AIBridgeInterception, error)
 	UpdateAIBridgeInterceptionEnded(ctx context.Context, arg UpdateAIBridgeInterceptionEndedParams) (AIBridgeInterception, error)
 	// Records heartbeat liveness for an active Gateway DRPC session. The database sets the

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -636,6 +636,10 @@ type sqlcQuerier interface {
 	GetLastChatMessageByRole(ctx context.Context, arg GetLastChatMessageByRoleParams) (ChatMessage, error)
 	GetLastUpdateCheck(ctx context.Context) (string, error)
 	GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, initiatorID uuid.UUID) (AIBridgeInterception, error)
+	// Returns only the identifier, so a caller that may write annotations but not
+	// read interceptions can locate the row to write to. A null client_session_id
+	// matches any session.
+	GetLatestAIBridgeInterceptionIDByInitiator(ctx context.Context, arg GetLatestAIBridgeInterceptionIDByInitiatorParams) (uuid.UUID, error)
 	GetLatestCryptoKeyByFeature(ctx context.Context, feature CryptoKeyFeature) (CryptoKey, error)
 	GetLatestWorkspaceAgentContextSnapshot(ctx context.Context, workspaceAgentID uuid.UUID) (WorkspaceAgentContextSnapshot, error)
 	GetLatestWorkspaceAppStatusByAppID(ctx context.Context, appID uuid.UUID) (WorkspaceAppStatus, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1419,11 +1419,9 @@ type sqlcQuerier interface {
 	UnsetDefaultChatModelConfigs(ctx context.Context) error
 	// Merges client-supplied work context into the annotations object. The keys
 	// are built explicitly so no other annotation key can be written through
-	// this query, and jsonb_strip_nulls drops the arguments left NULL so they
-	// keep whatever value the row already holds. Linear issues and pull request
-	// URLs accumulate as sorted sets: the supplied values are unioned with the
-	// ones already stored, discarding a non-array value left by an older
-	// annotation shape.
+	// this query. Every key accumulates as a sorted set: the supplied values are
+	// unioned with the ones already stored, discarding a non-array value left by
+	// an older annotation shape. A NULL argument leaves its key untouched.
 	UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg UpdateAIBridgeInterceptionAnnotationsParams) (AIBridgeInterception, error)
 	UpdateAIBridgeInterceptionEnded(ctx context.Context, arg UpdateAIBridgeInterceptionEndedParams) (AIBridgeInterception, error)
 	// Records heartbeat liveness for an active Gateway DRPC session. The database sets the

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1561,6 +1561,47 @@ func (q *sqlQuerier) GetAIBridgeUserPromptsByInterceptionID(ctx context.Context,
 	return items, nil
 }
 
+const getLatestAIBridgeInterceptionByInitiator = `-- name: GetLatestAIBridgeInterceptionByInitiator :one
+SELECT
+	id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
+FROM
+	aibridge_interceptions
+WHERE
+	initiator_id = $1::uuid
+ORDER BY
+	started_at DESC
+LIMIT 1
+`
+
+func (q *sqlQuerier) GetLatestAIBridgeInterceptionByInitiator(ctx context.Context, initiatorID uuid.UUID) (AIBridgeInterception, error) {
+	row := q.db.QueryRowContext(ctx, getLatestAIBridgeInterceptionByInitiator, initiatorID)
+	var i AIBridgeInterception
+	err := row.Scan(
+		&i.ID,
+		&i.InitiatorID,
+		&i.Provider,
+		&i.Model,
+		&i.StartedAt,
+		&i.Metadata,
+		&i.EndedAt,
+		&i.APIKeyID,
+		&i.Client,
+		&i.ThreadParentID,
+		&i.ThreadRootID,
+		&i.ClientSessionID,
+		&i.SessionID,
+		&i.ProviderName,
+		&i.CredentialKind,
+		&i.CredentialHint,
+		&i.AgentFirewallSessionID,
+		&i.AgentFirewallSequenceNumber,
+		&i.ErrorType,
+		&i.ErrorMessage,
+		&i.Annotations,
+	)
+	return i, err
+}
+
 const insertAIBridgeInterception = `-- name: InsertAIBridgeInterception :one
 INSERT INTO aibridge_interceptions (
 	id, api_key_id, initiator_id, provider, provider_name, model, metadata, annotations, started_at, client, client_session_id, thread_parent_id, thread_root_id, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number
@@ -2668,6 +2709,63 @@ func (q *sqlQuerier) ListAIBridgeUserPromptsByInterceptionIDs(ctx context.Contex
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateAIBridgeInterceptionAnnotations = `-- name: UpdateAIBridgeInterceptionAnnotations :one
+UPDATE aibridge_interceptions
+	SET annotations = annotations || jsonb_strip_nulls(jsonb_build_object(
+		'linear_issue_id', $1::text,
+		'repo', $2::text,
+		'branch', $3::text
+	))
+WHERE
+	id = $4::uuid
+RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
+`
+
+type UpdateAIBridgeInterceptionAnnotationsParams struct {
+	LinearIssueID sql.NullString `db:"linear_issue_id" json:"linear_issue_id"`
+	Repo          sql.NullString `db:"repo" json:"repo"`
+	Branch        sql.NullString `db:"branch" json:"branch"`
+	ID            uuid.UUID      `db:"id" json:"id"`
+}
+
+// Merges client-supplied work context into the annotations object. The keys
+// are built explicitly so no other annotation key can be written through
+// this query, and jsonb_strip_nulls drops the arguments left NULL so they
+// keep whatever value the row already holds.
+func (q *sqlQuerier) UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg UpdateAIBridgeInterceptionAnnotationsParams) (AIBridgeInterception, error) {
+	row := q.db.QueryRowContext(ctx, updateAIBridgeInterceptionAnnotations,
+		arg.LinearIssueID,
+		arg.Repo,
+		arg.Branch,
+		arg.ID,
+	)
+	var i AIBridgeInterception
+	err := row.Scan(
+		&i.ID,
+		&i.InitiatorID,
+		&i.Provider,
+		&i.Model,
+		&i.StartedAt,
+		&i.Metadata,
+		&i.EndedAt,
+		&i.APIKeyID,
+		&i.Client,
+		&i.ThreadParentID,
+		&i.ThreadRootID,
+		&i.ClientSessionID,
+		&i.SessionID,
+		&i.ProviderName,
+		&i.CredentialKind,
+		&i.CredentialHint,
+		&i.AgentFirewallSessionID,
+		&i.AgentFirewallSequenceNumber,
+		&i.ErrorType,
+		&i.ErrorMessage,
+		&i.Annotations,
+	)
+	return i, err
 }
 
 const updateAIBridgeInterceptionEnded = `-- name: UpdateAIBridgeInterceptionEnded :one

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2713,32 +2713,71 @@ func (q *sqlQuerier) ListAIBridgeUserPromptsByInterceptionIDs(ctx context.Contex
 
 const updateAIBridgeInterceptionAnnotations = `-- name: UpdateAIBridgeInterceptionAnnotations :one
 UPDATE aibridge_interceptions
-	SET annotations = annotations || jsonb_strip_nulls(jsonb_build_object(
-		'linear_issue_id', $1::text,
-		'repo', $2::text,
-		'branch', $3::text
-	))
+	SET annotations = annotations
+		|| jsonb_strip_nulls(jsonb_build_object(
+			'repo', $1::text,
+			'branch', $2::text
+		))
+		|| CASE
+			WHEN $3::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('linear_issue_ids', (
+				SELECT COALESCE(jsonb_agg(DISTINCT issue ORDER BY issue), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'linear_issue_ids') = 'array'
+							THEN annotations -> 'linear_issue_ids'
+							ELSE '[]'::jsonb
+						END
+					) AS issue
+					UNION
+					SELECT unnest($3::text[]) AS issue
+				) merged
+			))
+		END
+		|| CASE
+			WHEN $4::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('github_pr_urls', (
+				SELECT COALESCE(jsonb_agg(DISTINCT pr ORDER BY pr), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'github_pr_urls') = 'array'
+							THEN annotations -> 'github_pr_urls'
+							ELSE '[]'::jsonb
+						END
+					) AS pr
+					UNION
+					SELECT unnest($4::text[]) AS pr
+				) merged
+			))
+		END
 WHERE
-	id = $4::uuid
+	id = $5::uuid
 RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api_key_id, client, thread_parent_id, thread_root_id, client_session_id, session_id, provider_name, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number, error_type, error_message, annotations
 `
 
 type UpdateAIBridgeInterceptionAnnotationsParams struct {
-	LinearIssueID sql.NullString `db:"linear_issue_id" json:"linear_issue_id"`
-	Repo          sql.NullString `db:"repo" json:"repo"`
-	Branch        sql.NullString `db:"branch" json:"branch"`
-	ID            uuid.UUID      `db:"id" json:"id"`
+	Repo           sql.NullString `db:"repo" json:"repo"`
+	Branch         sql.NullString `db:"branch" json:"branch"`
+	LinearIssueIds []string       `db:"linear_issue_ids" json:"linear_issue_ids"`
+	GithubPrUrls   []string       `db:"github_pr_urls" json:"github_pr_urls"`
+	ID             uuid.UUID      `db:"id" json:"id"`
 }
 
 // Merges client-supplied work context into the annotations object. The keys
 // are built explicitly so no other annotation key can be written through
 // this query, and jsonb_strip_nulls drops the arguments left NULL so they
-// keep whatever value the row already holds.
+// keep whatever value the row already holds. Linear issues and pull request
+// URLs accumulate as sorted sets: the supplied values are unioned with the
+// ones already stored, discarding a non-array value left by an older
+// annotation shape.
 func (q *sqlQuerier) UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg UpdateAIBridgeInterceptionAnnotationsParams) (AIBridgeInterception, error) {
 	row := q.db.QueryRowContext(ctx, updateAIBridgeInterceptionAnnotations,
-		arg.LinearIssueID,
 		arg.Repo,
 		arg.Branch,
+		pq.Array(arg.LinearIssueIds),
+		pq.Array(arg.GithubPrUrls),
 		arg.ID,
 	)
 	var i AIBridgeInterception

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2426,8 +2426,8 @@ SELECT
 	COALESCE(sr.firewall_active, false) AS firewall_active,
 	COALESCE(sli.linear_issue_ids, ARRAY[]::text[])::text[] AS linear_issue_ids,
 	COALESCE(sli.github_pr_urls, ARRAY[]::text[])::text[] AS github_pr_urls,
-	COALESCE(sr.repos, ARRAY[]::text[])::text[] AS repos,
-	COALESCE(sr.branches, ARRAY[]::text[])::text[] AS branches
+	COALESCE(sli.repos, ARRAY[]::text[])::text[] AS repos,
+	COALESCE(sli.branches, ARRAY[]::text[])::text[] AS branches
 FROM
 	session_page sp
 JOIN
@@ -2439,13 +2439,7 @@ LEFT JOIN LATERAL (
 		ARRAY_AGG(DISTINCT ai.provider ORDER BY ai.provider) AS providers,
 		ARRAY_AGG(DISTINCT ai.model ORDER BY ai.model) AS models,
 		ARRAY_AGG(ai.id) AS interception_ids,
-		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active,
-		-- Client-supplied annotations, absent on interceptions that were
-		-- never annotated.
-		ARRAY_AGG(DISTINCT ai.annotations ->> 'repo' ORDER BY ai.annotations ->> 'repo')
-			FILTER (WHERE ai.annotations ->> 'repo' IS NOT NULL) AS repos,
-		ARRAY_AGG(DISTINCT ai.annotations ->> 'branch' ORDER BY ai.annotations ->> 'branch')
-			FILTER (WHERE ai.annotations ->> 'branch' IS NOT NULL) AS branches
+		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active
 	FROM aibridge_interceptions ai
 	WHERE ai.session_id = sp.session_id
 		AND ai.initiator_id = sp.initiator_id
@@ -2516,7 +2510,21 @@ LEFT JOIN LATERAL (
 			CROSS JOIN LATERAL jsonb_array_elements_text(pi.annotations -> 'github_pr_urls') AS pr
 			WHERE pi.id = ANY(sr.interception_ids)
 				AND jsonb_typeof(pi.annotations -> 'github_pr_urls') = 'array'
-		) AS github_pr_urls
+		) AS github_pr_urls,
+		(
+			SELECT ARRAY_AGG(DISTINCT repo ORDER BY repo)
+			FROM aibridge_interceptions ri
+			CROSS JOIN LATERAL jsonb_array_elements_text(ri.annotations -> 'repos') AS repo
+			WHERE ri.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(ri.annotations -> 'repos') = 'array'
+		) AS repos,
+		(
+			SELECT ARRAY_AGG(DISTINCT branch ORDER BY branch)
+			FROM aibridge_interceptions bi
+			CROSS JOIN LATERAL jsonb_array_elements_text(bi.annotations -> 'branches') AS branch
+			WHERE bi.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(bi.annotations -> 'branches') = 'array'
+		) AS branches
 ) sli ON true
 ORDER BY
 	sp.last_active_at DESC,
@@ -2783,12 +2791,8 @@ func (q *sqlQuerier) ListAIBridgeUserPromptsByInterceptionIDs(ctx context.Contex
 const updateAIBridgeInterceptionAnnotations = `-- name: UpdateAIBridgeInterceptionAnnotations :one
 UPDATE aibridge_interceptions
 	SET annotations = annotations
-		|| jsonb_strip_nulls(jsonb_build_object(
-			'repo', $1::text,
-			'branch', $2::text
-		))
 		|| CASE
-			WHEN $3::text[] IS NULL THEN '{}'::jsonb
+			WHEN $1::text[] IS NULL THEN '{}'::jsonb
 			ELSE jsonb_build_object('linear_issue_ids', (
 				SELECT COALESCE(jsonb_agg(DISTINCT issue ORDER BY issue), '[]'::jsonb)
 				FROM (
@@ -2800,12 +2804,12 @@ UPDATE aibridge_interceptions
 						END
 					) AS issue
 					UNION
-					SELECT unnest($3::text[]) AS issue
+					SELECT unnest($1::text[]) AS issue
 				) merged
 			))
 		END
 		|| CASE
-			WHEN $4::text[] IS NULL THEN '{}'::jsonb
+			WHEN $2::text[] IS NULL THEN '{}'::jsonb
 			ELSE jsonb_build_object('github_pr_urls', (
 				SELECT COALESCE(jsonb_agg(DISTINCT pr ORDER BY pr), '[]'::jsonb)
 				FROM (
@@ -2817,7 +2821,41 @@ UPDATE aibridge_interceptions
 						END
 					) AS pr
 					UNION
-					SELECT unnest($4::text[]) AS pr
+					SELECT unnest($2::text[]) AS pr
+				) merged
+			))
+		END
+		|| CASE
+			WHEN $3::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('repos', (
+				SELECT COALESCE(jsonb_agg(DISTINCT repo ORDER BY repo), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'repos') = 'array'
+							THEN annotations -> 'repos'
+							ELSE '[]'::jsonb
+						END
+					) AS repo
+					UNION
+					SELECT unnest($3::text[]) AS repo
+				) merged
+			))
+		END
+		|| CASE
+			WHEN $4::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('branches', (
+				SELECT COALESCE(jsonb_agg(DISTINCT branch ORDER BY branch), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'branches') = 'array'
+							THEN annotations -> 'branches'
+							ELSE '[]'::jsonb
+						END
+					) AS branch
+					UNION
+					SELECT unnest($4::text[]) AS branch
 				) merged
 			))
 		END
@@ -2827,26 +2865,24 @@ RETURNING id, initiator_id, provider, model, started_at, metadata, ended_at, api
 `
 
 type UpdateAIBridgeInterceptionAnnotationsParams struct {
-	Repo           sql.NullString `db:"repo" json:"repo"`
-	Branch         sql.NullString `db:"branch" json:"branch"`
-	LinearIssueIds []string       `db:"linear_issue_ids" json:"linear_issue_ids"`
-	GithubPrUrls   []string       `db:"github_pr_urls" json:"github_pr_urls"`
-	ID             uuid.UUID      `db:"id" json:"id"`
+	LinearIssueIds []string  `db:"linear_issue_ids" json:"linear_issue_ids"`
+	GithubPrUrls   []string  `db:"github_pr_urls" json:"github_pr_urls"`
+	Repos          []string  `db:"repos" json:"repos"`
+	Branches       []string  `db:"branches" json:"branches"`
+	ID             uuid.UUID `db:"id" json:"id"`
 }
 
 // Merges client-supplied work context into the annotations object. The keys
 // are built explicitly so no other annotation key can be written through
-// this query, and jsonb_strip_nulls drops the arguments left NULL so they
-// keep whatever value the row already holds. Linear issues and pull request
-// URLs accumulate as sorted sets: the supplied values are unioned with the
-// ones already stored, discarding a non-array value left by an older
-// annotation shape.
+// this query. Every key accumulates as a sorted set: the supplied values are
+// unioned with the ones already stored, discarding a non-array value left by
+// an older annotation shape. A NULL argument leaves its key untouched.
 func (q *sqlQuerier) UpdateAIBridgeInterceptionAnnotations(ctx context.Context, arg UpdateAIBridgeInterceptionAnnotationsParams) (AIBridgeInterception, error) {
 	row := q.db.QueryRowContext(ctx, updateAIBridgeInterceptionAnnotations,
-		arg.Repo,
-		arg.Branch,
 		pq.Array(arg.LinearIssueIds),
 		pq.Array(arg.GithubPrUrls),
+		pq.Array(arg.Repos),
+		pq.Array(arg.Branches),
 		arg.ID,
 	)
 	var i AIBridgeInterception

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2392,7 +2392,11 @@ SELECT
 	sp.last_active_at AS last_active_at,
 	COALESCE(bnc.total, 0)::bigint AS network_calls_total,
 	COALESCE(bnc.blocked, 0)::bigint AS network_calls_blocked,
-	COALESCE(sr.firewall_active, false) AS firewall_active
+	COALESCE(sr.firewall_active, false) AS firewall_active,
+	COALESCE(sli.linear_issue_ids, ARRAY[]::text[])::text[] AS linear_issue_ids,
+	COALESCE(sli.github_pr_urls, ARRAY[]::text[])::text[] AS github_pr_urls,
+	COALESCE(sr.repos, ARRAY[]::text[])::text[] AS repos,
+	COALESCE(sr.branches, ARRAY[]::text[])::text[] AS branches
 FROM
 	session_page sp
 JOIN
@@ -2404,7 +2408,13 @@ LEFT JOIN LATERAL (
 		ARRAY_AGG(DISTINCT ai.provider ORDER BY ai.provider) AS providers,
 		ARRAY_AGG(DISTINCT ai.model ORDER BY ai.model) AS models,
 		ARRAY_AGG(ai.id) AS interception_ids,
-		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active
+		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active,
+		-- Client-supplied annotations, absent on interceptions that were
+		-- never annotated.
+		ARRAY_AGG(DISTINCT ai.annotations ->> 'repo' ORDER BY ai.annotations ->> 'repo')
+			FILTER (WHERE ai.annotations ->> 'repo' IS NOT NULL) AS repos,
+		ARRAY_AGG(DISTINCT ai.annotations ->> 'branch' ORDER BY ai.annotations ->> 'branch')
+			FILTER (WHERE ai.annotations ->> 'branch' IS NOT NULL) AS branches
 	FROM aibridge_interceptions ai
 	WHERE ai.session_id = sp.session_id
 		AND ai.initiator_id = sp.initiator_id
@@ -2457,6 +2467,26 @@ LEFT JOIN LATERAL (
 		AND afi.agent_firewall_session_id IS NOT NULL
 		AND afi.agent_firewall_sequence_number IS NOT NULL
 ) bnc ON true
+LEFT JOIN LATERAL (
+	-- Flatten the per-interception arrays into one sorted set each for the
+	-- session. Kept out of the sr aggregate because expanding a JSONB array
+	-- there would multiply the rows it aggregates over.
+	SELECT
+		(
+			SELECT ARRAY_AGG(DISTINCT issue ORDER BY issue)
+			FROM aibridge_interceptions li
+			CROSS JOIN LATERAL jsonb_array_elements_text(li.annotations -> 'linear_issue_ids') AS issue
+			WHERE li.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(li.annotations -> 'linear_issue_ids') = 'array'
+		) AS linear_issue_ids,
+		(
+			SELECT ARRAY_AGG(DISTINCT pr ORDER BY pr)
+			FROM aibridge_interceptions pi
+			CROSS JOIN LATERAL jsonb_array_elements_text(pi.annotations -> 'github_pr_urls') AS pr
+			WHERE pi.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(pi.annotations -> 'github_pr_urls') = 'array'
+		) AS github_pr_urls
+) sli ON true
 ORDER BY
 	sp.last_active_at DESC,
 	sp.session_id DESC
@@ -2498,6 +2528,10 @@ type ListAIBridgeSessionsRow struct {
 	NetworkCallsTotal     int64           `db:"network_calls_total" json:"network_calls_total"`
 	NetworkCallsBlocked   int64           `db:"network_calls_blocked" json:"network_calls_blocked"`
 	FirewallActive        bool            `db:"firewall_active" json:"firewall_active"`
+	LinearIssueIds        []string        `db:"linear_issue_ids" json:"linear_issue_ids"`
+	GithubPrUrls          []string        `db:"github_pr_urls" json:"github_pr_urls"`
+	Repos                 []string        `db:"repos" json:"repos"`
+	Branches              []string        `db:"branches" json:"branches"`
 }
 
 // Returns paginated sessions with aggregated metadata, token counts, and
@@ -2556,6 +2590,10 @@ func (q *sqlQuerier) ListAIBridgeSessions(ctx context.Context, arg ListAIBridgeS
 			&i.NetworkCallsTotal,
 			&i.NetworkCallsBlocked,
 			&i.FirewallActive,
+			pq.Array(&i.LinearIssueIds),
+			pq.Array(&i.GithubPrUrls),
+			pq.Array(&i.Repos),
+			pq.Array(&i.Branches),
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1602,6 +1602,37 @@ func (q *sqlQuerier) GetLatestAIBridgeInterceptionByInitiator(ctx context.Contex
 	return i, err
 }
 
+const getLatestAIBridgeInterceptionIDByInitiator = `-- name: GetLatestAIBridgeInterceptionIDByInitiator :one
+SELECT
+	id
+FROM
+	aibridge_interceptions
+WHERE
+	initiator_id = $1::uuid
+	AND (
+		$2::text IS NULL
+		OR client_session_id = $2::text
+	)
+ORDER BY
+	started_at DESC
+LIMIT 1
+`
+
+type GetLatestAIBridgeInterceptionIDByInitiatorParams struct {
+	InitiatorID     uuid.UUID      `db:"initiator_id" json:"initiator_id"`
+	ClientSessionID sql.NullString `db:"client_session_id" json:"client_session_id"`
+}
+
+// Returns only the identifier, so a caller that may write annotations but not
+// read interceptions can locate the row to write to. A null client_session_id
+// matches any session.
+func (q *sqlQuerier) GetLatestAIBridgeInterceptionIDByInitiator(ctx context.Context, arg GetLatestAIBridgeInterceptionIDByInitiatorParams) (uuid.UUID, error) {
+	row := q.db.QueryRowContext(ctx, getLatestAIBridgeInterceptionIDByInitiator, arg.InitiatorID, arg.ClientSessionID)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const insertAIBridgeInterception = `-- name: InsertAIBridgeInterception :one
 INSERT INTO aibridge_interceptions (
 	id, api_key_id, initiator_id, provider, provider_name, model, metadata, annotations, started_at, client, client_session_id, thread_parent_id, thread_root_id, credential_kind, credential_hint, agent_firewall_session_id, agent_firewall_sequence_number

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2964,7 +2964,10 @@ WITH usage AS (
 			WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
 			THEN ai.annotations -> 'capabilities'
 			ELSE '[]'::jsonb
-		END) AS capability_sets
+		END) AS capability_sets,
+		-- The whole annotation object per interception, so optional columns can
+		-- be projected from any annotation key without a query change.
+		JSONB_AGG(DISTINCT ai.annotations) AS annotation_sets
 	FROM aibridge_token_usages tu
 	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
 	JOIN users ON users.id = ai.initiator_id
@@ -3003,7 +3006,8 @@ SELECT
 		SELECT STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value)
 		FROM jsonb_array_elements(usage.capability_sets) AS capability_set(value),
 			jsonb_array_elements_text(capability_set.value) AS capability(value)
-	), '')::text AS capabilities
+	), '')::text AS capabilities,
+	usage.annotation_sets::jsonb AS annotation_sets
 FROM usage
 ORDER BY usage.user_id, usage.group_id, usage.provider, usage.provider_name, usage.model
 `
@@ -3015,21 +3019,22 @@ type ExportOrganizationAISpendParams struct {
 }
 
 type ExportOrganizationAISpendRow struct {
-	UserID           uuid.UUID     `db:"user_id" json:"user_id"`
-	Username         string        `db:"username" json:"username"`
-	GroupID          uuid.NullUUID `db:"group_id" json:"group_id"`
-	GroupName        string        `db:"group_name" json:"group_name"`
-	OrganizationID   uuid.UUID     `db:"organization_id" json:"organization_id"`
-	OrganizationName string        `db:"organization_name" json:"organization_name"`
-	Model            string        `db:"model" json:"model"`
-	Provider         string        `db:"provider" json:"provider"`
-	ProviderName     string        `db:"provider_name" json:"provider_name"`
-	InputTokens      int64         `db:"input_tokens" json:"input_tokens"`
-	OutputTokens     int64         `db:"output_tokens" json:"output_tokens"`
-	CacheReadTokens  int64         `db:"cache_read_tokens" json:"cache_read_tokens"`
-	CacheWriteTokens int64         `db:"cache_write_tokens" json:"cache_write_tokens"`
-	CostMicros       int64         `db:"cost_micros" json:"cost_micros"`
-	Capabilities     string        `db:"capabilities" json:"capabilities"`
+	UserID           uuid.UUID       `db:"user_id" json:"user_id"`
+	Username         string          `db:"username" json:"username"`
+	GroupID          uuid.NullUUID   `db:"group_id" json:"group_id"`
+	GroupName        string          `db:"group_name" json:"group_name"`
+	OrganizationID   uuid.UUID       `db:"organization_id" json:"organization_id"`
+	OrganizationName string          `db:"organization_name" json:"organization_name"`
+	Model            string          `db:"model" json:"model"`
+	Provider         string          `db:"provider" json:"provider"`
+	ProviderName     string          `db:"provider_name" json:"provider_name"`
+	InputTokens      int64           `db:"input_tokens" json:"input_tokens"`
+	OutputTokens     int64           `db:"output_tokens" json:"output_tokens"`
+	CacheReadTokens  int64           `db:"cache_read_tokens" json:"cache_read_tokens"`
+	CacheWriteTokens int64           `db:"cache_write_tokens" json:"cache_write_tokens"`
+	CostMicros       int64           `db:"cost_micros" json:"cost_micros"`
+	Capabilities     string          `db:"capabilities" json:"capabilities"`
+	AnnotationSets   json.RawMessage `db:"annotation_sets" json:"annotation_sets"`
 }
 
 // Returns per-user, per-group, per-model, per-provider aggregated AI spend for
@@ -3066,6 +3071,7 @@ func (q *sqlQuerier) ExportOrganizationAISpend(ctx context.Context, arg ExportOr
 			&i.CacheWriteTokens,
 			&i.CostMicros,
 			&i.Capabilities,
+			&i.AnnotationSets,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -88,6 +88,24 @@ ORDER BY
 	started_at DESC
 LIMIT 1;
 
+-- name: GetLatestAIBridgeInterceptionIDByInitiator :one
+-- Returns only the identifier, so a caller that may write annotations but not
+-- read interceptions can locate the row to write to. A null client_session_id
+-- matches any session.
+SELECT
+	id
+FROM
+	aibridge_interceptions
+WHERE
+	initiator_id = @initiator_id::uuid
+	AND (
+		sqlc.narg('client_session_id')::text IS NULL
+		OR client_session_id = sqlc.narg('client_session_id')::text
+	)
+ORDER BY
+	started_at DESC
+LIMIT 1;
+
 -- name: GetAIBridgeInterceptionLineageByToolCallID :one
 -- Look up the parent interception and the root of the thread by finding
 -- which interception recorded a tool usage with the given tool call ID.

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -28,17 +28,11 @@ RETURNING *;
 -- name: UpdateAIBridgeInterceptionAnnotations :one
 -- Merges client-supplied work context into the annotations object. The keys
 -- are built explicitly so no other annotation key can be written through
--- this query, and jsonb_strip_nulls drops the arguments left NULL so they
--- keep whatever value the row already holds. Linear issues and pull request
--- URLs accumulate as sorted sets: the supplied values are unioned with the
--- ones already stored, discarding a non-array value left by an older
--- annotation shape.
+-- this query. Every key accumulates as a sorted set: the supplied values are
+-- unioned with the ones already stored, discarding a non-array value left by
+-- an older annotation shape. A NULL argument leaves its key untouched.
 UPDATE aibridge_interceptions
 	SET annotations = annotations
-		|| jsonb_strip_nulls(jsonb_build_object(
-			'repo', sqlc.narg('repo')::text,
-			'branch', sqlc.narg('branch')::text
-		))
 		|| CASE
 			WHEN sqlc.narg('linear_issue_ids')::text[] IS NULL THEN '{}'::jsonb
 			ELSE jsonb_build_object('linear_issue_ids', (
@@ -70,6 +64,40 @@ UPDATE aibridge_interceptions
 					) AS pr
 					UNION
 					SELECT unnest(sqlc.narg('github_pr_urls')::text[]) AS pr
+				) merged
+			))
+		END
+		|| CASE
+			WHEN sqlc.narg('repos')::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('repos', (
+				SELECT COALESCE(jsonb_agg(DISTINCT repo ORDER BY repo), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'repos') = 'array'
+							THEN annotations -> 'repos'
+							ELSE '[]'::jsonb
+						END
+					) AS repo
+					UNION
+					SELECT unnest(sqlc.narg('repos')::text[]) AS repo
+				) merged
+			))
+		END
+		|| CASE
+			WHEN sqlc.narg('branches')::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('branches', (
+				SELECT COALESCE(jsonb_agg(DISTINCT branch ORDER BY branch), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'branches') = 'array'
+							THEN annotations -> 'branches'
+							ELSE '[]'::jsonb
+						END
+					) AS branch
+					UNION
+					SELECT unnest(sqlc.narg('branches')::text[]) AS branch
 				) merged
 			))
 		END
@@ -566,8 +594,8 @@ SELECT
 	COALESCE(sr.firewall_active, false) AS firewall_active,
 	COALESCE(sli.linear_issue_ids, ARRAY[]::text[])::text[] AS linear_issue_ids,
 	COALESCE(sli.github_pr_urls, ARRAY[]::text[])::text[] AS github_pr_urls,
-	COALESCE(sr.repos, ARRAY[]::text[])::text[] AS repos,
-	COALESCE(sr.branches, ARRAY[]::text[])::text[] AS branches
+	COALESCE(sli.repos, ARRAY[]::text[])::text[] AS repos,
+	COALESCE(sli.branches, ARRAY[]::text[])::text[] AS branches
 FROM
 	session_page sp
 JOIN
@@ -579,13 +607,7 @@ LEFT JOIN LATERAL (
 		ARRAY_AGG(DISTINCT ai.provider ORDER BY ai.provider) AS providers,
 		ARRAY_AGG(DISTINCT ai.model ORDER BY ai.model) AS models,
 		ARRAY_AGG(ai.id) AS interception_ids,
-		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active,
-		-- Client-supplied annotations, absent on interceptions that were
-		-- never annotated.
-		ARRAY_AGG(DISTINCT ai.annotations ->> 'repo' ORDER BY ai.annotations ->> 'repo')
-			FILTER (WHERE ai.annotations ->> 'repo' IS NOT NULL) AS repos,
-		ARRAY_AGG(DISTINCT ai.annotations ->> 'branch' ORDER BY ai.annotations ->> 'branch')
-			FILTER (WHERE ai.annotations ->> 'branch' IS NOT NULL) AS branches
+		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active
 	FROM aibridge_interceptions ai
 	WHERE ai.session_id = sp.session_id
 		AND ai.initiator_id = sp.initiator_id
@@ -662,7 +684,21 @@ LEFT JOIN LATERAL (
 			CROSS JOIN LATERAL jsonb_array_elements_text(pi.annotations -> 'github_pr_urls') AS pr
 			WHERE pi.id = ANY(sr.interception_ids)
 				AND jsonb_typeof(pi.annotations -> 'github_pr_urls') = 'array'
-		) AS github_pr_urls
+		) AS github_pr_urls,
+		(
+			SELECT ARRAY_AGG(DISTINCT repo ORDER BY repo)
+			FROM aibridge_interceptions ri
+			CROSS JOIN LATERAL jsonb_array_elements_text(ri.annotations -> 'repos') AS repo
+			WHERE ri.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(ri.annotations -> 'repos') = 'array'
+		) AS repos,
+		(
+			SELECT ARRAY_AGG(DISTINCT branch ORDER BY branch)
+			FROM aibridge_interceptions bi
+			CROSS JOIN LATERAL jsonb_array_elements_text(bi.annotations -> 'branches') AS branch
+			WHERE bi.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(bi.annotations -> 'branches') = 'array'
+		) AS branches
 ) sli ON true
 ORDER BY
 	sp.last_active_at DESC,

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -545,7 +545,11 @@ SELECT
 	sp.last_active_at AS last_active_at,
 	COALESCE(bnc.total, 0)::bigint AS network_calls_total,
 	COALESCE(bnc.blocked, 0)::bigint AS network_calls_blocked,
-	COALESCE(sr.firewall_active, false) AS firewall_active
+	COALESCE(sr.firewall_active, false) AS firewall_active,
+	COALESCE(sli.linear_issue_ids, ARRAY[]::text[])::text[] AS linear_issue_ids,
+	COALESCE(sli.github_pr_urls, ARRAY[]::text[])::text[] AS github_pr_urls,
+	COALESCE(sr.repos, ARRAY[]::text[])::text[] AS repos,
+	COALESCE(sr.branches, ARRAY[]::text[])::text[] AS branches
 FROM
 	session_page sp
 JOIN
@@ -557,7 +561,13 @@ LEFT JOIN LATERAL (
 		ARRAY_AGG(DISTINCT ai.provider ORDER BY ai.provider) AS providers,
 		ARRAY_AGG(DISTINCT ai.model ORDER BY ai.model) AS models,
 		ARRAY_AGG(ai.id) AS interception_ids,
-		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active
+		BOOL_OR(ai.agent_firewall_session_id IS NOT NULL) AS firewall_active,
+		-- Client-supplied annotations, absent on interceptions that were
+		-- never annotated.
+		ARRAY_AGG(DISTINCT ai.annotations ->> 'repo' ORDER BY ai.annotations ->> 'repo')
+			FILTER (WHERE ai.annotations ->> 'repo' IS NOT NULL) AS repos,
+		ARRAY_AGG(DISTINCT ai.annotations ->> 'branch' ORDER BY ai.annotations ->> 'branch')
+			FILTER (WHERE ai.annotations ->> 'branch' IS NOT NULL) AS branches
 	FROM aibridge_interceptions ai
 	WHERE ai.session_id = sp.session_id
 		AND ai.initiator_id = sp.initiator_id
@@ -616,6 +626,26 @@ LEFT JOIN LATERAL (
 		AND afi.agent_firewall_session_id IS NOT NULL
 		AND afi.agent_firewall_sequence_number IS NOT NULL
 ) bnc ON true
+LEFT JOIN LATERAL (
+	-- Flatten the per-interception arrays into one sorted set each for the
+	-- session. Kept out of the sr aggregate because expanding a JSONB array
+	-- there would multiply the rows it aggregates over.
+	SELECT
+		(
+			SELECT ARRAY_AGG(DISTINCT issue ORDER BY issue)
+			FROM aibridge_interceptions li
+			CROSS JOIN LATERAL jsonb_array_elements_text(li.annotations -> 'linear_issue_ids') AS issue
+			WHERE li.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(li.annotations -> 'linear_issue_ids') = 'array'
+		) AS linear_issue_ids,
+		(
+			SELECT ARRAY_AGG(DISTINCT pr ORDER BY pr)
+			FROM aibridge_interceptions pi
+			CROSS JOIN LATERAL jsonb_array_elements_text(pi.annotations -> 'github_pr_urls') AS pr
+			WHERE pi.id = ANY(sr.interception_ids)
+				AND jsonb_typeof(pi.annotations -> 'github_pr_urls') = 'array'
+		) AS github_pr_urls
+) sli ON true
 ORDER BY
 	sp.last_active_at DESC,
 	sp.session_id DESC

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -25,6 +25,32 @@ WHERE
 	AND ended_at IS NULL
 RETURNING *;
 
+-- name: UpdateAIBridgeInterceptionAnnotations :one
+-- Merges client-supplied work context into the annotations object. The keys
+-- are built explicitly so no other annotation key can be written through
+-- this query, and jsonb_strip_nulls drops the arguments left NULL so they
+-- keep whatever value the row already holds.
+UPDATE aibridge_interceptions
+	SET annotations = annotations || jsonb_strip_nulls(jsonb_build_object(
+		'linear_issue_id', sqlc.narg('linear_issue_id')::text,
+		'repo', sqlc.narg('repo')::text,
+		'branch', sqlc.narg('branch')::text
+	))
+WHERE
+	id = @id::uuid
+RETURNING *;
+
+-- name: GetLatestAIBridgeInterceptionByInitiator :one
+SELECT
+	*
+FROM
+	aibridge_interceptions
+WHERE
+	initiator_id = @initiator_id::uuid
+ORDER BY
+	started_at DESC
+LIMIT 1;
+
 -- name: GetAIBridgeInterceptionLineageByToolCallID :one
 -- Look up the parent interception and the root of the thread by finding
 -- which interception recorded a tool usage with the given tool call ID.

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -29,13 +29,50 @@ RETURNING *;
 -- Merges client-supplied work context into the annotations object. The keys
 -- are built explicitly so no other annotation key can be written through
 -- this query, and jsonb_strip_nulls drops the arguments left NULL so they
--- keep whatever value the row already holds.
+-- keep whatever value the row already holds. Linear issues and pull request
+-- URLs accumulate as sorted sets: the supplied values are unioned with the
+-- ones already stored, discarding a non-array value left by an older
+-- annotation shape.
 UPDATE aibridge_interceptions
-	SET annotations = annotations || jsonb_strip_nulls(jsonb_build_object(
-		'linear_issue_id', sqlc.narg('linear_issue_id')::text,
-		'repo', sqlc.narg('repo')::text,
-		'branch', sqlc.narg('branch')::text
-	))
+	SET annotations = annotations
+		|| jsonb_strip_nulls(jsonb_build_object(
+			'repo', sqlc.narg('repo')::text,
+			'branch', sqlc.narg('branch')::text
+		))
+		|| CASE
+			WHEN sqlc.narg('linear_issue_ids')::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('linear_issue_ids', (
+				SELECT COALESCE(jsonb_agg(DISTINCT issue ORDER BY issue), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'linear_issue_ids') = 'array'
+							THEN annotations -> 'linear_issue_ids'
+							ELSE '[]'::jsonb
+						END
+					) AS issue
+					UNION
+					SELECT unnest(sqlc.narg('linear_issue_ids')::text[]) AS issue
+				) merged
+			))
+		END
+		|| CASE
+			WHEN sqlc.narg('github_pr_urls')::text[] IS NULL THEN '{}'::jsonb
+			ELSE jsonb_build_object('github_pr_urls', (
+				SELECT COALESCE(jsonb_agg(DISTINCT pr ORDER BY pr), '[]'::jsonb)
+				FROM (
+					SELECT jsonb_array_elements_text(
+						CASE
+							WHEN jsonb_typeof(annotations -> 'github_pr_urls') = 'array'
+							THEN annotations -> 'github_pr_urls'
+							ELSE '[]'::jsonb
+						END
+					) AS pr
+					UNION
+					SELECT unnest(sqlc.narg('github_pr_urls')::text[]) AS pr
+				) merged
+			))
+		END
 WHERE
 	id = @id::uuid
 RETURNING *;

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -446,7 +446,10 @@ WITH usage AS (
 			WHEN jsonb_typeof(ai.annotations -> 'capabilities') = 'array'
 			THEN ai.annotations -> 'capabilities'
 			ELSE '[]'::jsonb
-		END) AS capability_sets
+		END) AS capability_sets,
+		-- The whole annotation object per interception, so optional columns can
+		-- be projected from any annotation key without a query change.
+		JSONB_AGG(DISTINCT ai.annotations) AS annotation_sets
 	FROM aibridge_token_usages tu
 	JOIN aibridge_interceptions ai ON ai.id = tu.interception_id
 	JOIN users ON users.id = ai.initiator_id
@@ -485,6 +488,7 @@ SELECT
 		SELECT STRING_AGG(DISTINCT capability.value, ';' ORDER BY capability.value)
 		FROM jsonb_array_elements(usage.capability_sets) AS capability_set(value),
 			jsonb_array_elements_text(capability_set.value) AS capability(value)
-	), '')::text AS capabilities
+	), '')::text AS capabilities,
+	usage.annotation_sets::jsonb AS annotation_sets
 FROM usage
 ORDER BY usage.user_id, usage.group_id, usage.provider, usage.provider_name, usage.model;

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -447,10 +447,10 @@ type AIBridgeInterceptionAnnotations struct {
 	// to. Each entry is a https://github.com/{owner}/{repo}/pull/{number} URL,
 	// validated before it is stored. Sorted ascending and free of duplicates.
 	GitHubPRURLs *[]string `json:"github_pr_urls,omitempty"`
-	// Repo names the repository the interception operated on.
-	Repo *string `json:"repo,omitempty"`
-	// Branch names the branch the interception operated on.
-	Branch *string `json:"branch,omitempty"`
+	// Repos names the repositories the interception operated on.
+	Repos *[]string `json:"repos,omitempty"`
+	// Branches names the branches the interception operated on.
+	Branches *[]string `json:"branches,omitempty"`
 }
 
 // AIBridgeInterceptionCapabilities returns annotations recording the given

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -430,14 +430,23 @@ func (a UserLinkClaims) Value() (driver.Value, error) {
 	return json.Marshal(a)
 }
 
-// AIBridgeInterceptionAnnotations holds server-derived annotations recorded on
-// an AI Bridge interception.
+// AIBridgeInterceptionAnnotations holds annotations recorded on an AI Bridge
+// interception. Capabilities is derived by the server at insert time. The
+// remaining fields are asserted by the client after the fact and are only
+// written through UpdateAIBridgeInterceptionAnnotations.
 type AIBridgeInterceptionAnnotations struct {
 	// Capabilities lists the capabilities the initiator held when the
 	// interception was recorded. A nil pointer omits the key and means
 	// capabilities were not resolved, which is distinct from a pointer to an
 	// empty slice meaning the initiator held none.
 	Capabilities *[]string `json:"capabilities,omitempty"`
+	// LinearIssueID identifies the Linear issue the interception contributed
+	// to, e.g. "ENG-1234".
+	LinearIssueID *string `json:"linear_issue_id,omitempty"`
+	// Repo names the repository the interception operated on.
+	Repo *string `json:"repo,omitempty"`
+	// Branch names the branch the interception operated on.
+	Branch *string `json:"branch,omitempty"`
 }
 
 // AIBridgeInterceptionCapabilities returns annotations recording the given

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -440,9 +440,13 @@ type AIBridgeInterceptionAnnotations struct {
 	// capabilities were not resolved, which is distinct from a pointer to an
 	// empty slice meaning the initiator held none.
 	Capabilities *[]string `json:"capabilities,omitempty"`
-	// LinearIssueID identifies the Linear issue the interception contributed
-	// to, e.g. "ENG-1234".
-	LinearIssueID *string `json:"linear_issue_id,omitempty"`
+	// LinearIssueIDs lists the Linear issues the interception contributed to,
+	// e.g. "ENG-1234". Sorted ascending and free of duplicates.
+	LinearIssueIDs *[]string `json:"linear_issue_ids,omitempty"`
+	// GitHubPRURLs lists the GitHub pull requests the interception contributed
+	// to. Each entry is a https://github.com/{owner}/{repo}/pull/{number} URL,
+	// validated before it is stored. Sorted ascending and free of duplicates.
+	GitHubPRURLs *[]string `json:"github_pr_urls,omitempty"`
 	// Repo names the repository the interception operated on.
 	Repo *string `json:"repo,omitempty"`
 	// Branch names the branch the interception operated on.

--- a/coderd/mcp/mcp.go
+++ b/coderd/mcp/mcp.go
@@ -35,13 +35,33 @@ type Server struct {
 	handler http.Handler
 }
 
+// ServerOption customizes a Server.
+type ServerOption func(*serverOptions)
+
+type serverOptions struct {
+	instructions string
+}
+
+// WithInstructions overrides the instruction text sent to clients during
+// initialization.
+func WithInstructions(instructions string) ServerOption {
+	return func(o *serverOptions) {
+		o.instructions = instructions
+	}
+}
+
 // NewServer creates a new MCP HTTP server
-func NewServer(logger slog.Logger) (*Server, error) {
+func NewServer(logger slog.Logger, opts ...ServerOption) (*Server, error) {
+	options := serverOptions{instructions: MCPServerInstructions}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	mcpSrv := mcp.NewServer(&mcp.Implementation{
 		Name:    MCPServerName,
 		Version: buildinfo.Version(),
 	}, &mcp.ServerOptions{
-		Instructions: MCPServerInstructions,
+		Instructions: options.instructions,
 		Logger:       stdslog.New(&slogHandler{logger: logger}),
 	})
 
@@ -72,6 +92,11 @@ func NewServer(logger slog.Logger) (*Server, error) {
 // ServeHTTP implements http.Handler interface
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.handler.ServeHTTP(w, r)
+}
+
+// AddTool registers a tool that is not backed by a [toolsdk.GenericTool].
+func (s *Server) AddTool(tool *mcp.Tool, handler mcp.ToolHandler) {
+	s.mcpServer.AddTool(tool, handler)
 }
 
 // Register all available MCP tools with the server excluding:

--- a/coderd/mcp/mcp_e2e_test.go
+++ b/coderd/mcp/mcp_e2e_test.go
@@ -1454,8 +1454,8 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 			Arguments: map[string]any{
 				"linear_issue_ids": []string{" ENG-1234 "},
 				"github_pr_urls":   []string{"https://github.com/coder/coder/pull/28300"},
-				"repo":             "coder/coder",
-				"branch":           "main",
+				"repos":            []string{"coder/coder"},
+				"branches":         []string{"main"},
 			},
 		})
 		require.NoError(t, err)
@@ -1479,7 +1479,7 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 			Arguments: map[string]any{
 				"linear_issue_ids": []string{"PLAT-988"},
 				"github_pr_urls":   []string{"https://github.com/coder/coder/pull/28299"},
-				"branch":           "scott/feature",
+				"branches":         []string{"scott/feature"},
 			},
 		})
 		require.NoError(t, err)
@@ -1494,8 +1494,8 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 			"https://github.com/coder/coder/pull/28299",
 			"https://github.com/coder/coder/pull/28300",
 		}, *got.Annotations.GitHubPRURLs)
-		require.Equal(t, "coder/coder", *got.Annotations.Repo)
-		require.Equal(t, "scott/feature", *got.Annotations.Branch)
+		require.Equal(t, []string{"coder/coder"}, *got.Annotations.Repos)
+		require.Equal(t, []string{"main", "scott/feature"}, *got.Annotations.Branches)
 		// The update merges, so the server-derived key survives.
 		require.NotNil(t, got.Annotations.Capabilities)
 		require.Equal(t, []string{"workspace"}, *got.Annotations.Capabilities)
@@ -1539,7 +1539,7 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 
 		result, err := session.CallTool(ctx, &mcp.CallToolParams{
 			Name:      agplcoderd.MCPToolNameAnnotateInterception,
-			Arguments: map[string]any{"repo": "coder/coder"},
+			Arguments: map[string]any{"repos": []string{"coder/coder"}},
 		})
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -1579,7 +1579,7 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 			Name: agplcoderd.MCPToolNameAnnotateInterception,
 			Arguments: map[string]any{
 				"session_id": " claude-session-a ",
-				"repo":       "coder/coder",
+				"repos":      []string{"coder/coder"},
 			},
 		})
 		require.NoError(t, err)
@@ -1597,11 +1597,11 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 		systemCtx := dbauthz.AsSystemRestricted(ctx)
 		got, err := api.Database.GetAIBridgeInterceptionByID(systemCtx, targeted.ID)
 		require.NoError(t, err)
-		require.Equal(t, "coder/coder", *got.Annotations.Repo)
+		require.Equal(t, []string{"coder/coder"}, *got.Annotations.Repos)
 
 		untouched, err := api.Database.GetAIBridgeInterceptionByID(systemCtx, newest.ID)
 		require.NoError(t, err)
-		require.Nil(t, untouched.Annotations.Repo)
+		require.Nil(t, untouched.Annotations.Repos)
 	})
 
 	t.Run("UnknownSession", func(t *testing.T) {
@@ -1620,7 +1620,7 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 			Name: agplcoderd.MCPToolNameAnnotateInterception,
 			Arguments: map[string]any{
 				"session_id": "no-such-session",
-				"repo":       "coder/coder",
+				"repos":      []string{"coder/coder"},
 			},
 		})
 		require.NoError(t, err)

--- a/coderd/mcp/mcp_e2e_test.go
+++ b/coderd/mcp/mcp_e2e_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -30,6 +32,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	mcpserver "github.com/coder/coder/v2/coderd/mcp"
 	"github.com/coder/coder/v2/coderd/oauth2provider/oauth2providertest"
 	"github.com/coder/coder/v2/coderd/rbac"
@@ -1543,6 +1546,88 @@ func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
 		text, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok, "expected TextContent, got %T", result.Content[0])
 		require.Contains(t, text.Text, "no AI Gateway interception to annotate")
+	})
+
+	t.Run("TargetsTheSuppliedSession", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// A plain member can annotate but cannot read interceptions, which
+		// is the case the identifier lookup has to work under.
+		sessionUser, sessionMember := coderdtest.CreateAnotherUser(t, coderClient, firstUser.OrganizationID)
+		started := dbtime.Now()
+		targeted := dbgen.AIBridgeInterception(t, api.Database, database.InsertAIBridgeInterceptionParams{
+			InitiatorID:     sessionMember.ID,
+			ClientSessionID: sql.NullString{String: "claude-session-a", Valid: true},
+			StartedAt:       started.Add(-time.Hour),
+		}, nil)
+		newest := dbgen.AIBridgeInterception(t, api.Database, database.InsertAIBridgeInterceptionParams{
+			InitiatorID:     sessionMember.ID,
+			ClientSessionID: sql.NullString{String: "claude-session-b", Valid: true},
+			StartedAt:       started,
+		}, nil)
+
+		session, err := newIsolatedMCPClient(ctx, annotationsURL, "test-client-annotations-session", map[string]string{
+			"Authorization": "Bearer " + sessionUser.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: agplcoderd.MCPToolNameAnnotateInterception,
+			Arguments: map[string]any{
+				"session_id": " claude-session-a ",
+				"repo":       "coder/coder",
+			},
+		})
+		require.NoError(t, err)
+		text, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+		require.False(t, result.IsError, text.Text)
+
+		var payload struct {
+			InterceptionID string `json:"interception_id"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text.Text), &payload))
+		require.Equal(t, targeted.ID.String(), payload.InterceptionID)
+
+		//nolint:gocritic // The test asserts on stored annotations.
+		systemCtx := dbauthz.AsSystemRestricted(ctx)
+		got, err := api.Database.GetAIBridgeInterceptionByID(systemCtx, targeted.ID)
+		require.NoError(t, err)
+		require.Equal(t, "coder/coder", *got.Annotations.Repo)
+
+		untouched, err := api.Database.GetAIBridgeInterceptionByID(systemCtx, newest.ID)
+		require.NoError(t, err)
+		require.Nil(t, untouched.Annotations.Repo)
+	})
+
+	t.Run("UnknownSession", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		session, err := newIsolatedMCPClient(ctx, annotationsURL, "test-client-annotations-unknown-session", map[string]string{
+			"Authorization": "Bearer " + coderClient.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: agplcoderd.MCPToolNameAnnotateInterception,
+			Arguments: map[string]any{
+				"session_id": "no-such-session",
+				"repo":       "coder/coder",
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		text, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+		require.Contains(t, text.Text, `no AI Gateway interception for session "no-such-session"`)
 	})
 
 	t.Run("UnknownToolset", func(t *testing.T) {

--- a/coderd/mcp/mcp_e2e_test.go
+++ b/coderd/mcp/mcp_e2e_test.go
@@ -24,9 +24,12 @@ import (
 
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/agent/agenttest"
+	agplcoderd "github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	mcpserver "github.com/coder/coder/v2/coderd/mcp"
 	"github.com/coder/coder/v2/coderd/oauth2provider/oauth2providertest"
 	"github.com/coder/coder/v2/coderd/rbac"
@@ -1368,5 +1371,187 @@ func TestMCPHTTP_E2E_TransportIsolation(t *testing.T) {
 
 		require.Equal(t, int64(0), sentinel.hits.Load(),
 			"isolated client must NOT route requests through http.DefaultTransport")
+	})
+}
+
+func TestMCPHTTP_E2E_AnnotationsToolset(t *testing.T) {
+	t.Parallel()
+
+	coderClient, closer, api := coderdtest.NewWithAPI(t, nil)
+	t.Cleanup(func() {
+		_ = closer.Close()
+	})
+
+	firstUser := coderdtest.CreateFirstUser(t, coderClient)
+	interception := dbgen.AIBridgeInterception(t, api.Database, database.InsertAIBridgeInterceptionParams{
+		InitiatorID: firstUser.UserID,
+		Annotations: database.AIBridgeInterceptionCapabilities([]string{"workspace"}),
+	}, nil)
+
+	annotationsURL := api.AccessURL.String() + mcpserver.MCPEndpoint + "?toolset=annotations"
+
+	t.Run("OnlyExposesTheAnnotationTool", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		session, err := newIsolatedMCPClient(ctx, annotationsURL, "test-client-annotations-list", map[string]string{
+			"Authorization": "Bearer " + coderClient.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		require.Contains(t, session.InitializeResult().Instructions, agplcoderd.MCPToolNameAnnotateInterception)
+
+		tools, err := session.ListTools(ctx, nil)
+		require.NoError(t, err)
+		require.Len(t, tools.Tools, 1)
+		require.Equal(t, agplcoderd.MCPToolNameAnnotateInterception, tools.Tools[0].Name)
+	})
+
+	t.Run("StandardToolsetAlsoExposesIt", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		session, err := newIsolatedMCPClient(ctx, api.AccessURL.String()+mcpserver.MCPEndpoint, "test-client-annotations-standard", map[string]string{
+			"Authorization": "Bearer " + coderClient.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		require.Equal(t, mcpserver.MCPServerInstructions, session.InitializeResult().Instructions)
+
+		tools, err := session.ListTools(ctx, nil)
+		require.NoError(t, err)
+		names := make([]string, 0, len(tools.Tools))
+		for _, tool := range tools.Tools {
+			names = append(names, tool.Name)
+		}
+		require.Contains(t, names, agplcoderd.MCPToolNameAnnotateInterception)
+		require.Greater(t, len(names), 1)
+	})
+
+	t.Run("AnnotatesAndAccumulates", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		session, err := newIsolatedMCPClient(ctx, annotationsURL, "test-client-annotations-call", map[string]string{
+			"Authorization": "Bearer " + coderClient.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: agplcoderd.MCPToolNameAnnotateInterception,
+			Arguments: map[string]any{
+				"linear_issue_ids": []string{" ENG-1234 "},
+				"github_pr_urls":   []string{"https://github.com/coder/coder/pull/28300"},
+				"repo":             "coder/coder",
+				"branch":           "main",
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.Len(t, result.Content, 1)
+		text, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+		// Server-derived annotations stay out of the model's view.
+		require.NotContains(t, text.Text, "capabilities")
+
+		var payload struct {
+			Annotated      bool   `json:"annotated"`
+			InterceptionID string `json:"interception_id"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text.Text), &payload))
+		require.True(t, payload.Annotated)
+		require.Equal(t, interception.ID.String(), payload.InterceptionID)
+
+		result, err = session.CallTool(ctx, &mcp.CallToolParams{
+			Name: agplcoderd.MCPToolNameAnnotateInterception,
+			Arguments: map[string]any{
+				"linear_issue_ids": []string{"PLAT-988"},
+				"github_pr_urls":   []string{"https://github.com/coder/coder/pull/28299"},
+				"branch":           "scott/feature",
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		got, err := api.Database.GetAIBridgeInterceptionByID(dbauthz.AsSystemRestricted(ctx), interception.ID) //nolint:gocritic // The test asserts on stored annotations.
+		require.NoError(t, err)
+		require.NotNil(t, got.Annotations.LinearIssueIDs)
+		require.Equal(t, []string{"ENG-1234", "PLAT-988"}, *got.Annotations.LinearIssueIDs)
+		require.NotNil(t, got.Annotations.GitHubPRURLs)
+		require.Equal(t, []string{
+			"https://github.com/coder/coder/pull/28299",
+			"https://github.com/coder/coder/pull/28300",
+		}, *got.Annotations.GitHubPRURLs)
+		require.Equal(t, "coder/coder", *got.Annotations.Repo)
+		require.Equal(t, "scott/feature", *got.Annotations.Branch)
+		// The update merges, so the server-derived key survives.
+		require.NotNil(t, got.Annotations.Capabilities)
+		require.Equal(t, []string{"workspace"}, *got.Annotations.Capabilities)
+	})
+
+	t.Run("RejectsInvalidPullRequestURL", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		session, err := newIsolatedMCPClient(ctx, annotationsURL, "test-client-annotations-invalid", map[string]string{
+			"Authorization": "Bearer " + coderClient.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      agplcoderd.MCPToolNameAnnotateInterception,
+			Arguments: map[string]any{"github_pr_urls": []string{"javascript:alert(1)"}},
+		})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		text, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+		require.Contains(t, text.Text, "must look like https://github.com/")
+	})
+
+	t.Run("NoInterception", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		otherClient, _ := coderdtest.CreateAnotherUser(t, coderClient, firstUser.OrganizationID)
+		session, err := newIsolatedMCPClient(ctx, annotationsURL, "test-client-annotations-empty", map[string]string{
+			"Authorization": "Bearer " + otherClient.SessionToken(),
+		})
+		require.NoError(t, err)
+		defer func() {
+			_ = session.Close()
+		}()
+
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      agplcoderd.MCPToolNameAnnotateInterception,
+			Arguments: map[string]any{"repo": "coder/coder"},
+		})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		text, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+		require.Contains(t, text.Text, "no AI Gateway interception to annotate")
+	})
+
+	t.Run("UnknownToolset", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		res, err := coderClient.Request(ctx, http.MethodPost, mcpserver.MCPEndpoint+"?toolset=bogus", nil)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})
 }

--- a/coderd/mcp_annotations.go
+++ b/coderd/mcp_annotations.go
@@ -40,15 +40,15 @@ const mcpAnnotateInterceptionDescription = "Record the work context for the " +
 	"soon as you know the repository, branch, or Linear issues you are " +
 	"working on, and again whenever any of them change, including when you " +
 	"open a pull request. Supply only the fields you are confident about; " +
-	"omitted fields keep their previous value. Issues and pull requests " +
-	"accumulate, so passing a new one keeps the earlier ones. Pass session_id " +
+	"omitted fields keep their previous value. Every field accumulates, so " +
+	"passing a new value keeps the earlier ones. Pass session_id " +
 	"whenever the session context supplies one. Do not guess."
 
 type mcpAnnotateInterceptionArgs struct {
 	LinearIssueIDs []string `json:"linear_issue_ids"`
 	GitHubPRURLs   []string `json:"github_pr_urls"`
-	Repo           string   `json:"repo"`
-	Branch         string   `json:"branch"`
+	Repos          []string `json:"repos"`
+	Branches       []string `json:"branches"`
 	SessionID      string   `json:"session_id"`
 }
 
@@ -65,13 +65,15 @@ var mcpAnnotateInterceptionSchema = map[string]any{
 			"items":       map[string]any{"type": "string"},
 			"description": `GitHub pull request URLs the work produced, e.g. ["https://github.com/coder/coder/pull/1234"]. These are added to the pull requests already recorded rather than replacing them.`,
 		},
-		"repo": map[string]any{
-			"type":        "string",
-			"description": `Repository the work targets, e.g. "coder/coder".`,
+		"repos": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": `Repositories the work targets, e.g. ["coder/coder"]. These are added to the repositories already recorded rather than replacing them.`,
 		},
-		"branch": map[string]any{
-			"type":        "string",
-			"description": "Git branch the work targets.",
+		"branches": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Git branches the work targets. These are added to the branches already recorded rather than replacing them.",
 		},
 		"session_id": map[string]any{
 			"type":        "string",
@@ -117,8 +119,8 @@ func registerMCPAnnotationTool(srv *mcp.Server, db database.Store, initiatorID u
 		params, err := annotations.Params(annotations.Input{
 			LinearIssueIDs: args.LinearIssueIDs,
 			GitHubPRURLs:   args.GitHubPRURLs,
-			Repo:           args.Repo,
-			Branch:         args.Branch,
+			Repos:          args.Repos,
+			Branches:       args.Branches,
 		})
 		if err != nil {
 			return mcpToolError(err), nil

--- a/coderd/mcp_annotations.go
+++ b/coderd/mcp_annotations.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/google/uuid"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/aibridge/annotations"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/mcp"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 )
@@ -29,8 +31,9 @@ const MCPAnnotationsInstructions = "Coder AI Gateway work-context annotation. " 
 	"Linear issues, and GitHub pull requests the current work belongs to, so " +
 	"the recorded activity can be attributed later. Call it as soon as you " +
 	"know any of those values, and again whenever they change or you learn a " +
-	"new issue or pull request. Never ask the user for these values and never " +
-	"guess them."
+	"new issue or pull request. When the session context supplies an AI " +
+	"Gateway session ID, pass it as session_id on every call. Never ask the " +
+	"user for these values and never guess them."
 
 const mcpAnnotateInterceptionDescription = "Record the work context for the " +
 	"current AI Gateway activity so it can be attributed later. Call this as " +
@@ -38,13 +41,15 @@ const mcpAnnotateInterceptionDescription = "Record the work context for the " +
 	"working on, and again whenever any of them change, including when you " +
 	"open a pull request. Supply only the fields you are confident about; " +
 	"omitted fields keep their previous value. Issues and pull requests " +
-	"accumulate, so passing a new one keeps the earlier ones. Do not guess."
+	"accumulate, so passing a new one keeps the earlier ones. Pass session_id " +
+	"whenever the session context supplies one. Do not guess."
 
 type mcpAnnotateInterceptionArgs struct {
 	LinearIssueIDs []string `json:"linear_issue_ids"`
 	GitHubPRURLs   []string `json:"github_pr_urls"`
 	Repo           string   `json:"repo"`
 	Branch         string   `json:"branch"`
+	SessionID      string   `json:"session_id"`
 }
 
 var mcpAnnotateInterceptionSchema = map[string]any{
@@ -68,16 +73,21 @@ var mcpAnnotateInterceptionSchema = map[string]any{
 			"type":        "string",
 			"description": "Git branch the work targets.",
 		},
+		"session_id": map[string]any{
+			"type":        "string",
+			"description": "AI Gateway session identifier supplied by the session context. Pass it verbatim whenever it is available so the annotation lands on this session rather than the most recent activity. Omit it when the context does not supply one, and never guess it.",
+		},
 	},
 	"required": []string{},
 }
 
 // registerMCPAnnotationTool registers the annotation tool on srv. The tool
-// annotates the most recent interception initiated by initiatorID, which is the
-// interception carrying the model turn that decided to call it. Database calls
-// run with the actor installed on the request context by the API key
-// middleware, so the caller's own permissions authorize both the read and the
-// write.
+// annotates the interception matching the supplied session ID, or the most
+// recent interception initiated by initiatorID when no session ID is given.
+// Every lookup is scoped to initiatorID, so a session ID supplied by the model
+// can only reach that user's own interceptions. The write runs with the actor
+// installed on the request context by the API key middleware, so the caller's
+// own permissions authorize it.
 func registerMCPAnnotationTool(srv *mcp.Server, db database.Store, initiatorID uuid.UUID) error {
 	if db == nil {
 		return xerrors.New("database cannot be nil")
@@ -114,15 +124,33 @@ func registerMCPAnnotationTool(srv *mcp.Server, db database.Store, initiatorID u
 			return mcpToolError(err), nil
 		}
 
-		interception, err := db.GetLatestAIBridgeInterceptionByInitiator(ctx, initiatorID)
+		sessionID := strings.TrimSpace(args.SessionID)
+		lookup := database.GetLatestAIBridgeInterceptionIDByInitiatorParams{
+			InitiatorID: initiatorID,
+		}
+		if sessionID != "" {
+			lookup.ClientSessionID = sql.NullString{String: sessionID, Valid: true}
+		}
+
+		// The lookup runs as the system because a user may annotate an
+		// interception without being allowed to read interceptions. It
+		// returns an identifier only, filtered to initiatorID.
+		//nolint:gocritic // See above.
+		interceptionID, err := db.GetLatestAIBridgeInterceptionIDByInitiator(dbauthz.AsSystemRestricted(ctx), lookup)
 		if errors.Is(err, sql.ErrNoRows) {
+			if sessionID != "" {
+				// A supplied session ID that matches nothing is reported
+				// rather than widened to the latest interception, so a
+				// wrong ID cannot annotate unrelated activity.
+				return mcpToolError(xerrors.Errorf("no AI Gateway interception for session %q", sessionID)), nil
+			}
 			return mcpToolError(xerrors.New("no AI Gateway interception to annotate")), nil
 		}
 		if err != nil {
 			return mcpToolError(xerrors.Errorf("load latest interception: %w", err)), nil
 		}
 
-		params.ID = interception.ID
+		params.ID = interceptionID
 		updated, err := db.UpdateAIBridgeInterceptionAnnotations(ctx, params)
 		if err != nil {
 			return mcpToolError(xerrors.Errorf("annotate interception: %w", err)), nil

--- a/coderd/mcp_annotations.go
+++ b/coderd/mcp_annotations.go
@@ -1,0 +1,155 @@
+package coderd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/aibridge/annotations"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/mcp"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+)
+
+// MCPToolNameAnnotateInterception is the tool that records work context on an
+// AI Gateway interception.
+const MCPToolNameAnnotateInterception = "coder_annotate_interception"
+
+// MCPAnnotationsInstructions is the server instruction text used by the
+// annotations toolset. It is sent during initialization, so a client that
+// honors server instructions sees it before the first tool call.
+const MCPAnnotationsInstructions = "Coder AI Gateway work-context annotation. " +
+	"Every request you send through the Coder AI Gateway is recorded. Call " +
+	MCPToolNameAnnotateInterception + " to attach the repository, branch, " +
+	"Linear issues, and GitHub pull requests the current work belongs to, so " +
+	"the recorded activity can be attributed later. Call it as soon as you " +
+	"know any of those values, and again whenever they change or you learn a " +
+	"new issue or pull request. Never ask the user for these values and never " +
+	"guess them."
+
+const mcpAnnotateInterceptionDescription = "Record the work context for the " +
+	"current AI Gateway activity so it can be attributed later. Call this as " +
+	"soon as you know the repository, branch, or Linear issues you are " +
+	"working on, and again whenever any of them change, including when you " +
+	"open a pull request. Supply only the fields you are confident about; " +
+	"omitted fields keep their previous value. Issues and pull requests " +
+	"accumulate, so passing a new one keeps the earlier ones. Do not guess."
+
+type mcpAnnotateInterceptionArgs struct {
+	LinearIssueIDs []string `json:"linear_issue_ids"`
+	GitHubPRURLs   []string `json:"github_pr_urls"`
+	Repo           string   `json:"repo"`
+	Branch         string   `json:"branch"`
+}
+
+var mcpAnnotateInterceptionSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"linear_issue_ids": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": `Linear issue identifiers the work belongs to, e.g. ["ENG-1234"]. These are added to the issues already recorded rather than replacing them.`,
+		},
+		"github_pr_urls": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": `GitHub pull request URLs the work produced, e.g. ["https://github.com/coder/coder/pull/1234"]. These are added to the pull requests already recorded rather than replacing them.`,
+		},
+		"repo": map[string]any{
+			"type":        "string",
+			"description": `Repository the work targets, e.g. "coder/coder".`,
+		},
+		"branch": map[string]any{
+			"type":        "string",
+			"description": "Git branch the work targets.",
+		},
+	},
+	"required": []string{},
+}
+
+// registerMCPAnnotationTool registers the annotation tool on srv. The tool
+// annotates the most recent interception initiated by initiatorID, which is the
+// interception carrying the model turn that decided to call it. Database calls
+// run with the actor installed on the request context by the API key
+// middleware, so the caller's own permissions authorize both the read and the
+// write.
+func registerMCPAnnotationTool(srv *mcp.Server, db database.Store, initiatorID uuid.UUID) error {
+	if db == nil {
+		return xerrors.New("database cannot be nil")
+	}
+	if initiatorID == uuid.Nil {
+		return xerrors.New("initiator ID cannot be nil")
+	}
+
+	srv.AddTool(&sdkmcp.Tool{
+		Name:        MCPToolNameAnnotateInterception,
+		Description: mcpAnnotateInterceptionDescription,
+		InputSchema: mcpAnnotateInterceptionSchema,
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint:    false,
+			DestructiveHint: ptr.Ref(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   ptr.Ref(false),
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args mcpAnnotateInterceptionArgs
+		if len(req.Params.Arguments) > 0 {
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return mcpToolError(xerrors.Errorf("decode arguments: %w", err)), nil
+			}
+		}
+
+		params, err := annotations.Params(annotations.Input{
+			LinearIssueIDs: args.LinearIssueIDs,
+			GitHubPRURLs:   args.GitHubPRURLs,
+			Repo:           args.Repo,
+			Branch:         args.Branch,
+		})
+		if err != nil {
+			return mcpToolError(err), nil
+		}
+
+		interception, err := db.GetLatestAIBridgeInterceptionByInitiator(ctx, initiatorID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return mcpToolError(xerrors.New("no AI Gateway interception to annotate")), nil
+		}
+		if err != nil {
+			return mcpToolError(xerrors.Errorf("load latest interception: %w", err)), nil
+		}
+
+		params.ID = interception.ID
+		updated, err := db.UpdateAIBridgeInterceptionAnnotations(ctx, params)
+		if err != nil {
+			return mcpToolError(xerrors.Errorf("annotate interception: %w", err)), nil
+		}
+
+		// The result omits the annotations read back from the row so
+		// server-derived keys such as capabilities stay out of the
+		// conversation.
+		result, err := json.Marshal(map[string]any{
+			"annotated":       true,
+			"interception_id": updated.ID.String(),
+		})
+		if err != nil {
+			return mcpToolError(xerrors.Errorf("encode result: %w", err)), nil
+		}
+		return &sdkmcp.CallToolResult{
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: string(result)}},
+		}, nil
+	})
+	return nil
+}
+
+// mcpToolError reports a failure the model can act on, rather than failing the
+// JSON-RPC call.
+func mcpToolError(err error) *sdkmcp.CallToolResult {
+	return &sdkmcp.CallToolResult{
+		IsError: true,
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: err.Error()}},
+	}
+}

--- a/coderd/mcp_http.go
+++ b/coderd/mcp_http.go
@@ -22,16 +22,35 @@ import (
 type MCPToolset string
 
 const (
-	MCPToolsetStandard MCPToolset = "standard"
-	MCPToolsetChatGPT  MCPToolset = "chatgpt"
+	MCPToolsetStandard    MCPToolset = "standard"
+	MCPToolsetChatGPT     MCPToolset = "chatgpt"
+	MCPToolsetAnnotations MCPToolset = "annotations"
 )
 
 // mcpHTTPHandler creates the MCP HTTP transport handler
 // It supports a "toolset" query parameter to select the set of tools to register.
 func (api *API) mcpHTTPHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		toolset := MCPToolset(r.URL.Query().Get("toolset"))
+		// Default to standard toolset if no toolset is specified.
+		if toolset == "" {
+			toolset = MCPToolsetStandard
+		}
+		if toolset != MCPToolsetStandard && toolset != MCPToolsetChatGPT &&
+			toolset != MCPToolsetAnnotations {
+			httpapi.Write(r.Context(), w, http.StatusBadRequest, codersdk.Response{
+				Message: fmt.Sprintf("Invalid toolset: %s", toolset),
+			})
+			return
+		}
+
+		var serverOpts []mcp.ServerOption
+		if toolset == MCPToolsetAnnotations {
+			serverOpts = append(serverOpts, mcp.WithInstructions(MCPAnnotationsInstructions))
+		}
+
 		// Create MCP server instance for each request
-		mcpServer, err := mcp.NewServer(api.Logger.Named("mcp"))
+		mcpServer, err := mcp.NewServer(api.Logger.Named("mcp"), serverOpts...)
 		if err != nil {
 			api.Logger.Error(r.Context(), "failed to create MCP server", slog.Error(err))
 			httpapi.Write(r.Context(), w, http.StatusInternalServerError, codersdk.Response{
@@ -69,27 +88,27 @@ func (api *API) mcpHTTPHandler() http.Handler {
 			return api.agentProvider.AgentConn(ctx, agentID)
 		})
 
-		toolset := MCPToolset(r.URL.Query().Get("toolset"))
-		// Default to standard toolset if no toolset is specified.
-		if toolset == "" {
-			toolset = MCPToolsetStandard
-		}
-
 		switch toolset {
 		case MCPToolsetStandard:
 			if err := mcpServer.RegisterTools(authenticatedClient, toolOpt); err != nil {
 				api.Logger.Warn(r.Context(), "failed to register MCP tools", slog.Error(err))
 			}
+			if err := registerMCPAnnotationTool(mcpServer, api.Database, httpmw.APIKey(r).UserID); err != nil {
+				api.Logger.Warn(r.Context(), "failed to register MCP annotation tool", slog.Error(err))
+			}
 			mcpServer.RegisterPrompts()
+		case MCPToolsetAnnotations:
+			if err := registerMCPAnnotationTool(mcpServer, api.Database, httpmw.APIKey(r).UserID); err != nil {
+				api.Logger.Error(r.Context(), "failed to register MCP annotation tool", slog.Error(err))
+				httpapi.Write(r.Context(), w, http.StatusInternalServerError, codersdk.Response{
+					Message: "MCP server initialization failed",
+				})
+				return
+			}
 		case MCPToolsetChatGPT:
 			if err := mcpServer.RegisterChatGPTTools(authenticatedClient, toolOpt); err != nil {
 				api.Logger.Warn(r.Context(), "failed to register MCP tools", slog.Error(err))
 			}
-		default:
-			httpapi.Write(r.Context(), w, http.StatusBadRequest, codersdk.Response{
-				Message: fmt.Sprintf("Invalid toolset: %s", toolset),
-			})
-			return
 		}
 
 		// Handle the MCP request

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3532,7 +3532,8 @@ func filterExternalMCPConfigsForTurn(
 
 func builtinPlanToolAllowed(name string, isRootChat bool) bool {
 	switch name {
-	case "read_file", "execute", "process_output", "read_skill", "read_skill_file":
+	case "read_file", "execute", "process_output", "read_skill", "read_skill_file",
+		"annotate_interception":
 		return true
 	case "write_file", "edit_files", "list_templates", "read_template",
 		"create_workspace", "start_workspace", "stop_workspace", "propose_plan", "spawn_agent",
@@ -3605,29 +3606,30 @@ func activeToolNamesForTurn(
 
 func allowedExploreToolNames(allTools []fantasy.AgentTool) []string {
 	builtinExplorePolicy := map[string]bool{
-		"read_file":            true,
-		"write_file":           false,
-		"edit_files":           false,
-		"execute":              true,
-		"process_output":       true,
-		"process_list":         false,
-		"process_signal":       false,
-		"list_templates":       false,
-		"read_template":        false,
-		"create_workspace":     false,
-		"start_workspace":      false,
-		"stop_workspace":       false,
-		"propose_plan":         false,
-		"spawn_agent":          false,
-		"wait_agent":           false,
-		"message_agent":        false,
-		"interrupt_agent":      false,
-		"close_agent":          false,
-		"list_agents":          false,
-		"list_subagent_models": false,
-		"read_skill":           true,
-		"read_skill_file":      true,
-		"ask_user_question":    false,
+		"read_file":             true,
+		"write_file":            false,
+		"edit_files":            false,
+		"execute":               true,
+		"process_output":        true,
+		"process_list":          false,
+		"process_signal":        false,
+		"list_templates":        false,
+		"read_template":         false,
+		"create_workspace":      false,
+		"start_workspace":       false,
+		"stop_workspace":        false,
+		"propose_plan":          false,
+		"spawn_agent":           false,
+		"wait_agent":            false,
+		"message_agent":         false,
+		"interrupt_agent":       false,
+		"close_agent":           false,
+		"list_agents":           false,
+		"list_subagent_models":  false,
+		"read_skill":            true,
+		"read_skill_file":       true,
+		"ask_user_question":     false,
+		"annotate_interception": true,
 	}
 
 	toolNames := make([]string, 0, len(allTools))

--- a/coderd/x/chatd/chattool/annotateinterception.go
+++ b/coderd/x/chatd/chattool/annotateinterception.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"regexp"
-	"strings"
 
 	"charm.land/fantasy"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/aibridge/annotations"
 	"github.com/coder/coder/v2/coderd/database"
 )
 
@@ -28,24 +27,6 @@ type annotateInterceptionArgs struct {
 	Branch         string   `json:"branch,omitempty" description:"Git branch the work targets."`
 }
 
-// maxAnnotationValueLength bounds each annotation value. The values are model
-// generated and are stored verbatim in a JSONB column that is also read back
-// into CSV exports.
-const maxAnnotationValueLength = 256
-
-// maxLinearIssueIDs bounds how many issues a single call may add. The stored
-// set can still grow across calls.
-const maxLinearIssueIDs = 16
-
-// maxGitHubPRURLs bounds how many pull request URLs a single call may add. The
-// stored set can still grow across calls.
-const maxGitHubPRURLs = 16
-
-// githubPRURLPattern matches the canonical GitHub pull request URL. The stored
-// value is rendered as a link target, so anything else, including other
-// schemes and hosts, is rejected before it reaches the database.
-var githubPRURLPattern = regexp.MustCompile(`^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+$`)
-
 // AnnotateInterception returns a tool that records work context on the AI
 // Bridge interception carrying the current model request. db must not be nil
 // and options.OwnerID must not be uuid.Nil.
@@ -61,15 +42,14 @@ func AnnotateInterception(db database.Store, options AnnotateInterceptionOptions
 			"Issues and pull requests accumulate, so pass a new one as soon "+
 			"as the work touches it and earlier ones are kept. Do not guess.",
 		func(ctx context.Context, args annotateInterceptionArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			params, err := annotationParams(args)
+			params, err := annotations.Params(annotations.Input{
+				LinearIssueIDs: args.LinearIssueIDs,
+				GitHubPRURLs:   args.GitHubPRURLs,
+				Repo:           args.Repo,
+				Branch:         args.Branch,
+			})
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
-			}
-			if len(params.LinearIssueIds) == 0 && len(params.GithubPrUrls) == 0 &&
-				!params.Repo.Valid && !params.Branch.Valid {
-				return fantasy.NewTextErrorResponse(
-					"provide at least one of linear_issue_ids, github_pr_urls, repo, or branch",
-				), nil
 			}
 
 			ownerCtx, err := asOwner(ctx, db, options.OwnerID)
@@ -106,83 +86,4 @@ func AnnotateInterception(db database.Store, options AnnotateInterceptionOptions
 			}), nil
 		},
 	)
-}
-
-// annotationParams trims the arguments and maps empty values to NULL, which
-// the update query treats as "leave unchanged".
-func annotationParams(args annotateInterceptionArgs) (database.UpdateAIBridgeInterceptionAnnotationsParams, error) {
-	var params database.UpdateAIBridgeInterceptionAnnotationsParams
-	for _, field := range []struct {
-		name  string
-		value string
-		dest  *sql.NullString
-	}{
-		{"repo", args.Repo, &params.Repo},
-		{"branch", args.Branch, &params.Branch},
-	} {
-		value, err := trimAnnotationValue(field.name, field.value)
-		if err != nil {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
-		}
-		if value == "" {
-			continue
-		}
-		*field.dest = sql.NullString{String: value, Valid: true}
-	}
-
-	if len(args.LinearIssueIDs) > maxLinearIssueIDs {
-		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-			"linear_issue_ids accepts at most %d issues per call", maxLinearIssueIDs,
-		)
-	}
-	var issues []string
-	for _, issue := range args.LinearIssueIDs {
-		value, err := trimAnnotationValue("linear_issue_ids", issue)
-		if err != nil {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
-		}
-		if value == "" {
-			continue
-		}
-		issues = append(issues, value)
-	}
-	if len(issues) > 0 {
-		params.LinearIssueIds = issues
-	}
-
-	if len(args.GitHubPRURLs) > maxGitHubPRURLs {
-		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-			"github_pr_urls accepts at most %d URLs per call", maxGitHubPRURLs,
-		)
-	}
-	var prs []string
-	for _, pr := range args.GitHubPRURLs {
-		value, err := trimAnnotationValue("github_pr_urls", pr)
-		if err != nil {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
-		}
-		if value == "" {
-			continue
-		}
-		if !githubPRURLPattern.MatchString(value) {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-				"github_pr_urls entry %q must look like https://github.com/{owner}/{repo}/pull/{number}", value,
-			)
-		}
-		prs = append(prs, value)
-	}
-	if len(prs) > 0 {
-		params.GithubPrUrls = prs
-	}
-	return params, nil
-}
-
-func trimAnnotationValue(name string, value string) (string, error) {
-	value = strings.TrimSpace(value)
-	if len(value) > maxAnnotationValueLength {
-		return "", xerrors.Errorf(
-			"%s must be %d characters or fewer", name, maxAnnotationValueLength,
-		)
-	}
-	return value, nil
 }

--- a/coderd/x/chatd/chattool/annotateinterception.go
+++ b/coderd/x/chatd/chattool/annotateinterception.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"regexp"
 	"strings"
 
 	"charm.land/fantasy"
@@ -21,15 +22,29 @@ type AnnotateInterceptionOptions struct {
 }
 
 type annotateInterceptionArgs struct {
-	LinearIssueID string `json:"linear_issue_id,omitempty" description:"Linear issue identifier the work belongs to, e.g. \"ENG-1234\"."`
-	Repo          string `json:"repo,omitempty" description:"Repository the work targets, e.g. \"coder/coder\"."`
-	Branch        string `json:"branch,omitempty" description:"Git branch the work targets."`
+	LinearIssueIDs []string `json:"linear_issue_ids,omitempty" description:"Linear issue identifiers the work belongs to, e.g. [\"ENG-1234\"]. These are added to the issues already recorded rather than replacing them."`
+	GitHubPRURLs   []string `json:"github_pr_urls,omitempty" description:"GitHub pull request URLs the work produced, e.g. [\"https://github.com/coder/coder/pull/1234\"]. These are added to the pull requests already recorded rather than replacing them."`
+	Repo           string   `json:"repo,omitempty" description:"Repository the work targets, e.g. \"coder/coder\"."`
+	Branch         string   `json:"branch,omitempty" description:"Git branch the work targets."`
 }
 
 // maxAnnotationValueLength bounds each annotation value. The values are model
 // generated and are stored verbatim in a JSONB column that is also read back
 // into CSV exports.
 const maxAnnotationValueLength = 256
+
+// maxLinearIssueIDs bounds how many issues a single call may add. The stored
+// set can still grow across calls.
+const maxLinearIssueIDs = 16
+
+// maxGitHubPRURLs bounds how many pull request URLs a single call may add. The
+// stored set can still grow across calls.
+const maxGitHubPRURLs = 16
+
+// githubPRURLPattern matches the canonical GitHub pull request URL. The stored
+// value is rendered as a link target, so anything else, including other
+// schemes and hosts, is rejected before it reaches the database.
+var githubPRURLPattern = regexp.MustCompile(`^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+$`)
 
 // AnnotateInterception returns a tool that records work context on the AI
 // Bridge interception carrying the current model request. db must not be nil
@@ -39,18 +54,21 @@ func AnnotateInterception(db database.Store, options AnnotateInterceptionOptions
 		"annotate_interception",
 		"Record the work context for the current model request so this "+
 			"activity can be attributed later. Call it as soon as you know "+
-			"the repository, branch, or Linear issue you are working on, and "+
-			"again whenever any of them change. Supply only the fields you "+
+			"the repository, branch, or Linear issues you are working on, and "+
+			"again whenever any of them change, including when you open a "+
+			"pull request. Supply only the fields you "+
 			"are confident about; omitted fields keep their previous value. "+
-			"Do not guess.",
+			"Issues and pull requests accumulate, so pass a new one as soon "+
+			"as the work touches it and earlier ones are kept. Do not guess.",
 		func(ctx context.Context, args annotateInterceptionArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			params, err := annotationParams(args)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			if !params.LinearIssueID.Valid && !params.Repo.Valid && !params.Branch.Valid {
+			if len(params.LinearIssueIds) == 0 && len(params.GithubPrUrls) == 0 &&
+				!params.Repo.Valid && !params.Branch.Valid {
 				return fantasy.NewTextErrorResponse(
-					"provide at least one of linear_issue_id, repo, or branch",
+					"provide at least one of linear_issue_ids, github_pr_urls, repo, or branch",
 				), nil
 			}
 
@@ -99,20 +117,72 @@ func annotationParams(args annotateInterceptionArgs) (database.UpdateAIBridgeInt
 		value string
 		dest  *sql.NullString
 	}{
-		{"linear_issue_id", args.LinearIssueID, &params.LinearIssueID},
 		{"repo", args.Repo, &params.Repo},
 		{"branch", args.Branch, &params.Branch},
 	} {
-		value := strings.TrimSpace(field.value)
+		value, err := trimAnnotationValue(field.name, field.value)
+		if err != nil {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
+		}
 		if value == "" {
 			continue
 		}
-		if len(value) > maxAnnotationValueLength {
-			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
-				"%s must be %d characters or fewer", field.name, maxAnnotationValueLength,
-			)
-		}
 		*field.dest = sql.NullString{String: value, Valid: true}
 	}
+
+	if len(args.LinearIssueIDs) > maxLinearIssueIDs {
+		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+			"linear_issue_ids accepts at most %d issues per call", maxLinearIssueIDs,
+		)
+	}
+	var issues []string
+	for _, issue := range args.LinearIssueIDs {
+		value, err := trimAnnotationValue("linear_issue_ids", issue)
+		if err != nil {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
+		}
+		if value == "" {
+			continue
+		}
+		issues = append(issues, value)
+	}
+	if len(issues) > 0 {
+		params.LinearIssueIds = issues
+	}
+
+	if len(args.GitHubPRURLs) > maxGitHubPRURLs {
+		return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+			"github_pr_urls accepts at most %d URLs per call", maxGitHubPRURLs,
+		)
+	}
+	var prs []string
+	for _, pr := range args.GitHubPRURLs {
+		value, err := trimAnnotationValue("github_pr_urls", pr)
+		if err != nil {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, err
+		}
+		if value == "" {
+			continue
+		}
+		if !githubPRURLPattern.MatchString(value) {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+				"github_pr_urls entry %q must look like https://github.com/{owner}/{repo}/pull/{number}", value,
+			)
+		}
+		prs = append(prs, value)
+	}
+	if len(prs) > 0 {
+		params.GithubPrUrls = prs
+	}
 	return params, nil
+}
+
+func trimAnnotationValue(name string, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) > maxAnnotationValueLength {
+		return "", xerrors.Errorf(
+			"%s must be %d characters or fewer", name, maxAnnotationValueLength,
+		)
+	}
+	return value, nil
 }

--- a/coderd/x/chatd/chattool/annotateinterception.go
+++ b/coderd/x/chatd/chattool/annotateinterception.go
@@ -1,0 +1,118 @@
+package chattool
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// AnnotateInterceptionOptions configures the annotate_interception tool.
+type AnnotateInterceptionOptions struct {
+	// OwnerID is the user whose AI Bridge interceptions are annotated. It is
+	// also the identity the database calls are authorized as.
+	OwnerID uuid.UUID
+}
+
+type annotateInterceptionArgs struct {
+	LinearIssueID string `json:"linear_issue_id,omitempty" description:"Linear issue identifier the work belongs to, e.g. \"ENG-1234\"."`
+	Repo          string `json:"repo,omitempty" description:"Repository the work targets, e.g. \"coder/coder\"."`
+	Branch        string `json:"branch,omitempty" description:"Git branch the work targets."`
+}
+
+// maxAnnotationValueLength bounds each annotation value. The values are model
+// generated and are stored verbatim in a JSONB column that is also read back
+// into CSV exports.
+const maxAnnotationValueLength = 256
+
+// AnnotateInterception returns a tool that records work context on the AI
+// Bridge interception carrying the current model request. db must not be nil
+// and options.OwnerID must not be uuid.Nil.
+func AnnotateInterception(db database.Store, options AnnotateInterceptionOptions) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		"annotate_interception",
+		"Record the work context for the current model request so this "+
+			"activity can be attributed later. Call it as soon as you know "+
+			"the repository, branch, or Linear issue you are working on, and "+
+			"again whenever any of them change. Supply only the fields you "+
+			"are confident about; omitted fields keep their previous value. "+
+			"Do not guess.",
+		func(ctx context.Context, args annotateInterceptionArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			params, err := annotationParams(args)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(err.Error()), nil
+			}
+			if !params.LinearIssueID.Valid && !params.Repo.Valid && !params.Branch.Valid {
+				return fantasy.NewTextErrorResponse(
+					"provide at least one of linear_issue_id, repo, or branch",
+				), nil
+			}
+
+			ownerCtx, err := asOwner(ctx, db, options.OwnerID)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(err.Error()), nil
+			}
+
+			interception, err := db.GetLatestAIBridgeInterceptionByInitiator(ownerCtx, options.OwnerID)
+			if errors.Is(err, sql.ErrNoRows) {
+				return fantasy.NewTextErrorResponse(
+					"no AI Bridge interception to annotate",
+				), nil
+			}
+			if err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("load latest interception: %w", err).Error(),
+				), nil
+			}
+
+			params.ID = interception.ID
+			updated, err := db.UpdateAIBridgeInterceptionAnnotations(ownerCtx, params)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("annotate interception: %w", err).Error(),
+				), nil
+			}
+
+			// The response omits the annotations read back from the row so
+			// server-derived keys such as capabilities stay out of the
+			// conversation.
+			return toolResponse(map[string]any{
+				"annotated":       true,
+				"interception_id": updated.ID.String(),
+			}), nil
+		},
+	)
+}
+
+// annotationParams trims the arguments and maps empty values to NULL, which
+// the update query treats as "leave unchanged".
+func annotationParams(args annotateInterceptionArgs) (database.UpdateAIBridgeInterceptionAnnotationsParams, error) {
+	var params database.UpdateAIBridgeInterceptionAnnotationsParams
+	for _, field := range []struct {
+		name  string
+		value string
+		dest  *sql.NullString
+	}{
+		{"linear_issue_id", args.LinearIssueID, &params.LinearIssueID},
+		{"repo", args.Repo, &params.Repo},
+		{"branch", args.Branch, &params.Branch},
+	} {
+		value := strings.TrimSpace(field.value)
+		if value == "" {
+			continue
+		}
+		if len(value) > maxAnnotationValueLength {
+			return database.UpdateAIBridgeInterceptionAnnotationsParams{}, xerrors.Errorf(
+				"%s must be %d characters or fewer", field.name, maxAnnotationValueLength,
+			)
+		}
+		*field.dest = sql.NullString{String: value, Valid: true}
+	}
+	return params, nil
+}

--- a/coderd/x/chatd/chattool/annotateinterception.go
+++ b/coderd/x/chatd/chattool/annotateinterception.go
@@ -23,8 +23,8 @@ type AnnotateInterceptionOptions struct {
 type annotateInterceptionArgs struct {
 	LinearIssueIDs []string `json:"linear_issue_ids,omitempty" description:"Linear issue identifiers the work belongs to, e.g. [\"ENG-1234\"]. These are added to the issues already recorded rather than replacing them."`
 	GitHubPRURLs   []string `json:"github_pr_urls,omitempty" description:"GitHub pull request URLs the work produced, e.g. [\"https://github.com/coder/coder/pull/1234\"]. These are added to the pull requests already recorded rather than replacing them."`
-	Repo           string   `json:"repo,omitempty" description:"Repository the work targets, e.g. \"coder/coder\"."`
-	Branch         string   `json:"branch,omitempty" description:"Git branch the work targets."`
+	Repos          []string `json:"repos,omitempty" description:"Repositories the work targets, e.g. [\"coder/coder\"]. These are added to the repositories already recorded rather than replacing them."`
+	Branches       []string `json:"branches,omitempty" description:"Git branches the work targets. These are added to the branches already recorded rather than replacing them."`
 }
 
 // AnnotateInterception returns a tool that records work context on the AI
@@ -39,14 +39,14 @@ func AnnotateInterception(db database.Store, options AnnotateInterceptionOptions
 			"again whenever any of them change, including when you open a "+
 			"pull request. Supply only the fields you "+
 			"are confident about; omitted fields keep their previous value. "+
-			"Issues and pull requests accumulate, so pass a new one as soon "+
+			"Every field accumulates, so pass a new value as soon "+
 			"as the work touches it and earlier ones are kept. Do not guess.",
 		func(ctx context.Context, args annotateInterceptionArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			params, err := annotations.Params(annotations.Input{
 				LinearIssueIDs: args.LinearIssueIDs,
 				GitHubPRURLs:   args.GitHubPRURLs,
-				Repo:           args.Repo,
-				Branch:         args.Branch,
+				Repos:          args.Repos,
+				Branches:       args.Branches,
 			})
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil

--- a/coderd/x/chatd/chattool/annotateinterception_test.go
+++ b/coderd/x/chatd/chattool/annotateinterception_test.go
@@ -43,7 +43,7 @@ func TestAnnotateInterception(t *testing.T) {
 		}, nil)
 
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
-		resp, err := tool.Run(ctx, call(`{"linear_issue_id":" ENG-1234 ","repo":"coder/coder","branch":"main"}`))
+		resp, err := tool.Run(ctx, call(`{"linear_issue_ids":[" ENG-1234 "],"repo":"coder/coder","branch":"main"}`))
 		require.NoError(t, err)
 
 		var result struct {
@@ -58,8 +58,8 @@ func TestAnnotateInterception(t *testing.T) {
 
 		got, err := db.GetAIBridgeInterceptionByID(ctx, latest.ID)
 		require.NoError(t, err)
-		require.NotNil(t, got.Annotations.LinearIssueID)
-		require.Equal(t, "ENG-1234", *got.Annotations.LinearIssueID)
+		require.NotNil(t, got.Annotations.LinearIssueIDs)
+		require.Equal(t, []string{"ENG-1234"}, *got.Annotations.LinearIssueIDs)
 		require.Equal(t, "coder/coder", *got.Annotations.Repo)
 		require.Equal(t, "main", *got.Annotations.Branch)
 		// The update merges, so the server-derived key survives.
@@ -91,7 +91,85 @@ func TestAnnotateInterception(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "coder/coder", *got.Annotations.Repo)
 		require.Equal(t, "scott/feature", *got.Annotations.Branch)
-		require.Nil(t, got.Annotations.LinearIssueID)
+		require.Nil(t, got.Annotations.LinearIssueIDs)
+	})
+
+	t.Run("IssuesAccumulate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID,
+		}, nil)
+
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+		_, err := tool.Run(ctx, call(`{"linear_issue_ids":["PLAT-999"]}`))
+		require.NoError(t, err)
+		_, err = tool.Run(ctx, call(`{"linear_issue_ids":["PLAT-988","PLAT-999"]}`))
+		require.NoError(t, err)
+
+		got, err := db.GetAIBridgeInterceptionByID(ctx, interception.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.Annotations.LinearIssueIDs)
+		require.Equal(t, []string{"PLAT-988", "PLAT-999"}, *got.Annotations.LinearIssueIDs)
+	})
+
+	t.Run("PullRequestsAccumulate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID,
+		}, nil)
+
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+		_, err := tool.Run(ctx, call(`{"github_pr_urls":["https://github.com/coder/coder/pull/28300"]}`))
+		require.NoError(t, err)
+		_, err = tool.Run(ctx, call(`{"github_pr_urls":["https://github.com/coder/coder/pull/28299"]}`))
+		require.NoError(t, err)
+
+		got, err := db.GetAIBridgeInterceptionByID(ctx, interception.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.Annotations.GitHubPRURLs)
+		require.Equal(t, []string{
+			"https://github.com/coder/coder/pull/28299",
+			"https://github.com/coder/coder/pull/28300",
+		}, *got.Annotations.GitHubPRURLs)
+	})
+
+	t.Run("RejectsNonPullRequestURLs", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID,
+		}, nil)
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+
+		for _, url := range []string{
+			"javascript:alert(1)",
+			"http://github.com/coder/coder/pull/1",
+			"https://github.example.com/coder/coder/pull/1",
+			"https://github.com/coder/coder/issues/1",
+			"https://github.com/coder/coder/pull/1?x=y",
+		} {
+			input, err := json.Marshal(map[string][]string{"github_pr_urls": {url}})
+			require.NoError(t, err)
+			resp, err := tool.Run(ctx, call(string(input)))
+			require.NoError(t, err)
+			require.Contains(t, resp.Content, "must look like https://github.com/", "url %q", url)
+		}
+
+		// A rejected call writes nothing.
+		got, err := db.GetAIBridgeInterceptionByID(ctx, interception.ID)
+		require.NoError(t, err)
+		require.Nil(t, got.Annotations.GitHubPRURLs)
 	})
 
 	t.Run("NoFields", func(t *testing.T) {
@@ -102,7 +180,7 @@ func TestAnnotateInterception(t *testing.T) {
 		user := dbgen.User(t, db, database.User{})
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
 
-		resp, err := tool.Run(ctx, call(`{"repo":"   "}`))
+		resp, err := tool.Run(ctx, call(`{"repo":"   ","linear_issue_ids":[]}`))
 		require.NoError(t, err)
 		require.Contains(t, resp.Content, "provide at least one of")
 	})

--- a/coderd/x/chatd/chattool/annotateinterception_test.go
+++ b/coderd/x/chatd/chattool/annotateinterception_test.go
@@ -42,7 +42,7 @@ func TestAnnotateInterception(t *testing.T) {
 		}, nil)
 
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
-		resp, err := tool.Run(ctx, call(`{"linear_issue_ids":[" ENG-1234 "],"repo":"coder/coder","branch":"main"}`))
+		resp, err := tool.Run(ctx, call(`{"linear_issue_ids":[" ENG-1234 "],"repos":["coder/coder"],"branches":["main"]}`))
 		require.NoError(t, err)
 
 		var result struct {
@@ -59,15 +59,15 @@ func TestAnnotateInterception(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, got.Annotations.LinearIssueIDs)
 		require.Equal(t, []string{"ENG-1234"}, *got.Annotations.LinearIssueIDs)
-		require.Equal(t, "coder/coder", *got.Annotations.Repo)
-		require.Equal(t, "main", *got.Annotations.Branch)
+		require.Equal(t, []string{"coder/coder"}, *got.Annotations.Repos)
+		require.Equal(t, []string{"main"}, *got.Annotations.Branches)
 		// The update merges, so the server-derived key survives.
 		require.NotNil(t, got.Annotations.Capabilities)
 		require.Equal(t, []string{"workspace"}, *got.Annotations.Capabilities)
 
 		untouched, err := db.GetAIBridgeInterceptionByID(ctx, older.ID)
 		require.NoError(t, err)
-		require.Nil(t, untouched.Annotations.Repo)
+		require.Nil(t, untouched.Annotations.Repos)
 	})
 
 	t.Run("OmittedFieldsKeepPreviousValues", func(t *testing.T) {
@@ -81,15 +81,16 @@ func TestAnnotateInterception(t *testing.T) {
 		}, nil)
 
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
-		_, err := tool.Run(ctx, call(`{"repo":"coder/coder","branch":"main"}`))
+		_, err := tool.Run(ctx, call(`{"repos":["coder/coder"],"branches":["main"]}`))
 		require.NoError(t, err)
-		_, err = tool.Run(ctx, call(`{"branch":"scott/feature"}`))
+		_, err = tool.Run(ctx, call(`{"branches":["scott/feature"]}`))
 		require.NoError(t, err)
 
 		got, err := db.GetAIBridgeInterceptionByID(ctx, interception.ID)
 		require.NoError(t, err)
-		require.Equal(t, "coder/coder", *got.Annotations.Repo)
-		require.Equal(t, "scott/feature", *got.Annotations.Branch)
+		require.Equal(t, []string{"coder/coder"}, *got.Annotations.Repos)
+		// Branches accumulate rather than overwriting.
+		require.Equal(t, []string{"main", "scott/feature"}, *got.Annotations.Branches)
 		require.Nil(t, got.Annotations.LinearIssueIDs)
 	})
 
@@ -169,7 +170,7 @@ func TestAnnotateInterception(t *testing.T) {
 		user := dbgen.User(t, db, database.User{})
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
 
-		resp, err := tool.Run(ctx, call(`{"repo":"   ","linear_issue_ids":[]}`))
+		resp, err := tool.Run(ctx, call(`{"repos":["   "],"linear_issue_ids":[]}`))
 		require.NoError(t, err)
 		require.Contains(t, resp.Content, "provide at least one of")
 	})
@@ -182,7 +183,7 @@ func TestAnnotateInterception(t *testing.T) {
 		user := dbgen.User(t, db, database.User{})
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
 
-		resp, err := tool.Run(ctx, call(`{"repo":"coder/coder"}`))
+		resp, err := tool.Run(ctx, call(`{"repos":["coder/coder"]}`))
 		require.NoError(t, err)
 		require.Contains(t, resp.Content, "no AI Bridge interception to annotate")
 	})
@@ -199,7 +200,7 @@ func TestAnnotateInterception(t *testing.T) {
 		}, nil)
 
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
-		resp, err := tool.Run(ctx, call(`{"repo":"coder/coder"}`))
+		resp, err := tool.Run(ctx, call(`{"repos":["coder/coder"]}`))
 		require.NoError(t, err)
 		require.Contains(t, resp.Content, "no AI Bridge interception to annotate")
 	})

--- a/coderd/x/chatd/chattool/annotateinterception_test.go
+++ b/coderd/x/chatd/chattool/annotateinterception_test.go
@@ -2,7 +2,6 @@ package chattool_test
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -152,19 +151,9 @@ func TestAnnotateInterception(t *testing.T) {
 		}, nil)
 		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
 
-		for _, url := range []string{
-			"javascript:alert(1)",
-			"http://github.com/coder/coder/pull/1",
-			"https://github.example.com/coder/coder/pull/1",
-			"https://github.com/coder/coder/issues/1",
-			"https://github.com/coder/coder/pull/1?x=y",
-		} {
-			input, err := json.Marshal(map[string][]string{"github_pr_urls": {url}})
-			require.NoError(t, err)
-			resp, err := tool.Run(ctx, call(string(input)))
-			require.NoError(t, err)
-			require.Contains(t, resp.Content, "must look like https://github.com/", "url %q", url)
-		}
+		resp, err := tool.Run(ctx, call(`{"github_pr_urls":["javascript:alert(1)"]}`))
+		require.NoError(t, err)
+		require.Contains(t, resp.Content, "must look like https://github.com/")
 
 		// A rejected call writes nothing.
 		got, err := db.GetAIBridgeInterceptionByID(ctx, interception.ID)
@@ -183,21 +172,6 @@ func TestAnnotateInterception(t *testing.T) {
 		resp, err := tool.Run(ctx, call(`{"repo":"   ","linear_issue_ids":[]}`))
 		require.NoError(t, err)
 		require.Contains(t, resp.Content, "provide at least one of")
-	})
-
-	t.Run("ValueTooLong", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
-
-		input, err := json.Marshal(map[string]string{"repo": strings.Repeat("a", 257)})
-		require.NoError(t, err)
-		resp, err := tool.Run(ctx, call(string(input)))
-		require.NoError(t, err)
-		require.Contains(t, resp.Content, "256 characters or fewer")
 	})
 
 	t.Run("NoInterception", func(t *testing.T) {

--- a/coderd/x/chatd/chattool/annotateinterception_test.go
+++ b/coderd/x/chatd/chattool/annotateinterception_test.go
@@ -1,0 +1,154 @@
+package chattool_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestAnnotateInterception(t *testing.T) {
+	t.Parallel()
+
+	call := func(input string) fantasy.ToolCall {
+		return fantasy.ToolCall{ID: "call-1", Name: "annotate_interception", Input: input}
+	}
+
+	t.Run("AnnotatesLatestInterception", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		now := dbtime.Now()
+		older := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID,
+			StartedAt:   now.Add(-time.Hour),
+			Annotations: database.AIBridgeInterceptionCapabilities([]string{"workspace"}),
+		}, nil)
+		latest := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID,
+			StartedAt:   now,
+			Annotations: database.AIBridgeInterceptionCapabilities([]string{"workspace"}),
+		}, nil)
+
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+		resp, err := tool.Run(ctx, call(`{"linear_issue_id":" ENG-1234 ","repo":"coder/coder","branch":"main"}`))
+		require.NoError(t, err)
+
+		var result struct {
+			Annotated      bool   `json:"annotated"`
+			InterceptionID string `json:"interception_id"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		require.True(t, result.Annotated)
+		require.Equal(t, latest.ID.String(), result.InterceptionID)
+		// Server-derived annotations stay out of the model's view.
+		require.NotContains(t, resp.Content, "capabilities")
+
+		got, err := db.GetAIBridgeInterceptionByID(ctx, latest.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.Annotations.LinearIssueID)
+		require.Equal(t, "ENG-1234", *got.Annotations.LinearIssueID)
+		require.Equal(t, "coder/coder", *got.Annotations.Repo)
+		require.Equal(t, "main", *got.Annotations.Branch)
+		// The update merges, so the server-derived key survives.
+		require.NotNil(t, got.Annotations.Capabilities)
+		require.Equal(t, []string{"workspace"}, *got.Annotations.Capabilities)
+
+		untouched, err := db.GetAIBridgeInterceptionByID(ctx, older.ID)
+		require.NoError(t, err)
+		require.Nil(t, untouched.Annotations.Repo)
+	})
+
+	t.Run("OmittedFieldsKeepPreviousValues", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		interception := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: user.ID,
+		}, nil)
+
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+		_, err := tool.Run(ctx, call(`{"repo":"coder/coder","branch":"main"}`))
+		require.NoError(t, err)
+		_, err = tool.Run(ctx, call(`{"branch":"scott/feature"}`))
+		require.NoError(t, err)
+
+		got, err := db.GetAIBridgeInterceptionByID(ctx, interception.ID)
+		require.NoError(t, err)
+		require.Equal(t, "coder/coder", *got.Annotations.Repo)
+		require.Equal(t, "scott/feature", *got.Annotations.Branch)
+		require.Nil(t, got.Annotations.LinearIssueID)
+	})
+
+	t.Run("NoFields", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+
+		resp, err := tool.Run(ctx, call(`{"repo":"   "}`))
+		require.NoError(t, err)
+		require.Contains(t, resp.Content, "provide at least one of")
+	})
+
+	t.Run("ValueTooLong", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+
+		input, err := json.Marshal(map[string]string{"repo": strings.Repeat("a", 257)})
+		require.NoError(t, err)
+		resp, err := tool.Run(ctx, call(string(input)))
+		require.NoError(t, err)
+		require.Contains(t, resp.Content, "256 characters or fewer")
+	})
+
+	t.Run("NoInterception", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+
+		resp, err := tool.Run(ctx, call(`{"repo":"coder/coder"}`))
+		require.NoError(t, err)
+		require.Contains(t, resp.Content, "no AI Bridge interception to annotate")
+	})
+
+	t.Run("OtherUsersInterceptionIsInvisible", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		other := dbgen.User(t, db, database.User{})
+		_ = dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+			InitiatorID: other.ID,
+		}, nil)
+
+		tool := chattool.AnnotateInterception(db, chattool.AnnotateInterceptionOptions{OwnerID: user.ID})
+		resp, err := tool.Run(ctx, call(`{"repo":"coder/coder"}`))
+		require.NoError(t, err)
+		require.Contains(t, resp.Content, "no AI Bridge interception to annotate")
+	})
+}

--- a/coderd/x/chatd/generation_preparer.go
+++ b/coderd/x/chatd/generation_preparer.go
@@ -458,6 +458,9 @@ func (server *Server) prepareGeneration(
 		chattool.ProcessOutput(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
 		chattool.ProcessList(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
 		chattool.ProcessSignal(chattool.ProcessToolOptions{GetWorkspaceConn: workspaceCtx.getWorkspaceConn}),
+		chattool.AnnotateInterception(server.db, chattool.AnnotateInterceptionOptions{
+			OwnerID: chat.OwnerID,
+		}),
 	}
 	if isPlanModeTurn && isRootChat {
 		tools = append(tools, chattool.NewAskUserQuestionTool())

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -121,8 +121,8 @@ When no workspace is attached and you need to create one:
 </workspace-template-selection>
 
 <work-context-annotation>
-Call annotate_interception as soon as you know the repository, branch, or Linear issue your current work belongs to, and again whenever any of them change.
-Pass only the fields you are confident about; omitted fields keep their previous value. Do not guess, and do not ask the user for these values.
+Call annotate_interception as soon as you know the repository, branch, or Linear issues your current work belongs to, and again whenever any of them change or you open a pull request.
+Pass only the fields you are confident about; omitted fields keep their previous value. Issues and pull requests accumulate across calls, so pass each new one as you start work on it rather than replacing the earlier one. Do not guess, and do not ask the user for these values.
 The annotation applies to the model request that carries the call, so annotate early in a turn rather than at the end.
 </work-context-annotation>
 

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -120,6 +120,12 @@ When no workspace is attached and you need to create one:
 - Call read_template only when you need parameter or preset details before create_workspace.
 </workspace-template-selection>
 
+<work-context-annotation>
+Call annotate_interception as soon as you know the repository, branch, or Linear issue your current work belongs to, and again whenever any of them change.
+Pass only the fields you are confident about; omitted fields keep their previous value. Do not guess, and do not ask the user for these values.
+The annotation applies to the model request that carries the call, so annotate early in a turn rather than at the end.
+</work-context-annotation>
+
 <planning>
 Propose a plan when:
 - The task is too ambiguous to implement with confidence.

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -207,7 +207,15 @@ type AIBridgeSessionThreadsResponse struct {
 	// list than NetworkCalls.Total means the list was truncated. Empty when the
 	// session did not pass through Agent Firewall.
 	NetworkCallLogs []AgentFirewallLog `json:"network_call_logs,omitempty"`
-	Threads         []AIBridgeThread   `json:"threads"`
+	// LinearIssueIDs lists the distinct Linear issue identifiers annotated on
+	// the session's interceptions, sorted ascending. Empty when no interception
+	// in the session was annotated with one. GitHubPRURLs, Repos, and Branches
+	// are the same for their respective annotations.
+	LinearIssueIDs []string         `json:"linear_issue_ids,omitempty"`
+	GitHubPRURLs   []string         `json:"github_pr_urls,omitempty"`
+	Repos          []string         `json:"repos,omitempty"`
+	Branches       []string         `json:"branches,omitempty"`
+	Threads        []AIBridgeThread `json:"threads"`
 }
 
 // AIBridgeSessionThreadsTokenUsage represents aggregated token usage

--- a/docs/reference/api/aigateway.md
+++ b/docs/reference/api/aigateway.md
@@ -184,8 +184,14 @@ Alias: also available at /api/v2/aibridge/sessions/{session_id} for backward com
 
 ```json
 {
+  "branches": [
+    "string"
+  ],
   "client": "string",
   "ended_at": "2019-08-24T14:15:22Z",
+  "github_pr_urls": [
+    "string"
+  ],
   "id": "string",
   "initiator": {
     "avatar_url": "http://example.com",
@@ -193,6 +199,9 @@ Alias: also available at /api/v2/aibridge/sessions/{session_id} for backward com
     "name": "string",
     "username": "string"
   },
+  "linear_issue_ids": [
+    "string"
+  ],
   "metadata": {
     "property1": null,
     "property2": null
@@ -228,6 +237,9 @@ Alias: also available at /api/v2/aibridge/sessions/{session_id} for backward com
   "page_ended_at": "2019-08-24T14:15:22Z",
   "page_started_at": "2019-08-24T14:15:22Z",
   "providers": [
+    "string"
+  ],
+  "repos": [
     "string"
   ],
   "started_at": "2019-08-24T14:15:22Z",

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1877,9 +1877,9 @@ Requires organization-level administrator permissions.
 
 #### Enumerated Values
 
-| Parameter | Value(s)                                               |
-|-----------|--------------------------------------------------------|
-| `columns` | `branch`, `github_pr_urls`, `linear_issue_ids`, `repo` |
+| Parameter | Value(s)                                                  |
+|-----------|-----------------------------------------------------------|
+| `columns` | `branches`, `github_pr_urls`, `linear_issue_ids`, `repos` |
 
 ### Responses
 

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1863,15 +1863,23 @@ Returns per-user, per-group, per-model, per-provider aggregated AI spend for the
 The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.
 An explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.
 The capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.
+The optional columns query parameter appends annotation-derived columns after the fixed ones, in the order requested. Each cell lists the distinct values the annotation held across the interceptions behind the row, semicolon-separated.
 Requires organization-level administrator permissions.
 
 ### Parameters
 
-| Name           | In    | Type              | Required | Description                     |
-|----------------|-------|-------------------|----------|---------------------------------|
-| `organization` | path  | string(uuid)      | true     | Organization ID                 |
-| `period_start` | query | string(date-time) | false    | Inclusive lower bound (RFC3339) |
-| `period_end`   | query | string(date-time) | false    | Exclusive upper bound (RFC3339) |
+| Name           | In    | Type              | Required | Description                                 |
+|----------------|-------|-------------------|----------|---------------------------------------------|
+| `organization` | path  | string(uuid)      | true     | Organization ID                             |
+| `period_start` | query | string(date-time) | false    | Inclusive lower bound (RFC3339)             |
+| `period_end`   | query | string(date-time) | false    | Exclusive upper bound (RFC3339)             |
+| `columns`      | query | string            | false    | Comma-separated optional annotation columns |
+
+#### Enumerated Values
+
+| Parameter | Value(s)                                               |
+|-----------|--------------------------------------------------------|
+| `columns` | `branch`, `github_pr_urls`, `linear_issue_ids`, `repo` |
 
 ### Responses
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -680,8 +680,14 @@ title: Schemas
 
 ```json
 {
+  "branches": [
+    "string"
+  ],
   "client": "string",
   "ended_at": "2019-08-24T14:15:22Z",
+  "github_pr_urls": [
+    "string"
+  ],
   "id": "string",
   "initiator": {
     "avatar_url": "http://example.com",
@@ -689,6 +695,9 @@ title: Schemas
     "name": "string",
     "username": "string"
   },
+  "linear_issue_ids": [
+    "string"
+  ],
   "metadata": {
     "property1": null,
     "property2": null
@@ -724,6 +733,9 @@ title: Schemas
   "page_ended_at": "2019-08-24T14:15:22Z",
   "page_started_at": "2019-08-24T14:15:22Z",
   "providers": [
+    "string"
+  ],
+  "repos": [
     "string"
   ],
   "started_at": "2019-08-24T14:15:22Z",
@@ -806,10 +818,13 @@ title: Schemas
 
 | Name                   | Type                                                                                     | Required | Restrictions | Description                                                                                                                                                                                                                                                                                                                                           |
 |------------------------|------------------------------------------------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `branches`             | array of string                                                                          | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `client`               | string                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `ended_at`             | string                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
+| `github_pr_urls`       | array of string                                                                          | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `id`                   | string                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `initiator`            | [codersdk.MinimalUser](#codersdkminimaluser)                                             | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
+| `linear_issue_ids`     | array of string                                                                          | false    |              | Linear issue ids lists the distinct Linear issue identifiers annotated on the session's interceptions, sorted ascending. Empty when no interception in the session was annotated with one. GitHubPRURLs, Repos, and Branches are the same for their respective annotations.                                                                           |
 | `metadata`             | object                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | » `[any property]`     | any                                                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `models`               | array of string                                                                          | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
@@ -820,6 +835,7 @@ title: Schemas
 | `page_ended_at`        | string                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `page_started_at`      | string                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `providers`            | array of string                                                                          | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
+| `repos`                | array of string                                                                          | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `started_at`           | string                                                                                   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `threads`              | array of [codersdk.AIBridgeThread](#codersdkaibridgethread)                              | false    |              |                                                                                                                                                                                                                                                                                                                                                       |
 | `token_usage_summary`  | [codersdk.AIBridgeSessionThreadsTokenUsage](#codersdkaibridgesessionthreadstokenusage)   | false    |              |                                                                                                                                                                                                                                                                                                                                                       |

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1105,6 +1108,84 @@ var AISpendExportCSVHeader = []string{
 	"cost_micros", "period_start", "period_end",
 }
 
+// aiSpendExportOptionalColumns are the annotation-derived columns the export
+// accepts through the columns query parameter, in canonical order.
+var aiSpendExportOptionalColumns = []string{"linear_issue_ids", "github_pr_urls", "repo", "branch"}
+
+// parseAISpendExportColumns resolves the requested optional columns from the
+// comma-separated columns query parameter, preserving the requested order and
+// dropping repeats. On invalid input it writes the error response and returns
+// ok=false.
+func parseAISpendExportColumns(ctx context.Context, rw http.ResponseWriter, r *http.Request) (columns []string, ok bool) {
+	raw := strings.TrimSpace(r.URL.Query().Get("columns"))
+	if raw == "" {
+		return nil, true
+	}
+
+	seen := make(map[string]struct{})
+	for _, value := range strings.Split(raw, ",") {
+		column := strings.TrimSpace(value)
+		if column == "" {
+			continue
+		}
+		if !slices.Contains(aiSpendExportOptionalColumns, column) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: fmt.Sprintf("Unsupported column %q.", column),
+				Detail: fmt.Sprintf("columns accepts: %s.",
+					strings.Join(aiSpendExportOptionalColumns, ", ")),
+			})
+			return nil, false
+		}
+		if _, duplicate := seen[column]; duplicate {
+			continue
+		}
+		seen[column] = struct{}{}
+		columns = append(columns, column)
+	}
+	return columns, true
+}
+
+// aiSpendExportAnnotationCell collapses the values a single annotation key holds
+// across the interceptions behind one export row into one semicolon-separated
+// cell, sorted and free of duplicates. String and array values both contribute;
+// any other JSON type contributes nothing. sets is the aggregated array of
+// per-interception annotation objects.
+func aiSpendExportAnnotationCell(sets json.RawMessage, key string) string {
+	if len(sets) == 0 {
+		return ""
+	}
+	var annotations []map[string]json.RawMessage
+	if err := json.Unmarshal(sets, &annotations); err != nil {
+		return ""
+	}
+
+	values := make(map[string]struct{})
+	for _, annotation := range annotations {
+		raw, found := annotation[key]
+		if !found {
+			continue
+		}
+		var single string
+		if err := json.Unmarshal(raw, &single); err == nil {
+			if single != "" {
+				values[single] = struct{}{}
+			}
+			continue
+		}
+		var multiple []string
+		if err := json.Unmarshal(raw, &multiple); err != nil {
+			continue
+		}
+		for _, value := range multiple {
+			if value != "" {
+				values[value] = struct{}{}
+			}
+		}
+	}
+
+	return strings.Join(slices.Sorted(maps.Keys(values)), ";")
+}
+
 // csvFormulaPrefixes are the leading characters a spreadsheet treats as the
 // start of a formula rather than text.
 const csvFormulaPrefixes = "=+-@\t\r"
@@ -1200,6 +1281,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 // @Description The optional period_start and period_end query parameters bound the period and are interpreted as UTC. They must be provided together and span at most 31 days. When both are omitted, the current UTC monthly period is used.
 // @Description An explicit period_start must fall within the configured AI Gateway data retention window, since older token usage is purged. The default period is narrowed to that window instead, and every row echoes the applied bounds.
 // @Description The capabilities column lists the distinct capabilities the user held across the interceptions behind the row, semicolon-separated. It is empty for interceptions recorded without capability annotations.
+// @Description The optional columns query parameter appends annotation-derived columns after the fixed ones, in the order requested. Each cell lists the distinct values the annotation held across the interceptions behind the row, semicolon-separated.
 // @Description Requires organization-level administrator permissions.
 // @ID export-organization-ai-spend-as-csv
 // @Security CoderSessionToken
@@ -1208,6 +1290,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param period_start query string false "Inclusive lower bound (RFC3339)" format(date-time)
 // @Param period_end query string false "Exclusive upper bound (RFC3339)" format(date-time)
+// @Param columns query string false "Comma-separated optional annotation columns" Enums(linear_issue_ids,github_pr_urls,repo,branch)
 // @Success 200
 // @Router /api/v2/organizations/{organization}/ai/spend/export [get]
 func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Request) {
@@ -1223,6 +1306,10 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 	}
 
 	periodStart, periodEnd, ok := api.aiSpendExportPeriod(ctx, rw, r)
+	if !ok {
+		return
+	}
+	optionalColumns, ok := parseAISpendExportColumns(ctx, rw, r)
 	if !ok {
 		return
 	}
@@ -1247,13 +1334,13 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 
 	var buf bytes.Buffer
 	cw := csv.NewWriter(&buf)
-	if err := cw.Write(AISpendExportCSVHeader); err != nil {
+	if err := cw.Write(append(slices.Clone(AISpendExportCSVHeader), optionalColumns...)); err != nil {
 		logger.Error(ctx, "failed to write AI spend export header", slog.Error(err))
 		httpapi.InternalServerError(rw, err)
 		return
 	}
 	for _, row := range rows {
-		if err := cw.Write([]string{
+		record := []string{
 			row.UserID.String(),
 			escapeCSVCell(row.Username),
 			escapeCSVCell(row.Capabilities),
@@ -1271,7 +1358,11 @@ func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Reques
 			strconv.FormatInt(row.CostMicros, 10),
 			start,
 			end,
-		}); err != nil {
+		}
+		for _, column := range optionalColumns {
+			record = append(record, escapeCSVCell(aiSpendExportAnnotationCell(row.AnnotationSets, column)))
+		}
+		if err := cw.Write(record); err != nil {
 			logger.Error(ctx, "failed to write AI spend export row", slog.Error(err))
 			httpapi.InternalServerError(rw, err)
 			return

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -1110,7 +1110,7 @@ var AISpendExportCSVHeader = []string{
 
 // aiSpendExportOptionalColumns are the annotation-derived columns the export
 // accepts through the columns query parameter, in canonical order.
-var aiSpendExportOptionalColumns = []string{"linear_issue_ids", "github_pr_urls", "repo", "branch"}
+var aiSpendExportOptionalColumns = []string{"linear_issue_ids", "github_pr_urls", "repos", "branches"}
 
 // parseAISpendExportColumns resolves the requested optional columns from the
 // comma-separated columns query parameter, preserving the requested order and
@@ -1290,7 +1290,7 @@ func (api *API) aiSpendExportPeriod(ctx context.Context, rw http.ResponseWriter,
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param period_start query string false "Inclusive lower bound (RFC3339)" format(date-time)
 // @Param period_end query string false "Exclusive upper bound (RFC3339)" format(date-time)
-// @Param columns query string false "Comma-separated optional annotation columns" Enums(linear_issue_ids,github_pr_urls,repo,branch)
+// @Param columns query string false "Comma-separated optional annotation columns" Enums(linear_issue_ids,github_pr_urls,repos,branches)
 // @Success 200
 // @Router /api/v2/organizations/{organization}/ai/spend/export [get]
 func (api *API) exportOrganizationAISpend(rw http.ResponseWriter, r *http.Request) {

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -1668,15 +1668,14 @@ func TestAIBridgeGetSessionThreads(t *testing.T) {
 		now := dbtime.Now()
 		issues := func(ids ...string) *[]string { return &ids }
 		prs := func(urls ...string) *[]string { return &urls }
-		repo := "coder/coder"
-		branch := "main"
+		values := func(vs ...string) *[]string { return &vs }
 
 		for i, annotations := range []database.AIBridgeInterceptionAnnotations{
-			{LinearIssueIDs: issues("ENG-5678"), Repo: &repo, Branch: &branch},
+			{LinearIssueIDs: issues("ENG-5678"), Repos: values("coder/coder"), Branches: values("main")},
 			// Duplicates across interceptions collapse into one entry.
 			{
 				LinearIssueIDs: issues("ENG-1234", "ENG-5678"),
-				Repo:           &repo,
+				Repos:          values("coder/coder"),
 				GitHubPRURLs:   prs("https://github.com/coder/coder/pull/28300"),
 			},
 			{},
@@ -4779,20 +4778,18 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
 
 		issues := func(ids ...string) *[]string { return &ids }
+		values := func(vs ...string) *[]string { return &vs }
 		prURL := "https://github.com/coder/coder/pull/28300"
-		repo := "coder/coder"
-		branchMain := "main"
-		branchFeature := "scott/x/annotations"
 
 		// Three interceptions collapse into one row: the issue sets union, the
 		// two branches both appear, and the unannotated one contributes nothing.
 		for _, annotations := range []database.AIBridgeInterceptionAnnotations{
-			{LinearIssueIDs: issues("ENG-5678"), Repo: &repo, Branch: &branchMain},
+			{LinearIssueIDs: issues("ENG-5678"), Repos: values("coder/coder"), Branches: values("main")},
 			{
 				LinearIssueIDs: issues("ENG-1234", "ENG-5678"),
 				GitHubPRURLs:   &[]string{prURL},
-				Repo:           &repo,
-				Branch:         &branchFeature,
+				Repos:          values("coder/coder"),
+				Branches:       values("scott/x/annotations"),
 			},
 			{},
 		} {
@@ -4822,7 +4819,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitLong)
 			res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
 				// Repeats collapse and the requested order is preserved.
-				"columns": "branch, repo ,linear_issue_ids,branch,github_pr_urls",
+				"columns": "branches, repos ,linear_issue_ids,branches,github_pr_urls",
 			})
 			defer res.Body.Close()
 			require.Equal(t, http.StatusOK, res.StatusCode)
@@ -4831,7 +4828,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			require.Len(t, records, 2)
 			require.Equal(t,
 				append(slices.Clone(entcoderd.AISpendExportCSVHeader),
-					"branch", "repo", "linear_issue_ids", "github_pr_urls"),
+					"branches", "repos", "linear_issue_ids", "github_pr_urls"),
 				records[0])
 
 			row := records[1]
@@ -4849,7 +4846,7 @@ func TestExportOrganizationAISpend(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitLong)
 			res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
-				"columns": "repo,capabilities",
+				"columns": "repos,capabilities",
 			})
 			defer res.Body.Close()
 			require.Equal(t, http.StatusBadRequest, res.StatusCode)

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -1659,6 +1659,47 @@ func TestAIBridgeGetSessionThreads(t *testing.T) {
 		require.Equal(t, "sk-a...efgh", res.Threads[0].CredentialHint)
 	})
 
+	t.Run("AnnotationSummary", func(t *testing.T) {
+		t.Parallel()
+		client, db, firstUser := coderdenttest.NewWithDatabase(t, aibridgeOpts(t))
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		now := dbtime.Now()
+		issues := func(ids ...string) *[]string { return &ids }
+		prs := func(urls ...string) *[]string { return &urls }
+		repo := "coder/coder"
+		branch := "main"
+
+		for i, annotations := range []database.AIBridgeInterceptionAnnotations{
+			{LinearIssueIDs: issues("ENG-5678"), Repo: &repo, Branch: &branch},
+			// Duplicates across interceptions collapse into one entry.
+			{
+				LinearIssueIDs: issues("ENG-1234", "ENG-5678"),
+				Repo:           &repo,
+				GitHubPRURLs:   prs("https://github.com/coder/coder/pull/28300"),
+			},
+			{},
+		} {
+			startedAt := now.Add(time.Duration(i) * time.Minute)
+			endedAt := startedAt.Add(time.Minute)
+			dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID:     firstUser.UserID,
+				Provider:        "anthropic",
+				Model:           "claude-sonnet-5",
+				StartedAt:       startedAt,
+				ClientSessionID: sql.NullString{String: "annotated-session", Valid: true},
+				Annotations:     annotations,
+			}, &endedAt)
+		}
+
+		res, err := client.AIBridgeGetSessionThreads(ctx, "annotated-session", uuid.Nil, uuid.Nil, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"ENG-1234", "ENG-5678"}, res.LinearIssueIDs)
+		require.Equal(t, []string{"https://github.com/coder/coder/pull/28300"}, res.GitHubPRURLs)
+		require.Equal(t, []string{"coder/coder"}, res.Repos)
+		require.Equal(t, []string{"main"}, res.Branches)
+	})
+
 	t.Run("ThreadsWithAgentFirewallCorrelation", func(t *testing.T) {
 		t.Parallel()
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, aibridgeOpts(t))

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -4757,6 +4758,107 @@ func TestExportOrganizationAISpend(t *testing.T) {
 		records := readAISpendExportResponse(t, res)
 		require.Len(t, records, 2)
 		require.Equal(t, "future;workspace", records[1][2])
+	})
+
+	t.Run("OptionalAnnotationColumns", func(t *testing.T) {
+		t.Parallel()
+
+		// Use fixed dates to keep the test deterministic.
+		now := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+
+		db, ps := dbtestutil.NewDB(t)
+		adminClient, targetUser, group := setupAICostControlTest(t, aiCostControlTestOptions{
+			GroupName: "export-annotation-columns-group",
+			Clock:     clock,
+			Database:  db,
+			Pubsub:    ps,
+		})
+		inMonth := time.Date(2026, time.March, 10, 8, 0, 0, 0, time.UTC)
+		effectiveGroupID := uuid.NullUUID{UUID: group.ID, Valid: true}
+
+		issues := func(ids ...string) *[]string { return &ids }
+		prURL := "https://github.com/coder/coder/pull/28300"
+		repo := "coder/coder"
+		branchMain := "main"
+		branchFeature := "scott/x/annotations"
+
+		// Three interceptions collapse into one row: the issue sets union, the
+		// two branches both appear, and the unannotated one contributes nothing.
+		for _, annotations := range []database.AIBridgeInterceptionAnnotations{
+			{LinearIssueIDs: issues("ENG-5678"), Repo: &repo, Branch: &branchMain},
+			{
+				LinearIssueIDs: issues("ENG-1234", "ENG-5678"),
+				GitHubPRURLs:   &[]string{prURL},
+				Repo:           &repo,
+				Branch:         &branchFeature,
+			},
+			{},
+		} {
+			intc := dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+				InitiatorID: targetUser.ID, Provider: "anthropic", ProviderName: "anthropic-prod",
+				Model: "claude-4", StartedAt: inMonth, Annotations: annotations,
+			}, nil)
+			dbgen.AIBridgeTokenUsage(t, db, database.InsertAIBridgeTokenUsageParams{
+				InterceptionID: intc.ID, CreatedAt: inMonth, EffectiveGroupID: effectiveGroupID,
+				InputTokens: 100, OutputTokens: 50, CostMicros: sql.NullInt64{Int64: 1000, Valid: true},
+			})
+		}
+
+		t.Run("OmittedLeavesHeaderUnchanged", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+			res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, nil)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			records := readAISpendExportResponse(t, res)
+			require.Equal(t, entcoderd.AISpendExportCSVHeader, records[0])
+		})
+
+		t.Run("RequestedColumnsFollowRequestOrder", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+			res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
+				// Repeats collapse and the requested order is preserved.
+				"columns": "branch, repo ,linear_issue_ids,branch,github_pr_urls",
+			})
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			records := readAISpendExportResponse(t, res)
+			require.Len(t, records, 2)
+			require.Equal(t,
+				append(slices.Clone(entcoderd.AISpendExportCSVHeader),
+					"branch", "repo", "linear_issue_ids", "github_pr_urls"),
+				records[0])
+
+			row := records[1]
+			fixed := len(entcoderd.AISpendExportCSVHeader)
+			// Sums stay unaffected by the annotation expansion.
+			require.Equal(t, "300", row[10])
+			require.Equal(t, "3000", row[14])
+			require.Equal(t, "main;scott/x/annotations", row[fixed])
+			require.Equal(t, "coder/coder", row[fixed+1])
+			require.Equal(t, "ENG-1234;ENG-5678", row[fixed+2])
+			require.Equal(t, prURL, row[fixed+3])
+		})
+
+		t.Run("UnsupportedColumnIsRejected", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+			res := requestAISpendExport(ctx, t, adminClient, group.OrganizationID, map[string]string{
+				"columns": "repo,capabilities",
+			})
+			defer res.Body.Close()
+			require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			var apiErr codersdk.Response
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&apiErr))
+			require.Contains(t, apiErr.Message, `Unsupported column "capabilities"`)
+			require.Contains(t, apiErr.Detail, "linear_issue_ids")
+		})
 	})
 
 	t.Run("SeparateRowPerGroup", func(t *testing.T) {

--- a/examples/templates/x/docker-ai-gateway-annotations/README.md
+++ b/examples/templates/x/docker-ai-gateway-annotations/README.md
@@ -23,6 +23,12 @@ Two pieces of configuration make that work:
 | `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` | Claude Code sends Anthropic traffic through the AI Gateway as the workspace owner, so each request is recorded as an interception. |
 | MCP server `coder-ai-gateway`                   | Registers `coder_annotate_interception` with Claude Code so it can attach a repository, branch, Linear issues, and GitHub pull requests to the interception. |
 
+The gateway serves each provider under its configured name, so
+`ANTHROPIC_BASE_URL` is `<access-url>/api/v2/ai-gateway/<provider-name>`. Set
+`ai_gateway_provider` to the provider name on the deployment; a request to a
+name the gateway does not serve returns 404, which Claude Code reports as a
+problem with the selected model.
+
 The MCP server is registered against the `annotations` toolset:
 
 ```text
@@ -36,7 +42,8 @@ describing when to call it, so no prompt file or `CLAUDE.md` is needed.
 
 - A Premium license with AI Governance. `/api/v2/ai-gateway/*` requires the
   AI Bridge entitlement, and no interceptions are recorded without it.
-- At least one Anthropic AI Gateway provider configured on the deployment.
+- At least one Anthropic AI Gateway provider configured on the deployment,
+  with its name set in `ai_gateway_provider`.
 - The `oauth2` and `mcp-server-http` experiments enabled. Development
   builds bypass this check.
 - An access URL the workspace container can reach. The template rewrites
@@ -45,11 +52,13 @@ describing when to call it, so no prompt file or `CLAUDE.md` is needed.
 
 ## Variables
 
-| Variable              | Default   | Purpose                                          |
-|-----------------------|-----------|--------------------------------------------------|
-| `docker_socket`       | `""`      | Docker socket URI.                               |
-| `claude_code_version` | `latest`  | Version passed to the Claude Code installer.     |
-| `access_url_override` | `""`      | Deployment URL to use inside the container.      |
+| Variable              | Default     | Purpose                                          |
+|-----------------------|-------------|--------------------------------------------------|
+| `docker_socket`       | `""`        | Docker socket URI.                               |
+| `claude_code_version` | `latest`    | Version passed to the Claude Code installer.     |
+| `ai_gateway_provider` | `anthropic` | AI Gateway provider name serving Anthropic.      |
+| `claude_model`        | `""`        | Pins `ANTHROPIC_MODEL` when set.                 |
+| `access_url_override` | `""`        | Deployment URL to use inside the container.      |
 
 ## Verifying
 

--- a/examples/templates/x/docker-ai-gateway-annotations/README.md
+++ b/examples/templates/x/docker-ai-gateway-annotations/README.md
@@ -22,6 +22,7 @@ Two pieces of configuration make that work:
 |-----------------------------------------------|-------------------------------------------------------------------------------|
 | `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` | Claude Code sends Anthropic traffic through the AI Gateway as the workspace owner, so each request is recorded as an interception. |
 | MCP server `coder-ai-gateway`                   | Registers `coder_annotate_interception` with Claude Code so it can attach a repository, branch, Linear issues, and GitHub pull requests to the interception. |
+| `SessionStart` hook                             | Prints the Claude Code session ID into the model's context, so the tool can be told which session to annotate. |
 
 The gateway serves each provider under its configured name, so
 `ANTHROPIC_BASE_URL` is `<access-url>/api/v2/ai-gateway/<provider-name>`. Set
@@ -36,7 +37,22 @@ The MCP server is registered against the `annotations` toolset:
 ```
 
 That toolset exposes only the annotation tool and sends server instructions
-describing when to call it, so no prompt file or `CLAUDE.md` is needed.
+describing when to call it. The start script also writes the same
+instructions to `~/.claude/CLAUDE.md`, appends them to the system prompt of
+the Claude Code app, and pre-approves the tool in `~/.claude/settings.json`,
+because server instructions alone did not reliably produce a call.
+
+## Session targeting
+
+The start script installs a `SessionStart` hook at
+`~/.claude/hooks/coder-ai-gateway-session.py`. Claude Code passes the hook
+event as JSON on stdin and injects the hook's stdout into the model's
+context, so the hook prints the session ID and instructs the model to pass
+it as `session_id`. The gateway records the same identifier as
+`client_session_id` from the `X-Claude-Code-Session-Id` header, so the
+server resolves the exact interception instead of the caller's most recent
+one. Without a session ID the tool falls back to the most recent
+interception.
 
 ## Deployment requirements
 
@@ -77,9 +93,12 @@ describing when to call it, so no prompt file or `CLAUDE.md` is needed.
 
 ## Limitations
 
-- The tool annotates the most recent interception initiated by the calling
-  user. Running another AI Gateway client concurrently under the same
-  account can send an annotation to the wrong interception.
+- Without a `session_id` the tool annotates the most recent interception
+  initiated by the calling user, so a concurrent AI Gateway client under
+  the same account can absorb the annotation.
+- A `session_id` is asserted by the model. The lookup is scoped to the
+  calling user, so a wrong value can only reach that user's own
+  interceptions.
 - `claude mcp add-json` stores the workspace owner's session token in
   `~/.claude.json`.
 - Annotation values other than server-derived capabilities are asserted by

--- a/examples/templates/x/docker-ai-gateway-annotations/README.md
+++ b/examples/templates/x/docker-ai-gateway-annotations/README.md
@@ -1,0 +1,77 @@
+---
+display_name: Docker + AI Gateway Annotations
+description: Docker template that routes Claude Code through the AI Gateway and registers the interception annotation MCP tool
+icon: ../../../../site/static/icon/docker.png
+maintainer_github: coder
+tags: [docker, container, ai-gateway, claude-code]
+---
+
+> **Experimental**: This template configures the experimental MCP HTTP
+> endpoint and the interception annotation tool. Both are prototypes
+> subject to change. Do not rely on this for production workloads.
+
+# Docker + AI Gateway Annotations
+
+This template provisions a Docker workspace where Claude Code is wired to
+the Coder AI Gateway and can annotate its own recorded activity with the
+work it is doing.
+
+Two pieces of configuration make that work:
+
+| Configuration                                 | Effect                                                                        |
+|-----------------------------------------------|-------------------------------------------------------------------------------|
+| `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` | Claude Code sends Anthropic traffic through the AI Gateway as the workspace owner, so each request is recorded as an interception. |
+| MCP server `coder-ai-gateway`                   | Registers `coder_annotate_interception` with Claude Code so it can attach a repository, branch, Linear issues, and GitHub pull requests to the interception. |
+
+The MCP server is registered against the `annotations` toolset:
+
+```text
+<access-url>/api/experimental/mcp/http?toolset=annotations
+```
+
+That toolset exposes only the annotation tool and sends server instructions
+describing when to call it, so no prompt file or `CLAUDE.md` is needed.
+
+## Deployment requirements
+
+- A Premium license with AI Governance. `/api/v2/ai-gateway/*` requires the
+  AI Bridge entitlement, and no interceptions are recorded without it.
+- At least one Anthropic AI Gateway provider configured on the deployment.
+- The `oauth2` and `mcp-server-http` experiments enabled. Development
+  builds bypass this check.
+- An access URL the workspace container can reach. The template rewrites
+  `localhost` and `127.0.0.1` to `host.docker.internal`; set
+  `access_url_override` when that is not enough.
+
+## Variables
+
+| Variable              | Default   | Purpose                                          |
+|-----------------------|-----------|--------------------------------------------------|
+| `docker_socket`       | `""`      | Docker socket URI.                               |
+| `claude_code_version` | `latest`  | Version passed to the Claude Code installer.     |
+| `access_url_override` | `""`      | Deployment URL to use inside the container.      |
+
+## Verifying
+
+1. Open the **Claude Code** app in the workspace and confirm the MCP server
+   is connected with `/mcp`.
+2. Ask Claude to work on something in a repository, or tell it the issue
+   you are working on.
+3. Open **AI Gateway** in the dashboard, select the session, and check the
+   summary rows for repository, branch, Linear issues, and pull requests.
+4. Export spend with the annotation columns:
+
+   ```sh
+   curl -H "Coder-Session-Token: $TOKEN" \
+     "$CODER_URL/api/v2/organizations/$ORG/ai/spend/export?columns=linear_issue_ids,github_pr_urls,repo,branch"
+   ```
+
+## Limitations
+
+- The tool annotates the most recent interception initiated by the calling
+  user. Running another AI Gateway client concurrently under the same
+  account can send an annotation to the wrong interception.
+- `claude mcp add-json` stores the workspace owner's session token in
+  `~/.claude.json`.
+- Annotation values other than server-derived capabilities are asserted by
+  the client and are not verified.

--- a/examples/templates/x/docker-ai-gateway-annotations/main.tf
+++ b/examples/templates/x/docker-ai-gateway-annotations/main.tf
@@ -157,8 +157,9 @@ locals {
 
     - The user names an issue, for example `PLAT-666` or `ENG-1234`. Pass it in
       `linear_issue_ids`.
-    - You learn the repository or branch you are working in. Pass `repo` as
-      `owner/name` and `branch` as the current branch.
+    - You learn the repository or branch you are working in. Pass the
+      repository as `repos` in `owner/name` form and the current branch as
+      `branches`.
     - A pull request is opened or referenced. Pass its URL in `github_pr_urls`.
 
     Rules:

--- a/examples/templates/x/docker-ai-gateway-annotations/main.tf
+++ b/examples/templates/x/docker-ai-gateway-annotations/main.tf
@@ -1,0 +1,214 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}
+
+variable "docker_socket" {
+  default     = ""
+  description = "(Optional) Docker socket URI"
+  type        = string
+}
+
+variable "claude_code_version" {
+  default     = "latest"
+  description = "Version of the Claude Code CLI to install."
+  type        = string
+}
+
+variable "access_url_override" {
+  default     = ""
+  description = <<-EOT
+    (Optional) Deployment URL to use inside the workspace container. Set this
+    when the container cannot resolve the deployment access URL, for example a
+    local development deployment reachable only on a specific host address.
+  EOT
+  type        = string
+}
+
+provider "docker" {
+  # Defaulting to null if the variable is an empty string lets us have an optional variable without having to set our own default
+  host = var.docker_socket != "" ? var.docker_socket : null
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+locals {
+  # The container reaches the deployment through the Docker host gateway when
+  # the access URL points at the host loopback address.
+  access_url = var.access_url_override != "" ? var.access_url_override : replace(data.coder_workspace.me.access_url, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
+
+  # Claude Code sends Anthropic traffic here, so every request is recorded as an
+  # AI Gateway interception.
+  anthropic_base_url = "${local.access_url}/api/v2/ai-gateway/anthropic"
+
+  # The annotations toolset exposes only coder_annotate_interception and sends
+  # instructions describing when to call it.
+  mcp_url = "${local.access_url}/api/experimental/mcp/http?toolset=annotations"
+}
+
+resource "coder_agent" "main" {
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
+    set -e
+
+    # Prepare user home with default files on first start.
+    if [ ! -f ~/.init_done ]; then
+      cp -rT /etc/skel ~
+      touch ~/.init_done
+    fi
+  EOT
+
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
+
+    # Route Claude Code through the Coder AI Gateway, authenticated as the
+    # workspace owner.
+    ANTHROPIC_BASE_URL   = local.anthropic_base_url
+    ANTHROPIC_AUTH_TOKEN = data.coder_workspace_owner.me.session_token
+  }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "0_cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "RAM Usage"
+    key          = "1_ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+}
+
+# Installs the Claude Code CLI and registers the Coder MCP server that hosts the
+# interception annotation tool. The session token is written into the user-scope
+# MCP configuration at ~/.claude.json.
+resource "coder_script" "claude_code" {
+  count              = data.coder_workspace.me.start_count
+  agent_id           = coder_agent.main.id
+  display_name       = "Claude Code"
+  icon               = "/icon/claude.svg"
+  run_on_start       = true
+  start_blocks_login = false
+  script             = <<-EOT
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! command -v claude >/dev/null 2>&1; then
+      curl -fsSL https://claude.ai/install.sh | bash -s -- "${var.claude_code_version}"
+    fi
+
+    # Ensure interactive shells find the CLI.
+    if ! grep -q 'HOME/.local/bin' "$HOME/.bashrc" 2>/dev/null; then
+      echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$HOME/.bashrc"
+    fi
+
+    # add-json merges into the user-scope config, so re-running replaces only
+    # this server entry.
+    claude mcp add-json --scope user coder-ai-gateway "$(
+      printf '{"type":"http","url":"%s","headers":{"Coder-Session-Token":"%s"}}' \
+        '${local.mcp_url}' '${data.coder_workspace_owner.me.session_token}'
+    )"
+  EOT
+}
+
+resource "coder_app" "claude" {
+  agent_id     = coder_agent.main.id
+  slug         = "claude"
+  display_name = "Claude Code"
+  icon         = "/icon/claude.svg"
+  open_in      = "slim-window"
+  command      = <<-EOT
+    #!/usr/bin/env bash
+    set -e
+    export PATH="$HOME/.local/bin:$PATH"
+    exec claude
+  EOT
+}
+
+module "code-server" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/code-server/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  order    = 1
+}
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  lifecycle {
+    ignore_changes = all
+  }
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
+}
+
+resource "docker_container" "workspace" {
+  count = data.coder_workspace.me.start_count
+  image = "codercom/example-base:ubuntu"
+  # Uses lower() to avoid Docker restriction on container names.
+  name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  # Hostname makes the shell more user friendly: coder@my-workspace:~$
+  hostname = data.coder_workspace.me.name
+  # Use the docker gateway if the access URL is 127.0.0.1
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+}

--- a/examples/templates/x/docker-ai-gateway-annotations/main.tf
+++ b/examples/templates/x/docker-ai-gateway-annotations/main.tf
@@ -76,8 +76,35 @@ locals {
   # Claude Code namespaces MCP tools as mcp__<server>__<tool>.
   annotation_tool = "mcp__coder-ai-gateway__coder_annotate_interception"
 
-  # Merges the annotation tool into permissions.allow. Claude Code writes
-  # settings.json itself, so the file usually exists already.
+  # SessionStart hook. Claude Code passes the hook event as JSON on stdin and
+  # injects the hook's stdout into the model's context, so printing the session
+  # ID is enough to make it available to the annotation tool. Printing nothing
+  # leaves the session unidentified and the tool falls back to the initiator's
+  # most recent activity.
+  session_hook_script = <<-EOT
+    import json
+    import sys
+
+    try:
+        payload = json.load(sys.stdin)
+    except ValueError:
+        sys.exit(0)
+
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        sys.exit(0)
+
+    print(
+        "Coder AI Gateway session ID: " + session_id + ". "
+        "Pass this value verbatim as `session_id` on every "
+        "`${local.annotation_tool}` call."
+    )
+  EOT
+
+  # Merges the annotation tool into permissions.allow and the SessionStart hook
+  # into hooks. Claude Code writes settings.json itself, so the file usually
+  # exists already. Both merges are keyed on the exact value so repeated starts
+  # do not duplicate entries.
   settings_merge_script = <<-EOT
     import json
     import os
@@ -85,6 +112,7 @@ locals {
 
     path = os.path.expanduser("~/.claude/settings.json")
     tool = sys.argv[1]
+    hook_command = sys.argv[2]
     try:
         with open(path) as handle:
             settings = json.load(handle)
@@ -96,6 +124,21 @@ locals {
     allow = permissions.setdefault("allow", [])
     if tool not in allow:
         allow.append(tool)
+
+    hooks = settings.setdefault("hooks", {})
+    session_start = hooks.setdefault("SessionStart", [])
+    installed = any(
+        hook.get("command") == hook_command
+        for matcher in session_start
+        if isinstance(matcher, dict)
+        for hook in matcher.get("hooks", [])
+        if isinstance(hook, dict)
+    )
+    if not installed:
+        session_start.append(
+            {"hooks": [{"type": "command", "command": hook_command}]}
+        )
+
     with open(path, "w") as handle:
         json.dump(settings, handle, indent=2)
         handle.write("\n")
@@ -124,6 +167,9 @@ locals {
       whenever a value changes or a new issue or pull request appears.
     - Pass only the fields you are confident about. Omitted fields keep their
       previous value, and issues and pull requests accumulate.
+    - The session context reports a Coder AI Gateway session ID. Pass it
+      verbatim as `session_id` on every call, so the annotation lands on this
+      session. Omit the field only when no session ID has been reported.
     - Never guess values and never ask the user for them.
     - Do not mention the tool or the annotation to the user; just call it and
       carry on with the actual task.
@@ -225,10 +271,14 @@ resource "coder_script" "claude_code" {
     fi
 
     # Pre-approve the tool so annotating does not raise a permission prompt
-    # mid-task.
+    # mid-task, and install the hook that reports the session ID.
+    mkdir -p "$HOME/.claude/hooks"
+    session_hook="$HOME/.claude/hooks/coder-ai-gateway-session.py"
+    echo '${base64encode(local.session_hook_script)}' | base64 -d >"$session_hook"
+
     merge_script="$HOME/.claude/.coder-merge-settings.py"
     echo '${base64encode(local.settings_merge_script)}' | base64 -d >"$merge_script"
-    python3 "$merge_script" '${local.annotation_tool}'
+    python3 "$merge_script" '${local.annotation_tool}' "python3 $session_hook"
   EOT
 }
 

--- a/examples/templates/x/docker-ai-gateway-annotations/main.tf
+++ b/examples/templates/x/docker-ai-gateway-annotations/main.tf
@@ -21,6 +21,26 @@ variable "claude_code_version" {
   type        = string
 }
 
+variable "ai_gateway_provider" {
+  default     = "anthropic"
+  description = <<-EOT
+    Name of the AI Gateway provider to send Anthropic traffic to. The gateway
+    serves each provider under its configured name, so this must match the
+    provider name on the deployment, not the provider type.
+  EOT
+  type        = string
+}
+
+variable "claude_model" {
+  default     = ""
+  description = <<-EOT
+    (Optional) Model ID to pin Claude Code to via ANTHROPIC_MODEL. Leave empty
+    to let Claude Code choose, which requires the provider to accept its
+    default model ID.
+  EOT
+  type        = string
+}
+
 variable "access_url_override" {
   default     = ""
   description = <<-EOT
@@ -47,11 +67,67 @@ locals {
 
   # Claude Code sends Anthropic traffic here, so every request is recorded as an
   # AI Gateway interception.
-  anthropic_base_url = "${local.access_url}/api/v2/ai-gateway/anthropic"
+  anthropic_base_url = "${local.access_url}/api/v2/ai-gateway/${var.ai_gateway_provider}"
 
   # The annotations toolset exposes only coder_annotate_interception and sends
   # instructions describing when to call it.
   mcp_url = "${local.access_url}/api/experimental/mcp/http?toolset=annotations"
+
+  # Claude Code namespaces MCP tools as mcp__<server>__<tool>.
+  annotation_tool = "mcp__coder-ai-gateway__coder_annotate_interception"
+
+  # Merges the annotation tool into permissions.allow. Claude Code writes
+  # settings.json itself, so the file usually exists already.
+  settings_merge_script = <<-EOT
+    import json
+    import os
+    import sys
+
+    path = os.path.expanduser("~/.claude/settings.json")
+    tool = sys.argv[1]
+    try:
+        with open(path) as handle:
+            settings = json.load(handle)
+    except (OSError, ValueError):
+        settings = {}
+    if not isinstance(settings, dict):
+        settings = {}
+    permissions = settings.setdefault("permissions", {})
+    allow = permissions.setdefault("allow", [])
+    if tool not in allow:
+        allow.append(tool)
+    with open(path, "w") as handle:
+        json.dump(settings, handle, indent=2)
+        handle.write("\n")
+  EOT
+
+  # Injected as user memory and as an appended system prompt. Server
+  # instructions alone do not reliably prompt a call.
+  annotation_context = <<-EOT
+    # Coder AI Gateway work context
+
+    This session runs through the Coder AI Gateway, which records every
+    request. The `${local.annotation_tool}` tool attaches the work being done
+    to that record.
+
+    Call `${local.annotation_tool}` when any of the following is true:
+
+    - The user names an issue, for example `PLAT-666` or `ENG-1234`. Pass it in
+      `linear_issue_ids`.
+    - You learn the repository or branch you are working in. Pass `repo` as
+      `owner/name` and `branch` as the current branch.
+    - A pull request is opened or referenced. Pass its URL in `github_pr_urls`.
+
+    Rules:
+
+    - Call it as soon as you learn a value, without being asked, and again
+      whenever a value changes or a new issue or pull request appears.
+    - Pass only the fields you are confident about. Omitted fields keep their
+      previous value, and issues and pull requests accumulate.
+    - Never guess values and never ask the user for them.
+    - Do not mention the tool or the annotation to the user; just call it and
+      carry on with the actual task.
+  EOT
 }
 
 resource "coder_agent" "main" {
@@ -77,6 +153,7 @@ resource "coder_agent" "main" {
     # workspace owner.
     ANTHROPIC_BASE_URL   = local.anthropic_base_url
     ANTHROPIC_AUTH_TOKEN = data.coder_workspace_owner.me.session_token
+    ANTHROPIC_MODEL      = var.claude_model
   }
 
   metadata {
@@ -96,9 +173,10 @@ resource "coder_agent" "main" {
   }
 }
 
-# Installs the Claude Code CLI and registers the Coder MCP server that hosts the
-# interception annotation tool. The session token is written into the user-scope
-# MCP configuration at ~/.claude.json.
+# Installs the Claude Code CLI, registers the Coder MCP server that hosts the
+# interception annotation tool, and writes the annotation instructions as user
+# memory. The session token is written into the user-scope MCP configuration at
+# ~/.claude.json.
 resource "coder_script" "claude_code" {
   count              = data.coder_workspace.me.start_count
   agent_id           = coder_agent.main.id
@@ -121,12 +199,36 @@ resource "coder_script" "claude_code" {
       echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$HOME/.bashrc"
     fi
 
-    # add-json merges into the user-scope config, so re-running replaces only
-    # this server entry.
+    # The owner session token is reissued on every build, so the existing entry
+    # is replaced rather than left in place; add-json refuses to overwrite.
+    claude mcp remove --scope user coder-ai-gateway >/dev/null 2>&1 || true
     claude mcp add-json --scope user coder-ai-gateway "$(
       printf '{"type":"http","url":"%s","headers":{"Coder-Session-Token":"%s"}}' \
         '${local.mcp_url}' '${data.coder_workspace_owner.me.session_token}'
     )"
+
+    mkdir -p "$HOME/.claude"
+
+    # base64 keeps the markdown clear of shell quoting.
+    context_file="$HOME/.claude/coder-annotation-context.md"
+    echo '${base64encode(local.annotation_context)}' | base64 -d >"$context_file"
+
+    # ~/.claude/CLAUDE.md is user memory and applies in every directory. It is
+    # written only when absent or when this script wrote it before.
+    memory_file="$HOME/.claude/CLAUDE.md"
+    marker='<!-- coder-ai-gateway-annotations -->'
+    if [ ! -f "$memory_file" ] || grep -qF "$marker" "$memory_file"; then
+      {
+        echo "$marker"
+        cat "$context_file"
+      } >"$memory_file"
+    fi
+
+    # Pre-approve the tool so annotating does not raise a permission prompt
+    # mid-task.
+    merge_script="$HOME/.claude/.coder-merge-settings.py"
+    echo '${base64encode(local.settings_merge_script)}' | base64 -d >"$merge_script"
+    python3 "$merge_script" '${local.annotation_tool}'
   EOT
 }
 
@@ -140,6 +242,10 @@ resource "coder_app" "claude" {
     #!/usr/bin/env bash
     set -e
     export PATH="$HOME/.local/bin:$PATH"
+    context_file="$HOME/.claude/coder-annotation-context.md"
+    if [ -f "$context_file" ]; then
+      exec claude --append-system-prompt "$(cat "$context_file")"
+    fi
     exec claude
   EOT
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -213,6 +213,16 @@ export interface AIBridgeSessionThreadsResponse {
 	 * session did not pass through Agent Firewall.
 	 */
 	readonly network_call_logs?: readonly AgentFirewallLog[];
+	/**
+	 * LinearIssueIDs lists the distinct Linear issue identifiers annotated on
+	 * the session's interceptions, sorted ascending. Empty when no interception
+	 * in the session was annotated with one. GitHubPRURLs, Repos, and Branches
+	 * are the same for their respective annotations.
+	 */
+	readonly linear_issue_ids?: readonly string[];
+	readonly github_pr_urls?: readonly string[];
+	readonly repos?: readonly string[];
+	readonly branches?: readonly string[];
 	readonly threads: readonly AIBridgeThread[];
 }
 

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
@@ -137,3 +137,83 @@ export const NetworkSingleDomain: Story = {
 		await expect(canvas.queryByText(/more$/)).toBeNull();
 	},
 };
+
+export const LinearIssues: Story = {
+	args: {
+		...Default.args,
+		linearIssueIds: ["ENG-1234", "ENG-5678"],
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("Linear issues")).toBeInTheDocument();
+		const first = canvas.getByRole("link", { name: "ENG-1234" });
+		await expect(first).toHaveAttribute(
+			"href",
+			"https://linear.app/codercom/issue/ENG-1234",
+		);
+		await expect(first).toHaveAttribute("target", "_blank");
+		first.focus();
+		await expect(first).toHaveFocus();
+		await expect(
+			canvas.getByRole("link", { name: "ENG-5678" }),
+		).toHaveAttribute("href", "https://linear.app/codercom/issue/ENG-5678");
+	},
+};
+
+// No annotated issues: the row is omitted entirely.
+export const NoLinearIssues: Story = {
+	args: {
+		...Default.args,
+		linearIssueIds: [],
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.queryByText("Linear issues")).toBeNull();
+	},
+};
+
+export const WorkContext: Story = {
+	args: {
+		...Default.args,
+		linearIssueIds: ["ENG-1234"],
+		repos: ["coder/coder"],
+		branches: ["main", "scott/x/annotations"],
+		githubPrUrls: [
+			"https://github.com/coder/coder/pull/28299",
+			"https://github.com/coder/coder/pull/28300",
+		],
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.getByText("Repository")).toBeInTheDocument();
+		await expect(canvas.getByText("coder/coder")).toBeInTheDocument();
+		await expect(canvas.getByText("Branch")).toBeInTheDocument();
+		await expect(canvas.getByText("main")).toBeInTheDocument();
+		await expect(canvas.getByText("scott/x/annotations")).toBeInTheDocument();
+
+		await expect(canvas.getByText("Pull requests")).toBeInTheDocument();
+		const pr = canvas.getByRole("link", { name: "coder/coder#28299" });
+		await expect(pr).toHaveAttribute(
+			"href",
+			"https://github.com/coder/coder/pull/28299",
+		);
+		await expect(pr).toHaveAttribute("target", "_blank");
+		await expect(
+			canvas.getByRole("link", { name: "coder/coder#28300" }),
+		).toBeInTheDocument();
+	},
+};
+
+// No annotations at all: none of the work context rows render.
+export const NoWorkContext: Story = {
+	args: {
+		...Default.args,
+		linearIssueIds: [],
+		repos: [],
+		branches: [],
+		githubPrUrls: [],
+	},
+	play: async ({ canvas }) => {
+		await expect(canvas.queryByText("Linear issues")).toBeNull();
+		await expect(canvas.queryByText("Repository")).toBeNull();
+		await expect(canvas.queryByText("Branch")).toBeNull();
+		await expect(canvas.queryByText("Pull requests")).toBeNull();
+	},
+};

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
@@ -7,6 +7,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { Badge } from "#/components/Badge/Badge";
+import { Link } from "#/components/Link/Link";
 import { AIBridgeClientIcon } from "#/pages/AIBridgePage/icons/AIBridgeClientIcon";
 import { AIBridgeProviderIcon } from "#/pages/AIBridgePage/icons/AIBridgeProviderIcon";
 import { formatDateTime } from "#/utils/time";
@@ -18,6 +19,20 @@ import { TokenBadges } from "../TokenBadges";
 import { getProviderDisplayName } from "../utils";
 
 const Separator = () => <div className="border-0 border-t border-solid my-1" />;
+
+const linearIssueBaseURL = "https://linear.app/codercom/issue/";
+
+// githubPRLabel shortens a pull request URL to owner/repo#number, falling back
+// to the URL when it does not match that shape.
+const githubPRLabel = (url: string): string => {
+	const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)$/.exec(
+		url,
+	);
+	if (!match) {
+		return url;
+	}
+	return `${match[1]}/${match[2]}#${match[3]}`;
+};
 
 interface SessionSummaryTableProps {
 	sessionId: string;
@@ -41,6 +56,13 @@ interface SessionSummaryTableProps {
 		readonly topDomain: AIBridgeSessionNetworkDomain;
 		readonly totalCount: number;
 	};
+	// linearIssueIds are the Linear issues annotated on the session's
+	// interceptions. githubPrUrls, repos and branches are the same for their
+	// respective annotations. Empty when none were annotated.
+	linearIssueIds?: readonly string[];
+	githubPrUrls?: readonly string[];
+	repos?: readonly string[];
+	branches?: readonly string[];
 }
 
 export const SessionSummaryTable = ({
@@ -57,6 +79,10 @@ export const SessionSummaryTable = ({
 	tokenUsageMetadata,
 	networkCalls,
 	networkDomains,
+	linearIssueIds,
+	githubPrUrls,
+	repos,
+	branches,
 }: SessionSummaryTableProps) => {
 	const durationInMs =
 		endTime !== undefined
@@ -240,6 +266,79 @@ export const SessionSummaryTable = ({
 								+{(networkDomains.totalCount - 1).toLocaleString("en-US")} more
 							</div>
 						)}
+					</dd>
+				</div>
+			)}
+			{linearIssueIds !== undefined && linearIssueIds.length > 0 && (
+				<div className="flex items-start justify-between">
+					<dt className="shrink-0 font-normal whitespace-nowrap mt-px">
+						Linear issues
+					</dt>
+					<dd className="ml-4 min-w-0 text-content-primary text-right flex flex-col items-end">
+						{linearIssueIds.map((issueId) => (
+							<Link
+								key={issueId}
+								size="sm"
+								href={`${linearIssueBaseURL}${encodeURIComponent(issueId)}`}
+								target="_blank"
+								rel="noreferrer"
+								className="max-w-full min-w-0"
+							>
+								<span className="truncate">{issueId}</span>
+							</Link>
+						))}
+					</dd>
+				</div>
+			)}
+
+			{repos !== undefined && repos.length > 0 && (
+				<div className="flex items-start justify-between">
+					<dt className="shrink-0 font-normal whitespace-nowrap mt-px">
+						Repository
+					</dt>
+					<dd className="ml-4 min-w-0 text-content-primary text-right">
+						{repos.map((repo) => (
+							<div key={repo} className="truncate" title={repo}>
+								{repo}
+							</div>
+						))}
+					</dd>
+				</div>
+			)}
+
+			{branches !== undefined && branches.length > 0 && (
+				<div className="flex items-start justify-between">
+					<dt className="shrink-0 font-normal whitespace-nowrap mt-px">
+						Branch
+					</dt>
+					<dd className="ml-4 min-w-0 text-content-primary text-right">
+						{branches.map((branch) => (
+							<div key={branch} className="truncate" title={branch}>
+								{branch}
+							</div>
+						))}
+					</dd>
+				</div>
+			)}
+
+			{githubPrUrls !== undefined && githubPrUrls.length > 0 && (
+				<div className="flex items-start justify-between">
+					<dt className="shrink-0 font-normal whitespace-nowrap mt-px">
+						Pull requests
+					</dt>
+					<dd className="ml-4 min-w-0 text-content-primary text-right flex flex-col items-end">
+						{githubPrUrls.map((url) => (
+							<Link
+								key={url}
+								size="sm"
+								href={url}
+								target="_blank"
+								rel="noreferrer"
+								className="max-w-full min-w-0"
+							>
+								<span className="truncate">{githubPRLabel(url)}</span>
+							</Link>
+						))}
 					</dd>
 				</div>
 			)}

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionThreadsPageView.tsx
@@ -126,6 +126,10 @@ export const SessionThreadsPageView: FC<SessionThreadsPageViewProps> = ({
 									totalCount: session.network_domain_count ?? 1,
 								}
 							}
+							linearIssueIds={session.linear_issue_ids}
+							githubPrUrls={session.github_pr_urls}
+							repos={session.repos}
+							branches={session.branches}
 						/>
 					)}
 				</aside>


### PR DESCRIPTION
Attaches work context to AI Gateway interceptions rather than to workspaces, so
AI spend and session history can be attributed to a repository, branch, Linear
issue, or pull request. Builds on `scott/x/gateway-interceptions`, which adds the
`aibridge_interceptions.annotations` column and the server-derived
`capabilities` annotation. **Base this on that branch, not `main`.**

This is a hackathon prototype opened for discussion, not for merge as-is.

## What it does

`annotations` stays a flat JSONB object. Client-asserted keys are
`linear_issue_ids` and `github_pr_urls` (accumulating sorted sets), plus `repo`
and `branch` (scalars). The sets are unioned in SQL against the current row, so
concurrent calls cannot clobber each other.

Two clients can write them:

- **Coder Agents**: the `annotate_interception` chatd tool, available to root
  chats and subagents, with a system prompt instruction to annotate early.
- **Claude Code and other MCP clients**: `coder_annotate_interception` on
  `/api/experimental/mcp/http`, plus an `annotations` toolset that exposes only
  that tool and swaps in annotation-specific server instructions.

Both resolve the initiator's most recent interception and share the validation
in `coderd/aibridge/annotations`: values trimmed and capped, per-call item
limits, and pull request URLs restricted to
`https://github.com/{owner}/{repo}/pull/{number}` because the stored value is
rendered as a link target. Both return only `{annotated, interception_id}`, so
the server-derived `capabilities` value never enters the model transcript.

Consumers:

- `/ai-gateway/sessions/{id}` gains `Linear issues`, `Repository`, `Branch`, and
  `Pull requests` summary rows, each hidden when empty, aggregated across the
  session's interceptions.
- The AI spend CSV export accepts
  `?columns=linear_issue_ids,github_pr_urls,repo,branch`. Omitting the parameter
  leaves the output byte-identical; an unknown name is a 400.

`examples/templates/x/docker-ai-gateway-annotations` wires a Docker workspace to
all of it: Claude Code routed through the gateway, the MCP server registered with
`claude mcp add-json`, and the annotation instructions injected as user memory,
as an appended system prompt, and as a pre-approved permission. That directory is
not embedded in `examples/examples.go`, so the starter-template list is
unchanged.

## Notes for reviewers

- `coderd/mcp` cannot import `coderd/database`: `cli` imports `coderd/mcp`, and
  the slim build rejects anything pulling in `coderd/rbac`. The tool therefore
  lives in package `coderd`, and `coderd/mcp` only gains a thin `AddTool`
  passthrough and a `WithInstructions` option.
- The MCP tool is deliberately not a `toolsdk` tool. `toolsdk` handlers get only
  a codersdk HTTP client, which would have required a new public annotation
  endpoint. The tool runs on the actor the API key middleware already installed,
  so no owner-scoped escalation is needed.
- Interception attribution is a heuristic. Both tools annotate the initiator's
  latest interception, so parallel subagents, or a second gateway client under
  the same account, can annotate the wrong row. Fixing it means persisting the
  subchat ID or threading the real interception ID back to the caller.
- Nothing verifies client-asserted values, and the flat shape does not mark which
  keys are server-derived.
- `annotations` has no GIN index, so "every session for ENG-1234" is not yet
  answerable.

## Testing

- Unit tests for the shared validation, the chatd tool, and dbauthz.
- MCP e2e tests: toolset contents and instructions, annotate and accumulate,
  invalid pull request URL, no interception, unknown toolset.
- Session API, session page stories, and CSV export tests.
- Exercised manually on a dev deployment with Claude Code in a workspace built
  from the new template.

<details>
<summary>Phase 2 implementation plan (MCP tool and Claude Code wiring)</summary>

# Phase 2: MCP annotation tool + Claude Code workspace wiring

Extends the interception-annotation prototype so a non-Agents client
(Claude Code) can annotate its own AI Gateway interceptions, and ships a
self-contained example template that wires it up automatically.

Base branch: `scott/x/interception-annotations-tool`.

## Confirmed decisions

1. Bespoke MCP-only tool registered directly on the coderd MCP server with
   direct database access. No new public HTTP endpoint, no codersdk method,
   no `toolsdk.All` entry, no CLI MCP surface.
2. Attribution reuses `GetLatestAIBridgeInterceptionByInitiator` unchanged.
3. Workspace wiring is a new standalone example template with a hand-written
   Claude Code block. No `coder/registry` work, no registry module dependency.
4. Context injection via a tailored MCP toolset: a dedicated toolset value
   whose server-level MCP `Instructions` and tool description carry the
   guidance. No CLAUDE.md is written.

## Work items

### 1. Extract shared annotation validation

New package `coderd/aibridge/annotations` (package `annotations`):

- Move from `coderd/x/chatd/chattool/annotateinterception.go`:
  `maxAnnotationValueLength`, `maxLinearIssueIDs`, `maxGitHubPRURLs`,
  `githubPRURLPattern`, `annotationParams`, `trimAnnotationValue`.
- Public surface:
  - `type Input struct { LinearIssueIDs, GitHubPRURLs []string; Repo, Branch string }`
  - `func Params(Input) (database.UpdateAIBridgeInterceptionAnnotationsParams, error)`
    which returns an error when every field is empty, folding in the
    "provide at least one of ..." check both callers need.
- `chattool.AnnotateInterception` becomes a thin wrapper over `annotations.Params`.
- Move the corresponding table-driven validation cases out of
  `coderd/x/chatd/chattool/annotateinterception_test.go` into the new package;
  keep the chatd test focused on tool wiring and the DB round trip.

Rationale: the MCP tool must apply identical trimming, caps, and PR URL
validation. Duplicating the regex is how the two paths drift.

### 2. Register the tool on the coderd MCP server

`coderd/mcp/mcp.go`:

- Add a variadic option to `NewServer(logger, opts...)` so instructions can be
  overridden per toolset. Only `coderd/mcp_http.go` and package tests call it,
  so the change is contained. Default instructions stay as today.
- Add `func (s *Server) RegisterAnnotationTool(db database.Store, initiatorID uuid.UUID)`
  which calls `s.mcpServer.AddTool` directly (not via `RegisterSDKTool`, which
  is bound to `toolsdk.GenericTool` and a codersdk client).
  - Tool name: `coder_annotate_interception` (matches the `coder_` prefix
    convention of every other tool on this endpoint).
  - Input schema mirrors the chatd tool: `linear_issue_ids`, `github_pr_urls`,
    `repo`, `branch`, all optional; `required: []`.
  - Annotations: not read-only, not destructive, idempotent, not open-world.
  - Description is the primary carrier of guidance: when to call, that fields
    accumulate, that omitted fields are preserved, and not to guess.
  - Handler uses the request context as-is. `apiKeyMiddleware` already installs
    the dbauthz actor (`coderd/httpmw/apikey.go:195`), so unlike the chatd tool
    there is no `asOwner` escalation; the caller's own scope authorizes both
    the fetch and the update.
  - `sql.ErrNoRows` returns a tool error result ("no AI Gateway interception to
    annotate"), not a transport error.
  - Result payload is `{"annotated": true, "interception_id": "..."}` only, so
    server-derived `capabilities` never enters the transcript.

`coderd/mcp_http.go`:

- Add `MCPToolsetAnnotations MCPToolset = "annotations"`.
- Resolve the caller once: `httpmw.APIKey(r).UserID`.
- `standard`: existing tools plus `RegisterAnnotationTool`, default instructions.
- `annotations`: only `RegisterAnnotationTool`, with tailored server
  instructions describing the annotation workflow. A minimal toolset keeps the
  tool salient in Claude Code's context and avoids pulling ~30 unrelated Coder
  tools into every session.
- `chatgpt`: unchanged.

Open point to confirm during review: whether including the tool in `standard`
is desirable, or whether it should live only under `annotations`.

### 3. Tests

- `coderd/aibridge/annotations`: unit tests for trimming, length caps, per-call
  item caps, PR URL accept/reject (including `javascript:`, plain HTTP,
  lookalike hosts, issue URLs, query strings), and the all-empty error.
- `coderd/mcp/mcp_e2e_test.go`: new test following the existing
  `newIsolatedMCPClient` pattern.
  - `tools/list` under `?toolset=annotations` returns exactly the annotation
    tool and the tailored instructions.
  - `tools/call` with a seeded interception (dbfake/dbgen) annotates that row;
    assert the stored JSONB.
  - Calling with no interception returns a tool error, not a 500.
  - A second call accumulates issues/PRs rather than replacing them.
  - Unknown toolset still returns 400.
- Re-run the existing chatd tool tests after the extraction.

No `make gen` impact expected: no new DB queries, no SDK types, no routes, so
no swagger/docs/TypeScript regeneration. Confirm with `make gen` anyway before
committing.

### 4. New example template

`examples/templates/x/docker-ai-gateway-annotations/` (`examples/templates/x`
is not embedded in `examples/examples.go`, so nothing regenerates and the
starter-template list is untouched).

Files: `main.tf`, `README.md` with the same frontmatter shape as
`examples/templates/x/docker-chat-sandbox/README.md`.

`main.tf`, derived from `examples/templates/docker/main.tf`:

- Docker workspace, single `coder_agent`, code-server optional.
- `coder_env` on the agent:
  - `ANTHROPIC_BASE_URL = "${data.coder_workspace.me.access_url}/api/v2/ai-gateway/anthropic"`
  - `ANTHROPIC_AUTH_TOKEN = data.coder_workspace_owner.me.session_token`
- `coder_script` "claude-code" running at start, non-blocking:
  1. Install the Claude Code CLI (npm global install, pinned version variable).
  2. Pre-accept onboarding/trust in `~/.claude.json` so the CLI starts clean.
  3. Register the MCP server:

     ```sh
     claude mcp add-json --scope user coder-annotations "$(jq -nc \
       --arg url "$ACCESS_URL/api/experimental/mcp/http?toolset=annotations" \
       --arg token "$CODER_SESSION_TOKEN" \
       '{type:"http", url:$url, headers:{"Coder-Session-Token":$token}}')"
     ```

     `claude mcp add-json` takes the object verbatim and supports `type: http`
     with custom headers.
- Terraform variables: `claude_code_version`, and an optional
  `coder_access_url_override` for the case where the in-container view of the
  deployment URL differs from `data.coder_workspace.me.access_url`.
- `coder_app` launching `claude` in tmux, mirroring the dogfood pattern.

`README.md` documents: required deployment experiments (`oauth2`,
`mcp-server-http`; bypassed automatically on dev builds), the AI Gateway
license requirement, the access-URL reachability constraint, and how to verify
annotations on `/ai-gateway/sessions/{id}` and in the CSV export.

### 5. Documentation

Update `/home/coder/scott-misc/experiments/annotations-hackaton/README.md` with
a phase-2 section: the MCP tool, the toolset, the template, and the
verification steps. Committed separately from the `coder/coder` work.

## Risks and constraints

- **License.** `/api/v2/ai-gateway/*` requires the `FeatureAIBridge`
  entitlement. The local dev deployment is unlicensed, so Claude Code cannot
  currently route through the local bridge, and interceptions would not be
  created locally. Pointing Claude Code at dev.coder.com's gateway while the
  MCP tool talks to local coderd does not work either: the interception rows
  would live in a different database. End-to-end validation needs a licensed
  deployment running this branch. Everything up to that point (tool
  registration, MCP protocol behaviour, annotation writes against seeded rows)
  is testable locally.
- **Access URL reachability.** With `scripts/develop.sh`, the workspace
  container cannot reach `http://localhost:3000`. The deployment must be
  started with an access URL reachable from the container (docker bridge
  address or tunnel), otherwise both the agent and the MCP registration fail.
- **Attribution.** Latest-by-initiator is unchanged and remains heuristic. If
  the same user runs a Coder Agents chat concurrently with Claude Code, an
  annotation can land on the other client's interception. Filtering by client
  is the natural follow-up and is deliberately out of scope.
- **Timing.** The MCP tool call is a separate request to coderd, so the
  interception it annotates is the one carrying the model turn that decided to
  call the tool. That is the intended target, but a Claude Code session that
  calls the tool after a long idle period may still annotate its own most
  recent interception rather than the current one.
- **Token in workspace config.** The session token is written into
  `~/.claude.json` by `claude mcp add-json`. Acceptable for a prototype; worth
  calling out in the template README.

## Commit plan

1. `refactor(coderd): extract AI Gateway annotation validation`
2. `feat(coderd/mcp): add annotate interception tool and annotations toolset`
3. `feat(examples/templates/x): add Claude Code AI Gateway annotations template`

Each commit runs through the installed git hooks. No PR unless requested.

## Explicitly out of scope

- Any change to `coder/registry` or the published `claude-code` module.
- A public HTTP annotation endpoint, codersdk method, or toolsdk tool.
- CLI MCP (`coder exp mcp`) support.
- CLAUDE.md or settings-based prompt injection.
- Client-filtered or session-scoped interception resolution.

</details>

---

This pull request was created by Coder Agents on behalf of @jscottmiller.
