### PR TITLE
fix(enterprise/dbcrypt): clear leftover FKs before key revoke

### DIFF
--- a/enterprise/dbcrypt/cliutil.go
+++ b/enterprise/dbcrypt/cliutil.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"strings"
 
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -130,6 +131,10 @@ func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciphe
 				}
 			}
 
+			if err := rewriteMCPServerUserTokens(ctx, log, cryptTx, uid, ciphers[0].HexDigest()); err != nil {
+				return err
+			}
+
 			return nil
 		}, &database.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
@@ -207,6 +212,13 @@ func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciphe
 			return xerrors.Errorf("update user ai provider key id=%s ai_provider_id=%s user_id=%s: %w", key.ID, key.AIProviderID, key.UserID, err)
 		}
 		log.Debug(ctx, "encrypted user ai provider key", slog.F("user_ai_provider_key_id", key.ID), slog.F("ai_provider_id", key.AIProviderID), slog.F("user_id", key.UserID), slog.F("current", idx+1), slog.F("cipher", ciphers[0].HexDigest()))
+	}
+
+	if err := rewriteCryptoKeys(ctx, log, cryptDB, sqlDB, ciphers[0].HexDigest()); err != nil {
+		return err
+	}
+	if err := rewriteMCPServerConfigs(ctx, log, cryptDB, ciphers[0].HexDigest()); err != nil {
+		return err
 	}
 
 	// Revoke old keys
@@ -338,6 +350,10 @@ func Decrypt(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciph
 				log.Debug(ctx, "decrypted gitsshkey", slog.F("user_id", uid), slog.F("current", idx+1))
 			}
 
+			if err := rewriteMCPServerUserTokens(ctx, log, tx, uid, ""); err != nil {
+				return err
+			}
+
 			return nil
 		}, &database.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
@@ -408,6 +424,13 @@ func Decrypt(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciph
 		log.Debug(ctx, "decrypted user ai provider key", slog.F("user_ai_provider_key_id", key.ID), slog.F("ai_provider_id", key.AIProviderID), slog.F("user_id", key.UserID), slog.F("current", idx+1))
 	}
 
