### PR TITLE
fix(site): prevent duplicate menu when right-clicking chat kebab

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -362,6 +362,14 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 									<DropdownMenuContent
 										align="end"
 										className="[&_[role=menuitem]]:text-[13px]"
+										// The dropdown is portaled to the body, but React
+										// portals bubble events through the React tree, so a
+										// right-click inside the menu would still reach the
+										// row's context-menu trigger and open a duplicate menu.
+										onContextMenu={(e) => {
+											e.preventDefault();
+											e.stopPropagation();
+										}}
 									>
 										<ChatActionsMenuItems
 											{...sharedMenuItemProps}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -339,10 +339,6 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												isActiveChat && "opacity-100",
 											)}
 											aria-label={`Open actions for ${chat.title}`}
-											// The kebab already opens its own dropdown;
-											// swallow right-click events on it so the
-											// row-level context menu doesn't also open on
-											// top of the dropdown.
 											onContextMenuCapture={(e) => {
 												e.preventDefault();
 												e.stopPropagation();

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -339,6 +339,15 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												isActiveChat && "opacity-100",
 											)}
 											aria-label={`Open actions for ${chat.title}`}
+											// The kebab already opens its own dropdown;
+											// suppress the row-level right-click context
+											// menu here so a right-click on the kebab
+											// doesn't show a duplicate menu next to the
+											// dropdown.
+											onContextMenu={(e) => {
+												e.preventDefault();
+												e.stopPropagation();
+											}}
 										>
 											<EllipsisVerticalIcon className="size-3.5" />
 										</Button>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -340,13 +340,24 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											)}
 											aria-label={`Open actions for ${chat.title}`}
 											// The kebab already opens its own dropdown;
-											// suppress the row-level right-click context
-											// menu here so a right-click on the kebab
-											// doesn't show a duplicate menu next to the
-											// dropdown.
-											onContextMenu={(e) => {
+											// swallow right-click events on it so the
+											// row-level context menu doesn't also open on
+											// top of the dropdown.
+											onContextMenuCapture={(e) => {
 												e.preventDefault();
 												e.stopPropagation();
+											}}
+											onMouseDownCapture={(e) => {
+												if (e.button === 2) {
+													e.preventDefault();
+													e.stopPropagation();
+												}
+											}}
+											onPointerDownCapture={(e) => {
+												if (e.button === 2) {
+													e.preventDefault();
+													e.stopPropagation();
+												}
 											}}
 										>
 											<EllipsisVerticalIcon className="size-3.5" />


### PR DESCRIPTION
Right-clicking the kebab (⋮) button on a chat in the agents sidebar was showing two menus: the kebab's own dropdown **and** the row-level right-click context menu.

The kebab lives inside the row's \`ContextMenuTrigger\`, so the \`contextmenu\` event on the button bubbles up and opens the row's context menu on top of the dropdown that the button already owns.

Fix: swallow \`contextmenu\` on the kebab \`Button\` so only its dropdown is associated with the button. Right-clicking anywhere else on the row still opens the row context menu as before.

> Generated with Coder Agents on behalf of @tracyjohnsonux.