### PR TITLE
docs: clarify who can set AI model prices and how they are keyed

### DIFF
--- a/docs/ai-coder/ai-gateway/cost-controls.md
+++ b/docs/ai-coder/ai-gateway/cost-controls.md
@@ -238,8 +238,10 @@ price for it yourself.
 
 Use the experimental `coder exp ai-model-prices` command to set model prices
 for your deployment. It requires AI Governance, which is included with a
-Premium license, and the `ai_model_price:update` permission. Run
-`coder exp ai-model-prices --help` for the full reference.
+Premium license, and the Owner
+[role](../../admin/users/groups-roles.md) or a custom role granting
+`ai_model_price:update`. Run `coder exp ai-model-prices --help` for the full
+reference.
 
 List the prices this deployment holds, optionally narrowed to one provider or
 model. The `source` column reports whether a price is a default price
@@ -285,6 +287,10 @@ coder exp ai-model-prices update prices.json
 >   unpriced, so past spend does not change.
 > - A price you set takes precedence over the default and stays in effect
 >   across upgrades, so it does not pick up later price books.
+> - A price is keyed by provider type and model, so every configured provider
+>   of that type shares it.
+> - `openai-compat` providers cannot be priced. They pass through to any
+>   upstream vendor, so a single price would be wrong for most of them.
 > - This command is experimental and can change without notice.
 
 ## Monitor spend

--- a/enterprise/cli/exp_aimodelprices.go
+++ b/enterprise/cli/exp_aimodelprices.go
@@ -47,6 +47,8 @@ Coder's price book:
       "cache_write_price": null
     }
   ]
+  * A price is keyed by provider type and model, so every configured
+    provider of that type shares it.
   * Prices are micro-units per million tokens, so 3000000 is $3.00 per
     million tokens.
   * A 'null' price is unknown and adds no cost. An explicit 0 declares the
@@ -97,7 +99,7 @@ func (r *RootCmd) aiModelPricesList() *serpent.Command {
 		Options: serpent.OptionSet{
 			{
 				Flag:        "provider",
-				Description: "Only show models for this provider.",
+				Description: "Only show models for this provider type.",
 				Value:       serpent.StringOf(&provider),
 			},
 			{
@@ -202,9 +204,10 @@ func (r *RootCmd) aiModelPricesUpdate() *serpent.Command {
 		Middleware: serpent.Chain(serpent.RequireRangeArgs(0, 1)),
 		Options: serpent.OptionSet{
 			{
-				Flag:        "provider",
-				Description: "Provider of the model to price.",
-				Value:       serpent.StringOf(&provider),
+				Flag: "provider",
+				Description: "Provider type of the model to price. Every configured " +
+					"provider of that type shares the price.",
+				Value: serpent.StringOf(&provider),
 			},
 			{
 				Flag:        "model",


### PR DESCRIPTION
The docs named the `ai_model_price:update` permission but never said which role holds it, and nothing anywhere explained that a price is keyed by provider type and model, so every configured provider of that type shares it. This names the Owner role, documents the keying and why `openai-compat` cannot be priced, and repeats both in the CLI's `--provider` descriptions and `update` help.

> [!NOTE]
> Initially generated by Claude Opus 5, modified and reviewed by @ssncferreira
