### PR TITLE
fix(site/src/pages/AgentsPage/components): fix model selector trigger layout on form-style pages

### DIFF
--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -398,7 +398,7 @@ const CompactIntegerField: FC<CompactIntegerFieldProps> = ({
 				disabled={disabled}
 				className="min-w-0 w-full border-none bg-transparent p-0 text-sm font-medium leading-6 text-content-placeholder outline-none disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
 			/>
-			<span className="shrink-0 text-xs font-normal leading-[18px] text-content-placeholder">
+			<span className="shrink-0 text-xs font-normal leading-[18px] text-content-secondary">
 				{label}
 			</span>
 		</label>

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1452,7 +1452,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 								options={modelOptions}
 								disabled={isDisabled}
 								placeholder={modelSelectorPlaceholder}
-								className="md:shrink"
+								className="md:h-auto md:w-auto md:shrink"
 								dropdownSide="top"
 								dropdownAlign="start"
 								enableMobileFullWidthDropdown

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -216,6 +216,33 @@ export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
 	],
 };
 
+// A model name longer than the trigger truncates while the provider icon
+// keeps its full size; without shrink-0 on the icon wrapper, flex
+// shrinking combined with preflight's img max-width scales the icon down.
+export const FormFieldTriggerTruncatesLongModelName: Story = {
+	args: {
+		options: [
+			{
+				...MockModelSelectorOption,
+				id: "openai/gpt-4o-mini-extended",
+				model: "gpt-4o-mini-extended-ultra-long-context-preview",
+				displayName: "GPT-4o mini Extended Ultra Long Context Preview Edition",
+				contextLimit: 1_000_000,
+			},
+		],
+		value: "openai/gpt-4o-mini-extended",
+		className:
+			"h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-sm md:w-[18rem]",
+	},
+	decorators: [
+		(Story) => (
+			<div className="w-[30rem]">
+				<Story />
+			</div>
+		),
+	],
+};
+
 // ---------------------------------------------------------------------------
 // Multiple providers (grouped)
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -67,6 +67,14 @@ const effortModel: ModelSelectorOption = {
 	],
 };
 
+const longNameModel: ModelSelectorOption = {
+	...MockModelSelectorOption,
+	id: "openai/gpt-4o-mini-extended",
+	model: "gpt-4o-mini-extended-ultra-long-context-preview",
+	displayName: "GPT-4o mini Extended Ultra Long Context Preview Edition",
+	contextLimit: 1_000_000,
+};
+
 const meta: Meta<typeof ModelSelector> = {
 	title: "pages/AgentsPage/ChatElements/ModelSelector",
 	component: ModelSelector,
@@ -221,16 +229,8 @@ export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
 // shrinking combined with preflight's img max-width scales the icon down.
 export const FormFieldTriggerTruncatesLongModelName: Story = {
 	args: {
-		options: [
-			{
-				...MockModelSelectorOption,
-				id: "openai/gpt-4o-mini-extended",
-				model: "gpt-4o-mini-extended-ultra-long-context-preview",
-				displayName: "GPT-4o mini Extended Ultra Long Context Preview Edition",
-				contextLimit: 1_000_000,
-			},
-		],
-		value: "openai/gpt-4o-mini-extended",
+		options: [longNameModel],
+		value: longNameModel.id,
 		className:
 			"h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-sm md:w-[18rem]",
 	},

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -194,6 +194,34 @@ export const Disabled: Story = {
 	},
 };
 
+// Form-style call sites (settings pages) stretch the trigger with
+// w-full + justify-between; the provider icon and label must stay
+// adjacent instead of the label floating to the center.
+export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
+	args: {
+		options: allModels,
+		value: "anthropic/claude-sonnet-4",
+		className:
+			"h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm",
+	},
+	decorators: [
+		(Story) => (
+			<div className="w-[30rem]">
+				<Story />
+			</div>
+		),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const icon = canvas.getByTestId("model-selector-trigger-icon");
+		const label = canvas.getByText("Claude Sonnet 4");
+		const gap =
+			label.getBoundingClientRect().left - icon.getBoundingClientRect().right;
+		expect(gap).toBeGreaterThanOrEqual(0);
+		expect(gap).toBeLessThan(12);
+	},
+};
+
 // ---------------------------------------------------------------------------
 // Multiple providers (grouped)
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -196,8 +196,10 @@ export const Disabled: Story = {
 
 // Form-style call sites (settings pages) stretch the trigger wider than
 // its content (w-full below the md breakpoint, fixed widths like
-// md:w-[18rem] above it) and pass justify-between; the provider icon and
-// label must stay adjacent instead of the label floating to the center.
+// md:w-[18rem] above it) and pass justify-between with an h-10 height.
+// The visual snapshot of this story guards that the provider icon and
+// label stay adjacent (instead of the label floating to the center) and
+// that the call site's h-10 wins over the component's base sizing.
 export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
 	args: {
 		options: allModels,
@@ -212,19 +214,6 @@ export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
 			</div>
 		),
 	],
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const icon = canvas.getByTestId("model-selector-trigger-icon");
-		const label = canvas.getByText("Claude Sonnet 4");
-		const gap =
-			label.getBoundingClientRect().left - icon.getBoundingClientRect().right;
-		expect(gap).toBeGreaterThanOrEqual(0);
-		expect(gap).toBeLessThan(12);
-		// The call site's h-10 must control the trigger height at every
-		// breakpoint so the field matches adjacent h-10 form buttons.
-		const trigger = canvas.getByRole("combobox", { name: "Claude Sonnet 4" });
-		expect(trigger.getBoundingClientRect().height).toBe(40);
-	},
 };
 
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -194,15 +194,16 @@ export const Disabled: Story = {
 	},
 };
 
