### PR TITLE
fix(site): scroll per-script logs selector on overflow

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -685,7 +685,10 @@ export const AgentRow: FC<AgentRowProps> = ({
 																	<span className="sr-only">More log tabs</span>
 																</button>
 															</DropdownMenuTrigger>
-															<DropdownMenuContent align="end">
+															<DropdownMenuContent
+																align="end"
+																className="max-h-56 overflow-y-auto"
+															>
 																<DropdownMenuRadioGroup
 																	value={selectedLogTab}
 																	onValueChange={handleSelectedLogTabChange}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Resolves [DEVEX-721](https://linear.app/codercom/issue/DEVEX-721/the-logs-selector-per-startup-script-needs-to-scroll-on-overflow).

Cap the overflow menu height and let it scroll, matching the existing pattern already used by `DownloadSelectedAgentLogsButton` (`max-h-56 overflow-y-auto`). No component swap needed, the `DropdownMenu` was the right primitive, it just lacked height/scroll constraints.

```diff
-<DropdownMenuContent align="end">
+<DropdownMenuContent align="end" className="max-h-56 overflow-y-auto">
```

<img width="504" height="325" alt="image" src="https://github.com/user-attachments/assets/363d9bc0-e3c3-4355-8d05-abb8c650a37a" />

<details>
<summary>Investigation / decision log</summary>

- The "logs selector per startup script" is the overflow kebab menu in `site/src/modules/resources/AgentRow.tsx`. When per-script log tabs don't fit horizontally, `useKebabMenu` moves the extras into a Radix `DropdownMenu` rendered as `DropdownMenuRadioItem`s.
- `menuContentClass` (`site/src/components/DropdownMenu/menuClasses.ts`) is `z-50 min-w-48 overflow-hidden ...` with no max-height, so an overlong menu is clipped instead of scrolling.
- `DownloadSelectedAgentLogsButton.tsx` already solves the identical problem on its own menu with `className="max-h-56 overflow-y-auto"`, so we reused that for consistency.
- Considered switching to the `Select` component (which has `SelectScrollUpButton`/`SelectScrollDownButton` chevrons) but that's a larger re-model of the trigger + items and reconciliation with the `Tabs`/`useKebabMenu` wiring. Deferred in favor of the minimal fix.

</details>