### PR TITLE
fix(site): freeze motion animations during Pixel captures

### DIFF
--- a/site/.storybook/preview.tsx
+++ b/site/.storybook/preview.tsx
@@ -1,7 +1,9 @@
 import "../src/index.css";
 import "../src/theme/globalFonts";
+import { isPixel } from "@coder/pixel-storybook/storyapi";
 import { DecoratorHelpers } from "@storybook/addon-themes";
 import type { Decorator, Parameters } from "@storybook/react-vite";
+import { MotionConfig, MotionGlobalConfig } from "motion/react";
 import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { withRouter } from "storybook-addon-remix-react-router";
@@ -11,6 +13,8 @@ import { AppearanceProvider } from "../src/theme/appearance";
 import { ThemeContextProvider } from "../src/theme/context";
 
 DecoratorHelpers.initializeThemeState(Object.keys(themes), "dark");
+
+MotionGlobalConfig.skipAnimations = isPixel();
 
 export const parameters: Parameters = {
 	options: {
@@ -120,4 +124,15 @@ const withTheme: Decorator = (Story, context) => {
 	);
 };
 
-export const decorators: Decorator[] = [withRouter, withQuery, withTheme];
+const withSkipAnimations: Decorator = (Story) => (
+	<MotionConfig skipAnimations={isPixel()}>
+		<Story />
+	</MotionConfig>
+);
+
+export const decorators: Decorator[] = [
+	withRouter,
+	withQuery,
+	withTheme,
+	withSkipAnimations,
+];

--- a/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
@@ -1,6 +1,6 @@
 import type { MotionProps } from "motion/react";
-import { MotionConfig, motion } from "motion/react";
-import type { ElementType, JSX } from "react";
+import { MotionConfig, MotionConfigContext, motion } from "motion/react";
+import { type ElementType, type JSX, useContext } from "react";
 
 import { cn } from "#/utils/cn";
 
@@ -40,16 +40,21 @@ const ShimmerComponent = ({
 		Component as keyof JSX.IntrinsicElements,
 	);
 
+	// skipAnimations jumps to the final keyframe, which leaves the
+	// gradient offscreen, so hold it centered for captures.
+	const { skipAnimations = false } = useContext(MotionConfigContext);
+
 	const dynamicSpread = (children?.length ?? 0) * spread;
 
 	return (
 		<MotionConfig reducedMotion="user">
 			<MotionComponent
-				data-pixel="ignore"
-				animate={{ backgroundPosition: "0% center" }}
+				animate={{
+					backgroundPosition: skipAnimations ? "50% center" : "0% center",
+				}}
 				className={cn(
 					"relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
-					"[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),hsl(var(--surface-primary)),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",
+					"[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),hsl(var(--surface-primary)),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat]",
 					className,
 				)}
 				initial={{ backgroundPosition: "100% center" }}

--- a/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
+++ b/site/src/pages/TemplateBuilder/BuildingTemplateLoader.tsx
@@ -6,8 +6,8 @@ import {
 	PackageIcon,
 	WrenchIcon,
 } from "lucide-react";
-import { motion } from "motion/react";
-import type { FC } from "react";
+import { MotionConfigContext, motion } from "motion/react";
+import { type FC, useContext } from "react";
 
 type FloatingIcon = {
 	name: string;
@@ -34,6 +34,10 @@ const ICONS: FloatingIcon[] = [
  * label.
  */
 export const BuildingTemplateLoader: FC = () => {
+	// skipAnimations jumps to each loop's final keyframe, which is
+	// blank here (icons offscreen, dots faded), so hold a visible frame.
+	const { skipAnimations = false } = useContext(MotionConfigContext);
+
 	return (
 		<div
 			className="relative flex flex-col items-center justify-end w-full min-h-[480px] overflow-hidden"
@@ -50,10 +54,14 @@ export const BuildingTemplateLoader: FC = () => {
 							left: `calc(50% + ${x}%)`,
 							top: `calc(50% + ${y}%)`,
 						}}
-						animate={{
-							y: ["-100vh", "0vh", "0vh", "0vh", "-100vh", "-100vh"],
-							opacity: [0, 1, 1, 0, 0, 0],
-						}}
+						animate={
+							skipAnimations
+								? { y: "0vh", opacity: 1 }
+								: {
+										y: ["-100vh", "0vh", "0vh", "0vh", "-100vh", "-100vh"],
+										opacity: [0, 1, 1, 0, 0, 0],
+									}
+						}
 						transition={{
 							duration: 7,
 							delay,
@@ -89,7 +97,9 @@ export const BuildingTemplateLoader: FC = () => {
 					<span>Building your template</span>
 					<span className="inline-flex gap-0.5">
 						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
+							animate={
+								skipAnimations ? { opacity: 1 } : { opacity: [0, 1, 1, 0] }
+							}
 							transition={{
 								duration: 1.5,
 								repeat: Number.POSITIVE_INFINITY,
@@ -99,7 +109,9 @@ export const BuildingTemplateLoader: FC = () => {
 							.
 						</motion.span>
 						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
+							animate={
+								skipAnimations ? { opacity: 1 } : { opacity: [0, 1, 1, 0] }
+							}
 							transition={{
 								duration: 1.5,
 								delay: 0.2,
@@ -110,7 +122,9 @@ export const BuildingTemplateLoader: FC = () => {
 							.
 						</motion.span>
 						<motion.span
-							animate={{ opacity: [0, 1, 1, 0] }}
+							animate={
+								skipAnimations ? { opacity: 1 } : { opacity: [0, 1, 1, 0] }
+							}
 							transition={{
 								duration: 1.5,
 								delay: 0.4,


### PR DESCRIPTION
Stop the shimmer component from causing changes in each storybook run.