-// Form-style call sites (settings pages) stretch the trigger with
-// w-full + justify-between; the provider icon and label must stay
-// adjacent instead of the label floating to the center.
+// Form-style call sites (settings pages) stretch the trigger wider than
+// its content (w-full below the md breakpoint, fixed widths like
+// md:w-[18rem] above it) and pass justify-between; the provider icon and
+// label must stay adjacent instead of the label floating to the center.
 export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
 	args: {
 		options: allModels,
 		value: "anthropic/claude-sonnet-4",
 		className:
-			"h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm",
+			"h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-sm md:w-[18rem]",
 	},
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -220,6 +220,10 @@ export const FormFieldTriggerKeepsIconAndLabelAdjacent: Story = {
 			label.getBoundingClientRect().left - icon.getBoundingClientRect().right;
 		expect(gap).toBeGreaterThanOrEqual(0);
 		expect(gap).toBeLessThan(12);
+		// The call site's h-10 must control the trigger height at every
+		// breakpoint so the field matches adjacent h-10 form buttons.
+		const trigger = canvas.getByRole("combobox", { name: "Claude Sonnet 4" });
+		expect(trigger.getBoundingClientRect().height).toBe(40);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -163,7 +163,11 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					type="button"
 					variant="subtle"
 					className={cn(
-						"h-7 md:h-auto min-w-0 shrink justify-start gap-1 rounded-full border-0 bg-surface-secondary px-2 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link md:w-auto md:shrink-0 [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
+						// No responsive size variants here: tailwind-merge resolves
+						// conflicts per modifier, so a base md:h-auto would silently
+						// defeat a call site's h-10 at the md breakpoint. Composer
+						// pill responsive sizing lives at its call site.
+						"h-7 min-w-0 shrink justify-start gap-1 rounded-full border-0 bg-surface-secondary px-2 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
 						className,
 					)}
 					onTouchStart={onTriggerTouchStart}

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -168,16 +168,21 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					)}
 					onTouchStart={onTriggerTouchStart}
 				>
