### PR TITLE
feat: attribute session counts by app family

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3878,14 +3878,6 @@ func (q *querier) GetDeploymentID(ctx context.Context) (string, error) {
 	return q.db.GetDeploymentID(ctx)
 }
 
-func (q *querier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAfter time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
-	return q.db.GetDeploymentWorkspaceAgentStats(ctx, createdAfter)
-}
-
-func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
-	return q.db.GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt)
-}
-
 func (q *querier) GetDeploymentWorkspaceStats(ctx context.Context) (database.GetDeploymentWorkspaceStatsRow, error) {
 	return q.db.GetDeploymentWorkspaceStats(ctx)
 }
@@ -4877,14 +4869,6 @@ func (q *querier) GetTemplateInsightsByInterval(ctx context.Context, arg databas
 	return q.db.GetTemplateInsightsByInterval(ctx, arg)
 }
 
-func (q *querier) GetTemplateInsightsByTemplate(ctx context.Context, arg database.GetTemplateInsightsByTemplateParams) ([]database.GetTemplateInsightsByTemplateRow, error) {
-	// Only used by prometheus metrics collector. No need to check update template perms.
-	if err := q.authorizeContext(ctx, policy.ActionViewInsights, rbac.ResourceTemplate); err != nil {
-		return nil, err
-	}
-	return q.db.GetTemplateInsightsByTemplate(ctx, arg)
-}
-
 func (q *querier) GetTemplateParameterInsights(ctx context.Context, arg database.GetTemplateParameterInsightsParams) ([]database.GetTemplateParameterInsightsRow, error) {
 	if err := q.authorizeTemplateInsights(ctx, arg.TemplateIDs); err != nil {
 		return nil, err
@@ -5625,22 +5609,6 @@ func (q *querier) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []
 		return nil, err
 	}
 	return q.db.GetWorkspaceAgentScriptsByAgentIDs(ctx, ids)
-}
-
-func (q *querier) GetWorkspaceAgentStats(ctx context.Context, createdAfter time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
-	return q.db.GetWorkspaceAgentStats(ctx, createdAfter)
-}
-
-func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAfter time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
-	return q.db.GetWorkspaceAgentStatsAndLabels(ctx, createdAfter)
-}
-
-func (q *querier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
-	return q.db.GetWorkspaceAgentUsageStats(ctx, createdAt)
-}
-
-func (q *querier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
-	return q.db.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt)
 }
 
 func (q *querier) GetWorkspaceAgentsByInstanceID(ctx context.Context, authInstanceID string) ([]database.WorkspaceAgent, error) {
@@ -9377,13 +9345,6 @@ func (q *querier) UpsertTelemetryItem(ctx context.Context, arg database.UpsertTe
 		return err
 	}
 	return q.db.UpsertTelemetryItem(ctx, arg)
-}
-
-func (q *querier) UpsertTemplateUsageStats(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
-		return err
-	}
-	return q.db.UpsertTemplateUsageStats(ctx)
 }
 
 func (q *querier) UpsertUserAIBudgetOverride(ctx context.Context, arg database.UpsertUserAIBudgetOverrideParams) (database.UserAIBudgetOverride, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"reflect"
 	"strconv"
@@ -3009,7 +3010,7 @@ func (s *MethodTestSuite) TestTemplate() {
 		check.Args(arg).Asserts(rbac.ResourceTemplate, policy.ActionViewInsights)
 	}))
 	s.Run("GetTemplateInsightsByTemplate", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetTemplateInsightsByTemplateParams{}
+		arg := database.GetTemplateInsightsByTemplateParams{AppFamilies: codersdk.SessionCountAppFamiliesJSON()}
 		dbm.EXPECT().GetTemplateInsightsByTemplate(gomock.Any(), arg).Return([]database.GetTemplateInsightsByTemplateRow{}, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceTemplate, policy.ActionViewInsights)
 	}))
@@ -3034,8 +3035,9 @@ func (s *MethodTestSuite) TestTemplate() {
 		check.Args(arg).Asserts(rbac.ResourceTemplate, policy.ActionViewInsights).Returns([]database.TemplateUsageStat{})
 	}))
 	s.Run("UpsertTemplateUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		dbm.EXPECT().UpsertTemplateUsageStats(gomock.Any()).Return(nil).AnyTimes()
-		check.Asserts(rbac.ResourceSystem, policy.ActionUpdate)
+		arg := codersdk.SessionCountAppFamiliesJSON()
+		dbm.EXPECT().UpsertTemplateUsageStats(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceSystem, policy.ActionUpdate)
 	}))
 	s.Run("UpdatePresetsLastInvalidatedAt", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		t1 := testutil.Fake(s.T(), faker, database.Template{})
@@ -5534,14 +5536,20 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		check.Args("foo").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
 	s.Run("GetDeploymentWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		t := time.Time{}
-		dbm.EXPECT().GetDeploymentWorkspaceAgentStats(gomock.Any(), t).Return(database.GetDeploymentWorkspaceAgentStatsRow{}, nil).AnyTimes()
-		check.Args(t).Asserts()
+		arg := database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:   time.Time{},
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		}
+		dbm.EXPECT().GetDeploymentWorkspaceAgentStats(gomock.Any(), arg).Return(database.GetDeploymentWorkspaceAgentStatsRow{}, nil).AnyTimes()
+		check.Args(arg).Asserts()
 	}))
 	s.Run("GetDeploymentWorkspaceAgentUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		t := time.Time{}
-		dbm.EXPECT().GetDeploymentWorkspaceAgentUsageStats(gomock.Any(), t).Return(database.GetDeploymentWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
-		check.Args(t).Asserts()
+		arg := database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:   time.Time{},
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		}
+		dbm.EXPECT().GetDeploymentWorkspaceAgentUsageStats(gomock.Any(), arg).Return(database.GetDeploymentWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
+		check.Args(arg).Asserts()
 	}))
 	s.Run("GetDeploymentWorkspaceStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetDeploymentWorkspaceStats(gomock.Any()).Return(database.GetDeploymentWorkspaceStatsRow{}, nil).AnyTimes()
@@ -5569,24 +5577,36 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		check.Args(arg).Asserts(rbac.ResourceSystem, policy.ActionUpdate)
 	}))
 	s.Run("GetWorkspaceAgentStatsAndLabels", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentStatsAndLabels(gomock.Any(), t).Return([]database.GetWorkspaceAgentStatsAndLabelsRow{}, nil).AnyTimes()
-		check.Args(t).Asserts()
+		arg := database.GetWorkspaceAgentStatsAndLabelsParams{
+			CreatedAt:   time.Time{},
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		}
+		dbm.EXPECT().GetWorkspaceAgentStatsAndLabels(gomock.Any(), arg).Return([]database.GetWorkspaceAgentStatsAndLabelsRow{}, nil).AnyTimes()
+		check.Args(arg).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentUsageStatsAndLabels", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentUsageStatsAndLabels(gomock.Any(), t).Return([]database.GetWorkspaceAgentUsageStatsAndLabelsRow{}, nil).AnyTimes()
-		check.Args(t).Asserts()
+		arg := database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+			CreatedAt:   time.Time{},
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		}
+		dbm.EXPECT().GetWorkspaceAgentUsageStatsAndLabels(gomock.Any(), arg).Return([]database.GetWorkspaceAgentUsageStatsAndLabelsRow{}, nil).AnyTimes()
+		check.Args(arg).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentStats(gomock.Any(), t).Return([]database.GetWorkspaceAgentStatsRow{}, nil).AnyTimes()
-		check.Args(t).Asserts()
+		arg := database.GetWorkspaceAgentStatsParams{
+			CreatedAt:   time.Time{},
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		}
+		dbm.EXPECT().GetWorkspaceAgentStats(gomock.Any(), arg).Return([]database.GetWorkspaceAgentStatsRow{}, nil).AnyTimes()
+		check.Args(arg).Asserts()
 	}))
 	s.Run("GetWorkspaceAgentUsageStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		t := time.Time{}
-		dbm.EXPECT().GetWorkspaceAgentUsageStats(gomock.Any(), t).Return([]database.GetWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
-		check.Args(t).Asserts()
+		arg := database.GetWorkspaceAgentUsageStatsParams{
+			CreatedAt:   time.Time{},
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		}
+		dbm.EXPECT().GetWorkspaceAgentUsageStats(gomock.Any(), arg).Return([]database.GetWorkspaceAgentUsageStatsRow{}, nil).AnyTimes()
+		check.Args(arg).Asserts()
 	}))
 	s.Run("GetWorkspaceProxyByHostname", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		p := testutil.Fake(s.T(), faker, database.WorkspaceProxy{WildcardHostname: "*.example.com"})
@@ -7946,4 +7966,101 @@ func TestAsExternalAuthChecker(t *testing.T) {
 			require.Error(t, err, "%s read should be denied", res.Type)
 		}
 	})
