### PR TITLE
feat: show runtime hours allocation banner to all users

### DIFF
--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -960,10 +960,8 @@ func measureAgentRuntimeMs(
 // never stacks both messages.
 //
 // These warnings reach admins only. The member-facing dashboard banner
-// (site/src/modules/dashboard/AgentRuntimeBanner) re-derives its ladder
-// client-side from the feature's serialized thresholds, including this
-// function's non-positive-allocation short-circuit, so keep the two in
-// sync.
+// (site/src/modules/dashboard/AgentRuntimeBanner) re-derives this ladder
+// client-side, so keep the two in sync.
 func appendAgentRuntimeHoursWarning(warnings []string, actualHours int64, allocation int64, softLimit *int64) []string {
 	// A zero allocation (explicit or the grandfathered premium default) has
 	// no thresholds to warn about: those deployments are steered by the

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -958,6 +958,12 @@ func measureAgentRuntimeMs(
 // appendAgentRuntimeHoursWarning appends at most one warning: reaching the
 // allocation supersedes the advisory soft limit, so the dashboard banner
 // never stacks both messages.
+//
+// These warnings reach admins only. The member-facing dashboard banner
+// (site/src/modules/dashboard/AgentRuntimeBanner) re-derives its ladder
+// client-side from the feature's serialized thresholds, including this
+// function's non-positive-allocation short-circuit, so keep the two in
+// sync.
 func appendAgentRuntimeHoursWarning(warnings []string, actualHours int64, allocation int64, softLimit *int64) []string {
 	// A zero allocation (explicit or the grandfathered premium default) has
 	// no thresholds to warn about: those deployments are steered by the

--- a/site/src/@types/storybook.d.ts
+++ b/site/src/@types/storybook.d.ts
@@ -1,5 +1,6 @@
 import type {
 	DeploymentValues,
+	Entitlements,
 	Experiments,
 	Feature,
 	FeatureName,
@@ -17,6 +18,8 @@ declare module "@storybook/react-vite" {
 		| { event: "open" | "error" | "close" };
 	interface Parameters {
 		features?: (FeatureName | ({ name: FeatureName } & Partial<Feature>))[];
+		/** Overrides applied on top of the entitlements built from `features`. */
+		entitlements?: Partial<Entitlements>;
 		experiments?: Experiments;
 		showOrganizations?: boolean;
 		organizations?: Organization[];

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.stories.tsx
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.stories.tsx
@@ -73,14 +73,12 @@ export const AtAllocation: Story = {
 		}),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// LicenseBannerView renders role="alert" only for the error (red)
-		// variant, so this query also pins the banner's severity.
+		// role="alert" is rendered only for the error (red) variant.
 		const banner = canvas.getByRole("alert");
 		await expect(banner).toHaveTextContent(
 			"Your deployment has used 100 of the 100 Coder Agent runtime hours included in the current license term. Contact your deployment administrator.",
 		);
-		// Non-dismissible, and members cannot fix the limit, so there is no
-		// dismiss affordance and no sales link.
+		// No dismiss affordance and no sales link.
 		await expect(canvas.queryByRole("button")).not.toBeInTheDocument();
 		await expect(canvas.queryByRole("link")).not.toBeInTheDocument();
 	},
@@ -106,8 +104,7 @@ export const AtHardLimit: Story = {
 	},
 };
 
-// A zero allocation reports the feature disabled rather than exhausted;
-// see appendAgentRuntimeHoursWarning in enterprise/coderd/license.
+// A zero allocation means the feature is disabled, not exhausted.
 export const ZeroAllocation: Story = {
 	render: () =>
 		renderAgentRuntimeBanner({
@@ -121,8 +118,7 @@ export const ZeroAllocation: Story = {
 	},
 };
 
-// When the usage measurement fails, actual is absent and members see
-// nothing; admins get the measurement diagnostic through LicenseBanner.
+// actual is absent when the usage measurement fails.
 export const MeasurementUnavailable: Story = {
 	render: () =>
 		renderAgentRuntimeBanner({
@@ -148,8 +144,7 @@ export const NotEntitled: Story = {
 	},
 };
 
-// CODAGT-860 acceptance: once a new license raises the allocation above
-// current usage, the refetched entitlements stop deriving a message.
+// A new license that raises the allocation above usage clears the banner.
 export const ClearedAfterAllocationRaised: Story = {
 	render: () =>
 		renderAgentRuntimeBanner({

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.stories.tsx
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.stories.tsx
@@ -1,0 +1,164 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import type { Feature } from "#/api/typesGenerated";
+import {
+	MockAppearanceConfig,
+	MockBuildInfo,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+} from "#/testHelpers/entities";
+import { DashboardContext, type DashboardValue } from "../DashboardProvider";
+import { AgentRuntimeBanner } from "./AgentRuntimeBanner";
+
+const renderAgentRuntimeBanner = (agentRuntimeHours: Feature) => {
+	const mockDashboardValue: DashboardValue = {
+		entitlements: {
+			...MockEntitlements,
+			has_license: true,
+			features: {
+				...MockEntitlements.features,
+				agent_runtime_hours: agentRuntimeHours,
+			},
+		},
+		experiments: MockExperiments,
+		appearance: MockAppearanceConfig,
+		buildInfo: MockBuildInfo,
+		organizations: [MockDefaultOrganization],
+		showOrganizations: false,
+		canViewOrganizationSettings: false,
+	};
+
+	return (
+		<DashboardContext value={mockDashboardValue}>
+			<AgentRuntimeBanner />
+		</DashboardContext>
+	);
+};
+
+const expectNoBanner = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	await expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+};
+
+const meta: Meta<typeof AgentRuntimeBanner> = {
+	title: "modules/dashboard/AgentRuntimeBanner",
+	component: AgentRuntimeBanner,
+};
+
+export default meta;
+type Story = StoryObj<typeof AgentRuntimeBanner>;
+
+export const BelowAllocation: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: true,
+			entitlement: "entitled",
+			actual: 99,
+			limit: 100,
+		}),
+	play: async ({ canvasElement }) => {
+		await expectNoBanner(canvasElement);
+	},
+};
+
+export const AtAllocation: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: true,
+			entitlement: "entitled",
+			actual: 100,
+			limit: 100,
+			soft_limit: 80,
+		}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// LicenseBannerView renders role="alert" only for the error (red)
+		// variant, so this query also pins the banner's severity.
+		const banner = canvas.getByRole("alert");
+		await expect(banner).toHaveTextContent(
+			"Your deployment has used 100 of the 100 Coder Agent runtime hours included in the current license term. Contact your deployment administrator.",
+		);
+		// Non-dismissible, and members cannot fix the limit, so there is no
+		// dismiss affordance and no sales link.
+		await expect(canvas.queryByRole("button")).not.toBeInTheDocument();
+		await expect(canvas.queryByRole("link")).not.toBeInTheDocument();
+	},
+};
+
+export const AtHardLimit: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: true,
+			entitlement: "entitled",
+			actual: 130,
+			limit: 100,
+			hard_limit: 120,
+		}),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByRole("alert");
+		await expect(banner).toHaveTextContent(
+			"Your deployment has used 130 of the 100 Coder Agent runtime hours included in the current license term, reaching the hard limit of 120 hours. Contact your deployment administrator.",
+		);
+		await expect(canvas.queryByRole("button")).not.toBeInTheDocument();
+		await expect(canvas.queryByRole("link")).not.toBeInTheDocument();
+	},
+};
+
+// A zero allocation reports the feature disabled rather than exhausted;
+// see appendAgentRuntimeHoursWarning in enterprise/coderd/license.
+export const ZeroAllocation: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: false,
+			entitlement: "entitled",
+			actual: 50,
+			limit: 0,
+		}),
+	play: async ({ canvasElement }) => {
+		await expectNoBanner(canvasElement);
+	},
+};
+
+// When the usage measurement fails, actual is absent and members see
+// nothing; admins get the measurement diagnostic through LicenseBanner.
+export const MeasurementUnavailable: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: true,
+			entitlement: "entitled",
+			limit: 100,
+		}),
+	play: async ({ canvasElement }) => {
+		await expectNoBanner(canvasElement);
+	},
+};
+
+export const NotEntitled: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: false,
+			entitlement: "not_entitled",
+			actual: 100,
+			limit: 100,
+		}),
+	play: async ({ canvasElement }) => {
+		await expectNoBanner(canvasElement);
+	},
+};
+
+// CODAGT-860 acceptance: once a new license raises the allocation above
+// current usage, the refetched entitlements stop deriving a message.
+export const ClearedAfterAllocationRaised: Story = {
+	render: () =>
+		renderAgentRuntimeBanner({
+			enabled: true,
+			entitlement: "entitled",
+			actual: 100,
+			limit: 200,
+		}),
+	play: async ({ canvasElement }) => {
+		await expectNoBanner(canvasElement);
+	},
+};

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.test.ts
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.test.ts
@@ -29,9 +29,7 @@ describe(agentRuntimeBannerMessage.name, () => {
 		).toBeNull();
 	});
 