-					{selectedModel && (
-						<span data-testid="model-selector-trigger-icon">
-							<ProviderIcon
-								provider={selectedModel.provider}
-								icon={selectedModel.providerIcon}
-								className="size-3 shrink-0"
-							/>
-						</span>
-					)}
-					<span className="truncate">{triggerLabel}</span>
+					{/* The icon and label form one flex child so call sites that
+					   override the trigger with justify-between keep them adjacent
+					   instead of stretching the label away from the icon. */}
+					<span className="flex min-w-0 items-center gap-1">
+						{selectedModel && (
+							<span data-testid="model-selector-trigger-icon">
+								<ProviderIcon
+									provider={selectedModel.provider}
+									icon={selectedModel.providerIcon}
+									className="size-3 shrink-0"
+								/>
+							</span>
+						)}
+						<span className="truncate">{triggerLabel}</span>
+					</span>
 					<ChevronDownIcon open={open} />
 				</Button>
 			</PopoverTrigger>

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -163,21 +163,17 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 					type="button"
 					variant="subtle"
 					className={cn(
-						// No responsive size variants here: tailwind-merge resolves
-						// conflicts per modifier, so a base md:h-auto would silently
-						// defeat a call site's h-10 at the md breakpoint. Composer
-						// pill responsive sizing lives at its call site.
 						"h-7 min-w-0 shrink justify-start gap-1 rounded-full border-0 bg-surface-secondary px-2 py-0.5 text-xs font-medium shadow-none transition-colors hover:bg-surface-tertiary hover:text-content-primary focus:ring-0 focus-visible:ring-2 focus-visible:ring-content-link [&>svg]:!size-3.5 [&>svg]:p-0 [&>svg]:shrink-0 [&>svg]:transition [&>svg]:hover:text-content-primary [&>img]:!size-3 [&>img]:!p-0",
 						className,
 					)}
 					onTouchStart={onTriggerTouchStart}
 				>
-					{/* The icon and label form one flex child so call sites that
-					   override the trigger with justify-between keep them adjacent
-					   instead of stretching the label away from the icon. */}
 					<span className="flex min-w-0 items-center gap-1">
 						{selectedModel && (
-							<span data-testid="model-selector-trigger-icon">
+							<span
+								className="flex shrink-0 items-center"
+								data-testid="model-selector-trigger-icon"
+							>
 								<ProviderIcon
 									provider={selectedModel.provider}
 									icon={selectedModel.providerIcon}


### PR DESCRIPTION
Selecting a model on form-style pages (deployment AI settings such as `/ai/settings/coder-agents`, the personal agent settings override rows, and the advisor override) rendered a broken trigger: the provider icon pinned to the far-left edge, the model name floating in the center, and the chevron on the right. At desktop widths the field also collapsed to content height (~22px) next to the 40px Clear/Save buttons.

Two defects in the shared `ModelSelector` trigger:

1. #28330 added the provider icon as a third direct flex child of the trigger button. Form call sites override the trigger with `justify-between` plus a width wider than its content, which spread icon, label, and chevron apart. The icon and label now form a single flex child so they stay adjacent under any `justify-*` override; the chevron stays a direct child because the `[&>svg]` trigger styles target it, and the label still truncates via `min-w-0`.
2. The base classes carried composer-pill responsive variants (`md:h-auto`, `md:w-auto`, `md:shrink-0`). tailwind-merge resolves conflicts per modifier, so `md:h-auto` silently defeated the call sites' `h-10` at the `md` breakpoint (and `md:w-auto` defeated `w-[22rem]` on the advisor row). The pill's responsive sizing now lives at its call site, so plain `h-10`/width overrides win everywhere. The composer pill is visually unchanged.

Also fixes the provider icon shrinking next to long model names: the icon's `span` wrapper was a plain flex item whose automatic minimum size collapses (preflight's `img { max-width: 100% }` scales the icon down as the wrapper shrinks). The wrapper is now a `shrink-0` flex container, so the label truncates while the icon keeps its 12px size (verified red-green with a temporary probe: 7.3px without the fix).

Adds `FormFieldTriggerKeepsIconAndLabelAdjacent` and `FormFieldTriggerTruncatesLongModelName` stories reproducing the form-style trigger for visual snapshot coverage. Both defects were verified red-green during development with temporary geometry probes (icon-label gap 63.5px and height 30px without the fixes; gap 4px and height 40px with them); per FE10 the committed story carries no geometry assertions and the pixel snapshot guards the layout.

Also recolors the advisor "Uses / turn" and "Max tokens" field labels from `content-placeholder` to `content-secondary` on the same settings surface.

Remote dogfood UAT ran against this branch across desktop and narrow viewports and passed.

> 🤖 Mux acted on behalf of @ibetitsmike to create this PR.



