### PR TITLE
feat: add file-transfer visibility to the connection log

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -224,25 +224,26 @@ func New(options Options) Agent {
 	hardCtx, hardCancel := context.WithCancel(context.Background())
 	gracefulCtx, gracefulCancel := context.WithCancel(hardCtx)
 	a := &agent{
-		clock:                   options.Clock,
-		tailnetListenPort:       options.TailnetListenPort,
-		reconnectingPTYTimeout:  options.ReconnectingPTYTimeout,
-		logger:                  options.Logger,
-		gracefulCtx:             gracefulCtx,
-		gracefulCancel:          gracefulCancel,
-		hardCtx:                 hardCtx,
-		hardCancel:              hardCancel,
-		coordDisconnected:       make(chan struct{}),
-		environmentVariables:    options.EnvironmentVariables,
-		client:                  options.Client,
-		filesystem:              options.Filesystem,
-		logDir:                  options.LogDir,
-		tempDir:                 options.TempDir,
-		scriptDataDir:           options.ScriptDataDir,
-		lifecycleUpdate:         make(chan struct{}, 1),
-		lifecycleReported:       make(chan codersdk.WorkspaceAgentLifecycle, 1),
-		lifecycleStates:         []agentsdk.PostLifecycleRequest{{State: codersdk.WorkspaceAgentLifecycleCreated}},
-		reportConnectionsUpdate: make(chan struct{}, 1),
+		clock:                      options.Clock,
+		tailnetListenPort:          options.TailnetListenPort,
+		reconnectingPTYTimeout:     options.ReconnectingPTYTimeout,
+		logger:                     options.Logger,
+		gracefulCtx:                gracefulCtx,
+		gracefulCancel:             gracefulCancel,
+		hardCtx:                    hardCtx,
+		hardCancel:                 hardCancel,
+		coordDisconnected:          make(chan struct{}),
+		environmentVariables:       options.EnvironmentVariables,
+		client:                     options.Client,
+		filesystem:                 options.Filesystem,
+		logDir:                     options.LogDir,
+		tempDir:                    options.TempDir,
+		scriptDataDir:              options.ScriptDataDir,
+		lifecycleUpdate:            make(chan struct{}, 1),
+		lifecycleReported:          make(chan codersdk.WorkspaceAgentLifecycle, 1),
+		lifecycleStates:            []agentsdk.PostLifecycleRequest{{State: codersdk.WorkspaceAgentLifecycleCreated}},
+		reportConnectionsUpdate:    make(chan struct{}, 1),
+		reportFileOperationsUpdate: make(chan struct{}, 1),
 		listeningPortsHandler: listeningPortsHandler{
 			getter:      options.ListeningPortsGetter,
 			ignorePorts: maps.Clone(options.IgnorePorts),
@@ -344,6 +345,10 @@ type agent struct {
 	reportConnectionsMu     sync.Mutex
 	reportConnections       []*proto.ReportConnectionRequest
 
+	reportFileOperationsUpdate chan struct{}
+	reportFileOperationsMu     sync.Mutex
+	reportFileOperations       []*proto.FileTransferOperation
+
 	logSender *agentsdk.LogSender
 
 	// agentFirewallLogProxy is a socket server that forwards Agent Firewall audit logs to coderd.
@@ -433,16 +438,18 @@ func (a *agent) init() {
 		BlockFileTransfer:          a.blockFileTransfer,
 		BlockReversePortForwarding: a.blockReversePortForwarding,
 		BlockLocalPortForwarding:   a.blockLocalPortForwarding,
-		ReportConnection: func(id uuid.UUID, magicType agentssh.MagicSessionType, ip string) func(code int, reason string) {
+		ReportConnection: func(id uuid.UUID, magicType agentssh.MagicSessionType, fileTransfer bool, ip string) func(code int, reason string) {
 			var connectionType proto.Connection_Type
-			switch magicType {
-			case agentssh.MagicSessionTypeSSH:
+			switch {
+			case fileTransfer:
+				connectionType = proto.Connection_FILE_TRANSFER
+			case magicType == agentssh.MagicSessionTypeSSH:
 				connectionType = proto.Connection_SSH
-			case agentssh.MagicSessionTypeVSCode:
+			case magicType == agentssh.MagicSessionTypeVSCode:
 				connectionType = proto.Connection_VSCODE
-			case agentssh.MagicSessionTypeJetBrains:
+			case magicType == agentssh.MagicSessionTypeJetBrains:
 				connectionType = proto.Connection_JETBRAINS
-			case agentssh.MagicSessionTypeUnknown:
+			case magicType == agentssh.MagicSessionTypeUnknown:
 				connectionType = proto.Connection_TYPE_UNSPECIFIED
 			default:
 				a.logger.Error(a.hardCtx, "unhandled magic session type when reporting connection", slog.F("magic_type", magicType))
@@ -451,6 +458,7 @@ func (a *agent) init() {
 
 			return a.reportConnection(id, connectionType, ip)
 		},
+		ReportFileTransfer: a.reportFileOperation,
 
 		ExperimentalContainers: a.devcontainers,
 	})
@@ -1064,6 +1072,16 @@ const (
 	// of memory which seems acceptable. We could reduce this if necessary by
 	// not using the proto struct directly.
 	reportConnectionBufferLimit = 2048
+
+	// reportFileOperationsBufferLimit limits the number of buffered file
+	// operation reports. Operations are already deduplicated and capped
+	// per session in agentssh, so hitting this limit means coderd has
+	// been unreachable for a while; new operations are dropped.
+	reportFileOperationsBufferLimit = 2048
+
+	// reportFileOperationsBatchSize bounds how many file operations are
+	// sent in a single ReportFileOperations RPC.
+	reportFileOperationsBatchSize = 100
 )
 
 func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_Type, ip string) (disconnected func(code int, reason string)) {
@@ -1141,6 +1159,124 @@ func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_T
 		select {
 		case a.reportConnectionsUpdate <- struct{}{}:
 		default:
+		}
+	}
+}
+
+// reportFileOperation enqueues a file operation observed during a
+// file-transfer session for reporting to coderd. Reporting is best
+// effort; operations are dropped when the buffer is full.
+func (a *agent) reportFileOperation(id uuid.UUID, op agentssh.FileTransferOperation) {
+	var protocol proto.FileTransferOperation_Protocol
+	switch op.Protocol {
+	case agentssh.FileTransferProtocolSFTP:
+		protocol = proto.FileTransferOperation_SFTP
+	case agentssh.FileTransferProtocolSCP:
+		protocol = proto.FileTransferOperation_SCP
+	case agentssh.FileTransferProtocolRsync:
+		protocol = proto.FileTransferOperation_RSYNC
+	default:
+		a.logger.Error(a.hardCtx, "unhandled file transfer protocol when reporting file operation", slog.F("protocol", op.Protocol))
+		return
+	}
+	var action proto.FileTransferOperation_Action
+	switch op.Action {
+	case agentssh.FileTransferActionDownload:
+		action = proto.FileTransferOperation_DOWNLOAD
+	case agentssh.FileTransferActionUpload:
+		action = proto.FileTransferOperation_UPLOAD
+	case agentssh.FileTransferActionBidirectional:
+		action = proto.FileTransferOperation_BIDIRECTIONAL
+	case agentssh.FileTransferActionRemove:
+		action = proto.FileTransferOperation_REMOVE
+	case agentssh.FileTransferActionRmdir:
+		action = proto.FileTransferOperation_RMDIR
+	case agentssh.FileTransferActionRename:
+		action = proto.FileTransferOperation_RENAME
+	case agentssh.FileTransferActionSymlink:
+		action = proto.FileTransferOperation_SYMLINK
+	case agentssh.FileTransferActionSetattr:
+		action = proto.FileTransferOperation_SETATTR
+	case agentssh.FileTransferActionHardlink:
+		action = proto.FileTransferOperation_HARDLINK
+	default:
+		a.logger.Error(a.hardCtx, "unhandled file transfer action when reporting file operation", slog.F("action", op.Action))
+		return
+	}
+
+	var target *string
+	if op.Target != "" {
+		target = &op.Target
+	}
+
+	a.reportFileOperationsMu.Lock()
+	defer a.reportFileOperationsMu.Unlock()
+
+	if len(a.reportFileOperations) >= reportFileOperationsBufferLimit {
+		a.logger.Warn(a.hardCtx, "file operation report buffer limit reached, dropping operation",
+			slog.F("limit", reportFileOperationsBufferLimit),
+			slog.F("connection_id", id),
+		)
+		return
+	}
+
+	a.reportFileOperations = append(a.reportFileOperations, &proto.FileTransferOperation{
+		ConnectionId: id[:],
+		Protocol:     protocol,
+		Action:       action,
+		Path:         op.Path,
+		Target:       target,
+		Timestamp:    timestamppb.New(time.Now()),
+	})
+	select {
+	case a.reportFileOperationsUpdate <- struct{}{}:
+	default:
+	}
+}
+
+// reportFileOperationsLoop streams buffered file operations to coderd
+// for the connection log. Like reportConnectionsLoop, sends are best
+// effort: a failed batch is logged and dropped.
+func (a *agent) reportFileOperationsLoop(ctx context.Context, aAPI proto.DRPCAgentClient211) error {
+	for {
+		select {
+		case <-a.reportFileOperationsUpdate:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		for {
+			a.reportFileOperationsMu.Lock()
+			if len(a.reportFileOperations) == 0 {
+				a.reportFileOperationsMu.Unlock()
+				break
+			}
+			batchSize := min(len(a.reportFileOperations), reportFileOperationsBatchSize)
+			batch := a.reportFileOperations[:batchSize]
+			// Release lock while we send the batch, this is safe
+			// since we only append to the slice.
+			a.reportFileOperationsMu.Unlock()
+
+			logger := a.logger.With(slog.F("batch_size", batchSize))
+			logger.Debug(ctx, "reporting file operations")
+			_, err := aAPI.ReportFileOperations(ctx, &proto.ReportFileOperationsRequest{
+				Operations: batch,
+			})
+			if err != nil {
+				// Do not fail the loop if we fail to report file
+				// operations, just log a warning and drop the batch.
+				logger.Warn(ctx, "failed to report file operations to server", slog.Error(err))
+			} else {
+				logger.Debug(ctx, "successfully reported file operations")
+			}
+
+			// Remove the batch we sent (or failed to send).
+			a.reportFileOperationsMu.Lock()
+			for i := range batchSize {
+				a.reportFileOperations[i] = nil // Release the pointers from the underlying array.
+			}
+			a.reportFileOperations = a.reportFileOperations[batchSize:]
+			a.reportFileOperationsMu.Unlock()
 		}
 	}
 }
@@ -1278,6 +1414,10 @@ func (a *agent) run() (retErr error) {
 	// Connection reports are part of auditing, we should keep sending them via
 	// gracefulShutdownBehaviorRemain.
 	connMan.startAgentAPI("report connections", gracefulShutdownBehaviorRemain, a.reportConnectionsLoop)
+
+	// File operations are reported during graceful shutdown as well so
+	// operations from sessions that are wrapping up are not lost.
+	connMan.startAgentAPI211("report file operations", gracefulShutdownBehaviorRemain, a.reportFileOperationsLoop)
 
 	// Push resolved workspace context (instructions, skills, MCP
 	// configs, MCP server tool lists) to coderd. The push loop
@@ -2614,6 +2754,35 @@ func (a *apiConnRoutineManager) startAgentAPI(
 func (a *apiConnRoutineManager) startAgentAPI210(
 	name string, behavior gracefulShutdownBehavior,
 	f func(context.Context, proto.DRPCAgentClient210) error,
+) {
+	logger := a.logger.With(slog.F("name", name))
+	var ctx context.Context
+	switch behavior {
+	case gracefulShutdownBehaviorStop:
+		ctx = a.stopCtx
+	case gracefulShutdownBehaviorRemain:
+		ctx = a.remainCtx
+	default:
+		panic("unknown behavior")
+	}
+	a.eg.Go(func() error {
+		logger.Debug(ctx, "starting agent routine")
+		err := f(ctx, a.aAPI)
+		err = shouldPropagateError(ctx, logger, err)
+		logger.Debug(ctx, "routine exited", slog.Error(err))
+		if err != nil {
+			return xerrors.Errorf("error in routine %s: %w", name, err)
+		}
+		return nil
+	})
+}
+
+// startAgentAPI211 is the v2.11 counterpart to startAgentAPI; it hands the
+// routine the full v2.11 Agent API client. Use it for routines that need
+// RPCs introduced after v2.10 (notably ReportFileOperations).
+func (a *apiConnRoutineManager) startAgentAPI211(
+	name string, behavior gracefulShutdownBehavior,
+	f func(context.Context, proto.DRPCAgentClient211) error,
 ) {
 	logger := a.logger.With(slog.F("name", name))
 	var ctx context.Context

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1393,7 +1393,20 @@ func TestAgent_SFTP(t *testing.T) {
 
 		// Close the client to trigger disconnect event.
 		_ = client.Close()
-		assertConnectionReport(t, agentClient, proto.Connection_SSH, 0, "")
+		assertConnectionReport(t, agentClient, proto.Connection_FILE_TRANSFER, 0, "")
+
+		// The file creation should be reported as a file operation.
+		// sftp's Create opens with O_RDWR|O_CREATE|O_TRUNC, so the
+		// observed action is bidirectional.
+		var ops []*proto.FileTransferOperation
+		require.Eventually(t, func() bool {
+			ops = agentClient.GetFileOperations()
+			return len(ops) >= 1
+		}, testutil.WaitMedium, testutil.IntervalFast, "waiting for file operation report")
+		require.Len(t, ops, 1)
+		assert.Equal(t, proto.FileTransferOperation_SFTP, ops[0].GetProtocol())
+		assert.Equal(t, proto.FileTransferOperation_BIDIRECTIONAL, ops[0].GetAction())
+		assert.Equal(t, remoteFile, ops[0].GetPath())
 	})
 
 	t.Run("CustomWorkingDirectory", func(t *testing.T) {
@@ -1426,7 +1439,7 @@ func TestAgent_SFTP(t *testing.T) {
 
 		// Close the client to trigger disconnect event.
 		_ = client.Close()
-		assertConnectionReport(t, agentClient, proto.Connection_SSH, 0, "")
+		assertConnectionReport(t, agentClient, proto.Connection_FILE_TRANSFER, 0, "")
 	})
 
 	t.Run("MissingWorkingDirectory", func(t *testing.T) {
@@ -1481,7 +1494,19 @@ func TestAgent_SCP(t *testing.T) {
 
 	// Close the client to trigger disconnect event.
 	scpClient.Close()
-	assertConnectionReport(t, agentClient, proto.Connection_SSH, 0, "")
+	assertConnectionReport(t, agentClient, proto.Connection_FILE_TRANSFER, 0, "")
+
+	// The upload should be reported as a single write operation rooted
+	// at the requested path, parsed from the scp command line.
+	var ops []*proto.FileTransferOperation
+	require.Eventually(t, func() bool {
+		ops = agentClient.GetFileOperations()
+		return len(ops) >= 1
+	}, testutil.WaitMedium, testutil.IntervalFast, "waiting for file operation report")
+	require.Len(t, ops, 1)
+	assert.Equal(t, proto.FileTransferOperation_SCP, ops[0].GetProtocol())
+	assert.Equal(t, proto.FileTransferOperation_UPLOAD, ops[0].GetAction())
+	assert.Equal(t, tempFile, ops[0].GetPath())
 }
 
 func TestAgent_FileTransferBlocked(t *testing.T) {
@@ -1516,7 +1541,10 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 		require.Error(t, err)
 		assertFileTransferBlocked(t, err.Error())
 
-		assertConnectionReport(t, agentClient, proto.Connection_SSH, agentssh.BlockedFileTransferErrorCode, "")
+		// Blocked attempts are still classified as file transfers.
+		assertConnectionReport(t, agentClient, proto.Connection_FILE_TRANSFER, agentssh.BlockedFileTransferErrorCode, "")
+		// No file operations are reported for blocked sessions.
+		assert.Empty(t, agentClient.GetFileOperations())
 	})
 
 	t.Run("SCP with go-scp package", func(t *testing.T) {
@@ -1540,7 +1568,10 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 		require.Error(t, err)
 		assertFileTransferBlocked(t, err.Error())
 
-		assertConnectionReport(t, agentClient, proto.Connection_SSH, agentssh.BlockedFileTransferErrorCode, "")
+		// Blocked attempts are still classified as file transfers.
+		assertConnectionReport(t, agentClient, proto.Connection_FILE_TRANSFER, agentssh.BlockedFileTransferErrorCode, "")
+		// No file operations are reported for blocked sessions.
+		assert.Empty(t, agentClient.GetFileOperations())
 	})
 
 	t.Run("Forbidden commands", func(t *testing.T) {
@@ -1577,7 +1608,13 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 				require.NoError(t, err)
 				assertFileTransferBlocked(t, string(msg))
 
-				assertConnectionReport(t, agentClient, proto.Connection_SSH, agentssh.BlockedFileTransferErrorCode, "")
+				// scp and rsync commands are classified as file
+				// transfers; nc and the sftp client binary are not.
+				expectedType := proto.Connection_SSH
+				if c == "scp" || c == "rsync" {
+					expectedType = proto.Connection_FILE_TRANSFER
+				}
+				assertConnectionReport(t, agentClient, expectedType, agentssh.BlockedFileTransferErrorCode, "")
 			})
 		}
 	})

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -87,7 +87,11 @@ const (
 // BlockedFileTransferCommands contains a list of restricted file transfer commands.
 var BlockedFileTransferCommands = []string{"nc", "rsync", "scp", "sftp"}
 
-type reportConnectionFunc func(id uuid.UUID, sessionType MagicSessionType, ip string) (disconnected func(code int, reason string))
+// reportConnectionFunc reports the start of a connection to coderd for the
+// connection log. fileTransfer indicates that the session was classified
+// as a file transfer (SFTP, SCP, rsync) and should be reported as such
+// instead of a plain SSH session.
+type reportConnectionFunc func(id uuid.UUID, sessionType MagicSessionType, fileTransfer bool, ip string) (disconnected func(code int, reason string))
 
 // Config sets configuration parameters for the agent SSH server.
 type Config struct {
@@ -126,6 +130,11 @@ type Config struct {
 	BlockLocalPortForwarding bool
 	// ReportConnection.
 	ReportConnection reportConnectionFunc
+	// ReportFileTransfer reports a file operation observed during a
+	// file-transfer session (SFTP, SCP, rsync) for the connection log.
+	// The id matches the session's connection report so operations can
+	// be grouped with the session.
+	ReportFileTransfer func(id uuid.UUID, op FileTransferOperation)
 	// Experimental: allow connecting to running containers via Docker exec.
 	// Note that this is different from the devcontainers feature, which uses
 	// subagents.
@@ -192,7 +201,10 @@ func NewServer(ctx context.Context, logger slog.Logger, prometheusRegistry *prom
 		config.EnvInfo = &usershell.SystemEnvInfo{}
 	}
 	if config.ReportConnection == nil {
-		config.ReportConnection = func(uuid.UUID, MagicSessionType, string) func(int, string) { return func(int, string) {} }
+		config.ReportConnection = func(uuid.UUID, MagicSessionType, bool, string) func(int, string) { return func(int, string) {} }
+	}
+	if config.ReportFileTransfer == nil {
+		config.ReportFileTransfer = func(uuid.UUID, FileTransferOperation) {}
 	}
 
 	forwardHandler := &ssh.ForwardedTCPHandler{}
@@ -434,10 +446,17 @@ func (s *Server) sessionHandler(session ssh.Session) {
 		remoteAddrString = remoteAddr.String()
 	}
 
+	// Classify file-transfer sessions (SFTP subsystem, scp, rsync) so
+	// they can be reported distinctly from plain SSH in the connection
+	// log. IDE sessions (VS Code, JetBrains) keep their more specific
+	// type.
+	fileTransfer, isFileTransfer := classifyFileTransfer(session)
+	reportAsFileTransfer := isFileTransfer && magicTypeForFileTransfer(magicType)
+
 	if !s.trackSession(session, true) {
 		reason := "unable to accept new session, server is closing"
 		// Report connection attempt even if we couldn't accept it.
-		disconnected := s.config.ReportConnection(id, magicType, remoteAddrString)
+		disconnected := s.config.ReportConnection(id, magicType, reportAsFileTransfer, remoteAddrString)
 		defer disconnected(1, reason)
 
 		logger.Info(ctx, reason)
@@ -472,7 +491,7 @@ func (s *Server) sessionHandler(session ssh.Session) {
 		scr := &sessionCloseTracker{Session: session}
 		session = scr
 
-		disconnected := s.config.ReportConnection(id, magicType, remoteAddrString)
+		disconnected := s.config.ReportConnection(id, magicType, reportAsFileTransfer, remoteAddrString)
 		defer func() {
 			logger.Info(ctx, "ssh session closed",
 				codersdk.ConnectionDirectionAgentToClient.SlogField(),
@@ -497,6 +516,18 @@ func (s *Server) sessionHandler(session ssh.Session) {
 		return
 	}
 
+	// Emit file operations only for sessions reported as file transfers
+	// so every operation row groups under a file_transfer session row in
+	// the connection log. The transfer was permitted if we got here.
+	var emitOp func(FileTransferOperation)
+	if reportSession && reportAsFileTransfer {
+		emitter := newFileTransferOpEmitter(logger, id, s.config.ReportFileTransfer)
+		emitOp = emitter.Emit
+		if fileTransfer.InitialOperation != nil {
+			emitOp(*fileTransfer.InitialOperation)
+		}
+	}
+
 	container, containerUser, env := extractContainerInfo(env)
 	if container != "" {
 		s.logger.Debug(ctx, "container info",
@@ -513,7 +544,7 @@ func (s *Server) sessionHandler(session ssh.Session) {
 			_ = session.Exit(1)
 			return
 		}
-		err := s.sftpHandler(logger, session)
+		err := s.sftpHandler(logger, session, emitOp)
 		if err != nil {
 			closeCause(err.Error())
 		}
@@ -858,7 +889,7 @@ func handleSignal(logger slog.Logger, ssig ssh.Signal, signaler interface{ Signa
 	}
 }
 
-func (s *Server) sftpHandler(logger slog.Logger, session ssh.Session) error {
+func (s *Server) sftpHandler(logger slog.Logger, session ssh.Session, emitOp func(FileTransferOperation)) error {
 	s.metrics.sftpConnectionsTotal.Add(1)
 
 	ctx := session.Context()
@@ -886,7 +917,16 @@ func (s *Server) sftpHandler(logger slog.Logger, session ssh.Session) error {
 		opts = append(opts, sftp.WithServerWorkingDirectory(dir))
 	}
 
-	server, err := sftp.NewServer(session, opts...)
+	// Observe file operations for the connection log by passively
+	// decoding the client-to-server request stream. The decoder is
+	// bounded and fail-open: on malformed input it stops decoding
+	// without affecting the SFTP session.
+	var rwc io.ReadWriteCloser = session
+	if emitOp != nil {
+		rwc = newSFTPAuditSession(session, newSFTPRequestDecoder(emitOp))
+	}
+
+	server, err := sftp.NewServer(rwc, opts...)
 	if err != nil {
 		logger.Debug(ctx, "initialize sftp server", slog.Error(err))
 		return xerrors.Errorf("initialize sftp server: %w", err)

--- a/agent/agentssh/filetransfer.go
+++ b/agent/agentssh/filetransfer.go
@@ -1,0 +1,254 @@
+package agentssh
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/google/uuid"
+
+	"cdr.dev/slog/v3"
+)
+
+// FileTransferProtocol identifies the protocol carrying a file-transfer
+// session.
+type FileTransferProtocol string
+
+const (
+	FileTransferProtocolSFTP  FileTransferProtocol = "sftp"
+	FileTransferProtocolSCP   FileTransferProtocol = "scp"
+	FileTransferProtocolRsync FileTransferProtocol = "rsync"
+)
+
+// FileTransferAction is the kind of file operation observed during a
+// file-transfer session. A download is a transfer from the workspace to
+// the client, an upload is a transfer from the client to the workspace,
+// and bidirectional is a file opened for both at once, where either may
+// have occurred.
+type FileTransferAction string
+
+const (
+	FileTransferActionDownload      FileTransferAction = "download"
+	FileTransferActionUpload        FileTransferAction = "upload"
+	FileTransferActionBidirectional FileTransferAction = "bidirectional"
+	FileTransferActionRemove        FileTransferAction = "remove"
+	FileTransferActionRmdir         FileTransferAction = "rmdir"
+	FileTransferActionRename        FileTransferAction = "rename"
+	FileTransferActionSymlink       FileTransferAction = "symlink"
+	// FileTransferActionSetattr records file attribute changes:
+	// truncation, permissions, ownership, and timestamps.
+	FileTransferActionSetattr FileTransferAction = "setattr"
+	// FileTransferActionHardlink records creation of a hard link. Path
+	// is the existing file, Target is the new link.
+	FileTransferActionHardlink FileTransferAction = "hardlink"
+)
+
+// FileTransferOperation is a single observed file operation, reported to
+// coderd for the connection log.
+type FileTransferOperation struct {
+	Protocol FileTransferProtocol
+	Action   FileTransferAction
+	Path     string
+	// Target is the second path for operations that have one, such as
+	// the destination of a rename or the target of a symlink.
+	Target string
+}
+
+// FileTransferSession describes a session recognized as a file transfer.
+type FileTransferSession struct {
+	Protocol FileTransferProtocol
+	// InitialOperation is the operation implied by the command line for
+	// exec-based transfers (scp, rsync). Nil for SFTP, whose operations
+	// are observed per-request, and for command lines whose direction
+	// could not be determined.
+	InitialOperation *FileTransferOperation
+}
+
+// classifyFileTransfer determines whether an SSH session is a file
+// transfer. It recognizes the SFTP subsystem and exec sessions whose
+// command is scp or rsync. nc is deliberately not classified: it is a
+// generic networking tool with no reliable file semantics (it remains
+// subject to BlockFileTransfer).
+//
+// Warning: like fileTransferBlocked, this is a "do not trespass" sign,
+// not a security boundary. A user can rename binaries or wrap them in
+// shell scripts to evade classification.
+func classifyFileTransfer(session ssh.Session) (FileTransferSession, bool) {
+	if session.Subsystem() == "sftp" {
+		return FileTransferSession{Protocol: FileTransferProtocolSFTP}, true
+	}
+	if session.Subsystem() != "" {
+		return FileTransferSession{}, false
+	}
+
+	cmd := session.Command()
+	if len(cmd) == 0 {
+		return FileTransferSession{}, false
+	}
+
+	// In case the binary is an absolute path, /usr/sbin/scp.
+	switch filepath.Base(cmd[0]) {
+	case "scp":
+		fts := FileTransferSession{Protocol: FileTransferProtocolSCP}
+		if op, ok := parseSCPCommand(cmd); ok {
+			fts.InitialOperation = &op
+		}
+		return fts, true
+	case "rsync":
+		fts := FileTransferSession{Protocol: FileTransferProtocolRsync}
+		if op, ok := parseRsyncCommand(cmd); ok {
+			fts.InitialOperation = &op
+		}
+		return fts, true
+	default:
+		return FileTransferSession{}, false
+	}
+}
+
+// parseSCPCommand extracts the direction and root path from a remote scp
+// server invocation, e.g. "scp -r -t /tmp" or "scp -qf file". The remote
+// side always runs with -t (sink mode: client uploads to the workspace)
+// or -f (source mode: client downloads from the workspace), followed by
+// the target path. The path is the requested root operand; recursive
+// transfers copy files beneath it that are not individually visible at
+// the command line.
+func parseSCPCommand(cmd []string) (FileTransferOperation, bool) {
+	var (
+		action  FileTransferAction
+		doneOpt bool
+		path    string
+	)
+	for _, arg := range cmd[1:] {
+		if !doneOpt && strings.HasPrefix(arg, "-") {
+			if arg == "--" {
+				doneOpt = true
+				continue
+			}
+			// Flags may be combined, e.g. -qrt.
+			if strings.ContainsRune(arg, 't') {
+				action = FileTransferActionUpload
+			}
+			if strings.ContainsRune(arg, 'f') {
+				action = FileTransferActionDownload
+			}
+			continue
+		}
+		// First non-flag operand is the path.
+		path = arg
+		break
+	}
+	if action == "" || path == "" {
+		return FileTransferOperation{}, false
+	}
+	return FileTransferOperation{
+		Protocol: FileTransferProtocolSCP,
+		Action:   action,
+		Path:     path,
+	}, true
+}
+
+// parseRsyncCommand extracts the direction and root path from a remote
+// rsync server invocation, e.g. "rsync --server --sender -vlogDtpre.iLsfxC . /tmp".
+// The remote side runs with --server; --sender means the workspace sends
+// (client downloads), otherwise the workspace receives (client uploads).
+// The path is the last operand ("." is a placeholder preceding it).
+func parseRsyncCommand(cmd []string) (FileTransferOperation, bool) {
+	var (
+		server  bool
+		sender  bool
+		doneOpt bool
+		path    string
+	)
+	for _, arg := range cmd[1:] {
+		if !doneOpt && strings.HasPrefix(arg, "-") {
+			switch arg {
+			case "--server":
+				server = true
+			case "--sender":
+				sender = true
+			case "--":
+				doneOpt = true
+			}
+			continue
+		}
+		if arg == "." {
+			continue
+		}
+		// The last operand is the path.
+		path = arg
+	}
+	if !server || path == "" {
+		return FileTransferOperation{}, false
+	}
+	action := FileTransferActionUpload
+	if sender {
+		action = FileTransferActionDownload
+	}
+	return FileTransferOperation{
+		Protocol: FileTransferProtocolRsync,
+		Action:   action,
+		Path:     path,
+	}, true
+}
+
+// magicTypeForFileTransfer returns whether a session with the given magic
+// type should be reported as a file transfer when classified as one. Only
+// plain SSH sessions are re-typed; IDE sessions (VS Code, JetBrains) keep
+// their more specific type.
+func magicTypeForFileTransfer(magicType MagicSessionType) bool {
+	return magicType == MagicSessionTypeSSH || magicType == MagicSessionTypeUnknown
+}
+
+// maxFileTransferOpsPerSession bounds the number of file operations
+// reported for a single session. Long-lived SFTP sessions (e.g. sshfs
+// mounts) can touch a very large number of files; beyond the cap, new
+// operations are dropped and a debug log records the loss.
+const maxFileTransferOpsPerSession = 512
+
+// fileTransferOpEmitter deduplicates and caps file operations for one
+// session before handing them to the configured report function.
+type fileTransferOpEmitter struct {
+	logger slog.Logger
+	id     uuid.UUID
+	report func(id uuid.UUID, op FileTransferOperation)
+
+	mu      sync.Mutex
+	seen    map[string]struct{}
+	dropped bool
+}
+
+func newFileTransferOpEmitter(logger slog.Logger, id uuid.UUID, report func(id uuid.UUID, op FileTransferOperation)) *fileTransferOpEmitter {
+	return &fileTransferOpEmitter{
+		logger: logger,
+		id:     id,
+		report: report,
+		seen:   make(map[string]struct{}),
+	}
+}
+
+// Emit reports one file operation. Identical operations within the same
+// session are reported once; e.g. sshfs re-opens the same files
+// constantly. Safe for concurrent use.
+func (e *fileTransferOpEmitter) Emit(op FileTransferOperation) {
+	key := string(op.Action) + "\x00" + op.Path + "\x00" + op.Target
+	e.mu.Lock()
+	if _, ok := e.seen[key]; ok {
+		e.mu.Unlock()
+		return
+	}
+	if len(e.seen) >= maxFileTransferOpsPerSession {
+		if !e.dropped {
+			e.dropped = true
+			e.logger.Debug(context.Background(), "file transfer operation cap reached, dropping further operations",
+				slog.F("cap", maxFileTransferOpsPerSession))
+		}
+		e.mu.Unlock()
+		return
+	}
+	e.seen[key] = struct{}{}
+	e.mu.Unlock()
+
+	e.report(e.id, op)
+}

--- a/agent/agentssh/filetransfer_internal_test.go
+++ b/agent/agentssh/filetransfer_internal_test.go
@@ -1,0 +1,189 @@
+package agentssh
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+)
+
+func TestParseSCPCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		cmd    []string
+		wantOK bool
+		want   FileTransferOperation
+	}{
+		{
+			name:   "Upload",
+			cmd:    []string{"scp", "-t", "/tmp"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolSCP,
+				Action:   FileTransferActionUpload,
+				Path:     "/tmp",
+			},
+		},
+		{
+			name:   "Download",
+			cmd:    []string{"scp", "-f", "secrets.txt"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolSCP,
+				Action:   FileTransferActionDownload,
+				Path:     "secrets.txt",
+			},
+		},
+		{
+			name:   "CombinedFlags",
+			cmd:    []string{"scp", "-qrt", "/home/coder"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolSCP,
+				Action:   FileTransferActionUpload,
+				Path:     "/home/coder",
+			},
+		},
+		{
+			name:   "SeparateFlags",
+			cmd:    []string{"scp", "-v", "-f", "-p", "file with spaces"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolSCP,
+				Action:   FileTransferActionDownload,
+				Path:     "file with spaces",
+			},
+		},
+		{
+			name:   "DoubleDash",
+			cmd:    []string{"scp", "-t", "--", "-weird-path"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolSCP,
+				Action:   FileTransferActionUpload,
+				Path:     "-weird-path",
+			},
+		},
+		{
+			name:   "NoDirection",
+			cmd:    []string{"scp", "/tmp"},
+			wantOK: false,
+		},
+		{
+			name:   "NoPath",
+			cmd:    []string{"scp", "-t"},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			op, ok := parseSCPCommand(tt.cmd)
+			require.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.want, op)
+			}
+		})
+	}
+}
+
+func TestParseRsyncCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		cmd    []string
+		wantOK bool
+		want   FileTransferOperation
+	}{
+		{
+			name:   "Download",
+			cmd:    []string{"rsync", "--server", "--sender", "-vlogDtpre.iLsfxCIvu", ".", "/home/coder/project"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolRsync,
+				Action:   FileTransferActionDownload,
+				Path:     "/home/coder/project",
+			},
+		},
+		{
+			name:   "Upload",
+			cmd:    []string{"rsync", "--server", "-vlogDtpre.iLsfxCIvu", ".", "/tmp/dest"},
+			wantOK: true,
+			want: FileTransferOperation{
+				Protocol: FileTransferProtocolRsync,
+				Action:   FileTransferActionUpload,
+				Path:     "/tmp/dest",
+			},
+		},
+		{
+			name:   "NotServer",
+			cmd:    []string{"rsync", "-av", "src", "dst"},
+			wantOK: false,
+		},
+		{
+			name:   "NoPath",
+			cmd:    []string{"rsync", "--server", "."},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			op, ok := parseRsyncCommand(tt.cmd)
+			require.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.want, op)
+			}
+		})
+	}
+}
+
+func TestFileTransferOpEmitter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Dedupe", func(t *testing.T) {
+		t.Parallel()
+		var got []FileTransferOperation
+		emitter := newFileTransferOpEmitter(slog.Logger{}, uuid.New(), func(_ uuid.UUID, op FileTransferOperation) {
+			got = append(got, op)
+		})
+		op := FileTransferOperation{
+			Protocol: FileTransferProtocolSFTP,
+			Action:   FileTransferActionDownload,
+			Path:     "/tmp/file",
+		}
+		emitter.Emit(op)
+		emitter.Emit(op)
+		emitter.Emit(op)
+		require.Len(t, got, 1)
+
+		// A different action on the same path is a distinct operation.
+		op.Action = FileTransferActionUpload
+		emitter.Emit(op)
+		require.Len(t, got, 2)
+	})
+
+	t.Run("Cap", func(t *testing.T) {
+		t.Parallel()
+		count := 0
+		emitter := newFileTransferOpEmitter(slog.Logger{}, uuid.New(), func(uuid.UUID, FileTransferOperation) {
+			count++
+		})
+		for i := range maxFileTransferOpsPerSession + 100 {
+			emitter.Emit(FileTransferOperation{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionDownload,
+				Path:     "/tmp/file" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/676)%26)),
+			})
+		}
+		require.Equal(t, maxFileTransferOpsPerSession, count)
+	})
+}

--- a/agent/agentssh/jetbrainstrack.go
+++ b/agent/agentssh/jetbrainstrack.go
@@ -71,7 +71,7 @@ func NewJetbrainsChannelWatcher(ctx ssh.Context, logger slog.Logger, reportConne
 }
 
 func (w *JetbrainsChannelWatcher) Accept() (gossh.Channel, <-chan *gossh.Request, error) {
-	disconnected := w.reportConnection(uuid.New(), MagicSessionTypeJetBrains, w.originAddr)
+	disconnected := w.reportConnection(uuid.New(), MagicSessionTypeJetBrains, false, w.originAddr)
 
 	c, r, err := w.NewChannel.Accept()
 	if err != nil {

--- a/agent/agentssh/sftpaudit.go
+++ b/agent/agentssh/sftpaudit.go
@@ -1,0 +1,297 @@
+package agentssh
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/gliderlabs/ssh"
+)
+
+// SFTP protocol constants (SSH_FILEXFER version 3, the version served by
+// github.com/pkg/sftp). Only client-to-server request types the decoder
+// cares about are listed; all others are skipped by length.
+//
+// The wire format is specified in
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02 and
+// the @openssh.com extensions (including the historical SSH_FXP_SYMLINK
+// argument reversal) in
+// https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.
+const (
+	sshFxpOpen    = 3
+	sshFxpSetstat = 9
+	sshFxpRemove  = 13
+	// sshFxpMkdir is deliberately not logged: it carries no file
+	// contents, and uploads into the directory are logged individually.
+	sshFxpMkdir    = 14
+	sshFxpRmdir    = 15
+	sshFxpRename   = 18
+	sshFxpSymlink  = 20
+	sshFxpExtended = 200
+
+	// SSH_FXP_OPEN pflags.
+	sshFxfRead   = 0x00000001
+	sshFxfWrite  = 0x00000002
+	sshFxfAppend = 0x00000004
+	sshFxfCreat  = 0x00000008
+	sshFxfTrunc  = 0x00000010
+	sshFxfExcl   = 0x00000020
+
+	// sftpAuditMaxPayload caps the size of a request payload the decoder
+	// will buffer for parsing. Interesting requests carry paths and are
+	// tiny; anything larger (e.g. SSH_FXP_WRITE data) is skipped without
+	// buffering. Must comfortably exceed the longest expected path.
+	sftpAuditMaxPayload = 64 * 1024
+
+	// sftpAuditMaxPacket is a sanity bound on the declared packet
+	// length. Well-behaved clients send packets no larger than ~256KiB
+	// (32KiB data plus overhead is typical). A declared length beyond
+	// this indicates a corrupt or desynchronized stream, so the decoder
+	// disables itself rather than skipping gigabytes.
+	sftpAuditMaxPacket = 4 * 1024 * 1024
+)
+
+// sftpAuditSession wraps an SSH session serving SFTP, teeing bytes read
+// by the SFTP server (i.e. client-to-server requests) into a passive
+// protocol decoder. Writes and closes pass through untouched.
+type sftpAuditSession struct {
+	ssh.Session
+	dec *sftpRequestDecoder
+}
+
+func newSFTPAuditSession(session ssh.Session, dec *sftpRequestDecoder) *sftpAuditSession {
+	return &sftpAuditSession{Session: session, dec: dec}
+}
+
+func (s *sftpAuditSession) Read(p []byte) (int, error) {
+	n, err := s.Session.Read(p)
+	if n > 0 {
+		s.dec.feed(p[:n])
+	}
+	return n, err
+}
+
+var _ io.ReadWriteCloser = &sftpAuditSession{}
+
+// sftpRequestDecoder incrementally decodes the client-to-server SFTP
+// packet stream and emits file operations for requests that access or
+// mutate files. It is strictly passive and fail-open: it never blocks
+// the stream, allocates bounded memory, and permanently disables itself
+// if the stream doesn't parse as SFTP.
+//
+// Packet framing: uint32 length, byte type, payload of length-1 bytes.
+type sftpRequestDecoder struct {
+	emit func(FileTransferOperation)
+
+	buf      []byte
+	skip     uint64
+	disabled bool
+}
+
+func newSFTPRequestDecoder(emit func(FileTransferOperation)) *sftpRequestDecoder {
+	return &sftpRequestDecoder{emit: emit}
+}
+
+// feed consumes a chunk of the client-to-server byte stream. It never
+// fails; on malformed input the decoder disables itself.
+func (d *sftpRequestDecoder) feed(p []byte) {
+	if d.disabled {
+		return
+	}
+
+	for len(p) > 0 {
+		// Discard the remainder of a packet we chose not to parse.
+		if d.skip > 0 {
+			n := min(uint64(len(p)), d.skip)
+			d.skip -= n
+			p = p[n:]
+			continue
+		}
+
+		// Accumulate the 5-byte header (length + type).
+		if len(d.buf) < 5 {
+			need := 5 - len(d.buf)
+			n := min(need, len(p))
+			d.buf = append(d.buf, p[:n]...)
+			p = p[n:]
+			if len(d.buf) < 5 {
+				return
+			}
+		}
+
+		length := binary.BigEndian.Uint32(d.buf[:4])
+		typ := d.buf[4]
+		if length < 1 || length > sftpAuditMaxPacket {
+			d.disable()
+			return
+		}
+		payloadLen := uint64(length - 1)
+
+		if !d.interesting(typ) || payloadLen > sftpAuditMaxPayload {
+			// Skip the payload without buffering it.
+			d.buf = d.buf[:0]
+			d.skip = payloadLen
+			continue
+		}
+
+		// Accumulate the full payload for parsing.
+		total := 5 + int(payloadLen)
+		need := total - len(d.buf)
+		n := min(need, len(p))
+		d.buf = append(d.buf, p[:n]...)
+		p = p[n:]
+		if len(d.buf) < total {
+			return
+		}
+
+		d.parsePacket(typ, d.buf[5:total])
+		d.buf = d.buf[:0]
+	}
+}
+
+func (d *sftpRequestDecoder) disable() {
+	d.disabled = true
+	d.buf = nil
+}
+
+func (*sftpRequestDecoder) interesting(typ byte) bool {
+	switch typ {
+	case sshFxpOpen, sshFxpSetstat, sshFxpRemove, sshFxpRmdir, sshFxpRename, sshFxpSymlink, sshFxpExtended:
+		return true
+	default:
+		return false
+	}
+}
+
+// parsePacket decodes the payload of an interesting request and emits
+// the corresponding operation. The payload begins with a uint32 request
+// id for all handled types.
+func (d *sftpRequestDecoder) parsePacket(typ byte, payload []byte) {
+	// Consume the request id.
+	if _, payload, ok := sftpReadUint32(payload); ok {
+		switch typ {
+		case sshFxpOpen:
+			path, rest, ok := sftpReadString(payload)
+			if !ok {
+				return
+			}
+			pflags, _, ok := sftpReadUint32(rest)
+			if !ok {
+				return
+			}
+			action, ok := sftpOpenAction(pflags)
+			if !ok {
+				return
+			}
+			d.emitOp(action, path, "")
+		case sshFxpSetstat:
+			// Path followed by ATTRS. Attribute changes matter for
+			// auditing because they include truncation (destroys file
+			// contents without a remove or upload event) and timestamp
+			// changes (timestomping). The individual attributes are not
+			// distinguished.
+			if path, _, ok := sftpReadString(payload); ok {
+				d.emitOp(FileTransferActionSetattr, path, "")
+			}
+		case sshFxpRemove:
+			if path, _, ok := sftpReadString(payload); ok {
+				d.emitOp(FileTransferActionRemove, path, "")
+			}
+		case sshFxpRmdir:
+			if path, _, ok := sftpReadString(payload); ok {
+				d.emitOp(FileTransferActionRmdir, path, "")
+			}
+		case sshFxpRename:
+			oldPath, rest, ok := sftpReadString(payload)
+			if !ok {
+				return
+			}
+			newPath, _, ok := sftpReadString(rest)
+			if !ok {
+				return
+			}
+			d.emitOp(FileTransferActionRename, oldPath, newPath)
+		case sshFxpSymlink:
+			// Matching pkg/sftp's interpretation: the first string is
+			// the symlink target, the second is the link being created
+			// (the argument order in the protocol was historically
+			// reversed; see sshFxpSymlinkPacket in pkg/sftp).
+			targetPath, rest, ok := sftpReadString(payload)
+			if !ok {
+				return
+			}
+			linkPath, _, ok := sftpReadString(rest)
+			if !ok {
+				return
+			}
+			d.emitOp(FileTransferActionSymlink, linkPath, targetPath)
+		case sshFxpExtended:
+			name, rest, ok := sftpReadString(payload)
+			if !ok {
+				return
+			}
+			var action FileTransferAction
+			switch name {
+			case "posix-rename@openssh.com":
+				action = FileTransferActionRename
+			case "hardlink@openssh.com":
+				// A hard link adds a new name for existing content, so
+				// it can expose a file's data under another path.
+				action = FileTransferActionHardlink
+			default:
+				return
+			}
+			oldPath, rest, ok := sftpReadString(rest)
+			if !ok {
+				return
+			}
+			newPath, _, ok := sftpReadString(rest)
+			if !ok {
+				return
+			}
+			d.emitOp(action, oldPath, newPath)
+		}
+	}
+}
+
+func (d *sftpRequestDecoder) emitOp(action FileTransferAction, path, target string) {
+	d.emit(FileTransferOperation{
+		Protocol: FileTransferProtocolSFTP,
+		Action:   action,
+		Path:     path,
+		Target:   target,
+	})
+}
+
+// sftpOpenAction maps SSH_FXP_OPEN pflags to a transfer action: opening
+// for read is a download (workspace to client), opening for write is an
+// upload (client to workspace), and opening for both is bidirectional
+// (either may have occurred).
+func sftpOpenAction(pflags uint32) (FileTransferAction, bool) {
+	read := pflags&sshFxfRead != 0
+	write := pflags&(sshFxfWrite|sshFxfAppend|sshFxfCreat|sshFxfTrunc|sshFxfExcl) != 0
+	switch {
+	case read && write:
+		return FileTransferActionBidirectional, true
+	case write:
+		return FileTransferActionUpload, true
+	case read:
+		return FileTransferActionDownload, true
+	default:
+		return "", false
+	}
+}
+
+func sftpReadUint32(b []byte) (uint32, []byte, bool) {
+	if len(b) < 4 {
+		return 0, nil, false
+	}
+	return binary.BigEndian.Uint32(b[:4]), b[4:], true
+}
+
+func sftpReadString(b []byte) (string, []byte, bool) {
+	n, rest, ok := sftpReadUint32(b)
+	if !ok || uint64(len(rest)) < uint64(n) {
+		return "", nil, false
+	}
+	return string(rest[:n]), rest[n:], true
+}

--- a/agent/agentssh/sftpaudit_internal_test.go
+++ b/agent/agentssh/sftpaudit_internal_test.go
@@ -1,0 +1,253 @@
+package agentssh
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildSFTPPacket constructs a wire-format SFTP packet: uint32 length,
+// byte type, payload.
+func buildSFTPPacket(typ byte, payload []byte) []byte {
+	packet := make([]byte, 0, 5+len(payload))
+	packet = binary.BigEndian.AppendUint32(packet, uint32(1+len(payload))) // #nosec G115 - test payloads are small
+	packet = append(packet, typ)
+	return append(packet, payload...)
+}
+
+func sftpString(s string) []byte {
+	b := binary.BigEndian.AppendUint32(nil, uint32(len(s))) // #nosec G115 - test strings are small
+	return append(b, []byte(s)...)
+}
+
+func sftpUint32(v uint32) []byte {
+	return binary.BigEndian.AppendUint32(nil, v)
+}
+
+func TestSFTPRequestDecoder(t *testing.T) {
+	t.Parallel()
+
+	openPacket := func(path string, pflags uint32) []byte {
+		payload := sftpUint32(1) // request id
+		payload = append(payload, sftpString(path)...)
+		payload = append(payload, sftpUint32(pflags)...)
+		payload = append(payload, sftpUint32(0)...) // empty ATTRS flags
+		return buildSFTPPacket(sshFxpOpen, payload)
+	}
+
+	pathPacket := func(typ byte, path string) []byte {
+		payload := sftpUint32(2)
+		payload = append(payload, sftpString(path)...)
+		return buildSFTPPacket(typ, payload)
+	}
+
+	twoPathPacket := func(typ byte, a, b string) []byte {
+		payload := sftpUint32(3)
+		payload = append(payload, sftpString(a)...)
+		payload = append(payload, sftpString(b)...)
+		return buildSFTPPacket(typ, payload)
+	}
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  []FileTransferOperation
+	}{
+		{
+			name:  "OpenRead",
+			input: openPacket("/etc/passwd", sshFxfRead),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionDownload,
+				Path:     "/etc/passwd",
+			}},
+		},
+		{
+			name:  "OpenWrite",
+			input: openPacket("upload.bin", sshFxfWrite|sshFxfCreat|sshFxfTrunc),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionUpload,
+				Path:     "upload.bin",
+			}},
+		},
+		{
+			name:  "OpenBidirectional",
+			input: openPacket("db.sqlite", sshFxfRead|sshFxfWrite),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionBidirectional,
+				Path:     "db.sqlite",
+			}},
+		},
+		{
+			name: "Setstat",
+			input: buildSFTPPacket(sshFxpSetstat, func() []byte {
+				payload := sftpUint32(6)
+				payload = append(payload, sftpString("/tmp/stomped")...)
+				payload = append(payload, sftpUint32(0x00000008)...) // ACMODTIME flag
+				payload = append(payload, sftpUint32(0)...)          // atime
+				payload = append(payload, sftpUint32(0)...)          // mtime
+				return payload
+			}()),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionSetattr,
+				Path:     "/tmp/stomped",
+			}},
+		},
+		{
+			name: "Hardlink",
+			input: buildSFTPPacket(sshFxpExtended, func() []byte {
+				payload := sftpUint32(7)
+				payload = append(payload, sftpString("hardlink@openssh.com")...)
+				payload = append(payload, sftpString("/home/coder/secrets.env")...)
+				payload = append(payload, sftpString("/tmp/exposed")...)
+				return payload
+			}()),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionHardlink,
+				Path:     "/home/coder/secrets.env",
+				Target:   "/tmp/exposed",
+			}},
+		},
+		{
+			name:  "Remove",
+			input: pathPacket(sshFxpRemove, "/tmp/gone"),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionRemove,
+				Path:     "/tmp/gone",
+			}},
+		},
+		{
+			// Directory creation is deliberately not logged: it carries
+			// no file contents, and the uploads into the directory are
+			// logged individually.
+			name:  "MkdirIgnored",
+			input: pathPacket(sshFxpMkdir, "newdir"),
+			want:  nil,
+		},
+		{
+			name:  "Rmdir",
+			input: pathPacket(sshFxpRmdir, "olddir"),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionRmdir,
+				Path:     "olddir",
+			}},
+		},
+		{
+			name:  "Rename",
+			input: twoPathPacket(sshFxpRename, "a.txt", "b.txt"),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionRename,
+				Path:     "a.txt",
+				Target:   "b.txt",
+			}},
+		},
+		{
+			name: "Symlink",
+			// Wire order per pkg/sftp: target path first, then link path.
+			input: twoPathPacket(sshFxpSymlink, "/target", "/link"),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionSymlink,
+				Path:     "/link",
+				Target:   "/target",
+			}},
+		},
+		{
+			name: "PosixRename",
+			input: buildSFTPPacket(sshFxpExtended, func() []byte {
+				payload := sftpUint32(4)
+				payload = append(payload, sftpString("posix-rename@openssh.com")...)
+				payload = append(payload, sftpString("old")...)
+				payload = append(payload, sftpString("new")...)
+				return payload
+			}()),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionRename,
+				Path:     "old",
+				Target:   "new",
+			}},
+		},
+		{
+			name: "SkipsUninterestingPackets",
+			input: func() []byte {
+				// INIT (type 1), then a large WRITE-like packet (type 6),
+				// then an OPEN.
+				b := buildSFTPPacket(1, sftpUint32(3))
+				b = append(b, buildSFTPPacket(6, make([]byte, 32*1024))...)
+				b = append(b, openPacket("after-noise", sshFxfRead)...)
+				return b
+			}(),
+			want: []FileTransferOperation{{
+				Protocol: FileTransferProtocolSFTP,
+				Action:   FileTransferActionDownload,
+				Path:     "after-noise",
+			}},
+		},
+		{
+			name:  "GarbageDisables",
+			input: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			want:  nil,
+		},
+		{
+			name: "TruncatedStringFailsSafely",
+			input: buildSFTPPacket(sshFxpRemove, func() []byte {
+				payload := sftpUint32(5)
+				// Declared string length exceeds the remaining payload.
+				payload = append(payload, sftpUint32(1000)...)
+				payload = append(payload, []byte("short")...)
+				return payload
+			}()),
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Feed the whole input at once.
+			var got []FileTransferOperation
+			dec := newSFTPRequestDecoder(func(op FileTransferOperation) {
+				got = append(got, op)
+			})
+			dec.feed(tt.input)
+			require.Equal(t, tt.want, got)
+
+			// Feed byte-by-byte to exercise incremental buffering.
+			got = nil
+			dec = newSFTPRequestDecoder(func(op FileTransferOperation) {
+				got = append(got, op)
+			})
+			for _, b := range tt.input {
+				dec.feed([]byte{b})
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSFTPRequestDecoderDisabledStaysDisabled(t *testing.T) {
+	t.Parallel()
+
+	count := 0
+	dec := newSFTPRequestDecoder(func(FileTransferOperation) { count++ })
+	// A zero-length packet is invalid and disables the decoder.
+	dec.feed([]byte{0x00, 0x00, 0x00, 0x00, 0x00})
+	require.True(t, dec.disabled)
+
+	// Even a valid OPEN afterwards must be ignored.
+	payload := sftpUint32(1)
+	payload = append(payload, sftpString("/etc/passwd")...)
+	payload = append(payload, sftpUint32(sshFxfRead)...)
+	dec.feed(buildSFTPPacket(sshFxpOpen, payload))
+	require.Zero(t, count)
+}

--- a/coderd/agentapi/connectionlog.go
+++ b/coderd/agentapi/connectionlog.go
@@ -6,9 +6,9 @@ import (
 	"sync/atomic"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"storj.io/drpc/drpcerr"
 
 	"cdr.dev/slog/v3"
 	agentproto "github.com/coder/coder/v2/agent/proto"
@@ -110,6 +110,11 @@ func (a *ConnLogAPI) ReportConnection(ctx context.Context, req *agentproto.Repor
 		UserAgent: sql.NullString{},
 		// N/A
 		SlugOrPort: sql.NullString{},
+		// Only set for file operation events.
+		FileProtocol: database.NullConnectionLogFileProtocol{},
+		FileAction:   database.NullConnectionLogFileAction{},
+		FilePath:     sql.NullString{},
+		FileTarget:   sql.NullString{},
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("export connection log: %w", err)
@@ -119,10 +124,99 @@ func (a *ConnLogAPI) ReportConnection(ctx context.Context, req *agentproto.Repor
 }
 
 // ReportFileOperations records file operations observed during a
-// file-transfer session (SFTP, SCP, rsync) as connection log entries.
-// The schema and protocol land ahead of the implementation; agents
-// treat reports as best effort and tolerate this error, matching the
-// PushContextState rollout in API v2.10.
-func (*ConnLogAPI) ReportFileOperations(context.Context, *agentproto.ReportFileOperationsRequest) (*agentproto.ReportFileOperationsResponse, error) {
-	return nil, drpcerr.WithCode(xerrors.New("ReportFileOperations is not yet implemented"), drpcerr.Unimplemented)
+// file-transfer session (SFTP, SCP, rsync) as point-in-time connection
+// log entries. Each operation shares the connection_id of its parent
+// session so they can be grouped together.
+func (a *ConnLogAPI) ReportFileOperations(ctx context.Context, req *agentproto.ReportFileOperationsRequest) (*agentproto.ReportFileOperationsResponse, error) {
+	if len(req.GetOperations()) == 0 {
+		return &agentproto.ReportFileOperationsResponse{}, nil
+	}
+
+	var ws database.WorkspaceIdentity
+	if dbws, ok := a.Workspace.AsWorkspaceIdentity(); ok {
+		ws = dbws
+	}
+	if ws.Equal(database.WorkspaceIdentity{}) {
+		workspace, err := a.Database.GetWorkspaceByAgentID(ctx, a.AgentID)
+		if err != nil {
+			return nil, xerrors.Errorf("get workspace by agent id: %w", err)
+		}
+		ws = database.WorkspaceIdentityFromWorkspace(workspace)
+	}
+
+	connLogger := *a.ConnectionLogger.Load()
+	for _, op := range req.GetOperations() {
+		connectionID, err := uuid.FromBytes(op.GetConnectionId())
+		if err != nil {
+			return nil, xerrors.Errorf("connection id from bytes: %w", err)
+		}
+		if connectionID == uuid.Nil {
+			return nil, xerrors.New("connection ID cannot be nil")
+		}
+		protocol, err := db2sdk.ConnectionLogFileProtocolFromAgentProtoFileTransferProtocol(op.GetProtocol())
+		if err != nil {
+			return nil, err
+		}
+		action, err := db2sdk.ConnectionLogFileActionFromAgentProtoFileTransferAction(op.GetAction())
+		if err != nil {
+			return nil, err
+		}
+		if op.GetPath() == "" {
+			return nil, xerrors.New("file operation path cannot be empty")
+		}
+
+		err = connLogger.Upsert(ctx, database.UpsertConnectionLogParams{
+			ID:               uuid.New(),
+			Time:             op.GetTimestamp().AsTime(),
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			WorkspaceID:      ws.ID,
+			WorkspaceName:    ws.Name,
+			AgentName:        a.AgentName,
+			Type:             database.ConnectionTypeFileOperation,
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: protocol,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: action,
+				Valid:                   true,
+			},
+			FilePath: sql.NullString{String: op.GetPath(), Valid: true},
+			FileTarget: sql.NullString{
+				String: op.GetTarget(),
+				Valid:  op.GetTarget() != "",
+			},
+			// The parent file-transfer session's connection ID, so the
+			// operation can be grouped with it. File operation rows are
+			// excluded from the connect/disconnect pairing index, so
+			// sharing the ID never merges rows.
+			ConnectionID: uuid.NullUUID{
+				UUID:  connectionID,
+				Valid: true,
+			},
+			// File operations are point-in-time events: they are always
+			// "connected" and never receive a disconnect event.
+			ConnectionStatus: database.ConnectionStatusConnected,
+
+			// It's not possible to tell which user connected. Once we have
+			// the capability, this may be reported by the agent.
+			UserID: uuid.NullUUID{Valid: false},
+			// N/A
+			Code: sql.NullInt32{},
+			// N/A
+			IP: pqtype.Inet{},
+			// N/A
+			UserAgent: sql.NullString{},
+			// N/A
+			SlugOrPort: sql.NullString{},
+			// N/A
+			DisconnectReason: sql.NullString{},
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("export file operation log: %w", err)
+		}
+	}
+
+	return &agentproto.ReportFileOperationsResponse{}, nil
 }

--- a/coderd/agentapi/connectionlog_test.go
+++ b/coderd/agentapi/connectionlog_test.go
@@ -100,6 +100,24 @@ func TestConnectionLog(t *testing.T) {
 			status: 500,
 			reason: "because error says so",
 		},
+		{
+			name:   "File Transfer Connect",
+			id:     uuid.New(),
+			action: agentproto.Connection_CONNECT.Enum(),
+			typ:    agentproto.Connection_FILE_TRANSFER.Enum(),
+			time:   dbtime.Now(),
+			ip:     "127.0.0.1",
+		},
+		{
+			name:   "File Transfer Blocked Disconnect",
+			id:     uuid.New(),
+			action: agentproto.Connection_DISCONNECT.Enum(),
+			typ:    agentproto.Connection_FILE_TRANSFER.Enum(),
+			time:   dbtime.Now(),
+			ip:     "127.0.0.1",
+			status: 65,
+			reason: "file transfer blocked",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -165,6 +183,180 @@ func TestConnectionLog(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestReportFileOperations(t *testing.T) {
+	t.Parallel()
+
+	var (
+		owner = database.User{
+			ID:       uuid.New(),
+			Username: "cool-user",
+		}
+		workspace = database.Workspace{
+			ID:             uuid.New(),
+			OrganizationID: uuid.New(),
+			OwnerID:        owner.ID,
+			Name:           "cool-workspace",
+		}
+		agent = database.WorkspaceAgent{
+			ID:   uuid.New(),
+			Name: "cool-agent",
+		}
+	)
+
+	newAPI := func(t *testing.T, connLogger connectionlog.ConnectionLogger, expectDBLookup bool) *agentapi.ConnLogAPI {
+		mDB := dbmock.NewMockStore(gomock.NewController(t))
+		if expectDBLookup {
+			mDB.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
+		}
+		return &agentapi.ConnLogAPI{
+			ConnectionLogger: asAtomicPointer(connLogger),
+			Database:         mDB,
+			AgentID:          agent.ID,
+			AgentName:        agent.Name,
+			Workspace:        &agentapi.CachedWorkspaceFields{},
+		}
+	}
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		connLogger := connectionlog.NewFake()
+		api := newAPI(t, connLogger, true)
+
+		sessionID := uuid.New()
+		now := dbtime.Now()
+		target := "/home/coder/b.txt"
+		_, err := api.ReportFileOperations(context.Background(), &agentproto.ReportFileOperationsRequest{
+			Operations: []*agentproto.FileTransferOperation{
+				{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "/home/coder/secret.txt",
+					Timestamp:    timestamppb.New(now),
+				},
+				{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_RENAME,
+					Path:         "/home/coder/a.txt",
+					Target:       &target,
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		require.Len(t, connLogger.ConnectionLogs(), 2)
+		require.True(t, connLogger.Contains(t, database.UpsertConnectionLogParams{
+			Time:             dbtime.Time(now).In(time.UTC),
+			OrganizationID:   workspace.OrganizationID,
+			WorkspaceOwnerID: workspace.OwnerID,
+			WorkspaceID:      workspace.ID,
+			WorkspaceName:    workspace.Name,
+			AgentName:        agent.Name,
+			Type:             database.ConnectionTypeFileOperation,
+			ConnectionStatus: database.ConnectionStatusConnected,
+			ConnectionID:     uuid.NullUUID{UUID: sessionID, Valid: true},
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: database.ConnectionLogFileProtocolSftp,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionDownload,
+				Valid:                   true,
+			},
+			FilePath: sql.NullString{String: "/home/coder/secret.txt", Valid: true},
+		}))
+		require.True(t, connLogger.Contains(t, database.UpsertConnectionLogParams{
+			Type: database.ConnectionTypeFileOperation,
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionRename,
+				Valid:                   true,
+			},
+			FilePath:   sql.NullString{String: "/home/coder/a.txt", Valid: true},
+			FileTarget: sql.NullString{String: target, Valid: true},
+		}))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
+		connLogger := connectionlog.NewFake()
+		api := newAPI(t, connLogger, false)
+
+		_, err := api.ReportFileOperations(context.Background(), &agentproto.ReportFileOperationsRequest{})
+		require.NoError(t, err)
+		require.Empty(t, connLogger.ConnectionLogs())
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		t.Parallel()
+
+		sessionID := uuid.New()
+		now := dbtime.Now()
+		tests := []struct {
+			name string
+			op   *agentproto.FileTransferOperation
+		}{
+			{
+				name: "NilConnectionID",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: uuid.Nil[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "/etc/passwd",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+			{
+				name: "UnspecifiedProtocol",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_PROTOCOL_UNSPECIFIED,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "/etc/passwd",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+			{
+				name: "UnspecifiedAction",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_ACTION_UNSPECIFIED,
+					Path:         "/etc/passwd",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+			{
+				name: "EmptyPath",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				connLogger := connectionlog.NewFake()
+				api := newAPI(t, connLogger, true)
+
+				_, err := api.ReportFileOperations(context.Background(), &agentproto.ReportFileOperationsRequest{
+					Operations: []*agentproto.FileTransferOperation{tt.op},
+				})
+				require.Error(t, err)
+				require.Empty(t, connLogger.ConnectionLogs())
+			})
+		}
+	})
 }
 
 func agentProtoConnectionTypeToConnectionLog(t *testing.T, typ agentproto.Connection_Type) database.ConnectionType {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18949,6 +18949,14 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time"
                 },
+                "file_transfer_info": {
+                    "description": "FileTransferInfo is only set when ` + "`" + `type` + "`" + ` is\n` + "`" + `ConnectionTypeFileOperation` + "`" + `.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ConnectionLogFileTransferInfo"
+                        }
+                    ]
+                },
                 "id": {
                     "type": "string",
                     "format": "uuid"
@@ -18960,7 +18968,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.MinimalOrganization"
                 },
                 "ssh_info": {
-                    "description": "SSHInfo is only set when ` + "`" + `type` + "`" + ` is one of:\n- ` + "`" + `ConnectionTypeSSH` + "`" + `\n- ` + "`" + `ConnectionTypeReconnectingPTY` + "`" + `\n- ` + "`" + `ConnectionTypeVSCode` + "`" + `\n- ` + "`" + `ConnectionTypeJetBrains` + "`" + `",
+                    "description": "SSHInfo is only set when ` + "`" + `type` + "`" + ` is one of:\n- ` + "`" + `ConnectionTypeSSH` + "`" + `\n- ` + "`" + `ConnectionTypeReconnectingPTY` + "`" + `\n- ` + "`" + `ConnectionTypeVSCode` + "`" + `\n- ` + "`" + `ConnectionTypeJetBrains` + "`" + `\n- ` + "`" + `ConnectionTypeFileTransfer` + "`" + `",
                     "allOf": [
                         {
                             "$ref": "#/definitions/codersdk.ConnectionLogSSHInfo"
@@ -18990,6 +18998,68 @@ const docTemplate = `{
                     "format": "uuid"
                 },
                 "workspace_owner_username": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ConnectionLogFileAction": {
+            "type": "string",
+            "enum": [
+                "download",
+                "upload",
+                "bidirectional",
+                "remove",
+                "rmdir",
+                "rename",
+                "symlink",
+                "setattr",
+                "hardlink"
+            ],
+            "x-enum-varnames": [
+                "ConnectionLogFileActionDownload",
+                "ConnectionLogFileActionUpload",
+                "ConnectionLogFileActionBidirectional",
+                "ConnectionLogFileActionRemove",
+                "ConnectionLogFileActionRmdir",
+                "ConnectionLogFileActionRename",
+                "ConnectionLogFileActionSymlink",
+                "ConnectionLogFileActionSetattr",
+                "ConnectionLogFileActionHardlink"
+            ]
+        },
+        "codersdk.ConnectionLogFileProtocol": {
+            "type": "string",
+            "enum": [
+                "sftp",
+                "scp",
+                "rsync"
+            ],
+            "x-enum-varnames": [
+                "ConnectionLogFileProtocolSFTP",
+                "ConnectionLogFileProtocolSCP",
+                "ConnectionLogFileProtocolRsync"
+            ]
+        },
+        "codersdk.ConnectionLogFileTransferInfo": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/codersdk.ConnectionLogFileAction"
+                },
+                "connection_id": {
+                    "description": "ConnectionID matches the connection ID of the file_transfer\nsession the operation occurred in.",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "path": {
+                    "description": "Path is the path the operation was performed on. For SCP and\nrsync this is the requested root path from the command line, not\nnecessarily every file transferred.",
+                    "type": "string"
+                },
+                "protocol": {
+                    "$ref": "#/definitions/codersdk.ConnectionLogFileProtocol"
+                },
+                "target": {
+                    "description": "Target is only set for operations with a second path, such as the\ndestination of a rename or the target of a symlink.",
                     "type": "string"
                 }
             }
@@ -19065,7 +19135,9 @@ const docTemplate = `{
                 "reconnecting_pty",
                 "workspace_app",
                 "port_forwarding",
-                "tunnel"
+                "tunnel",
+                "file_transfer",
+                "file_operation"
             ],
             "x-enum-varnames": [
                 "ConnectionTypeSSH",
@@ -19074,7 +19146,9 @@ const docTemplate = `{
                 "ConnectionTypeReconnectingPTY",
                 "ConnectionTypeWorkspaceApp",
                 "ConnectionTypePortForwarding",
-                "ConnectionTypeTunnel"
+                "ConnectionTypeTunnel",
+                "ConnectionTypeFileTransfer",
+                "ConnectionTypeFileOperation"
             ]
         },
         "codersdk.ConvertLoginRequest": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -17129,6 +17129,14 @@
 					"type": "string",
 					"format": "date-time"
 				},
+				"file_transfer_info": {
+					"description": "FileTransferInfo is only set when `type` is\n`ConnectionTypeFileOperation`.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ConnectionLogFileTransferInfo"
+						}
+					]
+				},
 				"id": {
 					"type": "string",
 					"format": "uuid"
@@ -17140,7 +17148,7 @@
 					"$ref": "#/definitions/codersdk.MinimalOrganization"
 				},
 				"ssh_info": {
-					"description": "SSHInfo is only set when `type` is one of:\n- `ConnectionTypeSSH`\n- `ConnectionTypeReconnectingPTY`\n- `ConnectionTypeVSCode`\n- `ConnectionTypeJetBrains`",
+					"description": "SSHInfo is only set when `type` is one of:\n- `ConnectionTypeSSH`\n- `ConnectionTypeReconnectingPTY`\n- `ConnectionTypeVSCode`\n- `ConnectionTypeJetBrains`\n- `ConnectionTypeFileTransfer`",
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.ConnectionLogSSHInfo"
@@ -17170,6 +17178,64 @@
 					"format": "uuid"
 				},
 				"workspace_owner_username": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ConnectionLogFileAction": {
+			"type": "string",
+			"enum": [
+				"download",
+				"upload",
+				"bidirectional",
+				"remove",
+				"rmdir",
+				"rename",
+				"symlink",
+				"setattr",
+				"hardlink"
+			],
+			"x-enum-varnames": [
+				"ConnectionLogFileActionDownload",
+				"ConnectionLogFileActionUpload",
+				"ConnectionLogFileActionBidirectional",
+				"ConnectionLogFileActionRemove",
+				"ConnectionLogFileActionRmdir",
+				"ConnectionLogFileActionRename",
+				"ConnectionLogFileActionSymlink",
+				"ConnectionLogFileActionSetattr",
+				"ConnectionLogFileActionHardlink"
+			]
+		},
+		"codersdk.ConnectionLogFileProtocol": {
+			"type": "string",
+			"enum": ["sftp", "scp", "rsync"],
+			"x-enum-varnames": [
+				"ConnectionLogFileProtocolSFTP",
+				"ConnectionLogFileProtocolSCP",
+				"ConnectionLogFileProtocolRsync"
+			]
+		},
+		"codersdk.ConnectionLogFileTransferInfo": {
+			"type": "object",
+			"properties": {
+				"action": {
+					"$ref": "#/definitions/codersdk.ConnectionLogFileAction"
+				},
+				"connection_id": {
+					"description": "ConnectionID matches the connection ID of the file_transfer\nsession the operation occurred in.",
+					"type": "string",
+					"format": "uuid"
+				},
+				"path": {
+					"description": "Path is the path the operation was performed on. For SCP and\nrsync this is the requested root path from the command line, not\nnecessarily every file transferred.",
+					"type": "string"
+				},
+				"protocol": {
+					"$ref": "#/definitions/codersdk.ConnectionLogFileProtocol"
+				},
+				"target": {
+					"description": "Target is only set for operations with a second path, such as the\ndestination of a rename or the target of a symlink.",
 					"type": "string"
 				}
 			}
@@ -17245,7 +17311,9 @@
 				"reconnecting_pty",
 				"workspace_app",
 				"port_forwarding",
-				"tunnel"
+				"tunnel",
+				"file_transfer",
+				"file_operation"
 			],
 			"x-enum-varnames": [
 				"ConnectionTypeSSH",
@@ -17254,7 +17322,9 @@
 				"ConnectionTypeReconnectingPTY",
 				"ConnectionTypeWorkspaceApp",
 				"ConnectionTypePortForwarding",
-				"ConnectionTypeTunnel"
+				"ConnectionTypeTunnel",
+				"ConnectionTypeFileTransfer",
+				"ConnectionTypeFileOperation"
 			]
 		},
 		"codersdk.ConvertLoginRequest": {

--- a/coderd/connectionlog/connectionlog.go
+++ b/coderd/connectionlog/connectionlog.go
@@ -114,6 +114,22 @@ func (m *FakeConnectionLogger) Contains(t testing.TB, expected database.UpsertCo
 			t.Logf("connection log %d: expected DisconnectReason %s, got %s", idx+1, expected.DisconnectReason.String, cl.DisconnectReason.String)
 			continue
 		}
+		if expected.FileProtocol.Valid && cl.FileProtocol.ConnectionLogFileProtocol != expected.FileProtocol.ConnectionLogFileProtocol {
+			t.Logf("connection log %d: expected FileProtocol %s, got %s", idx+1, expected.FileProtocol.ConnectionLogFileProtocol, cl.FileProtocol.ConnectionLogFileProtocol)
+			continue
+		}
+		if expected.FileAction.Valid && cl.FileAction.ConnectionLogFileAction != expected.FileAction.ConnectionLogFileAction {
+			t.Logf("connection log %d: expected FileAction %s, got %s", idx+1, expected.FileAction.ConnectionLogFileAction, cl.FileAction.ConnectionLogFileAction)
+			continue
+		}
+		if expected.FilePath.Valid && cl.FilePath.String != expected.FilePath.String {
+			t.Logf("connection log %d: expected FilePath %s, got %s", idx+1, expected.FilePath.String, cl.FilePath.String)
+			continue
+		}
+		if expected.FileTarget.Valid && cl.FileTarget.String != expected.FileTarget.String {
+			t.Logf("connection log %d: expected FileTarget %s, got %s", idx+1, expected.FileTarget.String, cl.FileTarget.String)
+			continue
+		}
 		if !expected.Time.IsZero() && expected.Time != cl.Time {
 			t.Logf("connection log %d: expected Time %s, got %s", idx+1, expected.Time, cl.Time)
 			continue

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -437,6 +437,22 @@ func ConnectionLog(t testing.TB, db database.Store, seed database.UpsertConnecti
 			String: takeFirst(seed.DisconnectReason.String, ""),
 			Valid:  takeFirst(seed.DisconnectReason.Valid, false),
 		},
+		FileProtocol: database.NullConnectionLogFileProtocol{
+			ConnectionLogFileProtocol: takeFirst(seed.FileProtocol.ConnectionLogFileProtocol, ""),
+			Valid:                     takeFirst(seed.FileProtocol.Valid, false),
+		},
+		FileAction: database.NullConnectionLogFileAction{
+			ConnectionLogFileAction: takeFirst(seed.FileAction.ConnectionLogFileAction, ""),
+			Valid:                   takeFirst(seed.FileAction.Valid, false),
+		},
+		FilePath: sql.NullString{
+			String: takeFirst(seed.FilePath.String, ""),
+			Valid:  takeFirst(seed.FilePath.Valid, false),
+		},
+		FileTarget: sql.NullString{
+			String: takeFirst(seed.FileTarget.String, ""),
+			Valid:  takeFirst(seed.FileTarget.Valid, false),
+		},
 		ConnectionStatus: takeFirst(seed.ConnectionStatus, database.ConnectionStatusConnected),
 	}
 
@@ -463,6 +479,10 @@ func ConnectionLog(t testing.TB, db database.Store, seed database.UpsertConnecti
 		ConnectionID:     []uuid.UUID{arg.ConnectionID.UUID},
 		DisconnectReason: []string{arg.DisconnectReason.String},
 		DisconnectTime:   []time.Time{disconnectTime.Time},
+		FileProtocol:     []string{string(arg.FileProtocol.ConnectionLogFileProtocol)},
+		FileAction:       []string{string(arg.FileAction.ConnectionLogFileAction)},
+		FilePath:         []string{arg.FilePath.String},
+		FileTarget:       []string{arg.FileTarget.String},
 	})
 	require.NoError(t, err, "insert connection log")
 
@@ -470,10 +490,13 @@ func ConnectionLog(t testing.TB, db database.Store, seed database.UpsertConnecti
 	// conflict the DB keeps the original row's ID, so we can't
 	// rely on arg.ID. Match on the conflict key for rows with a
 	// connection_id, or by primary key for NULL connection_id.
+	// File operation rows are excluded from the conflict index (they
+	// share their parent session's connection_id and always insert as
+	// fresh rows), so they are matched by primary key too.
 	rows, err := db.GetConnectionLogsOffset(genCtx, database.GetConnectionLogsOffsetParams{})
 	require.NoError(t, err, "query connection logs")
 	for _, row := range rows {
-		if arg.ConnectionID.Valid {
+		if arg.ConnectionID.Valid && !arg.FileAction.Valid {
 			if row.ConnectionLog.ConnectionID == arg.ConnectionID &&
 				row.ConnectionLog.WorkspaceID == arg.WorkspaceID &&
 				row.ConnectionLog.AgentName == arg.AgentName {

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -1042,22 +1042,26 @@ func (r GetWorkspaceBuildAgentsByInstanceIDRow) RBACObject() rbac.Object {
 // still used as the canonical connection log event type throughout
 // the codebase.
 type UpsertConnectionLogParams struct {
-	ID               uuid.UUID        `db:"id" json:"id"`
-	OrganizationID   uuid.UUID        `db:"organization_id" json:"organization_id"`
-	WorkspaceOwnerID uuid.UUID        `db:"workspace_owner_id" json:"workspace_owner_id"`
-	WorkspaceID      uuid.UUID        `db:"workspace_id" json:"workspace_id"`
-	WorkspaceName    string           `db:"workspace_name" json:"workspace_name"`
-	AgentName        string           `db:"agent_name" json:"agent_name"`
-	Type             ConnectionType   `db:"type" json:"type"`
-	Code             sql.NullInt32    `db:"code" json:"code"`
-	IP               pqtype.Inet      `db:"ip" json:"ip"`
-	UserAgent        sql.NullString   `db:"user_agent" json:"user_agent"`
-	UserID           uuid.NullUUID    `db:"user_id" json:"user_id"`
-	SlugOrPort       sql.NullString   `db:"slug_or_port" json:"slug_or_port"`
-	ConnectionID     uuid.NullUUID    `db:"connection_id" json:"connection_id"`
-	DisconnectReason sql.NullString   `db:"disconnect_reason" json:"disconnect_reason"`
-	Time             time.Time        `db:"time" json:"time"`
-	ConnectionStatus ConnectionStatus `db:"connection_status" json:"connection_status"`
+	ID               uuid.UUID                     `db:"id" json:"id"`
+	OrganizationID   uuid.UUID                     `db:"organization_id" json:"organization_id"`
+	WorkspaceOwnerID uuid.UUID                     `db:"workspace_owner_id" json:"workspace_owner_id"`
+	WorkspaceID      uuid.UUID                     `db:"workspace_id" json:"workspace_id"`
+	WorkspaceName    string                        `db:"workspace_name" json:"workspace_name"`
+	AgentName        string                        `db:"agent_name" json:"agent_name"`
+	Type             ConnectionType                `db:"type" json:"type"`
+	Code             sql.NullInt32                 `db:"code" json:"code"`
+	IP               pqtype.Inet                   `db:"ip" json:"ip"`
+	UserAgent        sql.NullString                `db:"user_agent" json:"user_agent"`
+	UserID           uuid.NullUUID                 `db:"user_id" json:"user_id"`
+	SlugOrPort       sql.NullString                `db:"slug_or_port" json:"slug_or_port"`
+	ConnectionID     uuid.NullUUID                 `db:"connection_id" json:"connection_id"`
+	DisconnectReason sql.NullString                `db:"disconnect_reason" json:"disconnect_reason"`
+	FileProtocol     NullConnectionLogFileProtocol `db:"file_protocol" json:"file_protocol"`
+	FileAction       NullConnectionLogFileAction   `db:"file_action" json:"file_action"`
+	FilePath         sql.NullString                `db:"file_path" json:"file_path"`
+	FileTarget       sql.NullString                `db:"file_target" json:"file_target"`
+	Time             time.Time                     `db:"time" json:"time"`
+	ConnectionStatus ConnectionStatus              `db:"connection_status" json:"connection_status"`
 }
 
 func (r GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow) RBACObject() rbac.Object {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -85,8 +85,7 @@ type sqlcQuerier interface {
 	BatchUpsertChatHeartbeats(ctx context.Context, arg BatchUpsertChatHeartbeatsParams) error
 	// The pairing index is partial (file_action IS NULL): file operation
 	// events share the connection_id of their parent session, never pair
-	// with a disconnect event, and always insert as new rows. The predicate
-	// is required for Postgres to infer the partial unique index.
+	// with a disconnect event, and always insert as new rows.
 	BatchUpsertConnectionLogs(ctx context.Context, arg BatchUpsertConnectionLogsParams) error
 	BulkMarkNotificationMessagesFailed(ctx context.Context, arg BulkMarkNotificationMessagesFailedParams) (int64, error)
 	BulkMarkNotificationMessagesSent(ctx context.Context, arg BulkMarkNotificationMessagesSentParams) (int64, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -13179,7 +13179,8 @@ const batchUpsertConnectionLogs = `-- name: BatchUpsertConnectionLogs :exec
 INSERT INTO connection_logs (
     id, connect_time, organization_id, workspace_owner_id, workspace_id,
     workspace_name, agent_name, type, code, ip, user_agent, user_id,
-    slug_or_port, connection_id, disconnect_reason, disconnect_time
+    slug_or_port, connection_id, disconnect_reason, disconnect_time,
+    file_protocol, file_action, file_path, file_target
 )
 SELECT
     u.id,
@@ -13199,7 +13200,11 @@ SELECT
     NULLIF(u.slug_or_port, ''),
     NULLIF(u.connection_id, '00000000-0000-0000-0000-000000000000'::uuid),
     NULLIF(u.disconnect_reason, ''),
-    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz)
+    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz),
+    NULLIF(u.file_protocol, '')::connection_log_file_protocol,
+    NULLIF(u.file_action, '')::connection_log_file_action,
+    NULLIF(u.file_path, ''),
+    NULLIF(u.file_target, '')
 FROM (
     SELECT
         unnest($1::uuid[]) AS id,
@@ -13218,7 +13223,11 @@ FROM (
         unnest($14::text[]) AS slug_or_port,
         unnest($15::uuid[]) AS connection_id,
         unnest($16::text[]) AS disconnect_reason,
-        unnest($17::timestamptz[]) AS disconnect_time
+        unnest($17::timestamptz[]) AS disconnect_time,
+        unnest($18::text[]) AS file_protocol,
+        unnest($19::text[]) AS file_action,
+        unnest($20::text[]) AS file_path,
+        unnest($21::text[]) AS file_target
 ) AS u
 ON CONFLICT (connection_id, workspace_id, agent_name) WHERE file_action IS NULL
 DO UPDATE SET
@@ -13267,12 +13276,15 @@ type BatchUpsertConnectionLogsParams struct {
 	ConnectionID     []uuid.UUID      `db:"connection_id" json:"connection_id"`
 	DisconnectReason []string         `db:"disconnect_reason" json:"disconnect_reason"`
 	DisconnectTime   []time.Time      `db:"disconnect_time" json:"disconnect_time"`
+	FileProtocol     []string         `db:"file_protocol" json:"file_protocol"`
+	FileAction       []string         `db:"file_action" json:"file_action"`
+	FilePath         []string         `db:"file_path" json:"file_path"`
+	FileTarget       []string         `db:"file_target" json:"file_target"`
 }
 
 // The pairing index is partial (file_action IS NULL): file operation
 // events share the connection_id of their parent session, never pair
-// with a disconnect event, and always insert as new rows. The predicate
-// is required for Postgres to infer the partial unique index.
+// with a disconnect event, and always insert as new rows.
 func (q *sqlQuerier) BatchUpsertConnectionLogs(ctx context.Context, arg BatchUpsertConnectionLogsParams) error {
 	_, err := q.db.ExecContext(ctx, batchUpsertConnectionLogs,
 		pq.Array(arg.ID),
@@ -13292,6 +13304,10 @@ func (q *sqlQuerier) BatchUpsertConnectionLogs(ctx context.Context, arg BatchUps
 		pq.Array(arg.ConnectionID),
 		pq.Array(arg.DisconnectReason),
 		pq.Array(arg.DisconnectTime),
+		pq.Array(arg.FileProtocol),
+		pq.Array(arg.FileAction),
+		pq.Array(arg.FilePath),
+		pq.Array(arg.FileTarget),
 	)
 	return err
 }

--- a/coderd/database/queries/connectionlogs.sql
+++ b/coderd/database/queries/connectionlogs.sql
@@ -259,7 +259,8 @@ WHERE connection_logs.id = old_logs.id;
 INSERT INTO connection_logs (
     id, connect_time, organization_id, workspace_owner_id, workspace_id,
     workspace_name, agent_name, type, code, ip, user_agent, user_id,
-    slug_or_port, connection_id, disconnect_reason, disconnect_time
+    slug_or_port, connection_id, disconnect_reason, disconnect_time,
+    file_protocol, file_action, file_path, file_target
 )
 SELECT
     u.id,
@@ -279,7 +280,11 @@ SELECT
     NULLIF(u.slug_or_port, ''),
     NULLIF(u.connection_id, '00000000-0000-0000-0000-000000000000'::uuid),
     NULLIF(u.disconnect_reason, ''),
-    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz)
+    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz),
+    NULLIF(u.file_protocol, '')::connection_log_file_protocol,
+    NULLIF(u.file_action, '')::connection_log_file_action,
+    NULLIF(u.file_path, ''),
+    NULLIF(u.file_target, '')
 FROM (
     SELECT
         unnest(sqlc.arg('id')::uuid[]) AS id,
@@ -298,12 +303,15 @@ FROM (
         unnest(sqlc.arg('slug_or_port')::text[]) AS slug_or_port,
         unnest(sqlc.arg('connection_id')::uuid[]) AS connection_id,
         unnest(sqlc.arg('disconnect_reason')::text[]) AS disconnect_reason,
-        unnest(sqlc.arg('disconnect_time')::timestamptz[]) AS disconnect_time
+        unnest(sqlc.arg('disconnect_time')::timestamptz[]) AS disconnect_time,
+        unnest(sqlc.arg('file_protocol')::text[]) AS file_protocol,
+        unnest(sqlc.arg('file_action')::text[]) AS file_action,
+        unnest(sqlc.arg('file_path')::text[]) AS file_path,
+        unnest(sqlc.arg('file_target')::text[]) AS file_target
 ) AS u
 -- The pairing index is partial (file_action IS NULL): file operation
 -- events share the connection_id of their parent session, never pair
--- with a disconnect event, and always insert as new rows. The predicate
--- is required for Postgres to infer the partial unique index.
+-- with a disconnect event, and always insert as new rows.
 ON CONFLICT (connection_id, workspace_id, agent_name) WHERE file_action IS NULL
 DO UPDATE SET
     -- Pick the earliest real connect_time. The zero sentinel

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1509,6 +1509,10 @@ func (api *API) logTunnelConnection(agentID uuid.UUID, statusCode int32, userID 
 		SlugOrPort:       sql.NullString{},
 		ConnectionID:     uuid.NullUUID{},
 		DisconnectReason: sql.NullString{},
+		FileProtocol:     database.NullConnectionLogFileProtocol{},
+		FileAction:       database.NullConnectionLogFileAction{},
+		FilePath:         sql.NullString{},
+		FileTarget:       sql.NullString{},
 		ConnectionStatus: database.ConnectionStatusConnected,
 	})
 	if err != nil {

--- a/coderd/workspaceapps/db.go
+++ b/coderd/workspaceapps/db.go
@@ -559,6 +559,10 @@ func (p *DBTokenProvider) connLogInitRequest(w http.ResponseWriter, r *http.Requ
 			// N/A
 			ConnectionID:     uuid.NullUUID{},
 			DisconnectReason: sql.NullString{},
+			FileProtocol:     database.NullConnectionLogFileProtocol{},
+			FileAction:       database.NullConnectionLogFileAction{},
+			FilePath:         sql.NullString{},
+			FileTarget:       sql.NullString{},
 		})
 		if err != nil {
 			logger.Error(ctx, "upsert connection log failed", slog.Error(err))

--- a/codersdk/connectionlog.go
+++ b/codersdk/connectionlog.go
@@ -33,7 +33,12 @@ type ConnectionLog struct {
 	// - `ConnectionTypeReconnectingPTY`
 	// - `ConnectionTypeVSCode`
 	// - `ConnectionTypeJetBrains`
+	// - `ConnectionTypeFileTransfer`
 	SSHInfo *ConnectionLogSSHInfo `json:"ssh_info,omitempty"`
+
+	// FileTransferInfo is only set when `type` is
+	// `ConnectionTypeFileOperation`.
+	FileTransferInfo *ConnectionLogFileTransferInfo `json:"file_transfer_info,omitempty"`
 }
 
 // ConnectionType is the type of connection that the agent is receiving.
@@ -49,6 +54,13 @@ const (
 	// ConnectionTypeTunnel records accepted and denied tailnet tunnel
 	// requests made by authenticated users.
 	ConnectionTypeTunnel ConnectionType = "tunnel"
+	// ConnectionTypeFileTransfer records file-transfer sessions (SFTP,
+	// SCP, rsync), which would otherwise be recorded as plain SSH.
+	ConnectionTypeFileTransfer ConnectionType = "file_transfer"
+	// ConnectionTypeFileOperation records individual file operations
+	// observed during a file-transfer session. Events share the
+	// connection ID of their parent file_transfer session.
+	ConnectionTypeFileOperation ConnectionType = "file_operation"
 )
 
 // ConnectionLogStatus is the status of a connection log entry.
@@ -89,6 +101,53 @@ type ConnectionLogSSHInfo struct {
 	// ExitCode is the exit code of the SSH session. It is omitted if a
 	// disconnect event with the same connection ID has not yet been seen.
 	ExitCode *int32 `json:"exit_code,omitempty"`
+}
+
+// ConnectionLogFileProtocol is the protocol that carried a file
+// operation.
+type ConnectionLogFileProtocol string
+
+const (
+	ConnectionLogFileProtocolSFTP  ConnectionLogFileProtocol = "sftp"
+	ConnectionLogFileProtocolSCP   ConnectionLogFileProtocol = "scp"
+	ConnectionLogFileProtocolRsync ConnectionLogFileProtocol = "rsync"
+)
+
+// ConnectionLogFileAction is the kind of file operation observed.
+// A download is a transfer from the workspace to the client, an upload
+// is a transfer from the client to the workspace, and bidirectional is
+// a file opened for both at once, where either may have occurred.
+type ConnectionLogFileAction string
+
+const (
+	ConnectionLogFileActionDownload      ConnectionLogFileAction = "download"
+	ConnectionLogFileActionUpload        ConnectionLogFileAction = "upload"
+	ConnectionLogFileActionBidirectional ConnectionLogFileAction = "bidirectional"
+	ConnectionLogFileActionRemove        ConnectionLogFileAction = "remove"
+	ConnectionLogFileActionRmdir         ConnectionLogFileAction = "rmdir"
+	ConnectionLogFileActionRename        ConnectionLogFileAction = "rename"
+	ConnectionLogFileActionSymlink       ConnectionLogFileAction = "symlink"
+	// ConnectionLogFileActionSetattr records file attribute changes:
+	// truncation, permissions, ownership, and timestamps.
+	ConnectionLogFileActionSetattr ConnectionLogFileAction = "setattr"
+	// ConnectionLogFileActionHardlink records creation of a hard link.
+	// Path is the existing file, Target is the new link.
+	ConnectionLogFileActionHardlink ConnectionLogFileAction = "hardlink"
+)
+
+type ConnectionLogFileTransferInfo struct {
+	// ConnectionID matches the connection ID of the file_transfer
+	// session the operation occurred in.
+	ConnectionID uuid.UUID                 `json:"connection_id" format:"uuid"`
+	Protocol     ConnectionLogFileProtocol `json:"protocol"`
+	Action       ConnectionLogFileAction   `json:"action"`
+	// Path is the path the operation was performed on. For SCP and
+	// rsync this is the requested root path from the command line, not
+	// necessarily every file transferred.
+	Path string `json:"path"`
+	// Target is only set for operations with a second path, such as the
+	// destination of a rename or the target of a symlink.
+	Target string `json:"target,omitempty"`
 }
 
 type ConnectionLogsRequest struct {

--- a/docs/admin/monitoring/connection-logs.md
+++ b/docs/admin/monitoring/connection-logs.md
@@ -28,6 +28,56 @@ Agent-reported events do not identify the Coder user who connected. To
 attribute SSH and IDE activity to a user, correlate them with tunnel
 events for the same workspace and agent.
 
+## File Transfers
+
+The connection log records file-transfer sessions and the file operations
+performed within them. Like SSH and IDE sessions, these events are
+reported by workspace agents, and their receipt by the server is not
+guaranteed.
+
+When a client starts an SFTP, `scp`, or `rsync` session against a
+workspace, the session is recorded with the `file_transfer` type instead
+of `ssh`. Sessions denied by
+[`CODER_AGENT_BLOCK_FILE_TRANSFER`](../../reference/cli/agent.md#--block-file-transfer)
+are also recorded as `file_transfer`, with exit code `65`.
+
+While a transfer session is open, the agent streams the file operations
+it observes as `file_operation` events. Each records the protocol, the
+kind of operation, and the path:
+
+- **SFTP** sessions are served inside the agent, so each operation is
+  observed directly: downloads, uploads, directory creation and removal,
+  file removal, renames, symlinks, hard links, and attribute changes
+  (truncation, permissions, ownership, timestamps). A `bidirectional`
+  operation is a file opened for reading and writing at once, such as
+  in-place editing; treat it as though both a download and an upload may
+  have occurred. Attribute changes made through an already-open file
+  handle are not individually logged, but opening the handle itself is.
+- **`scp` and `rsync`** sessions run as external commands, so only the
+  direction and the requested root path from the command line are
+  recorded, not every file in a recursive transfer.
+- **`nc`** has no reliable file semantics and is not classified; it
+  appears as a plain `ssh` session.
+
+File operation events share the `connection_id` of their parent
+`file_transfer` session, so filtering by `connection_id:<uuid>` returns
+the session and all of its recorded operations. Identical operations are
+recorded once per session, and at most 512 operations are recorded per
+session. Like workspace app connections, file operation events are
+point-in-time records: they have no close time and are excluded from
+`status:` filter results.
+
+Recording file transfers requires that both the workspace agent and the
+Coder server support it (agent API v2.11). Older agents report transfer
+sessions as plain `ssh` events without file details.
+
+Keep in mind that file-transfer classification is best-effort and not a
+security boundary: a user with SSH access can move data in ways the agent
+cannot recognize, such as renamed binaries, `curl` uploads, or writing
+files through a shell. Use
+[`CODER_AGENT_BLOCK_FILE_TRANSFER`](../../reference/cli/agent.md#--block-file-transfer)
+together with endpoint controls if you need enforcement.
+
 ## Tunnel Connections
 
 The connection log records the authorization decision for each request to add a tunnel to a workspace agent.

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -485,6 +485,13 @@ curl -X GET http://coder-server:8080/api/v2/connectionlog?limit=0 \
     {
       "agent_name": "string",
       "connect_time": "2019-08-24T14:15:22Z",
+      "file_transfer_info": {
+        "action": "download",
+        "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+        "path": "string",
+        "protocol": "sftp",
+        "target": "string"
+      },
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "ip": "string",
       "organization": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -4316,6 +4316,13 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 {
   "agent_name": "string",
   "connect_time": "2019-08-24T14:15:22Z",
+  "file_transfer_info": {
+    "action": "download",
+    "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+    "path": "string",
+    "protocol": "sftp",
+    "target": "string"
+  },
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
   "ip": "string",
   "organization": {
@@ -4370,20 +4377,71 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name                       | Type                                                           | Required | Restrictions | Description                                                                                                                                              |
-|----------------------------|----------------------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent_name`               | string                                                         | false    |              |                                                                                                                                                          |
-| `connect_time`             | string                                                         | false    |              |                                                                                                                                                          |
-| `id`                       | string                                                         | false    |              |                                                                                                                                                          |
-| `ip`                       | string                                                         | false    |              |                                                                                                                                                          |
-| `organization`             | [codersdk.MinimalOrganization](#codersdkminimalorganization)   | false    |              |                                                                                                                                                          |
-| `ssh_info`                 | [codersdk.ConnectionLogSSHInfo](#codersdkconnectionlogsshinfo) | false    |              | Ssh info is only set when `type` is one of: - `ConnectionTypeSSH` - `ConnectionTypeReconnectingPTY` - `ConnectionTypeVSCode` - `ConnectionTypeJetBrains` |
-| `type`                     | [codersdk.ConnectionType](#codersdkconnectiontype)             | false    |              |                                                                                                                                                          |
-| `web_info`                 | [codersdk.ConnectionLogWebInfo](#codersdkconnectionlogwebinfo) | false    |              | Web info is only set when `type` is one of: - `ConnectionTypePortForwarding` - `ConnectionTypeWorkspaceApp` - `ConnectionTypeTunnel`                     |
-| `workspace_id`             | string                                                         | false    |              |                                                                                                                                                          |
-| `workspace_name`           | string                                                         | false    |              |                                                                                                                                                          |
-| `workspace_owner_id`       | string                                                         | false    |              |                                                                                                                                                          |
-| `workspace_owner_username` | string                                                         | false    |              |                                                                                                                                                          |
+| Name                       | Type                                                                             | Required | Restrictions | Description                                                                                                                                                                             |
+|----------------------------|----------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent_name`               | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `connect_time`             | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `file_transfer_info`       | [codersdk.ConnectionLogFileTransferInfo](#codersdkconnectionlogfiletransferinfo) | false    |              | File transfer info is only set when `type` is `ConnectionTypeFileOperation`.                                                                                                            |
+| `id`                       | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `ip`                       | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `organization`             | [codersdk.MinimalOrganization](#codersdkminimalorganization)                     | false    |              |                                                                                                                                                                                         |
+| `ssh_info`                 | [codersdk.ConnectionLogSSHInfo](#codersdkconnectionlogsshinfo)                   | false    |              | Ssh info is only set when `type` is one of: - `ConnectionTypeSSH` - `ConnectionTypeReconnectingPTY` - `ConnectionTypeVSCode` - `ConnectionTypeJetBrains` - `ConnectionTypeFileTransfer` |
+| `type`                     | [codersdk.ConnectionType](#codersdkconnectiontype)                               | false    |              |                                                                                                                                                                                         |
+| `web_info`                 | [codersdk.ConnectionLogWebInfo](#codersdkconnectionlogwebinfo)                   | false    |              | Web info is only set when `type` is one of: - `ConnectionTypePortForwarding` - `ConnectionTypeWorkspaceApp` - `ConnectionTypeTunnel`                                                    |
+| `workspace_id`             | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `workspace_name`           | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `workspace_owner_id`       | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `workspace_owner_username` | string                                                                           | false    |              |                                                                                                                                                                                         |
+
+## codersdk.ConnectionLogFileAction
+
+```json
+"download"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                                                                             |
+|------------------------------------------------------------------------------------------------------|
+| `bidirectional`, `download`, `hardlink`, `remove`, `rename`, `rmdir`, `setattr`, `symlink`, `upload` |
+
+## codersdk.ConnectionLogFileProtocol
+
+```json
+"sftp"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)               |
+|------------------------|
+| `rsync`, `scp`, `sftp` |
+
+## codersdk.ConnectionLogFileTransferInfo
+
+```json
+{
+  "action": "download",
+  "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+  "path": "string",
+  "protocol": "sftp",
+  "target": "string"
+}
+```
+
+### Properties
+
+| Name            | Type                                                                     | Required | Restrictions | Description                                                                                                                                                       |
+|-----------------|--------------------------------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `action`        | [codersdk.ConnectionLogFileAction](#codersdkconnectionlogfileaction)     | false    |              |                                                                                                                                                                   |
+| `connection_id` | string                                                                   | false    |              | Connection ID matches the connection ID of the file_transfer session the operation occurred in.                                                                   |
+| `path`          | string                                                                   | false    |              | Path is the path the operation was performed on. For SCP and rsync this is the requested root path from the command line, not necessarily every file transferred. |
+| `protocol`      | [codersdk.ConnectionLogFileProtocol](#codersdkconnectionlogfileprotocol) | false    |              |                                                                                                                                                                   |
+| `target`        | string                                                                   | false    |              | Target is only set for operations with a second path, such as the destination of a rename or the target of a symlink.                                             |
 
 ## codersdk.ConnectionLogResponse
 
@@ -4393,6 +4451,13 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     {
       "agent_name": "string",
       "connect_time": "2019-08-24T14:15:22Z",
+      "file_transfer_info": {
+        "action": "download",
+        "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+        "path": "string",
+        "protocol": "sftp",
+        "target": "string"
+      },
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "ip": "string",
       "organization": {
@@ -4531,9 +4596,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                       |
-|------------------------------------------------------------------------------------------------|
-| `jetbrains`, `port_forwarding`, `reconnecting_pty`, `ssh`, `tunnel`, `vscode`, `workspace_app` |
+| Value(s)                                                                                                                          |
+|-----------------------------------------------------------------------------------------------------------------------------------|
+| `file_operation`, `file_transfer`, `jetbrains`, `port_forwarding`, `reconnecting_pty`, `ssh`, `tunnel`, `vscode`, `workspace_app` |
 
 ## codersdk.ConvertLoginRequest
 

--- a/enterprise/coderd/connectionlog.go
+++ b/enterprise/coderd/connectionlog.go
@@ -128,8 +128,9 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 	}
 
 	var (
-		webInfo *codersdk.ConnectionLogWebInfo
-		sshInfo *codersdk.ConnectionLogSSHInfo
+		webInfo          *codersdk.ConnectionLogWebInfo
+		sshInfo          *codersdk.ConnectionLogSSHInfo
+		fileTransferInfo *codersdk.ConnectionLogFileTransferInfo
 	)
 
 	switch dblog.ConnectionLog.Type {
@@ -145,7 +146,8 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 	case database.ConnectionTypeSsh,
 		database.ConnectionTypeReconnectingPty,
 		database.ConnectionTypeJetbrains,
-		database.ConnectionTypeVscode:
+		database.ConnectionTypeVscode,
+		database.ConnectionTypeFileTransfer:
 		sshInfo = &codersdk.ConnectionLogSSHInfo{
 			ConnectionID:     dblog.ConnectionLog.ConnectionID.UUID,
 			DisconnectReason: dblog.ConnectionLog.DisconnectReason.String,
@@ -155,6 +157,14 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 		}
 		if dblog.ConnectionLog.Code.Valid {
 			sshInfo.ExitCode = &dblog.ConnectionLog.Code.Int32
+		}
+	case database.ConnectionTypeFileOperation:
+		fileTransferInfo = &codersdk.ConnectionLogFileTransferInfo{
+			ConnectionID: dblog.ConnectionLog.ConnectionID.UUID,
+			Protocol:     codersdk.ConnectionLogFileProtocol(dblog.ConnectionLog.FileProtocol.ConnectionLogFileProtocol),
+			Action:       codersdk.ConnectionLogFileAction(dblog.ConnectionLog.FileAction.ConnectionLogFileAction),
+			Path:         dblog.ConnectionLog.FilePath.String,
+			Target:       dblog.ConnectionLog.FileTarget.String,
 		}
 	}
 
@@ -176,5 +186,6 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 		IP:                     ip,
 		WebInfo:                webInfo,
 		SSHInfo:                sshInfo,
+		FileTransferInfo:       fileTransferInfo,
 	}
 }

--- a/enterprise/coderd/connectionlog/connectionlog.go
+++ b/enterprise/coderd/connectionlog/connectionlog.go
@@ -244,7 +244,11 @@ func (b *DBBatcher) addToBatch(item database.UpsertConnectionLogParams) {
 		entry.connectTime = item.Time
 	}
 
-	if !item.ConnectionID.Valid {
+	// File operation events share the connection_id of their parent
+	// file-transfer session but are point-in-time, insert-only rows.
+	// They must not be deduplicated against the session's connect and
+	// disconnect events (or each other), so they bypass the keyed batch.
+	if !item.ConnectionID.Valid || item.Type == database.ConnectionTypeFileOperation {
 		b.nullConnIDBatch = append(b.nullConnIDBatch, entry)
 		return
 	}
@@ -401,6 +405,10 @@ func (b *DBBatcher) buildParams() database.BatchUpsertConnectionLogsParams {
 		connectionID     = make([]uuid.UUID, 0, count)
 		disconnectReason = make([]string, 0, count)
 		disconnectTime   = make([]time.Time, 0, count)
+		fileProtocol     = make([]string, 0, count)
+		fileAction       = make([]string, 0, count)
+		filePath         = make([]string, 0, count)
+		fileTarget       = make([]string, 0, count)
 	)
 
 	appendEntry := func(e batchEntry) {
@@ -421,6 +429,19 @@ func (b *DBBatcher) buildParams() database.BatchUpsertConnectionLogsParams {
 		connectionID = append(connectionID, e.ConnectionID.UUID)
 		disconnectReason = append(disconnectReason, e.DisconnectReason.String)
 		disconnectTime = append(disconnectTime, e.disconnectTime)
+		// The batch query NULLIFs empty strings before casting to the
+		// enum types, so invalid values are stored as NULL.
+		var protocol, action string
+		if e.FileProtocol.Valid {
+			protocol = string(e.FileProtocol.ConnectionLogFileProtocol)
+		}
+		if e.FileAction.Valid {
+			action = string(e.FileAction.ConnectionLogFileAction)
+		}
+		fileProtocol = append(fileProtocol, protocol)
+		fileAction = append(fileAction, action)
+		filePath = append(filePath, e.FilePath.String)
+		fileTarget = append(fileTarget, e.FileTarget.String)
 	}
 
 	for _, entry := range b.dedupedBatch {
@@ -448,6 +469,10 @@ func (b *DBBatcher) buildParams() database.BatchUpsertConnectionLogsParams {
 		ConnectionID:     connectionID,
 		DisconnectReason: disconnectReason,
 		DisconnectTime:   disconnectTime,
+		FileProtocol:     fileProtocol,
+		FileAction:       fileAction,
+		FilePath:         filePath,
+		FileTarget:       fileTarget,
 	}
 }
 

--- a/enterprise/coderd/connectionlog/connectionlog_internal_test.go
+++ b/enterprise/coderd/connectionlog/connectionlog_internal_test.go
@@ -196,6 +196,43 @@ func Test_addToBatch(t *testing.T) {
 		require.Equal(t, disconnect.Time, got.disconnectTime)
 	})
 
+	t.Run("FileOperationsNeverDedup", func(t *testing.T) {
+		t.Parallel()
+
+		b := &DBBatcher{
+			maxBatchSize: 100,
+			dedupedBatch: make(map[uuid.UUID]batchEntry),
+		}
+
+		wsID := uuid.New()
+		connID := uuid.New()
+
+		// A file-transfer session's connect/disconnect pair and two
+		// file operations sharing its connection ID. The operations
+		// must not merge with the session entry or each other.
+		connect := fakeConnectEvent(wsID, "agent1", connID)
+		connect.Type = database.ConnectionTypeFileTransfer
+		disconnect := fakeDisconnectEvent(wsID, "agent1", connID)
+		disconnect.Type = database.ConnectionTypeFileTransfer
+
+		op1 := fakeConnectEvent(wsID, "agent1", connID)
+		op1.Type = database.ConnectionTypeFileOperation
+		op1.FilePath = sql.NullString{String: "/tmp/a", Valid: true}
+		op2 := fakeConnectEvent(wsID, "agent1", connID)
+		op2.Type = database.ConnectionTypeFileOperation
+		op2.FilePath = sql.NullString{String: "/tmp/b", Valid: true}
+
+		b.addToBatch(connect)
+		b.addToBatch(op1)
+		b.addToBatch(op2)
+		b.addToBatch(disconnect)
+
+		require.Equal(t, 3, b.batchLen())
+		require.Len(t, b.dedupedBatch, 1, "session pair should merge")
+		require.Len(t, b.nullConnIDBatch, 2, "file operations must be insert-only")
+		require.Equal(t, database.ConnectionStatusDisconnected, b.dedupedBatch[connID].ConnectionStatus)
+	})
+
 	t.Run("DuplicateDisconnectsPreserveConnectTime", func(t *testing.T) {
 		t.Parallel()
 

--- a/enterprise/coderd/connectionlog_test.go
+++ b/enterprise/coderd/connectionlog_test.go
@@ -295,4 +295,112 @@ func TestConnectionLogs(t *testing.T) {
 		require.True(t, logs.ConnectionLogs[0].SSHInfo.DisconnectTime.Equal(now))
 		require.Equal(t, updatedClog.DisconnectReason.String, logs.ConnectionLogs[0].SSHInfo.DisconnectReason)
 	})
+
+	t.Run("FileTransferInfo", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		client, db, _ := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+			ConnectionLogging: true,
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAuditLog:      1,
+					codersdk.FeatureConnectionLog: 1,
+				},
+			},
+		})
+
+		now := dbtime.Now()
+		connID := uuid.New()
+		ws := createWorkspace(t, db)
+		// A file-transfer session row and two file operation rows
+		// sharing its connection ID. The operations must insert as
+		// separate rows despite the shared connection ID.
+		session := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+			Time:             now.Add(-time.Hour),
+			Type:             database.ConnectionTypeFileTransfer,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			ConnectionID:     uuid.NullUUID{UUID: connID, Valid: true},
+		})
+		_ = dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+			Time:             now.Add(-time.Minute),
+			Type:             database.ConnectionTypeFileOperation,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			WorkspaceName:    session.WorkspaceName,
+			AgentName:        session.AgentName,
+			ConnectionID:     uuid.NullUUID{UUID: connID, Valid: true},
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: database.ConnectionLogFileProtocolSftp,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionDownload,
+				Valid:                   true,
+			},
+			FilePath: sql.NullString{String: "/home/coder/secret.txt", Valid: true},
+		})
+		_ = dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+			Time:             now,
+			Type:             database.ConnectionTypeFileOperation,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			WorkspaceName:    session.WorkspaceName,
+			AgentName:        session.AgentName,
+			ConnectionID:     uuid.NullUUID{UUID: connID, Valid: true},
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: database.ConnectionLogFileProtocolSftp,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionRename,
+				Valid:                   true,
+			},
+			FilePath:   sql.NullString{String: "/home/coder/a.txt", Valid: true},
+			FileTarget: sql.NullString{String: "/home/coder/b.txt", Valid: true},
+		})
+
+		// The session and its operations are grouped by connection_id.
+		logs, err := client.ConnectionLogs(ctx, codersdk.ConnectionLogsRequest{
+			SearchQuery: "connection_id:" + connID.String(),
+		})
+		require.NoError(t, err)
+		require.Len(t, logs.ConnectionLogs, 3)
+
+		// Results are ordered by connect_time descending.
+		renameLog := logs.ConnectionLogs[0]
+		require.Equal(t, codersdk.ConnectionTypeFileOperation, renameLog.Type)
+		require.Nil(t, renameLog.SSHInfo)
+		require.Nil(t, renameLog.WebInfo)
+		require.NotNil(t, renameLog.FileTransferInfo)
+		require.Equal(t, connID, renameLog.FileTransferInfo.ConnectionID)
+		require.Equal(t, codersdk.ConnectionLogFileProtocolSFTP, renameLog.FileTransferInfo.Protocol)
+		require.Equal(t, codersdk.ConnectionLogFileActionRename, renameLog.FileTransferInfo.Action)
+		require.Equal(t, "/home/coder/a.txt", renameLog.FileTransferInfo.Path)
+		require.Equal(t, "/home/coder/b.txt", renameLog.FileTransferInfo.Target)
+
+		readLog := logs.ConnectionLogs[1]
+		require.NotNil(t, readLog.FileTransferInfo)
+		require.Equal(t, codersdk.ConnectionLogFileActionDownload, readLog.FileTransferInfo.Action)
+		require.Equal(t, "/home/coder/secret.txt", readLog.FileTransferInfo.Path)
+		require.Empty(t, readLog.FileTransferInfo.Target)
+
+		sessionLog := logs.ConnectionLogs[2]
+		require.Equal(t, codersdk.ConnectionTypeFileTransfer, sessionLog.Type)
+		require.NotNil(t, sessionLog.SSHInfo)
+		require.Nil(t, sessionLog.FileTransferInfo)
+
+		// File operations are point-in-time events and excluded from
+		// status filter results.
+		logs, err = client.ConnectionLogs(ctx, codersdk.ConnectionLogsRequest{
+			SearchQuery: "status:ongoing connection_id:" + connID.String(),
+		})
+		require.NoError(t, err)
+		require.Len(t, logs.ConnectionLogs, 1)
+		require.Equal(t, codersdk.ConnectionTypeFileTransfer, logs.ConnectionLogs[0].Type)
+	})
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3696,8 +3696,69 @@ export interface ConnectionLog {
 	 * - `ConnectionTypeReconnectingPTY`
 	 * - `ConnectionTypeVSCode`
 	 * - `ConnectionTypeJetBrains`
+	 * - `ConnectionTypeFileTransfer`
 	 */
 	readonly ssh_info?: ConnectionLogSSHInfo;
+	/**
+	 * FileTransferInfo is only set when `type` is
+	 * `ConnectionTypeFileOperation`.
+	 */
+	readonly file_transfer_info?: ConnectionLogFileTransferInfo;
+}
+
+// From codersdk/connectionlog.go
+export type ConnectionLogFileAction =
+	| "bidirectional"
+	| "download"
+	| "hardlink"
+	| "remove"
+	| "rename"
+	| "rmdir"
+	| "setattr"
+	| "symlink"
+	| "upload";
+
+export const ConnectionLogFileActions: ConnectionLogFileAction[] = [
+	"bidirectional",
+	"download",
+	"hardlink",
+	"remove",
+	"rename",
+	"rmdir",
+	"setattr",
+	"symlink",
+	"upload",
+];
+
+// From codersdk/connectionlog.go
+export type ConnectionLogFileProtocol = "rsync" | "scp" | "sftp";
+
+export const ConnectionLogFileProtocols: ConnectionLogFileProtocol[] = [
+	"rsync",
+	"scp",
+	"sftp",
+];
+
+// From codersdk/connectionlog.go
+export interface ConnectionLogFileTransferInfo {
+	/**
+	 * ConnectionID matches the connection ID of the file_transfer
+	 * session the operation occurred in.
+	 */
+	readonly connection_id: string;
+	readonly protocol: ConnectionLogFileProtocol;
+	readonly action: ConnectionLogFileAction;
+	/**
+	 * Path is the path the operation was performed on. For SCP and
+	 * rsync this is the requested root path from the command line, not
+	 * necessarily every file transferred.
+	 */
+	readonly path: string;
+	/**
+	 * Target is only set for operations with a second path, such as the
+	 * destination of a rename or the target of a symlink.
+	 */
+	readonly target?: string;
 }
 
 // From codersdk/connectionlog.go
@@ -3761,6 +3822,8 @@ export const ConnectionMethods: ConnectionMethod[] = ["derp", "direct", ""];
 
 // From codersdk/connectionlog.go
 export type ConnectionType =
+	| "file_operation"
+	| "file_transfer"
 	| "jetbrains"
 	| "port_forwarding"
 	| "reconnecting_pty"
@@ -3770,6 +3833,8 @@ export type ConnectionType =
 	| "workspace_app";
 
 export const ConnectionTypes: ConnectionType[] = [
+	"file_operation",
+	"file_transfer",
 	"jetbrains",
 	"port_forwarding",
 	"reconnecting_pty",

--- a/site/src/pages/ConnectionLogPage/ConnectionLogPageView.stories.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogPageView.stories.tsx
@@ -13,6 +13,8 @@ import type { UsePaginatedQueryResult } from "#/hooks/usePaginatedQuery";
 import {
 	MockConnectedSSHConnectionLog,
 	MockDisconnectedSSHConnectionLog,
+	MockFileOperationConnectionLog,
+	MockFileTransferConnectionLog,
 	MockPermissions,
 	MockUserOwner,
 } from "#/testHelpers/entities";
@@ -43,6 +45,8 @@ const meta: Meta<typeof ConnectionLogPageView> = {
 		connectionLogs: [
 			MockConnectedSSHConnectionLog,
 			MockDisconnectedSSHConnectionLog,
+			MockFileTransferConnectionLog,
+			MockFileOperationConnectionLog,
 		],
 		isConnectionLogVisible: true,
 		filterProps: defaultFilterProps,

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.tsx
@@ -1,8 +1,53 @@
 import type { FC, ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
-import type { ConnectionLog } from "#/api/typesGenerated";
+import type {
+	ConnectionLog,
+	ConnectionLogFileAction,
+	ConnectionLogFileProtocol,
+} from "#/api/typesGenerated";
 import { Link } from "#/components/Link/Link";
 import { connectionTypeToFriendlyName } from "#/utils/connection";
+
+const fileProtocolToFriendlyName = (
+	protocol: ConnectionLogFileProtocol,
+): string => {
+	switch (protocol) {
+		case "sftp":
+			return "SFTP";
+		case "scp":
+			return "SCP";
+		case "rsync":
+			return "rsync";
+	}
+};
+
+// fileActionToDescription phrases the file action for a sentence like
+// "SFTP session <action> <path>". For SCP/rsync the path is the
+// requested root, so the phrasing stays non-committal about individual
+// files.
+const fileActionToDescription = (action: ConnectionLogFileAction): string => {
+	switch (action) {
+		case "download":
+			return "downloaded";
+		case "upload":
+			return "uploaded";
+		case "bidirectional":
+			// Opened for both directions at once; either may have occurred.
+			return "downloaded and/or uploaded";
+		case "remove":
+			return "removed";
+		case "rmdir":
+			return "removed directory";
+		case "rename":
+			return "renamed";
+		case "symlink":
+			return "created symlink";
+		case "setattr":
+			return "changed attributes of";
+		case "hardlink":
+			return "created hard link to";
+	}
+};
 
 interface ConnectionLogDescriptionProps {
 	connectionLog: ConnectionLog;
@@ -11,8 +56,13 @@ interface ConnectionLogDescriptionProps {
 export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 	connectionLog,
 }) => {
-	const { type, workspace_owner_username, workspace_name, web_info } =
-		connectionLog;
+	const {
+		type,
+		workspace_owner_username,
+		workspace_name,
+		web_info,
+		file_transfer_info,
+	} = connectionLog;
 
 	switch (type) {
 		case "port_forwarding":
@@ -75,7 +125,8 @@ export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 		case "reconnecting_pty":
 		case "ssh":
 		case "jetbrains":
-		case "vscode": {
+		case "vscode":
+		case "file_transfer": {
 			const friendlyType = connectionTypeToFriendlyName(type);
 			return (
 				<span>
@@ -86,6 +137,31 @@ export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 						</RouterLink>
 					</Link>{" "}
 					workspace{" "}
+				</span>
+			);
+		}
+
+		case "file_operation": {
+			if (!file_transfer_info) return null;
+			const { protocol, action, path, target } = file_transfer_info;
+			const friendlyProtocol = fileProtocolToFriendlyName(protocol);
+			const actionText = fileActionToDescription(action);
+			return (
+				<span>
+					{friendlyProtocol} session {actionText} <strong>{path}</strong>
+					{target && (
+						<>
+							{" "}
+							→ <strong>{target}</strong>
+						</>
+					)}{" "}
+					in {workspace_owner_username}'s{" "}
+					<Link asChild showExternalIcon={false} className="text-base">
+						<RouterLink to={`/@${workspace_owner_username}/${workspace_name}`}>
+							<strong>{workspace_name}</strong>
+						</RouterLink>
+					</Link>{" "}
+					workspace
 				</span>
 			);
 		}

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.stories.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.stories.tsx
@@ -3,6 +3,8 @@ import { Table, TableBody } from "#/components/Table/Table";
 import {
 	MockConnectedSSHConnectionLog,
 	MockDisconnectedSSHConnectionLog,
+	MockFileOperationConnectionLog,
+	MockFileTransferConnectionLog,
 	MockWebConnectionLog,
 } from "#/testHelpers/entities";
 import { ConnectionLogRow } from "./ConnectionLogRow";
@@ -65,6 +67,84 @@ export const DisconnectedSSHError: Story = {
 			ssh_info: {
 				...MockDisconnectedSSHConnectionLog.ssh_info!,
 				exit_code: 130, // 128 + SIGINT
+			},
+		},
+	},
+};
+
+export const BlockedFileTransfer: Story = {
+	args: {
+		connectionLog: MockFileTransferConnectionLog,
+	},
+};
+
+export const CompletedFileTransfer: Story = {
+	args: {
+		connectionLog: {
+			...MockFileTransferConnectionLog,
+			ssh_info: {
+				...MockFileTransferConnectionLog.ssh_info!,
+				disconnect_reason: "",
+				exit_code: 0,
+			},
+		},
+	},
+};
+
+export const FileOperationDownload: Story = {
+	args: {
+		connectionLog: MockFileOperationConnectionLog,
+	},
+};
+
+export const FileOperationUpload: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				action: "upload",
+				path: "/home/coder/upload.tar.gz",
+			},
+		},
+	},
+};
+
+export const FileOperationRename: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				action: "rename",
+				path: "/home/coder/old-name.txt",
+				target: "/home/coder/new-name.txt",
+			},
+		},
+	},
+};
+
+export const FileOperationSCPUpload: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				protocol: "scp",
+				action: "upload",
+				path: "/home/coder/project",
+			},
+		},
+	},
+};
+
+export const FileOperationLongPath: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				path: "/home/coder/some/deeply/nested/directory/structure/with/a/very/long/path/to/an/important/file/that/should/not/break/the/layout.json",
 			},
 		},
 	},

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3138,6 +3138,32 @@ export const MockDisconnectedSSHConnectionLog: TypesGen.ConnectionLog = {
 	},
 };
 
