### PR TITLE
fix(coderd/x/chatd/mcpclient): serialize parameterless tool schemas with empty properties

### DIFF
--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -629,11 +629,14 @@ func newMCPTool(
 }
 
 func splitInputSchema(schema any) (map[string]any, []string) {
-	m, ok := schema.(map[string]any)
-	if !ok {
-		return nil, nil
-	}
+	m, _ := schema.(map[string]any)
 	properties, _ := m["properties"].(map[string]any)
+	if properties == nil {
+		// A tool with no parameters has no "properties" object. A nil
+		// map serializes to JSON null, which some providers reject as
+		// an invalid schema, so normalize to an empty object.
+		properties = map[string]any{}
+	}
 	var required []string
 	if rawRequired, ok := m["required"].([]any); ok {
 		for _, r := range rawRequired {

--- a/coderd/x/chatd/mcpclient/mcpclient_test.go
+++ b/coderd/x/chatd/mcpclient/mcpclient_test.go
@@ -645,6 +645,45 @@ func TestConnectAll_NilRequiredBecomesEmptySlice(t *testing.T) {
 	assert.Equal(t, "[]", string(bs))
 }
 
+// TestConnectAll_NilPropertiesBecomesEmptyMap verifies that a tool
+// whose inputSchema omits "properties" produces an empty map instead
+// of nil.  A nil map serializes to JSON null, which some providers
+// reject as an invalid schema.
+func TestConnectAll_NilPropertiesBecomesEmptyMap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+	// noArgsTool defines a tool that takes no parameters at all.
+	noArgsTool := testTool{
+		tool: &mcp.Tool{
+			Name:        "no_args",
+			Description: "A tool with no parameters",
+			InputSchema: map[string]any{
+				"type": "object",
+			},
+		},
+		handler: func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return textToolResult("ok"), nil
+		},
+	}
+
+	ts := newTestMCPServer(t, noArgsTool)
+	cfg := makeConfig("srv", ts.URL)
+	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil, nil)
+	t.Cleanup(cleanup)
+	require.Len(t, tools, 1)
+
+	info := tools[0].Info()
+	require.NotNil(t, info.Parameters, "Parameters should never be nil")
+	assert.Empty(t, info.Parameters, "Parameters should be empty for tools without parameters")
+
+	// Verify it serializes to {} not null.
+	bs, err := json.Marshal(info.Parameters)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(bs))
+}
+
 // TestConnectAll_APIKeyAuth verifies that api_key auth sends the
 // configured header and value on every request.
 func TestConnectAll_APIKeyAuth(t *testing.T) {


### PR DESCRIPTION
MCP tools whose `inputSchema` omits `"properties"` (no-argument tools) produced a nil parameters map, which serialized the wire tool schema as `"properties": null`. Some providers reject a null properties object as an invalid schema.

#28380 (merged) guards the wire sink (`chatloop.buildToolDefinitions`). This PR normalizes the other half: `mcpclient.splitInputSchema` returns an empty object instead of nil, so `Info().Parameters` is never nil for consumers beyond the wire path (model-intent wrapping, tool search), mirroring the existing nil-required guard.

## Stack Context

Bottom of a stack that fixes MCP tool input-schema loss end to end: this PR fixes the remaining `properties: null` corruption at the schema split, the next PRs preserve full input schemas (`$defs`, `$ref`, `additionalProperties`, ...) through chatd and the workspace MCP path instead of flattening them to properties + required.

> 🤖 Mux authored this PR on Mike's behalf.

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high -->
