### PR TITLE
fix(agent/agentscripts): report script log setup failures in the workspace dashboard

### DIFF
--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -271,10 +271,6 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 	}
 
 	scriptDataDir := filepath.Join(r.DataDir(), script.LogSourceID.String())
-	err := r.Filesystem.MkdirAll(scriptDataDir, 0o700)
-	if err != nil {
-		return xerrors.Errorf("%s script: create script temp dir: %w", scriptDataDir, err)
-	}
 
 	logger := r.Logger.With(
 		slog.F("log_source_id", script.LogSourceID),
@@ -282,45 +278,6 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 		slog.F("script_data_dir", scriptDataDir),
 	)
 	logger.Info(ctx, "running agent script", slog.F("script", script.Script))
-
-	logDir := filepath.Dir(logPath)
-	if err = r.Filesystem.MkdirAll(logDir, 0o700); err != nil {
-		return xerrors.Errorf("create script log file directory %q: %w", logDir, err)
-	}
-
-	fileWriter, err := r.Filesystem.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return xerrors.Errorf("open %s script log file: %w", logPath, err)
-	}
-	defer func() {
-		err := fileWriter.Close()
-		if err != nil {
-			logger.Warn(ctx, fmt.Sprintf("close %s script log file", logPath), slog.Error(err))
-		}
-	}()
-
-	var cmd *exec.Cmd
-	cmdCtx := ctx
-	if script.Timeout > 0 {
-		var ctxCancel context.CancelFunc
-		cmdCtx, ctxCancel = context.WithTimeout(ctx, script.Timeout)
-		defer ctxCancel()
-	}
-	cmdPty, err := r.SSHServer.CreateCommand(cmdCtx, script.Script, nil, nil)
-	if err != nil {
-		return xerrors.Errorf("%s script: create command: %w", logPath, err)
-	}
-	cmd = cmdPty.AsExec()
-	cmd.SysProcAttr = cmdSysProcAttr()
-	cmd.WaitDelay = 10 * time.Second
-	cmd.Cancel = cmdCancel(ctx, logger, cmd)
-
-	// Expose env vars that can be used in the script for storing data
-	// and binaries. In the future, we may want to expose more env vars
-	// for the script to use, like CODER_SCRIPT_DATA_DIR for persistent
-	// storage.
-	cmd.Env = append(cmd.Env, "CODER_SCRIPT_DATA_DIR="+scriptDataDir)
-	cmd.Env = append(cmd.Env, "CODER_SCRIPT_BIN_DIR="+r.ScriptBinDir())
 
 	scriptLogger := r.GetScriptLogger(script.LogSourceID)
 	// If ctx is canceled here (or in a writer below), we may be
@@ -333,13 +290,9 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 		}
 	}()
 
-	infoW := agentsdk.LogsWriter(ctx, scriptLogger.Send, script.LogSourceID, codersdk.LogLevelInfo)
-	defer infoW.Close()
-	errW := agentsdk.LogsWriter(ctx, scriptLogger.Send, script.LogSourceID, codersdk.LogLevelError)
-	defer errW.Close()
-	cmd.Stdout = io.MultiWriter(fileWriter, infoW)
-	cmd.Stderr = io.MultiWriter(fileWriter, errW)
-
+	// Report the completion timing even if script log setup fails below, so
+	// the failure is visible in the workspace dashboard.
+	var err error
 	start := dbtime.Now()
 	defer func() {
 		end := dbtime.Now()
@@ -411,6 +364,62 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 		}
 	}()
 
+	if err = r.Filesystem.MkdirAll(scriptDataDir, 0o700); err != nil {
+		err = xerrors.Errorf("%s script: create script temp dir: %w", scriptDataDir, err)
+		sendSetupError(ctx, logger, scriptLogger, err)
+		return err
+	}
+
+	logDir := filepath.Dir(logPath)
+	if err = r.Filesystem.MkdirAll(logDir, 0o700); err != nil {
+		err = xerrors.Errorf("create script log file directory %q: %w", logDir, err)
+		sendSetupError(ctx, logger, scriptLogger, err)
+		return err
+	}
+
+	fileWriter, err := r.Filesystem.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		err = xerrors.Errorf("open %s script log file: %w", logPath, err)
+		sendSetupError(ctx, logger, scriptLogger, err)
+		return err
+	}
+	defer func() {
+		err := fileWriter.Close()
+		if err != nil {
+			logger.Warn(ctx, fmt.Sprintf("close %s script log file", logPath), slog.Error(err))
+		}
+	}()
+
+	var cmd *exec.Cmd
+	cmdCtx := ctx
+	if script.Timeout > 0 {
+		var ctxCancel context.CancelFunc
+		cmdCtx, ctxCancel = context.WithTimeout(ctx, script.Timeout)
+		defer ctxCancel()
+	}
+	cmdPty, err := r.SSHServer.CreateCommand(cmdCtx, script.Script, nil, nil)
+	if err != nil {
+		return xerrors.Errorf("%s script: create command: %w", logPath, err)
+	}
+	cmd = cmdPty.AsExec()
+	cmd.SysProcAttr = cmdSysProcAttr()
+	cmd.WaitDelay = 10 * time.Second
+	cmd.Cancel = cmdCancel(ctx, logger, cmd)
+
+	// Expose env vars that can be used in the script for storing data
+	// and binaries. In the future, we may want to expose more env vars
+	// for the script to use, like CODER_SCRIPT_DATA_DIR for persistent
+	// storage.
+	cmd.Env = append(cmd.Env, "CODER_SCRIPT_DATA_DIR="+scriptDataDir)
+	cmd.Env = append(cmd.Env, "CODER_SCRIPT_BIN_DIR="+r.ScriptBinDir())
+
+	infoW := agentsdk.LogsWriter(ctx, scriptLogger.Send, script.LogSourceID, codersdk.LogLevelInfo)
+	defer infoW.Close()
+	errW := agentsdk.LogsWriter(ctx, scriptLogger.Send, script.LogSourceID, codersdk.LogLevelError)
+	defer errW.Close()
+	cmd.Stdout = io.MultiWriter(fileWriter, infoW)
+	cmd.Stderr = io.MultiWriter(fileWriter, errW)
+
 	err = cmd.Start()
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -455,6 +464,18 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 		err = ErrTimeout
 	}
 	return err
