### PR TITLE
fix: preserve full workspace MCP tool input schemas from agent to coderd

### DIFF
--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -1027,30 +1027,15 @@ type ToolInfo struct {
 	InputSchema map[string]any
 }
 
-// Only type, properties, and required are exposed through ToolInfo;
-// empty schemas leave InputSchema unset.
+// The schema map is passed through whole so coderd sees every key the
+// server reported ($defs, additionalProperties, combinators, ...);
+// non-object and empty schemas leave InputSchema unset.
 func toolInputSchemaMap(schema any) map[string]any {
 	m, ok := schema.(map[string]any)
-	if !ok {
+	if !ok || len(m) == 0 {
 		return nil
 	}
-	out := map[string]any{}
-	if typ, ok := m["type"].(string); ok && typ != "" {
-		out["type"] = typ
-	}
-	// Preserve an empty "properties" object: dropping it collapses the
-	// schema to nil by the time the tool definition is rebuilt, and a
-	// nil properties serializes to JSON null, which OpenAI rejects.
-	if properties, ok := m["properties"].(map[string]any); ok {
-		out["properties"] = properties
-	}
-	if required, ok := m["required"].([]any); ok && len(required) > 0 {
-		out["required"] = required
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return m
 }
 
 // cloneServerStatuses deep-copies a catalog so callers cannot mutate the

--- a/agent/x/agentmcp/manager_internal_test.go
+++ b/agent/x/agentmcp/manager_internal_test.go
@@ -298,6 +298,29 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "tools reload timed out after 1m0s")
 }
 
+// TestToolInputSchemaMap verifies that object schemas pass through
+// whole, so keys beyond type, properties, and required ($defs,
+// additionalProperties, combinators, ...) reach coderd, while
+// non-object and empty schemas leave InputSchema unset.
+func TestToolInputSchemaMap(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, toolInputSchemaMap(nil))
+	require.Nil(t, toolInputSchemaMap("bogus"))
+	require.Nil(t, toolInputSchemaMap(map[string]any{}))
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"filter": map[string]any{"$ref": "#/$defs/Filter"},
+		},
+		"required":             []any{"filter"},
+		"additionalProperties": false,
+		"$defs":                map[string]any{"Filter": map[string]any{"type": "string"}},
+	}
+	require.Equal(t, schema, toolInputSchemaMap(schema))
+}
+
 // runFakeMCPServer implements a minimal JSON-RPC / MCP server over
 // stdin/stdout, just enough for initialize + tools/list.
 func runFakeMCPServer() {

--- a/coderd/x/chatd/chattool/mcpworkspace.go
+++ b/coderd/x/chatd/chattool/mcpworkspace.go
@@ -34,6 +34,9 @@ const maxModelToolNameLen = 64
 // registered alongside built-in chat tools.
 type WorkspaceMCPTool struct {
 	info fantasy.ToolInfo
+	// inputSchema is the tool's complete input schema as pushed by the
+	// workspace agent, preserving keys the flattened info cannot carry.
+	inputSchema map[string]any
 	// routingName is the unsanitized "serverName__toolName" form the
 	// workspace agent expects: it splits on "__" to locate the server and
 	// calls the original tool name. info.Name is the sanitized, provider-safe
@@ -114,10 +117,18 @@ func buildWorkspaceMCPTool(
 			Required:    required,
 			Parallel:    true,
 		},
+		inputSchema:     tool.InputSchema,
 		routingName:     tool.Name,
 		getConn:         getConn,
 		invalidateCache: invalidateCache,
 	}
+}
+
+// FullInputSchema returns the tool's complete input schema, or nil for
+// payloads carrying only the flattened Schema/Required pair, in which
+// case callers reconstruct a schema from Info().
+func (t *WorkspaceMCPTool) FullInputSchema() map[string]any {
+	return t.inputSchema
 }
 
 // ServerName returns the originating MCP server name from the unsanitized

--- a/coderd/x/chatd/chattool/mcpworkspace_test.go
+++ b/coderd/x/chatd/chattool/mcpworkspace_test.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/fantasy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
@@ -153,6 +154,45 @@ func TestWorkspaceMCPTool_InvalidateOn404(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
 	})
