### PR TITLE
feat: surface file-transfer operations in the connection log

### DIFF
--- a/coderd/agentapi/connectionlog.go
+++ b/coderd/agentapi/connectionlog.go
@@ -6,9 +6,9 @@ import (
 	"sync/atomic"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"storj.io/drpc/drpcerr"
 
 	"cdr.dev/slog/v3"
 	agentproto "github.com/coder/coder/v2/agent/proto"
@@ -110,6 +110,11 @@ func (a *ConnLogAPI) ReportConnection(ctx context.Context, req *agentproto.Repor
 		UserAgent: sql.NullString{},
 		// N/A
 		SlugOrPort: sql.NullString{},
+		// Only set for file operation events.
+		FileProtocol: database.NullConnectionLogFileProtocol{},
+		FileAction:   database.NullConnectionLogFileAction{},
+		FilePath:     sql.NullString{},
+		FileTarget:   sql.NullString{},
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("export connection log: %w", err)
@@ -119,10 +124,99 @@ func (a *ConnLogAPI) ReportConnection(ctx context.Context, req *agentproto.Repor
 }
 
 // ReportFileOperations records file operations observed during a
-// file-transfer session (SFTP, SCP, rsync) as connection log entries.
-// The schema and protocol land ahead of the implementation; agents
-// treat reports as best effort and tolerate this error, matching the
-// PushContextState rollout in API v2.10.
-func (*ConnLogAPI) ReportFileOperations(context.Context, *agentproto.ReportFileOperationsRequest) (*agentproto.ReportFileOperationsResponse, error) {
-	return nil, drpcerr.WithCode(xerrors.New("ReportFileOperations is not yet implemented"), drpcerr.Unimplemented)
+// file-transfer session (SFTP, SCP, rsync) as point-in-time connection
+// log entries. Each operation shares the connection_id of its parent
+// session so they can be grouped together.
+func (a *ConnLogAPI) ReportFileOperations(ctx context.Context, req *agentproto.ReportFileOperationsRequest) (*agentproto.ReportFileOperationsResponse, error) {
+	if len(req.GetOperations()) == 0 {
+		return &agentproto.ReportFileOperationsResponse{}, nil
+	}
+
+	var ws database.WorkspaceIdentity
+	if dbws, ok := a.Workspace.AsWorkspaceIdentity(); ok {
+		ws = dbws
+	}
+	if ws.Equal(database.WorkspaceIdentity{}) {
+		workspace, err := a.Database.GetWorkspaceByAgentID(ctx, a.AgentID)
+		if err != nil {
+			return nil, xerrors.Errorf("get workspace by agent id: %w", err)
+		}
+		ws = database.WorkspaceIdentityFromWorkspace(workspace)
+	}
+
+	connLogger := *a.ConnectionLogger.Load()
+	for _, op := range req.GetOperations() {
+		connectionID, err := uuid.FromBytes(op.GetConnectionId())
+		if err != nil {
+			return nil, xerrors.Errorf("connection id from bytes: %w", err)
+		}
+		if connectionID == uuid.Nil {
+			return nil, xerrors.New("connection ID cannot be nil")
+		}
+		protocol, err := db2sdk.ConnectionLogFileProtocolFromAgentProtoFileTransferProtocol(op.GetProtocol())
+		if err != nil {
+			return nil, err
+		}
+		action, err := db2sdk.ConnectionLogFileActionFromAgentProtoFileTransferAction(op.GetAction())
+		if err != nil {
+			return nil, err
+		}
+		if op.GetPath() == "" {
+			return nil, xerrors.New("file operation path cannot be empty")
+		}
+
+		err = connLogger.Upsert(ctx, database.UpsertConnectionLogParams{
+			ID:               uuid.New(),
+			Time:             op.GetTimestamp().AsTime(),
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			WorkspaceID:      ws.ID,
+			WorkspaceName:    ws.Name,
+			AgentName:        a.AgentName,
+			Type:             database.ConnectionTypeFileOperation,
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: protocol,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: action,
+				Valid:                   true,
+			},
+			FilePath: sql.NullString{String: op.GetPath(), Valid: true},
+			FileTarget: sql.NullString{
+				String: op.GetTarget(),
+				Valid:  op.GetTarget() != "",
+			},
+			// The parent file-transfer session's connection ID, so the
+			// operation can be grouped with it. File operation rows are
+			// excluded from the connect/disconnect pairing index, so
+			// sharing the ID never merges rows.
+			ConnectionID: uuid.NullUUID{
+				UUID:  connectionID,
+				Valid: true,
+			},
+			// File operations are point-in-time events: they are always
+			// "connected" and never receive a disconnect event.
+			ConnectionStatus: database.ConnectionStatusConnected,
+
+			// It's not possible to tell which user connected. Once we have
+			// the capability, this may be reported by the agent.
+			UserID: uuid.NullUUID{Valid: false},
+			// N/A
+			Code: sql.NullInt32{},
+			// N/A
+			IP: pqtype.Inet{},
+			// N/A
+			UserAgent: sql.NullString{},
+			// N/A
+			SlugOrPort: sql.NullString{},
+			// N/A
+			DisconnectReason: sql.NullString{},
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("export file operation log: %w", err)
+		}
+	}
+
+	return &agentproto.ReportFileOperationsResponse{}, nil
 }

--- a/coderd/agentapi/connectionlog_test.go
+++ b/coderd/agentapi/connectionlog_test.go
@@ -100,6 +100,24 @@ func TestConnectionLog(t *testing.T) {
 			status: 500,
 			reason: "because error says so",
 		},
+		{
+			name:   "File Transfer Connect",
+			id:     uuid.New(),
+			action: agentproto.Connection_CONNECT.Enum(),
+			typ:    agentproto.Connection_FILE_TRANSFER.Enum(),
+			time:   dbtime.Now(),
+			ip:     "127.0.0.1",
+		},
+		{
+			name:   "File Transfer Blocked Disconnect",
+			id:     uuid.New(),
+			action: agentproto.Connection_DISCONNECT.Enum(),
+			typ:    agentproto.Connection_FILE_TRANSFER.Enum(),
+			time:   dbtime.Now(),
+			ip:     "127.0.0.1",
+			status: 65,
+			reason: "file transfer blocked",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -165,6 +183,180 @@ func TestConnectionLog(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestReportFileOperations(t *testing.T) {
+	t.Parallel()
+
+	var (
+		owner = database.User{
+			ID:       uuid.New(),
+			Username: "cool-user",
+		}
+		workspace = database.Workspace{
+			ID:             uuid.New(),
+			OrganizationID: uuid.New(),
+			OwnerID:        owner.ID,
+			Name:           "cool-workspace",
+		}
+		agent = database.WorkspaceAgent{
+			ID:   uuid.New(),
+			Name: "cool-agent",
+		}
+	)
+
+	newAPI := func(t *testing.T, connLogger connectionlog.ConnectionLogger, expectDBLookup bool) *agentapi.ConnLogAPI {
+		mDB := dbmock.NewMockStore(gomock.NewController(t))
+		if expectDBLookup {
+			mDB.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
+		}
+		return &agentapi.ConnLogAPI{
+			ConnectionLogger: asAtomicPointer(connLogger),
+			Database:         mDB,
+			AgentID:          agent.ID,
+			AgentName:        agent.Name,
+			Workspace:        &agentapi.CachedWorkspaceFields{},
+		}
+	}
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		connLogger := connectionlog.NewFake()
+		api := newAPI(t, connLogger, true)
+
+		sessionID := uuid.New()
+		now := dbtime.Now()
+		target := "/home/coder/b.txt"
+		_, err := api.ReportFileOperations(context.Background(), &agentproto.ReportFileOperationsRequest{
+			Operations: []*agentproto.FileTransferOperation{
+				{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "/home/coder/secret.txt",
+					Timestamp:    timestamppb.New(now),
+				},
+				{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_RENAME,
+					Path:         "/home/coder/a.txt",
+					Target:       &target,
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		require.Len(t, connLogger.ConnectionLogs(), 2)
+		require.True(t, connLogger.Contains(t, database.UpsertConnectionLogParams{
+			Time:             dbtime.Time(now).In(time.UTC),
+			OrganizationID:   workspace.OrganizationID,
+			WorkspaceOwnerID: workspace.OwnerID,
+			WorkspaceID:      workspace.ID,
+			WorkspaceName:    workspace.Name,
+			AgentName:        agent.Name,
+			Type:             database.ConnectionTypeFileOperation,
+			ConnectionStatus: database.ConnectionStatusConnected,
+			ConnectionID:     uuid.NullUUID{UUID: sessionID, Valid: true},
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: database.ConnectionLogFileProtocolSftp,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionDownload,
+				Valid:                   true,
+			},
+			FilePath: sql.NullString{String: "/home/coder/secret.txt", Valid: true},
+		}))
+		require.True(t, connLogger.Contains(t, database.UpsertConnectionLogParams{
+			Type: database.ConnectionTypeFileOperation,
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionRename,
+				Valid:                   true,
+			},
+			FilePath:   sql.NullString{String: "/home/coder/a.txt", Valid: true},
+			FileTarget: sql.NullString{String: target, Valid: true},
+		}))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
+		connLogger := connectionlog.NewFake()
+		api := newAPI(t, connLogger, false)
+
+		_, err := api.ReportFileOperations(context.Background(), &agentproto.ReportFileOperationsRequest{})
+		require.NoError(t, err)
+		require.Empty(t, connLogger.ConnectionLogs())
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		t.Parallel()
+
+		sessionID := uuid.New()
+		now := dbtime.Now()
+		tests := []struct {
+			name string
+			op   *agentproto.FileTransferOperation
+		}{
+			{
+				name: "NilConnectionID",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: uuid.Nil[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "/etc/passwd",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+			{
+				name: "UnspecifiedProtocol",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_PROTOCOL_UNSPECIFIED,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "/etc/passwd",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+			{
+				name: "UnspecifiedAction",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_ACTION_UNSPECIFIED,
+					Path:         "/etc/passwd",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+			{
+				name: "EmptyPath",
+				op: &agentproto.FileTransferOperation{
+					ConnectionId: sessionID[:],
+					Protocol:     agentproto.FileTransferOperation_SFTP,
+					Action:       agentproto.FileTransferOperation_DOWNLOAD,
+					Path:         "",
+					Timestamp:    timestamppb.New(now),
+				},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				connLogger := connectionlog.NewFake()
+				api := newAPI(t, connLogger, true)
+
+				_, err := api.ReportFileOperations(context.Background(), &agentproto.ReportFileOperationsRequest{
+					Operations: []*agentproto.FileTransferOperation{tt.op},
+				})
+				require.Error(t, err)
+				require.Empty(t, connLogger.ConnectionLogs())
+			})
+		}
+	})
 }
 
 func agentProtoConnectionTypeToConnectionLog(t *testing.T, typ agentproto.Connection_Type) database.ConnectionType {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18949,6 +18949,14 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time"
                 },
+                "file_transfer_info": {
+                    "description": "FileTransferInfo is only set when ` + "`" + `type` + "`" + ` is\n` + "`" + `ConnectionTypeFileOperation` + "`" + `.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ConnectionLogFileTransferInfo"
+                        }
+                    ]
+                },
                 "id": {
                     "type": "string",
                     "format": "uuid"
@@ -18960,7 +18968,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.MinimalOrganization"
                 },
                 "ssh_info": {
-                    "description": "SSHInfo is only set when ` + "`" + `type` + "`" + ` is one of:\n- ` + "`" + `ConnectionTypeSSH` + "`" + `\n- ` + "`" + `ConnectionTypeReconnectingPTY` + "`" + `\n- ` + "`" + `ConnectionTypeVSCode` + "`" + `\n- ` + "`" + `ConnectionTypeJetBrains` + "`" + `",
+                    "description": "SSHInfo is only set when ` + "`" + `type` + "`" + ` is one of:\n- ` + "`" + `ConnectionTypeSSH` + "`" + `\n- ` + "`" + `ConnectionTypeReconnectingPTY` + "`" + `\n- ` + "`" + `ConnectionTypeVSCode` + "`" + `\n- ` + "`" + `ConnectionTypeJetBrains` + "`" + `\n- ` + "`" + `ConnectionTypeFileTransfer` + "`" + `",
                     "allOf": [
                         {
                             "$ref": "#/definitions/codersdk.ConnectionLogSSHInfo"
@@ -18990,6 +18998,68 @@ const docTemplate = `{
                     "format": "uuid"
                 },
                 "workspace_owner_username": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ConnectionLogFileAction": {
+            "type": "string",
+            "enum": [
+                "download",
+                "upload",
+                "bidirectional",
+                "remove",
+                "rmdir",
+                "rename",
+                "symlink",
+                "setattr",
+                "hardlink"
+            ],
+            "x-enum-varnames": [
+                "ConnectionLogFileActionDownload",
+                "ConnectionLogFileActionUpload",
+                "ConnectionLogFileActionBidirectional",
+                "ConnectionLogFileActionRemove",
+                "ConnectionLogFileActionRmdir",
+                "ConnectionLogFileActionRename",
+                "ConnectionLogFileActionSymlink",
+                "ConnectionLogFileActionSetattr",
+                "ConnectionLogFileActionHardlink"
+            ]
+        },
+        "codersdk.ConnectionLogFileProtocol": {
+            "type": "string",
+            "enum": [
+                "sftp",
+                "scp",
+                "rsync"
+            ],
+            "x-enum-varnames": [
+                "ConnectionLogFileProtocolSFTP",
+                "ConnectionLogFileProtocolSCP",
+                "ConnectionLogFileProtocolRsync"
+            ]
+        },
+        "codersdk.ConnectionLogFileTransferInfo": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/codersdk.ConnectionLogFileAction"
+                },
+                "connection_id": {
+                    "description": "ConnectionID matches the connection ID of the file_transfer\nsession the operation occurred in.",
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "path": {
+                    "description": "Path is the path the operation was performed on. For SCP and\nrsync this is the requested root path from the command line, not\nnecessarily every file transferred.",
+                    "type": "string"
+                },
+                "protocol": {
+                    "$ref": "#/definitions/codersdk.ConnectionLogFileProtocol"
+                },
+                "target": {
+                    "description": "Target is only set for operations with a second path, such as the\ndestination of a rename or the target of a symlink.",
                     "type": "string"
                 }
             }
@@ -19065,7 +19135,9 @@ const docTemplate = `{
                 "reconnecting_pty",
                 "workspace_app",
                 "port_forwarding",
-                "tunnel"
+                "tunnel",
+                "file_transfer",
+                "file_operation"
             ],
             "x-enum-varnames": [
                 "ConnectionTypeSSH",
@@ -19074,7 +19146,9 @@ const docTemplate = `{
                 "ConnectionTypeReconnectingPTY",
                 "ConnectionTypeWorkspaceApp",
                 "ConnectionTypePortForwarding",
-                "ConnectionTypeTunnel"
+                "ConnectionTypeTunnel",
+                "ConnectionTypeFileTransfer",
+                "ConnectionTypeFileOperation"
             ]
         },
         "codersdk.ConvertLoginRequest": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -17129,6 +17129,14 @@
 					"type": "string",
 					"format": "date-time"
 				},
+				"file_transfer_info": {
+					"description": "FileTransferInfo is only set when `type` is\n`ConnectionTypeFileOperation`.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ConnectionLogFileTransferInfo"
+						}
+					]
+				},
 				"id": {
 					"type": "string",
 					"format": "uuid"
@@ -17140,7 +17148,7 @@
 					"$ref": "#/definitions/codersdk.MinimalOrganization"
 				},
 				"ssh_info": {
-					"description": "SSHInfo is only set when `type` is one of:\n- `ConnectionTypeSSH`\n- `ConnectionTypeReconnectingPTY`\n- `ConnectionTypeVSCode`\n- `ConnectionTypeJetBrains`",
+					"description": "SSHInfo is only set when `type` is one of:\n- `ConnectionTypeSSH`\n- `ConnectionTypeReconnectingPTY`\n- `ConnectionTypeVSCode`\n- `ConnectionTypeJetBrains`\n- `ConnectionTypeFileTransfer`",
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.ConnectionLogSSHInfo"
@@ -17170,6 +17178,64 @@
 					"format": "uuid"
 				},
 				"workspace_owner_username": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ConnectionLogFileAction": {
+			"type": "string",
+			"enum": [
+				"download",
+				"upload",
+				"bidirectional",
+				"remove",
+				"rmdir",
+				"rename",
+				"symlink",
+				"setattr",
+				"hardlink"
+			],
+			"x-enum-varnames": [
+				"ConnectionLogFileActionDownload",
+				"ConnectionLogFileActionUpload",
+				"ConnectionLogFileActionBidirectional",
+				"ConnectionLogFileActionRemove",
+				"ConnectionLogFileActionRmdir",
+				"ConnectionLogFileActionRename",
+				"ConnectionLogFileActionSymlink",
+				"ConnectionLogFileActionSetattr",
+				"ConnectionLogFileActionHardlink"
+			]
+		},
+		"codersdk.ConnectionLogFileProtocol": {
+			"type": "string",
+			"enum": ["sftp", "scp", "rsync"],
+			"x-enum-varnames": [
+				"ConnectionLogFileProtocolSFTP",
+				"ConnectionLogFileProtocolSCP",
+				"ConnectionLogFileProtocolRsync"
+			]
+		},
+		"codersdk.ConnectionLogFileTransferInfo": {
+			"type": "object",
+			"properties": {
+				"action": {
+					"$ref": "#/definitions/codersdk.ConnectionLogFileAction"
+				},
+				"connection_id": {
+					"description": "ConnectionID matches the connection ID of the file_transfer\nsession the operation occurred in.",
+					"type": "string",
+					"format": "uuid"
+				},
+				"path": {
+					"description": "Path is the path the operation was performed on. For SCP and\nrsync this is the requested root path from the command line, not\nnecessarily every file transferred.",
+					"type": "string"
+				},
+				"protocol": {
+					"$ref": "#/definitions/codersdk.ConnectionLogFileProtocol"
+				},
+				"target": {
+					"description": "Target is only set for operations with a second path, such as the\ndestination of a rename or the target of a symlink.",
 					"type": "string"
 				}
 			}
@@ -17245,7 +17311,9 @@
 				"reconnecting_pty",
 				"workspace_app",
 				"port_forwarding",
-				"tunnel"
+				"tunnel",
+				"file_transfer",
+				"file_operation"
 			],
 			"x-enum-varnames": [
 				"ConnectionTypeSSH",
@@ -17254,7 +17322,9 @@
 				"ConnectionTypeReconnectingPTY",
 				"ConnectionTypeWorkspaceApp",
 				"ConnectionTypePortForwarding",
-				"ConnectionTypeTunnel"
+				"ConnectionTypeTunnel",
+				"ConnectionTypeFileTransfer",
+				"ConnectionTypeFileOperation"
 			]
 		},
 		"codersdk.ConvertLoginRequest": {

--- a/coderd/connectionlog/connectionlog.go
+++ b/coderd/connectionlog/connectionlog.go
@@ -114,6 +114,22 @@ func (m *FakeConnectionLogger) Contains(t testing.TB, expected database.UpsertCo
 			t.Logf("connection log %d: expected DisconnectReason %s, got %s", idx+1, expected.DisconnectReason.String, cl.DisconnectReason.String)
 			continue
 		}
+		if expected.FileProtocol.Valid && cl.FileProtocol.ConnectionLogFileProtocol != expected.FileProtocol.ConnectionLogFileProtocol {
+			t.Logf("connection log %d: expected FileProtocol %s, got %s", idx+1, expected.FileProtocol.ConnectionLogFileProtocol, cl.FileProtocol.ConnectionLogFileProtocol)
+			continue
+		}
+		if expected.FileAction.Valid && cl.FileAction.ConnectionLogFileAction != expected.FileAction.ConnectionLogFileAction {
+			t.Logf("connection log %d: expected FileAction %s, got %s", idx+1, expected.FileAction.ConnectionLogFileAction, cl.FileAction.ConnectionLogFileAction)
+			continue
+		}
+		if expected.FilePath.Valid && cl.FilePath.String != expected.FilePath.String {
+			t.Logf("connection log %d: expected FilePath %s, got %s", idx+1, expected.FilePath.String, cl.FilePath.String)
+			continue
+		}
+		if expected.FileTarget.Valid && cl.FileTarget.String != expected.FileTarget.String {
+			t.Logf("connection log %d: expected FileTarget %s, got %s", idx+1, expected.FileTarget.String, cl.FileTarget.String)
+			continue
+		}
 		if !expected.Time.IsZero() && expected.Time != cl.Time {
 			t.Logf("connection log %d: expected Time %s, got %s", idx+1, expected.Time, cl.Time)
 			continue

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -437,6 +437,22 @@ func ConnectionLog(t testing.TB, db database.Store, seed database.UpsertConnecti
 			String: takeFirst(seed.DisconnectReason.String, ""),
 			Valid:  takeFirst(seed.DisconnectReason.Valid, false),
 		},
+		FileProtocol: database.NullConnectionLogFileProtocol{
+			ConnectionLogFileProtocol: takeFirst(seed.FileProtocol.ConnectionLogFileProtocol, ""),
+			Valid:                     takeFirst(seed.FileProtocol.Valid, false),
+		},
+		FileAction: database.NullConnectionLogFileAction{
+			ConnectionLogFileAction: takeFirst(seed.FileAction.ConnectionLogFileAction, ""),
+			Valid:                   takeFirst(seed.FileAction.Valid, false),
+		},
+		FilePath: sql.NullString{
+			String: takeFirst(seed.FilePath.String, ""),
+			Valid:  takeFirst(seed.FilePath.Valid, false),
+		},
+		FileTarget: sql.NullString{
+			String: takeFirst(seed.FileTarget.String, ""),
+			Valid:  takeFirst(seed.FileTarget.Valid, false),
+		},
 		ConnectionStatus: takeFirst(seed.ConnectionStatus, database.ConnectionStatusConnected),
 	}
 
@@ -463,6 +479,10 @@ func ConnectionLog(t testing.TB, db database.Store, seed database.UpsertConnecti
 		ConnectionID:     []uuid.UUID{arg.ConnectionID.UUID},
 		DisconnectReason: []string{arg.DisconnectReason.String},
 		DisconnectTime:   []time.Time{disconnectTime.Time},
+		FileProtocol:     []string{string(arg.FileProtocol.ConnectionLogFileProtocol)},
+		FileAction:       []string{string(arg.FileAction.ConnectionLogFileAction)},
+		FilePath:         []string{arg.FilePath.String},
+		FileTarget:       []string{arg.FileTarget.String},
 	})
 	require.NoError(t, err, "insert connection log")
 
@@ -470,10 +490,13 @@ func ConnectionLog(t testing.TB, db database.Store, seed database.UpsertConnecti
 	// conflict the DB keeps the original row's ID, so we can't
 	// rely on arg.ID. Match on the conflict key for rows with a
 	// connection_id, or by primary key for NULL connection_id.
+	// File operation rows are excluded from the conflict index (they
+	// share their parent session's connection_id and always insert as
+	// fresh rows), so they are matched by primary key too.
 	rows, err := db.GetConnectionLogsOffset(genCtx, database.GetConnectionLogsOffsetParams{})
 	require.NoError(t, err, "query connection logs")
 	for _, row := range rows {
-		if arg.ConnectionID.Valid {
+		if arg.ConnectionID.Valid && !arg.FileAction.Valid {
 			if row.ConnectionLog.ConnectionID == arg.ConnectionID &&
 				row.ConnectionLog.WorkspaceID == arg.WorkspaceID &&
 				row.ConnectionLog.AgentName == arg.AgentName {

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -1042,22 +1042,26 @@ func (r GetWorkspaceBuildAgentsByInstanceIDRow) RBACObject() rbac.Object {
 // still used as the canonical connection log event type throughout
 // the codebase.
 type UpsertConnectionLogParams struct {
-	ID               uuid.UUID        `db:"id" json:"id"`
-	OrganizationID   uuid.UUID        `db:"organization_id" json:"organization_id"`
-	WorkspaceOwnerID uuid.UUID        `db:"workspace_owner_id" json:"workspace_owner_id"`
-	WorkspaceID      uuid.UUID        `db:"workspace_id" json:"workspace_id"`
-	WorkspaceName    string           `db:"workspace_name" json:"workspace_name"`
-	AgentName        string           `db:"agent_name" json:"agent_name"`
-	Type             ConnectionType   `db:"type" json:"type"`
-	Code             sql.NullInt32    `db:"code" json:"code"`
-	IP               pqtype.Inet      `db:"ip" json:"ip"`
-	UserAgent        sql.NullString   `db:"user_agent" json:"user_agent"`
-	UserID           uuid.NullUUID    `db:"user_id" json:"user_id"`
-	SlugOrPort       sql.NullString   `db:"slug_or_port" json:"slug_or_port"`
-	ConnectionID     uuid.NullUUID    `db:"connection_id" json:"connection_id"`
-	DisconnectReason sql.NullString   `db:"disconnect_reason" json:"disconnect_reason"`
-	Time             time.Time        `db:"time" json:"time"`
-	ConnectionStatus ConnectionStatus `db:"connection_status" json:"connection_status"`
+	ID               uuid.UUID                     `db:"id" json:"id"`
+	OrganizationID   uuid.UUID                     `db:"organization_id" json:"organization_id"`
+	WorkspaceOwnerID uuid.UUID                     `db:"workspace_owner_id" json:"workspace_owner_id"`
+	WorkspaceID      uuid.UUID                     `db:"workspace_id" json:"workspace_id"`
+	WorkspaceName    string                        `db:"workspace_name" json:"workspace_name"`
+	AgentName        string                        `db:"agent_name" json:"agent_name"`
+	Type             ConnectionType                `db:"type" json:"type"`
+	Code             sql.NullInt32                 `db:"code" json:"code"`
+	IP               pqtype.Inet                   `db:"ip" json:"ip"`
+	UserAgent        sql.NullString                `db:"user_agent" json:"user_agent"`
+	UserID           uuid.NullUUID                 `db:"user_id" json:"user_id"`
+	SlugOrPort       sql.NullString                `db:"slug_or_port" json:"slug_or_port"`
+	ConnectionID     uuid.NullUUID                 `db:"connection_id" json:"connection_id"`
+	DisconnectReason sql.NullString                `db:"disconnect_reason" json:"disconnect_reason"`
+	FileProtocol     NullConnectionLogFileProtocol `db:"file_protocol" json:"file_protocol"`
+	FileAction       NullConnectionLogFileAction   `db:"file_action" json:"file_action"`
+	FilePath         sql.NullString                `db:"file_path" json:"file_path"`
+	FileTarget       sql.NullString                `db:"file_target" json:"file_target"`
+	Time             time.Time                     `db:"time" json:"time"`
+	ConnectionStatus ConnectionStatus              `db:"connection_status" json:"connection_status"`
 }
 
 func (r GetLatestWorkspaceBuildWithStatusByWorkspaceIDRow) RBACObject() rbac.Object {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -85,8 +85,7 @@ type sqlcQuerier interface {
 	BatchUpsertChatHeartbeats(ctx context.Context, arg BatchUpsertChatHeartbeatsParams) error
 	// The pairing index is partial (file_action IS NULL): file operation
 	// events share the connection_id of their parent session, never pair
-	// with a disconnect event, and always insert as new rows. The predicate
-	// is required for Postgres to infer the partial unique index.
+	// with a disconnect event, and always insert as new rows.
 	BatchUpsertConnectionLogs(ctx context.Context, arg BatchUpsertConnectionLogsParams) error
 	BulkMarkNotificationMessagesFailed(ctx context.Context, arg BulkMarkNotificationMessagesFailedParams) (int64, error)
 	BulkMarkNotificationMessagesSent(ctx context.Context, arg BulkMarkNotificationMessagesSentParams) (int64, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -13179,7 +13179,8 @@ const batchUpsertConnectionLogs = `-- name: BatchUpsertConnectionLogs :exec
 INSERT INTO connection_logs (
     id, connect_time, organization_id, workspace_owner_id, workspace_id,
     workspace_name, agent_name, type, code, ip, user_agent, user_id,
-    slug_or_port, connection_id, disconnect_reason, disconnect_time
+    slug_or_port, connection_id, disconnect_reason, disconnect_time,
+    file_protocol, file_action, file_path, file_target
 )
 SELECT
     u.id,
@@ -13199,7 +13200,11 @@ SELECT
     NULLIF(u.slug_or_port, ''),
     NULLIF(u.connection_id, '00000000-0000-0000-0000-000000000000'::uuid),
     NULLIF(u.disconnect_reason, ''),
-    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz)
+    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz),
+    NULLIF(u.file_protocol, '')::connection_log_file_protocol,
+    NULLIF(u.file_action, '')::connection_log_file_action,
+    NULLIF(u.file_path, ''),
+    NULLIF(u.file_target, '')
 FROM (
     SELECT
         unnest($1::uuid[]) AS id,
@@ -13218,7 +13223,11 @@ FROM (
         unnest($14::text[]) AS slug_or_port,
         unnest($15::uuid[]) AS connection_id,
         unnest($16::text[]) AS disconnect_reason,
-        unnest($17::timestamptz[]) AS disconnect_time
+        unnest($17::timestamptz[]) AS disconnect_time,
+        unnest($18::text[]) AS file_protocol,
+        unnest($19::text[]) AS file_action,
+        unnest($20::text[]) AS file_path,
+        unnest($21::text[]) AS file_target
 ) AS u
 ON CONFLICT (connection_id, workspace_id, agent_name) WHERE file_action IS NULL
 DO UPDATE SET
@@ -13267,12 +13276,15 @@ type BatchUpsertConnectionLogsParams struct {
 	ConnectionID     []uuid.UUID      `db:"connection_id" json:"connection_id"`
 	DisconnectReason []string         `db:"disconnect_reason" json:"disconnect_reason"`
 	DisconnectTime   []time.Time      `db:"disconnect_time" json:"disconnect_time"`
+	FileProtocol     []string         `db:"file_protocol" json:"file_protocol"`
+	FileAction       []string         `db:"file_action" json:"file_action"`
+	FilePath         []string         `db:"file_path" json:"file_path"`
+	FileTarget       []string         `db:"file_target" json:"file_target"`
 }
 
 // The pairing index is partial (file_action IS NULL): file operation
 // events share the connection_id of their parent session, never pair
-// with a disconnect event, and always insert as new rows. The predicate
-// is required for Postgres to infer the partial unique index.
+// with a disconnect event, and always insert as new rows.
 func (q *sqlQuerier) BatchUpsertConnectionLogs(ctx context.Context, arg BatchUpsertConnectionLogsParams) error {
 	_, err := q.db.ExecContext(ctx, batchUpsertConnectionLogs,
 		pq.Array(arg.ID),
@@ -13292,6 +13304,10 @@ func (q *sqlQuerier) BatchUpsertConnectionLogs(ctx context.Context, arg BatchUps
 		pq.Array(arg.ConnectionID),
 		pq.Array(arg.DisconnectReason),
 		pq.Array(arg.DisconnectTime),
+		pq.Array(arg.FileProtocol),
+		pq.Array(arg.FileAction),
+		pq.Array(arg.FilePath),
+		pq.Array(arg.FileTarget),
 	)
 	return err
 }

--- a/coderd/database/queries/connectionlogs.sql
+++ b/coderd/database/queries/connectionlogs.sql
@@ -259,7 +259,8 @@ WHERE connection_logs.id = old_logs.id;
 INSERT INTO connection_logs (
     id, connect_time, organization_id, workspace_owner_id, workspace_id,
     workspace_name, agent_name, type, code, ip, user_agent, user_id,
-    slug_or_port, connection_id, disconnect_reason, disconnect_time
+    slug_or_port, connection_id, disconnect_reason, disconnect_time,
+    file_protocol, file_action, file_path, file_target
 )
 SELECT
     u.id,
@@ -279,7 +280,11 @@ SELECT
     NULLIF(u.slug_or_port, ''),
     NULLIF(u.connection_id, '00000000-0000-0000-0000-000000000000'::uuid),
     NULLIF(u.disconnect_reason, ''),
-    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz)
+    NULLIF(u.disconnect_time, '0001-01-01 00:00:00Z'::timestamptz),
+    NULLIF(u.file_protocol, '')::connection_log_file_protocol,
+    NULLIF(u.file_action, '')::connection_log_file_action,
+    NULLIF(u.file_path, ''),
+    NULLIF(u.file_target, '')
 FROM (
     SELECT
         unnest(sqlc.arg('id')::uuid[]) AS id,
@@ -298,12 +303,15 @@ FROM (
         unnest(sqlc.arg('slug_or_port')::text[]) AS slug_or_port,
         unnest(sqlc.arg('connection_id')::uuid[]) AS connection_id,
         unnest(sqlc.arg('disconnect_reason')::text[]) AS disconnect_reason,
-        unnest(sqlc.arg('disconnect_time')::timestamptz[]) AS disconnect_time
+        unnest(sqlc.arg('disconnect_time')::timestamptz[]) AS disconnect_time,
+        unnest(sqlc.arg('file_protocol')::text[]) AS file_protocol,
+        unnest(sqlc.arg('file_action')::text[]) AS file_action,
+        unnest(sqlc.arg('file_path')::text[]) AS file_path,
+        unnest(sqlc.arg('file_target')::text[]) AS file_target
 ) AS u
 -- The pairing index is partial (file_action IS NULL): file operation
 -- events share the connection_id of their parent session, never pair
--- with a disconnect event, and always insert as new rows. The predicate
--- is required for Postgres to infer the partial unique index.
+-- with a disconnect event, and always insert as new rows.
 ON CONFLICT (connection_id, workspace_id, agent_name) WHERE file_action IS NULL
 DO UPDATE SET
     -- Pick the earliest real connect_time. The zero sentinel

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1509,6 +1509,10 @@ func (api *API) logTunnelConnection(agentID uuid.UUID, statusCode int32, userID 
 		SlugOrPort:       sql.NullString{},
 		ConnectionID:     uuid.NullUUID{},
 		DisconnectReason: sql.NullString{},
+		FileProtocol:     database.NullConnectionLogFileProtocol{},
+		FileAction:       database.NullConnectionLogFileAction{},
+		FilePath:         sql.NullString{},
+		FileTarget:       sql.NullString{},
 		ConnectionStatus: database.ConnectionStatusConnected,
 	})
 	if err != nil {

--- a/coderd/workspaceapps/db.go
+++ b/coderd/workspaceapps/db.go
@@ -559,6 +559,10 @@ func (p *DBTokenProvider) connLogInitRequest(w http.ResponseWriter, r *http.Requ
 			// N/A
 			ConnectionID:     uuid.NullUUID{},
 			DisconnectReason: sql.NullString{},
+			FileProtocol:     database.NullConnectionLogFileProtocol{},
+			FileAction:       database.NullConnectionLogFileAction{},
+			FilePath:         sql.NullString{},
+			FileTarget:       sql.NullString{},
 		})
 		if err != nil {
 			logger.Error(ctx, "upsert connection log failed", slog.Error(err))

--- a/codersdk/connectionlog.go
+++ b/codersdk/connectionlog.go
@@ -33,7 +33,12 @@ type ConnectionLog struct {
 	// - `ConnectionTypeReconnectingPTY`
 	// - `ConnectionTypeVSCode`
 	// - `ConnectionTypeJetBrains`
+	// - `ConnectionTypeFileTransfer`
 	SSHInfo *ConnectionLogSSHInfo `json:"ssh_info,omitempty"`
+
+	// FileTransferInfo is only set when `type` is
+	// `ConnectionTypeFileOperation`.
+	FileTransferInfo *ConnectionLogFileTransferInfo `json:"file_transfer_info,omitempty"`
 }
 
 // ConnectionType is the type of connection that the agent is receiving.
@@ -49,6 +54,13 @@ const (
 	// ConnectionTypeTunnel records accepted and denied tailnet tunnel
 	// requests made by authenticated users.
 	ConnectionTypeTunnel ConnectionType = "tunnel"
+	// ConnectionTypeFileTransfer records file-transfer sessions (SFTP,
+	// SCP, rsync), which would otherwise be recorded as plain SSH.
+	ConnectionTypeFileTransfer ConnectionType = "file_transfer"
+	// ConnectionTypeFileOperation records individual file operations
+	// observed during a file-transfer session. Events share the
+	// connection ID of their parent file_transfer session.
+	ConnectionTypeFileOperation ConnectionType = "file_operation"
 )
 
 // ConnectionLogStatus is the status of a connection log entry.
@@ -89,6 +101,53 @@ type ConnectionLogSSHInfo struct {
 	// ExitCode is the exit code of the SSH session. It is omitted if a
 	// disconnect event with the same connection ID has not yet been seen.
 	ExitCode *int32 `json:"exit_code,omitempty"`
+}
+
+// ConnectionLogFileProtocol is the protocol that carried a file
+// operation.
+type ConnectionLogFileProtocol string
+
+const (
+	ConnectionLogFileProtocolSFTP  ConnectionLogFileProtocol = "sftp"
+	ConnectionLogFileProtocolSCP   ConnectionLogFileProtocol = "scp"
+	ConnectionLogFileProtocolRsync ConnectionLogFileProtocol = "rsync"
+)
+
+// ConnectionLogFileAction is the kind of file operation observed.
+// A download is a transfer from the workspace to the client, an upload
+// is a transfer from the client to the workspace, and bidirectional is
+// a file opened for both at once, where either may have occurred.
+type ConnectionLogFileAction string
+
+const (
+	ConnectionLogFileActionDownload      ConnectionLogFileAction = "download"
+	ConnectionLogFileActionUpload        ConnectionLogFileAction = "upload"
+	ConnectionLogFileActionBidirectional ConnectionLogFileAction = "bidirectional"
+	ConnectionLogFileActionRemove        ConnectionLogFileAction = "remove"
+	ConnectionLogFileActionRmdir         ConnectionLogFileAction = "rmdir"
+	ConnectionLogFileActionRename        ConnectionLogFileAction = "rename"
+	ConnectionLogFileActionSymlink       ConnectionLogFileAction = "symlink"
+	// ConnectionLogFileActionSetattr records file attribute changes:
+	// truncation, permissions, ownership, and timestamps.
+	ConnectionLogFileActionSetattr ConnectionLogFileAction = "setattr"
+	// ConnectionLogFileActionHardlink records creation of a hard link.
+	// Path is the existing file, Target is the new link.
+	ConnectionLogFileActionHardlink ConnectionLogFileAction = "hardlink"
+)
+
+type ConnectionLogFileTransferInfo struct {
+	// ConnectionID matches the connection ID of the file_transfer
+	// session the operation occurred in.
+	ConnectionID uuid.UUID                 `json:"connection_id" format:"uuid"`
+	Protocol     ConnectionLogFileProtocol `json:"protocol"`
+	Action       ConnectionLogFileAction   `json:"action"`
+	// Path is the path the operation was performed on. For SCP and
+	// rsync this is the requested root path from the command line, not
+	// necessarily every file transferred.
+	Path string `json:"path"`
+	// Target is only set for operations with a second path, such as the
+	// destination of a rename or the target of a symlink.
+	Target string `json:"target,omitempty"`
 }
 
 type ConnectionLogsRequest struct {

--- a/docs/admin/monitoring/connection-logs.md
+++ b/docs/admin/monitoring/connection-logs.md
@@ -28,6 +28,56 @@ Agent-reported events do not identify the Coder user who connected. To
 attribute SSH and IDE activity to a user, correlate them with tunnel
 events for the same workspace and agent.
 
+## File Transfers
+
+The connection log records file-transfer sessions and the file operations
+performed within them. Like SSH and IDE sessions, these events are
+reported by workspace agents, and their receipt by the server is not
+guaranteed.
+
+When a client starts an SFTP, `scp`, or `rsync` session against a
+workspace, the session is recorded with the `file_transfer` type instead
+of `ssh`. Sessions denied by
+[`CODER_AGENT_BLOCK_FILE_TRANSFER`](../../reference/cli/agent.md#--block-file-transfer)
+are also recorded as `file_transfer`, with exit code `65`.
+
+While a transfer session is open, the agent streams the file operations
+it observes as `file_operation` events. Each records the protocol, the
+kind of operation, and the path:
+
+- **SFTP** sessions are served inside the agent, so each operation is
+  observed directly: downloads, uploads, directory creation and removal,
+  file removal, renames, symlinks, hard links, and attribute changes
+  (truncation, permissions, ownership, timestamps). A `bidirectional`
+  operation is a file opened for reading and writing at once, such as
+  in-place editing; treat it as though both a download and an upload may
+  have occurred. Attribute changes made through an already-open file
+  handle are not individually logged, but opening the handle itself is.
+- **`scp` and `rsync`** sessions run as external commands, so only the
+  direction and the requested root path from the command line are
+  recorded, not every file in a recursive transfer.
+- **`nc`** has no reliable file semantics and is not classified; it
+  appears as a plain `ssh` session.
+
+File operation events share the `connection_id` of their parent
+`file_transfer` session, so filtering by `connection_id:<uuid>` returns
+the session and all of its recorded operations. Identical operations are
+recorded once per session, and at most 512 operations are recorded per
+session. Like workspace app connections, file operation events are
+point-in-time records: they have no close time and are excluded from
+`status:` filter results.
+
+Recording file transfers requires that both the workspace agent and the
+Coder server support it (agent API v2.11). Older agents report transfer
+sessions as plain `ssh` events without file details.
+
+Keep in mind that file-transfer classification is best-effort and not a
+security boundary: a user with SSH access can move data in ways the agent
+cannot recognize, such as renamed binaries, `curl` uploads, or writing
+files through a shell. Use
+[`CODER_AGENT_BLOCK_FILE_TRANSFER`](../../reference/cli/agent.md#--block-file-transfer)
+together with endpoint controls if you need enforcement.
+
 ## Tunnel Connections
 
 The connection log records the authorization decision for each request to add a tunnel to a workspace agent.

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -485,6 +485,13 @@ curl -X GET http://coder-server:8080/api/v2/connectionlog?limit=0 \
     {
       "agent_name": "string",
       "connect_time": "2019-08-24T14:15:22Z",
+      "file_transfer_info": {
+        "action": "download",
+        "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+        "path": "string",
+        "protocol": "sftp",
+        "target": "string"
+      },
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "ip": "string",
       "organization": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -4316,6 +4316,13 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 {
   "agent_name": "string",
   "connect_time": "2019-08-24T14:15:22Z",
+  "file_transfer_info": {
+    "action": "download",
+    "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+    "path": "string",
+    "protocol": "sftp",
+    "target": "string"
+  },
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
   "ip": "string",
   "organization": {
@@ -4370,20 +4377,71 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name                       | Type                                                           | Required | Restrictions | Description                                                                                                                                              |
-|----------------------------|----------------------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent_name`               | string                                                         | false    |              |                                                                                                                                                          |
-| `connect_time`             | string                                                         | false    |              |                                                                                                                                                          |
-| `id`                       | string                                                         | false    |              |                                                                                                                                                          |
-| `ip`                       | string                                                         | false    |              |                                                                                                                                                          |
-| `organization`             | [codersdk.MinimalOrganization](#codersdkminimalorganization)   | false    |              |                                                                                                                                                          |
-| `ssh_info`                 | [codersdk.ConnectionLogSSHInfo](#codersdkconnectionlogsshinfo) | false    |              | Ssh info is only set when `type` is one of: - `ConnectionTypeSSH` - `ConnectionTypeReconnectingPTY` - `ConnectionTypeVSCode` - `ConnectionTypeJetBrains` |
-| `type`                     | [codersdk.ConnectionType](#codersdkconnectiontype)             | false    |              |                                                                                                                                                          |
-| `web_info`                 | [codersdk.ConnectionLogWebInfo](#codersdkconnectionlogwebinfo) | false    |              | Web info is only set when `type` is one of: - `ConnectionTypePortForwarding` - `ConnectionTypeWorkspaceApp` - `ConnectionTypeTunnel`                     |
-| `workspace_id`             | string                                                         | false    |              |                                                                                                                                                          |
-| `workspace_name`           | string                                                         | false    |              |                                                                                                                                                          |
-| `workspace_owner_id`       | string                                                         | false    |              |                                                                                                                                                          |
-| `workspace_owner_username` | string                                                         | false    |              |                                                                                                                                                          |
+| Name                       | Type                                                                             | Required | Restrictions | Description                                                                                                                                                                             |
+|----------------------------|----------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent_name`               | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `connect_time`             | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `file_transfer_info`       | [codersdk.ConnectionLogFileTransferInfo](#codersdkconnectionlogfiletransferinfo) | false    |              | File transfer info is only set when `type` is `ConnectionTypeFileOperation`.                                                                                                            |
+| `id`                       | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `ip`                       | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `organization`             | [codersdk.MinimalOrganization](#codersdkminimalorganization)                     | false    |              |                                                                                                                                                                                         |
+| `ssh_info`                 | [codersdk.ConnectionLogSSHInfo](#codersdkconnectionlogsshinfo)                   | false    |              | Ssh info is only set when `type` is one of: - `ConnectionTypeSSH` - `ConnectionTypeReconnectingPTY` - `ConnectionTypeVSCode` - `ConnectionTypeJetBrains` - `ConnectionTypeFileTransfer` |
+| `type`                     | [codersdk.ConnectionType](#codersdkconnectiontype)                               | false    |              |                                                                                                                                                                                         |
+| `web_info`                 | [codersdk.ConnectionLogWebInfo](#codersdkconnectionlogwebinfo)                   | false    |              | Web info is only set when `type` is one of: - `ConnectionTypePortForwarding` - `ConnectionTypeWorkspaceApp` - `ConnectionTypeTunnel`                                                    |
+| `workspace_id`             | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `workspace_name`           | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `workspace_owner_id`       | string                                                                           | false    |              |                                                                                                                                                                                         |
+| `workspace_owner_username` | string                                                                           | false    |              |                                                                                                                                                                                         |
+
+## codersdk.ConnectionLogFileAction
+
+```json
+"download"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                                                                             |
+|------------------------------------------------------------------------------------------------------|
+| `bidirectional`, `download`, `hardlink`, `remove`, `rename`, `rmdir`, `setattr`, `symlink`, `upload` |
+
+## codersdk.ConnectionLogFileProtocol
+
+```json
+"sftp"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)               |
+|------------------------|
+| `rsync`, `scp`, `sftp` |
+
+## codersdk.ConnectionLogFileTransferInfo
+
+```json
+{
+  "action": "download",
+  "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+  "path": "string",
+  "protocol": "sftp",
+  "target": "string"
+}
+```
+
+### Properties
+
+| Name            | Type                                                                     | Required | Restrictions | Description                                                                                                                                                       |
+|-----------------|--------------------------------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `action`        | [codersdk.ConnectionLogFileAction](#codersdkconnectionlogfileaction)     | false    |              |                                                                                                                                                                   |
+| `connection_id` | string                                                                   | false    |              | Connection ID matches the connection ID of the file_transfer session the operation occurred in.                                                                   |
+| `path`          | string                                                                   | false    |              | Path is the path the operation was performed on. For SCP and rsync this is the requested root path from the command line, not necessarily every file transferred. |
+| `protocol`      | [codersdk.ConnectionLogFileProtocol](#codersdkconnectionlogfileprotocol) | false    |              |                                                                                                                                                                   |
+| `target`        | string                                                                   | false    |              | Target is only set for operations with a second path, such as the destination of a rename or the target of a symlink.                                             |
 
 ## codersdk.ConnectionLogResponse
 
@@ -4393,6 +4451,13 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     {
       "agent_name": "string",
       "connect_time": "2019-08-24T14:15:22Z",
+      "file_transfer_info": {
+        "action": "download",
+        "connection_id": "d3547de1-d1f2-4344-b4c2-17169b7526f9",
+        "path": "string",
+        "protocol": "sftp",
+        "target": "string"
+      },
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "ip": "string",
       "organization": {
@@ -4531,9 +4596,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                       |
-|------------------------------------------------------------------------------------------------|
-| `jetbrains`, `port_forwarding`, `reconnecting_pty`, `ssh`, `tunnel`, `vscode`, `workspace_app` |
+| Value(s)                                                                                                                          |
+|-----------------------------------------------------------------------------------------------------------------------------------|
+| `file_operation`, `file_transfer`, `jetbrains`, `port_forwarding`, `reconnecting_pty`, `ssh`, `tunnel`, `vscode`, `workspace_app` |
 
 ## codersdk.ConvertLoginRequest
 

--- a/enterprise/coderd/connectionlog.go
+++ b/enterprise/coderd/connectionlog.go
@@ -128,8 +128,9 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 	}
 
 	var (
-		webInfo *codersdk.ConnectionLogWebInfo
-		sshInfo *codersdk.ConnectionLogSSHInfo
+		webInfo          *codersdk.ConnectionLogWebInfo
+		sshInfo          *codersdk.ConnectionLogSSHInfo
+		fileTransferInfo *codersdk.ConnectionLogFileTransferInfo
 	)
 
 	switch dblog.ConnectionLog.Type {
@@ -145,7 +146,8 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 	case database.ConnectionTypeSsh,
 		database.ConnectionTypeReconnectingPty,
 		database.ConnectionTypeJetbrains,
-		database.ConnectionTypeVscode:
+		database.ConnectionTypeVscode,
+		database.ConnectionTypeFileTransfer:
 		sshInfo = &codersdk.ConnectionLogSSHInfo{
 			ConnectionID:     dblog.ConnectionLog.ConnectionID.UUID,
 			DisconnectReason: dblog.ConnectionLog.DisconnectReason.String,
@@ -155,6 +157,14 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 		}
 		if dblog.ConnectionLog.Code.Valid {
 			sshInfo.ExitCode = &dblog.ConnectionLog.Code.Int32
+		}
+	case database.ConnectionTypeFileOperation:
+		fileTransferInfo = &codersdk.ConnectionLogFileTransferInfo{
+			ConnectionID: dblog.ConnectionLog.ConnectionID.UUID,
+			Protocol:     codersdk.ConnectionLogFileProtocol(dblog.ConnectionLog.FileProtocol.ConnectionLogFileProtocol),
+			Action:       codersdk.ConnectionLogFileAction(dblog.ConnectionLog.FileAction.ConnectionLogFileAction),
+			Path:         dblog.ConnectionLog.FilePath.String,
+			Target:       dblog.ConnectionLog.FileTarget.String,
 		}
 	}
 
@@ -176,5 +186,6 @@ func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.Co
 		IP:                     ip,
 		WebInfo:                webInfo,
 		SSHInfo:                sshInfo,
+		FileTransferInfo:       fileTransferInfo,
 	}
 }

--- a/enterprise/coderd/connectionlog/connectionlog.go
+++ b/enterprise/coderd/connectionlog/connectionlog.go
@@ -244,7 +244,11 @@ func (b *DBBatcher) addToBatch(item database.UpsertConnectionLogParams) {
 		entry.connectTime = item.Time
 	}
 
-	if !item.ConnectionID.Valid {
+	// File operation events share the connection_id of their parent
+	// file-transfer session but are point-in-time, insert-only rows.
+	// They must not be deduplicated against the session's connect and
+	// disconnect events (or each other), so they bypass the keyed batch.
+	if !item.ConnectionID.Valid || item.Type == database.ConnectionTypeFileOperation {
 		b.nullConnIDBatch = append(b.nullConnIDBatch, entry)
 		return
 	}
@@ -401,6 +405,10 @@ func (b *DBBatcher) buildParams() database.BatchUpsertConnectionLogsParams {
 		connectionID     = make([]uuid.UUID, 0, count)
 		disconnectReason = make([]string, 0, count)
 		disconnectTime   = make([]time.Time, 0, count)
+		fileProtocol     = make([]string, 0, count)
+		fileAction       = make([]string, 0, count)
+		filePath         = make([]string, 0, count)
+		fileTarget       = make([]string, 0, count)
 	)
 
 	appendEntry := func(e batchEntry) {
@@ -421,6 +429,19 @@ func (b *DBBatcher) buildParams() database.BatchUpsertConnectionLogsParams {
 		connectionID = append(connectionID, e.ConnectionID.UUID)
 		disconnectReason = append(disconnectReason, e.DisconnectReason.String)
 		disconnectTime = append(disconnectTime, e.disconnectTime)
+		// The batch query NULLIFs empty strings before casting to the
+		// enum types, so invalid values are stored as NULL.
+		var protocol, action string
+		if e.FileProtocol.Valid {
+			protocol = string(e.FileProtocol.ConnectionLogFileProtocol)
+		}
+		if e.FileAction.Valid {
+			action = string(e.FileAction.ConnectionLogFileAction)
+		}
+		fileProtocol = append(fileProtocol, protocol)
+		fileAction = append(fileAction, action)
+		filePath = append(filePath, e.FilePath.String)
+		fileTarget = append(fileTarget, e.FileTarget.String)
 	}
 
 	for _, entry := range b.dedupedBatch {
@@ -448,6 +469,10 @@ func (b *DBBatcher) buildParams() database.BatchUpsertConnectionLogsParams {
 		ConnectionID:     connectionID,
 		DisconnectReason: disconnectReason,
 		DisconnectTime:   disconnectTime,
+		FileProtocol:     fileProtocol,
+		FileAction:       fileAction,
+		FilePath:         filePath,
+		FileTarget:       fileTarget,
 	}
 }
 

--- a/enterprise/coderd/connectionlog/connectionlog_internal_test.go
+++ b/enterprise/coderd/connectionlog/connectionlog_internal_test.go
@@ -196,6 +196,43 @@ func Test_addToBatch(t *testing.T) {
 		require.Equal(t, disconnect.Time, got.disconnectTime)
 	})
 
+	t.Run("FileOperationsNeverDedup", func(t *testing.T) {
+		t.Parallel()
+
+		b := &DBBatcher{
+			maxBatchSize: 100,
+			dedupedBatch: make(map[uuid.UUID]batchEntry),
+		}
+
+		wsID := uuid.New()
+		connID := uuid.New()
+
+		// A file-transfer session's connect/disconnect pair and two
+		// file operations sharing its connection ID. The operations
+		// must not merge with the session entry or each other.
+		connect := fakeConnectEvent(wsID, "agent1", connID)
+		connect.Type = database.ConnectionTypeFileTransfer
+		disconnect := fakeDisconnectEvent(wsID, "agent1", connID)
+		disconnect.Type = database.ConnectionTypeFileTransfer
+
+		op1 := fakeConnectEvent(wsID, "agent1", connID)
+		op1.Type = database.ConnectionTypeFileOperation
+		op1.FilePath = sql.NullString{String: "/tmp/a", Valid: true}
+		op2 := fakeConnectEvent(wsID, "agent1", connID)
+		op2.Type = database.ConnectionTypeFileOperation
+		op2.FilePath = sql.NullString{String: "/tmp/b", Valid: true}
+
+		b.addToBatch(connect)
+		b.addToBatch(op1)
+		b.addToBatch(op2)
+		b.addToBatch(disconnect)
+
+		require.Equal(t, 3, b.batchLen())
+		require.Len(t, b.dedupedBatch, 1, "session pair should merge")
+		require.Len(t, b.nullConnIDBatch, 2, "file operations must be insert-only")
+		require.Equal(t, database.ConnectionStatusDisconnected, b.dedupedBatch[connID].ConnectionStatus)
+	})
+
 	t.Run("DuplicateDisconnectsPreserveConnectTime", func(t *testing.T) {
 		t.Parallel()
 

--- a/enterprise/coderd/connectionlog_test.go
+++ b/enterprise/coderd/connectionlog_test.go
@@ -295,4 +295,112 @@ func TestConnectionLogs(t *testing.T) {
 		require.True(t, logs.ConnectionLogs[0].SSHInfo.DisconnectTime.Equal(now))
 		require.Equal(t, updatedClog.DisconnectReason.String, logs.ConnectionLogs[0].SSHInfo.DisconnectReason)
 	})
+
+	t.Run("FileTransferInfo", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		client, db, _ := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+			ConnectionLogging: true,
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAuditLog:      1,
+					codersdk.FeatureConnectionLog: 1,
+				},
+			},
+		})
+
+		now := dbtime.Now()
+		connID := uuid.New()
+		ws := createWorkspace(t, db)
+		// A file-transfer session row and two file operation rows
+		// sharing its connection ID. The operations must insert as
+		// separate rows despite the shared connection ID.
+		session := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+			Time:             now.Add(-time.Hour),
+			Type:             database.ConnectionTypeFileTransfer,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			ConnectionID:     uuid.NullUUID{UUID: connID, Valid: true},
+		})
+		_ = dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+			Time:             now.Add(-time.Minute),
+			Type:             database.ConnectionTypeFileOperation,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			WorkspaceName:    session.WorkspaceName,
+			AgentName:        session.AgentName,
+			ConnectionID:     uuid.NullUUID{UUID: connID, Valid: true},
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: database.ConnectionLogFileProtocolSftp,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionDownload,
+				Valid:                   true,
+			},
+			FilePath: sql.NullString{String: "/home/coder/secret.txt", Valid: true},
+		})
+		_ = dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+			Time:             now,
+			Type:             database.ConnectionTypeFileOperation,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+			WorkspaceName:    session.WorkspaceName,
+			AgentName:        session.AgentName,
+			ConnectionID:     uuid.NullUUID{UUID: connID, Valid: true},
+			FileProtocol: database.NullConnectionLogFileProtocol{
+				ConnectionLogFileProtocol: database.ConnectionLogFileProtocolSftp,
+				Valid:                     true,
+			},
+			FileAction: database.NullConnectionLogFileAction{
+				ConnectionLogFileAction: database.ConnectionLogFileActionRename,
+				Valid:                   true,
+			},
+			FilePath:   sql.NullString{String: "/home/coder/a.txt", Valid: true},
+			FileTarget: sql.NullString{String: "/home/coder/b.txt", Valid: true},
+		})
+
+		// The session and its operations are grouped by connection_id.
+		logs, err := client.ConnectionLogs(ctx, codersdk.ConnectionLogsRequest{
+			SearchQuery: "connection_id:" + connID.String(),
+		})
+		require.NoError(t, err)
+		require.Len(t, logs.ConnectionLogs, 3)
+
+		// Results are ordered by connect_time descending.
+		renameLog := logs.ConnectionLogs[0]
+		require.Equal(t, codersdk.ConnectionTypeFileOperation, renameLog.Type)
+		require.Nil(t, renameLog.SSHInfo)
+		require.Nil(t, renameLog.WebInfo)
+		require.NotNil(t, renameLog.FileTransferInfo)
+		require.Equal(t, connID, renameLog.FileTransferInfo.ConnectionID)
+		require.Equal(t, codersdk.ConnectionLogFileProtocolSFTP, renameLog.FileTransferInfo.Protocol)
+		require.Equal(t, codersdk.ConnectionLogFileActionRename, renameLog.FileTransferInfo.Action)
+		require.Equal(t, "/home/coder/a.txt", renameLog.FileTransferInfo.Path)
+		require.Equal(t, "/home/coder/b.txt", renameLog.FileTransferInfo.Target)
+
+		readLog := logs.ConnectionLogs[1]
+		require.NotNil(t, readLog.FileTransferInfo)
+		require.Equal(t, codersdk.ConnectionLogFileActionDownload, readLog.FileTransferInfo.Action)
+		require.Equal(t, "/home/coder/secret.txt", readLog.FileTransferInfo.Path)
+		require.Empty(t, readLog.FileTransferInfo.Target)
+
+		sessionLog := logs.ConnectionLogs[2]
+		require.Equal(t, codersdk.ConnectionTypeFileTransfer, sessionLog.Type)
+		require.NotNil(t, sessionLog.SSHInfo)
+		require.Nil(t, sessionLog.FileTransferInfo)
+
+		// File operations are point-in-time events and excluded from
+		// status filter results.
+		logs, err = client.ConnectionLogs(ctx, codersdk.ConnectionLogsRequest{
+			SearchQuery: "status:ongoing connection_id:" + connID.String(),
+		})
+		require.NoError(t, err)
+		require.Len(t, logs.ConnectionLogs, 1)
+		require.Equal(t, codersdk.ConnectionTypeFileTransfer, logs.ConnectionLogs[0].Type)
+	})
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3696,8 +3696,69 @@ export interface ConnectionLog {
 	 * - `ConnectionTypeReconnectingPTY`
 	 * - `ConnectionTypeVSCode`
 	 * - `ConnectionTypeJetBrains`
+	 * - `ConnectionTypeFileTransfer`
 	 */
 	readonly ssh_info?: ConnectionLogSSHInfo;
+	/**
+	 * FileTransferInfo is only set when `type` is
+	 * `ConnectionTypeFileOperation`.
+	 */
+	readonly file_transfer_info?: ConnectionLogFileTransferInfo;
+}
+
+// From codersdk/connectionlog.go
+export type ConnectionLogFileAction =
+	| "bidirectional"
+	| "download"
+	| "hardlink"
+	| "remove"
+	| "rename"
+	| "rmdir"
+	| "setattr"
+	| "symlink"
+	| "upload";
+
+export const ConnectionLogFileActions: ConnectionLogFileAction[] = [
+	"bidirectional",
+	"download",
+	"hardlink",
+	"remove",
+	"rename",
+	"rmdir",
+	"setattr",
+	"symlink",
+	"upload",
+];
+
+// From codersdk/connectionlog.go
+export type ConnectionLogFileProtocol = "rsync" | "scp" | "sftp";
+
+export const ConnectionLogFileProtocols: ConnectionLogFileProtocol[] = [
+	"rsync",
+	"scp",
+	"sftp",
+];
+
+// From codersdk/connectionlog.go
+export interface ConnectionLogFileTransferInfo {
+	/**
+	 * ConnectionID matches the connection ID of the file_transfer
+	 * session the operation occurred in.
+	 */
+	readonly connection_id: string;
+	readonly protocol: ConnectionLogFileProtocol;
+	readonly action: ConnectionLogFileAction;
+	/**
+	 * Path is the path the operation was performed on. For SCP and
+	 * rsync this is the requested root path from the command line, not
+	 * necessarily every file transferred.
+	 */
+	readonly path: string;
+	/**
+	 * Target is only set for operations with a second path, such as the
+	 * destination of a rename or the target of a symlink.
+	 */
+	readonly target?: string;
 }
 
 // From codersdk/connectionlog.go
@@ -3761,6 +3822,8 @@ export const ConnectionMethods: ConnectionMethod[] = ["derp", "direct", ""];
 
 // From codersdk/connectionlog.go
 export type ConnectionType =
+	| "file_operation"
+	| "file_transfer"
 	| "jetbrains"
 	| "port_forwarding"
 	| "reconnecting_pty"
@@ -3770,6 +3833,8 @@ export type ConnectionType =
 	| "workspace_app";
 
 export const ConnectionTypes: ConnectionType[] = [
+	"file_operation",
+	"file_transfer",
 	"jetbrains",
 	"port_forwarding",
 	"reconnecting_pty",

--- a/site/src/pages/ConnectionLogPage/ConnectionLogPageView.stories.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogPageView.stories.tsx
@@ -13,6 +13,8 @@ import type { UsePaginatedQueryResult } from "#/hooks/usePaginatedQuery";
 import {
 	MockConnectedSSHConnectionLog,
 	MockDisconnectedSSHConnectionLog,
+	MockFileOperationConnectionLog,
+	MockFileTransferConnectionLog,
 	MockPermissions,
 	MockUserOwner,
 } from "#/testHelpers/entities";
@@ -43,6 +45,8 @@ const meta: Meta<typeof ConnectionLogPageView> = {
 		connectionLogs: [
 			MockConnectedSSHConnectionLog,
 			MockDisconnectedSSHConnectionLog,
+			MockFileTransferConnectionLog,
+			MockFileOperationConnectionLog,
 		],
 		isConnectionLogVisible: true,
 		filterProps: defaultFilterProps,

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogDescription/ConnectionLogDescription.tsx
@@ -1,8 +1,53 @@
 import type { FC, ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
-import type { ConnectionLog } from "#/api/typesGenerated";
+import type {
+	ConnectionLog,
+	ConnectionLogFileAction,
+	ConnectionLogFileProtocol,
+} from "#/api/typesGenerated";
 import { Link } from "#/components/Link/Link";
 import { connectionTypeToFriendlyName } from "#/utils/connection";
+
+const fileProtocolToFriendlyName = (
+	protocol: ConnectionLogFileProtocol,
+): string => {
+	switch (protocol) {
+		case "sftp":
+			return "SFTP";
+		case "scp":
+			return "SCP";
+		case "rsync":
+			return "rsync";
+	}
+};
+
+// fileActionToDescription phrases the file action for a sentence like
+// "SFTP session <action> <path>". For SCP/rsync the path is the
+// requested root, so the phrasing stays non-committal about individual
+// files.
+const fileActionToDescription = (action: ConnectionLogFileAction): string => {
+	switch (action) {
+		case "download":
+			return "downloaded";
+		case "upload":
+			return "uploaded";
+		case "bidirectional":
+			// Opened for both directions at once; either may have occurred.
+			return "downloaded and/or uploaded";
+		case "remove":
+			return "removed";
+		case "rmdir":
+			return "removed directory";
+		case "rename":
+			return "renamed";
+		case "symlink":
+			return "created symlink";
+		case "setattr":
+			return "changed attributes of";
+		case "hardlink":
+			return "created hard link to";
+	}
+};
 
 interface ConnectionLogDescriptionProps {
 	connectionLog: ConnectionLog;
@@ -11,8 +56,13 @@ interface ConnectionLogDescriptionProps {
 export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 	connectionLog,
 }) => {
-	const { type, workspace_owner_username, workspace_name, web_info } =
-		connectionLog;
+	const {
+		type,
+		workspace_owner_username,
+		workspace_name,
+		web_info,
+		file_transfer_info,
+	} = connectionLog;
 
 	switch (type) {
 		case "port_forwarding":
@@ -75,7 +125,8 @@ export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 		case "reconnecting_pty":
 		case "ssh":
 		case "jetbrains":
-		case "vscode": {
+		case "vscode":
+		case "file_transfer": {
 			const friendlyType = connectionTypeToFriendlyName(type);
 			return (
 				<span>
@@ -86,6 +137,31 @@ export const ConnectionLogDescription: FC<ConnectionLogDescriptionProps> = ({
 						</RouterLink>
 					</Link>{" "}
 					workspace{" "}
+				</span>
+			);
+		}
+
+		case "file_operation": {
+			if (!file_transfer_info) return null;
+			const { protocol, action, path, target } = file_transfer_info;
+			const friendlyProtocol = fileProtocolToFriendlyName(protocol);
+			const actionText = fileActionToDescription(action);
+			return (
+				<span>
+					{friendlyProtocol} session {actionText} <strong>{path}</strong>
+					{target && (
+						<>
+							{" "}
+							→ <strong>{target}</strong>
+						</>
+					)}{" "}
+					in {workspace_owner_username}'s{" "}
+					<Link asChild showExternalIcon={false} className="text-base">
+						<RouterLink to={`/@${workspace_owner_username}/${workspace_name}`}>
+							<strong>{workspace_name}</strong>
+						</RouterLink>
+					</Link>{" "}
+					workspace
 				</span>
 			);
 		}

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.stories.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.stories.tsx
@@ -3,6 +3,8 @@ import { Table, TableBody } from "#/components/Table/Table";
 import {
 	MockConnectedSSHConnectionLog,
 	MockDisconnectedSSHConnectionLog,
+	MockFileOperationConnectionLog,
+	MockFileTransferConnectionLog,
 	MockWebConnectionLog,
 } from "#/testHelpers/entities";
 import { ConnectionLogRow } from "./ConnectionLogRow";
@@ -65,6 +67,84 @@ export const DisconnectedSSHError: Story = {
 			ssh_info: {
 				...MockDisconnectedSSHConnectionLog.ssh_info!,
 				exit_code: 130, // 128 + SIGINT
+			},
+		},
+	},
+};
+
+export const BlockedFileTransfer: Story = {
+	args: {
+		connectionLog: MockFileTransferConnectionLog,
+	},
+};
+
+export const CompletedFileTransfer: Story = {
+	args: {
+		connectionLog: {
+			...MockFileTransferConnectionLog,
+			ssh_info: {
+				...MockFileTransferConnectionLog.ssh_info!,
+				disconnect_reason: "",
+				exit_code: 0,
+			},
+		},
+	},
+};
+
+export const FileOperationDownload: Story = {
+	args: {
+		connectionLog: MockFileOperationConnectionLog,
+	},
+};
+
+export const FileOperationUpload: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				action: "upload",
+				path: "/home/coder/upload.tar.gz",
+			},
+		},
+	},
+};
+
+export const FileOperationRename: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				action: "rename",
+				path: "/home/coder/old-name.txt",
+				target: "/home/coder/new-name.txt",
+			},
+		},
+	},
+};
+
+export const FileOperationSCPUpload: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				protocol: "scp",
+				action: "upload",
+				path: "/home/coder/project",
+			},
+		},
+	},
+};
+
+export const FileOperationLongPath: Story = {
+	args: {
+		connectionLog: {
+			...MockFileOperationConnectionLog,
+			file_transfer_info: {
+				...MockFileOperationConnectionLog.file_transfer_info!,
+				path: "/home/coder/some/deeply/nested/directory/structure/with/a/very/long/path/to/an/important/file/that/should/not/break/the/layout.json",
 			},
 		},
 	},

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3138,6 +3138,32 @@ export const MockDisconnectedSSHConnectionLog: TypesGen.ConnectionLog = {
 	},
 };
 
+export const MockFileTransferConnectionLog: TypesGen.ConnectionLog = {
+	...MockDisconnectedSSHConnectionLog,
+	id: "104d54e8-2fd8-42f6-9cf9-e57eabb384fd",
+	type: "file_transfer",
+	ssh_info: {
+		connection_id: "8b3f81ed-b3ba-4b4a-a15b-c437936b2286",
+		disconnect_reason: "process exited with error status: 65",
+		disconnect_time: "2022-05-19T16:49:57.122Z",
+		exit_code: 65, // File transfer blocked.
+	},
+};
+
+export const MockFileOperationConnectionLog: TypesGen.ConnectionLog = {
+	...MockConnectedSSHConnectionLog,
+	id: "b2cd7b2e-2fd8-42f6-9cf9-e57eabb384fd",
+	type: "file_operation",
+	ssh_info: undefined,
+	file_transfer_info: {
+		connection_id: "8b3f81ed-b3ba-4b4a-a15b-c437936b2286",
+		protocol: "sftp",
+		action: "download",
+		path: "/home/coder/secrets.env",
+		target: undefined,
+	},
+};
+
 export const MockWorkspaceQuota: TypesGen.WorkspaceQuota = {
 	credits_consumed: 0,
 	budget: 100,

--- a/site/src/utils/connection.ts
+++ b/site/src/utils/connection.ts
@@ -16,6 +16,10 @@ export const connectionTypeToFriendlyName = (type: ConnectionType): string => {
 			return "Workspace App";
 		case "tunnel":
 			return "Tunnel";
+		case "file_transfer":
+			return "File Transfer";
+		case "file_operation":
+			return "File Operation";
 	}
 };
 
@@ -34,7 +38,9 @@ export const connectionTypeIsWeb = (type: ConnectionType): boolean => {
 		case "reconnecting_pty":
 		case "ssh":
 		case "jetbrains":
-		case "vscode": {
+		case "vscode":
+		case "file_transfer":
+		case "file_operation": {
 			return false;
 		}
 	}


### PR DESCRIPTION
Final PR in the file-transfer visibility stack, on top of #28334. The coderd side: storing, serving, and displaying agent-reported file operations.

Previously, a file transfer was indistinguishable from any other SSH session in the connection log: SFTP is served in-process by the agent, so pulling files out of a workspace left no distinct trace. With this PR, each observed operation becomes a `file_operation` row in `connection_logs`, sharing the connection ID of its parent `file_transfer` session so a session and everything it touched can be audited together (`connection_id:<uuid>` search returns both).

- `ReportFileOperations` (previously an `Unimplemented` stub) validates agent reports and inserts operation rows with the protocol, action, path, and optional second path (rename destination, symlink/hardlink target). Like other agent-reported rows, they carry no user attribution; auditors correlate via the adjacent `tunnel` row and the workspace owner.
- The enterprise batcher exempts operation rows from connect/disconnect deduplication.
- The connection log API returns a `file_transfer_info` detail object, and the UI describes each operation ("SFTP session downloaded /home/coder/secrets.txt").
- Docs cover semantics and limitations: scp/rsync record only the requested root path, `nc` remains an unclassified `ssh` session, the 512-op session cap, the agent v2.11 requirement, and that this is visibility, not a security boundary.

A large rsync or scp of many files produces a single operation row (direction + root path parsed from argv); only SFTP is decoded per-operation, bounded by per-session dedup and the 512 cap.
