### PR TITLE
test: cover declarative script ordering end to end

### DIFF
--- a/provisioner/terraform/script_order_e2e_internal_test.go
+++ b/provisioner/terraform/script_order_e2e_internal_test.go
@@ -1,0 +1,147 @@
+package terraform
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/provisionersdk/proto"
+)
+
+func TestScriptOrderEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	for _, step := range []string{"plan", "state"} {
+		t.Run(step, func(t *testing.T) {
+			t.Parallel()
+
+			modules, graph := loadScriptOrderFixture(t, "script-order", step)
+			state, err := ConvertState(context.Background(), modules, graph, slogtest.Make(t, nil))
+			require.NoError(t, err)
+
+			require.Equal(t, &ScriptOrder{Graphs: []ScriptOrderGraph{
+				scriptOrderTestGraph(
+					"coder_agent.main",
+					ScriptOrderPhaseShutdown,
+					"coder_script.stop_a",
+					"coder_script.stop_b",
+				),
+				{
+					RuntimeAddress: "coder_agent.main",
+					Phase:          ScriptOrderPhaseStartup,
+					Scripts: []string{
+						"coder_script.counted[0]",
+						"coder_script.counted[1]",
+						`coder_script.keyed["api"]`,
+						`coder_script.keyed["worker"]`,
+						"coder_script.root_start",
+						"module.dependents.coder_script.module_script",
+						"module.dependents.module.nested.coder_script.nested",
+						"module.prerequisites.coder_script.module_script",
+						"module.prerequisites.module.nested.coder_script.nested",
+					},
+					Dependencies: []ScriptOrderDependency{
+						scriptOrderTestDependency("coder_script.counted[0]", "coder_script.root_start", ScriptOrderRequirementSuccess),
+						scriptOrderTestDependency("coder_script.counted[1]", "coder_script.root_start", ScriptOrderRequirementSuccess),
+						scriptOrderTestDependency(`coder_script.keyed["api"]`, "coder_script.counted[1]", ScriptOrderRequirementCompletion),
+						scriptOrderTestDependency(`coder_script.keyed["worker"]`, "coder_script.counted[1]", ScriptOrderRequirementCompletion),
+						scriptOrderTestDependency(`coder_script.keyed["worker"]`, "coder_script.root_start", ScriptOrderRequirementSuccess),
+						scriptOrderTestDependency("module.dependents.coder_script.module_script", "module.prerequisites.coder_script.module_script", ScriptOrderRequirementCompletion),
+						scriptOrderTestDependency("module.dependents.coder_script.module_script", "module.prerequisites.module.nested.coder_script.nested", ScriptOrderRequirementCompletion),
+						scriptOrderTestDependency("module.dependents.module.nested.coder_script.nested", "module.dependents.coder_script.module_script", ScriptOrderRequirementSuccess),
+						scriptOrderTestDependency("module.dependents.module.nested.coder_script.nested", "module.prerequisites.coder_script.module_script", ScriptOrderRequirementCompletion),
+						scriptOrderTestDependency("module.dependents.module.nested.coder_script.nested", "module.prerequisites.module.nested.coder_script.nested", ScriptOrderRequirementCompletion),
+						scriptOrderTestDependency("module.prerequisites.module.nested.coder_script.nested", "module.prerequisites.coder_script.module_script", ScriptOrderRequirementSuccess),
+					},
+				},
+			}}, state.ScriptOrder)
+
+			scripts := scriptOrderScriptsByAddress(state)
+			require.Len(t, scripts, 12)
+			unordered, ok := scripts["coder_script.unordered"]
+			require.True(t, ok)
+			require.Empty(t, unordered.Dependencies)
+
+			worker, ok := scripts[`coder_script.keyed["worker"]`]
+			require.True(t, ok)
+			require.Equal(t, []*proto.ScriptDependency{
+				{
+					PrerequisiteResourceAddress: "coder_script.counted[1]",
+					Requirement:                 proto.ScriptDependencyRequirement_SCRIPT_DEPENDENCY_REQUIREMENT_COMPLETION,
+				},
+				{
+					PrerequisiteResourceAddress: "coder_script.root_start",
+					Requirement:                 proto.ScriptDependencyRequirement_SCRIPT_DEPENDENCY_REQUIREMENT_SUCCESS,
+				},
+			}, worker.Dependencies)
+		})
+	}
+}
+
+func TestScriptOrderEndToEndRejectsCrossAgentDependency(t *testing.T) {
+	t.Parallel()
+
+	for _, step := range []string{"plan", "state"} {
+		t.Run(step, func(t *testing.T) {
+			t.Parallel()
+
+			modules, graph := loadScriptOrderFixture(t, "script-order-cross-agent", step)
+			state, err := ConvertState(context.Background(), modules, graph, slogtest.Make(t, nil))
+			require.Error(t, err)
+			require.Nil(t, state)
+			require.ErrorContains(t, err, "data.coder_script_order.cross_agent")
+			require.ErrorContains(t, err, "coder_agent.one")
+			require.ErrorContains(t, err, "coder_agent.two")
+			require.ErrorContains(t, err, "cross-agent dependencies are not supported")
+		})
+	}
+}
+
+func loadScriptOrderFixture(t *testing.T, name, step string) ([]*tfjson.StateModule, string) {
+	t.Helper()
+
+	directory := filepath.Join("testdata", "resources", name)
+	raw, err := os.ReadFile(filepath.Join(directory, name+".tf"+step+".json"))
+	require.NoError(t, err)
+
+	var modules []*tfjson.StateModule
+	switch step {
+	case "plan":
+		var plan tfjson.Plan
+		require.NoError(t, json.Unmarshal(raw, &plan))
+		modules = planModules(&plan)
+	case "state":
+		var state tfjson.State
+		require.NoError(t, json.Unmarshal(raw, &state))
+		modules = append(modules, state.Values.RootModule)
+	default:
+		t.Fatalf("unknown Terraform step %q", step)
+	}
+
+	graph, err := os.ReadFile(filepath.Join(directory, name+".tf"+step+".dot"))
+	require.NoError(t, err)
+	return modules, string(graph)
+}
+
+func scriptOrderScriptsByAddress(state *State) map[string]*proto.Script {
+	scripts := map[string]*proto.Script{}
+	for _, resource := range state.Resources {
+		for _, agent := range resource.Agents {
+			for _, script := range agent.Scripts {
+				scripts[script.ResourceAddress] = script
+			}
+			for _, devcontainer := range agent.Devcontainers {
+				for _, script := range devcontainer.Scripts {
+					scripts[script.ResourceAddress] = script
+				}
+			}
+		}
+	}
+	return scripts
+}

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/converted_state.plan.golden
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/converted_state.plan.golden
@@ -1,0 +1,1 @@
+"validate script order graph: script order data source \"data.coder_script_order.cross_agent\" rule 0: selector \"coder_script.two\" expands to script \"coder_script.two\" on agent runtime \"coder_agent.two\", but selector \"coder_script.one\" expands to script \"coder_script.one\" on agent runtime \"coder_agent.one\"; cross-agent dependencies are not supported"

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/converted_state.state.golden
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/converted_state.state.golden
@@ -1,0 +1,1 @@
+"validate script order graph: script order data source \"data.coder_script_order.cross_agent\" rule 0: selector \"coder_script.two\" expands to script \"coder_script.two\" on agent runtime \"coder_agent.two\", but selector \"coder_script.one\" expands to script \"coder_script.one\" on agent runtime \"coder_agent.one\"; cross-agent dependencies are not supported"

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tf
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">=2.0.0"
+    }
+  }
+}
+
+resource "coder_agent" "one" {
+  os   = "linux"
+  arch = "amd64"
+}
+
+resource "coder_agent" "two" {
+  os   = "linux"
+  arch = "amd64"
+}
+
+resource "coder_script" "one" {
+  agent_id     = coder_agent.one.id
+  display_name = "Agent one"
+  script       = "echo one"
+  run_on_start = true
+}
+
+resource "coder_script" "two" {
+  agent_id     = coder_agent.two.id
+  display_name = "Agent two"
+  script       = "echo two"
+  run_on_start = true
+}
+
+data "coder_script_order" "cross_agent" {
+  rule {
+    run   = ["coder_script.two"]
+    after = ["coder_script.one"]
+  }
+}
+
+resource "null_resource" "one" {
+  depends_on = [coder_agent.one]
+}
+
+resource "null_resource" "two" {
+  depends_on = [coder_agent.two]
+}

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfplan.dot
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfplan.dot
@@ -1,0 +1,31 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_agent.one (expand)" [label = "coder_agent.one", shape = "box"]
+		"[root] coder_agent.two (expand)" [label = "coder_agent.two", shape = "box"]
+		"[root] coder_script.one (expand)" [label = "coder_script.one", shape = "box"]
+		"[root] coder_script.two (expand)" [label = "coder_script.two", shape = "box"]
+		"[root] data.coder_script_order.cross_agent (expand)" [label = "data.coder_script_order.cross_agent", shape = "box"]
+		"[root] null_resource.one (expand)" [label = "null_resource.one", shape = "box"]
+		"[root] null_resource.two (expand)" [label = "null_resource.two", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
+		"[root] coder_agent.one (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent.two (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_script.one (expand)" -> "[root] coder_agent.one (expand)"
+		"[root] coder_script.two (expand)" -> "[root] coder_agent.two (expand)"
+		"[root] data.coder_script_order.cross_agent (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] null_resource.one (expand)" -> "[root] coder_agent.one (expand)"
+		"[root] null_resource.one (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] null_resource.two (expand)" -> "[root] coder_agent.two (expand)"
+		"[root] null_resource.two (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.one (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.two (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_script_order.cross_agent (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.one (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.two (expand)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfplan.json
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfplan.json
@@ -1,0 +1,537 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_agent.one",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "one",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "api_key_scope": "all",
+            "arch": "amd64",
+            "auth": "token",
+            "connection_timeout": 120,
+            "dir": null,
+            "env": null,
+            "metadata": [],
+            "motd_file": null,
+            "order": null,
+            "os": "linux",
+            "resources_monitoring": [],
+            "shutdown_script": null,
+            "startup_script": null,
+            "startup_script_behavior": "non-blocking",
+            "troubleshooting_url": null
+          },
+          "sensitive_values": {
+            "display_apps": [],
+            "metadata": [],
+            "resources_monitoring": [],
+            "token": true
+          }
+        },
+        {
+          "address": "coder_agent.two",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "two",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "api_key_scope": "all",
+            "arch": "amd64",
+            "auth": "token",
+            "connection_timeout": 120,
+            "dir": null,
+            "env": null,
+            "metadata": [],
+            "motd_file": null,
+            "order": null,
+            "os": "linux",
+            "resources_monitoring": [],
+            "shutdown_script": null,
+            "startup_script": null,
+            "startup_script_behavior": "non-blocking",
+            "troubleshooting_url": null
+          },
+          "sensitive_values": {
+            "display_apps": [],
+            "metadata": [],
+            "resources_monitoring": [],
+            "token": true
+          }
+        },
+        {
+          "address": "coder_script.one",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "one",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Agent one",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo one",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.two",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "two",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Agent two",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo two",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "null_resource.one",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "one",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "triggers": null
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "null_resource.two",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "two",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "triggers": null
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "coder_agent.one",
+      "mode": "managed",
+      "type": "coder_agent",
+      "name": "one",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "api_key_scope": "all",
+          "arch": "amd64",
+          "auth": "token",
+          "connection_timeout": 120,
+          "dir": null,
+          "env": null,
+          "metadata": [],
+          "motd_file": null,
+          "order": null,
+          "os": "linux",
+          "resources_monitoring": [],
+          "shutdown_script": null,
+          "startup_script": null,
+          "startup_script_behavior": "non-blocking",
+          "troubleshooting_url": null
+        },
+        "after_unknown": {
+          "display_apps": true,
+          "id": true,
+          "init_script": true,
+          "metadata": [],
+          "resources_monitoring": [],
+          "token": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "display_apps": [],
+          "metadata": [],
+          "resources_monitoring": [],
+          "token": true
+        }
+      }
+    },
+    {
+      "address": "coder_agent.two",
+      "mode": "managed",
+      "type": "coder_agent",
+      "name": "two",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "api_key_scope": "all",
+          "arch": "amd64",
+          "auth": "token",
+          "connection_timeout": 120,
+          "dir": null,
+          "env": null,
+          "metadata": [],
+          "motd_file": null,
+          "order": null,
+          "os": "linux",
+          "resources_monitoring": [],
+          "shutdown_script": null,
+          "startup_script": null,
+          "startup_script_behavior": "non-blocking",
+          "troubleshooting_url": null
+        },
+        "after_unknown": {
+          "display_apps": true,
+          "id": true,
+          "init_script": true,
+          "metadata": [],
+          "resources_monitoring": [],
+          "token": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "display_apps": [],
+          "metadata": [],
+          "resources_monitoring": [],
+          "token": true
+        }
+      }
+    },
+    {
+      "address": "coder_script.one",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "one",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Agent one",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo one",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.two",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "two",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Agent two",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo two",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "null_resource.one",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "one",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "null_resource.two",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "two",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.15.5",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "data.coder_script_order.cross_agent",
+            "mode": "data",
+            "type": "coder_script_order",
+            "name": "cross_agent",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "id": "9c73d178-841f-4c82-ac32-1296d6b510ee",
+              "rule": [
+                {
+                  "after": [
+                    "coder_script.one"
+                  ],
+                  "requires": "success",
+                  "run": [
+                    "coder_script.two"
+                  ]
+                }
+              ]
+            },
+            "sensitive_values": {
+              "rule": [
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "coder": {
+        "name": "coder",
+        "full_name": "registry.terraform.io/coder/coder",
+        "version_constraint": ">= 2.0.0"
+      },
+      "null": {
+        "name": "null",
+        "full_name": "registry.terraform.io/hashicorp/null"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_agent.one",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "one",
+          "provider_config_key": "coder",
+          "expressions": {
+            "arch": {
+              "constant_value": "amd64"
+            },
+            "os": {
+              "constant_value": "linux"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_agent.two",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "two",
+          "provider_config_key": "coder",
+          "expressions": {
+            "arch": {
+              "constant_value": "amd64"
+            },
+            "os": {
+              "constant_value": "linux"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.one",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "one",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.one.id",
+                "coder_agent.one"
+              ]
+            },
+            "display_name": {
+              "constant_value": "Agent one"
+            },
+            "run_on_start": {
+              "constant_value": true
+            },
+            "script": {
+              "constant_value": "echo one"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.two",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "two",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.two.id",
+                "coder_agent.two"
+              ]
+            },
+            "display_name": {
+              "constant_value": "Agent two"
+            },
+            "run_on_start": {
+              "constant_value": true
+            },
+            "script": {
+              "constant_value": "echo two"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "null_resource.one",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "one",
+          "provider_config_key": "null",
+          "schema_version": 0,
+          "depends_on": [
+            "coder_agent.one"
+          ]
+        },
+        {
+          "address": "null_resource.two",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "two",
+          "provider_config_key": "null",
+          "schema_version": 0,
+          "depends_on": [
+            "coder_agent.two"
+          ]
+        },
+        {
+          "address": "data.coder_script_order.cross_agent",
+          "mode": "data",
+          "type": "coder_script_order",
+          "name": "cross_agent",
+          "provider_config_key": "coder",
+          "expressions": {
+            "rule": [
+              {
+                "after": {
+                  "constant_value": [
+                    "coder_script.one"
+                  ]
+                },
+                "run": {
+                  "constant_value": [
+                    "coder_script.two"
+                  ]
+                }
+              }
+            ]
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "coder_agent.one",
+      "attribute": [
+        "id"
+      ]
+    },
+    {
+      "resource": "coder_agent.two",
+      "attribute": [
+        "id"
+      ]
+    }
+  ],
+  "timestamp": "2026-08-18T15:09:32Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfstate.dot
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfstate.dot
@@ -1,0 +1,31 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_agent.one (expand)" [label = "coder_agent.one", shape = "box"]
+		"[root] coder_agent.two (expand)" [label = "coder_agent.two", shape = "box"]
+		"[root] coder_script.one (expand)" [label = "coder_script.one", shape = "box"]
+		"[root] coder_script.two (expand)" [label = "coder_script.two", shape = "box"]
+		"[root] data.coder_script_order.cross_agent (expand)" [label = "data.coder_script_order.cross_agent", shape = "box"]
+		"[root] null_resource.one (expand)" [label = "null_resource.one", shape = "box"]
+		"[root] null_resource.two (expand)" [label = "null_resource.two", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
+		"[root] coder_agent.one (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent.two (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_script.one (expand)" -> "[root] coder_agent.one (expand)"
+		"[root] coder_script.two (expand)" -> "[root] coder_agent.two (expand)"
+		"[root] data.coder_script_order.cross_agent (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] null_resource.one (expand)" -> "[root] coder_agent.one (expand)"
+		"[root] null_resource.one (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] null_resource.two (expand)" -> "[root] coder_agent.two (expand)"
+		"[root] null_resource.two (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.one (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.two (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_script_order.cross_agent (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.one (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.two (expand)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfstate.json
+++ b/provisioner/terraform/testdata/resources/script-order-cross-agent/script-order-cross-agent.tfstate.json
@@ -1,0 +1,216 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.15.5",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.coder_script_order.cross_agent",
+          "mode": "data",
+          "type": "coder_script_order",
+          "name": "cross_agent",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "id": "bc60abf5-0c6a-4229-82f4-df69a788d3b3",
+            "rule": [
+              {
+                "after": [
+                  "coder_script.one"
+                ],
+                "requires": "success",
+                "run": [
+                  "coder_script.two"
+                ]
+              }
+            ]
+          },
+          "sensitive_values": {
+            "rule": [
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "address": "coder_agent.one",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "one",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "api_key_scope": "all",
+            "arch": "amd64",
+            "auth": "token",
+            "connection_timeout": 120,
+            "dir": null,
+            "display_apps": [
+              {
+                "port_forwarding_helper": true,
+                "ssh_helper": true,
+                "vscode": true,
+                "vscode_insiders": false,
+                "web_terminal": true
+              }
+            ],
+            "env": null,
+            "id": "426236bc-d654-46b1-a0c1-f1c79e2afd6e",
+            "init_script": "",
+            "metadata": [],
+            "motd_file": null,
+            "order": null,
+            "os": "linux",
+            "resources_monitoring": [],
+            "shutdown_script": null,
+            "startup_script": null,
+            "startup_script_behavior": "non-blocking",
+            "token": "ad04578f-f39f-4093-8152-00ea1878aa68",
+            "troubleshooting_url": null
+          },
+          "sensitive_values": {
+            "display_apps": [
+              {}
+            ],
+            "metadata": [],
+            "resources_monitoring": [],
+            "token": true
+          }
+        },
+        {
+          "address": "coder_agent.two",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "two",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "api_key_scope": "all",
+            "arch": "amd64",
+            "auth": "token",
+            "connection_timeout": 120,
+            "dir": null,
+            "display_apps": [
+              {
+                "port_forwarding_helper": true,
+                "ssh_helper": true,
+                "vscode": true,
+                "vscode_insiders": false,
+                "web_terminal": true
+              }
+            ],
+            "env": null,
+            "id": "9906ee45-c3ef-44d3-a158-cba818a74c2e",
+            "init_script": "",
+            "metadata": [],
+            "motd_file": null,
+            "order": null,
+            "os": "linux",
+            "resources_monitoring": [],
+            "shutdown_script": null,
+            "startup_script": null,
+            "startup_script_behavior": "non-blocking",
+            "token": "d9092c27-62bb-4817-8dd1-2aa1a7235d04",
+            "troubleshooting_url": null
+          },
+          "sensitive_values": {
+            "display_apps": [
+              {}
+            ],
+            "metadata": [],
+            "resources_monitoring": [],
+            "token": true
+          }
+        },
+        {
+          "address": "coder_script.one",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "one",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "426236bc-d654-46b1-a0c1-f1c79e2afd6e",
+            "cron": null,
+            "display_name": "Agent one",
+            "icon": null,
+            "id": "1c78d9d8-c107-480d-acfe-f428fb1c5ff8",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo one",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.one"
+          ]
+        },
+        {
+          "address": "coder_script.two",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "two",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "9906ee45-c3ef-44d3-a158-cba818a74c2e",
+            "cron": null,
+            "display_name": "Agent two",
+            "icon": null,
+            "id": "39176bc3-693b-4acb-a338-514485e06811",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo two",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.two"
+          ]
+        },
+        {
+          "address": "null_resource.one",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "one",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "7718877299584460557",
+            "triggers": null
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.one"
+          ]
+        },
+        {
+          "address": "null_resource.two",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "two",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "2625573999607757437",
+            "triggers": null
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.two"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/provisioner/terraform/testdata/resources/script-order/converted_state.plan.golden
+++ b/provisioner/terraform/testdata/resources/script-order/converted_state.plan.golden
@@ -1,0 +1,262 @@
+{
+  "Resources": [
+    {
+      "name": "workspace",
+      "type": "null_resource",
+      "agents": [
+        {
+          "name": "main",
+          "operating_system": "linux",
+          "architecture": "amd64",
+          "Auth": {
+            "Token": ""
+          },
+          "connection_timeout_seconds": 120,
+          "display_apps": {
+            "vscode": true,
+            "web_terminal": true,
+            "ssh_helper": true,
+            "port_forwarding_helper": true
+          },
+          "scripts": [
+            {
+              "display_name": "Counted 0",
+              "script": "echo counted 0",
+              "run_on_start": true,
+              "resource_address": "coder_script.counted[0]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.root_start",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Counted 1",
+              "script": "echo counted 1",
+              "run_on_start": true,
+              "resource_address": "coder_script.counted[1]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.root_start",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Keyed api",
+              "script": "echo keyed api",
+              "run_on_start": true,
+              "resource_address": "coder_script.keyed[\"api\"]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.counted[1]",
+                  "requirement": 2
+                }
+              ]
+            },
+            {
+              "display_name": "Keyed worker",
+              "script": "echo keyed worker",
+              "run_on_start": true,
+              "resource_address": "coder_script.keyed[\"worker\"]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.counted[1]",
+                  "requirement": 2
+                },
+                {
+                  "prerequisite_resource_address": "coder_script.root_start",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Root start",
+              "script": "echo root start",
+              "run_on_start": true,
+              "resource_address": "coder_script.root_start"
+            },
+            {
+              "display_name": "Stop A",
+              "script": "echo stop A",
+              "run_on_stop": true,
+              "resource_address": "coder_script.stop_a"
+            },
+            {
+              "display_name": "Stop B",
+              "script": "echo stop B",
+              "run_on_stop": true,
+              "resource_address": "coder_script.stop_b",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.stop_a",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Unordered",
+              "script": "echo unordered",
+              "run_on_start": true,
+              "resource_address": "coder_script.unordered"
+            },
+            {
+              "display_name": "dependent module",
+              "script": "echo dependent module",
+              "run_on_start": true,
+              "resource_address": "module.dependents.coder_script.module_script",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "module.prerequisites.coder_script.module_script",
+                  "requirement": 2
+                },
+                {
+                  "prerequisite_resource_address": "module.prerequisites.module.nested.coder_script.nested",
+                  "requirement": 2
+                }
+              ]
+            },
+            {
+              "display_name": "dependent nested",
+              "script": "echo dependent nested",
+              "run_on_start": true,
+              "resource_address": "module.dependents.module.nested.coder_script.nested",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "module.dependents.coder_script.module_script",
+                  "requirement": 1
+                },
+                {
+                  "prerequisite_resource_address": "module.prerequisites.coder_script.module_script",
+                  "requirement": 2
+                },
+                {
+                  "prerequisite_resource_address": "module.prerequisites.module.nested.coder_script.nested",
+                  "requirement": 2
+                }
+              ]
+            },
+            {
+              "display_name": "prerequisite module",
+              "script": "echo prerequisite module",
+              "run_on_start": true,
+              "resource_address": "module.prerequisites.coder_script.module_script"
+            },
+            {
+              "display_name": "prerequisite nested",
+              "script": "echo prerequisite nested",
+              "run_on_start": true,
+              "resource_address": "module.prerequisites.module.nested.coder_script.nested",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "module.prerequisites.coder_script.module_script",
+                  "requirement": 1
+                }
+              ]
+            }
+          ],
+          "resources_monitoring": {},
+          "api_key_scope": "all"
+        }
+      ]
+    }
+  ],
+  "Parameters": [],
+  "Presets": [],
+  "ExternalAuthProviders": [],
+  "AITasks": [],
+  "HasAITasks": false,
+  "HasExternalAgents": false,
+  "ScriptOrder": {
+    "Graphs": [
+      {
+        "RuntimeAddress": "coder_agent.main",
+        "Phase": "shutdown",
+        "Scripts": [
+          "coder_script.stop_a",
+          "coder_script.stop_b"
+        ],
+        "Dependencies": [
+          {
+            "ScriptAddress": "coder_script.stop_b",
+            "PrerequisiteAddress": "coder_script.stop_a",
+            "Requirement": "success"
+          }
+        ]
+      },
+      {
+        "RuntimeAddress": "coder_agent.main",
+        "Phase": "startup",
+        "Scripts": [
+          "coder_script.counted[0]",
+          "coder_script.counted[1]",
+          "coder_script.keyed[\"api\"]",
+          "coder_script.keyed[\"worker\"]",
+          "coder_script.root_start",
+          "module.dependents.coder_script.module_script",
+          "module.dependents.module.nested.coder_script.nested",
+          "module.prerequisites.coder_script.module_script",
+          "module.prerequisites.module.nested.coder_script.nested"
+        ],
+        "Dependencies": [
+          {
+            "ScriptAddress": "coder_script.counted[0]",
+            "PrerequisiteAddress": "coder_script.root_start",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "coder_script.counted[1]",
+            "PrerequisiteAddress": "coder_script.root_start",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "coder_script.keyed[\"api\"]",
+            "PrerequisiteAddress": "coder_script.counted[1]",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "coder_script.keyed[\"worker\"]",
+            "PrerequisiteAddress": "coder_script.counted[1]",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "coder_script.keyed[\"worker\"]",
+            "PrerequisiteAddress": "coder_script.root_start",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "module.dependents.coder_script.module_script",
+            "PrerequisiteAddress": "module.prerequisites.coder_script.module_script",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.dependents.coder_script.module_script",
+            "PrerequisiteAddress": "module.prerequisites.module.nested.coder_script.nested",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.dependents.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.dependents.coder_script.module_script",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "module.dependents.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.prerequisites.coder_script.module_script",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.dependents.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.prerequisites.module.nested.coder_script.nested",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.prerequisites.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.prerequisites.coder_script.module_script",
+            "Requirement": "success"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/provisioner/terraform/testdata/resources/script-order/converted_state.state.golden
+++ b/provisioner/terraform/testdata/resources/script-order/converted_state.state.golden
@@ -1,0 +1,263 @@
+{
+  "Resources": [
+    {
+      "name": "workspace",
+      "type": "null_resource",
+      "agents": [
+        {
+          "id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+          "name": "main",
+          "operating_system": "linux",
+          "architecture": "amd64",
+          "Auth": {
+            "Token": "72b8de2c-dbf9-4dcb-a6c7-2112091de0c5"
+          },
+          "connection_timeout_seconds": 120,
+          "display_apps": {
+            "vscode": true,
+            "web_terminal": true,
+            "ssh_helper": true,
+            "port_forwarding_helper": true
+          },
+          "scripts": [
+            {
+              "display_name": "Counted 0",
+              "script": "echo counted 0",
+              "run_on_start": true,
+              "resource_address": "coder_script.counted[0]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.root_start",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Counted 1",
+              "script": "echo counted 1",
+              "run_on_start": true,
+              "resource_address": "coder_script.counted[1]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.root_start",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Keyed api",
+              "script": "echo keyed api",
+              "run_on_start": true,
+              "resource_address": "coder_script.keyed[\"api\"]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.counted[1]",
+                  "requirement": 2
+                }
+              ]
+            },
+            {
+              "display_name": "Keyed worker",
+              "script": "echo keyed worker",
+              "run_on_start": true,
+              "resource_address": "coder_script.keyed[\"worker\"]",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.counted[1]",
+                  "requirement": 2
+                },
+                {
+                  "prerequisite_resource_address": "coder_script.root_start",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Root start",
+              "script": "echo root start",
+              "run_on_start": true,
+              "resource_address": "coder_script.root_start"
+            },
+            {
+              "display_name": "Stop A",
+              "script": "echo stop A",
+              "run_on_stop": true,
+              "resource_address": "coder_script.stop_a"
+            },
+            {
+              "display_name": "Stop B",
+              "script": "echo stop B",
+              "run_on_stop": true,
+              "resource_address": "coder_script.stop_b",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "coder_script.stop_a",
+                  "requirement": 1
+                }
+              ]
+            },
+            {
+              "display_name": "Unordered",
+              "script": "echo unordered",
+              "run_on_start": true,
+              "resource_address": "coder_script.unordered"
+            },
+            {
+              "display_name": "dependent module",
+              "script": "echo dependent module",
+              "run_on_start": true,
+              "resource_address": "module.dependents.coder_script.module_script",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "module.prerequisites.coder_script.module_script",
+                  "requirement": 2
+                },
+                {
+                  "prerequisite_resource_address": "module.prerequisites.module.nested.coder_script.nested",
+                  "requirement": 2
+                }
+              ]
+            },
+            {
+              "display_name": "dependent nested",
+              "script": "echo dependent nested",
+              "run_on_start": true,
+              "resource_address": "module.dependents.module.nested.coder_script.nested",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "module.dependents.coder_script.module_script",
+                  "requirement": 1
+                },
+                {
+                  "prerequisite_resource_address": "module.prerequisites.coder_script.module_script",
+                  "requirement": 2
+                },
+                {
+                  "prerequisite_resource_address": "module.prerequisites.module.nested.coder_script.nested",
+                  "requirement": 2
+                }
+              ]
+            },
+            {
+              "display_name": "prerequisite module",
+              "script": "echo prerequisite module",
+              "run_on_start": true,
+              "resource_address": "module.prerequisites.coder_script.module_script"
+            },
+            {
+              "display_name": "prerequisite nested",
+              "script": "echo prerequisite nested",
+              "run_on_start": true,
+              "resource_address": "module.prerequisites.module.nested.coder_script.nested",
+              "dependencies": [
+                {
+                  "prerequisite_resource_address": "module.prerequisites.coder_script.module_script",
+                  "requirement": 1
+                }
+              ]
+            }
+          ],
+          "resources_monitoring": {},
+          "api_key_scope": "all"
+        }
+      ]
+    }
+  ],
+  "Parameters": [],
+  "Presets": [],
+  "ExternalAuthProviders": [],
+  "AITasks": [],
+  "HasAITasks": false,
+  "HasExternalAgents": false,
+  "ScriptOrder": {
+    "Graphs": [
+      {
+        "RuntimeAddress": "coder_agent.main",
+        "Phase": "shutdown",
+        "Scripts": [
+          "coder_script.stop_a",
+          "coder_script.stop_b"
+        ],
+        "Dependencies": [
+          {
+            "ScriptAddress": "coder_script.stop_b",
+            "PrerequisiteAddress": "coder_script.stop_a",
+            "Requirement": "success"
+          }
+        ]
+      },
+      {
+        "RuntimeAddress": "coder_agent.main",
+        "Phase": "startup",
+        "Scripts": [
+          "coder_script.counted[0]",
+          "coder_script.counted[1]",
+          "coder_script.keyed[\"api\"]",
+          "coder_script.keyed[\"worker\"]",
+          "coder_script.root_start",
+          "module.dependents.coder_script.module_script",
+          "module.dependents.module.nested.coder_script.nested",
+          "module.prerequisites.coder_script.module_script",
+          "module.prerequisites.module.nested.coder_script.nested"
+        ],
+        "Dependencies": [
+          {
+            "ScriptAddress": "coder_script.counted[0]",
+            "PrerequisiteAddress": "coder_script.root_start",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "coder_script.counted[1]",
+            "PrerequisiteAddress": "coder_script.root_start",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "coder_script.keyed[\"api\"]",
+            "PrerequisiteAddress": "coder_script.counted[1]",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "coder_script.keyed[\"worker\"]",
+            "PrerequisiteAddress": "coder_script.counted[1]",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "coder_script.keyed[\"worker\"]",
+            "PrerequisiteAddress": "coder_script.root_start",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "module.dependents.coder_script.module_script",
+            "PrerequisiteAddress": "module.prerequisites.coder_script.module_script",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.dependents.coder_script.module_script",
+            "PrerequisiteAddress": "module.prerequisites.module.nested.coder_script.nested",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.dependents.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.dependents.coder_script.module_script",
+            "Requirement": "success"
+          },
+          {
+            "ScriptAddress": "module.dependents.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.prerequisites.coder_script.module_script",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.dependents.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.prerequisites.module.nested.coder_script.nested",
+            "Requirement": "completion"
+          },
+          {
+            "ScriptAddress": "module.prerequisites.module.nested.coder_script.nested",
+            "PrerequisiteAddress": "module.prerequisites.coder_script.module_script",
+            "Requirement": "success"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/provisioner/terraform/testdata/resources/script-order/modules/script-set/module.tf
+++ b/provisioner/terraform/testdata/resources/script-order/modules/script-set/module.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+variable "agent_id" {
+  type = string
+}
+
+variable "label" {
+  type = string
+}
+
+resource "coder_script" "module_script" {
+  agent_id     = var.agent_id
+  display_name = "${var.label} module"
+  script       = "echo ${var.label} module"
+  run_on_start = true
+}
+
+module "nested" {
+  source   = "./nested"
+  agent_id = var.agent_id
+  label    = var.label
+}
+
+data "coder_script_order" "nested" {
+  rule {
+    run   = ["module.nested"]
+    after = ["coder_script.module_script"]
+  }
+}

--- a/provisioner/terraform/testdata/resources/script-order/modules/script-set/nested/module.tf
+++ b/provisioner/terraform/testdata/resources/script-order/modules/script-set/nested/module.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+variable "agent_id" {
+  type = string
+}
+
+variable "label" {
+  type = string
+}
+
+resource "coder_script" "nested" {
+  agent_id     = var.agent_id
+  display_name = "${var.label} nested"
+  script       = "echo ${var.label} nested"
+  run_on_start = true
+}

--- a/provisioner/terraform/testdata/resources/script-order/script-order.tf
+++ b/provisioner/terraform/testdata/resources/script-order/script-order.tf
@@ -1,0 +1,115 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">=2.0.0"
+    }
+  }
+}
+
+resource "coder_agent" "main" {
+  os   = "linux"
+  arch = "amd64"
+}
+
+resource "coder_script" "root_start" {
+  agent_id     = coder_agent.main.id
+  display_name = "Root start"
+  script       = "echo root start"
+  run_on_start = true
+}
+
+resource "coder_script" "counted" {
+  count = 2
+
+  agent_id     = coder_agent.main.id
+  display_name = "Counted ${count.index}"
+  script       = "echo counted ${count.index}"
+  run_on_start = true
+}
+
+resource "coder_script" "keyed" {
+  for_each = toset(["api", "worker"])
+
+  agent_id     = coder_agent.main.id
+  display_name = "Keyed ${each.key}"
+  script       = "echo keyed ${each.key}"
+  run_on_start = true
+}
+
+resource "coder_script" "unordered" {
+  agent_id     = coder_agent.main.id
+  display_name = "Unordered"
+  script       = "echo unordered"
+  run_on_start = true
+}
+
+resource "coder_script" "stop_a" {
+  agent_id     = coder_agent.main.id
+  display_name = "Stop A"
+  script       = "echo stop A"
+  run_on_stop  = true
+}
+
+resource "coder_script" "stop_b" {
+  agent_id     = coder_agent.main.id
+  display_name = "Stop B"
+  script       = "echo stop B"
+  run_on_stop  = true
+}
+
+module "prerequisites" {
+  source   = "./modules/script-set"
+  agent_id = coder_agent.main.id
+  label    = "prerequisite"
+}
+
+module "dependents" {
+  source   = "./modules/script-set"
+  agent_id = coder_agent.main.id
+  label    = "dependent"
+}
+
+data "coder_script_order" "primary" {
+  rule {
+    run   = ["coder_script.counted"]
+    after = ["coder_script.root_start"]
+  }
+
+  rule {
+    run      = ["coder_script.keyed"]
+    after    = ["coder_script.counted[1]"]
+    requires = "completion"
+  }
+
+  rule {
+    run      = ["module.dependents"]
+    after    = ["module.prerequisites"]
+    requires = "completion"
+  }
+
+  rule {
+    run   = ["coder_script.stop_b"]
+    after = ["coder_script.stop_a"]
+  }
+}
+
+data "coder_script_order" "overlapping" {
+  rule {
+    run = [
+      "coder_script.counted[1]",
+      "coder_script.keyed[\"worker\"]",
+    ]
+    after = ["coder_script.root_start"]
+  }
+
+  rule {
+    run      = ["module.dependents"]
+    after    = ["module.prerequisites"]
+    requires = "completion"
+  }
+}
+
+resource "null_resource" "workspace" {
+  depends_on = [coder_agent.main]
+}

--- a/provisioner/terraform/testdata/resources/script-order/script-order.tfplan.dot
+++ b/provisioner/terraform/testdata/resources/script-order/script-order.tfplan.dot
@@ -1,0 +1,90 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
+		"[root] coder_script.counted (expand)" [label = "coder_script.counted", shape = "box"]
+		"[root] coder_script.keyed (expand)" [label = "coder_script.keyed", shape = "box"]
+		"[root] coder_script.root_start (expand)" [label = "coder_script.root_start", shape = "box"]
+		"[root] coder_script.stop_a (expand)" [label = "coder_script.stop_a", shape = "box"]
+		"[root] coder_script.stop_b (expand)" [label = "coder_script.stop_b", shape = "box"]
+		"[root] coder_script.unordered (expand)" [label = "coder_script.unordered", shape = "box"]
+		"[root] data.coder_script_order.overlapping (expand)" [label = "data.coder_script_order.overlapping", shape = "box"]
+		"[root] data.coder_script_order.primary (expand)" [label = "data.coder_script_order.primary", shape = "box"]
+		"[root] module.dependents.coder_script.module_script (expand)" [label = "module.dependents.coder_script.module_script", shape = "box"]
+		"[root] module.dependents.data.coder_script_order.nested (expand)" [label = "module.dependents.data.coder_script_order.nested", shape = "box"]
+		"[root] module.dependents.module.nested.coder_script.nested (expand)" [label = "module.dependents.module.nested.coder_script.nested", shape = "box"]
+		"[root] module.prerequisites.coder_script.module_script (expand)" [label = "module.prerequisites.coder_script.module_script", shape = "box"]
+		"[root] module.prerequisites.data.coder_script_order.nested (expand)" [label = "module.prerequisites.data.coder_script_order.nested", shape = "box"]
+		"[root] module.prerequisites.module.nested.coder_script.nested (expand)" [label = "module.prerequisites.module.nested.coder_script.nested", shape = "box"]
+		"[root] null_resource.workspace (expand)" [label = "null_resource.workspace", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_script.counted (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.keyed (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.root_start (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.stop_a (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.stop_b (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.unordered (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] data.coder_script_order.overlapping (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_script_order.primary (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.dependents (close)" -> "[root] module.dependents.coder_script.module_script (expand)"
+		"[root] module.dependents (close)" -> "[root] module.dependents.data.coder_script_order.nested (expand)"
+		"[root] module.dependents (close)" -> "[root] module.dependents.module.nested (close)"
+		"[root] module.dependents.coder_script.module_script (expand)" -> "[root] module.dependents.var.agent_id (expand)"
+		"[root] module.dependents.coder_script.module_script (expand)" -> "[root] module.dependents.var.label (expand)"
+		"[root] module.dependents.data.coder_script_order.nested (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.dependents.data.coder_script_order.nested (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.dependents.module.nested (close)" -> "[root] module.dependents.module.nested.coder_script.nested (expand)"
+		"[root] module.dependents.module.nested (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.dependents.module.nested.coder_script.nested (expand)" -> "[root] module.dependents.module.nested.var.agent_id (expand)"
+		"[root] module.dependents.module.nested.coder_script.nested (expand)" -> "[root] module.dependents.module.nested.var.label (expand)"
+		"[root] module.dependents.module.nested.var.agent_id (expand)" -> "[root] module.dependents.module.nested (expand)"
+		"[root] module.dependents.module.nested.var.agent_id (expand)" -> "[root] module.dependents.var.agent_id (expand)"
+		"[root] module.dependents.module.nested.var.label (expand)" -> "[root] module.dependents.module.nested (expand)"
+		"[root] module.dependents.module.nested.var.label (expand)" -> "[root] module.dependents.var.label (expand)"
+		"[root] module.dependents.var.agent_id (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] module.dependents.var.agent_id (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.dependents.var.label (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.prerequisites (close)" -> "[root] module.prerequisites.coder_script.module_script (expand)"
+		"[root] module.prerequisites (close)" -> "[root] module.prerequisites.data.coder_script_order.nested (expand)"
+		"[root] module.prerequisites (close)" -> "[root] module.prerequisites.module.nested (close)"
+		"[root] module.prerequisites.coder_script.module_script (expand)" -> "[root] module.prerequisites.var.agent_id (expand)"
+		"[root] module.prerequisites.coder_script.module_script (expand)" -> "[root] module.prerequisites.var.label (expand)"
+		"[root] module.prerequisites.data.coder_script_order.nested (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] module.prerequisites.data.coder_script_order.nested (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.prerequisites.module.nested (close)" -> "[root] module.prerequisites.module.nested.coder_script.nested (expand)"
+		"[root] module.prerequisites.module.nested (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] module.prerequisites.module.nested.coder_script.nested (expand)" -> "[root] module.prerequisites.module.nested.var.agent_id (expand)"
+		"[root] module.prerequisites.module.nested.coder_script.nested (expand)" -> "[root] module.prerequisites.module.nested.var.label (expand)"
+		"[root] module.prerequisites.module.nested.var.agent_id (expand)" -> "[root] module.prerequisites.module.nested (expand)"
+		"[root] module.prerequisites.module.nested.var.agent_id (expand)" -> "[root] module.prerequisites.var.agent_id (expand)"
+		"[root] module.prerequisites.module.nested.var.label (expand)" -> "[root] module.prerequisites.module.nested (expand)"
+		"[root] module.prerequisites.module.nested.var.label (expand)" -> "[root] module.prerequisites.var.label (expand)"
+		"[root] module.prerequisites.var.agent_id (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] module.prerequisites.var.agent_id (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] module.prerequisites.var.label (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] null_resource.workspace (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] null_resource.workspace (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.counted (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.keyed (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.root_start (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.stop_a (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.stop_b (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.unordered (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_script_order.overlapping (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_script_order.primary (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.dependents.coder_script.module_script (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.dependents.data.coder_script_order.nested (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.dependents.module.nested.coder_script.nested (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.prerequisites.coder_script.module_script (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.prerequisites.data.coder_script_order.nested (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.prerequisites.module.nested.coder_script.nested (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.workspace (expand)"
+		"[root] root" -> "[root] module.dependents (close)"
+		"[root] root" -> "[root] module.prerequisites (close)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/script-order/script-order.tfplan.json
+++ b/provisioner/terraform/testdata/resources/script-order/script-order.tfplan.json
@@ -1,0 +1,1566 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_agent.main",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "main",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "api_key_scope": "all",
+            "arch": "amd64",
+            "auth": "token",
+            "connection_timeout": 120,
+            "dir": null,
+            "env": null,
+            "metadata": [],
+            "motd_file": null,
+            "order": null,
+            "os": "linux",
+            "resources_monitoring": [],
+            "shutdown_script": null,
+            "startup_script": null,
+            "startup_script_behavior": "non-blocking",
+            "troubleshooting_url": null
+          },
+          "sensitive_values": {
+            "display_apps": [],
+            "metadata": [],
+            "resources_monitoring": [],
+            "token": true
+          }
+        },
+        {
+          "address": "coder_script.counted[0]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "counted",
+          "index": 0,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Counted 0",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo counted 0",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.counted[1]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "counted",
+          "index": 1,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Counted 1",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo counted 1",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.keyed[\"api\"]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "keyed",
+          "index": "api",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Keyed api",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo keyed api",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.keyed[\"worker\"]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "keyed",
+          "index": "worker",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Keyed worker",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo keyed worker",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.root_start",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "root_start",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Root start",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo root start",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.stop_a",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "stop_a",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Stop A",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": false,
+            "run_on_stop": true,
+            "script": "echo stop A",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.stop_b",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "stop_b",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Stop B",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": false,
+            "run_on_stop": true,
+            "script": "echo stop B",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "coder_script.unordered",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "unordered",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "cron": null,
+            "display_name": "Unordered",
+            "icon": null,
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo unordered",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "null_resource.workspace",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "workspace",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "triggers": null
+          },
+          "sensitive_values": {}
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.dependents.coder_script.module_script",
+              "mode": "managed",
+              "type": "coder_script",
+              "name": "module_script",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 1,
+              "values": {
+                "cron": null,
+                "display_name": "dependent module",
+                "icon": null,
+                "log_path": null,
+                "run_on_start": true,
+                "run_on_stop": false,
+                "script": "echo dependent module",
+                "start_blocks_login": false,
+                "timeout": 0
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.dependents",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.dependents.module.nested.coder_script.nested",
+                  "mode": "managed",
+                  "type": "coder_script",
+                  "name": "nested",
+                  "provider_name": "registry.terraform.io/coder/coder",
+                  "schema_version": 1,
+                  "values": {
+                    "cron": null,
+                    "display_name": "dependent nested",
+                    "icon": null,
+                    "log_path": null,
+                    "run_on_start": true,
+                    "run_on_stop": false,
+                    "script": "echo dependent nested",
+                    "start_blocks_login": false,
+                    "timeout": 0
+                  },
+                  "sensitive_values": {}
+                }
+              ],
+              "address": "module.dependents.module.nested"
+            }
+          ]
+        },
+        {
+          "resources": [
+            {
+              "address": "module.prerequisites.coder_script.module_script",
+              "mode": "managed",
+              "type": "coder_script",
+              "name": "module_script",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 1,
+              "values": {
+                "cron": null,
+                "display_name": "prerequisite module",
+                "icon": null,
+                "log_path": null,
+                "run_on_start": true,
+                "run_on_stop": false,
+                "script": "echo prerequisite module",
+                "start_blocks_login": false,
+                "timeout": 0
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.prerequisites",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.prerequisites.module.nested.coder_script.nested",
+                  "mode": "managed",
+                  "type": "coder_script",
+                  "name": "nested",
+                  "provider_name": "registry.terraform.io/coder/coder",
+                  "schema_version": 1,
+                  "values": {
+                    "cron": null,
+                    "display_name": "prerequisite nested",
+                    "icon": null,
+                    "log_path": null,
+                    "run_on_start": true,
+                    "run_on_stop": false,
+                    "script": "echo prerequisite nested",
+                    "start_blocks_login": false,
+                    "timeout": 0
+                  },
+                  "sensitive_values": {}
+                }
+              ],
+              "address": "module.prerequisites.module.nested"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "coder_agent.main",
+      "mode": "managed",
+      "type": "coder_agent",
+      "name": "main",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "api_key_scope": "all",
+          "arch": "amd64",
+          "auth": "token",
+          "connection_timeout": 120,
+          "dir": null,
+          "env": null,
+          "metadata": [],
+          "motd_file": null,
+          "order": null,
+          "os": "linux",
+          "resources_monitoring": [],
+          "shutdown_script": null,
+          "startup_script": null,
+          "startup_script_behavior": "non-blocking",
+          "troubleshooting_url": null
+        },
+        "after_unknown": {
+          "display_apps": true,
+          "id": true,
+          "init_script": true,
+          "metadata": [],
+          "resources_monitoring": [],
+          "token": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "display_apps": [],
+          "metadata": [],
+          "resources_monitoring": [],
+          "token": true
+        }
+      }
+    },
+    {
+      "address": "coder_script.counted[0]",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "counted",
+      "index": 0,
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Counted 0",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo counted 0",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.counted[1]",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "counted",
+      "index": 1,
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Counted 1",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo counted 1",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.keyed[\"api\"]",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "keyed",
+      "index": "api",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Keyed api",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo keyed api",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.keyed[\"worker\"]",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "keyed",
+      "index": "worker",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Keyed worker",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo keyed worker",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.root_start",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "root_start",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Root start",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo root start",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.stop_a",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "stop_a",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Stop A",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": false,
+          "run_on_stop": true,
+          "script": "echo stop A",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.stop_b",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "stop_b",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Stop B",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": false,
+          "run_on_stop": true,
+          "script": "echo stop B",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "coder_script.unordered",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "unordered",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "Unordered",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo unordered",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "null_resource.workspace",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "workspace",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.dependents.coder_script.module_script",
+      "module_address": "module.dependents",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "module_script",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "dependent module",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo dependent module",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.prerequisites.coder_script.module_script",
+      "module_address": "module.prerequisites",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "module_script",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "prerequisite module",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo prerequisite module",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.dependents.module.nested.coder_script.nested",
+      "module_address": "module.dependents.module.nested",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "nested",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "dependent nested",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo dependent nested",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.prerequisites.module.nested.coder_script.nested",
+      "module_address": "module.prerequisites.module.nested",
+      "mode": "managed",
+      "type": "coder_script",
+      "name": "nested",
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "cron": null,
+          "display_name": "prerequisite nested",
+          "icon": null,
+          "log_path": null,
+          "run_on_start": true,
+          "run_on_stop": false,
+          "script": "echo prerequisite nested",
+          "start_blocks_login": false,
+          "timeout": 0
+        },
+        "after_unknown": {
+          "agent_id": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.15.5",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "data.coder_script_order.overlapping",
+            "mode": "data",
+            "type": "coder_script_order",
+            "name": "overlapping",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "id": "29e0c6a7-e15b-4925-a723-c985048880d5",
+              "rule": [
+                {
+                  "after": [
+                    "coder_script.root_start"
+                  ],
+                  "requires": "success",
+                  "run": [
+                    "coder_script.counted[1]",
+                    "coder_script.keyed[\"worker\"]"
+                  ]
+                },
+                {
+                  "after": [
+                    "module.prerequisites"
+                  ],
+                  "requires": "completion",
+                  "run": [
+                    "module.dependents"
+                  ]
+                }
+              ]
+            },
+            "sensitive_values": {
+              "rule": [
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "address": "data.coder_script_order.primary",
+            "mode": "data",
+            "type": "coder_script_order",
+            "name": "primary",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "id": "eba40216-7d01-4852-b3be-c9104e8ffb32",
+              "rule": [
+                {
+                  "after": [
+                    "coder_script.root_start"
+                  ],
+                  "requires": "success",
+                  "run": [
+                    "coder_script.counted"
+                  ]
+                },
+                {
+                  "after": [
+                    "coder_script.counted[1]"
+                  ],
+                  "requires": "completion",
+                  "run": [
+                    "coder_script.keyed"
+                  ]
+                },
+                {
+                  "after": [
+                    "module.prerequisites"
+                  ],
+                  "requires": "completion",
+                  "run": [
+                    "module.dependents"
+                  ]
+                },
+                {
+                  "after": [
+                    "coder_script.stop_a"
+                  ],
+                  "requires": "success",
+                  "run": [
+                    "coder_script.stop_b"
+                  ]
+                }
+              ]
+            },
+            "sensitive_values": {
+              "rule": [
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false
+                  ]
+                },
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false
+                  ]
+                },
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false
+                  ]
+                },
+                {
+                  "after": [
+                    false
+                  ],
+                  "run": [
+                    false
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "child_modules": [
+          {
+            "resources": [
+              {
+                "address": "module.dependents.data.coder_script_order.nested",
+                "mode": "data",
+                "type": "coder_script_order",
+                "name": "nested",
+                "provider_name": "registry.terraform.io/coder/coder",
+                "schema_version": 1,
+                "values": {
+                  "id": "ad6f1b64-3a58-41bc-9687-ac1223447813",
+                  "rule": [
+                    {
+                      "after": [
+                        "coder_script.module_script"
+                      ],
+                      "requires": "success",
+                      "run": [
+                        "module.nested"
+                      ]
+                    }
+                  ]
+                },
+                "sensitive_values": {
+                  "rule": [
+                    {
+                      "after": [
+                        false
+                      ],
+                      "run": [
+                        false
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "address": "module.dependents"
+          },
+          {
+            "resources": [
+              {
+                "address": "module.prerequisites.data.coder_script_order.nested",
+                "mode": "data",
+                "type": "coder_script_order",
+                "name": "nested",
+                "provider_name": "registry.terraform.io/coder/coder",
+                "schema_version": 1,
+                "values": {
+                  "id": "5d9ddd40-1336-4515-b05d-13d493f9c9e1",
+                  "rule": [
+                    {
+                      "after": [
+                        "coder_script.module_script"
+                      ],
+                      "requires": "success",
+                      "run": [
+                        "module.nested"
+                      ]
+                    }
+                  ]
+                },
+                "sensitive_values": {
+                  "rule": [
+                    {
+                      "after": [
+                        false
+                      ],
+                      "run": [
+                        false
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "address": "module.prerequisites"
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "coder": {
+        "name": "coder",
+        "full_name": "registry.terraform.io/coder/coder",
+        "version_constraint": ">= 2.0.0"
+      },
+      "null": {
+        "name": "null",
+        "full_name": "registry.terraform.io/hashicorp/null"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_agent.main",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "main",
+          "provider_config_key": "coder",
+          "expressions": {
+            "arch": {
+              "constant_value": "amd64"
+            },
+            "os": {
+              "constant_value": "linux"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.counted",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "counted",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "display_name": {
+              "references": [
+                "count.index"
+              ]
+            },
+            "run_on_start": {
+              "constant_value": true
+            },
+            "script": {
+              "references": [
+                "count.index"
+              ]
+            }
+          },
+          "schema_version": 1,
+          "count_expression": {
+            "constant_value": 2
+          }
+        },
+        {
+          "address": "coder_script.keyed",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "keyed",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "display_name": {
+              "references": [
+                "each.key"
+              ]
+            },
+            "run_on_start": {
+              "constant_value": true
+            },
+            "script": {
+              "references": [
+                "each.key"
+              ]
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.root_start",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "root_start",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "display_name": {
+              "constant_value": "Root start"
+            },
+            "run_on_start": {
+              "constant_value": true
+            },
+            "script": {
+              "constant_value": "echo root start"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.stop_a",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "stop_a",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "display_name": {
+              "constant_value": "Stop A"
+            },
+            "run_on_stop": {
+              "constant_value": true
+            },
+            "script": {
+              "constant_value": "echo stop A"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.stop_b",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "stop_b",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "display_name": {
+              "constant_value": "Stop B"
+            },
+            "run_on_stop": {
+              "constant_value": true
+            },
+            "script": {
+              "constant_value": "echo stop B"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "coder_script.unordered",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "unordered",
+          "provider_config_key": "coder",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "display_name": {
+              "constant_value": "Unordered"
+            },
+            "run_on_start": {
+              "constant_value": true
+            },
+            "script": {
+              "constant_value": "echo unordered"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "null_resource.workspace",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "workspace",
+          "provider_config_key": "null",
+          "schema_version": 0,
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "data.coder_script_order.overlapping",
+          "mode": "data",
+          "type": "coder_script_order",
+          "name": "overlapping",
+          "provider_config_key": "coder",
+          "expressions": {
+            "rule": [
+              {
+                "after": {
+                  "constant_value": [
+                    "coder_script.root_start"
+                  ]
+                },
+                "run": {
+                  "constant_value": [
+                    "coder_script.counted[1]",
+                    "coder_script.keyed[\"worker\"]"
+                  ]
+                }
+              },
+              {
+                "after": {
+                  "constant_value": [
+                    "module.prerequisites"
+                  ]
+                },
+                "requires": {
+                  "constant_value": "completion"
+                },
+                "run": {
+                  "constant_value": [
+                    "module.dependents"
+                  ]
+                }
+              }
+            ]
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "data.coder_script_order.primary",
+          "mode": "data",
+          "type": "coder_script_order",
+          "name": "primary",
+          "provider_config_key": "coder",
+          "expressions": {
+            "rule": [
+              {
+                "after": {
+                  "constant_value": [
+                    "coder_script.root_start"
+                  ]
+                },
+                "run": {
+                  "constant_value": [
+                    "coder_script.counted"
+                  ]
+                }
+              },
+              {
+                "after": {
+                  "constant_value": [
+                    "coder_script.counted[1]"
+                  ]
+                },
+                "requires": {
+                  "constant_value": "completion"
+                },
+                "run": {
+                  "constant_value": [
+                    "coder_script.keyed"
+                  ]
+                }
+              },
+              {
+                "after": {
+                  "constant_value": [
+                    "module.prerequisites"
+                  ]
+                },
+                "requires": {
+                  "constant_value": "completion"
+                },
+                "run": {
+                  "constant_value": [
+                    "module.dependents"
+                  ]
+                }
+              },
+              {
+                "after": {
+                  "constant_value": [
+                    "coder_script.stop_a"
+                  ]
+                },
+                "run": {
+                  "constant_value": [
+                    "coder_script.stop_b"
+                  ]
+                }
+              }
+            ]
+          },
+          "schema_version": 1
+        }
+      ],
+      "module_calls": {
+        "dependents": {
+          "source": "./modules/script-set",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "label": {
+              "constant_value": "dependent"
+            }
+          },
+          "module": {
+            "resources": [
+              {
+                "address": "coder_script.module_script",
+                "mode": "managed",
+                "type": "coder_script",
+                "name": "module_script",
+                "provider_config_key": "coder",
+                "expressions": {
+                  "agent_id": {
+                    "references": [
+                      "var.agent_id"
+                    ]
+                  },
+                  "display_name": {
+                    "references": [
+                      "var.label"
+                    ]
+                  },
+                  "run_on_start": {
+                    "constant_value": true
+                  },
+                  "script": {
+                    "references": [
+                      "var.label"
+                    ]
+                  }
+                },
+                "schema_version": 1
+              },
+              {
+                "address": "data.coder_script_order.nested",
+                "mode": "data",
+                "type": "coder_script_order",
+                "name": "nested",
+                "provider_config_key": "coder",
+                "expressions": {
+                  "rule": [
+                    {
+                      "after": {
+                        "constant_value": [
+                          "coder_script.module_script"
+                        ]
+                      },
+                      "run": {
+                        "constant_value": [
+                          "module.nested"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 1
+              }
+            ],
+            "module_calls": {
+              "nested": {
+                "source": "./nested",
+                "expressions": {
+                  "agent_id": {
+                    "references": [
+                      "var.agent_id"
+                    ]
+                  },
+                  "label": {
+                    "references": [
+                      "var.label"
+                    ]
+                  }
+                },
+                "module": {
+                  "resources": [
+                    {
+                      "address": "coder_script.nested",
+                      "mode": "managed",
+                      "type": "coder_script",
+                      "name": "nested",
+                      "provider_config_key": "coder",
+                      "expressions": {
+                        "agent_id": {
+                          "references": [
+                            "var.agent_id"
+                          ]
+                        },
+                        "display_name": {
+                          "references": [
+                            "var.label"
+                          ]
+                        },
+                        "run_on_start": {
+                          "constant_value": true
+                        },
+                        "script": {
+                          "references": [
+                            "var.label"
+                          ]
+                        }
+                      },
+                      "schema_version": 1
+                    }
+                  ],
+                  "variables": {
+                    "agent_id": {},
+                    "label": {}
+                  }
+                }
+              }
+            },
+            "variables": {
+              "agent_id": {},
+              "label": {}
+            }
+          }
+        },
+        "prerequisites": {
+          "source": "./modules/script-set",
+          "expressions": {
+            "agent_id": {
+              "references": [
+                "coder_agent.main.id",
+                "coder_agent.main"
+              ]
+            },
+            "label": {
+              "constant_value": "prerequisite"
+            }
+          },
+          "module": {
+            "resources": [
+              {
+                "address": "coder_script.module_script",
+                "mode": "managed",
+                "type": "coder_script",
+                "name": "module_script",
+                "provider_config_key": "coder",
+                "expressions": {
+                  "agent_id": {
+                    "references": [
+                      "var.agent_id"
+                    ]
+                  },
+                  "display_name": {
+                    "references": [
+                      "var.label"
+                    ]
+                  },
+                  "run_on_start": {
+                    "constant_value": true
+                  },
+                  "script": {
+                    "references": [
+                      "var.label"
+                    ]
+                  }
+                },
+                "schema_version": 1
+              },
+              {
+                "address": "data.coder_script_order.nested",
+                "mode": "data",
+                "type": "coder_script_order",
+                "name": "nested",
+                "provider_config_key": "coder",
+                "expressions": {
+                  "rule": [
+                    {
+                      "after": {
+                        "constant_value": [
+                          "coder_script.module_script"
+                        ]
+                      },
+                      "run": {
+                        "constant_value": [
+                          "module.nested"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 1
+              }
+            ],
+            "module_calls": {
+              "nested": {
+                "source": "./nested",
+                "expressions": {
+                  "agent_id": {
+                    "references": [
+                      "var.agent_id"
+                    ]
+                  },
+                  "label": {
+                    "references": [
+                      "var.label"
+                    ]
+                  }
+                },
+                "module": {
+                  "resources": [
+                    {
+                      "address": "coder_script.nested",
+                      "mode": "managed",
+                      "type": "coder_script",
+                      "name": "nested",
+                      "provider_config_key": "coder",
+                      "expressions": {
+                        "agent_id": {
+                          "references": [
+                            "var.agent_id"
+                          ]
+                        },
+                        "display_name": {
+                          "references": [
+                            "var.label"
+                          ]
+                        },
+                        "run_on_start": {
+                          "constant_value": true
+                        },
+                        "script": {
+                          "references": [
+                            "var.label"
+                          ]
+                        }
+                      },
+                      "schema_version": 1
+                    }
+                  ],
+                  "variables": {
+                    "agent_id": {},
+                    "label": {}
+                  }
+                }
+              }
+            },
+            "variables": {
+              "agent_id": {},
+              "label": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "coder_agent.main",
+      "attribute": [
+        "id"
+      ]
+    }
+  ],
+  "timestamp": "2026-08-18T15:10:46Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/provisioner/terraform/testdata/resources/script-order/script-order.tfstate.dot
+++ b/provisioner/terraform/testdata/resources/script-order/script-order.tfstate.dot
@@ -1,0 +1,90 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
+		"[root] coder_script.counted (expand)" [label = "coder_script.counted", shape = "box"]
+		"[root] coder_script.keyed (expand)" [label = "coder_script.keyed", shape = "box"]
+		"[root] coder_script.root_start (expand)" [label = "coder_script.root_start", shape = "box"]
+		"[root] coder_script.stop_a (expand)" [label = "coder_script.stop_a", shape = "box"]
+		"[root] coder_script.stop_b (expand)" [label = "coder_script.stop_b", shape = "box"]
+		"[root] coder_script.unordered (expand)" [label = "coder_script.unordered", shape = "box"]
+		"[root] data.coder_script_order.overlapping (expand)" [label = "data.coder_script_order.overlapping", shape = "box"]
+		"[root] data.coder_script_order.primary (expand)" [label = "data.coder_script_order.primary", shape = "box"]
+		"[root] module.dependents.coder_script.module_script (expand)" [label = "module.dependents.coder_script.module_script", shape = "box"]
+		"[root] module.dependents.data.coder_script_order.nested (expand)" [label = "module.dependents.data.coder_script_order.nested", shape = "box"]
+		"[root] module.dependents.module.nested.coder_script.nested (expand)" [label = "module.dependents.module.nested.coder_script.nested", shape = "box"]
+		"[root] module.prerequisites.coder_script.module_script (expand)" [label = "module.prerequisites.coder_script.module_script", shape = "box"]
+		"[root] module.prerequisites.data.coder_script_order.nested (expand)" [label = "module.prerequisites.data.coder_script_order.nested", shape = "box"]
+		"[root] module.prerequisites.module.nested.coder_script.nested (expand)" [label = "module.prerequisites.module.nested.coder_script.nested", shape = "box"]
+		"[root] null_resource.workspace (expand)" [label = "null_resource.workspace", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_script.counted (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.keyed (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.root_start (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.stop_a (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.stop_b (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] coder_script.unordered (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] data.coder_script_order.overlapping (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_script_order.primary (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.dependents (close)" -> "[root] module.dependents.coder_script.module_script (expand)"
+		"[root] module.dependents (close)" -> "[root] module.dependents.data.coder_script_order.nested (expand)"
+		"[root] module.dependents (close)" -> "[root] module.dependents.module.nested (close)"
+		"[root] module.dependents.coder_script.module_script (expand)" -> "[root] module.dependents.var.agent_id (expand)"
+		"[root] module.dependents.coder_script.module_script (expand)" -> "[root] module.dependents.var.label (expand)"
+		"[root] module.dependents.data.coder_script_order.nested (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.dependents.data.coder_script_order.nested (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.dependents.module.nested (close)" -> "[root] module.dependents.module.nested.coder_script.nested (expand)"
+		"[root] module.dependents.module.nested (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.dependents.module.nested.coder_script.nested (expand)" -> "[root] module.dependents.module.nested.var.agent_id (expand)"
+		"[root] module.dependents.module.nested.coder_script.nested (expand)" -> "[root] module.dependents.module.nested.var.label (expand)"
+		"[root] module.dependents.module.nested.var.agent_id (expand)" -> "[root] module.dependents.module.nested (expand)"
+		"[root] module.dependents.module.nested.var.agent_id (expand)" -> "[root] module.dependents.var.agent_id (expand)"
+		"[root] module.dependents.module.nested.var.label (expand)" -> "[root] module.dependents.module.nested (expand)"
+		"[root] module.dependents.module.nested.var.label (expand)" -> "[root] module.dependents.var.label (expand)"
+		"[root] module.dependents.var.agent_id (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] module.dependents.var.agent_id (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.dependents.var.label (expand)" -> "[root] module.dependents (expand)"
+		"[root] module.prerequisites (close)" -> "[root] module.prerequisites.coder_script.module_script (expand)"
+		"[root] module.prerequisites (close)" -> "[root] module.prerequisites.data.coder_script_order.nested (expand)"
+		"[root] module.prerequisites (close)" -> "[root] module.prerequisites.module.nested (close)"
+		"[root] module.prerequisites.coder_script.module_script (expand)" -> "[root] module.prerequisites.var.agent_id (expand)"
+		"[root] module.prerequisites.coder_script.module_script (expand)" -> "[root] module.prerequisites.var.label (expand)"
+		"[root] module.prerequisites.data.coder_script_order.nested (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] module.prerequisites.data.coder_script_order.nested (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.prerequisites.module.nested (close)" -> "[root] module.prerequisites.module.nested.coder_script.nested (expand)"
+		"[root] module.prerequisites.module.nested (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] module.prerequisites.module.nested.coder_script.nested (expand)" -> "[root] module.prerequisites.module.nested.var.agent_id (expand)"
+		"[root] module.prerequisites.module.nested.coder_script.nested (expand)" -> "[root] module.prerequisites.module.nested.var.label (expand)"
+		"[root] module.prerequisites.module.nested.var.agent_id (expand)" -> "[root] module.prerequisites.module.nested (expand)"
+		"[root] module.prerequisites.module.nested.var.agent_id (expand)" -> "[root] module.prerequisites.var.agent_id (expand)"
+		"[root] module.prerequisites.module.nested.var.label (expand)" -> "[root] module.prerequisites.module.nested (expand)"
+		"[root] module.prerequisites.module.nested.var.label (expand)" -> "[root] module.prerequisites.var.label (expand)"
+		"[root] module.prerequisites.var.agent_id (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] module.prerequisites.var.agent_id (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] module.prerequisites.var.label (expand)" -> "[root] module.prerequisites (expand)"
+		"[root] null_resource.workspace (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] null_resource.workspace (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.counted (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.keyed (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.root_start (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.stop_a (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.stop_b (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_script.unordered (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_script_order.overlapping (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_script_order.primary (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.dependents.coder_script.module_script (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.dependents.data.coder_script_order.nested (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.dependents.module.nested.coder_script.nested (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.prerequisites.coder_script.module_script (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.prerequisites.data.coder_script_order.nested (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.prerequisites.module.nested.coder_script.nested (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.workspace (expand)"
+		"[root] root" -> "[root] module.dependents (close)"
+		"[root] root" -> "[root] module.prerequisites (close)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/script-order/script-order.tfstate.json
+++ b/provisioner/terraform/testdata/resources/script-order/script-order.tfstate.json
@@ -1,0 +1,607 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.15.5",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.coder_script_order.overlapping",
+          "mode": "data",
+          "type": "coder_script_order",
+          "name": "overlapping",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "id": "ae6b882e-7e75-4c45-90ed-db584e2d0e51",
+            "rule": [
+              {
+                "after": [
+                  "coder_script.root_start"
+                ],
+                "requires": "success",
+                "run": [
+                  "coder_script.counted[1]",
+                  "coder_script.keyed[\"worker\"]"
+                ]
+              },
+              {
+                "after": [
+                  "module.prerequisites"
+                ],
+                "requires": "completion",
+                "run": [
+                  "module.dependents"
+                ]
+              }
+            ]
+          },
+          "sensitive_values": {
+            "rule": [
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false,
+                  false
+                ]
+              },
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "address": "data.coder_script_order.primary",
+          "mode": "data",
+          "type": "coder_script_order",
+          "name": "primary",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "id": "f6c28208-f25f-4445-a959-2a2e26910c9d",
+            "rule": [
+              {
+                "after": [
+                  "coder_script.root_start"
+                ],
+                "requires": "success",
+                "run": [
+                  "coder_script.counted"
+                ]
+              },
+              {
+                "after": [
+                  "coder_script.counted[1]"
+                ],
+                "requires": "completion",
+                "run": [
+                  "coder_script.keyed"
+                ]
+              },
+              {
+                "after": [
+                  "module.prerequisites"
+                ],
+                "requires": "completion",
+                "run": [
+                  "module.dependents"
+                ]
+              },
+              {
+                "after": [
+                  "coder_script.stop_a"
+                ],
+                "requires": "success",
+                "run": [
+                  "coder_script.stop_b"
+                ]
+              }
+            ]
+          },
+          "sensitive_values": {
+            "rule": [
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false
+                ]
+              },
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false
+                ]
+              },
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false
+                ]
+              },
+              {
+                "after": [
+                  false
+                ],
+                "run": [
+                  false
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "address": "coder_agent.main",
+          "mode": "managed",
+          "type": "coder_agent",
+          "name": "main",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "api_key_scope": "all",
+            "arch": "amd64",
+            "auth": "token",
+            "connection_timeout": 120,
+            "dir": null,
+            "display_apps": [
+              {
+                "port_forwarding_helper": true,
+                "ssh_helper": true,
+                "vscode": true,
+                "vscode_insiders": false,
+                "web_terminal": true
+              }
+            ],
+            "env": null,
+            "id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "init_script": "",
+            "metadata": [],
+            "motd_file": null,
+            "order": null,
+            "os": "linux",
+            "resources_monitoring": [],
+            "shutdown_script": null,
+            "startup_script": null,
+            "startup_script_behavior": "non-blocking",
+            "token": "72b8de2c-dbf9-4dcb-a6c7-2112091de0c5",
+            "troubleshooting_url": null
+          },
+          "sensitive_values": {
+            "display_apps": [
+              {}
+            ],
+            "metadata": [],
+            "resources_monitoring": [],
+            "token": true
+          }
+        },
+        {
+          "address": "coder_script.counted[0]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "counted",
+          "index": 0,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Counted 0",
+            "icon": null,
+            "id": "86c3826b-4d8f-4e42-8c89-c9ae0936fc60",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo counted 0",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.counted[1]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "counted",
+          "index": 1,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Counted 1",
+            "icon": null,
+            "id": "154e864c-3202-4cae-a6fe-2851dbdef241",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo counted 1",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.keyed[\"api\"]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "keyed",
+          "index": "api",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Keyed api",
+            "icon": null,
+            "id": "0183c3df-7ac7-4917-b22c-ad7da66712f0",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo keyed api",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.keyed[\"worker\"]",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "keyed",
+          "index": "worker",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Keyed worker",
+            "icon": null,
+            "id": "e1d85ff5-8332-4519-8eb9-89f62518b6b8",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo keyed worker",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.root_start",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "root_start",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Root start",
+            "icon": null,
+            "id": "8dcecf0d-1f9b-449d-b9a8-94344f71028b",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo root start",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.stop_a",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "stop_a",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Stop A",
+            "icon": null,
+            "id": "4824277b-31c0-4e6a-83ca-686fc6f99da1",
+            "log_path": null,
+            "run_on_start": false,
+            "run_on_stop": true,
+            "script": "echo stop A",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.stop_b",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "stop_b",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Stop B",
+            "icon": null,
+            "id": "042438f1-6b7b-403e-9cdb-9e2df98ce1a9",
+            "log_path": null,
+            "run_on_start": false,
+            "run_on_stop": true,
+            "script": "echo stop B",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "coder_script.unordered",
+          "mode": "managed",
+          "type": "coder_script",
+          "name": "unordered",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+            "cron": null,
+            "display_name": "Unordered",
+            "icon": null,
+            "id": "4dedfb7a-435a-4a4a-a464-95c116771ec7",
+            "log_path": null,
+            "run_on_start": true,
+            "run_on_stop": false,
+            "script": "echo unordered",
+            "start_blocks_login": false,
+            "timeout": 0
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        },
+        {
+          "address": "null_resource.workspace",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "workspace",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "4346877974126598019",
+            "triggers": null
+          },
+          "sensitive_values": {},
+          "depends_on": [
+            "coder_agent.main"
+          ]
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.dependents.data.coder_script_order.nested",
+              "mode": "data",
+              "type": "coder_script_order",
+              "name": "nested",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 1,
+              "values": {
+                "id": "80e1bd95-39a3-434a-994e-0880eb981da5",
+                "rule": [
+                  {
+                    "after": [
+                      "coder_script.module_script"
+                    ],
+                    "requires": "success",
+                    "run": [
+                      "module.nested"
+                    ]
+                  }
+                ]
+              },
+              "sensitive_values": {
+                "rule": [
+                  {
+                    "after": [
+                      false
+                    ],
+                    "run": [
+                      false
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "address": "module.dependents.coder_script.module_script",
+              "mode": "managed",
+              "type": "coder_script",
+              "name": "module_script",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 1,
+              "values": {
+                "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+                "cron": null,
+                "display_name": "dependent module",
+                "icon": null,
+                "id": "1cae67a1-d682-44ec-9a9c-9469052de509",
+                "log_path": null,
+                "run_on_start": true,
+                "run_on_stop": false,
+                "script": "echo dependent module",
+                "start_blocks_login": false,
+                "timeout": 0
+              },
+              "sensitive_values": {},
+              "depends_on": [
+                "coder_agent.main"
+              ]
+            }
+          ],
+          "address": "module.dependents",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.dependents.module.nested.coder_script.nested",
+                  "mode": "managed",
+                  "type": "coder_script",
+                  "name": "nested",
+                  "provider_name": "registry.terraform.io/coder/coder",
+                  "schema_version": 1,
+                  "values": {
+                    "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+                    "cron": null,
+                    "display_name": "dependent nested",
+                    "icon": null,
+                    "id": "a36d8206-3965-4a2d-8d3a-c3a755e1e5fd",
+                    "log_path": null,
+                    "run_on_start": true,
+                    "run_on_stop": false,
+                    "script": "echo dependent nested",
+                    "start_blocks_login": false,
+                    "timeout": 0
+                  },
+                  "sensitive_values": {},
+                  "depends_on": [
+                    "coder_agent.main"
+                  ]
+                }
+              ],
+              "address": "module.dependents.module.nested"
+            }
+          ]
+        },
+        {
+          "resources": [
+            {
+              "address": "module.prerequisites.data.coder_script_order.nested",
+              "mode": "data",
+              "type": "coder_script_order",
+              "name": "nested",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 1,
+              "values": {
+                "id": "0fdd2950-5f0b-40b0-ac81-be32e41a662d",
+                "rule": [
+                  {
+                    "after": [
+                      "coder_script.module_script"
+                    ],
+                    "requires": "success",
+                    "run": [
+                      "module.nested"
+                    ]
+                  }
+                ]
+              },
+              "sensitive_values": {
+                "rule": [
+                  {
+                    "after": [
+                      false
+                    ],
+                    "run": [
+                      false
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "address": "module.prerequisites.coder_script.module_script",
+              "mode": "managed",
+              "type": "coder_script",
+              "name": "module_script",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 1,
+              "values": {
+                "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+                "cron": null,
+                "display_name": "prerequisite module",
+                "icon": null,
+                "id": "82be566d-5392-4c46-ba22-ce379d4be778",
+                "log_path": null,
+                "run_on_start": true,
+                "run_on_stop": false,
+                "script": "echo prerequisite module",
+                "start_blocks_login": false,
+                "timeout": 0
+              },
+              "sensitive_values": {},
+              "depends_on": [
+                "coder_agent.main"
+              ]
+            }
+          ],
+          "address": "module.prerequisites",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.prerequisites.module.nested.coder_script.nested",
+                  "mode": "managed",
+                  "type": "coder_script",
+                  "name": "nested",
+                  "provider_name": "registry.terraform.io/coder/coder",
+                  "schema_version": 1,
+                  "values": {
+                    "agent_id": "8ef96744-7278-4405-afcc-f5fb77f898fa",
+                    "cron": null,
+                    "display_name": "prerequisite nested",
+                    "icon": null,
+                    "id": "6e66880c-5d56-44a8-86aa-6eaf8ec88257",
+                    "log_path": null,
+                    "run_on_start": true,
+                    "run_on_stop": false,
+                    "script": "echo prerequisite nested",
+                    "start_blocks_login": false,
+                    "timeout": 0
+                  },
+                  "sensitive_values": {},
+                  "depends_on": [
+                    "coder_agent.main"
+                  ]
+                }
+              ],
+              "address": "module.prerequisites.module.nested"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add provider-generated plan and state fixtures covering startup and shutdown phases, count and for_each selectors, module descendants, overlapping rules, multiple data sources, cross-agent rejection, and unordered scripts.

Verify plan and state conversion produce identical deterministic graphs. The fixtures use committed output, so normal tests do not depend on an unpublished provider release.

<!-- STAKK_BODY_START -->
<!-- This section is managed by stakk. Manual edits will be overwritten. -->
<!-- https://github.com/glennib/stakk -->

---

<!--- STAKK_STACK: eyJ2ZXJzaW9uIjowLCJzdGFjayI6W3siYm9va21hcmtfbmFtZSI6Imdlb3JnZS9wbGF0LTM3NS1wcm90b3R5cGUvMDEtcGFyc2Utc2NyaXB0LW9yZGVyLXNlbGVjdG9ycyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQyIiwicHJfbnVtYmVyIjoyODM0Mn0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wMi12YWxpZGF0ZS1zY3JpcHQtb3JkZXItcnVsZXMiLCJwcl91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vY29kZXIvY29kZXIvcHVsbC8yODM0MyIsInByX251bWJlciI6MjgzNDN9LHsiYm9va21hcmtfbmFtZSI6Imdlb3JnZS9wbGF0LTM3NS1wcm90b3R5cGUvMDMtYnVpbGQtc2NyaXB0LW9yZGVyLWdyYXBocyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQ0IiwicHJfbnVtYmVyIjoyODM0NH0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wNC1zdXBwb3J0LWNvbmRpdGlvbmFsLWRlcGVuZGVuY2llcyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQ1IiwicHJfbnVtYmVyIjoyODM0NX0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wNS10cmFuc3BvcnQtc2NyaXB0LW9yZGVyLWRlcGVuZGVuY2llcyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzQ2IiwicHJfbnVtYmVyIjoyODM0Nn0seyJib29rbWFya19uYW1lIjoiZ2VvcmdlL3BsYXQtMzc1LXByb3RvdHlwZS8wNi1wZXJzaXN0LXNjcmlwdC1vcmRlci1kZXBlbmRlbmNpZXMiLCJwcl91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vY29kZXIvY29kZXIvcHVsbC8yODM0NyIsInByX251bWJlciI6MjgzNDd9LHsiYm9va21hcmtfbmFtZSI6Imdlb3JnZS9wbGF0LTM3NS1wcm90b3R5cGUvMDctZW5mb3JjZS1zY3JpcHQtZXhlY3V0aW9uLW9yZGVyIiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNDgiLCJwcl9udW1iZXIiOjI4MzQ4fSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzA4LWV4cG9zZS1za2lwcGVkLXNjcmlwdC10aW1pbmdzIiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNDkiLCJwcl9udW1iZXIiOjI4MzQ5fSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzA5LXJlcG9ydC1zY3JpcHQtb3JkZXItdXNhZ2UtdGVsZW1ldHJ5IiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNTAiLCJwcl9udW1iZXIiOjI4MzUwfSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzEwLWNvdmVyLWRlY2xhcmF0aXZlLXNjcmlwdC1vcmRlcmluZy1lbmQtdG8tZW5kIiwicHJfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NvZGVyL2NvZGVyL3B1bGwvMjgzNTEiLCJwcl9udW1iZXIiOjI4MzUxfSx7ImJvb2ttYXJrX25hbWUiOiJnZW9yZ2UvcGxhdC0zNzUtcHJvdG90eXBlLzExLWRvY3VtZW50LWRlY2xhcmF0aXZlLXNjcmlwdC1vcmRlcmluZyIsInByX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jb2Rlci9jb2Rlci9wdWxsLzI4MzUyIiwicHJfbnVtYmVyIjoyODM1Mn1dfQ== --->
This PR is part of a stack that merges into `main`:

1. https://github.com/coder/coder/pull/28342
2. https://github.com/coder/coder/pull/28343
3. https://github.com/coder/coder/pull/28344
4. https://github.com/coder/coder/pull/28345
5. https://github.com/coder/coder/pull/28346
6. https://github.com/coder/coder/pull/28347
7. https://github.com/coder/coder/pull/28348
8. https://github.com/coder/coder/pull/28349
9. https://github.com/coder/coder/pull/28350
10. https://github.com/coder/coder/pull/28351 👈
11. https://github.com/coder/coder/pull/28352

<sub>Created with [stakk](https://github.com/glennib/stakk)</sub>
<!-- STAKK_BODY_END -->