-	// Mirrors the non-positive-allocation short-circuit in the backend's
-	// appendAgentRuntimeHoursWarning: a zero allocation disables the
-	// feature rather than exhausting it.
+	// A zero allocation means the feature is disabled, not exhausted.
 	it("returns nothing for a zero allocation", () => {
 		expect(
 			agentRuntimeBannerMessage(entitledFeature({ actual: 50, limit: 0 })),

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.test.ts
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.test.ts
@@ -1,0 +1,102 @@
+import type { Feature } from "#/api/typesGenerated";
+import { agentRuntimeBannerMessage } from "./AgentRuntimeBanner";
+
+const entitledFeature = (overrides: Partial<Feature>): Feature => ({
+	enabled: true,
+	entitlement: "entitled",
+	...overrides,
+});
+
+describe(agentRuntimeBannerMessage.name, () => {
+	it("returns nothing without the feature", () => {
+		expect(agentRuntimeBannerMessage(undefined)).toBeNull();
+	});
+
+	it("returns nothing when not entitled", () => {
+		expect(
+			agentRuntimeBannerMessage({
+				enabled: false,
+				entitlement: "not_entitled",
+				actual: 100,
+				limit: 100,
+			}),
+		).toBeNull();
+	});
+
+	it("returns nothing without an allocation", () => {
+		expect(
+			agentRuntimeBannerMessage(entitledFeature({ actual: 100 })),
+		).toBeNull();
+	});
+
+	// Mirrors the non-positive-allocation short-circuit in the backend's
+	// appendAgentRuntimeHoursWarning: a zero allocation disables the
+	// feature rather than exhausting it.
+	it("returns nothing for a zero allocation", () => {
+		expect(
+			agentRuntimeBannerMessage(entitledFeature({ actual: 50, limit: 0 })),
+		).toBeNull();
+	});
+
+	it("returns nothing without a usage measurement", () => {
+		expect(
+			agentRuntimeBannerMessage(entitledFeature({ limit: 100 })),
+		).toBeNull();
+	});
+
+	it("returns nothing below the allocation", () => {
+		expect(
+			agentRuntimeBannerMessage(entitledFeature({ actual: 99, limit: 100 })),
+		).toBeNull();
+	});
+
+	it("reports the allocation from the first hour at it", () => {
+		expect(
+			agentRuntimeBannerMessage(entitledFeature({ actual: 100, limit: 100 })),
+		).toBe(
+			"Your deployment has used 100 of the 100 Coder Agent runtime hours included in the current license term. Contact your deployment administrator.",
+		);
+	});
+
+	it("keeps the allocation message while under the hard limit", () => {
+		expect(
+			agentRuntimeBannerMessage(
+				entitledFeature({ actual: 110, limit: 100, hard_limit: 120 }),
+			),
+		).toBe(
+			"Your deployment has used 110 of the 100 Coder Agent runtime hours included in the current license term. Contact your deployment administrator.",
+		);
+	});
+
+	it("reports the hard limit from the first hour at it", () => {
+		expect(
+			agentRuntimeBannerMessage(
+				entitledFeature({ actual: 120, limit: 100, hard_limit: 120 }),
+			),
+		).toBe(
+			"Your deployment has used 120 of the 100 Coder Agent runtime hours included in the current license term, reaching the hard limit of 120 hours. Contact your deployment administrator.",
+		);
+	});
+
+	// The advisory soft limit is admin-facing only; see LicenseBanner.
+	it("ignores the soft limit", () => {
+		expect(
+			agentRuntimeBannerMessage(
+				entitledFeature({ actual: 90, limit: 100, soft_limit: 80 }),
+			),
+		).toBeNull();
+	});
+
+	it("derives a message during the grace period", () => {
+		expect(
+			agentRuntimeBannerMessage({
+				enabled: true,
+				entitlement: "grace_period",
+				actual: 100,
+				limit: 100,
+			}),
+		).toBe(
+			"Your deployment has used 100 of the 100 Coder Agent runtime hours included in the current license term. Contact your deployment administrator.",
+		);
+	});
+});

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.tsx
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.tsx
@@ -3,14 +3,10 @@ import type { Feature } from "#/api/typesGenerated";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { LicenseBannerView } from "../LicenseBanner/LicenseBannerView";
 
-// Derives the member-facing runtime hours message from the feature's
-// serialized thresholds. The backend warning strings target admins and are
-// rendered by LicenseBanner behind the deployment permission, so members
-// need a message derived client-side. The guard and ladder mirror the
-// admin-facing appendAgentRuntimeHoursWarning
-// (enterprise/coderd/license/license.go): a non-positive allocation
-// disables the feature rather than exhausting it, and each rung supersedes
-// the ones below it so at most one message renders.
+// The backend warning strings are admin-only (rendered by LicenseBanner
+// behind the deployment permission), so the member message is derived
+// client-side. Keep the guard and ladder in sync with
+// appendAgentRuntimeHoursWarning (enterprise/coderd/license/license.go).
 export const agentRuntimeBannerMessage = (
 	feature: Feature | undefined,
 ): string | null => {
@@ -23,8 +19,6 @@ export const agentRuntimeBannerMessage = (
 		(entitlement !== "entitled" && entitlement !== "grace_period") ||
 		limit === undefined ||
 		limit <= 0 ||
-		// Without a measurement there is nothing actionable for members;
-		// admins see the measurement diagnostic through LicenseBanner.
 		actual === undefined
 	) {
 		return null;
@@ -42,10 +36,8 @@ export const agentRuntimeBannerMessage = (
 	return null;
 };
 
-// The runtime hours banner shown to users without the deployment
-// permission; see the mount in DashboardLayout. It reuses the license
-// banner chrome, which has no dismiss affordance, so the banner persists
-// until the entitlements refetch stops deriving a message.
+// Intentionally non-dismissible: the banner persists until an entitlements
+// refetch stops deriving a message.
 export const AgentRuntimeBanner: FC = () => {
 	const { entitlements } = useDashboard();
 	const message = agentRuntimeBannerMessage(

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.tsx
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.tsx
@@ -10,8 +10,7 @@ import { LicenseBannerView } from "../LicenseBanner/LicenseBannerView";
 // admin-facing appendAgentRuntimeHoursWarning
 // (enterprise/coderd/license/license.go): a non-positive allocation
 // disables the feature rather than exhausting it, and each rung supersedes
-// the ones below it so at most one message renders. Exported for the unit
-// test, so what it pins is what production renders.
+// the ones below it so at most one message renders.
 export const agentRuntimeBannerMessage = (
 	feature: Feature | undefined,
 ): string | null => {

--- a/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.tsx
+++ b/site/src/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner.tsx
@@ -1,0 +1,61 @@
+import type { FC } from "react";
+import type { Feature } from "#/api/typesGenerated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { LicenseBannerView } from "../LicenseBanner/LicenseBannerView";
+
+// Derives the member-facing runtime hours message from the feature's
+// serialized thresholds. The backend warning strings target admins and are
+// rendered by LicenseBanner behind the deployment permission, so members
+// need a message derived client-side. The guard and ladder mirror the
+// admin-facing appendAgentRuntimeHoursWarning
+// (enterprise/coderd/license/license.go): a non-positive allocation
+// disables the feature rather than exhausting it, and each rung supersedes
+// the ones below it so at most one message renders. Exported for the unit
+// test, so what it pins is what production renders.
+export const agentRuntimeBannerMessage = (
+	feature: Feature | undefined,
+): string | null => {
+	if (!feature) {
+		return null;
+	}
+
+	const { actual, entitlement, limit } = feature;
+	if (
+		(entitlement !== "entitled" && entitlement !== "grace_period") ||
+		limit === undefined ||
+		limit <= 0 ||
+		// Without a measurement there is nothing actionable for members;
+		// admins see the measurement diagnostic through LicenseBanner.
+		actual === undefined
+	) {
+		return null;
+	}
+
+	// decodeAgentRuntimeHours only sets hard_limit at or above the
+	// allocation, so the hard-limit rung is checked first.
+	const hardLimit = feature.hard_limit;
+	if (hardLimit !== undefined && actual >= hardLimit) {
+		return `Your deployment has used ${actual} of the ${limit} Coder Agent runtime hours included in the current license term, reaching the hard limit of ${hardLimit} hours. Contact your deployment administrator.`;
+	}
+	if (actual >= limit) {
+		return `Your deployment has used ${actual} of the ${limit} Coder Agent runtime hours included in the current license term. Contact your deployment administrator.`;
+	}
+	return null;
+};
+
+// The runtime hours banner shown to users without the deployment
+// permission; see the mount in DashboardLayout. It reuses the license
+// banner chrome, which has no dismiss affordance, so the banner persists
+// until the entitlements refetch stops deriving a message.
+export const AgentRuntimeBanner: FC = () => {
+	const { entitlements } = useDashboard();
+	const message = agentRuntimeBannerMessage(
+		entitlements.features.agent_runtime_hours,
+	);
+
+	if (!message) {
+		return null;
+	}
+
+	return <LicenseBannerView messages={[{ message, variant: "error" }]} />;
+};

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -7,7 +7,11 @@ import {
 import { buildInfoKey } from "#/api/queries/buildInfo";
 import { deploymentStatsQueryKey } from "#/api/queries/deployment";
 import { updateCheckQueryKey } from "#/api/queries/updateCheck";
-import type { UpdateCheckResponse } from "#/api/typesGenerated";
+import {
+	LicenseAgentRuntimeHoursAllocationReachedWarningText,
+	type UpdateCheckResponse,
+} from "#/api/typesGenerated";
+import { formatLicenseMessage } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
 import {
 	MockBuildInfo,
 	MockDeploymentStats,
@@ -108,6 +112,48 @@ export const UpdateAvailable: Story = {
 		await expect(
 			screen.getByText(/Coder v0\.12\.9 is now available/),
 		).toBeVisible();
+	},
+};
+
+export const RuntimeHoursBannerForMember: Story = {
+	parameters: {
+		user: MockUserMember,
+		permissions: MockNoPermissions,
+		features: [{ name: "agent_runtime_hours", actual: 100, limit: 100 }],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByText(
+				/used 100 of the 100 Coder Agent runtime hours .* Contact your deployment administrator/,
+			),
+		).toBeVisible();
+	},
+};
+
+// Admins keep the richer LicenseBanner warning for the same threshold, and
+// the member banner stays unmounted so the message never doubles up.
+export const RuntimeHoursWarningForAdmin: Story = {
+	parameters: {
+		features: [{ name: "agent_runtime_hours", actual: 100, limit: 100 }],
+		entitlements: {
+			warnings: [
+				formatLicenseMessage(
+					LicenseAgentRuntimeHoursAllocationReachedWarningText,
+					100,
+					100,
+				),
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByText(/used 100 of the 100 Coder Agent runtime hours/),
+		).toBeVisible();
+		await expect(
+			canvas.queryByText(/Contact your deployment administrator/),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -130,8 +130,8 @@ export const RuntimeHoursBannerForMember: Story = {
 	},
 };
 
-// Admins keep the richer LicenseBanner warning for the same threshold, and
-// the member banner stays unmounted so the message never doubles up.
+// Admins get the LicenseBanner warning without the member banner doubling
+// up the message.
 export const RuntimeHoursWarningForAdmin: Story = {
 	parameters: {
 		features: [{ name: "agent_runtime_hours", actual: 100, limit: 100 }],

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -123,11 +123,10 @@ export const RuntimeHoursBannerForMember: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(
-			await canvas.findByText(
-				/used 100 of the 100 Coder Agent runtime hours .* Contact your deployment administrator/,
-			),
-		).toBeVisible();
+		const banner = await canvas.findByRole("alert");
+		await expect(banner).toHaveTextContent(
+			/used 100 of the 100 Coder Agent runtime hours .* Contact your deployment administrator/,
+		);
 	},
 };
 
@@ -148,9 +147,10 @@ export const RuntimeHoursWarningForAdmin: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(
-			await canvas.findByText(/used 100 of the 100 Coder Agent runtime hours/),
-		).toBeVisible();
+		const banner = await canvas.findByRole("status");
+		await expect(banner).toHaveTextContent(
+			/used 100 of the 100 Coder Agent runtime hours/,
+		);
 		await expect(
 			canvas.queryByText(/Contact your deployment administrator/),
 		).not.toBeInTheDocument();

--- a/site/src/modules/dashboard/DashboardLayout.test.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.test.tsx
@@ -2,11 +2,6 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import {
-	type Entitlements,
-	LicenseAgentRuntimeHoursAllocationReachedWarningText,
-} from "#/api/typesGenerated";
-import { formatLicenseMessage } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
-import {
 	MockEntitlements,
 	MockNoPermissions,
 	MockPermissions,
@@ -21,14 +16,12 @@ import { DashboardLayout } from "./DashboardLayout";
 const renderDashboardLayout = async ({
 	actual,
 	entitlement = "entitled",
-	features,
 	limit,
 	permissions = MockPermissions,
 	warnings,
 }: {
 	actual?: number;
 	entitlement?: "entitled" | "grace_period" | "not_entitled";
-	features?: Partial<Entitlements["features"]>;
 	limit?: number;
 	permissions?: typeof MockPermissions;
 	warnings?: string[];
@@ -48,7 +41,6 @@ const renderDashboardLayout = async ({
 						...(actual !== undefined ? { actual } : {}),
 						...(limit !== undefined ? { limit } : {}),
 					},
-					...features,
 				},
 			});
 		}),
@@ -103,54 +95,6 @@ test("shows AI Governance over-limit warning in LicenseBanner for admin users", 
 			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
 		),
 	).toBeInTheDocument();
-});
-
-test("shows the runtime hours allocation banner to non-admin users", async () => {
-	await renderDashboardLayout({
-		permissions: MockNoPermissions,
-		features: {
-			agent_runtime_hours: {
-				enabled: true,
-				entitlement: "entitled",
-				actual: 100,
-				limit: 100,
-			},
-		},
-	});
-
-	expect(
-		screen.getByText(
-			/used 100 of the 100 Coder Agent runtime hours .* Contact your deployment administrator/,
-		),
-	).toBeInTheDocument();
-});
-
-test("admin users keep the LicenseBanner warning without the member banner", async () => {
-	await renderDashboardLayout({
-		permissions: MockPermissions,
-		warnings: [
-			formatLicenseMessage(
-				LicenseAgentRuntimeHoursAllocationReachedWarningText,
-				100,
-				100,
-			),
-		],
-		features: {
-			agent_runtime_hours: {
-				enabled: true,
-				entitlement: "entitled",
-				actual: 100,
-				limit: 100,
-			},
-		},
-	});
-
-	expect(
-		screen.getByText(/used 100 of the 100 Coder Agent runtime hours/),
-	).toBeInTheDocument();
-	expect(
-		screen.queryByText(/Contact your deployment administrator/),
-	).not.toBeInTheDocument();
 });
 
 test("renders a skip link before navigation content", async () => {

--- a/site/src/modules/dashboard/DashboardLayout.test.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.test.tsx
@@ -2,6 +2,11 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import {
+	type Entitlements,
+	LicenseAgentRuntimeHoursAllocationReachedWarningText,
+} from "#/api/typesGenerated";
+import { formatLicenseMessage } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
+import {
 	MockEntitlements,
 	MockNoPermissions,
 	MockPermissions,
@@ -16,12 +21,14 @@ import { DashboardLayout } from "./DashboardLayout";
 const renderDashboardLayout = async ({
 	actual,
 	entitlement = "entitled",
+	features,
 	limit,
 	permissions = MockPermissions,
 	warnings,
 }: {
 	actual?: number;
 	entitlement?: "entitled" | "grace_period" | "not_entitled";
+	features?: Partial<Entitlements["features"]>;
 	limit?: number;
 	permissions?: typeof MockPermissions;
 	warnings?: string[];
@@ -41,6 +48,7 @@ const renderDashboardLayout = async ({
 						...(actual !== undefined ? { actual } : {}),
 						...(limit !== undefined ? { limit } : {}),
 					},
+					...features,
 				},
 			});
 		}),
@@ -95,6 +103,54 @@ test("shows AI Governance over-limit warning in LicenseBanner for admin users", 
 			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
 		),
 	).toBeInTheDocument();
+});
+
+test("shows the runtime hours allocation banner to non-admin users", async () => {
+	await renderDashboardLayout({
+		permissions: MockNoPermissions,
+		features: {
+			agent_runtime_hours: {
+				enabled: true,
+				entitlement: "entitled",
+				actual: 100,
+				limit: 100,
+			},
+		},
+	});
+
+	expect(
+		screen.getByText(
+			/used 100 of the 100 Coder Agent runtime hours .* Contact your deployment administrator/,
+		),
+	).toBeInTheDocument();
+});
+
+test("admin users keep the LicenseBanner warning without the member banner", async () => {
+	await renderDashboardLayout({
+		permissions: MockPermissions,
+		warnings: [
+			formatLicenseMessage(
+				LicenseAgentRuntimeHoursAllocationReachedWarningText,
+				100,
+				100,
+			),
+		],
+		features: {
+			agent_runtime_hours: {
+				enabled: true,
+				entitlement: "entitled",
+				actual: 100,
+				limit: 100,
+			},
+		},
+	});
+
+	expect(
+		screen.getByText(/used 100 of the 100 Coder Agent runtime hours/),
+	).toBeInTheDocument();
+	expect(
+		screen.queryByText(/Contact your deployment administrator/),
+	).not.toBeInTheDocument();
 });
 
 test("renders a skip link before navigation content", async () => {

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -18,9 +18,6 @@ export const DashboardLayout: FC = () => {
 
 	return (
 		<>
-			{/* LicenseBanner already covers the runtime hours allocation for
-			    admins, so the member banner only mounts on its else branch to
-			    avoid double-bannering. */}
 			{canViewDeployment ? <LicenseBanner /> : <AgentRuntimeBanner />}
 			<AnnouncementBanners />
 

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -2,6 +2,7 @@ import { type FC, type HTMLAttributes, Suspense } from "react";
 import { Outlet } from "react-router";
 import { Loader } from "#/components/Loader/Loader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { AgentRuntimeBanner } from "#/modules/dashboard/AgentRuntimeBanner/AgentRuntimeBanner";
 import { AnnouncementBanners } from "#/modules/dashboard/AnnouncementBanners/AnnouncementBanners";
 import { LicenseBanner } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
 import { cn } from "#/utils/cn";
@@ -17,7 +18,10 @@ export const DashboardLayout: FC = () => {
 
 	return (
 		<>
-			{canViewDeployment && <LicenseBanner />}
+			{/* LicenseBanner already covers the runtime hours allocation for
+			    admins, so the member banner only mounts on its else branch to
+			    avoid double-bannering. */}
+			{canViewDeployment ? <LicenseBanner /> : <AgentRuntimeBanner />}
 			<AnnouncementBanners />
 
 			<div className="flex flex-col min-h-screen justify-between">

--- a/site/src/modules/dashboard/DashboardProvider.tsx
+++ b/site/src/modules/dashboard/DashboardProvider.tsx
@@ -50,12 +50,15 @@ export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
 	const organizationsQuery = useQuery(organizations(metadata.organizations));
 
+	// A query error is fatal only before that query has produced data.
+	// Entitlements poll in the background, so a transient refetch failure
+	// must keep rendering the cached dashboard instead of replacing it.
 	const error =
-		entitlementsQuery.error ||
-		appearanceQuery.error ||
-		experimentsQuery.error ||
-		buildInfoQuery.error ||
-		organizationsQuery.error;
+		(!entitlementsQuery.data && entitlementsQuery.error) ||
+		(!appearanceQuery.data && appearanceQuery.error) ||
+		(!experimentsQuery.data && experimentsQuery.error) ||
+		(!buildInfoQuery.data && buildInfoQuery.error) ||
+		(!organizationsQuery.data && organizationsQuery.error);
 
 	if (error) {
 		return <ErrorAlert error={error} />;

--- a/site/src/modules/dashboard/DashboardProvider.tsx
+++ b/site/src/modules/dashboard/DashboardProvider.tsx
@@ -36,7 +36,15 @@ export const DashboardContext = createContext<DashboardValue | undefined>(
 export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
 	const { metadata } = useEmbeddedMetadata();
 	const { permissions } = useAuthenticated();
-	const entitlementsQuery = useQuery(entitlements(metadata.entitlements));
+	const entitlementsQuery = useQuery({
+		...entitlements(metadata.entitlements),
+		// Entitlements now carry usage-driven warnings (agent runtime hours),
+		// and the embedded-metadata cache path disables every other refetch,
+		// so without polling a long-lived session would never show or clear
+		// the runtime hours banners.
+		refetchInterval: 5 * 60 * 1000,
+		refetchIntervalInBackground: false,
+	});
 	const experimentsQuery = useQuery(experiments(metadata.experiments));
 	const appearanceQuery = useQuery(appearance(metadata.appearance));
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));

--- a/site/src/modules/dashboard/DashboardProvider.tsx
+++ b/site/src/modules/dashboard/DashboardProvider.tsx
@@ -38,10 +38,8 @@ export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
 	const { permissions } = useAuthenticated();
 	const entitlementsQuery = useQuery({
 		...entitlements(metadata.entitlements),
-		// Entitlements now carry usage-driven warnings (agent runtime hours),
-		// and the embedded-metadata cache path disables every other refetch,
-		// so without polling a long-lived session would never show or clear
-		// the runtime hours banners.
+		// cachedQuery disables all refetches when embedded metadata seeds the
+		// cache, so poll to keep usage-driven warnings current.
 		refetchInterval: 5 * 60 * 1000,
 		refetchIntervalInBackground: false,
 	});
@@ -50,9 +48,8 @@ export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
 	const organizationsQuery = useQuery(organizations(metadata.organizations));
 
-	// A query error is fatal only before that query has produced data.
-	// Entitlements poll in the background, so a transient refetch failure
-	// must keep rendering the cached dashboard instead of replacing it.
+	// Entitlements poll, so a transient refetch error must not replace a
+	// rendered dashboard; an error is fatal only without cached data.
 	const error =
 		(!entitlementsQuery.data && entitlementsQuery.error) ||
 		(!appearanceQuery.data && appearanceQuery.error) ||

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -52,6 +52,7 @@ export const withDashboardProvider = (
 				}),
 			),
 		),
+		...parameters.entitlements,
 	};
 
 	return (


### PR DESCRIPTION
Shows the runtime hours allocation banner to all users, not just admins. Today only admins see entitlement warnings (`LicenseBanner` is gated behind `canViewDeployment` in `DashboardLayout`), so members get no signal when the deployment reaches its Coder Agent runtime hours allocation.

Adds `AgentRuntimeBanner`, mounted as the else branch of the `canViewDeployment` gate so admins keep the richer `LicenseBanner` without double-bannering. The component derives its ladder client-side from `entitlements.features.agent_runtime_hours` (`actual` vs `limit`/`hard_limit`), mirroring the admin-facing `appendAgentRuntimeHoursWarning` in `enterprise/coderd/license`: at or over the hard limit renders red hard-limit copy, at or over the allocation renders red allocation copy, otherwise nothing. It renders through `LicenseBannerView` with the `error` variant, so it is red and has no dismiss affordance, and the member CTA is "Contact your deployment administrator" rather than a sales link since members cannot fix the limit. The banner clears on entitlements refetch once a new license raises the allocation above current usage.

No `warnings_v2`/audience payload is needed: `GET /api/v2/entitlements` is served to all authenticated users and already carries `limit`, `soft_limit`, and `hard_limit` on the feature, so the client can derive severity itself (see the note on CODAGT-854).

Closes https://linear.app/codercom/issue/CODAGT-860/f5-all-users-allocation-banner-red-non-dismissible
