### PR TITLE
feat(agent/unit): support conditional dependencies

### DIFF
--- a/agent/unit/conditional.go
+++ b/agent/unit/conditional.go
@@ -1,0 +1,213 @@
+package unit
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+var (
+	ErrInvalidRequirement    = xerrors.New("invalid dependency requirement")
+	ErrInvalidOutcome        = xerrors.New("invalid unit outcome")
+	ErrSameOutcomeAlreadySet = xerrors.New("same outcome already set")
+)
+
+// Requirement describes the outcome a conditional dependency requires.
+type Requirement string
+
+const (
+	RequirementSuccess    Requirement = "success"
+	RequirementCompletion Requirement = "completion"
+)
+
+func (r Requirement) valid() bool {
+	return r == RequirementSuccess || r == RequirementCompletion
+}
+
+// Outcome represents a unit's progress and terminal result.
+type Outcome string
+
+const (
+	OutcomeNotRegistered Outcome = ""
+	OutcomePending       Outcome = "pending"
+	OutcomeRunning       Outcome = "running"
+	OutcomeSucceeded     Outcome = "succeeded"
+	OutcomeFailed        Outcome = "failed"
+	OutcomeTimedOut      Outcome = "timed_out"
+	OutcomeSkipped       Outcome = "skipped"
+)
+
+func (o Outcome) valid() bool {
+	switch o {
+	case OutcomePending, OutcomeRunning, OutcomeSucceeded, OutcomeFailed, OutcomeTimedOut, OutcomeSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+// Terminal reports whether the outcome is final for dependency evaluation.
+func (o Outcome) Terminal() bool {
+	switch o {
+	case OutcomeSucceeded, OutcomeFailed, OutcomeTimedOut, OutcomeSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+// Decision describes whether a unit should keep waiting, run, or be skipped.
+type Decision string
+
+const (
+	DecisionWaiting  Decision = "waiting"
+	DecisionRunnable Decision = "runnable"
+	DecisionSkipped  Decision = "skipped"
+)
+
+// ConditionalDependency is a point-in-time view of an unsatisfied
+// outcome-based dependency.
+type ConditionalDependency struct {
+	Unit           ID
+	DependsOn      ID
+	Requirement    Requirement
+	CurrentOutcome Outcome
+}
+
+// Evaluation is the current decision for a unit and its unsatisfied
+// outcome-based dependencies. UnmetDependencies is sorted by DependsOn.
+type Evaluation struct {
+	Decision          Decision
+	UnmetDependencies []ConditionalDependency
+}
+
+// AddConditionalDependency makes unit depend on the outcome of dependsOn.
+// These dependencies are independent from the exact-status dependencies added
+// by AddDependency.
+func (m *Manager) AddConditionalDependency(unit ID, dependsOn ID, requirement Requirement) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch {
+	case unit == "":
+		return xerrors.Errorf("dependent name cannot be empty: %w", ErrUnitIDRequired)
+	case dependsOn == "":
+		return xerrors.Errorf("dependency name cannot be empty: %w", ErrUnitIDRequired)
+	case !m.registered(unit):
+		return xerrors.Errorf("dependent unit %q must be registered first: %w", unit, ErrUnitNotFound)
+	case !requirement.valid():
+		return xerrors.Errorf("dependency from %q to %q requires %q: %w", unit, dependsOn, requirement, ErrInvalidRequirement)
+	}
+
+	if err := m.conditionalGraph.AddEdge(unit, dependsOn, requirement); err != nil {
+		return xerrors.Errorf("adding conditional edge for unit %q: %w", unit, errors.Join(ErrFailedToAddDependency, err))
+	}
+
+	m.broadcastOutcomeChangeUnsafe()
+	return nil
+}
+
+// UpdateOutcome updates a unit's outcome and wakes conditional dependency
+// waiters.
+func (m *Manager) UpdateOutcome(unit ID, outcome Outcome) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch {
+	case unit == "":
+		return xerrors.Errorf("updating outcome for unit %q: %w", unit, ErrUnitIDRequired)
+	case !m.registered(unit):
+		return xerrors.Errorf("unit %q must be registered first: %w", unit, ErrUnitNotFound)
+	case !outcome.valid():
+		return xerrors.Errorf("updating outcome for unit %q to %q: %w", unit, outcome, ErrInvalidOutcome)
+	}
+
+	u := m.units[unit]
+	if u.outcome == outcome {
+		return xerrors.Errorf("checking outcome for unit %q: %w", unit, ErrSameOutcomeAlreadySet)
+	}
+
+	u.outcome = outcome
+	m.units[unit] = u
+	m.broadcastOutcomeChangeUnsafe()
+	return nil
+}
+
+// Evaluate returns the current conditional dependency decision for a unit.
+func (m *Manager) Evaluate(id ID) (Evaluation, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.evaluateUnsafe(id)
+}
+
+// WaitForDecision waits until a unit is runnable, must be skipped, or ctx is
+// done. It never treats elapsed waiting time as dependency satisfaction.
+func (m *Manager) WaitForDecision(ctx context.Context, id ID) (Evaluation, error) {
+	for {
+		m.mu.RLock()
+		evaluation, err := m.evaluateUnsafe(id)
+		changed := m.outcomeChanged
+		m.mu.RUnlock()
+		if err != nil {
+			return Evaluation{}, err
+		}
+		if evaluation.Decision != DecisionWaiting {
+			return evaluation, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return Evaluation{}, ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+// evaluateUnsafe evaluates conditional dependencies. The caller must hold at
+// least a read lock.
+func (m *Manager) evaluateUnsafe(id ID) (Evaluation, error) {
+	if id == "" {
+		return Evaluation{}, xerrors.Errorf("unit ID cannot be empty: %w", ErrUnitIDRequired)
+	}
+	if !m.registered(id) {
+		return Evaluation{}, xerrors.Errorf("evaluating unit %q: %w", id, ErrUnitNotFound)
+	}
+
+	evaluation := Evaluation{Decision: DecisionRunnable}
+	for _, edge := range m.conditionalGraph.GetForwardAdjacentVertices(id) {
+		outcome := m.units[edge.To].outcome
+		satisfied := edge.Edge == RequirementSuccess && outcome == OutcomeSucceeded ||
+			edge.Edge == RequirementCompletion && outcome.Terminal()
+		if satisfied {
+			continue
+		}
+
+		evaluation.UnmetDependencies = append(evaluation.UnmetDependencies, ConditionalDependency{
+			Unit:           id,
+			DependsOn:      edge.To,
+			Requirement:    edge.Edge,
+			CurrentOutcome: outcome,
+		})
+		if edge.Edge == RequirementSuccess && outcome.Terminal() {
+			evaluation.Decision = DecisionSkipped
+		} else if evaluation.Decision != DecisionSkipped {
+			evaluation.Decision = DecisionWaiting
+		}
+	}
+
+	slices.SortFunc(evaluation.UnmetDependencies, func(a, b ConditionalDependency) int {
+		return strings.Compare(string(a.DependsOn), string(b.DependsOn))
+	})
+	return evaluation, nil
+}
+
+// broadcastOutcomeChangeUnsafe wakes all conditional dependency waiters. The
+// caller must hold the write lock.
+func (m *Manager) broadcastOutcomeChangeUnsafe() {
+	close(m.outcomeChanged)
+	m.outcomeChanged = make(chan struct{})
+}

--- a/agent/unit/conditional_test.go
+++ b/agent/unit/conditional_test.go
@@ -1,0 +1,326 @@
+package unit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/unit"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestManager_ConditionalDependencyValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("InvalidArguments", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		require.NoError(t, manager.Register(unitA))
+
+		err := manager.AddConditionalDependency("", unitB, unit.RequirementSuccess)
+		require.ErrorIs(t, err, unit.ErrUnitIDRequired)
+		err = manager.AddConditionalDependency(unitA, "", unit.RequirementSuccess)
+		require.ErrorIs(t, err, unit.ErrUnitIDRequired)
+		err = manager.AddConditionalDependency(unitB, unitA, unit.RequirementSuccess)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
+		err = manager.AddConditionalDependency(unitA, unitB, "unknown")
+		require.ErrorIs(t, err, unit.ErrInvalidRequirement)
+	})
+
+	t.Run("Cycle", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		require.NoError(t, manager.Register(unitA))
+		require.NoError(t, manager.Register(unitB))
+		require.NoError(t, manager.AddConditionalDependency(unitA, unitB, unit.RequirementSuccess))
+
+		err := manager.AddConditionalDependency(unitB, unitA, unit.RequirementCompletion)
+		require.ErrorIs(t, err, unit.ErrCycleDetected)
+	})
+}
+
+func TestManager_UpdateOutcome(t *testing.T) {
+	t.Parallel()
+
+	manager := unit.NewManager()
+	require.NoError(t, manager.Register(unitA))
+
+	snapshot, err := manager.Unit(unitA)
+	require.NoError(t, err)
+	require.Equal(t, unit.OutcomePending, snapshot.Outcome())
+
+	require.NoError(t, manager.UpdateOutcome(unitA, unit.OutcomeRunning))
+	snapshot, err = manager.Unit(unitA)
+	require.NoError(t, err)
+	require.Equal(t, unit.OutcomeRunning, snapshot.Outcome())
+
+	err = manager.UpdateOutcome(unitA, unit.OutcomeRunning)
+	require.ErrorIs(t, err, unit.ErrSameOutcomeAlreadySet)
+	err = manager.UpdateOutcome(unitA, "unknown")
+	require.ErrorIs(t, err, unit.ErrInvalidOutcome)
+	err = manager.UpdateOutcome(unitB, unit.OutcomeRunning)
+	require.ErrorIs(t, err, unit.ErrUnitNotFound)
+}
+
+func TestManager_ConditionalDependenciesPreserveStatusDependencies(t *testing.T) {
+	t.Parallel()
+
+	manager := unit.NewManager()
+	require.NoError(t, manager.Register(unitA))
+	require.NoError(t, manager.Register(unitB))
+	require.NoError(t, manager.AddConditionalDependency(unitA, unitB, unit.RequirementSuccess))
+
+	ready, err := manager.IsReady(unitA)
+	require.NoError(t, err)
+	require.True(t, ready)
+	evaluation, err := manager.Evaluate(unitA)
+	require.NoError(t, err)
+	require.Equal(t, unit.DecisionWaiting, evaluation.Decision)
+
+	require.NoError(t, manager.AddDependency(unitA, unitB, unit.StatusStarted))
+	ready, err = manager.IsReady(unitA)
+	require.NoError(t, err)
+	require.False(t, ready)
+	require.NoError(t, manager.UpdateStatus(unitB, unit.StatusStarted))
+	ready, err = manager.IsReady(unitA)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	evaluation, err = manager.Evaluate(unitA)
+	require.NoError(t, err)
+	require.Equal(t, unit.DecisionWaiting, evaluation.Decision)
+}
+
+func TestOutcome_Terminal(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		outcome  unit.Outcome
+		terminal bool
+	}{
+		{name: "not registered", outcome: unit.OutcomeNotRegistered},
+		{name: "pending", outcome: unit.OutcomePending},
+		{name: "running", outcome: unit.OutcomeRunning},
+		{name: "succeeded", outcome: unit.OutcomeSucceeded, terminal: true},
+		{name: "failed", outcome: unit.OutcomeFailed, terminal: true},
+		{name: "timed out", outcome: unit.OutcomeTimedOut, terminal: true},
+		{name: "skipped", outcome: unit.OutcomeSkipped, terminal: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.terminal, test.outcome.Terminal())
+		})
+	}
+}
+
+func TestManager_Evaluate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoDependenciesIsRunnable", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		require.NoError(t, manager.Register(unitA))
+
+		evaluation, err := manager.Evaluate(unitA)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionRunnable, evaluation.Decision)
+		require.Empty(t, evaluation.UnmetDependencies)
+	})
+
+	t.Run("SuccessRequiresSucceeded", func(t *testing.T) {
+		t.Parallel()
+
+		manager := conditionalManager(t, unit.RequirementSuccess)
+
+		evaluation, err := manager.Evaluate(unitA)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionWaiting, evaluation.Decision)
+		require.Equal(t, []unit.ConditionalDependency{{
+			Unit:           unitA,
+			DependsOn:      unitB,
+			Requirement:    unit.RequirementSuccess,
+			CurrentOutcome: unit.OutcomePending,
+		}}, evaluation.UnmetDependencies)
+
+		require.NoError(t, manager.UpdateOutcome(unitB, unit.OutcomeSucceeded))
+		evaluation, err = manager.Evaluate(unitA)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionRunnable, evaluation.Decision)
+		require.Empty(t, evaluation.UnmetDependencies)
+	})
+
+	for _, outcome := range []unit.Outcome{
+		unit.OutcomeFailed,
+		unit.OutcomeTimedOut,
+		unit.OutcomeSkipped,
+	} {
+		t.Run("SuccessSkipsAfter"+string(outcome), func(t *testing.T) {
+			t.Parallel()
+
+			manager := conditionalManager(t, unit.RequirementSuccess)
+			require.NoError(t, manager.UpdateOutcome(unitB, outcome))
+
+			evaluation, err := manager.Evaluate(unitA)
+			require.NoError(t, err)
+			require.Equal(t, unit.DecisionSkipped, evaluation.Decision)
+			require.Equal(t, outcome, evaluation.UnmetDependencies[0].CurrentOutcome)
+		})
+	}
+
+	for _, outcome := range []unit.Outcome{
+		unit.OutcomeSucceeded,
+		unit.OutcomeFailed,
+		unit.OutcomeTimedOut,
+		unit.OutcomeSkipped,
+	} {
+		t.Run("CompletionRunsAfter"+string(outcome), func(t *testing.T) {
+			t.Parallel()
+
+			manager := conditionalManager(t, unit.RequirementCompletion)
+			require.NoError(t, manager.UpdateOutcome(unitB, outcome))
+
+			evaluation, err := manager.Evaluate(unitA)
+			require.NoError(t, err)
+			require.Equal(t, unit.DecisionRunnable, evaluation.Decision)
+			require.Empty(t, evaluation.UnmetDependencies)
+		})
+	}
+
+	t.Run("UnmetDependenciesAreSorted", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		for _, id := range []unit.ID{unitA, unitB, unitC, unitD} {
+			require.NoError(t, manager.Register(id))
+		}
+		require.NoError(t, manager.AddConditionalDependency(unitA, unitD, unit.RequirementCompletion))
+		require.NoError(t, manager.AddConditionalDependency(unitA, unitB, unit.RequirementSuccess))
+		require.NoError(t, manager.AddConditionalDependency(unitA, unitC, unit.RequirementCompletion))
+		require.NoError(t, manager.UpdateOutcome(unitB, unit.OutcomeFailed))
+
+		evaluation, err := manager.Evaluate(unitA)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionSkipped, evaluation.Decision)
+		require.Equal(t, []unit.ID{unitB, unitC, unitD}, conditionalDependencyIDs(evaluation.UnmetDependencies))
+	})
+
+	t.Run("SkippedPropagatesByRequirement", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		for _, id := range []unit.ID{unitA, unitB, unitC, unitD} {
+			require.NoError(t, manager.Register(id))
+		}
+		require.NoError(t, manager.AddConditionalDependency(unitB, unitA, unit.RequirementSuccess))
+		require.NoError(t, manager.AddConditionalDependency(unitC, unitB, unit.RequirementCompletion))
+		require.NoError(t, manager.AddConditionalDependency(unitD, unitB, unit.RequirementSuccess))
+		require.NoError(t, manager.UpdateOutcome(unitA, unit.OutcomeFailed))
+
+		evaluation, err := manager.Evaluate(unitB)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionSkipped, evaluation.Decision)
+		require.NoError(t, manager.UpdateOutcome(unitB, unit.OutcomeSkipped))
+
+		evaluation, err = manager.Evaluate(unitC)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionRunnable, evaluation.Decision)
+		evaluation, err = manager.Evaluate(unitD)
+		require.NoError(t, err)
+		require.Equal(t, unit.DecisionSkipped, evaluation.Decision)
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		_, err := manager.Evaluate("")
+		require.ErrorIs(t, err, unit.ErrUnitIDRequired)
+		_, err = manager.Evaluate(unitA)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
+	})
+}
+
+func TestManager_WaitForDecision(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WakesWhenRunnable", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		manager := conditionalManager(t, unit.RequirementSuccess)
+		result := make(chan unit.Evaluation, 1)
+		errCh := make(chan error, 1)
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			evaluation, err := manager.WaitForDecision(ctx, unitA)
+			result <- evaluation
+			errCh <- err
+		}()
+		<-started
+
+		require.NoError(t, manager.UpdateOutcome(unitB, unit.OutcomeSucceeded))
+		require.Equal(t, unit.DecisionRunnable, testutil.RequireReceive(ctx, t, result).Decision)
+		require.NoError(t, testutil.RequireReceive(ctx, t, errCh))
+	})
+
+	t.Run("WakesWhenSkipped", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		manager := conditionalManager(t, unit.RequirementSuccess)
+		result := make(chan unit.Evaluation, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			evaluation, err := manager.WaitForDecision(ctx, unitA)
+			result <- evaluation
+			errCh <- err
+		}()
+
+		require.NoError(t, manager.UpdateOutcome(unitB, unit.OutcomeFailed))
+		require.Equal(t, unit.DecisionSkipped, testutil.RequireReceive(ctx, t, result).Decision)
+		require.NoError(t, testutil.RequireReceive(ctx, t, errCh))
+	})
+
+	t.Run("ContextCanceled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		manager := conditionalManager(t, unit.RequirementSuccess)
+
+		_, err := manager.WaitForDecision(ctx, unitA)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("UnregisteredUnit", func(t *testing.T) {
+		t.Parallel()
+
+		manager := unit.NewManager()
+		_, err := manager.WaitForDecision(context.Background(), unitA)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
+	})
+}
+
+func conditionalManager(t *testing.T, requirement unit.Requirement) *unit.Manager {
+	t.Helper()
+
+	manager := unit.NewManager()
+	require.NoError(t, manager.Register(unitA))
+	require.NoError(t, manager.Register(unitB))
+	require.NoError(t, manager.AddConditionalDependency(unitA, unitB, requirement))
+	return manager
+}
+
+func conditionalDependencyIDs(dependencies []unit.ConditionalDependency) []unit.ID {
+	ids := make([]unit.ID, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		ids = append(ids, dependency.DependsOn)
+	}
+	return ids
+}