+export const MockFileTransferConnectionLog: TypesGen.ConnectionLog = {
+	...MockDisconnectedSSHConnectionLog,
+	id: "104d54e8-2fd8-42f6-9cf9-e57eabb384fd",
+	type: "file_transfer",
+	ssh_info: {
+		connection_id: "8b3f81ed-b3ba-4b4a-a15b-c437936b2286",
+		disconnect_reason: "process exited with error status: 65",
+		disconnect_time: "2022-05-19T16:49:57.122Z",
+		exit_code: 65, // File transfer blocked.
+	},
+};
+
+export const MockFileOperationConnectionLog: TypesGen.ConnectionLog = {
+	...MockConnectedSSHConnectionLog,
+	id: "b2cd7b2e-2fd8-42f6-9cf9-e57eabb384fd",
+	type: "file_operation",
+	ssh_info: undefined,
+	file_transfer_info: {
+		connection_id: "8b3f81ed-b3ba-4b4a-a15b-c437936b2286",
+		protocol: "sftp",
+		action: "download",
+		path: "/home/coder/secrets.env",
+		target: undefined,
+	},
+};
+
 export const MockWorkspaceQuota: TypesGen.WorkspaceQuota = {
 	credits_consumed: 0,
 	budget: 100,

--- a/site/src/utils/connection.ts
+++ b/site/src/utils/connection.ts
@@ -16,6 +16,10 @@ export const connectionTypeToFriendlyName = (type: ConnectionType): string => {
 			return "Workspace App";
 		case "tunnel":
 			return "Tunnel";
+		case "file_transfer":
+			return "File Transfer";
+		case "file_operation":
+			return "File Operation";
 	}
 };
 
@@ -34,7 +38,9 @@ export const connectionTypeIsWeb = (type: ConnectionType): boolean => {
 		case "reconnecting_pty":
 		case "ssh":
 		case "jetbrains":
-		case "vscode": {
+		case "vscode":
+		case "file_transfer":
+		case "file_operation": {
 			return false;
 		}
 	}


### PR DESCRIPTION
Builds on the file-transfer schema and agent proto v2.11 foundation:

- The agent classifies sftp/scp/rsync sessions and reports them with the file_transfer connection type, including blocked attempts.
- A passive SFTP wire decoder observes open/remove/rmdir/rename/ symlink/setattr/hardlink requests; scp and rsync record direction and the requested root path from argv.
- Operations are deduplicated per session, capped at 512, and streamed in batches through ReportFileOperations to coderd, which stores them as file_operation rows sharing the parent session's connection ID.
- The connection log API and UI surface per-operation details.
