### PR TITLE
fix(coderd/x/gitsync): stop retrying unimplemented git provider types forever

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3995,7 +3995,7 @@ func (api *API) resolveChatDiffContents(
 		return result, nil
 	}
 
-	gp := api.resolveGitProvider(ctx, reference.RepositoryRef.RemoteOrigin)
+	gp, _ := api.resolveGitProvider(ctx, reference.RepositoryRef.RemoteOrigin)
 	if gp == nil {
 		return result, nil
 	}
@@ -4059,7 +4059,7 @@ func (api *API) resolveChatDiffReference(
 	// current open PR. This picks up new PRs after the previous
 	// one was closed.
 	if reference.RepositoryRef != nil && reference.RepositoryRef.Owner != "" {
-		gp := api.resolveGitProvider(ctx, reference.RepositoryRef.RemoteOrigin)
+		gp, _ := api.resolveGitProvider(ctx, reference.RepositoryRef.RemoteOrigin)
 		if gp != nil {
 			token, err := api.resolveChatGitAccessToken(ctx, chat.OwnerID, reference.RepositoryRef.RemoteOrigin)
 			if token == nil || errors.Is(err, gitsync.ErrNoTokenAvailable) {
@@ -4219,10 +4219,33 @@ func (api *API) resolveExternalAuth(ctx context.Context, origin string) (provide
 
 // resolveGitProvider finds the external auth config matching the
 // given remote origin URL and returns its git provider. Returns
-// nil if no matching git provider is configured.
-func (api *API) resolveGitProvider(ctx context.Context, origin string) gitprovider.Provider {
-	_, gp := api.resolveExternalAuth(ctx, origin)
-	return gp
+// (nil, nil) if no matching git provider is configured, or
+// (nil, gitsync.ErrProviderUnimplemented) if a matching config exists
+// but its git provider type is not yet implemented.
+func (api *API) resolveGitProvider(ctx context.Context, origin string) (gitprovider.Provider, error) {
+	origin = strings.TrimSpace(origin)
+	if origin == "" {
+		return nil, nil
+	}
+	for _, extAuth := range api.ExternalAuthConfigs {
+		if extAuth.Regex == nil || !extAuth.Regex.MatchString(origin) {
+			continue
+		}
+		p, err := extAuth.Git()
+		if err != nil {
+			api.Logger.Warn(ctx, "failed to construct git provider",
+				slog.F("provider_id", extAuth.ID),
+				slog.F("provider_type", extAuth.Type),
+				slog.Error(err),
+			)
+			continue
+		}
+		if p == nil {
+			return nil, gitsync.ErrProviderUnimplemented
+		}
+		return p, nil
+	}
+	return nil, nil
 }
 
 func (api *API) resolveChatGitAccessToken(

--- a/coderd/x/gitsync/gitsync.go
+++ b/coderd/x/gitsync/gitsync.go
@@ -29,10 +29,16 @@ const (
 )
 
 // ProviderResolver maps a git remote origin to the gitprovider
-// that handles it. Returns nil if no provider matches.
-type ProviderResolver func(ctx context.Context, origin string) gitprovider.Provider
+// that handles it. Returns nil, nil if no provider matches.
+// Returns ErrProviderUnimplemented if the origin matches a
+// provider whose git client is not yet implemented.
+type ProviderResolver func(ctx context.Context, origin string) (gitprovider.Provider, error)
 
 var ErrNoTokenAvailable error = errors.New("no token available")
+
+// ErrProviderUnimplemented indicates that the git provider type configured
+// for a remote origin is not yet implemented.
+var ErrProviderUnimplemented error = errors.New("git provider type is not implemented")
 
 // ErrRateLimitSkipped indicates that a row was skipped because
 // a prior request in the same group hit a rate limit.
@@ -159,7 +165,13 @@ func (r *Refresher) Refresh(
 	// duplicate resolution for rows in the same group.
 	var resolved []resolvedGroup
 	for key, indices := range groups {
-		provider := r.providers(ctx, key.origin)
+		provider, err := r.providers(ctx, key.origin)
+		if err != nil {
+			for _, i := range indices {
+				results[i].Error = err
+			}
+			continue
+		}
 		if provider == nil {
 			err := xerrors.Errorf("no provider for origin %q", key.origin)
 			for _, i := range indices {

--- a/coderd/x/gitsync/gitsync_test.go
+++ b/coderd/x/gitsync/gitsync_test.go
@@ -128,7 +128,7 @@ func TestRefresher_WithPRURL(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -184,7 +184,7 @@ func TestRefresher_BranchResolvesToPR(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -226,7 +226,7 @@ func TestRefresher_BranchNoPRYet(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -255,7 +255,7 @@ func TestRefresher_BranchNoPRYet(t *testing.T) {
 func TestRefresher_NoProviderForOrigin(t *testing.T) {
 	t.Parallel()
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return nil }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return nil, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -282,6 +282,38 @@ func TestRefresher_NoProviderForOrigin(t *testing.T) {
 	assert.Contains(t, res.Error.Error(), "no provider")
 }
 
+func TestRefresher_ProviderUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) {
+		return nil, gitsync.ErrProviderUnimplemented
+	}
+	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
+		return ptr.Ref("test-token"), nil
+	}
+
+	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+
+	row := database.ChatDiffStatus{
+		ChatID:          uuid.New(),
+		Url:             sql.NullString{String: "https://bitbucket.org/org/repo/pull/1", Valid: true},
+		GitRemoteOrigin: "https://bitbucket.org/org/repo",
+		GitBranch:       "feature",
+	}
+
+	ownerID := uuid.New()
+	results, err := r.Refresh(context.Background(), []gitsync.RefreshRequest{
+		{Row: row, OwnerID: ownerID},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	res := results[0]
+
+	assert.Nil(t, res.Params)
+	require.Error(t, res.Error)
+	assert.ErrorIs(t, res.Error, gitsync.ErrProviderUnimplemented)
+}
+
 func TestRefresher_TokenResolutionFails(t *testing.T) {
 	t.Parallel()
 
@@ -296,7 +328,7 @@ func TestRefresher_TokenResolutionFails(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return nil, errors.New("token lookup failed")
 	}
@@ -328,7 +360,7 @@ func TestRefresher_EmptyToken(t *testing.T) {
 
 	mp := &mockProvider{}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref(""), nil
 	}
@@ -366,7 +398,7 @@ func TestRefresher_ProviderFetchFails(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -402,7 +434,7 @@ func TestRefresher_PRURLParseFailure(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -440,7 +472,7 @@ func TestRefresher_BatchGroupsByOwnerAndOrigin(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 
 	var tokenCalls atomic.Int32
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
@@ -522,7 +554,7 @@ func TestRefresher_UsesInjectedClock(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -574,7 +606,7 @@ func TestRefresher_RateLimitSkipsRemainingInGroup(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}
@@ -695,7 +727,7 @@ func TestRefresher_CorrectTokenPerOrigin(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 
 	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
 
@@ -780,7 +812,7 @@ func TestRefresher_ConcurrentProcessing(t *testing.T) {
 		},
 	}
 
-	providers := func(_ context.Context, _ string) gitprovider.Provider { return mp }
+	providers := func(_ context.Context, _ string) (gitprovider.Provider, error) { return mp, nil }
 	tokens := func(_ context.Context, _ uuid.UUID, _ string) (*string, error) {
 		return ptr.Ref("test-token"), nil
 	}

--- a/coderd/x/gitsync/worker.go
+++ b/coderd/x/gitsync/worker.go
@@ -33,6 +33,13 @@ const (
 	// their account before retrying is useful.
 	NoTokenBackoff = 10 * time.Minute
 
+	// NotImplementedBackoff is the backoff duration applied to rows
+	// whose remote origin matches a git provider type that is not
+	// yet implemented (e.g. bitbucket, azure devops). Retrying
+	// frequently is futile until support is added, and rows are
+	// revived immediately by MarkStale on any new commit activity.
+	NotImplementedBackoff = 24 * time.Hour
+
 	// NoPRBackoff is the backoff applied when a branch has no
 	// associated pull request yet. Kept short so that PRs created
 	// shortly after a push (e.g. via `gh pr create`) are
@@ -216,11 +223,13 @@ func (w *Worker) tick(ctx context.Context) {
 				slog.F("chat_id", res.Request.Row.ChatID),
 				slog.Error(res.Error))
 			// Apply a longer backoff for rows whose owner has
-			// no linked token — retrying every 2 minutes is
-			// pointless until the user links their account.
+			// no linked token or whose git provider is unimplemented
+			// — retrying every 2 minutes is pointless.
 			backoff := DiffStatusTTL
 			if errors.Is(res.Error, ErrNoTokenAvailable) {
 				backoff = NoTokenBackoff
+			} else if errors.Is(res.Error, ErrProviderUnimplemented) {
+				backoff = NotImplementedBackoff
 			}
 			// Back off so the row isn't retried immediately.
 			if err := w.store.BackoffChatDiffStatus(ctx,

--- a/coderd/x/gitsync/worker_test.go
+++ b/coderd/x/gitsync/worker_test.go
@@ -82,7 +82,7 @@ func newTestRefresher(t *testing.T, clk quartz.Clock, opts ...testRefresherOpt) 
 		},
 	}
 
-	providers := func(context.Context, string) gitprovider.Provider { return prov }
+	providers := func(context.Context, string) (gitprovider.Provider, error) { return prov, nil }
 	tokens := func(context.Context, uuid.UUID, string) (*string, error) {
 		return ptr.Ref("tok"), nil
 	}
@@ -1119,8 +1119,8 @@ func TestRefreshChat_RefreshError(t *testing.T) {
 	store := dbmock.NewMockStore(ctrl)
 	// UpsertChatDiffStatus should NOT be called.
 
-	// Provider resolver returns nil → "no provider" error.
-	providers := func(context.Context, string) gitprovider.Provider { return nil }
+	// Provider resolver returns nil, nil → "no provider" error.
+	providers := func(context.Context, string) (gitprovider.Provider, error) { return nil, nil }
 	tokens := func(context.Context, uuid.UUID, string) (*string, error) {
 		return ptr.Ref("tok"), nil
 	}
@@ -1205,7 +1205,7 @@ func TestWorker_NoTokenBackoff(t *testing.T) {
 	// Token resolver returns empty token → ErrNoTokenAvailable.
 	// Provider methods should never be called.
 	prov := &mockProvider{}
-	providers := func(context.Context, string) gitprovider.Provider { return prov }
+	providers := func(context.Context, string) (gitprovider.Provider, error) { return prov, nil }
 	tokens := func(context.Context, uuid.UUID, string) (*string, error) {
 		return ptr.Ref(""), nil
 	}
@@ -1224,5 +1224,59 @@ func TestWorker_NoTokenBackoff(t *testing.T) {
 	// The backoff should use NoTokenBackoff (10min), not
 	// DiffStatusTTL (2min).
 	expectedStaleAt := mClock.Now().UTC().Add(gitsync.NoTokenBackoff)
+	assert.WithinDuration(t, expectedStaleAt, backoffArgs[0].StaleAt, time.Second)
+}
+
+func TestWorker_ProviderUnimplementedBackoff(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	chatID := uuid.New()
+	ownerID := uuid.New()
+
+	var mu sync.Mutex
+	var backoffArgs []database.BackoffChatDiffStatusParams
+	tickDone := make(chan struct{})
+
+	mClock := quartz.NewMock(t)
+
+	ctrl := gomock.NewController(t)
+	store := dbmock.NewMockStore(ctrl)
+
+	store.EXPECT().AcquireStaleChatDiffStatuses(gomock.Any(), gomock.Any()).
+		Return([]database.AcquireStaleChatDiffStatusesRow{
+			makeAcquiredRowWithBranch(chatID, ownerID, "feature"),
+		}, nil)
+	store.EXPECT().BackoffChatDiffStatus(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, arg database.BackoffChatDiffStatusParams) error {
+			mu.Lock()
+			backoffArgs = append(backoffArgs, arg)
+			mu.Unlock()
+			close(tickDone)
+			return nil
+		})
+
+	// Provider resolver returns ErrProviderUnimplemented.
+	providers := func(context.Context, string) (gitprovider.Provider, error) {
+		return nil, gitsync.ErrProviderUnimplemented
+	}
+	tokens := func(context.Context, uuid.UUID, string) (*string, error) {
+		return ptr.Ref("tok"), nil
+	}
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	refresher := gitsync.NewRefresher(providers, tokens, logger, mClock)
+	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
+
+	tickOnce(ctx, t, mClock, worker, tickDone)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, backoffArgs, 1)
+	assert.Equal(t, chatID, backoffArgs[0].ChatID)
+
+	// The backoff should use NotImplementedBackoff (24h), not
+	// DiffStatusTTL (2min).
+	expectedStaleAt := mClock.Now().UTC().Add(gitsync.NotImplementedBackoff)
 	assert.WithinDuration(t, expectedStaleAt, backoffArgs[0].StaleAt, time.Second)
 }


### PR DESCRIPTION
Closes #28141

## Summary

`coderd/x/gitsync` periodically queries stale `chat_diff_statuses` rows to refresh pull request metadata. Previously, when a configured external auth git provider type was not yet implemented (such as Bitbucket or Azure DevOps), `gitprovider.New` returned `(nil, nil)`, which `resolveGitProvider` collapsed to a bare `nil`.

In `Refresher.Refresh`, this was treated as a missing origin match and failed with `xerrors.Errorf("no provider for origin %q")`, causing `Worker.tick` to fall back to the standard `DiffStatusTTL` (120s) and requeue affected rows endlessly.

This PR addresses this churn by:
1. Defining a sentinel error `ErrProviderUnimplemented = errors.New("git provider type is not implemented")` in `gitsync`.
2. Updating `ProviderResolver` to `func(ctx context.Context, origin string) (gitprovider.Provider, error)` and propagating errors directly through `Refresher.Refresh`.
3. Updating `resolveGitProvider` in `coderd/exp_chats.go` to return `(nil, gitsync.ErrProviderUnimplemented)` when a matching external auth config exists but its provider type is unimplemented.
4. Adding `NotImplementedBackoff = 24 * time.Hour` in `Worker.tick` when `errors.Is(res.Error, ErrProviderUnimplemented)`. As confirmed in #28141, rows parked with this long backoff are revived immediately by `Worker.MarkStale` whenever new git activity/commits occur on the branch.
5. Adding unit tests for error propagation in `gitsync_test.go` (`TestRefresher_ProviderUnimplemented`) and worker backoff in `worker_test.go` (`TestWorker_ProviderUnimplementedBackoff`).

## Test Plan

- [x] Unit test `TestRefresher_ProviderUnimplemented` verifies that unimplemented provider errors are set on row results.
- [x] Unit test `TestWorker_ProviderUnimplementedBackoff` verifies that rows with `ErrProviderUnimplemented` back off with `NotImplementedBackoff` (24h).
- [x] All existing `TestWorker_`, `TestRefresher_`, and `TestRefreshChat_` unit tests pass.
- [x] Package compilation of `coderd` verified.

## AI Disclosure
This PR was prepared with AI assistance following Coder contribution guidelines, with human architectural review and verification of local regression tests.
