### PR TITLE
fix(coderd/x/chatd): stop flattening MCP and dynamic tool input schemas

### DIFF
--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -1727,6 +1727,14 @@ func isSerialToolCall(toolMap map[string]fantasy.AgentTool, toolNameAliases map[
 	return ok && serial.SerialToolCalls()
 }
 
+// fullSchemaTool is implemented by tools that can report their
+// complete JSON Schema input schema, preserving keys such as $defs,
+// additionalProperties, and combinators that fantasy.ToolInfo cannot
+// carry.
+type fullSchemaTool interface {
+	FullInputSchema() map[string]any
+}
+
 // buildToolDefinitions converts AgentTool definitions into the
 // fantasy.Tool slice expected by fantasy.Call. When activeTools
 // is non-empty, only function tools whose name appears in the
@@ -1740,21 +1748,24 @@ func buildToolDefinitions(tools []fantasy.AgentTool, activeTools []string, provi
 			continue
 		}
 
-		// Substitute an empty object for nil properties so that a tool
-		// with no parameters never serializes "properties" to null,
-		// which OpenAI rejects.
-		properties := info.Parameters
-		if properties == nil {
-			properties = map[string]any{}
-		}
-		inputSchema := map[string]any{
-			"type":       "object",
-			"properties": properties,
-		}
-		// Only include "required" when non-empty so that a nil slice
-		// never serializes to null, which OpenAI rejects.
-		if len(info.Required) > 0 {
-			inputSchema["required"] = info.Required
+		inputSchema := fullInputSchema(tool)
+		if inputSchema == nil {
+			// Substitute an empty object for nil properties so that a tool
+			// with no parameters never serializes "properties" to null,
+			// which OpenAI rejects.
+			properties := info.Parameters
+			if properties == nil {
+				properties = map[string]any{}
+			}
+			inputSchema = map[string]any{
+				"type":       "object",
+				"properties": properties,
+			}
+			// Only include "required" when non-empty so that a nil slice
+			// never serializes to null, which OpenAI rejects.
+			if len(info.Required) > 0 {
+				inputSchema["required"] = info.Required
+			}
 		}
 		schema.Normalize(inputSchema)
 		prepared = append(prepared, fantasy.FunctionTool{
@@ -1768,6 +1779,78 @@ func buildToolDefinitions(tools []fantasy.AgentTool, activeTools []string, provi
 		prepared = append(prepared, pt.Definition)
 	}
 	return prepared
+}
+
+// fullInputSchema returns a defensively normalized copy of the tool's
+// full input schema, or nil when the tool does not provide one and the
+// caller must reconstruct a schema from Info().
+func fullInputSchema(tool fantasy.AgentTool) map[string]any {
+	provider, ok := tool.(fullSchemaTool)
+	if !ok {
+		return nil
+	}
+	source := provider.FullInputSchema()
+	if source == nil {
+		return nil
+	}
+	inputSchema := make(map[string]any, len(source)+1)
+	for key, value := range source {
+		inputSchema[key] = value
+	}
+	// JSON-unmarshaled schemas carry "required" as []any, which some
+	// provider drivers silently drop on a []string type assertion.
+	// Coerce to []string, and drop the key when empty so it never
+	// serializes to null, which OpenAI rejects.
+	if raw, ok := inputSchema["required"]; ok {
+		required := coerceRequiredStrings(raw)
+		if len(required) > 0 {
+			inputSchema["required"] = required
+		} else {
+			delete(inputSchema, "required")
+		}
+	}
+	// MCP requires object roots, so a missing "type" on a root without
+	// combinators is an omission rather than intent.
+	if _, ok := inputSchema["type"]; !ok && !hasCombinatorRoot(inputSchema) {
+		inputSchema["type"] = "object"
+	}
+	if inputSchema["type"] == "object" {
+		if properties, _ := inputSchema["properties"].(map[string]any); properties == nil {
+			// A nil map serializes "properties" to null, which some
+			// providers reject as an invalid schema.
+			inputSchema["properties"] = map[string]any{}
+		}
+	}
+	return inputSchema
+}
+
+// coerceRequiredStrings converts a schema "required" value to
+// []string, accepting the []any shape JSON unmarshaling produces and
+// skipping non-string entries.
+func coerceRequiredStrings(raw any) []string {
+	switch typed := raw.(type) {
+	case []string:
+		return typed
+	case []any:
+		required := make([]string, 0, len(typed))
+		for _, entry := range typed {
+			if str, ok := entry.(string); ok {
+				required = append(required, str)
+			}
+		}
+		return required
+	default:
+		return nil
+	}
+}
+
+func hasCombinatorRoot(inputSchema map[string]any) bool {
+	for _, key := range []string{"$ref", "anyOf", "oneOf", "allOf"} {
+		if _, ok := inputSchema[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func shouldApplyAnthropicPromptCaching(model fantasy.LanguageModel) bool {

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -1768,6 +1768,7 @@ func buildToolDefinitions(tools []fantasy.AgentTool, activeTools []string, provi
 			}
 		}
 		schema.Normalize(inputSchema)
+		enforceObjectRoot(inputSchema)
 		prepared = append(prepared, fantasy.FunctionTool{
 			Name:            info.Name,
 			Description:     info.Description,
@@ -1781,9 +1782,9 @@ func buildToolDefinitions(tools []fantasy.AgentTool, activeTools []string, provi
 	return prepared
 }
 
-// fullInputSchema returns a defensively normalized copy of the tool's
-// full input schema, or nil when the tool does not provide one and the
-// caller must reconstruct a schema from Info().
+// fullInputSchema returns a copy of the tool's full input schema, or
+// nil when the tool does not provide one and the caller must
+// reconstruct a schema from Info().
 func fullInputSchema(tool fantasy.AgentTool) map[string]any {
 	provider, ok := tool.(fullSchemaTool)
 	if !ok {
@@ -1809,18 +1810,6 @@ func fullInputSchema(tool fantasy.AgentTool) map[string]any {
 			delete(inputSchema, "required")
 		}
 	}
-	// MCP requires object roots, so a missing "type" on a root without
-	// combinators is an omission rather than intent.
-	if _, ok := inputSchema["type"]; !ok && !hasCombinatorRoot(inputSchema) {
-		inputSchema["type"] = "object"
-	}
-	if inputSchema["type"] == "object" {
-		if properties, _ := inputSchema["properties"].(map[string]any); properties == nil {
-			// A nil map serializes "properties" to null, which some
-			// providers reject as an invalid schema.
-			inputSchema["properties"] = map[string]any{}
-		}
-	}
 	return inputSchema
 }
 
@@ -1844,13 +1833,55 @@ func coerceRequiredStrings(raw any) []string {
 	}
 }
 
-func hasCombinatorRoot(inputSchema map[string]any) bool {
-	for _, key := range []string{"$ref", "anyOf", "oneOf", "allOf"} {
+// bannedRootKeys are schema keywords providers reject at the root of a
+// tool input schema. OpenAI fails the whole request with 400 "schema
+// must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/
+// 'const'/'not' at the top level", which would stall every turn of a
+// chat carrying such a tool. "$ref" is included because it defines the
+// root shape elsewhere and would dangle once an object root is forced.
+var bannedRootKeys = [...]string{"$ref", "anyOf", "oneOf", "allOf", "enum", "const", "not"}
+
+// enforceObjectRoot forces a tool input schema into the plain object
+// root shape MCP mandates and every provider accepts: banned root
+// keywords are dropped, "type" becomes "object" (schema.Normalize can
+// rewrite a root type array into a root "anyOf", so this must run
+// after it), and "properties" is materialized so it never serializes
+// to null. Nested combinators, $defs, additionalProperties, and root
+// descriptions all survive, so spec-compliant schemas pass unchanged.
+func enforceObjectRoot(inputSchema map[string]any) {
+	stripped := false
+	for _, key := range bannedRootKeys {
 		if _, ok := inputSchema[key]; ok {
-			return true
+			delete(inputSchema, key)
+			stripped = true
 		}
 	}
-	return false
+	if inputSchema["type"] != "object" {
+		inputSchema["type"] = "object"
+	}
+	properties, _ := inputSchema["properties"].(map[string]any)
+	if properties == nil {
+		properties = map[string]any{}
+		inputSchema["properties"] = properties
+	}
+	if !stripped {
+		return
+	}
+	// Required entries whose property schemas lived inside a dropped
+	// keyword (e.g. an allOf branch) would dangle; filter them out.
+	if required, ok := inputSchema["required"].([]string); ok {
+		filtered := make([]string, 0, len(required))
+		for _, name := range required {
+			if _, ok := properties[name]; ok {
+				filtered = append(filtered, name)
+			}
+		}
+		if len(filtered) > 0 {
+			inputSchema["required"] = filtered
+		} else {
+			delete(inputSchema, "required")
+		}
+	}
 }
 
 func shouldApplyAnthropicPromptCaching(model fantasy.LanguageModel) bool {

--- a/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
@@ -3,6 +3,7 @@ package chatloop
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"iter"
 	"runtime"
@@ -1561,4 +1562,94 @@ func TestExecuteSingleTool_AllowsDeferredDirectCall(t *testing.T) {
 	text, ok := result.Result.(fantasy.ToolResultOutputContentText)
 	require.True(t, ok)
 	require.Equal(t, "ok", text.Text)
+}
+
+// fullSchemaTestTool models a tool that reports its complete input
+// schema alongside a flattened Info() view.
+type fullSchemaTestTool struct {
+	fantasy.AgentTool
+	schema map[string]any
+}
+
+func (fullSchemaTestTool) Info() fantasy.ToolInfo {
+	return fantasy.ToolInfo{
+		Name:        "full_schema_tool",
+		Description: "keeps schemas whole",
+		Parameters:  map[string]any{"fallback": map[string]any{"type": "string"}},
+	}
+}
+
+func (t fullSchemaTestTool) FullInputSchema() map[string]any { return t.schema }
+
+func (fullSchemaTestTool) ProviderOptions() fantasy.ProviderOptions { return nil }
+
+// TestBuildToolDefinitionsFullSchema verifies that a tool exposing a
+// full input schema reaches the wire whole, with "required" coerced
+// from the []any shape JSON unmarshaling produces to []string so
+// provider drivers that assert []string do not drop it.
+func TestBuildToolDefinitionsFullSchema(t *testing.T) {
+	t.Parallel()
+
+	source := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"filter": map[string]any{"$ref": "#/$defs/Filter"},
+		},
+		"required":             []any{"filter"},
+		"additionalProperties": false,
+		"$defs": map[string]any{
+			"Filter": map[string]any{"type": "string"},
+		},
+	}
+	defs := buildToolDefinitions([]fantasy.AgentTool{fullSchemaTestTool{schema: source}}, nil, nil)
+	require.Len(t, defs, 1)
+	ft, ok := defs[0].(fantasy.FunctionTool)
+	require.True(t, ok)
+	require.Equal(t, []string{"filter"}, ft.InputSchema["required"])
+	raw, err := json.Marshal(ft.InputSchema)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"type": "object",
+		"properties": {"filter": {"$ref": "#/$defs/Filter"}},
+		"required": ["filter"],
+		"additionalProperties": false,
+		"$defs": {"Filter": {"type": "string"}}
+	}`, string(raw))
+	// The tool's own schema map is not mutated by the coercion.
+	require.Equal(t, []any{"filter"}, source["required"])
+}
+
+// TestBuildToolDefinitionsFullSchemaNormalization verifies the
+// defensive guards on the full-schema path: a plain object root gets
+// "type" defaulted and a non-nil properties object, and an empty
+// "required" is dropped so it never serializes to null.
+func TestBuildToolDefinitionsFullSchemaNormalization(t *testing.T) {
+	t.Parallel()
+
+	source := map[string]any{
+		"description": "no explicit type",
+		"required":    []any{},
+	}
+	defs := buildToolDefinitions([]fantasy.AgentTool{fullSchemaTestTool{schema: source}}, nil, nil)
+	require.Len(t, defs, 1)
+	ft, ok := defs[0].(fantasy.FunctionTool)
+	require.True(t, ok)
+	raw, err := json.Marshal(ft.InputSchema)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"type":"object","properties":{},"description":"no explicit type"}`, string(raw))
+}
+
+// TestBuildToolDefinitionsFullSchemaNilFallsBack verifies that a tool
+// whose FullInputSchema returns nil produces the same reconstruction
+// from Info() as tools without one.
+func TestBuildToolDefinitionsFullSchemaNilFallsBack(t *testing.T) {
+	t.Parallel()
+
+	defs := buildToolDefinitions([]fantasy.AgentTool{fullSchemaTestTool{schema: nil}}, nil, nil)
+	require.Len(t, defs, 1)
+	ft, ok := defs[0].(fantasy.FunctionTool)
+	require.True(t, ok)
+	raw, err := json.Marshal(ft.InputSchema)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"type":"object","properties":{"fallback":{"type":"string"}}}`, string(raw))
 }

--- a/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_run_internal_test.go
@@ -1653,3 +1653,81 @@ func TestBuildToolDefinitionsFullSchemaNilFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"type":"object","properties":{"fallback":{"type":"string"}}}`, string(raw))
 }
+
+// TestBuildToolDefinitionsFullSchemaBannedRootKeywords verifies that
+// schema keywords OpenAI rejects at the top level of a tool schema are
+// stripped from the root, with an object root enforced, dangling
+// "required" entries filtered, and every other key (nested
+// combinators, $defs, additionalProperties, description) preserved.
+func TestBuildToolDefinitionsFullSchemaBannedRootKeywords(t *testing.T) {
+	t.Parallel()
+
+	source := map[string]any{
+		"$ref":  "#/$defs/Root",
+		"oneOf": []any{map[string]any{"required": []any{"kept"}}},
+		"anyOf": []any{map[string]any{"required": []any{"lost"}}},
+		"allOf": []any{map[string]any{"properties": map[string]any{"lost": map[string]any{"type": "string"}}}},
+		"enum":  []any{"a", "b"},
+		"const": "a",
+		"not":   map[string]any{"type": "string"},
+		"properties": map[string]any{
+			"kept": map[string]any{
+				"oneOf": []any{
+					map[string]any{"$ref": "#/$defs/Kept"},
+					map[string]any{"type": "integer"},
+				},
+			},
+		},
+		"required":             []any{"kept", "lost"},
+		"$defs":                map[string]any{"Kept": map[string]any{"type": "string"}},
+		"additionalProperties": false,
+		"description":          "root description",
+	}
+	defs := buildToolDefinitions([]fantasy.AgentTool{fullSchemaTestTool{schema: source}}, nil, nil)
+	require.Len(t, defs, 1)
+	ft, ok := defs[0].(fantasy.FunctionTool)
+	require.True(t, ok)
+	raw, err := json.Marshal(ft.InputSchema)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"type": "object",
+		"properties": {
+			"kept": {"oneOf": [{"$ref": "#/$defs/Kept"}, {"type": "integer"}]}
+		},
+		"required": ["kept"],
+		"$defs": {"Kept": {"type": "string"}},
+		"additionalProperties": false,
+		"description": "root description"
+	}`, string(raw))
+	// The tool's own schema map keeps its top-level keys.
+	require.Contains(t, source, "oneOf")
+	require.Contains(t, source, "$ref")
+	require.Equal(t, []any{"kept", "lost"}, source["required"])
+}
+
+// TestBuildToolDefinitionsFullSchemaRootTypeArray verifies that a root
+// type array, which schema.Normalize rewrites into a root "anyOf",
+// still reaches the wire as a plain object root instead of the
+// top-level combinator OpenAI rejects.
+func TestBuildToolDefinitionsFullSchemaRootTypeArray(t *testing.T) {
+	t.Parallel()
+
+	source := map[string]any{
+		"type": []any{"object", "null"},
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+		"required": []any{"name"},
+	}
+	defs := buildToolDefinitions([]fantasy.AgentTool{fullSchemaTestTool{schema: source}}, nil, nil)
+	require.Len(t, defs, 1)
+	ft, ok := defs[0].(fantasy.FunctionTool)
+	require.True(t, ok)
+	raw, err := json.Marshal(ft.InputSchema)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"type": "object",
+		"properties": {"name": {"type": "string"}},
+		"required": ["name"]
+	}`, string(raw))
+}

--- a/coderd/x/chatd/dynamictool.go
+++ b/coderd/x/chatd/dynamictool.go
@@ -19,6 +19,7 @@ import (
 type dynamicTool struct {
 	name        string
 	description string
+	inputSchema map[string]any
 	parameters  map[string]any
 	required    []string
 	opts        fantasy.ProviderOptions
@@ -56,6 +57,13 @@ func dynamicToolsFromSDK(logger slog.Logger, tools []codersdk.DynamicTool) []fan
 			} else {
 				dt.parameters = schema.Properties
 				dt.required = schema.Required
+				// Also keep the schema whole so keys the typed
+				// extraction cannot carry ($defs, combinators,
+				// additionalProperties, ...) reach the provider.
+				var full map[string]any
+				if err := json.Unmarshal(t.InputSchema, &full); err == nil {
+					dt.inputSchema = full
+				}
 			}
 		}
 		result = append(result, dt)
@@ -70,6 +78,12 @@ func (t *dynamicTool) Info() fantasy.ToolInfo {
 		Parameters:  t.parameters,
 		Required:    t.required,
 	}
+}
+
+// FullInputSchema returns the client-supplied input schema whole, or
+// nil when the client sent none or it failed to parse.
+func (t *dynamicTool) FullInputSchema() map[string]any {
+	return t.inputSchema
 }
 
 func (*dynamicTool) Run(_ context.Context, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {

--- a/coderd/x/chatd/dynamictool_internal_test.go
+++ b/coderd/x/chatd/dynamictool_internal_test.go
@@ -76,6 +76,35 @@ func TestDynamicToolsFromSDK(t *testing.T) {
 		require.Equal(t, "bad_schema", info.Name)
 		require.Nil(t, info.Parameters)
 		require.Nil(t, info.Required)
+		full, ok := result[0].(fullSchemaTool)
+		require.True(t, ok)
+		require.Nil(t, full.FullInputSchema())
+	})
+
+	t.Run("SchemaKeptWhole", func(t *testing.T) {
+		t.Parallel()
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		schema := `{"type":"object","properties":{"filter":{"$ref":"#/$defs/Filter"}},"required":["filter"],"additionalProperties":false,"$defs":{"Filter":{"type":"string"}}}`
+		tools := []codersdk.DynamicTool{
+			{
+				Name:        "ref_tool",
+				Description: "Schema with $defs",
+				InputSchema: json.RawMessage(schema),
+			},
+		}
+		result := dynamicToolsFromSDK(logger, tools)
+		require.Len(t, result, 1)
+
+		full, ok := result[0].(fullSchemaTool)
+		require.True(t, ok)
+		raw, err := json.Marshal(full.FullInputSchema())
+		require.NoError(t, err)
+		require.JSONEq(t, schema, string(raw))
+
+		// Info() keeps carrying the flattened pair.
+		info := result[0].Info()
+		require.Contains(t, info.Parameters, "filter")
+		require.Equal(t, []string{"filter"}, info.Required)
 	})
 
 	t.Run("MultipleTools", func(t *testing.T) {

--- a/coderd/x/chatd/mcp_tool_search.go
+++ b/coderd/x/chatd/mcp_tool_search.go
@@ -165,13 +165,26 @@ func configureDeferredMCPToolSearch(
 	return ordered, activeToolNames, candidateNames
 }
 
+// fullSchemaTool mirrors chatloop's structural interface for tools
+// that report their complete input schema, so deferral budgeting
+// reflects the real wire payload size.
+type fullSchemaTool interface {
+	FullInputSchema() map[string]any
+}
+
 func estimateDeferredMCPToolTokens(candidates []deferredMCPTool) float64 {
 	chars := 0
 	for _, candidate := range candidates {
 		info := candidate.tool.Info()
-		schema := map[string]any{"type": "object", "properties": info.Parameters}
-		if len(info.Required) > 0 {
-			schema["required"] = info.Required
+		var schema map[string]any
+		if provider, ok := candidate.tool.(fullSchemaTool); ok {
+			schema = provider.FullInputSchema()
+		}
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": info.Parameters}
+			if len(info.Required) > 0 {
+				schema["required"] = info.Required
+			}
 		}
 		serialized, _ := json.Marshal(schema)
 		chars += len(info.Name) + len(info.Description) + len(serialized)

--- a/coderd/x/chatd/mcp_tool_search_internal_test.go
+++ b/coderd/x/chatd/mcp_tool_search_internal_test.go
@@ -36,6 +36,38 @@ func testDeferredTool(name, description string, parameters map[string]any) defer
 	}}}
 }
 
+type deferredTestFullSchemaTool struct {
+	deferredTestAgentTool
+	schema map[string]any
+}
+
+func (t deferredTestFullSchemaTool) FullInputSchema() map[string]any { return t.schema }
+
+// TestEstimateDeferredMCPToolTokensPrefersFullSchema verifies that
+// deferral budgeting weighs the complete input schema when a tool
+// reports one, since that is what reactivation puts on the wire.
+func TestEstimateDeferredMCPToolTokensPrefersFullSchema(t *testing.T) {
+	t.Parallel()
+
+	parameters := map[string]any{"value": map[string]any{"type": "string"}}
+	flattened := testDeferredTool("server__tool", "desc", parameters)
+	full := deferredMCPTool{tool: deferredTestFullSchemaTool{
+		deferredTestAgentTool: deferredTestAgentTool{info: fantasy.ToolInfo{
+			Name: "server__tool", Description: "desc", Parameters: parameters,
+		}},
+		schema: map[string]any{
+			"type":       "object",
+			"properties": parameters,
+			"$defs": map[string]any{
+				"Filter": map[string]any{"type": "string", "description": strings.Repeat("x", 100)},
+			},
+		},
+	}}
+	require.Greater(t,
+		estimateDeferredMCPToolTokens([]deferredMCPTool{full}),
+		estimateDeferredMCPToolTokens([]deferredMCPTool{flattened}))
+}
+
 func TestDecideMCPToolSearch(t *testing.T) {
 	t.Parallel()
 	candidates := []deferredMCPTool{testDeferredTool("server__small", "small", map[string]any{"value": map[string]any{"type": "string"}})}

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -593,6 +593,7 @@ type mcpToolWrapper struct {
 	prefixedName    string
 	originalName    string
 	description     string
+	inputSchema     map[string]any
 	parameters      map[string]any
 	required        []string
 	modelIntent     bool
@@ -615,12 +616,13 @@ func newMCPTool(
 	session *mcp.ClientSession,
 	modelIntent bool,
 ) *mcpToolWrapper {
-	properties, required := splitInputSchema(tool.InputSchema)
+	inputSchema, properties, required := splitInputSchema(tool.InputSchema)
 	return &mcpToolWrapper{
 		configID:     configID,
 		prefixedName: truncateToolName(aidmcp.SanitizeToolName(serverSlug) + toolNameSep + aidmcp.SanitizeToolName(tool.Name)),
 		originalName: tool.Name,
 		description:  tool.Description,
+		inputSchema:  inputSchema,
 		parameters:   properties,
 		required:     required,
 		modelIntent:  modelIntent,
@@ -628,16 +630,18 @@ func newMCPTool(
 	}
 }
 
-func splitInputSchema(schema any) (map[string]any, []string) {
+// splitInputSchema returns the tool's full input schema map plus the
+// derived properties/required pair that fantasy.ToolInfo carries. The
+// full map is nil when the server sent no object schema.
+func splitInputSchema(schema any) (full map[string]any, properties map[string]any, required []string) {
 	m, _ := schema.(map[string]any)
-	properties, _ := m["properties"].(map[string]any)
+	properties, _ = m["properties"].(map[string]any)
 	if properties == nil {
 		// A tool with no parameters has no "properties" object. A nil
 		// map serializes to JSON null, which some providers reject as
 		// an invalid schema, so normalize to an empty object.
 		properties = map[string]any{}
 	}
-	var required []string
 	if rawRequired, ok := m["required"].([]any); ok {
 		for _, r := range rawRequired {
 			if str, ok := r.(string); ok {
@@ -645,7 +649,7 @@ func splitInputSchema(schema any) (map[string]any, []string) {
 			}
 		}
 	}
-	return properties, required
+	return m, properties, required
 }
 
 func (t *mcpToolWrapper) Info() fantasy.ToolInfo {
@@ -668,17 +672,7 @@ func (t *mcpToolWrapper) Info() fantasy.ToolInfo {
 	// "model_intent" so the LLM provides a human-readable
 	// description of each tool call.
 	wrapped := map[string]any{
-		"model_intent": map[string]any{
-			"type": "string",
-			"description": "A short, natural-language, present-participle " +
-				"phrase describing why you are calling this tool. " +
-				"This is shown to the user as a status label while " +
-				"the tool runs. Use plain English with no underscores " +
-				"or technical jargon. Keep it under 100 characters. " +
-				"Good examples: \"Reading the authentication module\", " +
-				"\"Searching for configuration files\", " +
-				"\"Creating a new workspace\".",
-		},
+		"model_intent": modelIntentPropertySchema(),
 		"properties": map[string]any{
 			"type":       "object",
 			"properties": t.parameters,
@@ -692,6 +686,57 @@ func (t *mcpToolWrapper) Info() fantasy.ToolInfo {
 		Required:    []string{"model_intent", "properties"},
 		Parallel:    true,
 	}
+}
+
+func modelIntentPropertySchema() map[string]any {
+	return map[string]any{
+		"type": "string",
+		"description": "A short, natural-language, present-participle " +
+			"phrase describing why you are calling this tool. " +
+			"This is shown to the user as a status label while " +
+			"the tool runs. Use plain English with no underscores " +
+			"or technical jargon. Keep it under 100 characters. " +
+			"Good examples: \"Reading the authentication module\", " +
+			"\"Searching for configuration files\", " +
+			"\"Creating a new workspace\".",
+	}
+}
+
+// FullInputSchema returns the tool's complete input schema, preserving
+// keys such as $defs, additionalProperties, and combinators that
+// Info() cannot carry. It returns nil when the server sent no object
+// schema, in which case callers reconstruct a schema from Info().
+func (t *mcpToolWrapper) FullInputSchema() map[string]any {
+	if t.inputSchema == nil {
+		return nil
+	}
+	if !t.modelIntent {
+		return t.inputSchema
+	}
+
+	// Nest the original schema under "properties" alongside
+	// "model_intent", mirroring Info(). "$defs" is hoisted to the
+	// wrapped root because "#/$defs/..." JSON pointers resolve from
+	// the document root and would dangle one level down.
+	inner := make(map[string]any, len(t.inputSchema))
+	for key, value := range t.inputSchema {
+		if key == "$defs" {
+			continue
+		}
+		inner[key] = value
+	}
+	wrapped := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"model_intent": modelIntentPropertySchema(),
+			"properties":   inner,
+		},
+		"required": []string{"model_intent", "properties"},
+	}
+	if defs, ok := t.inputSchema["$defs"]; ok {
+		wrapped["$defs"] = defs
+	}
+	return wrapped
 }
 
 func (t *mcpToolWrapper) Run(

--- a/coderd/x/chatd/mcpclient/mcpclient_test.go
+++ b/coderd/x/chatd/mcpclient/mcpclient_test.go
@@ -684,6 +684,118 @@ func TestConnectAll_NilPropertiesBecomesEmptyMap(t *testing.T) {
 	assert.Equal(t, "{}", string(bs))
 }
 
+// refSchemaTool defines a tool whose inputSchema carries keys beyond
+// properties and required: $defs with a $ref property, a root
+// description, and additionalProperties.
+func refSchemaTool() testTool {
+	return testTool{
+		tool: &mcp.Tool{
+			Name:        "filtered_search",
+			Description: "Searches with a structured filter",
+			InputSchema: map[string]any{
+				"type":        "object",
+				"description": "A search request",
+				"properties": map[string]any{
+					"filter": map[string]any{"$ref": "#/$defs/Filter"},
+				},
+				"required":             []string{"filter"},
+				"additionalProperties": false,
+				"$defs": map[string]any{
+					"Filter": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"kind": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+		handler: func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return textToolResult("ok"), nil
+		},
+	}
+}
+
+type fullSchemaTool interface {
+	FullInputSchema() map[string]any
+}
+
+// TestConnectAll_FullInputSchema verifies that the complete input
+// schema survives discovery, while Info() keeps carrying only the
+// flattened properties/required pair.
+func TestConnectAll_FullInputSchema(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+	ts := newTestMCPServer(t, refSchemaTool())
+	cfg := makeConfig("srv", ts.URL)
+	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil, nil)
+	t.Cleanup(cleanup)
+	require.Len(t, tools, 1)
+
+	full, ok := tools[0].(fullSchemaTool)
+	require.True(t, ok, "MCP tools should expose their full input schema")
+	schema := full.FullInputSchema()
+	require.NotNil(t, schema)
+	assert.Equal(t, false, schema["additionalProperties"])
+	assert.Equal(t, "A search request", schema["description"])
+	defs, ok := schema["$defs"].(map[string]any)
+	require.True(t, ok, "$defs should survive discovery")
+	assert.Contains(t, defs, "Filter")
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	filter, ok := properties["filter"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/Filter", filter["$ref"])
+
+	// Info() stays flattened: the properties map only, with derived
+	// required names.
+	info := tools[0].Info()
+	assert.Contains(t, info.Parameters, "filter")
+	assert.Len(t, info.Parameters, 1)
+	assert.Equal(t, []string{"filter"}, info.Required)
+}
+
+// TestConnectAll_FullInputSchema_ModelIntentHoistsDefs verifies that
+// the model_intent wrapper hoists $defs to the wrapped root so
+// "#/$defs/..." pointers keep resolving from the document root.
+func TestConnectAll_FullInputSchema_ModelIntentHoistsDefs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+	ts := newTestMCPServer(t, refSchemaTool())
+	cfg := makeConfig("srv", ts.URL)
+	cfg.ModelIntent = true
+	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil, nil)
+	t.Cleanup(cleanup)
+	require.Len(t, tools, 1)
+
+	full, ok := tools[0].(fullSchemaTool)
+	require.True(t, ok)
+	schema := full.FullInputSchema()
+	require.NotNil(t, schema)
+
+	assert.Equal(t, []string{"model_intent", "properties"}, schema["required"])
+	defs, ok := schema["$defs"].(map[string]any)
+	require.True(t, ok, "$defs should be hoisted to the wrapped root")
+	assert.Contains(t, defs, "Filter")
+
+	wrapped, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, wrapped, "model_intent")
+	inner, ok := wrapped["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, inner, "$defs")
+	assert.Equal(t, false, inner["additionalProperties"])
+	innerProperties, ok := inner["properties"].(map[string]any)
+	require.True(t, ok)
+	filter, ok := innerProperties["filter"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/Filter", filter["$ref"])
+}
+
 // TestConnectAll_APIKeyAuth verifies that api_key auth sends the
 // configured header and value on every request.
 func TestConnectAll_APIKeyAuth(t *testing.T) {


### PR DESCRIPTION
Coder reduced every tool input schema to a properties map plus a required list before it reached the provider. Keys such as `$defs`, `$ref`, `additionalProperties`, combinators, and root descriptions were silently dropped, so a spec-compliant MCP schema like `{"properties": {"filter": {"$ref": "#/$defs/Filter"}}, "$defs": {...}}` arrived at the provider with dangling `$ref`s and no `$defs`.

This PR carries the full schema on a side channel without touching `Info()` semantics, so tool search, catalog keyword extraction, and every other `ToolInfo` consumer are unaffected:

- `mcpToolWrapper` (external MCP) and `dynamicTool` keep the original schema map and expose it through a new `FullInputSchema()` method. In model-intent mode the wrapper hoists `$defs` to the wrapped root, because `#/$defs/...` JSON pointers resolve from the document root and would dangle when the schema is nested under `properties`.
- `chatloop.buildToolDefinitions` prefers the full schema when a tool provides one, coercing `required` to `[]string` (JSON-unmarshaled schemas carry `[]any`, which the Anthropic and Google drivers silently drop on a `[]string` type assertion). Tools without a full schema use the existing reconstruction path unchanged.
- Every wire schema then passes through `enforceObjectRoot`: root-level `$ref`/`oneOf`/`anyOf`/`allOf`/`enum`/`const`/`not` are dropped, `type` is forced to `object`, `properties` is materialized so it never serializes to null, and `required` entries whose property schemas lived inside a dropped keyword are filtered out. OpenAI rejects these keywords at the top level of a tool schema with a 400 that fails the whole request, which would stall every turn of a chat carrying such a tool (the old flattening masked this class entirely). Root-level unsupported keywords are intentionally treated as provider-unsafe; nested fidelity (`$defs`, nested combinators, `additionalProperties`, descriptions) is preserved, so spec-compliant MCP schemas pass through unchanged. This runs after `schema.Normalize`, which can itself rewrite a root type array into a root `anyOf`.
- Deferred MCP tool budgeting (`estimateDeferredMCPToolTokens`) weighs the real wire payload when a full schema is available.

OpenAI-compatible drivers pass `FunctionTool.InputSchema` through verbatim, so this PR alone restores full fidelity for that provider family. Anthropic and Google driver fixes land separately in the fantasy fork.

## Stack Context

Middle of a stack that fixes MCP tool input-schema loss end to end: below, the `properties: null` fix; above, the same passthrough for the workspace MCP path (agent to coderd).

> 🤖 Shux authored this PR on Mike's behalf.

<!-- shux-attribution: model=openai:gpt-5.6-sol thinking=high -->