+}
+
+// TestSessionCountAppFamiliesRequired ensures the session count queries fail
+// loudly when the app family registry is empty, so a forgotten parameter
+// surfaces as an error instead of silently dropping every family's sessions
+// from usage reporting.
+func TestSessionCountAppFamiliesRequired(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dbm := dbmock.NewMockStore(ctrl)
+	dbm.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+	q := dbauthz.New(dbm, &coderdtest.RecordingAuthorizer{Wrapped: &coderdtest.FakeAuthorizer{}}, slog.Make(), coderdtest.AccessControlStorePointer())
+	ctx := dbauthz.As(context.Background(), coderdtest.RandomRBACSubject())
+
+	_, err := q.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{})
+	require.ErrorContains(t, err, "developer error")
+	_, err = q.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{})
+	require.ErrorContains(t, err, "developer error")
+	_, err = q.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{})
+	require.ErrorContains(t, err, "developer error")
+	_, err = q.GetWorkspaceAgentStatsAndLabels(ctx, database.GetWorkspaceAgentStatsAndLabelsParams{})
+	require.ErrorContains(t, err, "developer error")
+	_, err = q.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{})
+	require.ErrorContains(t, err, "developer error")
+	_, err = q.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{})
+	require.ErrorContains(t, err, "developer error")
+	_, err = q.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{})
+	require.ErrorContains(t, err, "developer error")
+	err = q.UpsertTemplateUsageStats(ctx, nil)
+	require.ErrorContains(t, err, "developer error")
+}
+
+// TestSessionCountAppFamiliesMustMatchQueries covers registries that are
+// present but wrong. Each query hardcodes one probe per family, so a registry
+// whose keys drifted from codersdk.AttributedAppFamilies would report zero
+// for the affected family instead of failing.
+func TestSessionCountAppFamiliesMustMatchQueries(t *testing.T) {
+	t.Parallel()
+
+	valid := map[codersdk.AppFamilyName][]string{}
+	for _, family := range codersdk.AttributedAppFamilies() {
+		valid[family] = []string{string(family)}
+	}
+	without := func(drop codersdk.AppFamilyName) json.RawMessage {
+		families := maps.Clone(valid)
+		delete(families, drop)
+		return mustMarshalAppFamilies(t, families)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		appFamilies json.RawMessage
+		errContains string
+	}{
+		{"EmptyObject", json.RawMessage(`{}`), `missing family "vscode"`},
+		{"JSONNull", json.RawMessage(`null`), `missing family "vscode"`},
+		{"NotAnObject", json.RawMessage(`["vscode"]`), "must be a JSON object"},
+		{"MissingFamily", without(codersdk.AppFamilySSH), `missing family "ssh"`},
+		{"EmptyAppNames", mustMarshalAppFamilies(t, map[codersdk.AppFamilyName][]string{
+			codersdk.AppFamilyVSCode:          {"vscode"},
+			codersdk.AppFamilyJetBrains:       {"jetbrains"},
+			codersdk.AppFamilySSH:             {},
+			codersdk.AppFamilyReconnectingPTY: {"reconnecting_pty"},
+		}), `no app names for family "ssh"`},
+		{"UnknownFamily", mustMarshalAppFamilies(t, map[codersdk.AppFamilyName][]string{
+			codersdk.AppFamilyVSCode:          {"vscode"},
+			codersdk.AppFamilyJetBrains:       {"jetbrains"},
+			codersdk.AppFamilySSH:             {"ssh"},
+			codersdk.AppFamilyReconnectingPTY: {"reconnecting_pty"},
+			"emacs":                           {"emacs"},
+		}), `has family "emacs"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			dbm := dbmock.NewMockStore(ctrl)
+			dbm.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+			q := dbauthz.New(dbm, &coderdtest.RecordingAuthorizer{Wrapped: &coderdtest.FakeAuthorizer{}}, slog.Make(), coderdtest.AccessControlStorePointer())
+			ctx := dbauthz.As(context.Background(), coderdtest.RandomRBACSubject())
+
+			_, err := q.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{AppFamilies: tc.appFamilies})
+			require.ErrorContains(t, err, tc.errContains)
+			err = q.UpsertTemplateUsageStats(ctx, tc.appFamilies)
+			require.ErrorContains(t, err, tc.errContains)
+		})
+	}
+}
+
+func mustMarshalAppFamilies(t *testing.T, families map[codersdk.AppFamilyName][]string) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(families)
+	require.NoError(t, err)
+	return raw
 }

--- a/coderd/database/dbauthz/sessioncountparams.go
+++ b/coderd/database/dbauthz/sessioncountparams.go
@@ -1,0 +1,118 @@
+package dbauthz
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// The session count read queries take the app family attribution registry as
+// a single jsonb parameter. Every query hardcodes one probe per family, so a
+// registry that is empty, malformed, or keyed differently from
+// codersdk.AttributedAppFamilies would still run and return zero counts for
+// the affected families, silently dropping sessions from deployment stats,
+// insights, Prometheus, and telemetry. dbauthz wraps every production store,
+// including the transaction stores used by the rollup, so validating here
+// makes a wrong registry fail the call loudly instead of failing the data
+// quietly. These methods override the generated ones in dbauthz.go;
+// scripts/dbgen preserves methods defined outside that file.
+
+// validateSessionCountAppFamilies checks that the registry has exactly the
+// families the queries probe, each with at least one app name.
+func validateSessionCountAppFamilies(appFamilies json.RawMessage) error {
+	if len(appFamilies) == 0 {
+		return xerrors.New("developer error: session count app families must not be empty, populate them with codersdk.SessionCountAppFamiliesJSON()")
+	}
+
+	var families map[codersdk.AppFamilyName][]string
+	if err := json.Unmarshal(appFamilies, &families); err != nil {
+		return xerrors.Errorf("developer error: session count app families must be a JSON object of family to app names, populate them with codersdk.SessionCountAppFamiliesJSON(): %w", err)
+	}
+
+	required := codersdk.AttributedAppFamilies()
+	for _, family := range required {
+		appNames, ok := families[family]
+		if !ok {
+			return xerrors.Errorf("developer error: session count app families is missing family %q, which the queries probe; populate them with codersdk.SessionCountAppFamiliesJSON()", family)
+		}
+		if len(appNames) == 0 {
+			return xerrors.Errorf("developer error: session count app families has no app names for family %q, so its sessions would go uncounted", family)
+		}
+	}
+	for family := range families {
+		if !slices.Contains(required, family) {
+			return xerrors.Errorf("developer error: session count app families has family %q, which no query probes; add a probe per query or drop it from codersdk.AttributedAppFamilies", family)
+		}
+	}
+	return nil
+}
+
+func (q *querier) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return database.GetDeploymentWorkspaceAgentStatsRow{}, err
+	}
+	return q.db.GetDeploymentWorkspaceAgentStats(ctx, arg)
+}
+
+func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return database.GetDeploymentWorkspaceAgentUsageStatsRow{}, err
+	}
+	return q.db.GetDeploymentWorkspaceAgentUsageStats(ctx, arg)
+}
+
+func (q *querier) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return nil, err
+	}
+	return q.db.GetWorkspaceAgentStats(ctx, arg)
+}
+
+func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return nil, err
+	}
+	return q.db.GetWorkspaceAgentStatsAndLabels(ctx, arg)
+}
+
+func (q *querier) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return nil, err
+	}
+	return q.db.GetWorkspaceAgentUsageStats(ctx, arg)
+}
+
+func (q *querier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return nil, err
+	}
+	return q.db.GetWorkspaceAgentUsageStatsAndLabels(ctx, arg)
+}
+
+func (q *querier) GetTemplateInsightsByTemplate(ctx context.Context, arg database.GetTemplateInsightsByTemplateParams) ([]database.GetTemplateInsightsByTemplateRow, error) {
+	// Only used by prometheus metrics collector. No need to check update template perms.
+	if err := q.authorizeContext(ctx, policy.ActionViewInsights, rbac.ResourceTemplate); err != nil {
+		return nil, err
+	}
+	if err := validateSessionCountAppFamilies(arg.AppFamilies); err != nil {
+		return nil, err
+	}
+	return q.db.GetTemplateInsightsByTemplate(ctx, arg)
+}
+
+func (q *querier) UpsertTemplateUsageStats(ctx context.Context, appFamilies json.RawMessage) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
+		return err
+	}
+	if err := validateSessionCountAppFamilies(appFamilies); err != nil {
+		return err
+	}
+	return q.db.UpsertTemplateUsageStats(ctx, appFamilies)
+}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -5,6 +5,7 @@ package dbmetrics
 
 import (
 	"context"
+	"encoding/json"
 	"slices"
 	"time"
 
@@ -2024,17 +2025,17 @@ func (m queryMetricsStore) GetDeploymentID(ctx context.Context) (string, error) 
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (m queryMetricsStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetDeploymentWorkspaceAgentStats(ctx, createdAt)
+	r0, r1 := m.s.GetDeploymentWorkspaceAgentStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceAgentStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetDeploymentWorkspaceAgentStats").Inc()
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (m queryMetricsStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt)
+	r0, r1 := m.s.GetDeploymentWorkspaceAgentUsageStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceAgentUsageStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetDeploymentWorkspaceAgentUsageStats").Inc()
 	return r0, r1
@@ -3656,33 +3657,33 @@ func (m queryMetricsStore) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Contex
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetWorkspaceAgentStats(ctx, createdAt)
+	r0, r1 := m.s.GetWorkspaceAgentStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetWorkspaceAgentStats").Inc()
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetWorkspaceAgentStatsAndLabels(ctx, createdAt)
+	r0, r1 := m.s.GetWorkspaceAgentStatsAndLabels(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentStatsAndLabels").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetWorkspaceAgentStatsAndLabels").Inc()
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetWorkspaceAgentUsageStats(ctx, createdAt)
+	r0, r1 := m.s.GetWorkspaceAgentUsageStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentUsageStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetWorkspaceAgentUsageStats").Inc()
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (m queryMetricsStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt)
+	r0, r1 := m.s.GetWorkspaceAgentUsageStatsAndLabels(ctx, arg)
 	m.queryLatencies.WithLabelValues("GetWorkspaceAgentUsageStatsAndLabels").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetWorkspaceAgentUsageStatsAndLabels").Inc()
 	return r0, r1
@@ -6648,9 +6649,9 @@ func (m queryMetricsStore) UpsertTelemetryItem(ctx context.Context, arg database
 	return r0
 }
 
-func (m queryMetricsStore) UpsertTemplateUsageStats(ctx context.Context) error {
+func (m queryMetricsStore) UpsertTemplateUsageStats(ctx context.Context, arg json.RawMessage) error {
 	start := time.Now()
-	r0 := m.s.UpsertTemplateUsageStats(ctx)
+	r0 := m.s.UpsertTemplateUsageStats(ctx, arg)
 	m.queryLatencies.WithLabelValues("UpsertTemplateUsageStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertTemplateUsageStats").Inc()
 	return r0

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -11,6 +11,7 @@ package dbmock
 
 import (
 	context "context"
+	json "encoding/json"
 	reflect "reflect"
 	time "time"
 
@@ -3795,33 +3796,33 @@ func (mr *MockStoreMockRecorder) GetDeploymentID(ctx any) *gomock.Call {
 }
 
 // GetDeploymentWorkspaceAgentStats mocks base method.
-func (m *MockStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
+func (m *MockStore) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentStatsParams) (database.GetDeploymentWorkspaceAgentStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentStats", ctx, arg)
 	ret0, _ := ret[0].(database.GetDeploymentWorkspaceAgentStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeploymentWorkspaceAgentStats indicates an expected call of GetDeploymentWorkspaceAgentStats.
-func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentStats), ctx, arg)
 }
 
 // GetDeploymentWorkspaceAgentUsageStats mocks base method.
-func (m *MockStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+func (m *MockStore) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg database.GetDeploymentWorkspaceAgentUsageStatsParams) (database.GetDeploymentWorkspaceAgentUsageStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentUsageStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetDeploymentWorkspaceAgentUsageStats", ctx, arg)
 	ret0, _ := ret[0].(database.GetDeploymentWorkspaceAgentUsageStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeploymentWorkspaceAgentUsageStats indicates an expected call of GetDeploymentWorkspaceAgentUsageStats.
-func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentUsageStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceAgentUsageStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentUsageStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceAgentUsageStats), ctx, arg)
 }
 
 // GetDeploymentWorkspaceStats mocks base method.
@@ -6885,63 +6886,63 @@ func (mr *MockStoreMockRecorder) GetWorkspaceAgentScriptsByAgentIDs(ctx, ids any
 }
 
 // GetWorkspaceAgentStats mocks base method.
-func (m *MockStore) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsRow, error) {
+func (m *MockStore) GetWorkspaceAgentStats(ctx context.Context, arg database.GetWorkspaceAgentStatsParams) ([]database.GetWorkspaceAgentStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentStats", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentStats indicates an expected call of GetWorkspaceAgentStats.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStats), ctx, arg)
 }
 
 // GetWorkspaceAgentStatsAndLabels mocks base method.
-func (m *MockStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
+func (m *MockStore) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentStatsAndLabelsParams) ([]database.GetWorkspaceAgentStatsAndLabelsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentStatsAndLabels", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentStatsAndLabels", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentStatsAndLabelsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentStatsAndLabels indicates an expected call of GetWorkspaceAgentStatsAndLabels.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentStatsAndLabels(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentStatsAndLabels(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStatsAndLabels), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentStatsAndLabels), ctx, arg)
 }
 
 // GetWorkspaceAgentUsageStats mocks base method.
-func (m *MockStore) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
+func (m *MockStore) GetWorkspaceAgentUsageStats(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsParams) ([]database.GetWorkspaceAgentUsageStatsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStats", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStats", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentUsageStatsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentUsageStats indicates an expected call of GetWorkspaceAgentUsageStats.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStats(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStats(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStats), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStats", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStats), ctx, arg)
 }
 
 // GetWorkspaceAgentUsageStatsAndLabels mocks base method.
-func (m *MockStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+func (m *MockStore) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg database.GetWorkspaceAgentUsageStatsAndLabelsParams) ([]database.GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStatsAndLabels", ctx, createdAt)
+	ret := m.ctrl.Call(m, "GetWorkspaceAgentUsageStatsAndLabels", ctx, arg)
 	ret0, _ := ret[0].([]database.GetWorkspaceAgentUsageStatsAndLabelsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspaceAgentUsageStatsAndLabels indicates an expected call of GetWorkspaceAgentUsageStatsAndLabels.
-func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAt any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspaceAgentUsageStatsAndLabels(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStatsAndLabels), ctx, createdAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceAgentUsageStatsAndLabels", reflect.TypeOf((*MockStore)(nil).GetWorkspaceAgentUsageStatsAndLabels), ctx, arg)
 }
 
 // GetWorkspaceAgentsByInstanceID mocks base method.
@@ -12495,17 +12496,17 @@ func (mr *MockStoreMockRecorder) UpsertTelemetryItem(ctx, arg any) *gomock.Call 
 }
 
 // UpsertTemplateUsageStats mocks base method.
-func (m *MockStore) UpsertTemplateUsageStats(ctx context.Context) error {
+func (m *MockStore) UpsertTemplateUsageStats(ctx context.Context, appFamilies json.RawMessage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertTemplateUsageStats", ctx)
+	ret := m.ctrl.Call(m, "UpsertTemplateUsageStats", ctx, appFamilies)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertTemplateUsageStats indicates an expected call of UpsertTemplateUsageStats.
-func (mr *MockStoreMockRecorder) UpsertTemplateUsageStats(ctx any) *gomock.Call {
+func (mr *MockStoreMockRecorder) UpsertTemplateUsageStats(ctx, appFamilies any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTemplateUsageStats", reflect.TypeOf((*MockStore)(nil).UpsertTemplateUsageStats), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTemplateUsageStats", reflect.TypeOf((*MockStore)(nil).UpsertTemplateUsageStats), ctx, appFamilies)
 }
 
 // UpsertUserAIBudgetOverride mocks base method.

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -352,6 +352,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	clk := quartz.NewReal()
 	db, _ := dbtestutil.NewDB(t)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	appFamilies := codersdk.SessionCountAppFamiliesJSON()
 
 	defer func() {
 		if t.Failed() {
@@ -360,7 +361,10 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 			buf := &bytes.Buffer{}
 			enc := json.NewEncoder(buf)
 			enc.SetIndent("", "\t")
-			wasRows, err := db.GetWorkspaceAgentStats(ctx, now.AddDate(0, -7, 0))
+			wasRows, err := db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+				CreatedAt:   now.AddDate(0, -7, 0),
+				AppFamilies: appFamilies,
+			})
 			if err == nil {
 				_, _ = fmt.Fprintf(buf, "workspace agent stats: ")
 				_ = enc.Encode(wasRows)
@@ -422,7 +426,10 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	var err error
 	require.Eventuallyf(t, func() bool {
 		// Query all stats created not earlier than ~7 months ago
-		stats, err = db.GetWorkspaceAgentStats(ctx, now.AddDate(0, 0, -210))
+		stats, err = db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+			CreatedAt:   now.AddDate(0, 0, -210),
+			AppFamilies: appFamilies,
+		})
 		if err != nil {
 			return false
 		}
@@ -445,7 +452,10 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	// then
 	require.Eventuallyf(t, func() bool {
 		// Query all stats created not earlier than ~7 months ago
-		stats, err = db.GetWorkspaceAgentStats(ctx, now.AddDate(0, 0, -210))
+		stats, err = db.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+			CreatedAt:   now.AddDate(0, 0, -210),
+			AppFamilies: appFamilies,
+		})
 		if err != nil {
 			return false
 		}

--- a/coderd/database/dbrollup/dbrollup.go
+++ b/coderd/database/dbrollup/dbrollup.go
@@ -10,6 +10,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 const (
@@ -106,7 +107,7 @@ func (r *Rolluper) start(ctx context.Context) {
 				}
 
 				ev.TemplateUsageStats = true
-				return tx.UpsertTemplateUsageStats(ctx)
+				return tx.UpsertTemplateUsageStats(ctx, codersdk.SessionCountAppFamiliesJSON())
 			}, database.DefaultTXOptions().WithID("db_rollup"))
 		})
 

--- a/coderd/database/dbrollup/dbrollup_test.go
+++ b/coderd/database/dbrollup/dbrollup_test.go
@@ -3,6 +3,7 @@ package dbrollup_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -43,9 +44,9 @@ func (w *wrapUpsertDB) InTx(fn func(database.Store) error, opts *database.TxOpti
 	}, opts)
 }
 
-func (w *wrapUpsertDB) UpsertTemplateUsageStats(ctx context.Context) error {
+func (w *wrapUpsertDB) UpsertTemplateUsageStats(ctx context.Context, appFamilies json.RawMessage) error {
 	<-w.resume
-	return w.Store.UpsertTemplateUsageStats(ctx)
+	return w.Store.UpsertTemplateUsageStats(ctx, appFamilies)
 }
 
 func TestRollup_TwoInstancesUseLocking(t *testing.T) {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -6,6 +6,7 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -583,8 +584,15 @@ type sqlcQuerier interface {
 	GetDefaultOrganization(ctx context.Context) (Organization, error)
 	GetDefaultProxyConfig(ctx context.Context) (GetDefaultProxyConfigRow, error)
 	GetDeploymentID(ctx context.Context) (string, error)
-	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
-	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
+	// app_families maps each attributed family to its app names, so the probes
+	// below stay one expression per family: adding a family needs a new list in
+	// fams plus one probe here, because sqlc output columns are static.
+	// fams turns the jsonb parameter into arrays once for the whole query. The
+	// lateral decomposes session_counts once per row and sums each family from
+	// that single pass, which measured ~3x faster than probing the jsonb once
+	// per family. The subplan only runs for rows that survive the gate.
+	GetDeploymentWorkspaceAgentStats(ctx context.Context, arg GetDeploymentWorkspaceAgentStatsParams) (GetDeploymentWorkspaceAgentStatsRow, error)
+	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg GetDeploymentWorkspaceAgentUsageStatsParams) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
 	GetDeploymentWorkspaceStats(ctx context.Context) (GetDeploymentWorkspaceStatsRow, error)
 	GetEligibleProvisionerDaemonsByProvisionerJobIDs(ctx context.Context, provisionerJobIds []uuid.UUID) ([]GetEligibleProvisionerDaemonsByProvisionerJobIDsRow, error)
 	// Providers can be disabled independently of their model configs.
@@ -1036,10 +1044,10 @@ type sqlcQuerier interface {
 	GetWorkspaceAgentPortShare(ctx context.Context, arg GetWorkspaceAgentPortShareParams) (WorkspaceAgentPortShare, error)
 	GetWorkspaceAgentScriptTimingsByBuildID(ctx context.Context, id uuid.UUID) ([]GetWorkspaceAgentScriptTimingsByBuildIDRow, error)
 	GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]GetWorkspaceAgentScriptsByAgentIDsRow, error)
-	GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error)
-	GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
-	GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error)
-	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
+	GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspaceAgentStatsParams) ([]GetWorkspaceAgentStatsRow, error)
+	GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentStatsAndLabelsParams) ([]GetWorkspaceAgentStatsAndLabelsRow, error)
+	GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWorkspaceAgentUsageStatsParams) ([]GetWorkspaceAgentUsageStatsRow, error)
+	GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentUsageStatsAndLabelsParams) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error)
 	GetWorkspaceAgentsByInstanceID(ctx context.Context, authInstanceID string) ([]WorkspaceAgent, error)
 	GetWorkspaceAgentsByParentID(ctx context.Context, parentID uuid.UUID) ([]WorkspaceAgent, error)
 	GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAgent, error)
@@ -1740,7 +1748,7 @@ type sqlcQuerier interface {
 	// into a single table for efficient storage and querying. Half-hour buckets are
 	// used to store the data, and the minutes are summed for each user and template
 	// combination. The result is stored in the template_usage_stats table.
-	UpsertTemplateUsageStats(ctx context.Context) error
+	UpsertTemplateUsageStats(ctx context.Context, appFamilies json.RawMessage) error
 	UpsertUserAIBudgetOverride(ctx context.Context, arg UpsertUserAIBudgetOverrideParams) (UserAIBudgetOverride, error)
 	// UpsertUserAIProviderKey preserves the original id and created_at when the
 	// user/provider pair already exists. On conflict, callers provide id and

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -67,7 +67,11 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			ConnectionMedianLatencyMS: 2,
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
-		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:   dbtime.Now().Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
@@ -104,7 +108,11 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 			ConnectionMedianLatencyMS: 2,
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 1}),
 		})
-		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, dbtime.Now().Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:   dbtime.Now().Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
@@ -173,7 +181,11 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:   dbtime.Now().Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), stats.WorkspaceTxBytes)
@@ -210,7 +222,11 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, cutoff)
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:   cutoff,
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 		require.Zero(t, stats.SessionCountVSCode)
 		require.Equal(t, int64(1), stats.SessionCountSSH)
@@ -236,7 +252,11 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 
-		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:   dbtime.Now().Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, int64(3), stats.WorkspaceTxBytes)
@@ -765,28 +785,39 @@ func TestGetTemplateInsightsByTemplate(t *testing.T) {
 	insertStat(40*time.Second, templateID, userID, otherWorkspaceID, 0, map[string]int64{"reconnecting_pty": 1, "vscode": 1})
 	insertStat(time.Minute+5*time.Second, templateID, userID, otherWorkspaceID, 1, map[string]int64{"ssh": 1, "vscode": 1})
 
-	// Unknown apps do not contribute activity or active users.
-	insertStat(10*time.Second, templateID, uuid.New(), uuid.New(), 1, map[string]int64{"unknown": 1})
+	// An app outside every family is still activity, so its user counts as
+	// active even though the session lands in no usage bucket.
+	unattributedUserID := uuid.New()
+	insertStat(10*time.Second, templateID, unattributedUserID, uuid.New(), 1, map[string]int64{"unknown": 1})
 
-	// Unknown activity cannot supply a connection for known activity.
-	noKnownConnectionTemplateID := uuid.New()
-	noKnownConnectionUserID := uuid.New()
-	insertStat(15*time.Second, noKnownConnectionTemplateID, noKnownConnectionUserID, uuid.New(), 0, map[string]int64{"vscode": 1})
-	insertStat(30*time.Second, noKnownConnectionTemplateID, noKnownConnectionUserID, uuid.New(), 1, map[string]int64{"unknown": 1})
+	// Connections are read across the whole minute, so an unattributed session
+	// supplies the connection its user's attributed sessions lack.
+	sharedConnectionTemplateID := uuid.New()
+	sharedConnectionUserID := uuid.New()
+	insertStat(15*time.Second, sharedConnectionTemplateID, sharedConnectionUserID, uuid.New(), 0, map[string]int64{"vscode": 1})
+	insertStat(30*time.Second, sharedConnectionTemplateID, sharedConnectionUserID, uuid.New(), 1, map[string]int64{"unknown": 1})
 
+	appFamilies := codersdk.SessionCountAppFamiliesJSON()
 	insights, err := db.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{
-		StartTime: startTime,
-		EndTime:   endTime,
+		StartTime:   startTime,
+		EndTime:     endTime,
+		AppFamilies: appFamilies,
 	})
 	require.NoError(t, err)
-	require.Equal(t, []database.GetTemplateInsightsByTemplateRow{
+	// The query does not order its rows.
+	require.ElementsMatch(t, []database.GetTemplateInsightsByTemplateRow{
 		{
 			TemplateID:                  templateID,
-			ActiveUsers:                 1,
+			ActiveUsers:                 2,
 			UsageVscodeSeconds:          120,
 			UsageJetbrainsSeconds:       60,
 			UsageReconnectingPtySeconds: 60,
 			UsageSshSeconds:             120,
+		},
+		{
+			TemplateID:         sharedConnectionTemplateID,
+			ActiveUsers:        1,
+			UsageVscodeSeconds: 60,
 		},
 	}, insights)
 }
@@ -908,7 +939,11 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 		})
 
 		reqTime := dbtime.Now().Add(-time.Hour)
-		stats, err := db.GetWorkspaceAgentUsageStats(ctx, reqTime)
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
+			CreatedAt:   reqTime,
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		ws1Stats, ws2Stats := stats[0], stats[1]
@@ -951,7 +986,11 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"ssh": 3, "vscode": 1}), // Should be ignored.
 		})
 
-		stats, err := db.GetWorkspaceAgentUsageStats(ctx, dbtime.Now().Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
+			CreatedAt:   dbtime.Now().Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Len(t, stats, 1)
@@ -1186,7 +1225,11 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			SessionCounts: dbgen.SessionCounts(t, map[string]int64{"ssh": 1}),
 		})
 
-		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+			CreatedAt:   insertTime.Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Len(t, stats, 2)
@@ -1253,7 +1296,11 @@ func TestGetWorkspaceAgentUsageStatsAndLabels(t *testing.T) {
 			SessionCounts:             dbgen.SessionCounts(t, map[string]int64{"vscode": 3, "ssh": 1}), // Should be ignored.
 		})
 
-		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, insertTime.Add(-time.Hour))
+		appFamilies := codersdk.SessionCountAppFamiliesJSON()
+		stats, err := db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+			CreatedAt:   insertTime.Add(-time.Hour),
+			AppFamilies: appFamilies,
+		})
 		require.NoError(t, err)
 
 		require.Len(t, stats, 1)
@@ -19906,4 +19953,150 @@ func TestGetChatSiteConfigValue(t *testing.T) {
 	value, err = db.GetChatSiteConfigValue(ctx, "derp_mesh_key")
 	require.NoError(t, err)
 	require.Equal(t, database.GetChatSiteConfigValueRow{}, value)
+}
+
+func TestSessionCountsAttributeByFamily(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	err := migrations.Up(sqlDB)
+	require.NoError(t, err)
+	db := database.New(sqlDB)
+	ctx := context.Background()
+
+	cursorTemplate := uuid.New()
+	zedTemplate := uuid.New()
+	unknownTemplate := uuid.New()
+	for _, tc := range []struct {
+		templateID uuid.UUID
+		counts     map[string]int64
+	}{
+		{cursorTemplate, map[string]int64{"cursor": 2}},
+		{zedTemplate, map[string]int64{"zed": 1}},
+		{unknownTemplate, map[string]int64{"some_new_ide": 5}},
+	} {
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			TemplateID:                tc.templateID,
+			UserID:                    uuid.New(),
+			AgentID:                   uuid.New(),
+			ConnectionCount:           1,
+			ConnectionMedianLatencyMS: 1,
+			Usage:                     true,
+			SessionCounts:             dbgen.SessionCounts(t, tc.counts),
+		})
+	}
+
+	appFamilies := codersdk.SessionCountAppFamiliesJSON()
+
+	// A VS Code fork counts as VS Code, and Zed counts as SSH.
+	stats, err := db.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+		CreatedAt:   dbtime.Now().Add(-time.Hour),
+		AppFamilies: appFamilies,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), stats.SessionCountVSCode)
+	require.Equal(t, int64(1), stats.SessionCountSSH)
+	require.Zero(t, stats.SessionCountJetBrains)
+	require.Zero(t, stats.SessionCountReconnectingPTY)
+
+	insights, err := db.GetTemplateInsightsByTemplate(ctx, database.GetTemplateInsightsByTemplateParams{
+		StartTime:   dbtime.Now().Add(-time.Hour),
+		EndTime:     dbtime.Now().Add(time.Hour),
+		AppFamilies: appFamilies,
+	})
+	require.NoError(t, err)
+
+	byTemplate := make(map[uuid.UUID]database.GetTemplateInsightsByTemplateRow, len(insights))
+	for _, row := range insights {
+		byTemplate[row.TemplateID] = row
+	}
+	require.Equal(t, int64(60), byTemplate[cursorTemplate].UsageVscodeSeconds)
+	require.Equal(t, int64(60), byTemplate[zedTemplate].UsageSshSeconds)
+
+	// An app with no family is still activity, so the user is not counted idle.
+	unknown, ok := byTemplate[unknownTemplate]
+	require.True(t, ok, "a session with no family must still appear as usage")
+	require.Equal(t, int64(1), unknown.ActiveUsers)
+	require.Zero(t, unknown.UsageVscodeSeconds)
+	require.Zero(t, unknown.UsageSshSeconds)
+}
+
+// The rollup attributes session counts the same way the read queries do, so a
+// VS Code fork rolls up as VS Code, an SSH-speaking editor as SSH, and an app
+// with no family is still usage.
+func TestUpsertTemplateUsageStatsAttributesSessionCountsByFamily(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	err := migrations.Up(sqlDB)
+	require.NoError(t, err)
+	db := database.New(sqlDB)
+	ctx := context.Background()
+
+	cursorTemplate := uuid.New()
+	zedTemplate := uuid.New()
+	unknownTemplate := uuid.New()
+	// Stats must land in a bucket the rollup has already closed, and only rows
+	// reporting a connection are rolled up.
+	createdAt := dbtime.Now().Add(-time.Hour)
+	for _, tc := range []struct {
+		templateID uuid.UUID
+		counts     map[string]int64
+	}{
+		{cursorTemplate, map[string]int64{"cursor": 2}},
+		{zedTemplate, map[string]int64{"zed": 1}},
+		{unknownTemplate, map[string]int64{"some_new_ide": 5}},
+	} {
+		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
+			CreatedAt:                 createdAt,
+			TemplateID:                tc.templateID,
+			UserID:                    uuid.New(),
+			AgentID:                   uuid.New(),
+			ConnectionCount:           1,
+			ConnectionMedianLatencyMS: 1,
+			Usage:                     true,
+			SessionCounts:             dbgen.SessionCounts(t, tc.counts),
+		})
+	}
+
+	require.NoError(t, db.UpsertTemplateUsageStats(ctx, codersdk.SessionCountAppFamiliesJSON()))
+
+	stats, err := db.GetTemplateUsageStats(ctx, database.GetTemplateUsageStatsParams{
+		StartTime: createdAt.Add(-time.Hour),
+		EndTime:   dbtime.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	byTemplate := make(map[uuid.UUID]database.TemplateUsageStat, len(stats))
+	for _, row := range stats {
+		byTemplate[row.TemplateID] = row
+	}
+
+	cursor, ok := byTemplate[cursorTemplate]
+	require.True(t, ok, "a VS Code fork must be rolled up")
+	require.Equal(t, int16(1), cursor.UsageMins)
+	require.Equal(t, int16(1), cursor.VscodeMins)
+	require.Zero(t, cursor.SshMins)
+
+	zed, ok := byTemplate[zedTemplate]
+	require.True(t, ok, "an SSH-speaking editor must be rolled up")
+	require.Equal(t, int16(1), zed.UsageMins)
+	require.Equal(t, int16(1), zed.SshMins)
+	require.Zero(t, zed.VscodeMins)
+
+	// An app with no family is still activity, so it produces usage minutes
+	// without any family minutes.
+	unknown, ok := byTemplate[unknownTemplate]
+	require.True(t, ok, "a session with no family must still appear as usage")
+	require.Equal(t, int16(1), unknown.UsageMins)
+	require.Zero(t, unknown.VscodeMins)
+	require.Zero(t, unknown.SshMins)
+	require.Zero(t, unknown.JetbrainsMins)
+	require.Zero(t, unknown.ReconnectingPtyMins)
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -16855,29 +16855,37 @@ func (q *sqlQuerier) GetTemplateInsightsByInterval(ctx context.Context, arg GetT
 
 const getTemplateInsightsByTemplate = `-- name: GetTemplateInsightsByTemplate :many
 WITH
+	-- app_families maps each attributed family to its app names, so the
+	-- probes below stay one expression per family: adding a family needs a
+	-- new list in fams plus one probe here, because sqlc output columns are
+	-- static. fams turns the jsonb parameter into arrays once for the whole
+	-- query. These probes only ask whether any app of a family is present,
+	-- so the jsonb key-existence operator beats decomposing session_counts
+	-- per row (measured ~2.4x faster on a 1M row scan).
+	fams AS (
+		SELECT
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'ssh')) AS ssh,
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'reconnecting_pty')) AS reconnecting_pty,
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'vscode')) AS vscode,
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'jetbrains')) AS jetbrains
+	),
 	-- Deduplicate activity by template, user, and minute.
 	minute_activity AS (
 		SELECT
 			template_id,
 			user_id,
 			date_trunc('minute', created_at) AS minute,
-			BOOL_OR((session_counts ->> 'ssh')::bigint > 0) AS ssh,
-			BOOL_OR((session_counts ->> 'reconnecting_pty')::bigint > 0) AS reconnecting_pty,
-			BOOL_OR((session_counts ->> 'vscode')::bigint > 0) AS vscode,
-			BOOL_OR((session_counts ->> 'jetbrains')::bigint > 0) AS jetbrains,
+			BOOL_OR(session_counts ?| fams.ssh) AS ssh,
+			BOOL_OR(session_counts ?| fams.reconnecting_pty) AS reconnecting_pty,
+			BOOL_OR(session_counts ?| fams.vscode) AS vscode,
+			BOOL_OR(session_counts ?| fams.jetbrains) AS jetbrains,
 			BOOL_OR(connection_count > 0) AS has_connection
 		FROM
-			workspace_agent_stats
+			workspace_agent_stats, fams
 		WHERE
-			created_at >= $1::timestamptz
-			AND created_at < $2::timestamptz
-			-- Inclusion criteria to filter out empty results.
-			AND (
-				(session_counts ->> 'ssh')::bigint > 0
-				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
-				OR (session_counts ->> 'vscode')::bigint > 0
-				OR (session_counts ->> 'jetbrains')::bigint > 0
-			)
+			created_at >= $2::timestamptz
+			AND created_at < $3::timestamptz
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			template_id, user_id, minute
 	),
