### PR TITLE
feat(site/src): hide Browser, Desktop, and Debug panels behind the add-panel dropdown

### DIFF
--- a/site/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/site/src/components/DropdownMenu/DropdownMenu.tsx
@@ -54,6 +54,24 @@ export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({
 	);
 };
 
+export const DropdownMenuCheckboxItem: React.FC<
+	React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.CheckboxItem>
+> = ({ className, children, ...props }) => {
+	return (
+		<DropdownMenuPrimitive.CheckboxItem
+			className={cn(menuItemClass, "relative pr-8", className)}
+			{...props}
+		>
+			{children}
+			<span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CheckIcon className="size-4" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+		</DropdownMenuPrimitive.CheckboxItem>
+	);
+};
+
 export const DropdownMenuRadioItem: React.FC<
 	React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.RadioItem>
 > = ({ className, children, ...props }) => {

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -51,6 +51,7 @@ import {
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import { buildLongConversation } from "./components/ChatConversation/storyFixtures";
+import { visibleSingletonTabsStorageKeyPrefix } from "./utils/rightPanelTabStorage";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
 
 // ---------------------------------------------------------------------------
@@ -1803,7 +1804,32 @@ const mockAgentWithBrowserApp: TypesGen.WorkspaceAgent = {
 	apps: [...MockWorkspaceAgent.apps, mockAgentBrowserApp],
 };
 
+const singletonTabsStorageKey = `${visibleSingletonTabsStorageKeyPrefix}${AGENT_ID}`;
+
+/**
+ * Singleton panels start hidden, so a story that needs a visible Browser,
+ * Desktop, or Debug tab seeds the per-chat storage entry before mount.
+ */
+const seedVisibleSingletonTabs = (tabIds: readonly string[]) => {
+	localStorage.setItem(singletonTabsStorageKey, JSON.stringify(tabIds));
+	return () => {
+		localStorage.removeItem(singletonTabsStorageKey);
+	};
+};
+
+const clearVisibleSingletonTabs = () => {
+	localStorage.removeItem(singletonTabsStorageKey);
+	return () => {
+		localStorage.removeItem(singletonTabsStorageKey);
+	};
+};
+
+const openAddPanelMenu = async (canvas: ReturnType<typeof within>) => {
+	await userEvent.click(canvas.getByLabelText("Add panel"));
+};
+
 export const BrowserTabForHealthyAgentBrowserApp: Story = {
+	beforeEach: () => seedVisibleSingletonTabs(["browser"]),
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
@@ -1834,6 +1860,7 @@ export const BrowserTabForHealthyAgentBrowserApp: Story = {
 };
 
 export const BrowserTabForHealthDisabledAgentBrowserApp: Story = {
+	beforeEach: () => seedVisibleSingletonTabs(["browser"]),
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
@@ -1939,6 +1966,221 @@ export const PreservesUnavailableBrowserTab: Story = {
 		expect(canvas.queryByRole("tab", { name: "Browser" })).toBeNull();
 
 		expect(localStorage.getItem(sidebarTabStorageKey)).toBe("browser");
+	},
+};
+
+const renderWithSingletonSupport = () => (
+	<StoryAgentChatPageView
+		showSidebarPanel
+		debugLoggingEnabled
+		workspace={MockWorkspace}
+		workspaceAgent={mockAgentWithBrowserApp}
+		desktopChatId={AGENT_ID}
+		sshCommand="ssh coder.workspace"
+	/>
+);
+
+/**
+ * A new chat shows no singleton panel. The dropdown offers every supported
+ * panel as an unchecked toggle.
+ */
+export const SingletonPanelsHiddenByDefault: Story = {
+	beforeEach: clearVisibleSingletonTabs,
+	render: renderWithSingletonSupport,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await canvas.findByRole("tab", { name: "Summary" });
+		const tabLabels = canvas.getAllByRole("tab").map((tab) => tab.textContent);
+		expect(tabLabels).toEqual(["Summary", "Git", "Terminal"]);
+
+		await openAddPanelMenu(canvas);
+		for (const label of ["Browser", "Desktop", "Debug"]) {
+			const item = await body.findByRole("menuitemcheckbox", { name: label });
+			expect(item).toHaveAttribute("aria-checked", "false");
+		}
+	},
+};
+
+/**
+ * Toggling a dropdown entry shows the panel, activates it, and gives it a
+ * close control. Toggling the same entry again hides the panel.
+ */
+export const TogglesSingletonPanelFromDropdown: Story = {
+	beforeEach: clearVisibleSingletonTabs,
+	render: renderWithSingletonSupport,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await canvas.findByRole("tab", { name: "Summary" });
+
+		await openAddPanelMenu(canvas);
+		await userEvent.click(
+			await body.findByRole("menuitemcheckbox", { name: "Browser" }),
+		);
+
+		const browserTab = await canvas.findByRole("tab", { name: "Browser" });
+		await waitFor(() => {
+			expect(browserTab).toHaveAttribute("aria-selected", "true");
+		});
+		expect(
+			canvas.getByRole("button", { name: "Close Browser tab" }),
+		).toBeVisible();
+		expect(localStorage.getItem(singletonTabsStorageKey)).toBe('["browser"]');
+
+		await openAddPanelMenu(canvas);
+		expect(
+			await body.findByRole("menuitemcheckbox", { name: "Browser" }),
+		).toHaveAttribute("aria-checked", "true");
+
+		// Select another tab first: closing the active singleton selects a
+		// neighbor, and "Closes Active Singleton Panel" covers that path.
+		await userEvent.keyboard("{Escape}");
+		// The open menu marks the rest of the page aria-hidden, so wait for it
+		// to close before reaching a tab.
+		await waitFor(() => {
+			expect(
+				body.queryByRole("menuitemcheckbox", { name: "Browser" }),
+			).toBeNull();
+		});
+		await userEvent.click(canvas.getByRole("tab", { name: "Git" }));
+
+		await openAddPanelMenu(canvas);
+		await userEvent.click(
+			await body.findByRole("menuitemcheckbox", { name: "Browser" }),
+		);
+		await waitFor(() => {
+			expect(canvas.queryByRole("tab", { name: "Browser" })).toBeNull();
+		});
+		expect(localStorage.getItem(singletonTabsStorageKey)).toBe("[]");
+	},
+};
+
+/**
+ * The X control on a visible singleton tab removes the panel, unchecks the
+ * dropdown entry, and selects the neighboring tab.
+ */
+export const ClosesActiveSingletonPanel: Story = {
+	beforeEach: () => seedVisibleSingletonTabs(["browser", "debug"]),
+	render: renderWithSingletonSupport,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		const debugTab = await canvas.findByRole("tab", { name: "Debug" });
+		const tabLabels = canvas.getAllByRole("tab").map((tab) => tab.textContent);
+		expect(tabLabels).toEqual([
+			"Summary",
+			"Git",
+			"Debug",
+			"Browser",
+			"Terminal",
+		]);
+
+		await userEvent.click(debugTab);
+		await waitFor(() => {
+			expect(debugTab).toHaveAttribute("aria-selected", "true");
+		});
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Close Debug tab" }),
+		);
+
+		await waitFor(() => {
+			expect(canvas.queryByRole("tab", { name: "Debug" })).toBeNull();
+		});
+		// Closing the active tab selects the tab that took its position.
+		expect(canvas.getByRole("tab", { name: "Browser" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		expect(localStorage.getItem(singletonTabsStorageKey)).toBe('["browser"]');
+
+		await openAddPanelMenu(canvas);
+		expect(
+			await body.findByRole("menuitemcheckbox", { name: "Debug" }),
+		).toHaveAttribute("aria-checked", "false");
+	},
+};
+
+/** A singleton panel never appears twice, however often the user shows it. */
+export const ReopenedSingletonPanelStaysSingle: Story = {
+	beforeEach: () => seedVisibleSingletonTabs(["debug"]),
+	render: renderWithSingletonSupport,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await canvas.findByRole("tab", { name: "Debug" });
+
+		await openAddPanelMenu(canvas);
+		await userEvent.click(
+			await body.findByRole("menuitemcheckbox", { name: "Debug" }),
+		);
+		await waitFor(() => {
+			expect(canvas.queryByRole("tab", { name: "Debug" })).toBeNull();
+		});
+
+		await openAddPanelMenu(canvas);
+		await userEvent.click(
+			await body.findByRole("menuitemcheckbox", { name: "Debug" }),
+		);
+		await canvas.findByRole("tab", { name: "Debug" });
+
+		expect(canvas.getAllByRole("tab", { name: "Debug" })).toHaveLength(1);
+	},
+};
+
+/**
+ * A saved panel returns on the next mount. This proves the per-chat entry
+ * drives visibility instead of component state alone.
+ */
+export const RestoresPersistedSingletonPanel: Story = {
+	beforeEach: () => seedVisibleSingletonTabs(["desktop"]),
+	render: renderWithSingletonSupport,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByRole("tab", { name: "Desktop" });
+		expect(canvas.queryByRole("tab", { name: "Browser" })).toBeNull();
+		expect(canvas.queryByRole("tab", { name: "Debug" })).toBeNull();
+	},
+};
+
+/**
+ * An unsupported panel appears in neither the dropdown nor the tab list,
+ * even when storage still holds the saved choice from an earlier session.
+ */
+export const HidesUnsupportedSingletonPanels: Story = {
+	beforeEach: () => seedVisibleSingletonTabs(["browser", "desktop", "debug"]),
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			workspace={MockWorkspace}
+			workspaceAgent={MockWorkspaceAgent}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await canvas.findByRole("tab", { name: "Summary" });
+		const tabLabels = canvas.getAllByRole("tab").map((tab) => tab.textContent);
+		expect(tabLabels).toEqual(["Summary", "Git", "Terminal"]);
+
+		await openAddPanelMenu(canvas);
+		await body.findByText("New Terminal");
+		for (const label of ["Browser", "Desktop", "Debug"]) {
+			expect(body.queryByRole("menuitemcheckbox", { name: label })).toBeNull();
+		}
+
+		// The saved choice survives the loss of support.
+		expect(localStorage.getItem(singletonTabsStorageKey)).toBe(
+			'["browser","desktop","debug"]',
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1989,10 +1989,6 @@ const renderWithSingletonSupport = () => (
 	/>
 );
 
-/**
- * A new chat shows no singleton panel. The dropdown offers every supported
- * panel as an unchecked toggle.
- */
 export const SingletonPanelsHiddenByDefault: Story = {
 	beforeEach: clearVisibleSingletonTabs,
 	render: renderWithSingletonSupport,
@@ -2012,10 +2008,6 @@ export const SingletonPanelsHiddenByDefault: Story = {
 	},
 };
 
-/**
- * Toggling a dropdown entry shows the panel, activates it, and gives it a
- * close control. Toggling the same entry again hides the panel.
- */
 export const TogglesSingletonPanelFromDropdown: Story = {
 	beforeEach: clearVisibleSingletonTabs,
 	render: renderWithSingletonSupport,
@@ -2067,10 +2059,6 @@ export const TogglesSingletonPanelFromDropdown: Story = {
 	},
 };
 
-/**
- * The X control on a visible singleton tab removes the panel, unchecks the
- * dropdown entry, and selects the neighboring tab.
- */
 export const ClosesActiveSingletonPanel: Story = {
 	beforeEach: () => seedVisibleSingletonTabs(["browser", "debug"]),
 	render: renderWithSingletonSupport,
@@ -2100,7 +2088,6 @@ export const ClosesActiveSingletonPanel: Story = {
 		await waitFor(() => {
 			expect(canvas.queryByRole("tab", { name: "Debug" })).toBeNull();
 		});
-		// Closing the active tab selects the tab that took its position.
 		expect(canvas.getByRole("tab", { name: "Browser" })).toHaveAttribute(
 			"aria-selected",
 			"true",
@@ -2114,7 +2101,6 @@ export const ClosesActiveSingletonPanel: Story = {
 	},
 };
 
-/** A singleton panel never appears twice, however often the user shows it. */
 export const ReopenedSingletonPanelStaysSingle: Story = {
 	beforeEach: () => seedVisibleSingletonTabs(["debug"]),
 	render: renderWithSingletonSupport,
@@ -2172,8 +2158,6 @@ export const DoesNotPersistSingletonTabsForArchivedChat: Story = {
 			await body.findByRole("menuitemcheckbox", { name: "Debug" }),
 		);
 
-		// The panel still opens for the current view, so the read-only chat
-		// stays usable.
 		const debugTab = await canvas.findByRole("tab", { name: "Debug" });
 		await waitFor(() => {
 			expect(debugTab).toHaveAttribute("aria-selected", "true");
@@ -2183,10 +2167,6 @@ export const DoesNotPersistSingletonTabsForArchivedChat: Story = {
 	},
 };
 
-/**
- * A saved panel returns on the next mount. This proves the per-chat entry
- * drives visibility instead of component state alone.
- */
 export const RestoresPersistedSingletonPanel: Story = {
 	beforeEach: () => seedVisibleSingletonTabs(["desktop"]),
 	render: renderWithSingletonSupport,
@@ -2199,10 +2179,6 @@ export const RestoresPersistedSingletonPanel: Story = {
 	},
 };
 
-/**
- * An unsupported panel appears in neither the dropdown nor the tab list,
- * even when storage still holds the saved choice from an earlier session.
- */
 export const HidesUnsupportedSingletonPanels: Story = {
 	beforeEach: () => seedVisibleSingletonTabs(["browser", "desktop", "debug"]),
 	render: () => (
@@ -2227,7 +2203,6 @@ export const HidesUnsupportedSingletonPanels: Story = {
 			expect(body.queryByRole("menuitemcheckbox", { name: label })).toBeNull();
 		}
 
-		// The saved choice survives the loss of support.
 		expect(localStorage.getItem(singletonTabsStorageKey)).toBe(
 			'["browser","desktop","debug"]',
 		);

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -52,6 +52,7 @@ import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import { buildLongConversation } from "./components/ChatConversation/storyFixtures";
 import { visibleSingletonTabsStorageKeyPrefix } from "./utils/rightPanelTabStorage";
+import type { SingletonRightPanelTabId } from "./utils/rightPanelTabs";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
 
 // ---------------------------------------------------------------------------
@@ -1810,7 +1811,9 @@ const singletonTabsStorageKey = `${visibleSingletonTabsStorageKeyPrefix}${AGENT_
  * Singleton panels start hidden, so a story that needs a visible Browser,
  * Desktop, or Debug tab seeds the per-chat storage entry before mount.
  */
-const seedVisibleSingletonTabs = (tabIds: readonly string[]) => {
+const seedVisibleSingletonTabs = (
+	tabIds: readonly SingletonRightPanelTabId[],
+) => {
 	localStorage.setItem(singletonTabsStorageKey, JSON.stringify(tabIds));
 	return () => {
 		localStorage.removeItem(singletonTabsStorageKey);
@@ -1886,6 +1889,9 @@ export const BrowserTabForHealthDisabledAgentBrowserApp: Story = {
 };
 
 export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
+	// Seed the saved choice so the assertion proves the health gate hides
+	// the tab, instead of passing because panels start hidden.
+	beforeEach: () => seedVisibleSingletonTabs(["browser"]),
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
@@ -1906,6 +1912,9 @@ export const NoBrowserTabForUnhealthyAgentBrowserApp: Story = {
 };
 
 export const NoBrowserTabForAppOnNonBoundAgent: Story = {
+	// Seed the saved choice so the assertion proves the agent-binding gate
+	// hides the tab, instead of passing because panels start hidden.
+	beforeEach: () => seedVisibleSingletonTabs(["browser"]),
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
@@ -2130,6 +2139,47 @@ export const ReopenedSingletonPanelStaysSingle: Story = {
 		await canvas.findByRole("tab", { name: "Debug" });
 
 		expect(canvas.getAllByRole("tab", { name: "Debug" })).toHaveLength(1);
+	},
+};
+
+/**
+ * An archived chat is read-only, so showing a singleton panel must not write
+ * the per-chat entry. The archive flow clears that entry on purpose, and
+ * persisting here would recreate it for a chat the user cannot change.
+ */
+export const DoesNotPersistSingletonTabsForArchivedChat: Story = {
+	beforeEach: clearVisibleSingletonTabs,
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			chat={{ archived: true }}
+			isInputDisabled
+			debugLoggingEnabled
+			workspace={MockWorkspace}
+			workspaceAgent={mockAgentWithBrowserApp}
+			desktopChatId={AGENT_ID}
+			sshCommand="ssh coder.workspace"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await canvas.findByRole("tab", { name: "Summary" });
+
+		await openAddPanelMenu(canvas);
+		await userEvent.click(
+			await body.findByRole("menuitemcheckbox", { name: "Debug" }),
+		);
+
+		// The panel still opens for the current view, so the read-only chat
+		// stays usable.
+		const debugTab = await canvas.findByRole("tab", { name: "Debug" });
+		await waitFor(() => {
+			expect(debugTab).toHaveAttribute("aria-selected", "true");
+		});
+
+		expect(localStorage.getItem(singletonTabsStorageKey)).toBeNull();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -64,11 +64,16 @@ import { parsePullRequestUrl } from "./utils/pullRequest";
 import {
 	getPersistedDefaultTerminalHidden,
 	getPersistedRightPanelTabs,
+	getPersistedVisibleSingletonTabs,
 	savePersistedDefaultTerminalHidden,
 	savePersistedRightPanelTabs,
+	savePersistedVisibleSingletonTabs,
 } from "./utils/rightPanelTabStorage";
 import {
+	isSingletonRightPanelTabId,
 	type PortSelection,
+	type SingletonRightPanelTabId,
+	singletonRightPanelTabIds,
 	type UserRightPanelTab,
 	validateUserRightPanelTabs,
 } from "./utils/rightPanelTabs";
@@ -389,6 +394,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	>(() => getPersistedRightPanelTabs(agentId));
 	const [defaultTerminalHidden, setDefaultTerminalHiddenState] =
 		useState<boolean>(() => getPersistedDefaultTerminalHidden(agentId));
+	const [visibleSingletonTabs, setVisibleSingletonTabsState] = useState<
+		SingletonRightPanelTabId[]
+	>(() => getPersistedVisibleSingletonTabs(agentId));
 	const [pendingTabId, setPendingTabId] = useState<string | null>(null);
 	// One client session ID per page visit, shared by every terminal in this
 	// chat. It regenerates when this view remounts (switching chats or
@@ -414,16 +422,11 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		}
 	}, [agentId, defaultTerminalHidden, isArchived]);
 
-	const handleOpenDesktop = () => {
-		onSetShowSidebarPanel(true);
-		setPendingTabId(null);
-		setSidebarTabId("desktop");
-	};
-
-	const desktopPanelCtx = {
-		desktopChatId,
-		onOpenDesktop: desktopChatId ? handleOpenDesktop : undefined,
-	};
+	useEffect(() => {
+		if (!isArchived) {
+			savePersistedVisibleSingletonTabs(agentId, visibleSingletonTabs);
+		}
+	}, [agentId, isArchived, visibleSingletonTabs]);
 
 	const shouldShowSidebar = showSidebarPanel;
 
@@ -456,14 +459,28 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	})();
 
 	// Desktop is only available when the workspace and agent are ready;
-	// include it in the tab list on that same condition to avoid selecting
-	// "desktop" when no desktop panel is rendered.
+	// offer it as a singleton panel on that same condition to avoid
+	// selecting "desktop" when no desktop panel is rendered.
 	const availableDesktopChatId =
 		workspace && workspaceAgent ? desktopChatId : undefined;
 
 	const availableBrowserApp = workspace
 		? getAgentBrowserApp(workspaceAgent)
 		: undefined;
+
+	// Singleton panels the user can show or hide from the add-tab dropdown.
+	const singletonTabSupport: Record<SingletonRightPanelTabId, boolean> = {
+		browser: availableBrowserApp !== undefined,
+		desktop: availableDesktopChatId !== undefined,
+		debug: debugLoggingEnabled === true,
+	};
+	const supportedSingletonTabs = singletonRightPanelTabIds.filter(
+		(tabId) => singletonTabSupport[tabId],
+	);
+	// A saved choice survives a panel losing support, so the tab returns
+	// once the workspace, app, or debug setting is available again.
+	const isSingletonTabShown = (tabId: SingletonRightPanelTabId) =>
+		singletonTabSupport[tabId] && visibleSingletonTabs.includes(tabId);
 
 	const validatedUserRightPanelTabs = validateUserRightPanelTabs(
 		userRightPanelTabs,
@@ -480,9 +497,13 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const builtInSidebarTabConfigs = [
 		{ id: "summary", label: "Summary" },
 		{ id: "git", label: "Git" },
-		...(debugLoggingEnabled ? [{ id: "debug", label: "Debug" }] : []),
-		...(availableBrowserApp ? [{ id: "browser", label: "Browser" }] : []),
-		...(availableDesktopChatId ? [{ id: "desktop", label: "Desktop" }] : []),
+		...(isSingletonTabShown("debug") ? [{ id: "debug", label: "Debug" }] : []),
+		...(isSingletonTabShown("browser")
+			? [{ id: "browser", label: "Browser" }]
+			: []),
+		...(isSingletonTabShown("desktop")
+			? [{ id: "desktop", label: "Desktop" }]
+			: []),
 		...(hasBuiltInTerminal ? [{ id: "terminal", label: "Terminal" }] : []),
 	];
 	// Dense terminal numbering: position among unlabeled terminal tabs,
@@ -512,16 +533,30 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		}),
 	];
 	const sidebarTabIds = sidebarTabConfigs.map((tab) => tab.id);
-	const effectiveSidebarTabId = getEffectiveTabId(
-		sidebarTabIds,
-		sidebarTabId,
-		availableDesktopChatId,
-	);
+	const effectiveSidebarTabId = getEffectiveTabId(sidebarTabIds, sidebarTabId);
 
 	const activateRightPanelTab = (tabId: string) => {
 		onSetShowSidebarPanel(true);
 		setPendingTabId(null);
 		setSidebarTabId(tabId);
+	};
+
+	const showSingletonTab = (tabId: SingletonRightPanelTabId) => {
+		setVisibleSingletonTabsState((currentTabIds) =>
+			currentTabIds.includes(tabId) ? currentTabIds : [...currentTabIds, tabId],
+		);
+		activateRightPanelTab(tabId);
+	};
+
+	const handleOpenDesktop = () => {
+		showSingletonTab("desktop");
+	};
+
+	const desktopPanelCtx = {
+		desktopChatId,
+		// Only offer the action when the panel can render, which keeps a tool
+		// action from selecting a Desktop tab that the tab list omits.
+		onOpenDesktop: availableDesktopChatId ? handleOpenDesktop : undefined,
 	};
 
 	// Ignore late readiness from a tab the user already navigated past.
@@ -743,6 +778,10 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 
 		if (tabId === "terminal") {
 			setDefaultTerminalHiddenState(true);
+		} else if (isSingletonRightPanelTabId(tabId)) {
+			setVisibleSingletonTabsState((currentTabIds) =>
+				currentTabIds.filter((id) => id !== tabId),
+			);
 		} else {
 			setUserRightPanelTabsState((currentTabs) =>
 				currentTabs.filter((tab) => tab.id !== tabId),
@@ -759,9 +798,21 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		}
 	};
 
+	const handleToggleSingletonTab = (tabId: SingletonRightPanelTabId) => {
+		if (!singletonTabSupport[tabId]) {
+			return;
+		}
+		if (isSingletonTabShown(tabId)) {
+			handleCloseTab(tabId);
+			return;
+		}
+		showSingletonTab(tabId);
+	};
+
 	const sidebarTabs = sidebarTabConfigs.map((tab) => {
 		const isCloseable =
 			tab.id === "terminal" ||
+			isSingletonRightPanelTabId(tab.id) ||
 			validatedUserRightPanelTabs.some((userTab) => userTab.id === tab.id);
 		return {
 			id: tab.id,
@@ -980,6 +1031,11 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										agent={workspaceAgent}
 										host={wildcardHostname}
 										isRunning={workspace?.latest_build.status === "running"}
+										supportedSingletonTabs={supportedSingletonTabs}
+										visibleSingletonTabs={supportedSingletonTabs.filter((tabId) =>
+											isSingletonTabShown(tabId),
+										)}
+										onToggleSingletonTab={handleToggleSingletonTab}
 										onNewTerminal={handleAddTerminalTab}
 										onOpenWorkspaceApp={handleOpenWorkspaceAppTab}
 										onOpenCommandApp={handleOpenCommandAppTab}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -478,8 +478,11 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	);
 	// A saved choice survives a panel losing support, so the tab returns
 	// once the workspace, app, or debug setting is available again.
+	const shownSingletonTabs = supportedSingletonTabs.filter((tabId) =>
+		visibleSingletonTabs.includes(tabId),
+	);
 	const isSingletonTabShown = (tabId: SingletonRightPanelTabId) =>
-		singletonTabSupport[tabId] && visibleSingletonTabs.includes(tabId);
+		shownSingletonTabs.includes(tabId);
 
 	const validatedUserRightPanelTabs = validateUserRightPanelTabs(
 		userRightPanelTabs,
@@ -547,15 +550,13 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		activateRightPanelTab(tabId);
 	};
 
-	const handleOpenDesktop = () => {
-		showSingletonTab("desktop");
-	};
-
 	const desktopPanelCtx = {
 		desktopChatId,
 		// Only offer the action when the panel can render, which keeps a tool
 		// action from selecting a Desktop tab that the tab list omits.
-		onOpenDesktop: availableDesktopChatId ? handleOpenDesktop : undefined,
+		onOpenDesktop: availableDesktopChatId
+			? () => showSingletonTab("desktop")
+			: undefined,
 	};
 
 	// Ignore late readiness from a tab the user already navigated past.
@@ -803,9 +804,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		}
 		if (isSingletonTabShown(tabId)) {
 			handleCloseTab(tabId);
-			return;
+		} else {
+			showSingletonTab(tabId);
 		}
-		showSingletonTab(tabId);
 	};
 
 	const sidebarTabs = sidebarTabConfigs.map((tab) => {
@@ -1031,9 +1032,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										host={wildcardHostname}
 										isRunning={workspace?.latest_build.status === "running"}
 										supportedSingletonTabs={supportedSingletonTabs}
-										visibleSingletonTabs={supportedSingletonTabs.filter((tabId) =>
-											isSingletonTabShown(tabId),
-										)}
+										visibleSingletonTabs={shownSingletonTabs}
 										onToggleSingletonTab={handleToggleSingletonTab}
 										onNewTerminal={handleAddTerminalTab}
 										onOpenWorkspaceApp={handleOpenWorkspaceAppTab}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -468,7 +468,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		? getAgentBrowserApp(workspaceAgent)
 		: undefined;
 
-	// Singleton panels the user can show or hide from the add-tab dropdown.
 	const singletonTabSupport: Record<SingletonRightPanelTabId, boolean> = {
 		browser: availableBrowserApp !== undefined,
 		desktop: availableDesktopChatId !== undefined,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.stories.tsx
@@ -122,7 +122,7 @@ export const CloseableTabs: Story = {
 				label: "Terminal",
 				content: makePanelContent("Terminal"),
 			},
-			{ id: "debug", label: "Debug", content: makePanelContent("Debug") },
+			{ id: "summary", label: "Summary", content: makePanelContent("Summary") },
 			...Array.from({ length: 8 }, (_, index) => ({
 				id: `terminal-${index + 2}`,
 				label: `Terminal ${index + 2}`,
@@ -184,7 +184,7 @@ export const CloseableTabs: Story = {
 			canvas.queryByRole("button", { name: "Close Terminal tab" }),
 		).not.toBeInTheDocument();
 		expect(
-			canvas.queryByRole("button", { name: "Close Debug tab" }),
+			canvas.queryByRole("button", { name: "Close Summary tab" }),
 		).not.toBeInTheDocument();
 
 		expect(canvas.getByRole("tab", { name: "Terminal 2" })).toHaveAttribute(

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/getEffectiveTabId.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/getEffectiveTabId.test.ts
@@ -3,36 +3,32 @@ import { getEffectiveTabId } from "./getEffectiveTabId";
 
 describe("getEffectiveTabId", () => {
 	it("returns the active tab id when it matches a known tab", () => {
-		expect(
-			getEffectiveTabId(["git", "terminal", "debug"], "debug", undefined),
-		).toBe("debug");
+		expect(getEffectiveTabId(["git", "terminal", "debug"], "debug")).toBe(
+			"debug",
+		);
 	});
 
 	it("falls back to the first tab when the active id is unknown", () => {
-		expect(getEffectiveTabId(["git", "terminal"], "missing", undefined)).toBe(
-			"git",
-		);
+		expect(getEffectiveTabId(["git", "terminal"], "missing")).toBe("git");
 	});
 
 	it("falls back to the first tab when no active id is set", () => {
-		expect(getEffectiveTabId(["git", "terminal"], null, undefined)).toBe("git");
+		expect(getEffectiveTabId(["git", "terminal"], null)).toBe("git");
 	});
 
-	it("resolves to desktop when it is the active id and desktopChatId is set", () => {
-		expect(getEffectiveTabId(["git"], "desktop", "desktop-123")).toBe(
-			"desktop",
-		);
+	it("resolves to desktop when it is the active id and desktop is available", () => {
+		expect(getEffectiveTabId(["git", "desktop"], "desktop")).toBe("desktop");
 	});
 
-	it("returns desktop when the tab list is empty but desktop is available", () => {
-		expect(getEffectiveTabId([], null, "desktop-123")).toBe("desktop");
+	it("ignores a hidden singleton tab that is still the stored selection", () => {
+		expect(getEffectiveTabId(["summary", "git"], "desktop")).toBe("summary");
 	});
 
 	it("returns null when no tabs are available", () => {
-		expect(getEffectiveTabId([], null, undefined)).toBeNull();
+		expect(getEffectiveTabId([], null)).toBeNull();
 	});
 
-	it("ignores an unknown active id when only desktop is available", () => {
-		expect(getEffectiveTabId([], "git", "desktop-123")).toBe("desktop");
+	it("returns null when the active id has no matching tab", () => {
+		expect(getEffectiveTabId([], "git")).toBeNull();
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/getEffectiveTabId.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/getEffectiveTabId.ts
@@ -1,21 +1,14 @@
 /**
  * Resolves which sidebar tab should be active given the set of
- * available tab IDs, the currently stored selection, and whether
- * the desktop chat tab is available.
+ * available tab IDs and the currently stored selection.
  */
 export function getEffectiveTabId(
 	tabIds: readonly string[],
 	activeTabId: string | null,
-	desktopChatId: string | undefined,
 ): string | null {
-	const allIds = new Set(tabIds);
-	if (desktopChatId) {
-		allIds.add("desktop");
-	}
-
-	if (activeTabId !== null && allIds.has(activeTabId)) {
+	if (activeTabId !== null && tabIds.includes(activeTabId)) {
 		return activeTabId;
 	}
 
-	return tabIds[0] ?? (desktopChatId ? "desktop" : null);
+	return tabIds[0] ?? null;
 }

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
@@ -64,6 +64,9 @@ const meta = {
 		},
 		host: "*.apps.example.com",
 		isRunning: true,
+		supportedSingletonTabs: ["browser", "desktop", "debug"],
+		visibleSingletonTabs: ["desktop"],
+		onToggleSingletonTab: fn(),
 		onNewTerminal: fn(),
 		onOpenWorkspaceApp: fn(),
 		onOpenCommandApp: fn(),
@@ -112,8 +115,42 @@ export const Default: Story = {
 			expect(body.getByText("Ports (3)")).toBeInTheDocument();
 		});
 
+		// Only the singleton panels are toggles. Terminals are unlimited, so
+		// "New Terminal" stays a plain action.
+		expect(
+			body.getByRole("menuitemcheckbox", { name: "Desktop" }),
+		).toHaveAttribute("aria-checked", "true");
+		expect(
+			body.getByRole("menuitemcheckbox", { name: "Browser" }),
+		).toHaveAttribute("aria-checked", "false");
+		expect(
+			body.getByRole("menuitemcheckbox", { name: "Debug" }),
+		).toHaveAttribute("aria-checked", "false");
+		// "New Terminal" stays a plain action, so it is not a checkbox toggle.
+		expect(
+			body.queryAllByRole("menuitemcheckbox", { name: "New Terminal" }),
+		).toHaveLength(0);
+
 		// Radix closes the menu after each item click, so reopen between
 		// callback assertions.
+		await userEvent.click(
+			body.getByRole("menuitemcheckbox", { name: "Browser" }),
+		);
+		await expect(args.onToggleSingletonTab).toHaveBeenCalledWith("browser");
+
+		await openMenu();
+		await userEvent.click(
+			body.getByRole("menuitemcheckbox", { name: "Desktop" }),
+		);
+		await expect(args.onToggleSingletonTab).toHaveBeenCalledWith("desktop");
+
+		await openMenu();
+		await userEvent.click(
+			body.getByRole("menuitemcheckbox", { name: "Debug" }),
+		);
+		await expect(args.onToggleSingletonTab).toHaveBeenCalledWith("debug");
+
+		await openMenu();
 		await userEvent.click(body.getByText("New Terminal"));
 		await expect(args.onNewTerminal).toHaveBeenCalledTimes(1);
 
@@ -142,6 +179,21 @@ export const Default: Story = {
 	},
 };
 
+export const UnsupportedSingletonPanels: Story = {
+	args: {
+		supportedSingletonTabs: [],
+		visibleSingletonTabs: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByLabelText("Add panel"));
+
+		const body = within(document.body);
+		await body.findByText("New Terminal");
+		expect(body.queryByRole("menuitemcheckbox")).toBeNull();
+	},
+};
+
 export const ExcludesAgentBrowserApp: Story = {
 	args: {
 		agent: {
@@ -156,6 +208,10 @@ export const ExcludesAgentBrowserApp: Story = {
 		const body = within(document.body);
 		await waitFor(() => {
 			expect(body.getByText("Preview")).toBeInTheDocument();
+			// The reserved app drives the Browser toggle instead of a normal app item.
+			expect(
+				body.getByRole("menuitemcheckbox", { name: "Browser" }),
+			).toBeVisible();
 		});
 		expect(body.queryByText("agent-browser")).toBeNull();
 	},

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.stories.tsx
@@ -126,7 +126,6 @@ export const Default: Story = {
 		expect(
 			body.getByRole("menuitemcheckbox", { name: "Debug" }),
 		).toHaveAttribute("aria-checked", "false");
-		// "New Terminal" stays a plain action, so it is not a checkbox toggle.
 		expect(
 			body.queryAllByRole("menuitemcheckbox", { name: "New Terminal" }),
 		).toHaveLength(0);

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
@@ -83,9 +83,7 @@ export const RightPanelAddTabControl: FC<{
 	agent?: WorkspaceAgent;
 	host?: string;
 	isRunning?: boolean;
-	/** Singleton panels the deployment and workspace currently support. */
 	supportedSingletonTabs: readonly SingletonRightPanelTabId[];
-	/** Singleton panels currently shown in the tab list. */
 	visibleSingletonTabs: readonly SingletonRightPanelTabId[];
 	onToggleSingletonTab: (tabId: SingletonRightPanelTabId) => void;
 	onNewTerminal: () => void;

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
@@ -1,11 +1,14 @@
 import { cn } from "cn";
 import {
+	BugIcon,
 	ChevronDownIcon,
+	GlobeIcon,
 	LayoutGridIcon,
+	MonitorIcon,
 	PlusIcon,
 	SquareTerminalIcon,
 } from "lucide-react";
-import { type FC, useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 import type {
 	Workspace,
 	WorkspaceAgent,
@@ -14,6 +17,7 @@ import type {
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,
+	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuSeparator,
@@ -29,8 +33,21 @@ import {
 	canShowPortForwarding,
 	usePortsData,
 } from "#/modules/resources/usePortsData";
-import type { PortSelection } from "../../utils/rightPanelTabs";
+import type {
+	PortSelection,
+	SingletonRightPanelTabId,
+} from "../../utils/rightPanelTabs";
 import { PortsMenuItem } from "../WorkspacePillPorts";
+
+const singletonTabMenuEntries: readonly {
+	id: SingletonRightPanelTabId;
+	label: string;
+	icon: ReactNode;
+}[] = [
+	{ id: "browser", label: "Browser", icon: <GlobeIcon /> },
+	{ id: "desktop", label: "Desktop", icon: <MonitorIcon /> },
+	{ id: "debug", label: "Debug", icon: <BugIcon /> },
+];
 
 // usePortsData requires a workspace and agent, which are optional props on the
 // parent control, so the hook lives in this conditionally rendered component.
@@ -66,6 +83,11 @@ export const RightPanelAddTabControl: FC<{
 	agent?: WorkspaceAgent;
 	host?: string;
 	isRunning?: boolean;
+	/** Singleton panels the deployment and workspace currently support. */
+	supportedSingletonTabs: readonly SingletonRightPanelTabId[];
+	/** Singleton panels currently shown in the tab list. */
+	visibleSingletonTabs: readonly SingletonRightPanelTabId[];
+	onToggleSingletonTab: (tabId: SingletonRightPanelTabId) => void;
 	onNewTerminal: () => void;
 	onOpenWorkspaceApp?: (app: WorkspaceApp) => void;
 	onOpenCommandApp?: (app: WorkspaceApp) => void;
@@ -75,6 +97,9 @@ export const RightPanelAddTabControl: FC<{
 	agent,
 	host = "",
 	isRunning = false,
+	supportedSingletonTabs,
+	visibleSingletonTabs,
+	onToggleSingletonTab,
 	onNewTerminal,
 	onOpenWorkspaceApp,
 	onOpenCommandApp,
@@ -88,6 +113,9 @@ export const RightPanelAddTabControl: FC<{
 		) ?? [];
 	const canCreateTerminal =
 		workspace !== undefined && agent !== undefined && isRunning;
+	const singletonEntries = singletonTabMenuEntries.filter((entry) =>
+		supportedSingletonTabs.includes(entry.id),
+	);
 
 	return (
 		<div className="flex h-6 shrink-0 items-center overflow-hidden rounded-md border border-solid border-border-default bg-surface-primary text-content-secondary">
@@ -121,8 +149,24 @@ export const RightPanelAddTabControl: FC<{
 				<DropdownMenuContent
 					align="end"
 					side="bottom"
-					className="w-52 p-1 [&_[role=menuitem]]:py-1 [&_[role=menuitem]]:text-xs [&_img]:size-3.5! [&_svg]:size-3.5!"
+					className="w-52 p-1 [&_[role^=menuitem]]:py-1 [&_[role^=menuitem]]:text-xs [&_img]:size-3.5! [&_svg]:size-3.5!"
 				>
+					{singletonEntries.length > 0 && (
+						<>
+							{singletonEntries.map((entry) => (
+								<DropdownMenuCheckboxItem
+									key={entry.id}
+									checked={visibleSingletonTabs.includes(entry.id)}
+									onSelect={() => onToggleSingletonTab(entry.id)}
+								>
+									{entry.icon}
+									{entry.label}
+								</DropdownMenuCheckboxItem>
+							))}
+							<DropdownMenuSeparator className="my-1" />
+						</>
+					)}
+
 					<DropdownMenuItem
 						onSelect={onNewTerminal}
 						disabled={!canCreateTerminal}

--- a/site/src/pages/AgentsPage/utils/rightPanelTabStorage.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabStorage.ts
@@ -1,4 +1,10 @@
-import { isUserRightPanelTab, type UserRightPanelTab } from "./rightPanelTabs";
+import {
+	isSingletonRightPanelTabId,
+	isUserRightPanelTab,
+	type SingletonRightPanelTabId,
+	singletonRightPanelTabIds,
+	type UserRightPanelTab,
+} from "./rightPanelTabs";
 
 export const rightPanelTabStorageKeyPrefix = "agents.right-panel-tabs.";
 
@@ -40,6 +46,54 @@ export function savePersistedRightPanelTabs(
 	);
 }
 
+export const visibleSingletonTabsStorageKeyPrefix =
+	"agents.right-panel-singleton-tabs.";
+
+/**
+ * Singleton panels start hidden, so an absent or unreadable entry means no
+ * singleton tab is shown.
+ */
+export function getPersistedVisibleSingletonTabs(
+	chatID: string | undefined,
+): SingletonRightPanelTabId[] {
+	if (!chatID) {
+		return [];
+	}
+
+	const value = localStorage.getItem(
+		`${visibleSingletonTabsStorageKeyPrefix}${chatID}`,
+	);
+	if (!value) {
+		return [];
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!Array.isArray(parsed)) {
+			return [];
+		}
+		const storedIds = parsed.filter(isSingletonRightPanelTabId);
+		// Reading through the canonical list drops duplicates and keeps a
+		// stable order regardless of the order the user enabled the panels.
+		return singletonRightPanelTabIds.filter((id) => storedIds.includes(id));
+	} catch {
+		return [];
+	}
+}
+
+export function savePersistedVisibleSingletonTabs(
+	chatID: string | undefined,
+	tabIds: readonly SingletonRightPanelTabId[],
+): void {
+	if (!chatID) {
+		return;
+	}
+	localStorage.setItem(
+		`${visibleSingletonTabsStorageKeyPrefix}${chatID}`,
+		JSON.stringify(tabIds),
+	);
+}
+
 const defaultTerminalHiddenStorageKeyPrefix = "agents.default-terminal-hidden.";
 
 export function getPersistedDefaultTerminalHidden(
@@ -77,5 +131,6 @@ export function clearPersistedRightPanelState(
 		return;
 	}
 	localStorage.removeItem(`${rightPanelTabStorageKeyPrefix}${chatID}`);
+	localStorage.removeItem(`${visibleSingletonTabsStorageKeyPrefix}${chatID}`);
 	localStorage.removeItem(`${defaultTerminalHiddenStorageKeyPrefix}${chatID}`);
 }

--- a/site/src/pages/AgentsPage/utils/rightPanelTabs.test.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabs.test.ts
@@ -14,9 +14,12 @@ import {
 	clearPersistedRightPanelState,
 	getPersistedDefaultTerminalHidden,
 	getPersistedRightPanelTabs,
+	getPersistedVisibleSingletonTabs,
 	rightPanelTabStorageKeyPrefix,
 	savePersistedDefaultTerminalHidden,
 	savePersistedRightPanelTabs,
+	savePersistedVisibleSingletonTabs,
+	visibleSingletonTabsStorageKeyPrefix,
 } from "./rightPanelTabStorage";
 import {
 	type UserRightPanelTab,
@@ -229,15 +232,19 @@ describe("right-panel tab storage", () => {
 
 		savePersistedRightPanelTabs("chat-1", tabs);
 		savePersistedDefaultTerminalHidden("chat-1", true);
+		savePersistedVisibleSingletonTabs("chat-1", ["browser"]);
 		savePersistedRightPanelTabs("chat-2", tabs);
 		savePersistedDefaultTerminalHidden("chat-2", true);
+		savePersistedVisibleSingletonTabs("chat-2", ["debug"]);
 
 		clearPersistedRightPanelState("chat-1");
 
 		expect(getPersistedRightPanelTabs("chat-1")).toEqual([]);
 		expect(getPersistedDefaultTerminalHidden("chat-1")).toBe(false);
+		expect(getPersistedVisibleSingletonTabs("chat-1")).toEqual([]);
 		expect(getPersistedRightPanelTabs("chat-2")).toEqual(tabs);
 		expect(getPersistedDefaultTerminalHidden("chat-2")).toBe(true);
+		expect(getPersistedVisibleSingletonTabs("chat-2")).toEqual(["debug"]);
 	});
 
 	it("persists workspace_app tabs", () => {
@@ -308,6 +315,63 @@ describe("right-panel tab storage", () => {
 		);
 
 		expect(getPersistedRightPanelTabs("chat-1")).toEqual(tabs);
+	});
+});
+
+describe("singleton right-panel tab storage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("hides every singleton panel when nothing is stored", () => {
+		expect(getPersistedVisibleSingletonTabs("chat-1")).toEqual([]);
+	});
+
+	it("persists visible singleton panels per chat", () => {
+		savePersistedVisibleSingletonTabs("chat-1", ["browser", "debug"]);
+
+		expect(getPersistedVisibleSingletonTabs("chat-1")).toEqual([
+			"browser",
+			"debug",
+		]);
+		expect(getPersistedVisibleSingletonTabs("chat-2")).toEqual([]);
+	});
+
+	it("reads stored panels in a stable order without duplicates", () => {
+		localStorage.setItem(
+			`${visibleSingletonTabsStorageKeyPrefix}chat-1`,
+			JSON.stringify(["debug", "browser", "debug"]),
+		);
+
+		expect(getPersistedVisibleSingletonTabs("chat-1")).toEqual([
+			"browser",
+			"debug",
+		]);
+	});
+
+	it("ignores unknown panel IDs", () => {
+		localStorage.setItem(
+			`${visibleSingletonTabsStorageKeyPrefix}chat-1`,
+			JSON.stringify(["terminal", "summary", "desktop"]),
+		);
+
+		expect(getPersistedVisibleSingletonTabs("chat-1")).toEqual(["desktop"]);
+	});
+
+	it("ignores malformed stored values", () => {
+		localStorage.setItem(
+			`${visibleSingletonTabsStorageKeyPrefix}chat-1`,
+			"not-json",
+		);
+
+		expect(getPersistedVisibleSingletonTabs("chat-1")).toEqual([]);
+	});
+
+	it("ignores undefined chat IDs", () => {
+		savePersistedVisibleSingletonTabs(undefined, ["browser"]);
+
+		expect(getPersistedVisibleSingletonTabs(undefined)).toEqual([]);
+		expect(localStorage.length).toBe(0);
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
+++ b/site/src/pages/AgentsPage/utils/rightPanelTabs.ts
@@ -11,6 +11,25 @@ import { findWorkspaceAppWithAgent } from "#/modules/apps/workspaceApps";
 import { canShowPortForwarding } from "#/modules/resources/usePortsData";
 import { findWorkspaceAgent } from "#/utils/workspace";
 
+/**
+ * Built-in panels that the user shows or hides from the add-tab dropdown.
+ * Each one can appear at most once, so the tab ID is the panel ID.
+ */
+export const singletonRightPanelTabIds = [
+	"browser",
+	"desktop",
+	"debug",
+] as const;
+
+export type SingletonRightPanelTabId =
+	(typeof singletonRightPanelTabIds)[number];
+
+export function isSingletonRightPanelTabId(
+	value: unknown,
+): value is SingletonRightPanelTabId {
+	return singletonRightPanelTabIds.some((id) => id === value);
+}
+
 export type PortSelection = {
 	label: string;
 	port: number;


### PR DESCRIPTION
The Browser, Desktop, and Debug right-panel tabs appeared automatically whenever the deployment supported them, so every chat with an `agent-browser` app mounted the app iframe at page load even if the user never opened the panel.

These panels now start hidden and are toggled from the existing add-panel dropdown as checkbox items. Each visible tab gets an X close control, each panel can appear at most once, and visibility is persisted per chat. Unsupported panels are hidden from both the dropdown and the tab list, but a saved choice survives a temporary loss of support. Summary, Git, and Terminal are unchanged.

<img width="244" height="154" alt="image" src="https://github.com/user-attachments/assets/f70dbfef-510e-4f63-bf04-47c3822dea3b" />

Notes: `getEffectiveTabId` drops its unreachable `desktopChatId` fallback, `DropdownMenuCheckboxItem` is new and reuses `menuItemClass`, and existing chats lose these tabs on first load after deploy since there is no migration.

---

Opened by Coder Agents on behalf of @ethanndickson.
