### PR TITLE
feat(site): add provider icon to chat model selector

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -92,6 +92,66 @@ export const WithSelectedValue: Story = {
 	},
 };
 
+// The trigger leads with the selected model's provider icon, which is
+// presentational (alt="") and excluded from the accessible name.
+export const SelectedValueShowsProviderIcon: Story = {
+	args: {
+		options: allModels,
+		value: "anthropic/claude-sonnet-4",
+	},
+	play: async ({ canvasElement }) => {
+		const trigger = within(canvasElement).getByRole("combobox", {
+			name: "Claude Sonnet 4",
+		});
+		const icon = trigger.querySelector("img");
+		expect(icon).not.toBeNull();
+		expect(icon).toHaveAttribute("src", "/icon/anthropic.svg");
+	},
+};
+
+// A configured provider icon URL wins over the built-in provider mapping.
+export const SelectedValueShowsCustomProviderIcon: Story = {
+	args: {
+		options: [
+			{
+				...MockModelSelectorOption,
+				id: "anthropic-hyper/claude-opus-4",
+				provider: "anthropic",
+				providerId: "provider-anthropic-hyper",
+				providerLabel: "Hyper",
+				providerIcon: "/icon/coder.svg",
+				model: "claude-opus-4-20250514",
+				displayName: "Claude Opus 4",
+			},
+		],
+		value: "anthropic-hyper/claude-opus-4",
+	},
+	play: async ({ canvasElement }) => {
+		const trigger = within(canvasElement).getByRole("combobox", {
+			name: "Claude Opus 4",
+		});
+		expect(trigger.querySelector("img")).toHaveAttribute(
+			"src",
+			"/icon/coder.svg",
+		);
+	},
+};
+
+// No icon renders when no model is selected.
+export const PlaceholderShowsNoIcon: Story = {
+	args: {
+		value: "",
+	},
+	play: async ({ canvasElement }) => {
+		const trigger = within(canvasElement).getByRole("combobox", {
+			name: "Select model",
+		});
+		expect(trigger.querySelector("img")).toBeNull();
+		// Only the chevron svg renders; no Building2 fallback icon.
+		expect(trigger.querySelectorAll("svg")).toHaveLength(1);
+	},
+};
+
 export const CustomTriggerLabel: Story = {
 	args: {
 		options: openAIModels,

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -92,24 +92,22 @@ export const WithSelectedValue: Story = {
 	},
 };
 
-// The trigger leads with the selected model's provider icon, which is
-// presentational (alt="") and excluded from the accessible name.
 export const SelectedValueShowsProviderIcon: Story = {
 	args: {
 		options: allModels,
 		value: "anthropic/claude-sonnet-4",
 	},
 	play: async ({ canvasElement }) => {
-		const trigger = within(canvasElement).getByRole("combobox", {
-			name: "Claude Sonnet 4",
-		});
-		const icon = trigger.querySelector("img");
-		expect(icon).not.toBeNull();
-		expect(icon).toHaveAttribute("src", "/icon/anthropic.svg");
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("combobox", { name: "Claude Sonnet 4" }),
+		).toBeInTheDocument();
+		expect(
+			canvas.getByTestId("model-selector-trigger-icon"),
+		).toBeInTheDocument();
 	},
 };
 