@@ -16916,8 +16924,9 @@ GROUP BY
 `
 
 type GetTemplateInsightsByTemplateParams struct {
-	StartTime time.Time `db:"start_time" json:"start_time"`
-	EndTime   time.Time `db:"end_time" json:"end_time"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+	StartTime   time.Time       `db:"start_time" json:"start_time"`
+	EndTime     time.Time       `db:"end_time" json:"end_time"`
 }
 
 type GetTemplateInsightsByTemplateRow struct {
@@ -16932,7 +16941,7 @@ type GetTemplateInsightsByTemplateRow struct {
 // GetTemplateInsightsByTemplate is used for Prometheus metrics. Keep
 // in sync with GetTemplateInsights and UpsertTemplateUsageStats.
 func (q *sqlQuerier) GetTemplateInsightsByTemplate(ctx context.Context, arg GetTemplateInsightsByTemplateParams) ([]GetTemplateInsightsByTemplateRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTemplateInsightsByTemplate, arg.StartTime, arg.EndTime)
+	rows, err := q.db.QueryContext(ctx, getTemplateInsightsByTemplate, arg.AppFamilies, arg.StartTime, arg.EndTime)
 	if err != nil {
 		return nil, err
 	}
@@ -17428,6 +17437,20 @@ func (q *sqlQuerier) GetUserStatusCounts(ctx context.Context, arg GetUserStatusC
 
 const upsertTemplateUsageStats = `-- name: UpsertTemplateUsageStats :exec
 WITH
+	-- app_families maps each attributed family to its app names, so the
+	-- probes below stay one expression per family: adding a family needs a
+	-- new list in fams plus one probe here, because sqlc output columns are
+	-- static. fams turns the jsonb parameter into arrays once for the whole
+	-- query. These probes only ask whether any app of a family is present,
+	-- so the jsonb key-existence operator beats decomposing session_counts
+	-- per row (measured ~2.4x faster on a 1M row scan).
+	fams AS (
+		SELECT
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'ssh')) AS ssh,
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'reconnecting_pty')) AS reconnecting_pty,
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'vscode')) AS vscode,
+			ARRAY(SELECT jsonb_array_elements_text($1::jsonb -> 'jetbrains')) AS jetbrains
+	),
 	latest_start AS (
 		SELECT
 			-- Truncate to hour so that we always look at even ranges of data.
@@ -17506,29 +17529,23 @@ WITH
 			user_id,
 			-- Store each unique minute bucket for later merge between datasets.
 			array_agg(DISTINCT date_trunc('minute', created_at)) AS minute_buckets,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'ssh')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'reconnecting_pty')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'vscode')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'jetbrains')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.ssh THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.reconnecting_pty THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.vscode THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.jetbrains THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
 			-- NOTE(mafredri): The agent stats are currently very unreliable, and
 			-- sometimes the connections are missing, even during active sessions.
 			-- Since we can't fully rely on this, we check for "any connection
 			-- during this half-hour". A better solution here would be preferable.
 			MAX(connection_count) > 0 AS has_connection
 		FROM
-			workspace_agent_stats
+			workspace_agent_stats, fams
 		WHERE
 			-- created_at >= @start_time::timestamptz
 			-- AND created_at < @end_time::timestamptz
 			created_at >= (SELECT t FROM latest_start)
 			AND created_at < NOW()
-			-- Inclusion criteria to filter out empty results.
-			AND (
-				(session_counts ->> 'ssh')::bigint > 0
-				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
-				OR (session_counts ->> 'vscode')::bigint > 0
-				OR (session_counts ->> 'jetbrains')::bigint > 0
-			)
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			time_bucket, template_id, user_id
 	),
@@ -17681,8 +17698,8 @@ WHERE
 // into a single table for efficient storage and querying. Half-hour buckets are
 // used to store the data, and the minutes are summed for each user and template
 // combination. The result is stored in the template_usage_stats table.
-func (q *sqlQuerier) UpsertTemplateUsageStats(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, upsertTemplateUsageStats)
+func (q *sqlQuerier) UpsertTemplateUsageStats(ctx context.Context, appFamilies json.RawMessage) error {
+	_, err := q.db.ExecContext(ctx, upsertTemplateUsageStats, appFamilies)
 	return err
 }
 
@@ -35989,7 +36006,13 @@ func (q *sqlQuerier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {
 }
 
 const getDeploymentWorkspaceAgentStats = `-- name: GetDeploymentWorkspaceAgentStats :one
-WITH stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), stats AS (
 	SELECT
 		agent_id,
 		created_at,
@@ -36007,12 +36030,28 @@ SELECT
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
 	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+	coalesce(SUM(sc.vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
+	coalesce(SUM(sc.ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
+	coalesce(SUM(sc.jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
+CROSS JOIN LATERAL (
+	SELECT
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+	FROM fams, jsonb_each_text(stats.session_counts) AS sess
+	-- Gate on the same condition as the aggregate filters above so the
+	-- decompose runs only for the rows that are counted (one-time filter).
+	WHERE stats.rn = 1
+) AS sc
 `
+
+type GetDeploymentWorkspaceAgentStatsParams struct {
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+}
 
 type GetDeploymentWorkspaceAgentStatsRow struct {
 	WorkspaceRxBytes             int64   `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
@@ -36025,8 +36064,15 @@ type GetDeploymentWorkspaceAgentStatsRow struct {
 	SessionCountReconnectingPTY  int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentStats, createdAt)
+// app_families maps each attributed family to its app names, so the probes
+// below stay one expression per family: adding a family needs a new list in
+// fams plus one probe here, because sqlc output columns are static.
+// fams turns the jsonb parameter into arrays once for the whole query. The
+// lateral decomposes session_counts once per row and sums each family from
+// that single pass, which measured ~3x faster than probing the jsonb once
+// per family. The subplan only runs for rows that survive the gate.
+func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, arg GetDeploymentWorkspaceAgentStatsParams) (GetDeploymentWorkspaceAgentStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentStats, arg.CreatedAt, arg.AppFamilies)
 	var i GetDeploymentWorkspaceAgentStatsRow
 	err := row.Scan(
 		&i.WorkspaceRxBytes,
@@ -36042,7 +36088,13 @@ func (q *sqlQuerier) GetDeploymentWorkspaceAgentStats(ctx context.Context, creat
 }
 
 const getDeploymentWorkspaceAgentUsageStats = `-- name: GetDeploymentWorkspaceAgentUsageStats :one
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
 		coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
@@ -36068,10 +36120,10 @@ latest_minutes AS (
 ),
 latest_agent_stats AS (
 	SELECT
-		coalesce(SUM((stats.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((stats.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((stats.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((stats.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	FROM
 		latest_minutes
 	JOIN
@@ -36082,9 +36134,22 @@ latest_agent_stats AS (
 		AND stats.created_at >= latest_minutes.minute_bucket
 		AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
 		AND stats.usage
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(stats.session_counts) AS sess
+	) AS sc
 )
 SELECT workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats, latest_agent_stats
 `
+
+type GetDeploymentWorkspaceAgentUsageStatsParams struct {
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+}
 
 type GetDeploymentWorkspaceAgentUsageStatsRow struct {
 	WorkspaceRxBytes             int64   `db:"workspace_rx_bytes" json:"workspace_rx_bytes"`
@@ -36097,8 +36162,8 @@ type GetDeploymentWorkspaceAgentUsageStatsRow struct {
 	SessionCountReconnectingPTY  int64   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentUsageStats, createdAt)
+func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, arg GetDeploymentWorkspaceAgentUsageStatsParams) (GetDeploymentWorkspaceAgentUsageStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentWorkspaceAgentUsageStats, arg.CreatedAt, arg.AppFamilies)
 	var i GetDeploymentWorkspaceAgentUsageStatsRow
 	err := row.Scan(
 		&i.WorkspaceRxBytes,
@@ -36114,7 +36179,13 @@ func (q *sqlQuerier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, 
 }
 
 const getWorkspaceAgentStats = `-- name: GetWorkspaceAgentStats :many
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -36132,19 +36203,32 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
 		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
 	) AS a
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(a.session_counts) AS sess
+	) AS sc
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
 SELECT user_id, agent_stats.agent_id, workspace_id, template_id, aggregated_from, workspace_rx_bytes, workspace_tx_bytes, workspace_connection_latency_50, workspace_connection_latency_95, latest_agent_stats.agent_id, session_count_vscode, session_count_ssh, session_count_jetbrains, session_count_reconnecting_pty FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id
 `
+
+type GetWorkspaceAgentStatsParams struct {
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+}
 
 type GetWorkspaceAgentStatsRow struct {
 	UserID                       uuid.UUID `db:"user_id" json:"user_id"`
@@ -36163,8 +36247,8 @@ type GetWorkspaceAgentStatsRow struct {
 	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStats, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, arg GetWorkspaceAgentStatsParams) ([]GetWorkspaceAgentStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStats, arg.CreatedAt, arg.AppFamilies)
 	if err != nil {
 		return nil, err
 	}
@@ -36202,7 +36286,13 @@ func (q *sqlQuerier) GetWorkspaceAgentStats(ctx context.Context, createdAt time.
 }
 
 const getWorkspaceAgentStatsAndLabels = `-- name: GetWorkspaceAgentStatsAndLabels :many
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -36215,10 +36305,10 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
@@ -36227,6 +36317,14 @@ WITH agent_stats AS (
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
 	) AS a
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(a.session_counts) AS sess
+	) AS sc
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id
 )
@@ -36254,6 +36352,11 @@ ON
 	workspaces.id = agent_stats.workspace_id
 `
 
+type GetWorkspaceAgentStatsAndLabelsParams struct {
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+}
+
 type GetWorkspaceAgentStatsAndLabelsRow struct {
 	Username                    string  `db:"username" json:"username"`
 	AgentName                   string  `db:"agent_name" json:"agent_name"`
@@ -36268,8 +36371,8 @@ type GetWorkspaceAgentStatsAndLabelsRow struct {
 	ConnectionMedianLatencyMS   float64 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentStatsAndLabelsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStatsAndLabels, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentStatsAndLabelsParams) ([]GetWorkspaceAgentStatsAndLabelsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentStatsAndLabels, arg.CreatedAt, arg.AppFamilies)
 	if err != nil {
 		return nil, err
 	}
@@ -36304,7 +36407,13 @@ func (q *sqlQuerier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, create
 }
 
 const getWorkspaceAgentUsageStats = `-- name: GetWorkspaceAgentUsageStats :many
-WITH stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), stats AS (
 	SELECT
 		id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, usage, session_counts,
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
@@ -36329,14 +36438,30 @@ SELECT
 	-- Repeated so this row keeps the same layout as GetWorkspaceAgentStats, which
 	-- telemetry converts between.
 	agent_id,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
+	coalesce(SUM(sc.vscode) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
+	coalesce(SUM(sc.ssh) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
+	coalesce(SUM(sc.jetbrains) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
+CROSS JOIN LATERAL (
+	SELECT
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+	FROM fams, jsonb_each_text(stats.session_counts) AS sess
+	-- Gate on the same condition as the aggregate filters above so the
+	-- decompose runs only for the rows that are counted (one-time filter).
+	WHERE stats.in_latest_usage_minute
+) AS sc
 GROUP BY user_id, agent_id, workspace_id, template_id
 HAVING BOOL_OR(reports_latency)
 `
+
+type GetWorkspaceAgentUsageStatsParams struct {
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+}
 
 type GetWorkspaceAgentUsageStatsRow struct {
 	UserID                       uuid.UUID `db:"user_id" json:"user_id"`
@@ -36355,8 +36480,8 @@ type GetWorkspaceAgentUsageStatsRow struct {
 	SessionCountReconnectingPTY  int64     `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, arg GetWorkspaceAgentUsageStatsParams) ([]GetWorkspaceAgentUsageStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStats, arg.CreatedAt, arg.AppFamilies)
 	if err != nil {
 		return nil, err
 	}
@@ -36394,7 +36519,13 @@ func (q *sqlQuerier) GetWorkspaceAgentUsageStats(ctx context.Context, createdAt 
 }
 
 const getWorkspaceAgentUsageStatsAndLabels = `-- name: GetWorkspaceAgentUsageStatsAndLabels :many
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text($2::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -36409,12 +36540,20 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		agent_id,
-		coalesce(SUM((session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count
 	FROM workspace_agent_stats
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(workspace_agent_stats.session_counts) AS sess
+	) AS sc
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
 	WHERE usage AND created_at > now() - '1 minute'::interval
@@ -36448,6 +36587,11 @@ ON
 	workspaces.id = agent_stats.workspace_id
 `
 
+type GetWorkspaceAgentUsageStatsAndLabelsParams struct {
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	AppFamilies json.RawMessage `db:"app_families" json:"app_families"`
+}
+
 type GetWorkspaceAgentUsageStatsAndLabelsRow struct {
 	Username                    string  `db:"username" json:"username"`
 	AgentName                   string  `db:"agent_name" json:"agent_name"`
@@ -36462,8 +36606,8 @@ type GetWorkspaceAgentUsageStatsAndLabelsRow struct {
 	ConnectionMedianLatencyMS   float64 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
-func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, createdAt time.Time) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStatsAndLabels, createdAt)
+func (q *sqlQuerier) GetWorkspaceAgentUsageStatsAndLabels(ctx context.Context, arg GetWorkspaceAgentUsageStatsAndLabelsParams) ([]GetWorkspaceAgentUsageStatsAndLabelsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentUsageStatsAndLabels, arg.CreatedAt, arg.AppFamilies)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -148,29 +148,37 @@ FROM
 -- GetTemplateInsightsByTemplate is used for Prometheus metrics. Keep
 -- in sync with GetTemplateInsights and UpsertTemplateUsageStats.
 WITH
+	-- app_families maps each attributed family to its app names, so the
+	-- probes below stay one expression per family: adding a family needs a
+	-- new list in fams plus one probe here, because sqlc output columns are
+	-- static. fams turns the jsonb parameter into arrays once for the whole
+	-- query. These probes only ask whether any app of a family is present,
+	-- so the jsonb key-existence operator beats decomposing session_counts
+	-- per row (measured ~2.4x faster on a 1M row scan).
+	fams AS (
+		SELECT
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty,
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains
+	),
 	-- Deduplicate activity by template, user, and minute.
 	minute_activity AS (
 		SELECT
 			template_id,
 			user_id,
 			date_trunc('minute', created_at) AS minute,
-			BOOL_OR((session_counts ->> 'ssh')::bigint > 0) AS ssh,
-			BOOL_OR((session_counts ->> 'reconnecting_pty')::bigint > 0) AS reconnecting_pty,
-			BOOL_OR((session_counts ->> 'vscode')::bigint > 0) AS vscode,
-			BOOL_OR((session_counts ->> 'jetbrains')::bigint > 0) AS jetbrains,
+			BOOL_OR(session_counts ?| fams.ssh) AS ssh,
+			BOOL_OR(session_counts ?| fams.reconnecting_pty) AS reconnecting_pty,
+			BOOL_OR(session_counts ?| fams.vscode) AS vscode,
+			BOOL_OR(session_counts ?| fams.jetbrains) AS jetbrains,
 			BOOL_OR(connection_count > 0) AS has_connection
 		FROM
-			workspace_agent_stats
+			workspace_agent_stats, fams
 		WHERE
 			created_at >= @start_time::timestamptz
 			AND created_at < @end_time::timestamptz
-			-- Inclusion criteria to filter out empty results.
-			AND (
-				(session_counts ->> 'ssh')::bigint > 0
-				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
-				OR (session_counts ->> 'vscode')::bigint > 0
-				OR (session_counts ->> 'jetbrains')::bigint > 0
-			)
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			template_id, user_id, minute
 	),
@@ -490,6 +498,20 @@ WHERE
 -- used to store the data, and the minutes are summed for each user and template
 -- combination. The result is stored in the template_usage_stats table.
 WITH
+	-- app_families maps each attributed family to its app names, so the
+	-- probes below stay one expression per family: adding a family needs a
+	-- new list in fams plus one probe here, because sqlc output columns are
+	-- static. fams turns the jsonb parameter into arrays once for the whole
+	-- query. These probes only ask whether any app of a family is present,
+	-- so the jsonb key-existence operator beats decomposing session_counts
+	-- per row (measured ~2.4x faster on a 1M row scan).
+	fams AS (
+		SELECT
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty,
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+			ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains
+	),
 	latest_start AS (
 		SELECT
 			-- Truncate to hour so that we always look at even ranges of data.
@@ -568,29 +590,23 @@ WITH
 			user_id,
 			-- Store each unique minute bucket for later merge between datasets.
 			array_agg(DISTINCT date_trunc('minute', created_at)) AS minute_buckets,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'ssh')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'reconnecting_pty')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'vscode')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
-			COUNT(DISTINCT CASE WHEN (session_counts ->> 'jetbrains')::bigint > 0 THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.ssh THEN date_trunc('minute', created_at) ELSE NULL END) AS ssh_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.reconnecting_pty THEN date_trunc('minute', created_at) ELSE NULL END) AS reconnecting_pty_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.vscode THEN date_trunc('minute', created_at) ELSE NULL END) AS vscode_mins,
+			COUNT(DISTINCT CASE WHEN session_counts ?| fams.jetbrains THEN date_trunc('minute', created_at) ELSE NULL END) AS jetbrains_mins,
 			-- NOTE(mafredri): The agent stats are currently very unreliable, and
 			-- sometimes the connections are missing, even during active sessions.
 			-- Since we can't fully rely on this, we check for "any connection
 			-- during this half-hour". A better solution here would be preferable.
 			MAX(connection_count) > 0 AS has_connection
 		FROM
-			workspace_agent_stats
+			workspace_agent_stats, fams
 		WHERE
 			-- created_at >= @start_time::timestamptz
 			-- AND created_at < @end_time::timestamptz
 			created_at >= (SELECT t FROM latest_start)
 			AND created_at < NOW()
-			-- Inclusion criteria to filter out empty results.
-			AND (
-				(session_counts ->> 'ssh')::bigint > 0
-				OR (session_counts ->> 'reconnecting_pty')::bigint > 0
-				OR (session_counts ->> 'vscode')::bigint > 0
-				OR (session_counts ->> 'jetbrains')::bigint > 0
-			)
+			AND session_counts <> '{}'::jsonb
 		GROUP BY
 			time_bucket, template_id, user_id
 	),

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -66,7 +66,20 @@ WHERE
 	);
 
 -- name: GetDeploymentWorkspaceAgentStats :one
-WITH stats AS (
+-- app_families maps each attributed family to its app names, so the probes
+-- below stay one expression per family: adding a family needs a new list in
+-- fams plus one probe here, because sqlc output columns are static.
+-- fams turns the jsonb parameter into arrays once for the whole query. The
+-- lateral decomposes session_counts once per row and sums each family from
+-- that single pass, which measured ~3x faster than probing the jsonb once
+-- per family. The subplan only runs for rows that survive the gate.
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), stats AS (
 	SELECT
 		agent_id,
 		created_at,
@@ -84,14 +97,31 @@ SELECT
 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 	coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_50,
 	coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms) FILTER (WHERE connection_median_latency_ms > 0)), -1)::FLOAT AS workspace_connection_latency_95,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
-FROM stats;
+	coalesce(SUM(sc.vscode) FILTER (WHERE rn = 1), 0)::bigint AS session_count_vscode,
+	coalesce(SUM(sc.ssh) FILTER (WHERE rn = 1), 0)::bigint AS session_count_ssh,
+	coalesce(SUM(sc.jetbrains) FILTER (WHERE rn = 1), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE rn = 1), 0)::bigint AS session_count_reconnecting_pty
+FROM stats
+CROSS JOIN LATERAL (
+	SELECT
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+	FROM fams, jsonb_each_text(stats.session_counts) AS sess
+	-- Gate on the same condition as the aggregate filters above so the
+	-- decompose runs only for the rows that are counted (one-time filter).
+	WHERE stats.rn = 1
+) AS sc;
 
 -- name: GetDeploymentWorkspaceAgentUsageStats :one
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		coalesce(SUM(rx_bytes), 0)::bigint AS workspace_rx_bytes,
 		coalesce(SUM(tx_bytes), 0)::bigint AS workspace_tx_bytes,
@@ -117,10 +147,10 @@ latest_minutes AS (
 ),
 latest_agent_stats AS (
 	SELECT
-		coalesce(SUM((stats.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((stats.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((stats.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((stats.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	FROM
 		latest_minutes
 	JOIN
@@ -131,11 +161,25 @@ latest_agent_stats AS (
 		AND stats.created_at >= latest_minutes.minute_bucket
 		AND stats.created_at < latest_minutes.minute_bucket + '1 minute'::interval
 		AND stats.usage
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(stats.session_counts) AS sess
+	) AS sc
 )
 SELECT * FROM agent_stats, latest_agent_stats;
 
 -- name: GetWorkspaceAgentStats :many
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -153,21 +197,35 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
 		SELECT *, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
 	) AS a
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(a.session_counts) AS sess
+	) AS sc
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
 SELECT * FROM agent_stats JOIN latest_agent_stats ON agent_stats.agent_id = latest_agent_stats.agent_id;
 
 -- name: GetWorkspaceAgentUsageStats :many
-WITH stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), stats AS (
 	SELECT
 		*,
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
@@ -192,16 +250,33 @@ SELECT
 	-- Repeated so this row keeps the same layout as GetWorkspaceAgentStats, which
 	-- telemetry converts between.
 	agent_id,
-	coalesce(SUM((session_counts ->> 'vscode')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
-	coalesce(SUM((session_counts ->> 'ssh')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
-	coalesce(SUM((session_counts ->> 'jetbrains')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
-	coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
+	coalesce(SUM(sc.vscode) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_vscode,
+	coalesce(SUM(sc.ssh) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_ssh,
+	coalesce(SUM(sc.jetbrains) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_jetbrains,
+	coalesce(SUM(sc.reconnecting_pty) FILTER (WHERE in_latest_usage_minute), 0)::bigint AS session_count_reconnecting_pty
 FROM stats
+CROSS JOIN LATERAL (
+	SELECT
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+		coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+	FROM fams, jsonb_each_text(stats.session_counts) AS sess
+	-- Gate on the same condition as the aggregate filters above so the
+	-- decompose runs only for the rows that are counted (one-time filter).
+	WHERE stats.in_latest_usage_minute
+) AS sc
 GROUP BY user_id, agent_id, workspace_id, template_id
 HAVING BOOL_OR(reports_latency);
 
 -- name: GetWorkspaceAgentStatsAndLabels :many
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -214,10 +289,10 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		a.agent_id,
-		coalesce(SUM((a.session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((a.session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((a.session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((a.session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(a.connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(a.connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
@@ -226,6 +301,14 @@ WITH agent_stats AS (
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
 	) AS a
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(a.session_counts) AS sess
+	) AS sc
 	WHERE a.rn = 1
 	GROUP BY a.user_id, a.agent_id, a.workspace_id
 )
@@ -253,7 +336,13 @@ ON
 	workspaces.id = agent_stats.workspace_id;
 
 -- name: GetWorkspaceAgentUsageStatsAndLabels :many
-WITH agent_stats AS (
+WITH fams AS (
+	SELECT
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'vscode')) AS vscode,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'ssh')) AS ssh,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'jetbrains')) AS jetbrains,
+		ARRAY(SELECT jsonb_array_elements_text(@app_families::jsonb -> 'reconnecting_pty')) AS reconnecting_pty
+), agent_stats AS (
 	SELECT
 		user_id,
 		agent_id,
@@ -268,12 +357,20 @@ WITH agent_stats AS (
 ), latest_agent_stats AS (
 	SELECT
 		agent_id,
-		coalesce(SUM((session_counts ->> 'vscode')::bigint), 0)::bigint AS session_count_vscode,
-		coalesce(SUM((session_counts ->> 'ssh')::bigint), 0)::bigint AS session_count_ssh,
-		coalesce(SUM((session_counts ->> 'jetbrains')::bigint), 0)::bigint AS session_count_jetbrains,
-		coalesce(SUM((session_counts ->> 'reconnecting_pty')::bigint), 0)::bigint AS session_count_reconnecting_pty,
+		coalesce(SUM(sc.vscode), 0)::bigint AS session_count_vscode,
+		coalesce(SUM(sc.ssh), 0)::bigint AS session_count_ssh,
+		coalesce(SUM(sc.jetbrains), 0)::bigint AS session_count_jetbrains,
+		coalesce(SUM(sc.reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty,
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count
 	FROM workspace_agent_stats
+	CROSS JOIN LATERAL (
+		SELECT
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.vscode)), 0) AS vscode,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.ssh)), 0) AS ssh,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.jetbrains)), 0) AS jetbrains,
+			coalesce(SUM(sess.value::bigint) FILTER (WHERE sess.key = ANY (fams.reconnecting_pty)), 0) AS reconnecting_pty
+		FROM fams, jsonb_each_text(workspace_agent_stats.session_counts) AS sess
+	) AS sc
 	-- We only want the latest stats, but those stats might be
 	-- spread across multiple rows.
 	WHERE usage AND created_at > now() - '1 minute'::interval

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -138,13 +138,19 @@ func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 	)
 
 	if c.usage {
-		agentUsageStats, err := c.database.GetDeploymentWorkspaceAgentUsageStats(ctx, from)
+		agentUsageStats, err := c.database.GetDeploymentWorkspaceAgentUsageStats(ctx, database.GetDeploymentWorkspaceAgentUsageStatsParams{
+			CreatedAt:   from,
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		})
 		if err != nil {
 			return err
 		}
 		agentStats = database.GetDeploymentWorkspaceAgentStatsRow(agentUsageStats)
 	} else {
-		agentStats, err = c.database.GetDeploymentWorkspaceAgentStats(ctx, from)
+		agentStats, err = c.database.GetDeploymentWorkspaceAgentStats(ctx, database.GetDeploymentWorkspaceAgentStatsParams{
+			CreatedAt:   from,
+			AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+		})
 		if err != nil {
 			return err
 		}

--- a/coderd/prometheusmetrics/insights/metricscollector.go
+++ b/coderd/prometheusmetrics/insights/metricscollector.go
@@ -98,8 +98,9 @@ func (mc *MetricsCollector) Run(ctx context.Context) (func(), error) {
 		eg.Go(func() error {
 			var err error
 			templateInsights, err = mc.database.GetTemplateInsightsByTemplate(egCtx, database.GetTemplateInsightsByTemplateParams{
-				StartTime: startTime,
-				EndTime:   endTime,
+				StartTime:   startTime,
+				EndTime:     endTime,
+				AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
 			})
 			if err != nil {
 				mc.logger.Error(ctx, "unable to fetch template insights from database", slog.Error(err))

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -567,13 +567,19 @@ func AgentStats(ctx context.Context, logger slog.Logger, registerer prometheus.R
 			)
 			if usage {
 				var agentUsageStats []database.GetWorkspaceAgentUsageStatsAndLabelsRow
-				agentUsageStats, err = db.GetWorkspaceAgentUsageStatsAndLabels(ctx, createdAfter)
+				agentUsageStats, err = db.GetWorkspaceAgentUsageStatsAndLabels(ctx, database.GetWorkspaceAgentUsageStatsAndLabelsParams{
+					CreatedAt:   createdAfter,
+					AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+				})
 				stats = make([]database.GetWorkspaceAgentStatsAndLabelsRow, 0, len(agentUsageStats))
 				for _, agentUsageStat := range agentUsageStats {
 					stats = append(stats, database.GetWorkspaceAgentStatsAndLabelsRow(agentUsageStat))
 				}
 			} else {
-				stats, err = db.GetWorkspaceAgentStatsAndLabels(ctx, createdAfter)
+				stats, err = db.GetWorkspaceAgentStatsAndLabels(ctx, database.GetWorkspaceAgentStatsAndLabelsParams{
+					CreatedAt:   createdAfter,
+					AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+				})
 			}
 			if err != nil {
 				logger.Error(ctx, "can't get agent stats", slog.Error(err))

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -647,7 +647,10 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 	})
 	eg.Go(func() error {
 		if r.options.DeploymentConfig != nil && slices.Contains(r.options.DeploymentConfig.Experiments, string(codersdk.ExperimentWorkspaceUsage)) {
-			agentStats, err := r.options.Database.GetWorkspaceAgentUsageStats(ctx, createdAfter)
+			agentStats, err := r.options.Database.GetWorkspaceAgentUsageStats(ctx, database.GetWorkspaceAgentUsageStatsParams{
+				CreatedAt:   createdAfter,
+				AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+			})
 			if err != nil {
 				return xerrors.Errorf("get workspace agent stats: %w", err)
 			}
@@ -656,7 +659,10 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 				snapshot.WorkspaceAgentStats = append(snapshot.WorkspaceAgentStats, ConvertWorkspaceAgentStat(database.GetWorkspaceAgentStatsRow(stat)))
 			}
 		} else {
-			agentStats, err := r.options.Database.GetWorkspaceAgentStats(ctx, createdAfter)
+			agentStats, err := r.options.Database.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+				CreatedAt:   createdAfter,
+				AppFamilies: codersdk.SessionCountAppFamiliesJSON(),
+			})
 			if err != nil {
 				return xerrors.Errorf("get workspace agent stats: %w", err)
 			}

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -56,7 +56,11 @@ func TestBatchStats(t *testing.T) {
 	t.Log("flush 1 completed")
 
 	// Then: it should report no stats.
-	stats, err := store.GetWorkspaceAgentStats(ctx, t1)
+	appFamilies := codersdk.SessionCountAppFamiliesJSON()
+	stats, err := store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:   t1,
+		AppFamilies: appFamilies,
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Empty(t, stats, "should have no stats for workspace")
 
@@ -79,7 +83,10 @@ func TestBatchStats(t *testing.T) {
 	t.Log("flush 2 completed")
 
 	// Then: counts reach the right agent, normalized, without the zero entry.
-	stats, err = store.GetWorkspaceAgentStats(ctx, t2)
+	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:   t2,
+		AppFamilies: appFamilies,
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 2, "should have stats for both workspaces")
 	byAgent := make(map[uuid.UUID]database.GetWorkspaceAgentStatsRow)
@@ -118,7 +125,10 @@ func TestBatchStats(t *testing.T) {
 	// And we should finish inserting the stats
 	<-done
 
-	stats, err = store.GetWorkspaceAgentStats(ctx, t3)
+	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:   t3,
+		AppFamilies: appFamilies,
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 2, "should have stats for both workspaces")
 
@@ -137,7 +147,10 @@ func TestBatchStats(t *testing.T) {
 	require.Zero(t, f, "expected zero stats to have been flushed")
 	t.Log("flush 5 completed")
 
-	stats, err = store.GetWorkspaceAgentStats(ctx, t5)
+	stats, err = store.GetWorkspaceAgentStats(ctx, database.GetWorkspaceAgentStatsParams{
+		CreatedAt:   t5,
+		AppFamilies: appFamilies,
+	})
 	require.NoError(t, err, "should not error getting stats")
 	require.Len(t, stats, 0, "should have no stats for workspace")
 

--- a/codersdk/appname.go
+++ b/codersdk/appname.go
@@ -1,6 +1,8 @@
 package codersdk
 
 import (
+	"encoding/json"
+	"slices"
 	"strings"
 
 	utilstrings "github.com/coder/coder/v2/coderd/util/strings"
@@ -47,6 +49,73 @@ var appNameFamilies = map[string]AppFamilyName{
 	"zed":              AppFamilySSH,
 	"ssh":              AppFamilySSH,
 	"reconnecting_pty": AppFamilyReconnectingPTY,
+}
+
+// attributedAppFamilies are the families usage reporting has somewhere to
+// put, and the single definition of the families the session count read
+// queries know about. Every value in appNameFamilies must appear here or its
+// sessions go uncounted, which TestEveryFamilyIsAttributed enforces.
+//
+// Adding a family here is not enough on its own: see AttributedAppFamilies.
+var attributedAppFamilies = []AppFamilyName{
+	AppFamilyVSCode,
+	AppFamilyJetBrains,
+	AppFamilySSH,
+	AppFamilyReconnectingPTY,
+}
+
+// AttributedAppFamilies returns the families session count reporting can
+// attribute to, in registry order. It is the source of truth that dbauthz
+// validates the query parameter against, so a family that exists here but not
+// in the queries (or the reverse) fails loudly instead of silently reporting
+// zero.
+func AttributedAppFamilies() []AppFamilyName {
+	return slices.Clone(attributedAppFamilies)
+}
+
+// AppNamesInFamily returns the app names belonging to a family, sorted so
+// query parameters stay stable across calls.
+func AppNamesInFamily(family AppFamilyName) []string {
+	var names []string
+	for appName, appFamily := range appNameFamilies {
+		if appFamily == family {
+			names = append(names, appName)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// SessionCountAppFamilies returns the session count attribution registry:
+// every attributed family mapped to its sorted app names. The session count
+// read queries take it as one parameter, so a new app name reaches every
+// caller by being added to appNameFamilies alone.
+//
+// A new family costs more. sqlc output columns are static, so each family
+// needs, in addition to its attributedAppFamilies entry, one probe expression
+// in every query that reports per-family session counts (see
+// coderd/database/queries/workspaceagentstats.sql and insights.sql) plus the
+// matching output column. dbauthz validation rejects a registry whose
+// families do not match AttributedAppFamilies, and
+// TestAttributedAppFamiliesMatchQueries pins that list to what the queries
+// probe, so neither half can drift unnoticed.
+func SessionCountAppFamilies() map[AppFamilyName][]string {
+	families := make(map[AppFamilyName][]string, len(attributedAppFamilies))
+	for _, family := range attributedAppFamilies {
+		families[family] = AppNamesInFamily(family)
+	}
+	return families
+}
+
+// SessionCountAppFamiliesJSON is SessionCountAppFamilies marshaled for the
+// jsonb parameter the session count read queries accept.
+func SessionCountAppFamiliesJSON() json.RawMessage {
+	// Marshaling a map with a string-keyed type cannot fail.
+	data, err := json.Marshal(SessionCountAppFamilies())
+	if err != nil {
+		panic("developer error: marshal session count app families: " + err.Error())
+	}
+	return data
 }
 
 // AppNameFamily normalizes an app name and returns its family, or

--- a/codersdk/appname_internal_test.go
+++ b/codersdk/appname_internal_test.go
@@ -14,3 +14,13 @@ func TestAppNameFamilyKeysAreNormalized(t *testing.T) {
 		require.Equal(t, NormalizeAppName(name), name)
 	}
 }
+
+// A family with no destination in attributedAppFamilies silently drops its
+// sessions from usage reporting, so adding one must fail here first.
+func TestEveryFamilyIsAttributed(t *testing.T) {
+	t.Parallel()
+	for appName, family := range appNameFamilies {
+		require.Contains(t, attributedAppFamilies, family,
+			"app %q maps to family %q, which usage reporting cannot report", appName, family)
+	}
+}

--- a/codersdk/appname_test.go
+++ b/codersdk/appname_test.go
@@ -1,6 +1,9 @@
 package codersdk_test
 
 import (
+	"encoding/json"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -82,4 +85,74 @@ func TestAppNameFamily(t *testing.T) {
 			require.Equal(t, tc.want, codersdk.AppNameFamily(tc.input))
 		})
 	}
+}
+
+func TestAppNamesInFamily(t *testing.T) {
+	t.Parallel()
+
+	// Forks share the VS Code family, and the list is sorted.
+	vscode := codersdk.AppNamesInFamily(codersdk.AppFamilyVSCode)
+	require.Contains(t, vscode, "cursor")
+	require.Contains(t, vscode, "vscode")
+	require.True(t, slices.IsSorted(vscode))
+
+	// Zed speaks SSH, so it reports under the SSH family.
+	require.Equal(t, []string{"ssh", "zed"},
+		codersdk.AppNamesInFamily(codersdk.AppFamilySSH))
+
+	require.Empty(t, codersdk.AppNamesInFamily("no_such_family"))
+}
+
+// The SQL queries that report per-family session counts hardcode one probe
+// expression and one output column per family, because sqlc output columns
+// are static. This pins the Go registry to the families those queries know
+// about.
+//
+// When adding a family, update, in this order:
+//  1. attributedAppFamilies in appname.go.
+//  2. Every query that reports per-family session counts: the fams CTE list,
+//     the probe expression, and the output column, in
+//     coderd/database/queries/workspaceagentstats.sql and insights.sql.
+//  3. The Go readers of those columns, then this list.
+//
+// dbauthz validation rejects a registry that does not match
+// AttributedAppFamilies, so a family added to Go but not to SQL fails at
+// runtime too.
+func TestAttributedAppFamiliesMatchQueries(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []codersdk.AppFamilyName{
+		codersdk.AppFamilyVSCode,
+		codersdk.AppFamilyJetBrains,
+		codersdk.AppFamilySSH,
+		codersdk.AppFamilyReconnectingPTY,
+	}, codersdk.AttributedAppFamilies())
+
+	// The registry keys are what the queries index by name.
+	require.ElementsMatch(t, codersdk.AttributedAppFamilies(),
+		slices.Collect(maps.Keys(codersdk.SessionCountAppFamilies())),
+		"registry keys must match the attributed families")
+}
+
+func TestSessionCountAppFamilies(t *testing.T) {
+	t.Parallel()
+
+	families := codersdk.SessionCountAppFamilies()
+	require.Len(t, families, 4, "every attributed family must be present")
+	require.Contains(t, families, codersdk.AppFamilyVSCode)
+	require.Contains(t, families, codersdk.AppFamilyJetBrains)
+	require.Contains(t, families, codersdk.AppFamilySSH)
+	require.Contains(t, families, codersdk.AppFamilyReconnectingPTY)
+	require.Equal(t, codersdk.AppNamesInFamily(codersdk.AppFamilyVSCode), families[codersdk.AppFamilyVSCode])
+}
+
+func TestSessionCountAppFamiliesJSON(t *testing.T) {
+	t.Parallel()
+
+	raw := codersdk.SessionCountAppFamiliesJSON()
+	require.NotEmpty(t, raw)
+
+	var decoded map[codersdk.AppFamilyName][]string
+	require.NoError(t, json.Unmarshal(raw, &decoded), "registry must marshal to a valid jsonb object")
+	require.Equal(t, codersdk.SessionCountAppFamilies(), decoded)
 }


### PR DESCRIPTION
Groups app names into families on the read paths, so a session reported under a new name is counted rather than dropped.

- `codersdk` gains the attribution registry: `appNameFamilies` maps each known app name to a family, and `SessionCountAppFamiliesJSON()` renders the attributed families as a single jsonb parameter. A session reported as `cursor` counts as VS Code in template insights, deployment stats, Prometheus, and telemetry.
- The read queries take that one `app_families` parameter instead of four hardcoded name lists. Adding an alias to an existing family is one registry edit that flows everywhere. Adding a family is a registry edit plus one probe per reporting query, since sqlc output columns are static; validation and a pinning test turn a miss into a loud failure instead of a silently zeroed column.
- dbauthz validates the registry structurally: exactly the probed families, each with a non-empty alias list. `{}`, `null`, a renamed family, or an extra family fail with the offending key named. It overrides the generated stubs through the `scripts/dbgen` external-method mechanism, covering every production store including rollup transactions.
- The insights inclusion filter matches any session rather than the four known names, so an unrecognized app costs unattributed minutes instead of an idle user.
- The per-agent sum sites decompose `session_counts` once per row, one `jsonb_each_text` with a filtered sum per family, instead of a correlated subplan per family. Insights only tests key presence and keeps the `?|` probe, which is faster there.
- `TestEveryFamilyIsAttributed` fails if a family is added with nowhere to report it. `TestAttributedAppFamiliesMatchQueries` pins the registry to the families the SQL probes. `TestSessionCountsAttributeByFamily` and `TestUpsertTemplateUsageStatsAttributesSessionCountsByFamily` pin the behavior end to end, including the rollup: `cursor` as VS Code, `zed` as SSH, an unknown name still marking the user active.

### Measurements

PG 13, 1M rows, parallelism off, median of 3. The previous per-family correlated subplan against the shipped single-pass fold:

| case | per-family subplan | single-pass fold |
| --- | --- | --- |
| full scan, ungated sums | 3711 ms | 1126 ms |
| 1 minute window | 1.2-2.0 ms | 0.5-0.6 ms |
| gated by the `rn = 1` analogue | 1947 ms | 720 ms |

The gating predicates ride inside the lateral as one-time filters, so the decompose is skipped for rows that are not counted, and a per-agent `EXCEPT` in both directions over 5000 agents returns zero rows. The insights sites invert this: `?|` on the alias array measured 613 ms against 1500 ms for decomposing, so presence checks keep `?|`.

### Trade-offs

- **Family membership is a server-side alias list**, so counting a new IDE under an existing family still needs a Coder release. A per-name breakdown is a later phase.
- **The insights filters test key presence**, which equals a positive count only because writers strip non-positives. Testing the value there costs 2.4x, so this relies on the invariant that `workspace_agent_stats.session_counts` documents.
- **Attribution lives in one registry**, but a new family still needs one probe expression per reporting query. The structural validation and the pinning test make that requirement fail loudly rather than silently.
- **Lands before the producers**, so the alias plumbing sits unused until #28338. The other order would accept new names without counting them.

Depends on #28126. Phase 4 of #27410. Stacked on top: #29134 makes the count queries return per-app counts, and #29109 replaces the fixed per-family minute columns and the per-query probes.

<details>
<summary>Stack review decisions</summary>

Rebased onto main at `3ed8548e78`; the attribution patch is unchanged.

</details>

Update generated by Coder Agents for @EhabY.
