### PR TITLE
chore: refresh README links, quickstart, support sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,7 @@
 
 ## Quickstart
 
-The most convenient way to try Coder is to install it on your local machine and experiment with provisioning cloud development environments using Docker (works on Linux, macOS, and Windows).
-
-```shell
-# First, install Coder
-curl -L https://coder.com/install.sh | sh
-
-# Start the Coder server (caches data in ~/.cache/coder)
-coder server
-
-# Navigate to http://localhost:3000 to create your initial user,
-# create a Docker template and provision a workspace
-```
-
-## Install
-
-The easiest way to install Coder is to use the
+The easiest way to install Coder is the
 [install script](https://github.com/coder/coder/blob/main/install.sh) for Linux
 and macOS. For Windows, use the latest `..._installer.exe` file from GitHub
 Releases.
@@ -74,9 +59,19 @@ Releases.
 curl -L https://coder.com/install.sh | sh
 ```
 
-You can run the install script with `--dry-run` to see the commands that will be used to install without executing them. Run the install script with `--help` for additional flags.
+Run the script with `--dry-run` to preview the commands without executing them, or `--help` for additional flags. See the [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
 
-Once installed, you can start a production deployment with a single command:
+To try Coder locally (works on Linux, macOS, and Windows), start the server and provision a workspace using Docker:
+
+```shell
+# Start the Coder server (caches data in ~/.cache/coder)
+coder server
+
+# Navigate to http://localhost:3000 to create your initial user,
+# create a Docker template and provision a workspace
+```
+
+Once you're ready for a production deployment:
 
 ```shell
 # Automatically sets up an external access URL on *.try.coder.app
@@ -86,7 +81,7 @@ coder server
 coder server --postgres-url <url> --access-url <url>
 ```
 
-Use `coder --help` to get a list of flags and environment variables. See the [install guides](https://coder.com/docs/install) for a complete tutorial.
+Use `coder --help` to get a list of flags and environment variables.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 
 ## Quickstart
 
+> See our [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
+
 Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/latest) on Windows:
 
 ```shell
@@ -68,7 +70,7 @@ For a production deployment, add a PostgreSQL database (version 13 or higher) an
 coder server --postgres-url <url> --access-url <url>
 ```
 
-Without these flags, Coder uses a built-in database and sets up a `*.try.coder.app` access URL for evaluation. Use `coder --help` for the full list of flags and environment variables, or see the [install guides](https://coder.com/docs/install) for other install methods and a complete tutorial.
+Without these flags, Coder uses a built-in database and sets up a `*.try.coder.app` access URL for evaluation. Use `coder --help` for the full list of flags and environment variables.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <br>
   <br>
 
-[Quickstart](#quickstart) | [Docs](https://coder.com/docs) | [Why Coder](https://coder.com/why) | [Premium](https://coder.com/pricing#compare-plans)
+[Quickstart](#quickstart) | [Docs](https://coder.com/docs) | [Why Coder](https://coder.com/docs/about#why-coder) | [Premium](https://coder.com/pricing#compare-plans)
 
 [![discord](https://img.shields.io/discord/747933592273027093?label=discord)](https://cdr.co/discord-Y6fMxGdNRg)
 [![release](https://img.shields.io/github/v/release/coder/coder)](https://github.com/coder/coder/releases/latest)
@@ -75,8 +75,6 @@ curl -L https://coder.com/install.sh | sh
 ```
 
 You can run the install script with `--dry-run` to see the commands that will be used to install without executing them. Run the install script with `--help` for additional flags.
-
-> See [install](https://coder.com/docs/install) for additional methods.
 
 Once installed, you can start a production deployment with a single command:
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 - [**Coder Registry**](https://registry.coder.com): Templates, modules, and integrations for common development environments
 - [**VS Code Extension**](https://marketplace.visualstudio.com/items?itemName=coder.coder-remote): Open any Coder workspace in VS Code with a single click
 - [**JetBrains Toolbox Plugin**](https://plugins.jetbrains.com/plugin/26968-coder): Open any Coder workspace from JetBrains Toolbox with a single click
-- [**JetBrains Gateway Plugin**](https://plugins.jetbrains.com/plugin/19620-coder): Open any Coder workspace in JetBrains Gateway with a single click
-- [**Dev Containers**](https://github.com/coder/envbuilder): Build development environments using `devcontainer.json` on Docker, Kubernetes, and OpenShift
+- [**Dev Containers**](https://coder.com/docs/user-guides/devcontainers): Build development environments using `devcontainer.json` on Docker, Kubernetes, and OpenShift
 - [**Kubernetes Log Stream**](https://github.com/coder/coder-logstream-kube): Stream Kubernetes Pod events to the Coder startup logs
 - [**Self-Hosted VS Code Extension Marketplace**](https://github.com/coder/code-marketplace): A private extension marketplace that works in restricted or airgapped networks integrating with [code-server](https://github.com/coder/code-server).
 - [**GitHub Actions**](https://github.com/marketplace/actions/setup-coder): An action to set up the Coder CLI in GitHub workflows

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 ## Quickstart
 
-Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or the latest `..._installer.exe` from GitHub Releases on Windows:
+Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/latest) on Windows:
 
 ```shell
 curl -L https://coder.com/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Browse the [documentation](https://coder.com/docs) or visit a specific section b
 
 For community support, showcasing what you built, and feedback on in-progress features, join our [Discord](https://discord.gg/coder) or [GitHub Discussions](https://github.com/coder/coder/discussions).
 
-Need dedicated support? Our Premium license includes it. See [coder.com/pricing](https://coder.com/pricing) for plans.
+Dedicated support is included in Coder Premium. See [coder.com/pricing](https://coder.com/pricing).
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 
 ### Community
 
-- [**Coder Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
+- [**Coder Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community, get support, and hear about new product updates first
 - [**Community Templates**](https://registry.coder.com/templates): Community-contributed workspace templates in the Coder Registry
 - [**Community Modules**](https://registry.coder.com/modules): Community-contributed modules to extend Coder templates
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ New integrations are always in progress. Open an issue to request one. Contribut
 
 - [**Community Templates**](https://registry.coder.com/templates): Community-contributed workspace templates in the Coder Registry
 - [**Community Modules**](https://registry.coder.com/modules): Community-contributed modules to extend Coder templates
-- [**Provision Coder with Terraform**](https://github.com/ElliotG/coder-oss-tf): Provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS, IBMCloud K8s, OVHCloud K8s, and Scaleway K8s Kapsule with Terraform
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
 - [**Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
 [![discord](https://img.shields.io/discord/747933592273027093?label=discord)](https://cdr.co/discord-Y6fMxGdNRg)
 [![release](https://img.shields.io/github/v/release/coder/coder)](https://github.com/coder/coder/releases/latest)
 [![godoc](https://pkg.go.dev/badge/github.com/coder/coder.svg)](https://pkg.go.dev/github.com/coder/coder)
-[![Go Report Card](https://goreportcard.com/badge/github.com/coder/coder/v2)](https://goreportcard.com/report/github.com/coder/coder/v2)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9511/badge)](https://www.bestpractices.dev/projects/9511)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/coder/coder/badge)](https://scorecard.dev/viewer/?uri=github.com%2Fcoder%2Fcoder)
 [![license](https://img.shields.io/github/license/coder/coder)](./LICENSE)
@@ -52,7 +51,7 @@
 
 > See our [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
 
-Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/) on Windows:
+Try Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/) on Windows:
 
 ```shell
 curl -L https://coder.com/install.sh | sh
@@ -64,7 +63,7 @@ Start the server and open [http://localhost:3000](http://localhost:3000) to crea
 coder server
 ```
 
-For a production deployment, add a PostgreSQL database (version 13 or higher) and an external access URL:
+For a production deployment, add a PostgreSQL database (version 13 or higher) and an external access URL, and see our [validated architectures](https://coder.com/docs/admin/infrastructure/validated-architectures) for sizing and infrastructure guidance:
 
 ```shell
 coder server --postgres-url <url> --access-url <url>
@@ -79,7 +78,7 @@ Browse the [documentation](https://coder.com/docs) or visit a specific section b
 - [**Workspaces**](https://coder.com/docs/user-guides/workspace-management): Workspaces contain the IDEs, dependencies, and configuration information needed for software development
 - [**Templates**](https://coder.com/docs/admin/templates): Templates are written in Terraform and describe the infrastructure for workspaces
 - [**Coder Agents**](https://coder.com/docs/ai-coder/agents): Delegate coding work to AI agents running on your self-hosted infrastructure
-- [**AI Gateway**](https://coder.com/docs/ai-coder/ai-gateway): Centralize authentication, auditing, and MCP administration for AI tooling
+- [**AI Gateway**](https://coder.com/docs/ai-coder/ai-gateway): Centralize authentication, auditing, and cost controls for AI tooling
 - [**Administration**](https://coder.com/docs/admin): Learn how to operate Coder
 - [**Premium**](https://coder.com/pricing#compare-plans): Learn about paid features built for large teams
 - [**IDEs**](https://coder.com/docs/user-guides/workspace-access): Connect your existing editor to a workspace
@@ -100,7 +99,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 
 - [**Coder Registry**](https://registry.coder.com): Templates, modules, and integrations for common development environments
 - [**Coding Agents**](https://registry.coder.com/modules?search=tag%3Aagent): Run agents like Claude Code, Codex, and OpenCode isolated in Coder workspaces
-- [**Terraform Provider**](https://github.com/coder/terraform-provider-coderd): Declaratively manage your Coder deployment configuration as code
+- [**coderd Terraform Provider**](https://github.com/coder/terraform-provider-coderd): Declaratively manage your Coder deployment configuration as code
 - [**VS Code Extension**](https://marketplace.visualstudio.com/items?itemName=coder.coder-remote): Open any Coder workspace in VS Code with a single click
 - [**JetBrains Toolbox Plugin**](https://plugins.jetbrains.com/plugin/26968-coder): Open any Coder workspace from JetBrains Toolbox with a single click
 - [**Dev Containers**](https://coder.com/docs/user-guides/devcontainers): Build development environments using `devcontainer.json` on Docker, Kubernetes, and OpenShift
@@ -111,8 +110,8 @@ New integrations are always in progress. Open an issue to request one. Contribut
 ### Community
 
 - [**Coder Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community, get support, and hear about new product updates first
-- [**Community Templates**](https://registry.coder.com/templates): Community-contributed workspace templates in the Coder Registry
-- [**Community Modules**](https://registry.coder.com/modules): Community-contributed modules to extend Coder templates
+- [**Community Templates**](https://registry.coder.com/templates?search=status%3Acommunity): Community-contributed workspace templates in the Coder Registry
+- [**Community Modules**](https://registry.coder.com/modules?search=status%3Acommunity): Community-contributed modules to extend Coder templates
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
 - [**Coder Agents Chat Action**](https://github.com/coder/agents-chat-action): A GitHub Action that starts a Coder Agents chat against a GitHub issue or pull request
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 
 ### Community
 
-- [**Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
+- [**Coder Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
 - [**Community Templates**](https://registry.coder.com/templates): Community-contributed workspace templates in the Coder Registry
 - [**Community Modules**](https://registry.coder.com/modules): Community-contributed modules to extend Coder templates
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 > See our [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
 
-Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/latest) on Windows:
+Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/) on Windows:
 
 ```shell
 curl -L https://coder.com/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ## Quickstart
 
-> See our [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
+> Check out our [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
 
 Try Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or grab the latest binary or installer from [GitHub Releases](https://github.com/coder/coder/releases/) on Windows:
 
@@ -63,7 +63,7 @@ Start the server and open [http://localhost:3000](http://localhost:3000) to crea
 coder server
 ```
 
-For a production deployment, add a PostgreSQL database (version 13 or higher) and an external access URL, and see our [validated architectures](https://coder.com/docs/admin/infrastructure/validated-architectures) for sizing and infrastructure guidance:
+For a production deployment, add a PostgreSQL database (version 13 or later) and an external access URL, and see our [validated architectures](https://coder.com/docs/admin/infrastructure/validated-architectures) for sizing and infrastructure guidance:
 
 ```shell
 coder server --postgres-url <url> --access-url <url>
@@ -89,7 +89,7 @@ Browse the [documentation](https://coder.com/docs) or visit a specific section b
 
 For community support, showcasing what you built, and feedback on in-progress features, join our [Discord](https://discord.gg/coder) or [GitHub Discussions](https://github.com/coder/coder/discussions).
 
-Dedicated support is included in Coder Premium. See [coder.com/pricing](https://coder.com/pricing).
+Dedicated support is included in Coder Premium. For more information, visit [coder.com/pricing](https://coder.com/pricing).
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 - [**Community Templates**](https://registry.coder.com/templates): Community-contributed workspace templates in the Coder Registry
 - [**Community Modules**](https://registry.coder.com/modules): Community-contributed modules to extend Coder templates
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
+- [**Coder Agents Chat Action**](https://github.com/coder/agents-chat-action): A GitHub Action that starts a Coder Agents chat against a GitHub issue or pull request
 - [**Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 [![discord](https://img.shields.io/discord/747933592273027093?label=discord)](https://cdr.co/discord-Y6fMxGdNRg)
 [![release](https://img.shields.io/github/v/release/coder/coder)](https://github.com/coder/coder/releases/latest)
 [![godoc](https://pkg.go.dev/badge/github.com/coder/coder.svg)](https://pkg.go.dev/github.com/coder/coder)
+[![Go Report Card](https://goreportcard.com/badge/github.com/coder/coder/v2)](https://goreportcard.com/report/github.com/coder/coder/v2)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9511/badge)](https://www.bestpractices.dev/projects/9511)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/coder/coder/badge)](https://scorecard.dev/viewer/?uri=github.com%2Fcoder%2Fcoder)
 [![license](https://img.shields.io/github/license/coder/coder)](./LICENSE)
@@ -115,6 +116,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 
 - [**Coder Registry**](https://registry.coder.com): Templates, modules, and integrations for common development environments
 - [**Coding Agents**](https://registry.coder.com/modules?search=tag%3Aagent): Run agents like Claude Code, Codex, and OpenCode isolated in Coder workspaces
+- [**Terraform Provider**](https://github.com/coder/terraform-provider-coderd): Declaratively manage your Coder deployment configuration as code
 - [**VS Code Extension**](https://marketplace.visualstudio.com/items?itemName=coder.coder-remote): Open any Coder workspace in VS Code with a single click
 - [**JetBrains Toolbox Plugin**](https://plugins.jetbrains.com/plugin/26968-coder): Open any Coder workspace from JetBrains Toolbox with a single click
 - [**Dev Containers**](https://coder.com/docs/user-guides/devcontainers): Build development environments using `devcontainer.json` on Docker, Kubernetes, and OpenShift

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ New integrations are always in progress. Open an issue to request one. Contribut
 ### Official
 
 - [**Coder Registry**](https://registry.coder.com): Templates, modules, and integrations for common development environments
+- [**Coding Agents**](https://registry.coder.com/modules?search=tag%3Aagent): Run agents like Claude Code, Codex, and OpenCode isolated in Coder workspaces
 - [**VS Code Extension**](https://marketplace.visualstudio.com/items?itemName=coder.coder-remote): Open any Coder workspace in VS Code with a single click
 - [**JetBrains Toolbox Plugin**](https://plugins.jetbrains.com/plugin/26968-coder): Open any Coder workspace from JetBrains Toolbox with a single click
 - [**Dev Containers**](https://coder.com/docs/user-guides/devcontainers): Build development environments using `devcontainer.json` on Docker, Kubernetes, and OpenShift

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Browse the [documentation](https://coder.com/docs) or visit a specific section b
 - [**Workspaces**](https://coder.com/docs/user-guides/workspace-management): Workspaces contain the IDEs, dependencies, and configuration information needed for software development
 - [**Templates**](https://coder.com/docs/admin/templates): Templates are written in Terraform and describe the infrastructure for workspaces
 - [**Coder Agents**](https://coder.com/docs/ai-coder/agents): Delegate coding work to AI agents running on your self-hosted infrastructure
+- [**AI Gateway**](https://coder.com/docs/ai-coder/ai-gateway): Centralize authentication, auditing, and MCP administration for AI tooling
 - [**Administration**](https://coder.com/docs/admin): Learn how to operate Coder
 - [**Premium**](https://coder.com/pricing#compare-plans): Learn about paid features built for large teams
 - [**IDEs**](https://coder.com/docs/user-guides/workspace-access): Connect your existing editor to a workspace

--- a/README.md
+++ b/README.md
@@ -50,38 +50,25 @@
 
 ## Quickstart
 
-The easiest way to install Coder is the
-[install script](https://github.com/coder/coder/blob/main/install.sh) for Linux
-and macOS. For Windows, use the latest `..._installer.exe` file from GitHub
-Releases.
+Install Coder with the [install script](https://github.com/coder/coder/blob/main/install.sh) on Linux and macOS, or the latest `..._installer.exe` from GitHub Releases on Windows:
 
 ```shell
 curl -L https://coder.com/install.sh | sh
 ```
 
-Run the script with `--dry-run` to preview the commands without executing them, or `--help` for additional flags. See the [install guides](https://coder.com/docs/install) for other methods and a complete tutorial.
-
-To try Coder locally (works on Linux, macOS, and Windows), start the server and provision a workspace using Docker:
+Start the server and open [http://localhost:3000](http://localhost:3000) to create your initial user, create a Docker template, and provision your first workspace:
 
 ```shell
-# Start the Coder server (caches data in ~/.cache/coder)
 coder server
-
-# Navigate to http://localhost:3000 to create your initial user,
-# create a Docker template and provision a workspace
 ```
 
-Once you're ready for a production deployment:
+For a production deployment, add a PostgreSQL database (version 13 or higher) and an external access URL:
 
 ```shell
-# Automatically sets up an external access URL on *.try.coder.app
-coder server
-
-# Requires a PostgreSQL instance (version 13 or higher) and external access URL
 coder server --postgres-url <url> --access-url <url>
 ```
 
-Use `coder --help` to get a list of flags and environment variables.
+Without these flags, Coder uses a built-in database and sets up a `*.try.coder.app` access URL for evaluation. Use `coder --help` for the full list of flags and environment variables, or see the [install guides](https://coder.com/docs/install) for other install methods and a complete tutorial.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ Browse the [documentation](https://coder.com/docs) or visit a specific section b
 
 ## Support
 
-Feel free to [open an issue](https://github.com/coder/coder/issues/new) if you have questions, run into bugs, or have a feature request.
+[Open an issue](https://github.com/coder/coder/issues/new) for bugs and feature requests.
 
-[Join our Discord](https://discord.gg/coder) to provide feedback on in-progress features and chat with the community using Coder!
+For community support, showcasing what you built, and feedback on in-progress features, join our [Discord](https://discord.gg/coder) or [GitHub Discussions](https://github.com/coder/coder/discussions).
+
+Need dedicated support? Our Premium license includes it. See [coder.com/pricing](https://coder.com/pricing) for plans.
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ New integrations are always in progress. Open an issue to request one. Contribut
 
 ### Community
 
+- [**Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
 - [**Community Templates**](https://registry.coder.com/templates): Community-contributed workspace templates in the Coder Registry
 - [**Community Modules**](https://registry.coder.com/modules): Community-contributed modules to extend Coder templates
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
 - [**Coder Agents Chat Action**](https://github.com/coder/agents-chat-action): A GitHub Action that starts a Coder Agents chat against a GitHub issue or pull request
-- [**Discord**](https://cdr.co/discord-5hw2sjadGU): Chat with the community and provide feedback on in-progress features
 
 ## Contributing
 


### PR DESCRIPTION
Points README readers to the right places and cuts redundancy.

## Links

- Dev Containers now links to the docs, so people land on setup steps instead of the envbuilder repo
- Why Coder now links to the docs (https://coder.com/docs/about#why-coder) instead of the marketing page
- Removed JetBrains Gateway Plugin (retired)
- Removed the community Terraform provisioning link (outdated)
- Added AI Gateway to the docs section, since it's not discoverable otherwise
- Added Coding Agents, pointing to the registry modules for running Claude Code, Codex, and OpenCode isolated in Coder workspaces
- Added the Terraform provider (coderd) for declaratively managing Coder deployment configuration as code
- Added the Coder Agents Chat Action under community integrations
- Moved Coder Discord to the top of the community list and clarified it's where to get support and hear about new product updates first

## Structure

- Merged the redundant Quickstart and Install sections into one install → try locally → production flow, with a note up top pointing to the install guides. `coder server` now appears once per purpose instead of three times
- Windows install now says "latest binary or installer" and links to GitHub Releases
- Support section now spells out what goes where: issues for bugs and feature requests, Discord and GitHub Discussions for community support and showcasing what you built, and dedicated support included in Coder Premium (coder.com/pricing)

🤖 Generated with Coder Agents on behalf of @bpmct