### PR TITLE
feat(site): OAuth2 device, consent and public-client admin screens (early sketches)

### DIFF
--- a/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.stories.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.stories.tsx
@@ -32,6 +32,12 @@ type Story = StoryObj<typeof DeviceAuthConfirmView>;
 
 export const Default: Story = {};
 
+export const LongClientName: Story = {
+	args: {
+		clientName: "Internal platform provisioning service (staging)",
+	},
+};
+
 export const SingleScope: Story = {
 	args: {
 		clientName: "JetBrains Toolbox",

--- a/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.stories.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DeviceAuthConfirmView } from "./DeviceAuthConfirmView";
+
+const meta: Meta<typeof DeviceAuthConfirmView> = {
+	title: "pages/DeviceAuthPage/Confirm",
+	component: DeviceAuthConfirmView,
+	args: {
+		userCode: "WDJB-MJHT",
+		clientName: "Coder CLI",
+		username: "admin",
+		scopes: [
+			{
+				name: "workspace:read",
+				description: "View your workspaces and their status",
+			},
+			{
+				name: "workspace:ssh",
+				description: "Connect to your workspaces over SSH",
+			},
+			{
+				name: "template:read",
+				description: "View templates you have access to",
+			},
+		],
+		onApprove: () => {},
+		onDeny: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof DeviceAuthConfirmView>;
+
+export const Default: Story = {};
+
+export const SingleScope: Story = {
+	args: {
+		clientName: "JetBrains Toolbox",
+		scopes: [
+			{
+				name: "workspace:read",
+				description: "View your workspaces and their status",
+			},
+		],
+	},
+};
+
+export const Submitting: Story = {
+	args: {
+		isSubmitting: true,
+	},
+};

--- a/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.tsx
@@ -3,6 +3,11 @@ import type { FC } from "react";
 import { Button } from "#/components/Button/Button";
 import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
 import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { Welcome } from "#/components/Welcome/Welcome";
 import { DeviceCode } from "./DeviceCode";
 
@@ -28,6 +33,10 @@ type DeviceAuthConfirmViewProps = {
  * Step 2 of the device authorization flow: the authorization decision. Shows
  * the code back to the user (RFC 8628 §5.4), what is requesting access, and the
  * exact permissions being granted.
+ *
+ * Approve is the only `default` button; Deny is `outline`. Deny is not
+ * `destructive` — the user can start the flow again from their device, so
+ * nothing here is irreversible.
  */
 export const DeviceAuthConfirmView: FC<DeviceAuthConfirmViewProps> = ({
 	userCode,
@@ -41,82 +50,101 @@ export const DeviceAuthConfirmView: FC<DeviceAuthConfirmViewProps> = ({
 }) => {
 	return (
 		<SignInLayout>
-			<Welcome>Authorize {clientName}</Welcome>
+			<main className="w-full flex flex-col gap-6">
+				<div className="flex flex-col gap-2">
+					{/*
+					 * The heading stays fixed rather than interpolating the client
+					 * name: a long name wrapped to three lines and pushed the layout
+					 * past the viewport. The requester is named in the card below,
+					 * truncated with the full value recoverable.
+					 */}
+					<Welcome>Approve access</Welcome>
+					<p className="m-0 text-center text-sm text-content-secondary">
+						Confirm this matches the code shown on your device.
+					</p>
+				</div>
 
-			<p className="m-0 text-center text-sm text-content-secondary leading-normal">
-				Confirm this matches the code shown on your device.
-			</p>
+				<DeviceCode userCode={userCode} />
 
-			<DeviceCode userCode={userCode} className="mt-4" />
-
-			<div className="w-full mt-6 flex flex-col gap-4 rounded-lg border border-solid border-border p-4">
-				<div className="flex items-center gap-3">
-					<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-solid border-border bg-surface-secondary text-content-secondary">
-						{clientIcon ? (
-							<img
-								src={clientIcon}
-								alt=""
-								className="size-full object-contain p-1"
-							/>
-						) : (
-							<KeyRoundIcon className="size-icon-sm" />
-						)}
+				<div className="flex flex-col gap-4 rounded-md border border-solid border-border p-4">
+					<div className="flex items-center gap-3">
+						<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-solid border-border bg-surface-secondary">
+							{clientIcon ? (
+								<img
+									src={clientIcon}
+									alt=""
+									className="size-full object-contain p-1"
+								/>
+							) : (
+								<KeyRoundIcon
+									aria-hidden="true"
+									className="size-icon-sm text-content-secondary"
+								/>
+							)}
+						</div>
+						<div className="flex min-w-0 flex-col">
+							{/* Truncated rather than wrapped, with the full name recoverable. */}
+							<Tooltip>
+								{/*
+								 * Left as the default button trigger rather than `asChild` on a
+								 * span, so the truncated value is reachable by keyboard. The
+								 * repo's a11y lint rejects tabIndex on non-interactive elements.
+								 */}
+								<TooltipTrigger className="block w-full truncate border-none bg-transparent p-0 text-left text-sm text-content-primary">
+									{clientName}
+								</TooltipTrigger>
+								<TooltipContent>{clientName}</TooltipContent>
+							</Tooltip>
+							<span className="text-xs text-content-secondary">
+								is requesting access to your account
+							</span>
+						</div>
 					</div>
-					<div className="flex flex-col">
-						<span className="text-sm font-semibold text-content-primary">
-							{clientName}
-						</span>
+
+					<div className="flex flex-col gap-2">
 						<span className="text-xs text-content-secondary">
-							is requesting access to your account
+							Permissions requested
 						</span>
+						<ul className="m-0 flex list-none flex-col gap-2 p-0">
+							{scopes.map((scope) => (
+								<li key={scope.name} className="flex flex-col">
+									<span className="text-sm text-content-primary">
+										{scope.description}
+									</span>
+									{/* Mono because the scope is an identifier. */}
+									<span className="font-mono text-2xs text-content-secondary">
+										{scope.name}
+									</span>
+								</li>
+							))}
+						</ul>
 					</div>
 				</div>
+
+				<p className="m-0 text-center text-xs text-content-secondary">
+					Access is granted as {username}. If this didn't come from your device,
+					deny it.
+				</p>
 
 				<div className="flex flex-col gap-2">
-					<span className="text-xs font-medium uppercase tracking-wide text-content-secondary">
-						Permissions requested
-					</span>
-					<ul className="m-0 flex list-none flex-col gap-2 p-0">
-						{scopes.map((scope) => (
-							<li key={scope.name} className="flex flex-col">
-								<span className="text-sm text-content-primary">
-									{scope.description}
-								</span>
-								<span className="font-mono text-2xs text-content-secondary">
-									{scope.name}
-								</span>
-							</li>
-						))}
-					</ul>
+					<Button
+						className="w-full"
+						disabled={isSubmitting}
+						onClick={onApprove}
+					>
+						<Spinner loading={isSubmitting} />
+						{isSubmitting ? "Connecting…" : "Approve"}
+					</Button>
+					<Button
+						variant="outline"
+						className="w-full"
+						disabled={isSubmitting}
+						onClick={onDeny}
+					>
+						Deny
+					</Button>
 				</div>
-			</div>
-
-			<p className="m-0 mt-4 text-center text-xs text-content-secondary leading-normal">
-				Access is granted as{" "}
-				<strong className="font-medium text-content-primary">{username}</strong>
-				. If you didn't start this from your device, deny it.
-			</p>
-
-			<div className="w-full mt-4 flex flex-col gap-2">
-				<Button
-					size="lg"
-					className="w-full"
-					disabled={isSubmitting}
-					onClick={onApprove}
-				>
-					<Spinner loading={isSubmitting} />
-					Approve
-				</Button>
-				<Button
-					size="lg"
-					variant="outline"
-					className="w-full"
-					disabled={isSubmitting}
-					onClick={onDeny}
-				>
-					Deny
-				</Button>
-			</div>
+			</main>
 		</SignInLayout>
 	);
 };

--- a/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthConfirmView.tsx
@@ -1,0 +1,122 @@
+import { KeyRoundIcon } from "lucide-react";
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { Welcome } from "#/components/Welcome/Welcome";
+import { DeviceCode } from "./DeviceCode";
+
+export type DeviceAuthScope = {
+	/** The raw scope string, e.g. `workspace:read`. */
+	name: string;
+	/** Human readable description of what the scope allows. */
+	description: string;
+};
+
+type DeviceAuthConfirmViewProps = {
+	userCode: string;
+	clientName: string;
+	clientIcon?: string;
+	scopes: readonly DeviceAuthScope[];
+	username: string;
+	isSubmitting?: boolean;
+	onApprove: () => void;
+	onDeny: () => void;
+};
+
+/**
+ * Step 2 of the device authorization flow: the authorization decision. Shows
+ * the code back to the user (RFC 8628 §5.4), what is requesting access, and the
+ * exact permissions being granted.
+ */
+export const DeviceAuthConfirmView: FC<DeviceAuthConfirmViewProps> = ({
+	userCode,
+	clientName,
+	clientIcon,
+	scopes,
+	username,
+	isSubmitting = false,
+	onApprove,
+	onDeny,
+}) => {
+	return (
+		<SignInLayout>
+			<Welcome>Authorize {clientName}</Welcome>
+
+			<p className="m-0 text-center text-sm text-content-secondary leading-normal">
+				Confirm this matches the code shown on your device.
+			</p>
+
+			<DeviceCode userCode={userCode} className="mt-4" />
+
+			<div className="w-full mt-6 flex flex-col gap-4 rounded-lg border border-solid border-border p-4">
+				<div className="flex items-center gap-3">
+					<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-solid border-border bg-surface-secondary text-content-secondary">
+						{clientIcon ? (
+							<img
+								src={clientIcon}
+								alt=""
+								className="size-full object-contain p-1"
+							/>
+						) : (
+							<KeyRoundIcon className="size-icon-sm" />
+						)}
+					</div>
+					<div className="flex flex-col">
+						<span className="text-sm font-semibold text-content-primary">
+							{clientName}
+						</span>
+						<span className="text-xs text-content-secondary">
+							is requesting access to your account
+						</span>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-2">
+					<span className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+						Permissions requested
+					</span>
+					<ul className="m-0 flex list-none flex-col gap-2 p-0">
+						{scopes.map((scope) => (
+							<li key={scope.name} className="flex flex-col">
+								<span className="text-sm text-content-primary">
+									{scope.description}
+								</span>
+								<span className="font-mono text-2xs text-content-secondary">
+									{scope.name}
+								</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			</div>
+
+			<p className="m-0 mt-4 text-center text-xs text-content-secondary leading-normal">
+				Access is granted as{" "}
+				<strong className="font-medium text-content-primary">{username}</strong>
+				. If you didn't start this from your device, deny it.
+			</p>
+
+			<div className="w-full mt-4 flex flex-col gap-2">
+				<Button
+					size="lg"
+					className="w-full"
+					disabled={isSubmitting}
+					onClick={onApprove}
+				>
+					<Spinner loading={isSubmitting} />
+					Approve
+				</Button>
+				<Button
+					size="lg"
+					variant="outline"
+					className="w-full"
+					disabled={isSubmitting}
+					onClick={onDeny}
+				>
+					Deny
+				</Button>
+			</div>
+		</SignInLayout>
+	);
+};

--- a/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.stories.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.stories.tsx
@@ -27,10 +27,10 @@ export const Submitting: Story = {
 	},
 };
 
-export const InvalidCode: Story = {
+export const NotRecognized: Story = {
 	args: {
 		initialUserCode: "WDJB-MJHT",
-		error: "invalid",
+		error: "not-recognized",
 	},
 };
 
@@ -38,5 +38,17 @@ export const ExpiredCode: Story = {
 	args: {
 		initialUserCode: "WDJB-MJHT",
 		error: "expired",
+	},
+};
+
+/** Submitting an incomplete code: the button stays enabled and the field explains. */
+export const IncompleteCode: Story = {
+	args: {
+		initialUserCode: "WDJB",
+	},
+	play: async ({ canvas, userEvent }) => {
+		await userEvent.click(
+			await canvas.findByRole("button", { name: "Continue" }),
+		);
 	},
 };

--- a/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.stories.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DeviceAuthEnterCodeView } from "./DeviceAuthEnterCodeView";
+
+const meta: Meta<typeof DeviceAuthEnterCodeView> = {
+	title: "pages/DeviceAuthPage/EnterCode",
+	component: DeviceAuthEnterCodeView,
+	args: {
+		onSubmit: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof DeviceAuthEnterCodeView>;
+
+export const Empty: Story = {};
+
+export const Prefilled: Story = {
+	args: {
+		initialUserCode: "WDJB-MJHT",
+	},
+};
+
+export const Submitting: Story = {
+	args: {
+		initialUserCode: "WDJB-MJHT",
+		isSubmitting: true,
+	},
+};
+
+export const InvalidCode: Story = {
+	args: {
+		initialUserCode: "WDJB-MJHT",
+		error: "invalid",
+	},
+};
+
+export const ExpiredCode: Story = {
+	args: {
+		initialUserCode: "WDJB-MJHT",
+		error: "expired",
+	},
+};

--- a/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.tsx
@@ -7,7 +7,11 @@ import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Welcome } from "#/components/Welcome/Welcome";
 
-export type DeviceCodeError = "invalid" | "expired";
+/**
+ * Errors the server can return for a submitted code. Client-side format
+ * problems are handled inline as field validation instead.
+ */
+export type DeviceCodeError = "not-recognized" | "expired";
 
 type DeviceAuthEnterCodeViewProps = {
 	/** Pre-fills the field when the user arrives via `verification_uri_complete`. */
@@ -17,10 +21,12 @@ type DeviceAuthEnterCodeViewProps = {
 	onSubmit: (userCode: string) => void;
 };
 
+// Factual, non-accusatory: the code isn't recognized, the user isn't at fault.
 const errorMessages: Record<DeviceCodeError, string> = {
-	invalid: "That code isn't valid. Check for typos and try again.",
+	"not-recognized":
+		"This code isn't recognized. It may have already been used — start again on your device to get a new one.",
 	expired:
-		"That code has expired. Codes are only valid for a few minutes — start over on your device to get a new one.",
+		"This code has expired. Codes last a few minutes, so start again on your device to get a new one.",
 };
 
 /**
@@ -40,7 +46,8 @@ const formatUserCode = (value: string): string => {
 
 /**
  * Step 1 of the device authorization flow: the user types the code shown by
- * the CLI or app. Rendered as a standalone page with no dashboard chrome.
+ * the CLI or app. Standalone page, no navigation chrome — nothing else here is
+ * reachable until the flow completes.
  */
 export const DeviceAuthEnterCodeView: FC<DeviceAuthEnterCodeViewProps> = ({
 	initialUserCode = "",
@@ -49,66 +56,76 @@ export const DeviceAuthEnterCodeView: FC<DeviceAuthEnterCodeViewProps> = ({
 	onSubmit,
 }) => {
 	const [userCode, setUserCode] = useState(formatUserCode(initialUserCode));
-	const isComplete = userCode.replace("-", "").length === 8;
+	// Validation runs on submit, not on keystroke: the submit button stays
+	// enabled so the form can fail loudly and say what's missing.
+	const [formatError, setFormatError] = useState<string>();
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
-		if (isComplete && !isSubmitting) {
-			onSubmit(userCode);
+		if (isSubmitting) {
+			return;
 		}
+		if (userCode.replace("-", "").length !== 8) {
+			setFormatError("Enter all eight characters of the code, like WDJB-MJHT.");
+			return;
+		}
+		setFormatError(undefined);
+		onSubmit(userCode);
 	};
+
+	const fieldError = formatError;
 
 	return (
 		<SignInLayout>
-			<Welcome>Enter device code</Welcome>
-
-			<p className="m-0 text-center text-sm text-content-secondary leading-normal">
-				Enter the code shown in your terminal or app to connect it to your Coder
-				account.
-			</p>
-
-			<form className="w-full mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
-				{error && (
-					<Alert severity="error" prominent>
-						{errorMessages[error]}
-					</Alert>
-				)}
-
+			<main className="w-full flex flex-col gap-6">
 				<div className="flex flex-col gap-2">
-					<Label htmlFor="user-code">Device code</Label>
-					<Input
-						id="user-code"
-						name="user_code"
-						autoFocus
-						autoComplete="off"
-						spellCheck={false}
-						placeholder="XXXX-XXXX"
-						aria-invalid={error !== undefined}
-						aria-describedby="user-code-help"
-						value={userCode}
-						onChange={(event) =>
-							setUserCode(formatUserCode(event.target.value))
-						}
-						className="text-center font-mono text-base tracking-[0.2em] uppercase"
-					/>
-					<span
-						id="user-code-help"
-						className="text-xs text-content-secondary leading-normal"
-					>
-						Eight characters, letters and numbers only.
-					</span>
+					<Welcome>Connect your device</Welcome>
+					<p className="m-0 text-center text-sm text-content-secondary">
+						Enter the code shown in your terminal or app.
+					</p>
 				</div>
 
-				<Button
-					type="submit"
-					size="lg"
-					className="w-full"
-					disabled={!isComplete || isSubmitting}
+				{/* Alert carries the server-side condition; it is subtle by default. */}
+				{error && <Alert severity="error">{errorMessages[error]}</Alert>}
+
+				<form
+					className="flex flex-col gap-6"
+					onSubmit={handleSubmit}
+					noValidate
 				>
-					<Spinner loading={isSubmitting} />
-					Continue
-				</Button>
-			</form>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="user-code">Device code</Label>
+						<Input
+							id="user-code"
+							name="user_code"
+							autoFocus
+							autoComplete="off"
+							spellCheck={false}
+							placeholder="WDJB-MJHT"
+							value={userCode}
+							onChange={(event) =>
+								setUserCode(formatUserCode(event.target.value))
+							}
+							aria-invalid={fieldError ? true : undefined}
+							aria-describedby={fieldError ? "user-code-error" : undefined}
+							className="text-center font-mono"
+						/>
+						{fieldError && (
+							<p
+								id="user-code-error"
+								className="m-0 text-xs text-content-destructive"
+							>
+								{fieldError}
+							</p>
+						)}
+					</div>
+
+					<Button type="submit" className="w-full" disabled={isSubmitting}>
+						<Spinner loading={isSubmitting} />
+						{isSubmitting ? "Checking…" : "Continue"}
+					</Button>
+				</form>
+			</main>
 		</SignInLayout>
 	);
 };

--- a/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.tsx
@@ -101,21 +101,34 @@ export const DeviceAuthEnterCodeView: FC<DeviceAuthEnterCodeViewProps> = ({
 							autoFocus
 							autoComplete="off"
 							spellCheck={false}
-							placeholder="WDJB-MJHT"
+							/*
+							 * A mask, not a sample code: a realistic placeholder like
+							 * "WDJB-MJHT" reads as an already-filled field.
+							 */
+							placeholder="XXXX-XXXX"
 							value={userCode}
 							onChange={(event) =>
 								setUserCode(formatUserCode(event.target.value))
 							}
 							aria-invalid={fieldError ? true : undefined}
-							aria-describedby={fieldError ? "user-code-error" : undefined}
+							aria-describedby={
+								fieldError ? "user-code-error" : "user-code-hint"
+							}
 							className="text-center font-mono"
 						/>
-						{fieldError && (
+						{fieldError ? (
 							<p
 								id="user-code-error"
 								className="m-0 text-xs text-content-destructive"
 							>
 								{fieldError}
+							</p>
+						) : (
+							<p
+								id="user-code-hint"
+								className="m-0 text-xs text-content-secondary"
+							>
+								Eight characters, like WDJB-MJHT.
 							</p>
 						)}
 					</div>

--- a/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthEnterCodeView.tsx
@@ -1,0 +1,114 @@
+import { type FC, type FormEvent, useState } from "react";
+import { Alert } from "#/components/Alert/Alert";
+import { Button } from "#/components/Button/Button";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { Welcome } from "#/components/Welcome/Welcome";
+
+export type DeviceCodeError = "invalid" | "expired";
+
+type DeviceAuthEnterCodeViewProps = {
+	/** Pre-fills the field when the user arrives via `verification_uri_complete`. */
+	initialUserCode?: string;
+	isSubmitting?: boolean;
+	error?: DeviceCodeError;
+	onSubmit: (userCode: string) => void;
+};
+
+const errorMessages: Record<DeviceCodeError, string> = {
+	invalid: "That code isn't valid. Check for typos and try again.",
+	expired:
+		"That code has expired. Codes are only valid for a few minutes — start over on your device to get a new one.",
+};
+
+/**
+ * Formats free-form input into the `XXXX-XXXX` shape used by device codes, so
+ * the user can type with or without the separator.
+ */
+const formatUserCode = (value: string): string => {
+	const characters = value
+		.toUpperCase()
+		.replace(/[^A-Z0-9]/g, "")
+		.slice(0, 8);
+	if (characters.length <= 4) {
+		return characters;
+	}
+	return `${characters.slice(0, 4)}-${characters.slice(4)}`;
+};
+
+/**
+ * Step 1 of the device authorization flow: the user types the code shown by
+ * the CLI or app. Rendered as a standalone page with no dashboard chrome.
+ */
+export const DeviceAuthEnterCodeView: FC<DeviceAuthEnterCodeViewProps> = ({
+	initialUserCode = "",
+	isSubmitting = false,
+	error,
+	onSubmit,
+}) => {
+	const [userCode, setUserCode] = useState(formatUserCode(initialUserCode));
+	const isComplete = userCode.replace("-", "").length === 8;
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (isComplete && !isSubmitting) {
+			onSubmit(userCode);
+		}
+	};
+
+	return (
+		<SignInLayout>
+			<Welcome>Enter device code</Welcome>
+
+			<p className="m-0 text-center text-sm text-content-secondary leading-normal">
+				Enter the code shown in your terminal or app to connect it to your Coder
+				account.
+			</p>
+
+			<form className="w-full mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
+				{error && (
+					<Alert severity="error" prominent>
+						{errorMessages[error]}
+					</Alert>
+				)}
+
+				<div className="flex flex-col gap-2">
+					<Label htmlFor="user-code">Device code</Label>
+					<Input
+						id="user-code"
+						name="user_code"
+						autoFocus
+						autoComplete="off"
+						spellCheck={false}
+						placeholder="XXXX-XXXX"
+						aria-invalid={error !== undefined}
+						aria-describedby="user-code-help"
+						value={userCode}
+						onChange={(event) =>
+							setUserCode(formatUserCode(event.target.value))
+						}
+						className="text-center font-mono text-base tracking-[0.2em] uppercase"
+					/>
+					<span
+						id="user-code-help"
+						className="text-xs text-content-secondary leading-normal"
+					>
+						Eight characters, letters and numbers only.
+					</span>
+				</div>
+
+				<Button
+					type="submit"
+					size="lg"
+					className="w-full"
+					disabled={!isComplete || isSubmitting}
+				>
+					<Spinner loading={isSubmitting} />
+					Continue
+				</Button>
+			</form>
+		</SignInLayout>
+	);
+};

--- a/site/src/pages/DeviceAuthPage/DeviceAuthPage.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthPage.tsx
@@ -1,0 +1,88 @@
+import { type FC, useState } from "react";
+import { useSearchParams } from "react-router";
+import { pageTitle } from "#/utils/page";
+import {
+	DeviceAuthConfirmView,
+	type DeviceAuthScope,
+} from "./DeviceAuthConfirmView";
+import {
+	DeviceAuthEnterCodeView,
+	type DeviceCodeError,
+} from "./DeviceAuthEnterCodeView";
+import {
+	type DeviceAuthResult,
+	DeviceAuthResultView,
+} from "./DeviceAuthResultView";
+
+type Step =
+	| { name: "enter-code"; error?: DeviceCodeError }
+	| { name: "confirm" }
+	| { name: "result"; result: DeviceAuthResult };
+
+/**
+ * Device authorization grant (RFC 8628) browser flow. Standalone page, no
+ * dashboard chrome, registered at `/device`.
+ *
+ * 1. Enter code — skipped when the user arrives via `verification_uri_complete`
+ *    with a `user_code` query parameter.
+ * 2. Confirm — shows the code back to the user plus the requested scopes, and
+ *    is the authorization decision point.
+ * 3. Result — terminal screen. No redirect; the device polls for the outcome.
+ *
+ * TODO(oauth2-device-flow): the provider side of the grant does not exist yet
+ * (`coderd/oauth2provider/tokens.go`: "TODO: Client creds, device code"). The
+ * verification lookup and approve/deny calls below are the integration points;
+ * the client name and scopes come from the device code record.
+ */
+const DeviceAuthPage: FC = () => {
+	const [searchParams] = useSearchParams();
+	const prefilledUserCode = searchParams.get("user_code") ?? "";
+
+	const [step, setStep] = useState<Step>(
+		prefilledUserCode ? { name: "confirm" } : { name: "enter-code" },
+	);
+	const [userCode, setUserCode] = useState(prefilledUserCode);
+
+	// Placeholder until the API exposes the device code record.
+	const clientName = "Coder CLI";
+	const scopes: readonly DeviceAuthScope[] = [];
+	const username = "";
+
+	return (
+		<>
+			<title>{pageTitle("Authorize device")}</title>
+
+			{step.name === "enter-code" && (
+				<DeviceAuthEnterCodeView
+					initialUserCode={userCode}
+					error={step.error}
+					onSubmit={(submittedCode) => {
+						setUserCode(submittedCode);
+						setStep({ name: "confirm" });
+					}}
+				/>
+			)}
+
+			{step.name === "confirm" && (
+				<DeviceAuthConfirmView
+					userCode={userCode}
+					clientName={clientName}
+					scopes={scopes}
+					username={username}
+					onApprove={() => setStep({ name: "result", result: "approved" })}
+					onDeny={() => setStep({ name: "result", result: "denied" })}
+				/>
+			)}
+
+			{step.name === "result" && (
+				<DeviceAuthResultView
+					result={step.result}
+					clientName={clientName}
+					onStartOver={() => setStep({ name: "enter-code" })}
+				/>
+			)}
+		</>
+	);
+};
+
+export default DeviceAuthPage;

--- a/site/src/pages/DeviceAuthPage/DeviceAuthResultView.stories.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthResultView.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DeviceAuthResultView } from "./DeviceAuthResultView";
+
+const meta: Meta<typeof DeviceAuthResultView> = {
+	title: "pages/DeviceAuthPage/Result",
+	component: DeviceAuthResultView,
+	args: {
+		clientName: "Coder CLI",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof DeviceAuthResultView>;
+
+export const Approved: Story = {
+	args: {
+		result: "approved",
+	},
+};
+
+export const Denied: Story = {
+	args: {
+		result: "denied",
+	},
+};
+
+export const Expired: Story = {
+	args: {
+		result: "expired",
+		onStartOver: () => {},
+	},
+};

--- a/site/src/pages/DeviceAuthPage/DeviceAuthResultView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthResultView.tsx
@@ -1,5 +1,6 @@
 import { CircleCheckIcon, CircleSlashIcon, ClockIcon } from "lucide-react";
 import type { FC } from "react";
+import { Link as RouterLink } from "react-router";
 import { Button } from "#/components/Button/Button";
 import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
 import { Welcome } from "#/components/Welcome/Welcome";
@@ -9,38 +10,45 @@ export type DeviceAuthResult = "approved" | "denied" | "expired";
 type DeviceAuthResultViewProps = {
 	result: DeviceAuthResult;
 	clientName: string;
-	/** Only rendered for the `expired` state, which is recoverable. */
+	/** Only used by the `expired` state, which is recoverable in place. */
 	onStartOver?: () => void;
 };
 
+/**
+ * Icon and color are paired to the state, and never the only signal — the
+ * heading and body text say the same thing.
+ */
 const resultContent = {
 	approved: {
 		icon: CircleCheckIcon,
 		iconClassName: "text-content-success",
 		title: "Device connected",
 		body: (clientName: string) =>
-			`${clientName} now has access to your Coder account. Return to your device to continue — it picks up the result automatically.`,
+			`${clientName} can now access Coder on your behalf. Return to your device to continue — it picks up the result on its own.`,
 	},
 	denied: {
 		icon: CircleSlashIcon,
 		iconClassName: "text-content-destructive",
-		title: "Access denied",
+		title: "Device not connected",
 		body: (clientName: string) =>
-			`${clientName} was not given access to your Coder account. Nothing was shared.`,
+			`${clientName} was not given access, and nothing was shared. Your device will stop waiting shortly.`,
 	},
 	expired: {
 		icon: ClockIcon,
 		iconClassName: "text-content-warning",
 		title: "Code expired",
 		body: () =>
-			"This code expired before it was confirmed. Start the flow again on your device to get a new code.",
+			"This code expired before it was confirmed. Codes last a few minutes — start again on your device to get a new one.",
 	},
 } as const;
 
 /**
  * Step 3 of the device authorization flow: the terminal screen. There is no
- * redirect — the CLI or app is polling and picks up the result on its own, so
- * every state ends with "you can close this tab".
+ * redirect — the CLI or app polls and picks up the result itself — so each
+ * state ends by telling the user the tab is safe to close.
+ *
+ * Every state still offers one in-app destination, so the page is never a dead
+ * end.
  */
 export const DeviceAuthResultView: FC<DeviceAuthResultViewProps> = ({
 	result,
@@ -49,26 +57,43 @@ export const DeviceAuthResultView: FC<DeviceAuthResultViewProps> = ({
 }) => {
 	const content = resultContent[result];
 	const Icon = content.icon;
+	const isExpired = result === "expired";
 
 	return (
 		<SignInLayout>
-			<Welcome>{content.title}</Welcome>
+			<main className="w-full flex flex-col items-center gap-6">
+				<div className="flex flex-col items-center gap-2">
+					<Welcome>{content.title}</Welcome>
+					<Icon
+						aria-hidden="true"
+						className={`size-icon-lg ${content.iconClassName}`}
+					/>
+				</div>
 
-			<Icon className={`size-8 mt-4 ${content.iconClassName}`} />
+				<div className="flex flex-col gap-2">
+					<p className="m-0 text-center text-sm text-content-secondary">
+						{content.body(clientName)}
+					</p>
+					<p className="m-0 text-center text-sm text-content-secondary">
+						You can close this tab.
+					</p>
+				</div>
 
-			<p className="m-0 mt-4 text-center text-sm text-content-secondary leading-normal">
-				{content.body(clientName)}
-			</p>
-
-			<p className="m-0 mt-2 text-center text-sm text-content-secondary leading-normal">
-				You can close this tab.
-			</p>
-
-			{result === "expired" && onStartOver && (
-				<Button size="lg" className="w-full mt-6" onClick={onStartOver}>
-					Enter a new code
-				</Button>
-			)}
+				<div className="w-full flex flex-col gap-2">
+					{isExpired && onStartOver && (
+						<Button className="w-full" onClick={onStartOver}>
+							Enter a new code
+						</Button>
+					)}
+					<Button
+						className="w-full"
+						variant={isExpired ? "outline" : "default"}
+						asChild
+					>
+						<RouterLink to="/workspaces">Go to workspaces</RouterLink>
+					</Button>
+				</div>
+			</main>
 		</SignInLayout>
 	);
 };

--- a/site/src/pages/DeviceAuthPage/DeviceAuthResultView.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceAuthResultView.tsx
@@ -1,0 +1,74 @@
+import { CircleCheckIcon, CircleSlashIcon, ClockIcon } from "lucide-react";
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
+import { Welcome } from "#/components/Welcome/Welcome";
+
+export type DeviceAuthResult = "approved" | "denied" | "expired";
+
+type DeviceAuthResultViewProps = {
+	result: DeviceAuthResult;
+	clientName: string;
+	/** Only rendered for the `expired` state, which is recoverable. */
+	onStartOver?: () => void;
+};
+
+const resultContent = {
+	approved: {
+		icon: CircleCheckIcon,
+		iconClassName: "text-content-success",
+		title: "Device connected",
+		body: (clientName: string) =>
+			`${clientName} now has access to your Coder account. Return to your device to continue — it picks up the result automatically.`,
+	},
+	denied: {
+		icon: CircleSlashIcon,
+		iconClassName: "text-content-destructive",
+		title: "Access denied",
+		body: (clientName: string) =>
+			`${clientName} was not given access to your Coder account. Nothing was shared.`,
+	},
+	expired: {
+		icon: ClockIcon,
+		iconClassName: "text-content-warning",
+		title: "Code expired",
+		body: () =>
+			"This code expired before it was confirmed. Start the flow again on your device to get a new code.",
+	},
+} as const;
+
+/**
+ * Step 3 of the device authorization flow: the terminal screen. There is no
+ * redirect — the CLI or app is polling and picks up the result on its own, so
+ * every state ends with "you can close this tab".
+ */
+export const DeviceAuthResultView: FC<DeviceAuthResultViewProps> = ({
+	result,
+	clientName,
+	onStartOver,
+}) => {
+	const content = resultContent[result];
+	const Icon = content.icon;
+
+	return (
+		<SignInLayout>
+			<Welcome>{content.title}</Welcome>
+
+			<Icon className={`size-8 mt-4 ${content.iconClassName}`} />
+
+			<p className="m-0 mt-4 text-center text-sm text-content-secondary leading-normal">
+				{content.body(clientName)}
+			</p>
+
+			<p className="m-0 mt-2 text-center text-sm text-content-secondary leading-normal">
+				You can close this tab.
+			</p>
+
+			{result === "expired" && onStartOver && (
+				<Button size="lg" className="w-full mt-6" onClick={onStartOver}>
+					Enter a new code
+				</Button>
+			)}
+		</SignInLayout>
+	);
+};

--- a/site/src/pages/DeviceAuthPage/DeviceCode.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceCode.tsx
@@ -1,0 +1,40 @@
+import type { FC } from "react";
+import { cn } from "#/utils/cn";
+
+type DeviceCodeProps = {
+	/** The user code as returned by the device authorization endpoint. */
+	userCode: string;
+	className?: string;
+};
+
+/**
+ * Displays a device `user_code` in a large, legible, monospaced style so the
+ * user can compare it against the code shown on their device.
+ *
+ * RFC 8628 §5.4 requires the browser to show the code back to the user before
+ * the authorization decision, otherwise an attacker can trick a user into
+ * approving a code they never requested.
+ */
+export const DeviceCode: FC<DeviceCodeProps> = ({ userCode, className }) => {
+	return (
+		<div
+			className={cn(
+				`flex items-center justify-center w-full rounded-lg border border-solid
+				border-border bg-surface-secondary px-4 py-5`,
+				className,
+			)}
+		>
+			{/*
+			 * Screen readers get the code spelled out character by character;
+			 * sighted users get the large monospaced version.
+			 */}
+			<span className="sr-only">{userCode.split("").join(" ")}</span>
+			<span
+				aria-hidden="true"
+				className="font-mono text-3xl font-semibold tracking-[0.2em] text-content-primary"
+			>
+				{userCode}
+			</span>
+		</div>
+	);
+};

--- a/site/src/pages/DeviceAuthPage/DeviceCode.tsx
+++ b/site/src/pages/DeviceAuthPage/DeviceCode.tsx
@@ -8,18 +8,21 @@ type DeviceCodeProps = {
 };
 
 /**
- * Displays a device `user_code` in a large, legible, monospaced style so the
- * user can compare it against the code shown on their device.
+ * Displays a device `user_code` so the user can compare it against the code
+ * shown on their device.
  *
  * RFC 8628 §5.4 requires the browser to show the code back to the user before
  * the authorization decision, otherwise an attacker can trick a user into
  * approving a code they never requested.
+ *
+ * Mono is used because the code is an identifier, and `text-3xl` is the Kit's
+ * largest type step — no per-instance size, weight or tracking overrides.
  */
 export const DeviceCode: FC<DeviceCodeProps> = ({ userCode, className }) => {
 	return (
 		<div
 			className={cn(
-				`flex items-center justify-center w-full rounded-lg border border-solid
+				`flex items-center justify-center w-full rounded-md border border-solid
 				border-border bg-surface-secondary px-4 py-5`,
 				className,
 			)}
@@ -31,7 +34,7 @@ export const DeviceCode: FC<DeviceCodeProps> = ({ userCode, className }) => {
 			<span className="sr-only">{userCode.split("").join(" ")}</span>
 			<span
 				aria-hidden="true"
-				className="font-mono text-3xl font-semibold tracking-[0.2em] text-content-primary"
+				className="font-mono text-3xl text-content-primary"
 			>
 				{userCode}
 			</span>

--- a/site/src/pages/OAuth2ClientAdminPage/ClientTypeBadge.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/ClientTypeBadge.tsx
@@ -1,0 +1,27 @@
+import type { FC } from "react";
+import { Badge } from "#/components/Badge/Badge";
+
+export type OAuth2ClientType = "public" | "confidential";
+
+type ClientTypeBadgeProps = {
+	type: OAuth2ClientType;
+};
+
+/**
+ * Public vs confidential is a classification, not a status — what the client
+ * *is*, not what it's doing — so it's a Badge rather than a StatusIndicator.
+ *
+ * The colour is only an aid to scanning a long table; the text carries the
+ * meaning on its own.
+ */
+export const ClientTypeBadge: FC<ClientTypeBadgeProps> = ({ type }) => {
+	return type === "public" ? (
+		<Badge size="sm" variant="purple">
+			Public
+		</Badge>
+	) : (
+		<Badge size="sm" variant="default">
+			Confidential
+		</Badge>
+	);
+};

--- a/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientDetailView.stories.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientDetailView.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { OAuth2ClientDetailView } from "./OAuth2ClientDetailView";
+
+const meta: Meta<typeof OAuth2ClientDetailView> = {
+	title: "pages/OAuth2ClientAdmin/Detail",
+	component: OAuth2ClientDetailView,
+	args: {
+		name: "Internal deploy bot",
+		type: "confidential",
+		clientId: "9f2c1b7a-4e55-4c1f-9a2e-6d1f0c3b8a41",
+		callbackUrl: "https://deploy.internal.example.com/oauth/callback",
+		secrets: [
+			{ id: "s1", preview: "••••••••3f2a", lastUsedAt: "2 hours ago" },
+			{ id: "s2", preview: "••••••••91c4" },
+		],
+		onGenerateSecret: () => {},
+		onDeleteSecret: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OAuth2ClientDetailView>;
+
+export const Confidential: Story = {};
+
+/** No secret section at all — replaced by what the client authenticates with instead. */
+export const PublicClient: Story = {
+	args: {
+		name: "Coder CLI",
+		type: "public",
+		clientId: "3a71f0de-2c94-4f0b-b0d9-51b7c2e4a8d3",
+		callbackUrl: "http://localhost:4321/callback",
+		secrets: undefined,
+		onGenerateSecret: undefined,
+	},
+};
+
+/** A confidential client that can't authenticate yet. */
+export const ConfidentialNoSecrets: Story = {
+	args: {
+		secrets: [],
+	},
+};
+
+/** The one moment the full secret exists in the UI. */
+export const SecretJustGenerated: Story = {
+	args: {
+		newSecret: "coder_oauth2_1f9d8c7b6a5e4d3c2b1a0f9e8d7c6b5a",
+		secrets: [{ id: "s3", preview: "••••••••6b5a" }],
+	},
+};

--- a/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientDetailView.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientDetailView.tsx
@@ -1,0 +1,202 @@
+import { KeyRoundIcon, PlusIcon, ShieldCheckIcon } from "lucide-react";
+import type { FC } from "react";
+import { Alert } from "#/components/Alert/Alert";
+import { Button } from "#/components/Button/Button";
+import { CopyableValue } from "#/components/CopyableValue/CopyableValue";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { TableEmpty } from "#/components/TableEmpty/TableEmpty";
+import { ClientTypeBadge, type OAuth2ClientType } from "./ClientTypeBadge";
+
+export type OAuth2ClientSecret = {
+	id: string;
+	/** Truncated secret, e.g. `••••••••3f2a`. The full value is shown once. */
+	preview: string;
+	lastUsedAt?: string;
+};
+
+type OAuth2ClientDetailViewProps = {
+	name: string;
+	type: OAuth2ClientType;
+	clientId: string;
+	callbackUrl: string;
+	/** Only meaningful for confidential clients. */
+	secrets?: readonly OAuth2ClientSecret[];
+	/** Shown once, immediately after generation. */
+	newSecret?: string;
+	onGenerateSecret?: () => void;
+	onDeleteSecret?: (secret: OAuth2ClientSecret) => void;
+};
+
+/**
+ * Settings for a single OAuth2 client (Flow 3 — PLAT-504).
+ *
+ * The point of the screen: a public client has no client secret, so the secret
+ * section is **absent** rather than present-and-empty or present-and-disabled.
+ * A disabled secret field still tells the admin a secret exists somewhere, and
+ * an empty one invites them to look for the generate button. Neither is true.
+ *
+ * In its place, the credentials section states what the client authenticates
+ * with instead, so the absence reads as a deliberate answer rather than as
+ * something that failed to load.
+ */
+export const OAuth2ClientDetailView: FC<OAuth2ClientDetailViewProps> = ({
+	name,
+	type,
+	clientId,
+	callbackUrl,
+	secrets = [],
+	newSecret,
+	onGenerateSecret,
+	onDeleteSecret,
+}) => {
+	const isPublic = type === "public";
+
+	return (
+		<div className="flex flex-col gap-8 max-w-3xl">
+			<div className="flex flex-col gap-2">
+				<SettingsHeader>
+					<SettingsHeaderTitle>{name}</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						How this application authenticates and where Coder sends users back
+						to.
+					</SettingsHeaderDescription>
+				</SettingsHeader>
+				<div className="flex items-center gap-2">
+					<ClientTypeBadge type={type} />
+					<span className="text-xs text-content-secondary">
+						{isPublic
+							? "Runs on a user's machine — authenticates with PKCE"
+							: "Runs on a server — authenticates with a client secret"}
+					</span>
+				</div>
+			</div>
+
+			<section className="flex flex-col gap-4">
+				<h2 className="m-0 text-base font-semibold">Details</h2>
+				<dl className="m-0 grid grid-cols-[160px_1fr] gap-x-4 gap-y-3">
+					<dt className="text-sm text-content-secondary">Client ID</dt>
+					<dd className="m-0 min-w-0">
+						<CopyableValue value={clientId} className="font-mono text-sm">
+							{clientId}
+						</CopyableValue>
+					</dd>
+					<dt className="text-sm text-content-secondary">Callback URL</dt>
+					<dd className="m-0 min-w-0 truncate font-mono text-sm text-content-primary">
+						{callbackUrl}
+					</dd>
+				</dl>
+			</section>
+
+			<section className="flex flex-col gap-4">
+				<div className="flex items-center justify-between gap-4">
+					<h2 className="m-0 text-base font-semibold">
+						{isPublic ? "Authentication" : "Client secrets"}
+					</h2>
+					{!isPublic && onGenerateSecret && (
+						<Button size="sm" variant="outline" onClick={onGenerateSecret}>
+							<PlusIcon />
+							Generate secret
+						</Button>
+					)}
+				</div>
+
+				{isPublic ? (
+					<div className="flex items-start gap-3 rounded-md border border-solid border-border p-4">
+						<ShieldCheckIcon
+							aria-hidden="true"
+							className="mt-0.5 size-icon-sm shrink-0 text-content-secondary"
+						/>
+						<div className="flex flex-col gap-1">
+							<span className="text-sm text-content-primary">
+								This application uses PKCE
+							</span>
+							<span className="text-xs text-content-secondary">
+								Public clients can't keep a secret — anything shipped to a
+								user's machine can be read out of it. Instead, each
+								authorization request carries a one-time proof key that only
+								that request can redeem, so there's no long-lived credential to
+								store or rotate here.
+							</span>
+						</div>
+					</div>
+				) : (
+					<>
+						{newSecret && (
+							<Alert severity="warning" prominent>
+								<div className="flex flex-col gap-2">
+									<span>Copy this secret now. It won't be shown again.</span>
+									<CopyableValue
+										value={newSecret}
+										className="font-mono text-sm break-all"
+									>
+										{newSecret}
+									</CopyableValue>
+								</div>
+							</Alert>
+						)}
+
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Secret</TableHead>
+									<TableHead className="w-48">Last used</TableHead>
+									<TableHead className="w-24">
+										<span className="sr-only">Actions</span>
+									</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{secrets.length === 0 ? (
+									<TableEmpty
+										message="No client secrets"
+										description="This application can't authenticate until it has one."
+										cta={
+											onGenerateSecret ? (
+												<Button onClick={onGenerateSecret}>
+													<KeyRoundIcon />
+													Generate secret
+												</Button>
+											) : undefined
+										}
+									/>
+								) : (
+									secrets.map((secret) => (
+										<TableRow key={secret.id}>
+											<TableCell className="font-mono text-sm">
+												{secret.preview}
+											</TableCell>
+											<TableCell className="text-sm text-content-secondary">
+												{secret.lastUsedAt ?? "Never"}
+											</TableCell>
+											<TableCell className="text-right">
+												<Button
+													size="sm"
+													variant="outline"
+													onClick={() => onDeleteSecret?.(secret)}
+												>
+													Delete
+												</Button>
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</>
+				)}
+			</section>
+		</div>
+	);
+};

--- a/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientFormView.stories.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientFormView.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { OAuth2ClientFormView } from "./OAuth2ClientFormView";
+
+const meta: Meta<typeof OAuth2ClientFormView> = {
+	title: "pages/OAuth2ClientAdmin/Add",
+	component: OAuth2ClientFormView,
+	args: {
+		onSubmit: () => {},
+		onCancel: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OAuth2ClientFormView>;
+
+/** Confidential is the default: it's the type that behaves the way admins expect. */
+export const Confidential: Story = {};
+
+/** Choosing public replaces the secret promise with the PKCE explanation, in place. */
+export const Public: Story = {
+	args: {
+		initialType: "public",
+	},
+};
+
+/** Submit stays enabled; validation fires on submit and attaches to the field. */
+export const ValidationOnSubmit: Story = {
+	play: async ({ canvas, userEvent }) => {
+		await userEvent.click(
+			await canvas.findByRole("button", { name: "Add application" }),
+		);
+	},
+};
+
+export const Submitting: Story = {
+	args: {
+		isSubmitting: true,
+	},
+};

--- a/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientFormView.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientFormView.tsx
@@ -1,0 +1,198 @@
+import { type FC, type FormEvent, useState } from "react";
+import { Alert } from "#/components/Alert/Alert";
+import { Button } from "#/components/Button/Button";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
+import { Spinner } from "#/components/Spinner/Spinner";
+import type { OAuth2ClientType } from "./ClientTypeBadge";
+
+type OAuth2ClientFormViewProps = {
+	initialType?: OAuth2ClientType;
+	isSubmitting?: boolean;
+	onSubmit: (values: {
+		name: string;
+		callbackUrl: string;
+		type: OAuth2ClientType;
+	}) => void;
+	onCancel: () => void;
+};
+
+const typeOptions: {
+	value: OAuth2ClientType;
+	label: string;
+	description: string;
+}[] = [
+	{
+		value: "confidential",
+		label: "Confidential",
+		description:
+			"Runs on a server that can keep a secret — a web backend or an internal service. Authenticates with a client secret.",
+	},
+	{
+		value: "public",
+		label: "Public",
+		description:
+			"Runs on a user's machine — a CLI, desktop app, mobile app or SPA. Can't keep a secret, so it uses PKCE instead.",
+	},
+];
+
+/**
+ * Registering an OAuth2 client (Flow 3 — PLAT-504).
+ *
+ * Client type is chosen here rather than being derived later, because it
+ * determines whether the client has a secret at all. Two options that need
+ * comparing is exactly the RadioGroup case — a Select would hide the
+ * distinction the admin is being asked to make.
+ *
+ * The consequence of the choice is stated inline as it's made, rather than
+ * discovered on the next screen when the secret field they expected isn't there.
+ */
+export const OAuth2ClientFormView: FC<OAuth2ClientFormViewProps> = ({
+	initialType = "confidential",
+	isSubmitting = false,
+	onSubmit,
+	onCancel,
+}) => {
+	const [name, setName] = useState("");
+	const [callbackUrl, setCallbackUrl] = useState("");
+	const [type, setType] = useState<OAuth2ClientType>(initialType);
+	const [errors, setErrors] = useState<{ name?: string; callbackUrl?: string }>(
+		{},
+	);
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		// Validation runs on submit; the button is never disabled as the way of
+		// signalling that something is missing.
+		const nextErrors: typeof errors = {};
+		if (name.trim() === "") {
+			nextErrors.name = "Enter a name for this application.";
+		}
+		if (callbackUrl.trim() === "") {
+			nextErrors.callbackUrl = "Enter the URL Coder should redirect back to.";
+		}
+		setErrors(nextErrors);
+		if (Object.keys(nextErrors).length > 0) {
+			return;
+		}
+		onSubmit({ name, callbackUrl, type });
+	};
+
+	return (
+		<div className="flex flex-col gap-6 max-w-2xl">
+			<SettingsHeader>
+				<SettingsHeaderTitle>Add application</SettingsHeaderTitle>
+				<SettingsHeaderDescription>
+					Register an application that can request access to Coder on behalf of
+					your users.
+				</SettingsHeaderDescription>
+			</SettingsHeader>
+
+			<form onSubmit={handleSubmit} noValidate className="flex flex-col gap-6">
+				<h2 className="m-0 text-base font-semibold">General</h2>
+
+				<div className="flex flex-col gap-5">
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="client-name">Name</Label>
+						<Input
+							id="client-name"
+							value={name}
+							placeholder="My integration"
+							onChange={(event) => setName(event.target.value)}
+							aria-invalid={errors.name ? true : undefined}
+							aria-describedby={errors.name ? "client-name-error" : undefined}
+						/>
+						{errors.name && (
+							<p
+								id="client-name-error"
+								className="m-0 text-xs text-content-destructive"
+							>
+								{errors.name}
+							</p>
+						)}
+					</div>
+
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="callback-url">Callback URL</Label>
+						<Input
+							id="callback-url"
+							value={callbackUrl}
+							placeholder="https://example.com/oauth/callback"
+							onChange={(event) => setCallbackUrl(event.target.value)}
+							aria-invalid={errors.callbackUrl ? true : undefined}
+							aria-describedby={
+								errors.callbackUrl ? "callback-url-error" : undefined
+							}
+						/>
+						{errors.callbackUrl && (
+							<p
+								id="callback-url-error"
+								className="m-0 text-xs text-content-destructive"
+							>
+								{errors.callbackUrl}
+							</p>
+						)}
+					</div>
+				</div>
+
+				<h2 className="m-0 text-base font-semibold">Client type</h2>
+
+				<div className="flex flex-col gap-4">
+					<RadioGroup
+						value={type}
+						onValueChange={(value) => setType(value as OAuth2ClientType)}
+						aria-label="Client type"
+						className="gap-3"
+					>
+						{typeOptions.map((option) => (
+							<div key={option.value} className="flex items-start gap-2">
+								<RadioGroupItem
+									id={`client-type-${option.value}`}
+									value={option.value}
+									className="mt-1"
+								/>
+								<div className="flex flex-col gap-0.5">
+									<Label
+										htmlFor={`client-type-${option.value}`}
+										className="cursor-pointer"
+									>
+										{option.label}
+									</Label>
+									<span className="text-xs text-content-secondary">
+										{option.description}
+									</span>
+								</div>
+							</div>
+						))}
+					</RadioGroup>
+
+					{/*
+					 * Subtle, not prominent: this explains a consequence of the field
+					 * above it, it isn't a page-level condition.
+					 */}
+					<Alert severity="info">
+						{type === "public"
+							? "Public clients don't get a client secret. They prove the authorization request came from them using PKCE, which is generated per request and can't be extracted from the app."
+							: "Coder will generate a client secret after you save. Store it somewhere safe — it's shown once."}
+					</Alert>
+				</div>
+
+				<div className="flex items-center justify-end gap-2 border-t border-solid border-border pt-4">
+					<Button type="button" variant="outline" onClick={onCancel}>
+						Cancel
+					</Button>
+					<Button type="submit" disabled={isSubmitting}>
+						<Spinner loading={isSubmitting} />
+						{isSubmitting ? "Adding…" : "Add application"}
+					</Button>
+				</div>
+			</form>
+		</div>
+	);
+};

--- a/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientsPageView.stories.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientsPageView.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+	type OAuth2ClientSummary,
+	OAuth2ClientsPageView,
+} from "./OAuth2ClientsPageView";
+
+const clients: OAuth2ClientSummary[] = [
+	{
+		id: "1",
+		name: "Internal deploy bot",
+		type: "confidential",
+		callbackUrl: "https://deploy.internal.example.com/oauth/callback",
+	},
+	{
+		id: "2",
+		name: "Coder CLI",
+		type: "public",
+		callbackUrl: "http://localhost:4321/callback",
+	},
+	{
+		id: "3",
+		name: "Claude Desktop",
+		type: "public",
+		callbackUrl: "https://claude.ai/api/mcp/auth_callback",
+	},
+	{
+		id: "4",
+		name: "Backstage plugin",
+		type: "confidential",
+		callbackUrl: "https://backstage.example.com/api/auth/coder/handler/frame",
+	},
+];
+
+const meta: Meta<typeof OAuth2ClientsPageView> = {
+	title: "pages/OAuth2ClientAdmin/List",
+	component: OAuth2ClientsPageView,
+	args: {
+		clients,
+		onCreate: () => {},
+		onSelect: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OAuth2ClientsPageView>;
+
+/** Type is its own column, so an admin can see at a glance which clients have secrets. */
+export const Default: Story = {};
+
+export const Empty: Story = {
+	args: {
+		clients: [],
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		clients: undefined,
+		isLoading: true,
+	},
+};
+
+export const ViewOnly: Story = {
+	args: {
+		canCreate: false,
+	},
+};

--- a/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientsPageView.tsx
+++ b/site/src/pages/OAuth2ClientAdminPage/OAuth2ClientsPageView.tsx
@@ -1,0 +1,144 @@
+import { ChevronRightIcon, PlusIcon } from "lucide-react";
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import { Loader } from "#/components/Loader/Loader";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { TableEmpty } from "#/components/TableEmpty/TableEmpty";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { ClientTypeBadge, type OAuth2ClientType } from "./ClientTypeBadge";
+
+export type OAuth2ClientSummary = {
+	id: string;
+	name: string;
+	type: OAuth2ClientType;
+	callbackUrl: string;
+};
+
+type OAuth2ClientsPageViewProps = {
+	clients?: readonly OAuth2ClientSummary[];
+	isLoading?: boolean;
+	canCreate?: boolean;
+	onCreate: () => void;
+	onSelect: (client: OAuth2ClientSummary) => void;
+};
+
+/**
+ * Admin list of registered OAuth2 clients (Flow 3 — PLAT-504).
+ *
+ * Client type gets its own column rather than being tucked under the name: it
+ * decides whether a client has a secret at all, and as its own column it can be
+ * sorted and filtered later. Burying it as a subtitle would cost every
+ * operation an admin might want to perform on it.
+ */
+export const OAuth2ClientsPageView: FC<OAuth2ClientsPageViewProps> = ({
+	clients,
+	isLoading = false,
+	canCreate = true,
+	onCreate,
+	onSelect,
+}) => {
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex items-start justify-between gap-4">
+				<SettingsHeader>
+					<SettingsHeaderTitle>OAuth2 applications</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Applications that can request access to this deployment on behalf of
+						its users.
+					</SettingsHeaderDescription>
+				</SettingsHeader>
+				{canCreate && (
+					<Button onClick={onCreate}>
+						<PlusIcon />
+						Add application
+					</Button>
+				)}
+			</div>
+
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead className="w-1/3">Name</TableHead>
+						<TableHead className="w-32">Type</TableHead>
+						<TableHead>Callback URL</TableHead>
+						<TableHead className="w-12">
+							<span className="sr-only">Open</span>
+						</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{isLoading && (
+						<TableRow>
+							<TableCell colSpan={4}>
+								<Loader />
+							</TableCell>
+						</TableRow>
+					)}
+
+					{!isLoading && clients?.length === 0 && (
+						<TableEmpty
+							message="No applications yet"
+							description="Register an application to let it request access to Coder on behalf of your users."
+							cta={
+								canCreate ? (
+									<Button onClick={onCreate}>
+										<PlusIcon />
+										Add application
+									</Button>
+								) : undefined
+							}
+						/>
+					)}
+
+					{clients?.map((client) => (
+						<TableRow key={client.id} className="cursor-pointer">
+							<TableCell>
+								<button
+									type="button"
+									className="border-none bg-transparent p-0 text-left text-sm text-content-primary"
+									onClick={() => onSelect(client)}
+								>
+									{client.name}
+								</button>
+							</TableCell>
+							<TableCell>
+								<ClientTypeBadge type={client.type} />
+							</TableCell>
+							<TableCell className="min-w-0">
+								{/* Truncated rather than wrapped; the full URL matters, so it's on a tooltip. */}
+								<Tooltip>
+									<TooltipTrigger className="block w-full truncate border-none bg-transparent p-0 text-left text-sm text-content-secondary">
+										{client.callbackUrl}
+									</TooltipTrigger>
+									<TooltipContent>{client.callbackUrl}</TooltipContent>
+								</Tooltip>
+							</TableCell>
+							<TableCell className="w-12 text-right">
+								<ChevronRightIcon
+									aria-hidden="true"
+									className="size-icon-sm text-content-secondary"
+								/>
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</div>
+	);
+};

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentErrorView.stories.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentErrorView.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { OAuth2ConsentErrorView } from "./OAuth2ConsentErrorView";
+
+const meta: Meta<typeof OAuth2ConsentErrorView> = {
+	title: "pages/OAuth2ConsentPage/Error",
+	component: OAuth2ConsentErrorView,
+	args: {
+		clientName: "Claude Desktop",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OAuth2ConsentErrorView>;
+
+/** `errUnknownScope` — the scope isn't in the external catalog. */
+export const UnknownScope: Story = {
+	args: {
+		error: "unknown-scope",
+		scope: "workspace:teleport",
+	},
+};
+
+/** `errScopeNotAllowed` — a catalog scope outside the app's allowlist. */
+export const ScopeNotAllowed: Story = {
+	args: {
+		error: "scope-not-allowed",
+		scope: "user_secret:read",
+	},
+};
+
+/** `errNoGrantableScope` — the app's whole allowlist is unsupported here. */
+export const NoGrantableScope: Story = {
+	args: {
+		error: "no-grantable-scope",
+	},
+};
+
+export const InvalidRedirect: Story = {
+	args: {
+		error: "invalid-redirect",
+	},
+};
+
+export const UnknownClient: Story = {
+	args: {
+		error: "unknown-client",
+		clientName: undefined,
+	},
+};

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentErrorView.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentErrorView.tsx
@@ -1,0 +1,91 @@
+import type { FC } from "react";
+import { Link as RouterLink } from "react-router";
+import { Button } from "#/components/Button/Button";
+import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
+import { Welcome } from "#/components/Welcome/Welcome";
+
+/**
+ * Failures that stop the flow before a decision can be made. The first three
+ * mirror the errors added in coder/coder#28045
+ * (`errUnknownScope`, `errScopeNotAllowed`, `errNoGrantableScope`).
+ */
+export type OAuth2ConsentError =
+	| "unknown-scope"
+	| "scope-not-allowed"
+	| "no-grantable-scope"
+	| "invalid-redirect"
+	| "unknown-client";
+
+type OAuth2ConsentErrorViewProps = {
+	error: OAuth2ConsentError;
+	clientName?: string;
+	/** The offending scope, where the error is about one. */
+	scope?: string;
+};
+
+/**
+ * Copy is factual about what the request contained, and never blames the user —
+ * they didn't compose this request, the application did. Each state says who
+ * can fix it, because in every case that isn't the person reading the screen.
+ */
+const errorContent: Record<
+	OAuth2ConsentError,
+	{ title: string; body: (clientName: string, scope?: string) => string }
+> = {
+	"unknown-scope": {
+		title: "Permission not recognized",
+		body: (clientName, scope) =>
+			`${clientName} asked for ${scope ? `"${scope}"` : "a permission"}, which this deployment doesn't offer. Nothing was authorized. The application's developer needs to request a supported permission.`,
+	},
+	"scope-not-allowed": {
+		title: "Permission not allowed",
+		body: (clientName, scope) =>
+			`${clientName} asked for ${scope ? `"${scope}"` : "a permission"} that it isn't registered to use. Nothing was authorized. A Coder administrator can change which permissions this application may request.`,
+	},
+	"no-grantable-scope": {
+		title: "Application needs reconfiguring",
+		body: (clientName) =>
+			`None of the permissions ${clientName} is registered for are supported by this deployment, so there is nothing to authorize. A Coder administrator needs to re-register it with supported permissions.`,
+	},
+	"invalid-redirect": {
+		title: "Return address doesn't match",
+		body: (clientName) =>
+			`${clientName} asked to be sent to an address it isn't registered to use. Nothing was authorized, and you were not redirected — this is the check that stops an authorization being delivered somewhere it shouldn't go.`,
+	},
+	"unknown-client": {
+		title: "Application not found",
+		body: () =>
+			"The application that sent you here isn't registered with this deployment. Nothing was authorized. If you expected this to work, ask a Coder administrator to register it.",
+	},
+};
+
+/**
+ * Terminal error for the consent flow.
+ *
+ * There is deliberately no "try again" — the request is malformed at the
+ * source, so retrying it produces the same result. Per the Kit's error page
+ * guidance the screen still offers one in-app destination rather than dead-ending.
+ */
+export const OAuth2ConsentErrorView: FC<OAuth2ConsentErrorViewProps> = ({
+	error,
+	clientName = "The application",
+	scope,
+}) => {
+	const content = errorContent[error];
+
+	return (
+		<SignInLayout>
+			<main className="w-full flex flex-col items-center gap-6">
+				<Welcome>{content.title}</Welcome>
+
+				<p className="m-0 text-center text-sm text-content-secondary">
+					{content.body(clientName, scope)}
+				</p>
+
+				<Button className="w-full" asChild>
+					<RouterLink to="/workspaces">Go to workspaces</RouterLink>
+				</Button>
+			</main>
+		</SignInLayout>
+	);
+};

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentPage.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentPage.tsx
@@ -1,0 +1,58 @@
+import { type FC, useState } from "react";
+import { useSearchParams } from "react-router";
+import { pageTitle } from "#/utils/page";
+import { OAuth2ConsentPageView } from "./OAuth2ConsentPageView";
+import {
+	OAuth2ConsentRedirectView,
+	type OAuth2Decision,
+} from "./OAuth2ConsentRedirectView";
+
+/**
+ * OAuth2 authorization consent page (Flow 2 — PLAT-470 / PLAT-479).
+ *
+ * A third-party app redirects the user here with `client_id`, `scope` and
+ * `redirect_uri`; the user approves or denies; on approval the browser is sent
+ * back to the app with an authorization code.
+ *
+ * TODO(oauth2-consent): this is a sketch. Today the same URL is served by the
+ * Go template `site/static/oauth2allow.html` via `ShowAuthorizePage`
+ * (`coderd/oauth2provider/authorize.go`), so adopting this screen means the
+ * backend serving the SPA at `/oauth2/authorize` and exposing the app record —
+ * name, icon, requested scopes, redirect URI — to the frontend. The scope
+ * plumbing is being added in coder/coder#28045.
+ */
+const OAuth2ConsentPage: FC = () => {
+	const [searchParams] = useSearchParams();
+	const [decision, setDecision] = useState<OAuth2Decision>();
+
+	// Placeholders until the app record is available to the frontend.
+	const clientName = "Application";
+	const username = "";
+	const scopes = (searchParams.get("scope") ?? "").split(" ").filter(Boolean);
+	const redirectUri = searchParams.get("redirect_uri") ?? "";
+
+	return (
+		<>
+			<title>{pageTitle("Authorize access")}</title>
+
+			{decision ? (
+				<OAuth2ConsentRedirectView
+					decision={decision}
+					clientName={clientName}
+					redirectUri={redirectUri}
+				/>
+			) : (
+				<OAuth2ConsentPageView
+					clientName={clientName}
+					scopes={scopes}
+					username={username}
+					redirectUri={redirectUri}
+					onApprove={() => setDecision("approved")}
+					onDeny={() => setDecision("denied")}
+				/>
+			)}
+		</>
+	);
+};
+
+export default OAuth2ConsentPage;

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentPageView.stories.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentPageView.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { OAuth2ConsentPageView } from "./OAuth2ConsentPageView";
+
+const meta: Meta<typeof OAuth2ConsentPageView> = {
+	title: "pages/OAuth2ConsentPage/Consent",
+	component: OAuth2ConsentPageView,
+	args: {
+		clientName: "Claude Desktop",
+		username: "admin",
+		redirectUri: "https://claude.ai/api/mcp/auth_callback?state=abc123",
+		scopes: [
+			"workspace:read",
+			"workspace:create",
+			"coder:workspaces.operate",
+			"template:read",
+		],
+		onApprove: () => {},
+		onDeny: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OAuth2ConsentPageView>;
+
+export const Default: Story = {};
+
+/** The narrowest useful request: read-only access to workspaces. */
+export const ReadOnly: Story = {
+	args: {
+		clientName: "Workspace status dashboard",
+		scopes: ["workspace:read", "template:read", "user:read"],
+	},
+};
+
+/** Wildcards and delete permissions are labelled, not just coloured. */
+export const DestructiveScopes: Story = {
+	args: {
+		scopes: [
+			"workspace:*",
+			"workspace:read",
+			"user_secret:read",
+			"user_secret:delete",
+			"api_key:create",
+		],
+	},
+};
+
+/** `all`, or no scope at all, is a full grant — called out rather than listed. */
+export const UnrestrictedAccess: Story = {
+	args: {
+		scopes: ["all"],
+	},
+};
+
+/** No `scope` parameter: the backend treats this as unrestricted too. */
+export const NoScopeRequested: Story = {
+	args: {
+		scopes: [],
+	},
+};
+
+/** A scope this deployment's frontend has no description for. */
+export const UnrecognizedScope: Story = {
+	args: {
+		scopes: ["workspace:read", "quantum_widget:entangle"],
+	},
+};
+
+/** Long lists stay scannable because they're grouped by resource. */
+export const ManyScopes: Story = {
+	args: {
+		scopes: [
+			"workspace:read",
+			"workspace:create",
+			"workspace:start",
+			"workspace:stop",
+			"workspace:ssh",
+			"template:read",
+			"template:use",
+			"task:read",
+			"task:create",
+			"file:read",
+			"user:read",
+			"user:read_personal",
+			"api_key:read",
+		],
+	},
+};
+
+export const LongClientName: Story = {
+	args: {
+		clientName: "Internal integration platform connector (staging environment)",
+	},
+};
+
+export const Submitting: Story = {
+	args: {
+		isSubmitting: true,
+	},
+};

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentPageView.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentPageView.tsx
@@ -1,0 +1,143 @@
+import { AppWindowIcon } from "lucide-react";
+import type { FC } from "react";
+import { Alert } from "#/components/Alert/Alert";
+import { Button } from "#/components/Button/Button";
+import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { Welcome } from "#/components/Welcome/Welcome";
+import { ScopeList } from "./ScopeList";
+import { isUnrestricted } from "./scopes";
+
+type OAuth2ConsentPageViewProps = {
+	clientName: string;
+	clientIcon?: string;
+	/** Raw scope strings from the authorization request. */
+	scopes: readonly string[];
+	username: string;
+	/** Where the user is sent back to after approving; shown so they can check it. */
+	redirectUri: string;
+	isSubmitting?: boolean;
+	onApprove: () => void;
+	onDeny: () => void;
+};
+
+/** The host is the part of the redirect URI worth reading; the path is noise. */
+const redirectHost = (redirectUri: string): string => {
+	try {
+		return new URL(redirectUri).host;
+	} catch {
+		return redirectUri;
+	}
+};
+
+/**
+ * The OAuth2 consent screen: a third-party app has redirected the user here to
+ * ask for access. This is the authorization decision point for the standard
+ * web flow (Flow 2), as opposed to the device flow's confirm screen.
+ *
+ * Replaces the server-rendered `site/static/oauth2allow.html`, which says
+ * "full access to your account" and renders no scopes at all. coder/coder#28045
+ * adds a `Scopes` field to `RenderOAuthAllowData` and lists the raw strings;
+ * this screen describes them instead.
+ */
+export const OAuth2ConsentPageView: FC<OAuth2ConsentPageViewProps> = ({
+	clientName,
+	clientIcon,
+	scopes,
+	username,
+	redirectUri,
+	isSubmitting = false,
+	onApprove,
+	onDeny,
+}) => {
+	const unrestricted = isUnrestricted(scopes);
+
+	return (
+		<SignInLayout>
+			<main className="w-full flex flex-col gap-6">
+				<div className="flex flex-col gap-2">
+					{/*
+					 * The heading is fixed rather than interpolating the app name: a
+					 * long name wraps to several lines and pushes the decision buttons
+					 * off screen. The app is identified in the card below.
+					 */}
+					<Welcome>Authorize access</Welcome>
+					<p className="m-0 text-center text-sm text-content-secondary">
+						An application is asking to use your Coder account.
+					</p>
+				</div>
+
+				<div className="flex flex-col gap-4 rounded-md border border-solid border-border p-4">
+					<div className="flex items-center gap-3">
+						<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-solid border-border bg-surface-secondary">
+							{clientIcon ? (
+								<img
+									src={clientIcon}
+									alt=""
+									className="size-full object-contain p-1"
+								/>
+							) : (
+								<AppWindowIcon
+									aria-hidden="true"
+									className="size-icon-sm text-content-secondary"
+								/>
+							)}
+						</div>
+						<div className="flex min-w-0 flex-col">
+							<Tooltip>
+								{/* Truncated rather than wrapped, full value on the tooltip. */}
+								<TooltipTrigger className="block w-full truncate border-none bg-transparent p-0 text-left text-sm text-content-primary">
+									{clientName}
+								</TooltipTrigger>
+								<TooltipContent>{clientName}</TooltipContent>
+							</Tooltip>
+							<span className="text-xs text-content-secondary">
+								wants to act as {username}
+							</span>
+						</div>
+					</div>
+
+					{unrestricted ? (
+						<Alert severity="warning" prominent>
+							This application is asking for unrestricted access — it will be
+							able to do anything you can do, including deleting workspaces and
+							managing your API keys.
+						</Alert>
+					) : (
+						<ScopeList scopes={scopes} />
+					)}
+				</div>
+
+				<p className="m-0 text-center text-xs text-content-secondary">
+					After approving, you'll be sent to{" "}
+					<span className="font-mono">{redirectHost(redirectUri)}</span>. Only
+					approve applications you trust.
+				</p>
+
+				<div className="flex flex-col gap-2">
+					<Button
+						className="w-full"
+						disabled={isSubmitting}
+						onClick={onApprove}
+					>
+						<Spinner loading={isSubmitting} />
+						{isSubmitting ? "Authorizing…" : "Approve"}
+					</Button>
+					<Button
+						variant="outline"
+						className="w-full"
+						disabled={isSubmitting}
+						onClick={onDeny}
+					>
+						Deny
+					</Button>
+				</div>
+			</main>
+		</SignInLayout>
+	);
+};

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentRedirectView.stories.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentRedirectView.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { OAuth2ConsentRedirectView } from "./OAuth2ConsentRedirectView";
+
+const meta: Meta<typeof OAuth2ConsentRedirectView> = {
+	title: "pages/OAuth2ConsentPage/Redirect",
+	component: OAuth2ConsentRedirectView,
+	args: {
+		clientName: "Claude Desktop",
+		redirectUri: "https://claude.ai/api/mcp/auth_callback?state=abc123",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OAuth2ConsentRedirectView>;
+
+export const Approved: Story = {
+	args: {
+		decision: "approved",
+	},
+};
+
+export const Denied: Story = {
+	args: {
+		decision: "denied",
+	},
+};

--- a/site/src/pages/OAuth2ConsentPage/OAuth2ConsentRedirectView.tsx
+++ b/site/src/pages/OAuth2ConsentPage/OAuth2ConsentRedirectView.tsx
@@ -1,0 +1,55 @@
+import type { FC } from "react";
+import { Link } from "#/components/Link/Link";
+import { SignInLayout } from "#/components/SignInLayout/SignInLayout";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { Welcome } from "#/components/Welcome/Welcome";
+
+export type OAuth2Decision = "approved" | "denied";
+
+type OAuth2ConsentRedirectViewProps = {
+	decision: OAuth2Decision;
+	clientName: string;
+	/** Full redirect URI, used for the manual fallback link. */
+	redirectUri: string;
+};
+
+/**
+ * Shown between the decision and the redirect back to the requesting app.
+ *
+ * Unlike the device flow, this flow ends somewhere else: the browser returns to
+ * the app with an authorization code, so this screen is transient and must not
+ * tell the user to close the tab. It exists so a slow or blocked redirect isn't
+ * a blank page, and it always offers the link manually — the same fallback
+ * `LoginOAuthDevicePageView` uses.
+ */
+export const OAuth2ConsentRedirectView: FC<OAuth2ConsentRedirectViewProps> = ({
+	decision,
+	clientName,
+	redirectUri,
+}) => {
+	const approved = decision === "approved";
+
+	return (
+		<SignInLayout>
+			<main className="w-full flex flex-col items-center gap-6">
+				<Welcome>{approved ? "Access granted" : "Access not granted"}</Welcome>
+
+				<div className="flex flex-col items-center gap-2">
+					<p className="m-0 text-center text-sm text-content-secondary">
+						{approved
+							? `Taking you back to ${clientName}.`
+							: `${clientName} was not given access. Taking you back.`}
+					</p>
+					<p className="flex items-center justify-center gap-2 text-sm text-content-secondary">
+						<Spinner size="sm" loading />
+						Redirecting…
+					</p>
+				</div>
+
+				<p className="m-0 text-center text-xs text-content-secondary">
+					If nothing happens, <Link href={redirectUri}>continue manually</Link>.
+				</p>
+			</main>
+		</SignInLayout>
+	);
+};

--- a/site/src/pages/OAuth2ConsentPage/ScopeList.tsx
+++ b/site/src/pages/OAuth2ConsentPage/ScopeList.tsx
@@ -1,0 +1,80 @@
+import type { FC } from "react";
+import { Badge } from "#/components/Badge/Badge";
+import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import { type DescribedScope, groupScopes } from "./scopes";
+
+type ScopeListProps = {
+	scopes: readonly string[];
+};
+
+/**
+ * A destructive or undescribed permission carries a label as well as a
+ * description — colour alone is never the signal, and "delete" is the thing a
+ * user most needs to notice before approving.
+ */
+const ScopeBadge: FC<{ scope: DescribedScope }> = ({ scope }) => {
+	if (!scope.known) {
+		return (
+			<Badge size="xs" variant="warning">
+				Unrecognized
+			</Badge>
+		);
+	}
+	if (scope.risk === "destructive" || scope.risk === "unrestricted") {
+		return (
+			<Badge size="xs" variant="destructive">
+				Can delete
+			</Badge>
+		);
+	}
+	return null;
+};
+
+/**
+ * The permissions being granted, grouped by resource. Raw scope strings are
+ * kept visible under each description: the description is what the decision is
+ * made on, the identifier is what gets debugged later.
+ */
+export const ScopeList: FC<ScopeListProps> = ({ scopes }) => {
+	const groups = groupScopes(scopes);
+
+	const list = (
+		<div className="flex flex-col gap-4">
+			{groups.map((group) => (
+				<div key={group.title} className="flex flex-col gap-2">
+					<span className="text-xs text-content-secondary">{group.title}</span>
+					<ul className="m-0 flex list-none flex-col gap-2 p-0">
+						{group.scopes.map((scope) => (
+							<li key={scope.name} className="flex flex-col gap-0.5">
+								<span className="flex items-center gap-2 text-sm text-content-primary">
+									{scope.description}
+									<ScopeBadge scope={scope} />
+								</span>
+								{/* Mono because the scope name is an identifier. */}
+								<span className="font-mono text-2xs text-content-secondary">
+									{scope.name}
+								</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			))}
+		</div>
+	);
+
+	/*
+	 * A long request would otherwise push the Approve and Deny buttons below the
+	 * fold, which is how someone ends up approving without reading. The list
+	 * scrolls instead; the decision stays on screen. `viewportTabIndex` keeps the
+	 * scrollable region reachable by keyboard.
+	 */
+	if (scopes.length > 8) {
+		return (
+			<ScrollArea className="max-h-64" viewportTabIndex={0}>
+				{list}
+			</ScrollArea>
+		);
+	}
+
+	return list;
+};

--- a/site/src/pages/OAuth2ConsentPage/scopes.ts
+++ b/site/src/pages/OAuth2ConsentPage/scopes.ts
@@ -1,0 +1,420 @@
+/**
+ * Human descriptions for the external scope catalog.
+ *
+ * The catalog itself lives in `coderd/rbac/scopes_catalog.go` — `externalLowLevel`
+ * for `resource:action` names and `externalComposite` for the curated `coder:*`
+ * names. The backend hands the consent page raw scope strings (see the `Scopes`
+ * field added to `RenderOAuthAllowData` in coder/coder#28045); this module turns
+ * them into something a user can make a decision about.
+ *
+ * Keep this in sync with the catalog. An unknown scope is shown verbatim rather
+ * than hidden — the user should never approve a permission the page couldn't
+ * describe without being told that's what happened.
+ */
+
+export type ScopeRisk = "read" | "write" | "destructive" | "unrestricted";
+
+export type DescribedScope = {
+	/** Raw scope string, e.g. `workspace:read`. */
+	name: string;
+	/** Sentence-case description of what the scope allows. */
+	description: string;
+	risk: ScopeRisk;
+	/** False when the scope isn't in the catalog this page knows about. */
+	known: boolean;
+};
+
+export type ScopeGroup = {
+	/** Resource the scopes apply to, e.g. "Workspaces". */
+	title: string;
+	scopes: DescribedScope[];
+};
+
+type CatalogEntry = {
+	group: string;
+	description: string;
+	risk: ScopeRisk;
+};
+
+const catalog: Record<string, CatalogEntry> = {
+	// Unrestricted
+	all: {
+		group: "Everything",
+		description: "Full access to your account",
+		risk: "unrestricted",
+	},
+	application_connect: {
+		group: "Workspaces",
+		description: "Open apps running in your workspaces",
+		risk: "read",
+	},
+
+	// Workspaces
+	"workspace:read": {
+		group: "Workspaces",
+		description: "View your workspaces and their status",
+		risk: "read",
+	},
+	"workspace:create": {
+		group: "Workspaces",
+		description: "Create new workspaces",
+		risk: "write",
+	},
+	"workspace:update": {
+		group: "Workspaces",
+		description: "Change your workspace settings",
+		risk: "write",
+	},
+	"workspace:delete": {
+		group: "Workspaces",
+		description: "Delete your workspaces",
+		risk: "destructive",
+	},
+	"workspace:ssh": {
+		group: "Workspaces",
+		description: "Connect to your workspaces over SSH",
+		risk: "write",
+	},
+	"workspace:start": {
+		group: "Workspaces",
+		description: "Start your workspaces",
+		risk: "write",
+	},
+	"workspace:stop": {
+		group: "Workspaces",
+		description: "Stop your workspaces",
+		risk: "write",
+	},
+	"workspace:application_connect": {
+		group: "Workspaces",
+		description: "Open apps running in your workspaces",
+		risk: "read",
+	},
+	"workspace:*": {
+		group: "Workspaces",
+		description: "Full access to your workspaces, including deleting them",
+		risk: "destructive",
+	},
+
+	// Templates
+	"template:read": {
+		group: "Templates",
+		description: "View templates you have access to",
+		risk: "read",
+	},
+	"template:use": {
+		group: "Templates",
+		description: "Build workspaces from templates",
+		risk: "write",
+	},
+	"template:create": {
+		group: "Templates",
+		description: "Create templates",
+		risk: "write",
+	},
+	"template:update": {
+		group: "Templates",
+		description: "Change templates",
+		risk: "write",
+	},
+	"template:delete": {
+		group: "Templates",
+		description: "Delete templates",
+		risk: "destructive",
+	},
+	"template:*": {
+		group: "Templates",
+		description: "Full access to templates, including deleting them",
+		risk: "destructive",
+	},
+
+	// API keys
+	"api_key:read": {
+		group: "API keys",
+		description: "View your API keys",
+		risk: "read",
+	},
+	"api_key:create": {
+		group: "API keys",
+		description: "Create API keys on your behalf",
+		risk: "write",
+	},
+	"api_key:update": {
+		group: "API keys",
+		description: "Change your API keys",
+		risk: "write",
+	},
+	"api_key:delete": {
+		group: "API keys",
+		description: "Delete your API keys",
+		risk: "destructive",
+	},
+	"api_key:*": {
+		group: "API keys",
+		description: "Full access to your API keys",
+		risk: "destructive",
+	},
+
+	// Files
+	"file:read": {
+		group: "Files",
+		description: "Read files you have uploaded",
+		risk: "read",
+	},
+	"file:create": {
+		group: "Files",
+		description: "Upload files",
+		risk: "write",
+	},
+	"file:*": {
+		group: "Files",
+		description: "Full access to your files",
+		risk: "write",
+	},
+
+	// Profile
+	"user:read": {
+		group: "Profile",
+		description: "View your name and profile",
+		risk: "read",
+	},
+	"user:read_personal": {
+		group: "Profile",
+		description: "View your email address and personal details",
+		risk: "read",
+	},
+	"user:update_personal": {
+		group: "Profile",
+		description: "Change your personal details",
+		risk: "write",
+	},
+	"user:*": {
+		group: "Profile",
+		description: "Full access to your profile",
+		risk: "write",
+	},
+
+	// Secrets
+	"user_secret:read": {
+		group: "Secrets",
+		description: "Read secrets stored in your account",
+		risk: "read",
+	},
+	"user_secret:create": {
+		group: "Secrets",
+		description: "Add secrets to your account",
+		risk: "write",
+	},
+	"user_secret:update": {
+		group: "Secrets",
+		description: "Change secrets stored in your account",
+		risk: "write",
+	},
+	"user_secret:delete": {
+		group: "Secrets",
+		description: "Delete secrets stored in your account",
+		risk: "destructive",
+	},
+	"user_secret:*": {
+		group: "Secrets",
+		description: "Full access to secrets stored in your account",
+		risk: "destructive",
+	},
+
+	// Skills
+	"user_skill:read": {
+		group: "Skills",
+		description: "View your skills",
+		risk: "read",
+	},
+	"user_skill:create": {
+		group: "Skills",
+		description: "Add skills to your account",
+		risk: "write",
+	},
+	"user_skill:update": {
+		group: "Skills",
+		description: "Change your skills",
+		risk: "write",
+	},
+	"user_skill:delete": {
+		group: "Skills",
+		description: "Delete your skills",
+		risk: "destructive",
+	},
+	"user_skill:*": {
+		group: "Skills",
+		description: "Full access to your skills",
+		risk: "destructive",
+	},
+
+	// Tasks
+	"task:read": {
+		group: "Tasks",
+		description: "View your tasks",
+		risk: "read",
+	},
+	"task:create": {
+		group: "Tasks",
+		description: "Create tasks",
+		risk: "write",
+	},
+	"task:update": {
+		group: "Tasks",
+		description: "Change your tasks",
+		risk: "write",
+	},
+	"task:delete": {
+		group: "Tasks",
+		description: "Delete your tasks",
+		risk: "destructive",
+	},
+	"task:*": {
+		group: "Tasks",
+		description: "Full access to your tasks",
+		risk: "destructive",
+	},
+
+	// Organizations
+	"organization:read": {
+		group: "Organizations",
+		description: "View organizations you belong to",
+		risk: "read",
+	},
+	"organization:update": {
+		group: "Organizations",
+		description: "Change organization settings",
+		risk: "write",
+	},
+	"organization:delete": {
+		group: "Organizations",
+		description: "Delete organizations",
+		risk: "destructive",
+	},
+	"organization:*": {
+		group: "Organizations",
+		description: "Full access to organizations you belong to",
+		risk: "destructive",
+	},
+
+	// Composite coder:* scopes
+	"coder:workspaces.create": {
+		group: "Workspaces",
+		description: "Create and start workspaces",
+		risk: "write",
+	},
+	"coder:workspaces.operate": {
+		group: "Workspaces",
+		description: "Start, stop and connect to your workspaces",
+		risk: "write",
+	},
+	"coder:workspaces.delete": {
+		group: "Workspaces",
+		description: "Delete your workspaces",
+		risk: "destructive",
+	},
+	"coder:workspaces.access": {
+		group: "Workspaces",
+		description: "Connect to your workspaces and the apps running in them",
+		risk: "write",
+	},
+	"coder:templates.build": {
+		group: "Templates",
+		description: "Build workspaces from templates",
+		risk: "write",
+	},
+	"coder:templates.author": {
+		group: "Templates",
+		description: "Create and change templates",
+		risk: "write",
+	},
+	"coder:apikeys.manage_self": {
+		group: "API keys",
+		description: "Manage your own API keys",
+		risk: "write",
+	},
+};
+
+/** Groups are listed in this order; anything unlisted follows alphabetically. */
+const groupOrder = [
+	"Everything",
+	"Workspaces",
+	"Templates",
+	"Tasks",
+	"Files",
+	"Secrets",
+	"Skills",
+	"Profile",
+	"API keys",
+	"Organizations",
+];
+
+const riskOrder: Record<ScopeRisk, number> = {
+	unrestricted: 0,
+	destructive: 1,
+	write: 2,
+	read: 3,
+};
+
+export const describeScope = (name: string): DescribedScope => {
+	const entry = catalog[name];
+	if (!entry) {
+		return {
+			name,
+			// Shown rather than hidden: approving an undescribed permission
+			// silently is worse than admitting the page doesn't know it.
+			description: "This deployment didn't describe this permission",
+			risk: "write",
+			known: false,
+		};
+	}
+	return {
+		name,
+		description: entry.description,
+		risk: entry.risk,
+		known: true,
+	};
+};
+
+/**
+ * Groups scopes by resource, most consequential first within each group, and
+ * orders the groups so the ones users care most about come first.
+ */
+export const groupScopes = (names: readonly string[]): ScopeGroup[] => {
+	const groups = new Map<string, DescribedScope[]>();
+
+	for (const name of names) {
+		const title = catalog[name]?.group ?? "Other";
+		const scopes = groups.get(title) ?? [];
+		scopes.push(describeScope(name));
+		groups.set(title, scopes);
+	}
+
+	for (const scopes of groups.values()) {
+		scopes.sort((a, b) => riskOrder[a.risk] - riskOrder[b.risk]);
+	}
+
+	return [...groups.entries()]
+		.map(([title, scopes]) => ({ title, scopes }))
+		.sort((a, b) => {
+			const ai = groupOrder.indexOf(a.title);
+			const bi = groupOrder.indexOf(b.title);
+			if (ai === -1 && bi === -1) {
+				return a.title.localeCompare(b.title);
+			}
+			if (ai === -1) {
+				return 1;
+			}
+			if (bi === -1) {
+				return -1;
+			}
+			return ai - bi;
+		});
+};
+
+/**
+ * True when the request amounts to unrestricted access — either the `all`
+ * scope, or no scope at all, which the backend treats as a full grant.
+ */
+export const isUnrestricted = (names: readonly string[]): boolean =>
+	names.length === 0 || names.includes("all");

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -45,6 +45,9 @@ const OrganizationSettingsLayout = lazy(
 	() => import("./modules/management/OrganizationSettingsLayout"),
 );
 const CliAuthPage = lazy(() => import("./pages/CliAuthPage/CliAuthPage"));
+const DeviceAuthPage = lazy(
+	() => import("./pages/DeviceAuthPage/DeviceAuthPage"),
+);
 const CliInstallPage = lazy(
 	() => import("./pages/CliInstallPage/CliInstallPage"),
 );
@@ -826,6 +829,7 @@ export const router = createBrowserRouter(
 					element={<TerminalPage />}
 				/>
 				<Route path="/cli-auth" element={<CliAuthPage />} />
+				<Route path="/device" element={<DeviceAuthPage />} />
 				<Route path="/coder-cup" element={<CoderCupPage />} />
 				<Route path="/icons" element={<IconsPage />} />
 				<Route path="/tasks/:username/:taskId" element={<TaskPage />} />

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -48,6 +48,12 @@ const CliAuthPage = lazy(() => import("./pages/CliAuthPage/CliAuthPage"));
 const DeviceAuthPage = lazy(
 	() => import("./pages/DeviceAuthPage/DeviceAuthPage"),
 );
+// Sketch route. `/oauth2/authorize` is currently served by the Go template
+// `site/static/oauth2allow.html`, so this React page is only reachable once the
+// backend serves the SPA there. See pages/OAuth2ConsentPage/OAuth2ConsentPage.tsx.
+const OAuth2ConsentPage = lazy(
+	() => import("./pages/OAuth2ConsentPage/OAuth2ConsentPage"),
+);
 const CliInstallPage = lazy(
 	() => import("./pages/CliInstallPage/CliInstallPage"),
 );
@@ -830,6 +836,7 @@ export const router = createBrowserRouter(
 				/>
 				<Route path="/cli-auth" element={<CliAuthPage />} />
 				<Route path="/device" element={<DeviceAuthPage />} />
+				<Route path="/oauth2/authorize" element={<OAuth2ConsentPage />} />
 				<Route path="/coder-cup" element={<CoderCupPage />} />
 				<Route path="/icons" element={<IconsPage />} />
 				<Route path="/tasks/:username/:taskId" element={<TaskPage />} />


### PR DESCRIPTION
Early sketches of three OAuth2 surfaces, opened as a draft to get design feedback. **None of them are wired to anything** — they depend on backend work that isn't merged.

- **Flow 1 — Device authorization grant (RFC 8628)**, route `/device`
- **Flow 2 — Consent / scope page (PLAT-470 / PLAT-479)**, route `/oauth2/authorize`
- **Flow 3 — Public-client admin UI (PLAT-504)**, deployment settings

Flows 1 and 2 are standalone pages with no dashboard chrome, built on `SignInLayout` + `Welcome` like `/cli-auth` and `login/device`. Flow 3 is admin-facing and sits inside dashboard chrome. All three follow the Coder Kit guidance. 41 Storybook stories cover every state.

## Flow 1 — Device authorization

| Step | Component | States |
|---|---|---|
| 1. Enter code | `DeviceAuthEnterCodeView` | empty, prefilled, submitting, incomplete (field validation), not recognized, expired |
| 2. Confirm | `DeviceAuthConfirmView` | default, single scope, long client name, submitting |
| 3. Result | `DeviceAuthResultView` | approved, denied, expired |

Step 1 is skipped when the user arrives with `?user_code=` (the `verification_uri_complete` case). Step 2 shows the code back to the user because [RFC 8628 §5.4](https://datatracker.ietf.org/doc/html/rfc8628#section-5.4) requires it. Step 3 has no redirect — the CLI polls and picks up the result itself, so each state ends by saying the tab is safe to close.

## Flow 2 — Consent / scope page

| Screen | Component | States |
|---|---|---|
| Consent | `OAuth2ConsentPageView` | default, read-only, destructive scopes, unrestricted, no scope requested, unrecognized scope, many scopes, long client name, submitting |
| Redirect | `OAuth2ConsentRedirectView` | approved, denied |
| Error | `OAuth2ConsentErrorView` | unknown scope, scope not allowed, no grantable scope, invalid redirect, unknown client |

Builds on **#28045**, which adds `Scopes []string` to `RenderOAuthAllowData` and lists the raw strings. `scopes.ts` maps the catalog in `coderd/rbac/scopes_catalog.go` (`externalLowLevel` + `externalComposite`) to descriptions, groups them by resource and orders the most consequential first. Raw scope names stay visible in mono underneath — the description is what the decision is made on, the identifier is what gets debugged later. The three errors added in that PR (`errUnknownScope`, `errScopeNotAllowed`, `errNoGrantableScope`) each get a screen.

Decisions worth arguing about:

1. **`all`, or no scope at all, is a warning rather than a list item.** #28045 falls back to the existing "full access to your account" sentence. Listing a full grant as if it were one permission understates it, so it gets a prominent warning Alert — the one place `prominent` is used, which the Kit reserves for page-level conditions.
2. **Delete permissions carry a "Can delete" badge**, so the signal isn't colour alone.
3. **Unrecognized scopes are shown and labelled**, not hidden. Silently dropping a permission the user is about to grant is worse than admitting the page can't describe it.
4. **The redirect host is on the screen** — the user is being sent somewhere with a token, and should see where.
5. **Long scope lists scroll inside the card.** 13 scopes made the page 1210px and pushed Approve/Deny below the fold, which is how people approve without reading. Capped at 666px with the decision always visible.
6. **No "try again" on errors** — the request is malformed at the source. Each error says who can fix it, since it is never the person reading the screen.

## Flow 3 — Public-client admin UI (PLAT-504)

| Screen | Component | States |
|---|---|---|
| Client list | `OAuth2ClientsPageView` | default, empty, loading, view-only |
| Add application | `OAuth2ClientFormView` | confidential, public, validation on submit, submitting |
| Client detail | `OAuth2ClientDetailView` | confidential, public, confidential with no secrets, secret just generated |

Admin-facing, so these sit inside dashboard chrome rather than using `SignInLayout`. Sketched as new components rather than edits to `DeploymentSettingsPage/OAuth2AppsSettingsPage`, so the existing pages stay reviewable side by side.

Decisions worth arguing about:

1. **A public client's secret section is absent, not disabled or empty.** A disabled field still says a secret exists somewhere; an empty one invites the admin to hunt for the generate button. Neither is true, so the section is replaced by what the client authenticates with instead — the absence has to read as an answer, not as something that failed to load.
2. **Client type is its own table column.** The Kit's table guidance is explicit that a distinct attribute buried as a subtitle can't be sorted or filtered. Type decides whether a client has a secret at all, which makes it the second most useful column on the page.
3. **Type is a Badge, not a StatusIndicator.** Public/confidential is what a client *is*, not what it's *doing*. Colour only aids scanning; the text carries the meaning.
4. **The choice is explained where it's made.** Picking "Public" in the add form swaps the "we'll generate a secret" copy for the PKCE explanation inline, rather than letting the admin discover the missing field on the next screen.
5. **RadioGroup, not Select, for client type** — two options that need comparing, which is the case the Kit says RadioGroup exists for.

## Open questions for reviewers

1. **Neither flow has a backend.** `coderd/oauth2provider/tokens.go` has `// TODO: Client creds, device code`, and `metadata.go` advertises only `authorization_code` and `refresh_token`. Existing device-flow code (`GitDeviceAuth`, `LoginOAuthDevicePage`) is Coder acting as a *client* to GitHub, the mirror image of Flow 1.
2. **Flow 2 needs `/oauth2/authorize` served by the SPA.** That URL is currently rendered by the Go template `site/static/oauth2allow.html` via `ShowAuthorizePage`, so the registered route is unreachable until the backend serves the SPA there and exposes the app record — name, icon, scopes, redirect URI — to the frontend. Bigger decision than the visual design.
3. **Scope descriptions live in the frontend.** A deployment that adds scopes gets "Unrecognized". The alternative is the backend returning descriptions alongside the catalog, which is probably the right long-term answer.
4. **Does Coder's device implementation support `verification_uri_complete`?** It decides whether Flow 1 step 1 is ever skippable in practice.
5. **The two flows both list scopes and should share one component.** Kept separate here so each can be reviewed on its own; easy to extract once the treatment is agreed.
6. **`SignInLayout` clips at 200% zoom.** Out of scope here — it's shared with login, `/cli-auth` and `login/device`. At a 640x400 viewport the Confirm screen's `main` sits at `top: -139px`, so the top of the card is unreachable. Changing `h-screen` to `min-h-screen` with vertical padding fixes it (verified locally); wants its own PR.

<details>
<summary>Design system audit — changes made after reading the Coder Kit guidance</summary>

Flow 1 was first built against the components as they exist in `site/src/components`, then revised against the Kit docs. Twelve things changed, and Flow 2 was built to the same rules from the start:

| # | Guidance | What was wrong | Fix |
|---|---|---|---|
| 1 | Input: don't disable submit until the form is valid | Continue was disabled until 8 characters | Always enabled; validates on submit, error below the field via `aria-describedby` + `aria-invalid` |
| 2 | Alert: subtle is the default, `prominent` is for page-level messages | Both error alerts were `prominent` | Subtle |
| 3 | Content style: sentence case everywhere | `PERMISSIONS REQUESTED`, `uppercase` on the input | "Permissions requested"; input uppercases values, not styling |
| 4 | Typography: don't set size, weight or line height per instance | `font-semibold`, `tracking-[0.2em]`, `text-xs font-medium uppercase tracking-wide` | Scale tokens only |
| 5 | Icons: use `size-icon-*`, hide decorative icons | `size-8` on result icons | `size-icon-lg`, `aria-hidden` |
| 6 | Spacing: prefer `gap` over margins | `mt-4`/`mt-6` stacks | Flex columns with `gap` |
| 7 | Error page: no blame-the-user copy | "Access denied", "Check for typos" | "Device not connected"; "This code isn't recognized…" |
| 8 | Error page: always offer a way back | Denied and expired dead-ended | Every terminal state has one in-app destination |
| 9 | Button: change the label to say what's happening | Spinner with static label | "Checking…" / "Connecting…" / "Authorizing…" |
| 10 | Accessibility: every page needs a `<main>` landmark | Missing | Added to every screen |
| 11 | Content style: truncate don't wrap, pair with a tooltip | Client name could wrap | Truncated + tooltip |
| 12 | Accessibility: nothing clips at 200% zoom | A long client name in the `<h1>` grew Confirm to 758px and pushed the top off-screen | Headings are fixed; the requester is named in the card. Stable height at any name length |

A follow-up fix after review: the device code field used `WDJB-MJHT` as its placeholder, which read as an already-filled field. It's now an `XXXX-XXXX` mask with the example moved to helper text.

**Deliberate deviation:** `pages/error-page` prescribes a full-page `EmptyState` for terminal feedback. The result and error screens use `SignInLayout` + `Welcome` instead, so every step of a flow reads as one surface, while adopting the error-page rules (factual copy, always a way back). Happy to switch if reviewers disagree.
</details>

## Checks

`pnpm check` and `pnpm lint:types` pass.

---

🤖 Opened by Coder Agents on behalf of @designertyler.