+}
+
+// sendSetupError writes a script setup failure to the script's log stream so
+// the failure is visible in the workspace dashboard.
+func sendSetupError(ctx context.Context, logger slog.Logger, scriptLogger ScriptLogger, err error) {
+	if err := scriptLogger.Send(ctx, agentsdk.Log{
+		CreatedAt: dbtime.Now(),
+		Level:     codersdk.LogLevelError,
+		Output:    fmt.Sprintf("failed to set up script logging: %v", err),
+	}); err != nil {
+		logger.Warn(ctx, "send script setup error log", slog.Error(err))
+	}
 }
 
 func (r *Runner) Close() error {

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -2,6 +2,7 @@ package agentscripts_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentscripts"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
@@ -89,6 +91,64 @@ func TestExecuteCreatesMissingLogDir(t *testing.T) {
 	exists, err := afero.Exists(fs, logPath)
 	require.NoError(t, err)
 	require.True(t, exists, "expected log file to be created at %s", logPath)
+}
+
+func TestExecuteLogFileSetupFailure(t *testing.T) {
+	t.Parallel()
+
+	// A log path whose parent directory cannot be created must still surface
+	// the failure in the workspace dashboard.
+	fs := afero.NewOsFs()
+	logger := testutil.Logger(t)
+	s, err := agentssh.NewServer(context.Background(), logger, prometheus.NewRegistry(), fs, agentexec.DefaultExecer, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+
+	fLogger := newFakeScriptLogger()
+	runner := agentscripts.New(agentscripts.Options{
+		LogDir:      t.TempDir(),
+		DataDirBase: t.TempDir(),
+		Logger:      logger,
+		SSHServer:   s,
+		Filesystem:  fs,
+		GetScriptLogger: func(uuid.UUID) agentscripts.ScriptLogger {
+			return fLogger
+		},
+	})
+	defer runner.Close()
+
+	// An ancestor of the log path is a regular file, so MkdirAll fails.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	logPath := filepath.Join(blocker, "sub", "install.log")
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	aAPI := agenttest.NewFakeAgentAPI(t, logger, nil, nil)
+	err = runner.Init([]codersdk.WorkspaceAgentScript{{
+		LogSourceID: uuid.New(),
+		LogPath:     logPath,
+		Script:      "echo hello",
+	}}, aAPI.ScriptCompleted)
+	require.NoError(t, err)
+
+	err = runner.Execute(ctx, agentscripts.ExecuteAllScripts)
+	require.Error(t, err)
+
+	// The failure is written to the script's log stream.
+	log := testutil.TryReceive(ctx, t, fLogger.logs)
+	require.Equal(t, codersdk.LogLevelError, log.Level)
+	require.Contains(t, log.Output, "failed to set up script logging")
+
+	// Close joins the goroutine that records the completion timing.
+	require.NoError(t, runner.Close())
+
+	// The failure is recorded as an exit failure, not silently dropped.
+	timings := aAPI.GetTimings()
+	require.Len(t, timings, 1)
+	require.NotZero(t, timings[0].ExitCode)
+	require.Equal(t, proto.Timing_EXIT_FAILURE, timings[0].Status)
 }
 
 func TestEnv(t *testing.T) {


### PR DESCRIPTION
Fixes #28217

## What

When a `coder_script` fails to set up its log file (the script temp dir, log directory, or log file itself cannot be created), the failure is now surfaced in the workspace dashboard instead of being silently dropped.

## Why

`Runner.run()` previously returned on each log-setup error before the script logger and the completion reporter were registered. A setup failure therefore produced no log stream and no recorded timing, so the dashboard showed the script as if it had never run, with no error to diagnose.

## How

Reordered `run()` so the script logger (with its flush defer) and the completion reporter (which records `exit_code` and `status`) are wired up before any filesystem operation. Each setup failure path now sends an error-level line (`failed to set up script logging: ...`) to the script's log stream before returning. The reporter records the failure as an exit failure (`EXIT_FAILURE`, exit code 255 unless the underlying error carries its own code).

## Test

New `TestExecuteLogFileSetupFailure` regression test: a log path whose ancestor is a regular file forces `MkdirAll` to fail, then asserts the failure is visible in the log stream and recorded as an exit failure in the timing. Fails on the unfixed code (no log line, no timing), passes after.

## Notes

The local pre-commit hook (`make pre-commit`) could not be run on the author's Windows environment: it requires the full coder dev toolchain (GNU make, golangci-lint, protoc for codegen, typos) which is not installed, and the codegen toolchain is not feasible to bootstrap there. Equivalent local checks were run instead: `gofmt -l` clean, `go vet ./agent/agentscripts/` clean, and the full package test suite passes (`go test ./agent/agentscripts/ -count=1`). CI re-verifies everything on this draft PR.

## Checklist

- [x] Tests pass locally (package suite green)
- [x] `gofmt` and `go vet` clean
- [ ] `make pre-commit` (not runnable on Windows, see Notes)
- [x] Draft PR, push without force