--- a/agent/unit/manager.go
+++ b/agent/unit/manager.go
@@ -49,8 +49,9 @@ type ID string
 // is not aware of updates made to the dependency graph after it is initialized and should
 // not be cached.
 type Unit struct {
-	id     ID
-	status Status
+	id      ID
+	status  Status
+	outcome Outcome
 	// ready is true if all dependencies are satisfied.
 	// It does not have an accessor method on Unit, because a unit cannot know whether it is ready.
 	// Only the Manager can calculate whether a unit is ready based on knowledge of the dependency graph.
@@ -64,6 +65,11 @@ func (u Unit) ID() ID {
 
 func (u Unit) Status() Status {
 	return u.status
+}
+
+// Outcome returns the unit's outcome for conditional dependencies.
+func (u Unit) Outcome() Outcome {
+	return u.outcome
 }
 
 // Dependency represents a dependency relationship between units.
@@ -86,13 +92,23 @@ type Manager struct {
 
 	// Store vertex instances for each unit to ensure consistent references
 	units map[ID]Unit
+
+	// conditionalGraph stores outcome-based dependencies independently from the
+	// exact-status dependencies used by coder exp sync.
+	conditionalGraph *Graph[Requirement, ID]
+
+	// outcomeChanged is closed and replaced whenever a conditional dependency
+	// decision may have changed.
+	outcomeChanged chan struct{}
 }
 
 // NewManager creates a new Manager instance.
 func NewManager() *Manager {
 	return &Manager{
-		graph: &Graph[Status, ID]{},
-		units: make(map[ID]Unit),
+		graph:            &Graph[Status, ID]{},
+		units:            make(map[ID]Unit),
+		conditionalGraph: &Graph[Requirement, ID]{},
+		outcomeChanged:   make(chan struct{}),
 	}
 }
 
@@ -111,9 +127,10 @@ func (m *Manager) Register(id ID) error {
 	}
 
 	m.units[id] = Unit{
-		id:     id,
-		status: StatusPending,
-		ready:  true,
+		id:      id,
+		status:  StatusPending,
+		outcome: OutcomePending,
+		ready:   true,
 	}
 
 	return nil


### PR DESCRIPTION
Add success and completion requirements with context-cancellable dependency waiting. Preserve existing `coder exp sync status` semantics.

<!-- STAKK_BODY_START -->
<!-- This section is managed by stakk. Manual edits will be overwritten. -->
<!-- https://github.com/glennib/stakk -->

---

<!--- STAKK_STACK: eyJ2ZXJzaW9uIjowLCJzdGFjayI6W3siYm9va21hcmtfbmFtZSI6Imdlb3JnZS9wbGF0LTM3NS1wcm90b3R5cGUvMDEtcGFyc2Utc2NyaXB0LW9yZGVyLXNlbGVjdG9ycyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQyIiwicHJfbnVtYmVyIjoyODM0Mn0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wMi12YWxpZGF0ZS1zY3JpcHQtb3JkZXItcnVsZXMiLCJwcl91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vY29kZXIvY29kZXIvcHVsbC8yODM0MyIsInByX251bWJlciI6MjgzNDN9LHsiYm9va21hcmtfbmFtZSI6Imdlb3JnZS9wbGF0LTM3NS1wcm90b3R5cGUvMDMtYnVpbGQtc2NyaXB0LW9yZGVyLWdyYXBocyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQ0IiwicHJfbnVtYmVyIjoyODM0NH0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wNC1zdXBwb3J0LWNvbmRpdGlvbmFsLWRlcGVuZGVuY2llcyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQ1IiwicHJfbnVtYmVyIjoyODM0NX0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wNS10cmFuc3BvcnQtc2NyaXB0LW9yZGVyLWRlcGVuZGVuY2llcyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQ2IiwicHJfbnVtYmVyIjoyODM0Nn0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wNi1wZXJzaXN0LXNjcmlwdC1vcmRlci1kZXBlbmRlbmNpZXMiLCJwcl91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vY29kZXIvY29kZXIvcHVsbC8yODM0NyIsInByX251bWJlciI6MjgzNDd9LHsiYm9va21hcmtfbmFtZSI6Imdlb3JnZS9wbGF0LTM3NS1wcm90b3R5cGUvMDctZW5mb3JjZS1zY3JpcHQtZXhlY3V0aW9uLW9yZGVyIiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNDgiLCJwcl9udW1iZXIiOjI4MzQ4fSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzA4LWV4cG9zZS1za2lwcGVkLXNjcmlwdC10aW1pbmdzIiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNDkiLCJwcl9udW1iZXIiOjI4MzQ5fSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzA5LXJlcG9ydC1zY3JpcHQtb3JkZXItdXNhZ2UtdGVsZW1ldHJ5IiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNTAiLCJwcl9udW1iZXIiOjI4MzUwfSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzEwLWNvdmVyLWRlY2xhcmF0aXZlLXNjcmlwdC1vcmRlcmluZy1lbmQtdG8tZW5kIiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNTEiLCJwcl9udW1iZXIiOjI4MzUxfSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzExLWRvY3VtZW50LWRlY2xhcmF0aXZlLXNjcmlwdC1vcmRlcmluZyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzUyIiwicHJfbnVtYmVyIjoyODM1Mn1dfQ== --->
This PR is part of a stack that merges into `main`:

1. https://github.com/coder/coder/pull/28342
2. https://github.com/coder/coder/pull/28343
3. https://github.com/coder/coder/pull/28344
4. https://github.com/coder/coder/pull/28345 👈
5. https://github.com/coder/coder/pull/28346
6. https://github.com/coder/coder/pull/28347
7. https://github.com/coder/coder/pull/28348
8. https://github.com/coder/coder/pull/28349
9. https://github.com/coder/coder/pull/28350
10. https://github.com/coder/coder/pull/28351
11. https://github.com/coder/coder/pull/28352

<sub>Created with [stakk](https://github.com/glennib/stakk)</sub>
<!-- STAKK_BODY_END -->