+	if err := rewriteCryptoKeys(ctx, log, cryptDB, sqlDB, ""); err != nil {
+		return err
+	}
+	if err := rewriteMCPServerConfigs(ctx, log, cryptDB, ""); err != nil {
+		return err
+	}
+
 	// Revoke _all_ keys
 	for _, c := range ciphers {
 		if err := db.RevokeDBCryptKey(ctx, c.HexDigest()); err != nil {
@@ -447,6 +470,23 @@ UPDATE ai_providers
 	WHERE settings_key_id IS NOT NULL;
 DELETE FROM ai_provider_keys
 	WHERE api_key_key_id IS NOT NULL;
+UPDATE crypto_keys
+	SET secret = NULL,
+		secret_key_id = NULL
+	WHERE secret_key_id IS NOT NULL;
+UPDATE mcp_server_configs
+	SET oauth2_client_secret = '',
+		oauth2_client_secret_key_id = NULL,
+		api_key_value = '',
+		api_key_value_key_id = NULL,
+		custom_headers = '',
+		custom_headers_key_id = NULL
+	WHERE oauth2_client_secret_key_id IS NOT NULL
+		OR api_key_value_key_id IS NOT NULL
+		OR custom_headers_key_id IS NOT NULL;
+DELETE FROM mcp_server_user_tokens
+	WHERE access_token_key_id IS NOT NULL
+		OR refresh_token_key_id IS NOT NULL;
 COMMIT;
 `
 
@@ -478,4 +518,200 @@ func Delete(ctx context.Context, log slog.Logger, sqlDB *sql.DB) error {
 	}
 
 	return nil
+}
+
+// rewriteCryptoKeys re-encrypts every crypto_keys.secret under the primary
+// cipher, or writes plaintext when digest is empty (Decrypt). secret_key_id
+// is a FK to dbcrypt_keys.active_key_digest, so leftover values block revoke.
+func rewriteCryptoKeys(ctx context.Context, log slog.Logger, cryptDB database.Store, sqlDB *sql.DB, digest string) error {
+	keys, err := cryptDB.GetCryptoKeys(ctx)
+	if err != nil {
+		return xerrors.Errorf("get crypto keys: %w", err)
+	}
+	action := "encrypting"
+	if digest == "" {
+		action = "decrypting"
+	}
+	log.Info(ctx, action+" crypto keys", slog.F("key_count", len(keys)))
+	for idx, key := range keys {
+		if digest != "" && key.SecretKeyID.Valid && key.SecretKeyID.String == digest {
+			log.Debug(ctx, "skipping crypto key", slog.F("feature", key.Feature), slog.F("sequence", key.Sequence), slog.F("current", idx+1), slog.F("cipher", digest))
+			continue
+		}
+		if digest == "" && !key.SecretKeyID.Valid {
+			log.Debug(ctx, "skipping crypto key", slog.F("feature", key.Feature), slog.F("sequence", key.Sequence), slog.F("current", idx+1))
+			continue
+		}
+		if err := updateCryptoKeySecret(ctx, cryptDB, sqlDB, key); err != nil {
+			return err
+		}
+		log.Debug(ctx, "updated crypto key", slog.F("feature", key.Feature), slog.F("sequence", key.Sequence), slog.F("current", idx+1))
+	}
+	return nil
+}
+
+// updateCryptoKeySecret writes one crypto_keys row's secret and
+// secret_key_id. encryptField is a no-op when the primary cipher digest is
+// empty, so the same helper both re-encrypts (Rotate) and stores plaintext
+// (Decrypt). There is no store update for these columns.
+func updateCryptoKeySecret(ctx context.Context, crypt database.Store, sqlDB *sql.DB, key database.CryptoKey) error {
+	dbc, ok := crypt.(*dbCrypt)
+	if !ok {
+		return xerrors.Errorf("developer error: dbcrypt store is not *dbCrypt")
+	}
+	if !key.Secret.Valid {
+		return nil
+	}
+	secret := key.Secret.String
+	var digest sql.NullString
+	if err := dbc.encryptField(&secret, &digest); err != nil {
+		return xerrors.Errorf("encrypt crypto key feature=%s sequence=%d: %w", key.Feature, key.Sequence, err)
+	}
+	var digestArg any
+	if digest.Valid {
+		digestArg = digest.String
+	}
+	_, err := sqlDB.ExecContext(ctx, `
+		UPDATE crypto_keys
+		SET secret = $1, secret_key_id = $2
+		WHERE feature = $3 AND sequence = $4
+	`, secret, digestArg, key.Feature, key.Sequence)
+	if err != nil {
+		return xerrors.Errorf("update crypto key feature=%s sequence=%d: %w", key.Feature, key.Sequence, err)
+	}
+	return nil
+}
+
+// rewriteMCPServerConfigs re-encrypts or decrypts every MCP server config's
+// secret columns. oauth2_client_secret_key_id, api_key_value_key_id, and
+// custom_headers_key_id all FK to dbcrypt_keys.active_key_digest.
+func rewriteMCPServerConfigs(ctx context.Context, log slog.Logger, cryptDB database.Store, digest string) error {
+	cfgs, err := allMCPServerConfigs(ctx, cryptDB)
+	if err != nil {
+		return err
+	}
+	action := "encrypting"
+	if digest == "" {
+		action = "decrypting"
+	}
+	log.Info(ctx, action+" mcp server configs", slog.F("config_count", len(cfgs)))
+	for idx, cfg := range cfgs {
+		if digest != "" && mcpServerConfigEncryptedWith(cfg, digest) {
+			log.Debug(ctx, "skipping mcp server config", slog.F("mcp_server_config_id", cfg.ID), slog.F("current", idx+1), slog.F("cipher", digest))
+			continue
+		}
+		if digest == "" && !mcpServerConfigHasKeyID(cfg) {
+			log.Debug(ctx, "skipping mcp server config", slog.F("mcp_server_config_id", cfg.ID), slog.F("current", idx+1))
+			continue
+		}
+		if _, err := cryptDB.UpdateMCPServerConfig(ctx, mcpServerConfigUpdateParams(cfg)); err != nil {
+			return xerrors.Errorf("update mcp server config id=%s: %w", cfg.ID, err)
+		}
+		log.Debug(ctx, "updated mcp server config", slog.F("mcp_server_config_id", cfg.ID), slog.F("current", idx+1))
+	}
+	return nil
+}
+
+func allMCPServerConfigs(ctx context.Context, store database.Store) ([]database.MCPServerConfig, error) {
+	var all []database.MCPServerConfig
+	for _, deleted := range []bool{false, true} {
+		orgs, err := store.GetOrganizations(ctx, database.GetOrganizationsParams{Deleted: deleted})
+		if err != nil {
+			return nil, xerrors.Errorf("get organizations deleted=%t: %w", deleted, err)
+		}
+		for _, org := range orgs {
+			cfgs, err := store.GetMCPServerConfigsByOrganization(ctx, org.ID)
+			if err != nil {
+				return nil, xerrors.Errorf("get mcp server configs org=%s: %w", org.ID, err)
+			}
+			all = append(all, cfgs...)
+		}
+	}
+	return all, nil
+}
+
+func mcpServerConfigHasKeyID(cfg database.MCPServerConfig) bool {
+	return cfg.OAuth2ClientSecretKeyID.Valid || cfg.APIKeyValueKeyID.Valid || cfg.CustomHeadersKeyID.Valid
+}
+
+func mcpServerConfigEncryptedWith(cfg database.MCPServerConfig, digest string) bool {
+	return (!cfg.OAuth2ClientSecretKeyID.Valid || cfg.OAuth2ClientSecretKeyID.String == digest) &&
+		(!cfg.APIKeyValueKeyID.Valid || cfg.APIKeyValueKeyID.String == digest) &&
+		(!cfg.CustomHeadersKeyID.Valid || cfg.CustomHeadersKeyID.String == digest)
+}
+
+func mcpServerConfigUpdateParams(cfg database.MCPServerConfig) database.UpdateMCPServerConfigParams {
+	updatedBy := cfg.UpdatedBy.UUID
+	if !cfg.UpdatedBy.Valid {
+		updatedBy = cfg.CreatedBy.UUID
+	}
+	return database.UpdateMCPServerConfigParams{
+		DisplayName:             cfg.DisplayName,
+		Slug:                    cfg.Slug,
+		Description:             cfg.Description,
+		IconURL:                 cfg.IconURL,
+		Transport:               cfg.Transport,
+		Url:                     cfg.Url,
+		AuthType:                cfg.AuthType,
+		OAuth2ClientID:          cfg.OAuth2ClientID,
+		OAuth2ClientSecret:      cfg.OAuth2ClientSecret,
+		OAuth2ClientSecretKeyID: sql.NullString{},
+		OAuth2AuthURL:           cfg.OAuth2AuthURL,
+		OAuth2TokenURL:          cfg.OAuth2TokenURL,
+		OAuth2RevocationURL:     cfg.OAuth2RevocationURL,
+		OAuth2Scopes:            cfg.OAuth2Scopes,
+		APIKeyHeader:            cfg.APIKeyHeader,
+		APIKeyValue:             cfg.APIKeyValue,
+		APIKeyValueKeyID:        sql.NullString{},
+		CustomHeaders:           cfg.CustomHeaders,
+		CustomHeadersKeyID:      sql.NullString{},
+		ToolAllowList:           cfg.ToolAllowList,
+		ToolDenyList:            cfg.ToolDenyList,
+		Availability:            cfg.Availability,
+		Enabled:                 cfg.Enabled,
+		ModelIntent:             cfg.ModelIntent,
+		AllowInPlanMode:         cfg.AllowInPlanMode,
+		ForwardCoderHeaders:     cfg.ForwardCoderHeaders,
+		UpdatedBy:               updatedBy,
+		ID:                      cfg.ID,
+	}
+}
+
+// rewriteMCPServerUserTokens re-encrypts or decrypts one user's MCP OAuth
+// tokens. access_token_key_id and refresh_token_key_id FK to
+// dbcrypt_keys.active_key_digest.
+func rewriteMCPServerUserTokens(ctx context.Context, log slog.Logger, store database.Store, uid uuid.UUID, digest string) error {
+	tokens, err := store.GetMCPServerUserTokensByUserID(ctx, uid)
+	if err != nil {
+		return xerrors.Errorf("get mcp server user tokens for user %s: %w", uid, err)
+	}
+	for _, tok := range tokens {
+		if digest != "" && mcpServerUserTokenEncryptedWith(tok, digest) {
+			log.Debug(ctx, "skipping mcp server user token", slog.F("user_id", uid), slog.F("mcp_server_config_id", tok.MCPServerConfigID), slog.F("cipher", digest))
+			continue
+		}
+		if digest == "" && !tok.AccessTokenKeyID.Valid && !tok.RefreshTokenKeyID.Valid {
+			log.Debug(ctx, "skipping mcp server user token", slog.F("user_id", uid), slog.F("mcp_server_config_id", tok.MCPServerConfigID))
+			continue
+		}
+		if _, err := store.UpsertMCPServerUserToken(ctx, database.UpsertMCPServerUserTokenParams{
+			MCPServerConfigID: tok.MCPServerConfigID,
+			UserID:            tok.UserID,
+			AccessToken:       tok.AccessToken,
+			AccessTokenKeyID:  sql.NullString{},
+			RefreshToken:      tok.RefreshToken,
+			RefreshTokenKeyID: sql.NullString{},
+			TokenType:         tok.TokenType,
+			Expiry:            tok.Expiry,
+		}); err != nil {
+			return xerrors.Errorf("update mcp server user token user_id=%s config_id=%s: %w", tok.UserID, tok.MCPServerConfigID, err)
+		}
+		log.Debug(ctx, "updated mcp server user token", slog.F("user_id", uid), slog.F("mcp_server_config_id", tok.MCPServerConfigID))
+	}
+	return nil
+}
+
+func mcpServerUserTokenEncryptedWith(tok database.MCPServerUserToken, digest string) bool {
+	return (!tok.AccessTokenKeyID.Valid || tok.AccessTokenKeyID.String == digest) &&
+		(!tok.RefreshTokenKeyID.Valid || tok.RefreshTokenKeyID.String == digest)
 }

--- a/enterprise/dbcrypt/cliutil_test.go
+++ b/enterprise/dbcrypt/cliutil_test.go
@@ -115,6 +115,36 @@ func upsertUserAIProviderKey(ctx context.Context, t *testing.T, store database.S
 	return key
 }
 
+// upsertMCPServerUserToken inserts a mcp_server_user_tokens row through the
+// given store. There is no dbgen helper for this table, so this wraps the
+// raw UpsertMCPServerUserToken call for reuse across tests.
+func upsertMCPServerUserToken(ctx context.Context, t *testing.T, store database.Store, configID, userID uuid.UUID, accessToken, refreshToken string) database.MCPServerUserToken {
+	t.Helper()
+	tok, err := store.UpsertMCPServerUserToken(ctx, database.UpsertMCPServerUserTokenParams{
+		MCPServerConfigID: configID,
+		UserID:            userID,
+		AccessToken:       accessToken,
+		RefreshToken:      refreshToken,
+		TokenType:         "Bearer",
+	})
+	require.NoError(t, err)
+	return tok
+}
+
+// cryptoKeySecretRaw reads secret and secret_key_id for one crypto_keys row
+// directly from SQL. Store getters filter WHERE secret IS NOT NULL, so they
+// cannot observe a row whose secret was wiped by Delete.
+func cryptoKeySecretRaw(ctx context.Context, t *testing.T, sqlDB *sql.DB, feature database.CryptoKeyFeature, sequence int32) (secret, keyID sql.NullString) {
+	t.Helper()
+	err := sqlDB.QueryRowContext(ctx, `
+		SELECT secret, secret_key_id
+		FROM crypto_keys
+		WHERE feature = $1 AND sequence = $2
+	`, feature, sequence).Scan(&secret, &keyID)
+	require.NoError(t, err)
+	return secret, keyID
+}
+
 // decryptRawString decodes and decrypts a raw (base64) ciphertext value read
 // directly from the database, for comparison against the original plaintext.
 func decryptRawString(t *testing.T, c dbcrypt.Cipher, raw string) string {
@@ -1635,6 +1665,554 @@ func TestDeleteUserAIProviderKeys(t *testing.T) {
 	requireAllKeysRevoked(f.ctx, t, f.rawDB)
 }
 
+// TestRotateCryptoKeys covers the crypto_keys table (workspace-apps / OIDC
+// convert / tailnet resume secrets). Leftover rows here keep
+// secret_key_id pointing at dbcrypt_keys.active_key_digest, so revoke
+// fails with crypto_keys_secret_key_id_fkey unless Rotate walks them:
+//
+//	coder server dbcrypt rotate \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+//	  --new-key <base64 key B> \
+//	  --old-keys <base64 key A>
+func TestRotateCryptoKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		f := newRotateFixture(t)
+
+		const wantSecret = "workspace-app-secret"
+		seeded := dbgen.CryptoKey(t, f.cryptDBA, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+			Sequence: 1,
+			Secret:   sql.NullString{String: wantSecret, Valid: true},
+		})
+		require.Equal(t, f.cipherA.HexDigest(), seeded.SecretKeyID.String, "sanity check: seed must be encrypted under cipher A")
+
+		f.rotate(t)
+
+		got, err := f.rawDB.GetCryptoKeyByFeatureAndSequence(f.ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  seeded.Feature,
+			Sequence: seeded.Sequence,
+		})
+		require.NoError(t, err)
+		require.Equal(t, f.cipherB.HexDigest(), got.SecretKeyID.String)
+		require.Equal(t, wantSecret, decryptRawString(t, f.cipherB, got.Secret.String))
+	})
+
+	// DecryptErr simulates an operator omitting an old key from --old-keys.
+	// A crypto_keys row is encrypted under cipher C, registered in
+	// dbcrypt_keys but never passed to the rotation below, so Rotate fails
+	// immediately (see TestRotateUserLinks/DecryptErr for why) and leaves
+	// the row untouched.
+	//
+	//	# cipher C's key is missing from --old-keys here on purpose:
+	//	coder server dbcrypt rotate \
+	//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+	//	  --new-key <base64 key B> \
+	//	  --old-keys <base64 key A>
+	t.Run("DecryptErr", func(t *testing.T) {
+		t.Parallel()
+		f := newRotateFixture(t)
+
+		cipherC := newCipher(t)
+		cryptDBC := f.registerCipher(t, cipherC)
+		seeded := dbgen.CryptoKey(t, cryptDBC, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+			Sequence: 1,
+			Secret:   sql.NullString{String: "workspace-app-secret", Valid: true},
+		})
+		require.Equal(t, cipherC.HexDigest(), seeded.SecretKeyID.String, "sanity check: seed must be encrypted under cipher C")
+
+		err := f.rotateErr(t)
+		require.Error(t, err, "expected an error: cipher C is active in dbcrypt_keys but was never passed to Rotate")
+		var derr *dbcrypt.DecryptFailedError
+		require.ErrorAs(t, err, &derr, "expected a decrypt error")
+
+		got, getErr := f.rawDB.GetCryptoKeyByFeatureAndSequence(f.ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  seeded.Feature,
+			Sequence: seeded.Sequence,
+		})
+		require.NoError(t, getErr)
+		require.Equal(t, cipherC.HexDigest(), got.SecretKeyID.String, "row must remain encrypted under cipher C after a failed rotation")
+	})
+}
+
+// TestDecryptCryptoKeys covers the crypto_keys table when an operator
+// turns off database encryption. Leftover secret_key_id values must be
+// cleared or revoke fails with crypto_keys_secret_key_id_fkey:
+//
+//	coder server dbcrypt decrypt \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+//	  --keys <base64 key A>
+func TestDecryptCryptoKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		f := newDecryptFixture(t)
+
+		const wantSecret = "workspace-app-secret"
+		seeded := dbgen.CryptoKey(t, f.cryptDBA, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+			Sequence: 1,
+			Secret:   sql.NullString{String: wantSecret, Valid: true},
+		})
+		require.Equal(t, f.cipherA.HexDigest(), seeded.SecretKeyID.String, "sanity check: seed must be encrypted under cipher A")
+
+		f.decrypt(t)
+
+		got, err := f.rawDB.GetCryptoKeyByFeatureAndSequence(f.ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  seeded.Feature,
+			Sequence: seeded.Sequence,
+		})
+		require.NoError(t, err)
+		require.False(t, got.SecretKeyID.Valid, "key ID should be cleared after decrypt")
+		require.True(t, got.Secret.Valid)
+		require.Equal(t, wantSecret, got.Secret.String, "value should be stored as plaintext after decrypt")
+	})
+
+	// DecryptErr simulates an operator omitting a key from --keys. See
+	// TestDecryptUserLinks/DecryptErr for the underlying mechanism.
+	//
+	//	# cipher C's key is missing from --keys here on purpose:
+	//	coder server dbcrypt decrypt \
+	//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+	//	  --keys <base64 key A>
+	t.Run("DecryptErr", func(t *testing.T) {
+		t.Parallel()
+		f := newDecryptFixture(t)
+
+		cipherC := newCipher(t)
+		cryptDBC := f.registerCipher(t, cipherC)
+		seeded := dbgen.CryptoKey(t, cryptDBC, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+			Sequence: 1,
+			Secret:   sql.NullString{String: "workspace-app-secret", Valid: true},
+		})
+		require.Equal(t, cipherC.HexDigest(), seeded.SecretKeyID.String, "sanity check: seed must be encrypted under cipher C")
+
+		err := f.decryptErr(t)
+		require.Error(t, err, "expected an error: cipher C is active in dbcrypt_keys but was never passed to Decrypt")
+		var derr *dbcrypt.DecryptFailedError
+		require.ErrorAs(t, err, &derr, "expected a decrypt error")
+
+		got, getErr := f.rawDB.GetCryptoKeyByFeatureAndSequence(f.ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  seeded.Feature,
+			Sequence: seeded.Sequence,
+		})
+		require.NoError(t, getErr)
+		require.Equal(t, cipherC.HexDigest(), got.SecretKeyID.String, "row must remain encrypted under cipher C after a failed decrypt")
+	})
+}
+
+// TestDeleteCryptoKeys covers the crypto_keys table. Delete wipes the
+// encrypted secret in place (the row stays so feature/sequence history
+// remains) and must clear secret_key_id or revoke fails with
+// crypto_keys_secret_key_id_fkey:
+//
+//	coder server dbcrypt delete \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL"
+func TestDeleteCryptoKeys(t *testing.T) {
+	t.Parallel()
+	f := newDeleteFixture(t)
+
+	encKey := dbgen.CryptoKey(t, f.cryptDBA, database.CryptoKey{
+		Feature:  database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+		Sequence: 1,
+		Secret:   sql.NullString{String: "workspace-app-secret", Valid: true},
+	})
+	plainKey := dbgen.CryptoKey(t, f.rawDB, database.CryptoKey{
+		Feature:  database.CryptoKeyFeatureTailnetResume,
+		Sequence: 1,
+		Secret:   sql.NullString{String: "plain-tailnet-secret", Valid: true},
+	})
+
+	f.delete(t)
+
+	encSecret, encKeyID := cryptoKeySecretRaw(f.ctx, t, f.sqlDB, encKey.Feature, encKey.Sequence)
+	require.False(t, encSecret.Valid, "encrypted secret should be wiped")
+	require.False(t, encKeyID.Valid, "secret_key_id should be cleared")
+
+	plainSecret, plainKeyID := cryptoKeySecretRaw(f.ctx, t, f.sqlDB, plainKey.Feature, plainKey.Sequence)
+	require.True(t, plainSecret.Valid)
+	require.Equal(t, "plain-tailnet-secret", plainSecret.String, "never-encrypted secret should survive untouched")
+	require.False(t, plainKeyID.Valid)
+
+	requireAllKeysRevoked(f.ctx, t, f.rawDB)
+}
+
+// TestRotateMCPServerConfigs covers the mcp_server_configs table (OAuth
+// client secret, API key, and custom headers). Each of those columns has
+// a FK to dbcrypt_keys.active_key_digest, so leftover rows block revoke:
+//
+//	coder server dbcrypt rotate \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+//	  --new-key <base64 key B> \
+//	  --old-keys <base64 key A>
+func TestRotateMCPServerConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		f := newRotateFixture(t)
+
+		const (
+			wantOAuth   = "mcp-oauth-secret"
+			wantAPIKey  = "mcp-api-key"
+			wantHeaders = `{"X-Custom":"header-value"}`
+		)
+		seeded := dbgen.MCPServerConfig(t, f.cryptDBA, database.MCPServerConfig{
+			AuthType:           "oauth2",
+			OAuth2ClientID:     "client-id",
+			OAuth2ClientSecret: wantOAuth,
+			APIKeyValue:        wantAPIKey,
+			CustomHeaders:      wantHeaders,
+		})
+		require.Equal(t, f.cipherA.HexDigest(), seeded.OAuth2ClientSecretKeyID.String, "sanity check: oauth secret must be encrypted under cipher A")
+		require.Equal(t, f.cipherA.HexDigest(), seeded.APIKeyValueKeyID.String, "sanity check: api key must be encrypted under cipher A")
+		require.Equal(t, f.cipherA.HexDigest(), seeded.CustomHeadersKeyID.String, "sanity check: custom headers must be encrypted under cipher A")
+
+		f.rotate(t)
+
+		got, err := f.rawDB.GetMCPServerConfigByID(f.ctx, seeded.ID)
+		require.NoError(t, err)
+		require.Equal(t, f.cipherB.HexDigest(), got.OAuth2ClientSecretKeyID.String)
+		require.Equal(t, f.cipherB.HexDigest(), got.APIKeyValueKeyID.String)
+		require.Equal(t, f.cipherB.HexDigest(), got.CustomHeadersKeyID.String)
+		require.Equal(t, wantOAuth, decryptRawString(t, f.cipherB, got.OAuth2ClientSecret))
+		require.Equal(t, wantAPIKey, decryptRawString(t, f.cipherB, got.APIKeyValue))
+		require.Equal(t, wantHeaders, decryptRawString(t, f.cipherB, got.CustomHeaders))
+	})
+
+	// DecryptErr simulates an operator omitting an old key from --old-keys.
+	// An mcp_server_configs row is encrypted under cipher C, registered in
+	// dbcrypt_keys but never passed to the rotation below, so Rotate fails
+	// immediately (see TestRotateUserLinks/DecryptErr for why) and leaves
+	// the row untouched.
+	//
+	//	# cipher C's key is missing from --old-keys here on purpose:
+	//	coder server dbcrypt rotate \
+	//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+	//	  --new-key <base64 key B> \
+	//	  --old-keys <base64 key A>
+	t.Run("DecryptErr", func(t *testing.T) {
+		t.Parallel()
+		f := newRotateFixture(t)
+
+		cipherC := newCipher(t)
+		cryptDBC := f.registerCipher(t, cipherC)
+		seeded := dbgen.MCPServerConfig(t, cryptDBC, database.MCPServerConfig{
+			AuthType:           "oauth2",
+			OAuth2ClientSecret: "mcp-oauth-secret",
+		})
+		require.Equal(t, cipherC.HexDigest(), seeded.OAuth2ClientSecretKeyID.String, "sanity check: seed must be encrypted under cipher C")
+
+		err := f.rotateErr(t)
+		require.Error(t, err, "expected an error: cipher C is active in dbcrypt_keys but was never passed to Rotate")
+		var derr *dbcrypt.DecryptFailedError
+		require.ErrorAs(t, err, &derr, "expected a decrypt error")
+
+		got, getErr := f.rawDB.GetMCPServerConfigByID(f.ctx, seeded.ID)
+		require.NoError(t, getErr)
+		require.Equal(t, cipherC.HexDigest(), got.OAuth2ClientSecretKeyID.String, "row must remain encrypted under cipher C after a failed rotation")
+	})
+}
+
+// TestDecryptMCPServerConfigs covers the mcp_server_configs table when
+// an operator turns off database encryption:
+//
+//	coder server dbcrypt decrypt \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+//	  --keys <base64 key A>
+func TestDecryptMCPServerConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		f := newDecryptFixture(t)
+
+		const (
+			wantOAuth   = "mcp-oauth-secret"
+			wantAPIKey  = "mcp-api-key"
+			wantHeaders = `{"X-Custom":"header-value"}`
+		)
+		seeded := dbgen.MCPServerConfig(t, f.cryptDBA, database.MCPServerConfig{
+			AuthType:           "oauth2",
+			OAuth2ClientID:     "client-id",
+			OAuth2ClientSecret: wantOAuth,
+			APIKeyValue:        wantAPIKey,
+			CustomHeaders:      wantHeaders,
+		})
+		require.Equal(t, f.cipherA.HexDigest(), seeded.OAuth2ClientSecretKeyID.String, "sanity check: seed must be encrypted under cipher A")
+
+		f.decrypt(t)
+
+		got, err := f.rawDB.GetMCPServerConfigByID(f.ctx, seeded.ID)
+		require.NoError(t, err)
+		require.False(t, got.OAuth2ClientSecretKeyID.Valid)
+		require.False(t, got.APIKeyValueKeyID.Valid)
+		require.False(t, got.CustomHeadersKeyID.Valid)
+		require.Equal(t, wantOAuth, got.OAuth2ClientSecret)
+		require.Equal(t, wantAPIKey, got.APIKeyValue)
+		require.Equal(t, wantHeaders, got.CustomHeaders)
+	})
+
+	// DecryptErr simulates an operator omitting a key from --keys. See
+	// TestDecryptUserLinks/DecryptErr for the underlying mechanism.
+	//
+	//	# cipher C's key is missing from --keys here on purpose:
+	//	coder server dbcrypt decrypt \
+	//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+	//	  --keys <base64 key A>
+	t.Run("DecryptErr", func(t *testing.T) {
+		t.Parallel()
+		f := newDecryptFixture(t)
+
+		cipherC := newCipher(t)
+		cryptDBC := f.registerCipher(t, cipherC)
+		seeded := dbgen.MCPServerConfig(t, cryptDBC, database.MCPServerConfig{
+			AuthType:           "oauth2",
+			OAuth2ClientSecret: "mcp-oauth-secret",
+		})
+		require.Equal(t, cipherC.HexDigest(), seeded.OAuth2ClientSecretKeyID.String, "sanity check: seed must be encrypted under cipher C")
+
+		err := f.decryptErr(t)
+		require.Error(t, err, "expected an error: cipher C is active in dbcrypt_keys but was never passed to Decrypt")
+		var derr *dbcrypt.DecryptFailedError
+		require.ErrorAs(t, err, &derr, "expected a decrypt error")
+
+		got, getErr := f.rawDB.GetMCPServerConfigByID(f.ctx, seeded.ID)
+		require.NoError(t, getErr)
+		require.Equal(t, cipherC.HexDigest(), got.OAuth2ClientSecretKeyID.String, "row must remain encrypted under cipher C after a failed decrypt")
+	})
+}
+
+// TestDeleteMCPServerConfigs covers the mcp_server_configs table. Encrypted
+// secret columns are cleared in place (the config row stays) so revoke can
+// succeed:
+//
+//	coder server dbcrypt delete \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL"
+func TestDeleteMCPServerConfigs(t *testing.T) {
+	t.Parallel()
+	f := newDeleteFixture(t)
+
+	encCfg := dbgen.MCPServerConfig(t, f.cryptDBA, database.MCPServerConfig{
+		AuthType:           "oauth2",
+		OAuth2ClientSecret: "mcp-oauth-secret",
+		APIKeyValue:        "mcp-api-key",
+		CustomHeaders:      `{"X-Custom":"header-value"}`,
+	})
+	plainCfg := dbgen.MCPServerConfig(t, f.rawDB, database.MCPServerConfig{
+		AuthType:           "oauth2",
+		OAuth2ClientSecret: "plain-oauth-secret",
+		APIKeyValue:        "plain-api-key",
+		CustomHeaders:      `{"X-Plain":"plain-value"}`,
+	})
+
+	f.delete(t)
+
+	gotEnc, err := f.rawDB.GetMCPServerConfigByID(f.ctx, encCfg.ID)
+	require.NoError(t, err, "row should still exist, only cleared")
+	require.Empty(t, gotEnc.OAuth2ClientSecret)
+	require.False(t, gotEnc.OAuth2ClientSecretKeyID.Valid)
+	require.Empty(t, gotEnc.APIKeyValue)
+	require.False(t, gotEnc.APIKeyValueKeyID.Valid)
+	require.False(t, gotEnc.CustomHeadersKeyID.Valid)
+
+	gotPlain, err := f.rawDB.GetMCPServerConfigByID(f.ctx, plainCfg.ID)
+	require.NoError(t, err)
+	require.Equal(t, "plain-oauth-secret", gotPlain.OAuth2ClientSecret, "never-encrypted oauth secret should survive untouched")
+	require.Equal(t, "plain-api-key", gotPlain.APIKeyValue)
+	require.Equal(t, `{"X-Plain":"plain-value"}`, gotPlain.CustomHeaders)
+
+	requireAllKeysRevoked(f.ctx, t, f.rawDB)
+}
+
+// TestRotateMCPServerUserTokens covers the mcp_server_user_tokens table
+// (per-user MCP OAuth access and refresh tokens). Both key-id columns
+// reference dbcrypt_keys.active_key_digest:
+//
+//	coder server dbcrypt rotate \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+//	  --new-key <base64 key B> \
+//	  --old-keys <base64 key A>
+func TestRotateMCPServerUserTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		f := newRotateFixture(t)
+
+		// Tokens survive user soft-deletion (ON DELETE CASCADE is only
+		// for hard delete), so both a live and a deleted user's row
+		// are exercised.
+		live := dbgen.User(t, f.rawDB, database.User{})
+		deletedUser := dbgen.User(t, f.rawDB, database.User{Deleted: true})
+		cfg := dbgen.MCPServerConfig(t, f.rawDB, database.MCPServerConfig{
+			AuthType: "oauth2",
+		})
+
+		liveTok := upsertMCPServerUserToken(f.ctx, t, f.cryptDBA, cfg.ID, live.ID, "access-"+live.ID.String(), "refresh-"+live.ID.String())
+		deletedTok := upsertMCPServerUserToken(f.ctx, t, f.cryptDBA, cfg.ID, deletedUser.ID, "access-"+deletedUser.ID.String(), "refresh-"+deletedUser.ID.String())
+		require.Equal(t, f.cipherA.HexDigest(), liveTok.AccessTokenKeyID.String, "sanity check: seed must be encrypted under cipher A")
+		require.Equal(t, f.cipherA.HexDigest(), deletedTok.AccessTokenKeyID.String, "sanity check: deleted-user seed must be encrypted under cipher A")
+
+		f.rotate(t)
+
+		for _, u := range []database.User{live, deletedUser} {
+			tok, err := f.rawDB.GetMCPServerUserToken(f.ctx, database.GetMCPServerUserTokenParams{
+				MCPServerConfigID: cfg.ID,
+				UserID:            u.ID,
+			})
+			require.NoError(t, err, "user %s", u.ID)
+			require.Equal(t, f.cipherB.HexDigest(), tok.AccessTokenKeyID.String)
+			require.Equal(t, f.cipherB.HexDigest(), tok.RefreshTokenKeyID.String)
+			require.Equal(t, "access-"+u.ID.String(), decryptRawString(t, f.cipherB, tok.AccessToken))
+			require.Equal(t, "refresh-"+u.ID.String(), decryptRawString(t, f.cipherB, tok.RefreshToken))
+		}
+	})
+
+	// DecryptErr simulates an operator omitting an old key from --old-keys.
+	// A mcp_server_user_tokens row is encrypted under cipher C, registered
+	// in dbcrypt_keys but never passed to the rotation below, so Rotate
+	// fails immediately (see TestRotateUserLinks/DecryptErr for why) and
+	// leaves the row untouched.
+	//
+	//	# cipher C's key is missing from --old-keys here on purpose:
+	//	coder server dbcrypt rotate \
+	//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+	//	  --new-key <base64 key B> \
+	//	  --old-keys <base64 key A>
+	t.Run("DecryptErr", func(t *testing.T) {
+		t.Parallel()
+		f := newRotateFixture(t)
+
+		cipherC := newCipher(t)
+		cryptDBC := f.registerCipher(t, cipherC)
+		user := dbgen.User(t, f.rawDB, database.User{})
+		cfg := dbgen.MCPServerConfig(t, f.rawDB, database.MCPServerConfig{
+			AuthType: "oauth2",
+		})
+		seeded := upsertMCPServerUserToken(f.ctx, t, cryptDBC, cfg.ID, user.ID, "access-token", "refresh-token")
+		require.Equal(t, cipherC.HexDigest(), seeded.AccessTokenKeyID.String, "sanity check: seed must be encrypted under cipher C")
+
+		err := f.rotateErr(t)
+		require.Error(t, err, "expected an error: cipher C is active in dbcrypt_keys but was never passed to Rotate")
+		var derr *dbcrypt.DecryptFailedError
+		require.ErrorAs(t, err, &derr, "expected a decrypt error")
+
+		got, getErr := f.rawDB.GetMCPServerUserToken(f.ctx, database.GetMCPServerUserTokenParams{
+			MCPServerConfigID: cfg.ID,
+			UserID:            user.ID,
+		})
+		require.NoError(t, getErr)
+		require.Equal(t, cipherC.HexDigest(), got.AccessTokenKeyID.String, "row must remain encrypted under cipher C after a failed rotation")
+	})
+}
+
+// TestDecryptMCPServerUserTokens covers the mcp_server_user_tokens table
+// when an operator turns off database encryption:
+//
+//	coder server dbcrypt decrypt \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+//	  --keys <base64 key A>
+func TestDecryptMCPServerUserTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		f := newDecryptFixture(t)
+
+		live := dbgen.User(t, f.rawDB, database.User{})
+		deletedUser := dbgen.User(t, f.rawDB, database.User{Deleted: true})
+		cfg := dbgen.MCPServerConfig(t, f.rawDB, database.MCPServerConfig{
+			AuthType: "oauth2",
+		})
+
+		upsertMCPServerUserToken(f.ctx, t, f.cryptDBA, cfg.ID, live.ID, "access-"+live.ID.String(), "refresh-"+live.ID.String())
+		upsertMCPServerUserToken(f.ctx, t, f.cryptDBA, cfg.ID, deletedUser.ID, "access-"+deletedUser.ID.String(), "refresh-"+deletedUser.ID.String())
+
+		f.decrypt(t)
+
+		for _, u := range []database.User{live, deletedUser} {
+			tok, err := f.rawDB.GetMCPServerUserToken(f.ctx, database.GetMCPServerUserTokenParams{
+				MCPServerConfigID: cfg.ID,
+				UserID:            u.ID,
+			})
+			require.NoError(t, err, "user %s", u.ID)
+			require.False(t, tok.AccessTokenKeyID.Valid)
+			require.False(t, tok.RefreshTokenKeyID.Valid)
+			require.Equal(t, "access-"+u.ID.String(), tok.AccessToken)
+			require.Equal(t, "refresh-"+u.ID.String(), tok.RefreshToken)
+		}
+	})
+
+	// DecryptErr simulates an operator omitting a key from --keys. See
+	// TestDecryptUserLinks/DecryptErr for the underlying mechanism.
+	//
+	//	# cipher C's key is missing from --keys here on purpose:
+	//	coder server dbcrypt decrypt \
+	//	  --postgres-url "$CODER_PG_CONNECTION_URL" \
+	//	  --keys <base64 key A>
+	t.Run("DecryptErr", func(t *testing.T) {
+		t.Parallel()
+		f := newDecryptFixture(t)
+
+		cipherC := newCipher(t)
+		cryptDBC := f.registerCipher(t, cipherC)
+		user := dbgen.User(t, f.rawDB, database.User{})
+		cfg := dbgen.MCPServerConfig(t, f.rawDB, database.MCPServerConfig{
+			AuthType: "oauth2",
+		})
+		seeded := upsertMCPServerUserToken(f.ctx, t, cryptDBC, cfg.ID, user.ID, "access-token", "refresh-token")
+		require.Equal(t, cipherC.HexDigest(), seeded.AccessTokenKeyID.String, "sanity check: seed must be encrypted under cipher C")
+
+		err := f.decryptErr(t)
+		require.Error(t, err, "expected an error: cipher C is active in dbcrypt_keys but was never passed to Decrypt")
+		var derr *dbcrypt.DecryptFailedError
+		require.ErrorAs(t, err, &derr, "expected a decrypt error")
+
+		got, getErr := f.rawDB.GetMCPServerUserToken(f.ctx, database.GetMCPServerUserTokenParams{
+			MCPServerConfigID: cfg.ID,
+			UserID:            user.ID,
+		})
+		require.NoError(t, getErr)
+		require.Equal(t, cipherC.HexDigest(), got.AccessTokenKeyID.String, "row must remain encrypted under cipher C after a failed decrypt")
+	})
+}
+
+// TestDeleteMCPServerUserTokens covers the mcp_server_user_tokens table.
+// Encrypted rows are deleted so revoke can succeed:
+//
+//	coder server dbcrypt delete \
+//	  --postgres-url "$CODER_PG_CONNECTION_URL"
+func TestDeleteMCPServerUserTokens(t *testing.T) {
+	t.Parallel()
+	f := newDeleteFixture(t)
+
+	encUser := dbgen.User(t, f.rawDB, database.User{})
+	plainUser := dbgen.User(t, f.rawDB, database.User{})
+	cfg := dbgen.MCPServerConfig(t, f.rawDB, database.MCPServerConfig{
+		AuthType: "oauth2",
+	})
+	encTok := upsertMCPServerUserToken(f.ctx, t, f.cryptDBA, cfg.ID, encUser.ID, "access-token", "refresh-token")
+	plainTok := upsertMCPServerUserToken(f.ctx, t, f.rawDB, cfg.ID, plainUser.ID, "plain-access-token", "plain-refresh-token")
+
+	f.delete(t)
+
+	_, err := f.rawDB.GetMCPServerUserTokenByID(f.ctx, encTok.ID)
+	require.ErrorIs(t, err, sql.ErrNoRows, "encrypted mcp_server_user_tokens row should have been deleted")
+
+	gotPlain, err := f.rawDB.GetMCPServerUserTokenByID(f.ctx, plainTok.ID)
+	require.NoError(t, err, "never-encrypted mcp_server_user_tokens row should survive")
+	require.Equal(t, "plain-access-token", gotPlain.AccessToken)
+	require.Equal(t, "plain-refresh-token", gotPlain.RefreshToken)
+
+	requireAllKeysRevoked(f.ctx, t, f.rawDB)
+}
+
 // TestFullLifecycleAllHandledTables seeds one row in every table
 // Rotate/Decrypt/Delete actually loop over, then drives the operator
 // lifecycle end-to-end in a single database: seed data encrypted under
@@ -1642,13 +2220,6 @@ func TestDeleteUserAIProviderKeys(t *testing.T) {
 // delete a freshly re-encrypted row. One database with every handled table
 // populated together, closer to how an operator actually runs these
 // commands back to back, instead of one table at a time.
-//
-// This intentionally excludes crypto_keys, mcp_server_configs, and
-// mcp_server_user_tokens. Rotate/Decrypt don't clear those tables at all
-// (see issue #25381), so seeding them here would fail this test for a
-// reason unrelated to what it's meant to cover: whether the 7 tables
-// cliutil.go already handles stay consistent with each other across a full
-// rotate-decrypt-delete sequence.
 func TestFullLifecycleAllHandledTables(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -1699,6 +2270,18 @@ func TestFullLifecycleAllHandledTables(t *testing.T) {
 		APIKey:     "provider-api-key",
 	})
 	seededUserProviderKey := upsertUserAIProviderKey(ctx, t, cryptDBA, liveUser.ID, provider.ID, "user-api-key")
+	seededCryptoKey := dbgen.CryptoKey(t, cryptDBA, database.CryptoKey{
+		Feature:  database.CryptoKeyFeatureWorkspaceAppsAPIKey,
+		Sequence: 1,
+		Secret:   sql.NullString{String: "workspace-app-secret", Valid: true},
+	})
+	seededMCPCfg := dbgen.MCPServerConfig(t, cryptDBA, database.MCPServerConfig{
+		AuthType:           "oauth2",
+		OAuth2ClientSecret: "mcp-oauth-secret",
+		APIKeyValue:        "mcp-api-key",
+		CustomHeaders:      `{"X-Custom":"header-value"}`,
+	})
+	seededMCPTok := upsertMCPServerUserToken(ctx, t, cryptDBA, seededMCPCfg.ID, liveUser.ID, "mcp-access-token", "mcp-refresh-token")
 
 	require.Equal(t, cipherA.HexDigest(), provider.SettingsKeyID.String, "sanity check: ai_providers seeded under cipher A")
 	require.Equal(t, cipherA.HexDigest(), seededLink.OAuthAccessTokenKeyID.String, "sanity check: user_links seeded under cipher A")
@@ -1707,6 +2290,9 @@ func TestFullLifecycleAllHandledTables(t *testing.T) {
 	require.Equal(t, cipherA.HexDigest(), seededSSHKey.PrivateKeyKeyID.String, "sanity check: gitsshkeys seeded under cipher A")
 	require.Equal(t, cipherA.HexDigest(), seededProviderKey.ApiKeyKeyID.String, "sanity check: ai_provider_keys seeded under cipher A")
 	require.Equal(t, cipherA.HexDigest(), seededUserProviderKey.ApiKeyKeyID.String, "sanity check: user_ai_provider_keys seeded under cipher A")
+	require.Equal(t, cipherA.HexDigest(), seededCryptoKey.SecretKeyID.String, "sanity check: crypto_keys seeded under cipher A")
+	require.Equal(t, cipherA.HexDigest(), seededMCPCfg.OAuth2ClientSecretKeyID.String, "sanity check: mcp_server_configs seeded under cipher A")
+	require.Equal(t, cipherA.HexDigest(), seededMCPTok.AccessTokenKeyID.String, "sanity check: mcp_server_user_tokens seeded under cipher A")
 
 	// --- Rotate: cipher A -> cipher B ---
 	err = dbcrypt.Rotate(ctx, log, sqlDB, []dbcrypt.Cipher{cipherB, cipherA})
@@ -1754,6 +2340,27 @@ func TestFullLifecycleAllHandledTables(t *testing.T) {
 	}
 	require.True(t, foundUserProviderKey, "seeded user_ai_provider_keys row must still exist after rotate")
 
+	gotCryptoKey, err := rawDB.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+		Feature:  seededCryptoKey.Feature,
+		Sequence: seededCryptoKey.Sequence,
+	})
+	require.NoError(t, err)
+	require.Equal(t, cipherB.HexDigest(), gotCryptoKey.SecretKeyID.String)
+	require.Equal(t, "workspace-app-secret", decryptRawString(t, cipherB, gotCryptoKey.Secret.String))
+
+	gotMCPCfg, err := rawDB.GetMCPServerConfigByID(ctx, seededMCPCfg.ID)
+	require.NoError(t, err)
+	require.Equal(t, cipherB.HexDigest(), gotMCPCfg.OAuth2ClientSecretKeyID.String)
+	require.Equal(t, "mcp-oauth-secret", decryptRawString(t, cipherB, gotMCPCfg.OAuth2ClientSecret))
+
+	gotMCPTok, err := rawDB.GetMCPServerUserToken(ctx, database.GetMCPServerUserTokenParams{
+		MCPServerConfigID: seededMCPCfg.ID,
+		UserID:            liveUser.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, cipherB.HexDigest(), gotMCPTok.AccessTokenKeyID.String)
+	require.Equal(t, "mcp-access-token", decryptRawString(t, cipherB, gotMCPTok.AccessToken))
+
 	// --- Decrypt: cipher B -> plaintext ---
 	err = dbcrypt.Decrypt(ctx, log, sqlDB, []dbcrypt.Cipher{cipherB})
 	require.NoError(t, err, "decrypt should succeed and revoke cipher B even with every handled table populated at once")
@@ -1769,6 +2376,27 @@ func TestFullLifecycleAllHandledTables(t *testing.T) {
 	require.Len(t, secrets, 1)
 	require.False(t, secrets[0].ValueKeyID.Valid)
 	require.Equal(t, "super-secret-value", secrets[0].Value)
+
+	gotCryptoKey, err = rawDB.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+		Feature:  seededCryptoKey.Feature,
+		Sequence: seededCryptoKey.Sequence,
+	})
+	require.NoError(t, err)
+	require.False(t, gotCryptoKey.SecretKeyID.Valid)
+	require.Equal(t, "workspace-app-secret", gotCryptoKey.Secret.String)
+
+	gotMCPCfg, err = rawDB.GetMCPServerConfigByID(ctx, seededMCPCfg.ID)
+	require.NoError(t, err)
+	require.False(t, gotMCPCfg.OAuth2ClientSecretKeyID.Valid)
+	require.Equal(t, "mcp-oauth-secret", gotMCPCfg.OAuth2ClientSecret)
+
+	gotMCPTok, err = rawDB.GetMCPServerUserToken(ctx, database.GetMCPServerUserTokenParams{
+		MCPServerConfigID: seededMCPCfg.ID,
+		UserID:            liveUser.ID,
+	})
+	require.NoError(t, err)
+	require.False(t, gotMCPTok.AccessTokenKeyID.Valid)
+	require.Equal(t, "mcp-access-token", gotMCPTok.AccessToken)
 
 	// --- Delete: seed one more row under a fresh cipher, then wipe it ---
 	cipherC := newCipher(t)


### PR DESCRIPTION
`coder server dbcrypt decrypt`/`rotate`/`delete` never walked `crypto_keys`, `mcp_server_configs`, or `mcp_server_user_tokens`. Leftover `*_key_id` rows then blocked `RevokeDBCryptKey` with `crypto_keys_secret_key_id_fkey` (and the MCP equivalents).

Walk those three tables the same way the existing ones are walked:

- Rotate re-encrypts under the new cipher
- Decrypt writes plaintext and clears key IDs
- Delete wipes encrypted `crypto_keys`/`mcp_server_configs` columns in place and deletes encrypted MCP user tokens

Fixes #25381