+}
+
+// TestWorkspaceMCPTool_FullInputSchema verifies that a tool built from
+// a payload carrying the complete input schema exposes it whole, while
+// a legacy payload with only the flattened pair reports nil so callers
+// reconstruct a schema from Info().
+func TestWorkspaceMCPTool_FullInputSchema(t *testing.T) {
+	t.Parallel()
+
+	// getConn is never dialed: the schema is read from the built tool.
+	getConn := func(context.Context) (workspacesdk.AgentConn, error) {
+		return nil, xerrors.New("not dialed in this test")
+	}
+	full := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"filter": map[string]any{"$ref": "#/$defs/Filter"},
+		},
+		"required":             []any{"filter"},
+		"additionalProperties": false,
+		"$defs":                map[string]any{"Filter": map[string]any{"type": "string"}},
+	}
+
+	tool := chattool.NewWorkspaceMCPTool(workspacesdk.MCPToolInfo{
+		ServerName:  "srv",
+		Name:        "srv__search",
+		InputSchema: full,
+		Schema:      map[string]any{"filter": map[string]any{}},
+		Required:    []string{"filter"},
+	}, getConn, nil)
+	require.Equal(t, full, tool.FullInputSchema())
+
+	legacy := chattool.NewWorkspaceMCPTool(workspacesdk.MCPToolInfo{
+		ServerName: "srv",
+		Name:       "srv__search",
+		Schema:     map[string]any{"filter": map[string]any{}},
+		Required:   []string{"filter"},
+	}, getConn, nil)
+	require.Nil(t, legacy.FullInputSchema())
 }
 
 func TestWorkspaceMCPTool_SanitizesModelNameKeepsRoutingName(t *testing.T) {

--- a/coderd/x/chatd/context_prompt.go
+++ b/coderd/x/chatd/context_prompt.go
@@ -109,11 +109,12 @@ func workspaceMCPToolInfosFromResources(resources []database.ChatContextResource
 			if name == "" {
 				continue
 			}
-			properties, required := splitMCPInputSchema(t.GetInputSchema())
+			full, properties, required := splitMCPInputSchema(t.GetInputSchema())
 			out = append(out, workspacesdk.MCPToolInfo{
 				ServerName:  server,
 				Name:        server + mcpToolNameSeparator + name,
 				Description: t.GetDescription(),
+				InputSchema: full,
 				Schema:      properties,
 				Required:    required,
 			})
@@ -122,14 +123,19 @@ func workspaceMCPToolInfosFromResources(resources []database.ChatContextResource
 	return out
 }
 
-// splitMCPInputSchema splits a pushed JSON Schema object into the properties
-// map and required list the workspace MCP tool wrapper expects. A nil schema,
-// or one missing these keys, yields nil for the absent part.
-func splitMCPInputSchema(schema *structpb.Struct) (properties map[string]any, required []string) {
+// splitMCPInputSchema returns a pushed JSON Schema object whole, plus the
+// derived properties map and required list the workspace MCP tool wrapper
+// expects. Old agents push a schema already reduced to type, properties, and
+// required, which is itself a valid schema, so the full map works for both
+// payload generations. A nil or empty schema yields nil for every part.
+func splitMCPInputSchema(schema *structpb.Struct) (full map[string]any, properties map[string]any, required []string) {
 	if schema == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	m := schema.AsMap()
+	if len(m) == 0 {
+		return nil, nil, nil
+	}
 	if props, ok := m["properties"].(map[string]any); ok {
 		properties = props
 	}
@@ -140,7 +146,7 @@ func splitMCPInputSchema(schema *structpb.Struct) (properties map[string]any, re
 			}
 		}
 	}
-	return properties, required
+	return m, properties, required
 }
 
 // decodeInstructionContent decodes an instruction-file resource body and

--- a/coderd/x/chatd/context_prompt_internal_test.go
+++ b/coderd/x/chatd/context_prompt_internal_test.go
@@ -681,9 +681,13 @@ func TestWorkspaceMCPToolInfosFromResources(t *testing.T) {
 			"type": "object",
 			"properties": map[string]any{
 				"title": map[string]any{"type": "string"},
-				"body":  map[string]any{"type": "string"},
+				"body":  map[string]any{"$ref": "#/$defs/Body"},
 			},
-			"required": []any{"title"},
+			"required":             []any{"title"},
+			"additionalProperties": false,
+			"$defs": map[string]any{
+				"Body": map[string]any{"type": "string"},
+			},
 		})
 		resources := []database.ChatContextResource{
 			// Skipped: a config resource carries no tools.
@@ -719,6 +723,12 @@ func TestWorkspaceMCPToolInfosFromResources(t *testing.T) {
 		require.Contains(t, infos[0].Schema, "title")
 		require.Contains(t, infos[0].Schema, "body")
 		require.NotContains(t, infos[0].Schema, "required")
+		// InputSchema carries the pushed schema whole, including keys the
+		// flattened pair cannot represent.
+		require.Equal(t, false, infos[0].InputSchema["additionalProperties"])
+		require.Contains(t, infos[0].InputSchema, "$defs")
+		require.Contains(t, infos[0].InputSchema, "properties")
+		require.Equal(t, []any{"title"}, infos[0].InputSchema["required"])
 	})
 
 	t.Run("FallsBackToSourceWhenServerNameEmpty", func(t *testing.T) {

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -1229,7 +1229,12 @@ type MCPToolInfo struct {
 	Name string `json:"name"`
 	// Description is the tool's human-readable description.
 	Description string `json:"description"`
-	// Schema is the JSON Schema for the tool's input parameters.
+	// InputSchema is the tool's complete JSON Schema object as pushed
+	// by the agent. When non-nil it wins over Schema and Required,
+	// which carry only the flattened properties map and required list.
+	InputSchema map[string]any `json:"input_schema,omitempty"`
+	// Schema is the JSON Schema properties object for the tool's input
+	// parameters.
 	Schema map[string]any `json:"schema"`
 	// Required lists required parameter names.
 	Required []string `json:"required"`


### PR DESCRIPTION
The workspace MCP path lost tool schema fidelity twice: the workspace agent kept only `type`, `properties`, and `required` before proto encoding (`agentmcp.toolInputSchemaMap`), and coderd re-split the pushed proto `Struct` into a properties map plus required list for the tool wrapper (`splitMCPInputSchema`). Keys such as `$defs`, `$ref`, `additionalProperties`, and combinators never reached the provider.

- The agent now passes the schema map through whole; the proto `google.protobuf.Struct` already carries arbitrary JSON objects, so no proto change is needed.
- `workspacesdk.MCPToolInfo` gains an `InputSchema` field for the complete schema. The flattened `Schema`/`Required` pair stays populated with today's semantics for existing consumers.
- `WorkspaceMCPTool` stores the full schema and exposes it through `FullInputSchema()`, so the chatloop wire path from the previous PR prefers it.

Old agents push the reduced `{type, properties, required}` schema, which is itself a valid JSON Schema, so the same code path serves both payload generations without version detection. Payloads with no schema at all fall back to reconstruction from `Info()`.

## Stack Context

Top of a stack that fixes MCP tool input-schema loss end to end: below, the `properties: null` fix and the chatd-side full-schema passthrough for external MCP and dynamic tools.

> 🤖 Mux authored this PR on Mike's behalf.

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high -->