-// A configured provider icon URL wins over the built-in provider mapping.
 export const SelectedValueShowsCustomProviderIcon: Story = {
 	args: {
 		options: [
@@ -127,28 +125,27 @@ export const SelectedValueShowsCustomProviderIcon: Story = {
 		value: "anthropic-hyper/claude-opus-4",
 	},
 	play: async ({ canvasElement }) => {
-		const trigger = within(canvasElement).getByRole("combobox", {
-			name: "Claude Opus 4",
-		});
-		expect(trigger.querySelector("img")).toHaveAttribute(
-			"src",
-			"/icon/coder.svg",
-		);
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("combobox", { name: "Claude Opus 4" }),
+		).toBeInTheDocument();
+		const icon = canvas.getByTestId("model-selector-trigger-icon");
+		expect(icon.querySelector("img")).toHaveAttribute("src", "/icon/coder.svg");
 	},
 };
 
-// No icon renders when no model is selected.
 export const PlaceholderShowsNoIcon: Story = {
 	args: {
 		value: "",
 	},
 	play: async ({ canvasElement }) => {
-		const trigger = within(canvasElement).getByRole("combobox", {
-			name: "Select model",
-		});
-		expect(trigger.querySelector("img")).toBeNull();
-		// Only the chevron svg renders; no Building2 fallback icon.
-		expect(trigger.querySelectorAll("svg")).toHaveLength(1);
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("combobox", { name: "Select model" }),
+		).toBeInTheDocument();
+		expect(
+			canvas.queryByTestId("model-selector-trigger-icon"),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -169,11 +169,13 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					onTouchStart={onTriggerTouchStart}
 				>
 					{selectedModel && (
-						<ProviderIcon
-							provider={selectedModel.provider}
-							icon={selectedModel.providerIcon}
-							className="size-3 shrink-0"
-						/>
+						<span data-testid="model-selector-trigger-icon">
+							<ProviderIcon
+								provider={selectedModel.provider}
+								icon={selectedModel.providerIcon}
+								className="size-3 shrink-0"
+							/>
+						</span>
 					)}
 					<span className="truncate">{triggerLabel}</span>
 					<ChevronDownIcon open={open} />

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -163,9 +163,10 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					type="button"
 					variant="subtle"
 					className={cn(
-						// The img overrides undo Button's default-size img rules
+						// px-2 + gap-1 match the workspace and MCP pills. The img
+						// overrides undo Button's default-size img rules
 						// (size-icon-lg, p-0.5) so the provider icon renders at 12px.
-						"h-7 md:h-auto min-w-0 shrink justify-start gap-0.5 rounded-full border-0 bg-surface-secondary px-1 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link md:w-auto md:shrink-0 md:gap-1.5 [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
+						"h-7 md:h-auto min-w-0 shrink justify-start gap-1 rounded-full border-0 bg-surface-secondary px-2 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link md:w-auto md:shrink-0 [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
 						className,
 					)}
 					onTouchStart={onTriggerTouchStart}

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -163,11 +163,20 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					type="button"
 					variant="subtle"
 					className={cn(
-						"h-7 md:h-auto min-w-0 shrink justify-start gap-0.5 rounded-full border-0 bg-surface-secondary px-1 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link md:w-auto md:shrink-0 md:gap-1.5 [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary",
+						// The img overrides undo Button's default-size img rules
+						// (size-icon-lg, p-0.5) so the provider icon renders at 12px.
+						"h-7 md:h-auto min-w-0 shrink justify-start gap-0.5 rounded-full border-0 bg-surface-secondary px-1 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link md:w-auto md:shrink-0 md:gap-1.5 [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
 						className,
 					)}
 					onTouchStart={onTriggerTouchStart}
 				>
+					{selectedModel && (
+						<ProviderIcon
+							provider={selectedModel.provider}
+							icon={selectedModel.providerIcon}
+							className="size-3 shrink-0"
+						/>
+					)}
 					<span className="truncate">{triggerLabel}</span>
 					<ChevronDownIcon open={open} />
 				</Button>

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -163,9 +163,6 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					type="button"
 					variant="subtle"
 					className={cn(
-						// px-2 + gap-1 match the workspace and MCP pills. The img
-						// overrides undo Button's default-size img rules
-						// (size-icon-lg, p-0.5) so the provider icon renders at 12px.
 						"h-7 md:h-auto min-w-0 shrink justify-start gap-1 rounded-full border-0 bg-surface-secondary px-2 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link md:w-auto md:shrink-0 [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
 						className,
 					)}


### PR DESCRIPTION
Adds the AI provider icon to the left of the selected model name in the Coder Agents chat composer, matching the workspace pill. The icon reuses the existing `ProviderIcon` mapping (configured icon URL wins, falling back to the provider glyph, then a generic building icon). The img overrides undo `Button`'s default-size `[&>img]` rules (size-icon-lg, p-0.5) so the icon renders at 12px like the workspace pill's icon, and it only shows when a model is selected (never for the placeholder).

## Screenshots

### Before

<img width="811" height="229" alt="image" src="https://github.com/user-attachments/assets/6a77adb7-e68f-4675-8c79-8ca72c63d3d7" />

### After

<img width="811" height="213" alt="image" src="https://github.com/user-attachments/assets/e46fdd99-0563-4b4d-976c-800140206ce4" />

---

Generated by [Coder Agents](https://coder.com) on behalf of @DanielleMaywood
