### PR TITLE
chore: add supabase icon

### DIFF
--- a/site/src/theme/icons.json
+++ b/site/src/theme/icons.json
@@ -134,6 +134,7 @@
 	"rustrover.svg",
 	"slack.svg",
 	"sourcegraph-amp.svg",
+	"supabase.svg",
 	"swift.svg",
 	"tasks.svg",
 	"tensorflow.svg",

--- a/site/static/icon/supabase.svg
+++ b/site/static/icon/supabase.svg
@@ -1,0 +1,15 @@
+<svg width="109" height="113" viewBox="0 0 109 113" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint0_linear)"/>
+<path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
+<path d="M45.317 2.07103C48.1765 -1.53037 53.9745 0.442937 54.0434 5.041L54.4849 72.2922H9.83113C1.64038 72.2922 -2.92775 62.8321 2.1655 56.4175L45.317 2.07103Z" fill="#3ECF8E"/>
+<defs>
+<linearGradient id="paint0_linear" x1="53.9738" y1="54.974" x2="94.1635" y2="71.8295" gradientUnits="userSpaceOnUse">
+<stop stop-color="#249361"/>
+<stop offset="1" stop-color="#3ECF8E"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="36.1558" y1="30.578" x2="54.4844" y2="65.0806" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/site/static/icon/supabase.svg
+++ b/site/static/icon/supabase.svg
@@ -1,13 +1,13 @@
-<svg width="109" height="113" viewBox="0 0 109 113" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint0_linear)"/>
-<path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
-<path d="M45.317 2.07103C48.1765 -1.53037 53.9745 0.442937 54.0434 5.041L54.4849 72.2922H9.83113C1.64038 72.2922 -2.92775 62.8321 2.1655 56.4175L45.317 2.07103Z" fill="#3ECF8E"/>
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M145.726 243.459C139.166 248.713 129.959 245.834 129.8 237.126L128.489 113.653L132.5 113.653L228.006 113.653C246.87 113.653 257.394 131.548 245.663 143.328L145.726 243.459Z" fill="url(#paint0_linear)"/>
+<path d="M145.726 243.459C139.166 248.713 129.959 245.834 129.8 237.126L128.489 113.653L132.5 113.653L228.006 113.653C246.87 113.653 257.394 131.548 245.663 143.328L145.726 243.459Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
+<path d="M110.341 12.897C116.901 7.643 126.108 10.522 126.267 19.23L126.728 178.903H24.048C5.184 178.903 -5.34 161.008 6.391 149.228L110.341 12.897Z" fill="#3ECF8E"/>
 <defs>
-<linearGradient id="paint0_linear" x1="53.9738" y1="54.974" x2="94.1635" y2="71.8295" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint0_linear" x1="128.489" y1="135.999" x2="221.018" y2="171.012" gradientUnits="userSpaceOnUse">
 <stop stop-color="#249361"/>
 <stop offset="1" stop-color="#3ECF8E"/>
 </linearGradient>
-<linearGradient id="paint1_linear" x1="36.1558" y1="30.578" x2="54.4844" y2="65.0806" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint1_linear" x1="87.506" y1="91.516" x2="129.641" y2="167.003" gradientUnits="userSpaceOnUse">
 <stop/>
 <stop offset="1" stop-opacity="0"/>
 </linearGradient>

--- a/site/static/icon/supabase.svg
+++ b/site/static/icon/supabase.svg
@@ -1,15 +1,17 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M145.726 243.459C139.166 248.713 129.959 245.834 129.8 237.126L128.489 113.653L132.5 113.653L228.006 113.653C246.87 113.653 257.394 131.548 245.663 143.328L145.726 243.459Z" fill="url(#paint0_linear)"/>
-<path d="M145.726 243.459C139.166 248.713 129.959 245.834 129.8 237.126L128.489 113.653L132.5 113.653L228.006 113.653C246.87 113.653 257.394 131.548 245.663 143.328L145.726 243.459Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
-<path d="M110.341 12.897C116.901 7.643 126.108 10.522 126.267 19.23L126.728 178.903H24.048C5.184 178.903 -5.34 161.008 6.391 149.228L110.341 12.897Z" fill="#3ECF8E"/>
-<defs>
-<linearGradient id="paint0_linear" x1="128.489" y1="135.999" x2="221.018" y2="171.012" gradientUnits="userSpaceOnUse">
-<stop stop-color="#249361"/>
-<stop offset="1" stop-color="#3ECF8E"/>
-</linearGradient>
-<linearGradient id="paint1_linear" x1="87.506" y1="91.516" x2="129.641" y2="167.003" gradientUnits="userSpaceOnUse">
-<stop/>
-<stop offset="1" stop-opacity="0"/>
-</linearGradient>
-</defs>
+  <g transform="translate(73.5, 71.5) scale(2.265)">
+    <path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint0_linear)"/>
+    <path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
+    <path d="M45.317 2.07103C48.1765 -1.53037 53.9745 0.442937 54.0434 5.041L54.4849 72.2922H9.83113C1.64038 72.2922 -2.92775 62.8321 2.1655 56.4175L45.317 2.07103Z" fill="#3ECF8E"/>
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear" x1="53.9738" y1="54.974" x2="94.1635" y2="71.8295" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#249361"/>
+      <stop offset="1" stop-color="#3ECF8E"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="36.1558" y1="30.578" x2="54.4844" y2="65.0806" gradientUnits="userSpaceOnUse">
+      <stop/>
+      <stop offset="1" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
 </svg>

--- a/site/static/icon/supabase.svg
+++ b/site/static/icon/supabase.svg
@@ -1,17 +1,15 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(73.5, 71.5) scale(2.265)">
-    <path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint0_linear)"/>
-    <path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
-    <path d="M45.317 2.07103C48.1765 -1.53037 53.9745 0.442937 54.0434 5.041L54.4849 72.2922H9.83113C1.64038 72.2922 -2.92775 62.8321 2.1655 56.4175L45.317 2.07103Z" fill="#3ECF8E"/>
-  </g>
-  <defs>
-    <linearGradient id="paint0_linear" x1="53.9738" y1="54.974" x2="94.1635" y2="71.8295" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#249361"/>
-      <stop offset="1" stop-color="#3ECF8E"/>
-    </linearGradient>
-    <linearGradient id="paint1_linear" x1="36.1558" y1="30.578" x2="54.4844" y2="65.0806" gradientUnits="userSpaceOnUse">
-      <stop/>
-      <stop offset="1" stop-opacity="0"/>
-    </linearGradient>
-  </defs>
+<path d="M148.867 249.758C141.986 255.922 128.837 252.678 128.681 242.777L126.394 90.696H228.994C247.574 90.696 257.959 111.104 246.397 124.881L148.867 249.758Z" fill="url(#paint0_linear)"/>
+<path d="M148.867 249.758C141.986 255.922 128.837 252.678 128.681 242.777L126.697 90.696H228.994C247.574 90.696 257.959 111.104 246.397 124.881L148.867 249.758Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
+<path d="M107.133 4.691C114.014 -1.473 127.163 1.771 127.319 11.672L128.161 163.753H26.817C8.237 163.753 -2.148 143.345 9.414 129.568L107.133 4.691Z" fill="#3ECF8E"/>
+<defs>
+<linearGradient id="paint0_linear" x1="126.697" y1="124.503" x2="217.786" y2="162.717" gradientUnits="userSpaceOnUse">
+<stop stop-color="#249361"/>
+<stop offset="1" stop-color="#3ECF8E"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="86.340" y1="69.279" x2="127.894" y2="147.440" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+</defs>
 </svg>


### PR DESCRIPTION
Adds the Supabase icon to the built-in icons for use with external auth and modules.

- Adds `site/static/icon/supabase.svg` (official Supabase logo)
- Registers icon in `site/src/theme/icons.json`

The icon is full-color with good contrast on both light and dark backgrounds, so no special handling in `externalImages.ts` is needed.