### PR TITLE
test(cli): wait for OAuth server readiness

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -397,6 +397,15 @@ func TestServer(t *testing.T) {
 			createUserPostRestart                 bool
 		}
 
+		waitAuthMethods := func(t *testing.T, ctx context.Context, accessURL *url.URL) codersdk.AuthMethods {
+			t.Helper()
+
+			authMethodsURL := accessURL.JoinPath("api/v2/users/authmethods")
+			var authMethods codersdk.AuthMethods
+			testutil.RequireEventuallyResponseOK(ctx, t, authMethodsURL.String(), &authMethods)
+			return authMethods
+		}
+
 		runGitHubProviderTest := func(t *testing.T, tc testCase) {
 			t.Parallel()
 
@@ -450,10 +459,7 @@ func TestServer(t *testing.T) {
 				require.NotNil(t, accessURL)
 			}
 
-			client := codersdk.New(accessURL)
-
-			authMethods, err := client.AuthMethods(ctx)
-			require.NoError(t, err)
+			authMethods := waitAuthMethods(t, ctx, accessURL)
 			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
 			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
 
@@ -473,11 +479,9 @@ func TestServer(t *testing.T) {
 			inv, cfg = clitest.New(t, args...)
 			clitest.Start(t, inv)
 			accessURL = waitAccessURL(t, cfg)
-			client = codersdk.New(accessURL)
 
 			ctx = testutil.Context(t, testutil.WaitLong)
-			authMethods, err = client.AuthMethods(ctx)
-			require.NoError(t, err)
+			authMethods = waitAuthMethods(t, ctx, accessURL)
 			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
 			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
 		}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -397,12 +397,15 @@ func TestServer(t *testing.T) {
 			createUserPostRestart                 bool
 		}
 
-		waitAuthMethods := func(t *testing.T, ctx context.Context, accessURL *url.URL) codersdk.AuthMethods {
+		waitAuthMethods := func(t *testing.T, ctx context.Context, client *codersdk.Client) codersdk.AuthMethods {
 			t.Helper()
 
-			authMethodsURL := accessURL.JoinPath("api/v2/users/authmethods")
 			var authMethods codersdk.AuthMethods
-			testutil.RequireEventuallyResponseOK(ctx, t, authMethodsURL.String(), &authMethods)
+			testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+				var err error
+				authMethods, err = client.AuthMethods(ctx)
+				return err == nil
+			}, testutil.IntervalFast, "failed to get auth methods")
 			return authMethods
 		}
 
@@ -459,7 +462,8 @@ func TestServer(t *testing.T) {
 				require.NotNil(t, accessURL)
 			}
 
-			authMethods := waitAuthMethods(t, ctx, accessURL)
+			client := codersdk.New(accessURL)
+			authMethods := waitAuthMethods(t, ctx, client)
 			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
 			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
 
@@ -479,9 +483,10 @@ func TestServer(t *testing.T) {
 			inv, cfg = clitest.New(t, args...)
 			clitest.Start(t, inv)
 			accessURL = waitAccessURL(t, cfg)
+			client = codersdk.New(accessURL)
 
 			ctx = testutil.Context(t, testutil.WaitLong)
-			authMethods = waitAuthMethods(t, ctx, accessURL)
+			authMethods = waitAuthMethods(t, ctx, client)
 			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
 			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
 		}


### PR DESCRIPTION
The OAuth GitHub default provider test treated the config URL as proof that the restarted HTTP server was ready. On macOS, the first SDK request could reach the listener before it was ready to serve and fail with `readLoopPeekFailLocked`.

Poll `AuthMethods` through the Coder SDK with the existing bounded retry helper before asserting its response, both before and after the restart.

Closes https://linear.app/codercom/issue/ENG-3257/flake-testserveroauth2githubdefaultproviderallowedorg

<sub>Generated by Coder Agents.</sub>
