### PR TITLE
feat(coderd): lower chat stream silence timeout and make it configurable

### DIFF
--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -805,6 +805,10 @@ chat:
   # opt-in settings.
   # (default: false, type: bool)
   debugLoggingEnabled: false
+  # How long a chat model attempt may go without receiving a stream part before it
+  # is canceled and retried.
+  # (default: 5m, type: duration)
+  streamSilenceTimeout: 5m0s
   # HTTPS URL to receive chat agent lifecycle hook events (plain HTTP requires
   # --chat-hook-allow-insecure). Hooks are disabled when unset. Requires the
   # agent-lifecycle-hooks experiment.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17803,6 +17803,9 @@ const docTemplate = `{
                 },
                 "hook_url": {
                     "$ref": "#/definitions/serpent.URL"
+                },
+                "stream_silence_timeout": {
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16017,6 +16017,9 @@
 				},
 				"hook_url": {
 					"$ref": "#/definitions/serpent.URL"
+				},
+				"stream_silence_timeout": {
+					"type": "integer"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -944,6 +944,7 @@ func New(options *Options) *API {
 				AllowBYOKSet:                   true,
 				AIBridgeTransportFactory:       &api.AIBridgeTransportFactory,
 				AlwaysEnableDebugLogs:          options.DeploymentValues.AI.Chat.DebugLoggingEnabled.Value(),
+				StreamSilenceTimeout:           options.DeploymentValues.AI.Chat.StreamSilenceTimeout.Value(),
 				Experiments:                    experiments,
 				AgentConn:                      api.agentProvider.AgentConn,
 				AgentInactiveDisconnectTimeout: api.AgentInactiveDisconnectTimeout,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -179,6 +179,7 @@ type Server struct {
 	agentInactiveDisconnectTimeout time.Duration
 	dialTimeout                    time.Duration
 	instructionLookupTimeout       time.Duration
+	streamSilenceTimeout           time.Duration
 	createWorkspaceFn              chattool.CreateWorkspaceFn
 	startWorkspaceFn               chattool.StartWorkspaceFn
 	stopWorkspaceFn                chattool.StopWorkspaceFn
@@ -3044,11 +3045,15 @@ type Config struct {
 	ReplicaID uuid.UUID
 	// StreamPartsDialer dials remote stream parts. Nil uses the local
 	// in-process channel dialer for every stream.
-	StreamPartsDialer              StreamPartsDialer
-	PendingChatAcquireInterval     time.Duration
-	MaxChatsPerAcquire             int32
-	InFlightChatStaleAfter         time.Duration
-	ChatHeartbeatInterval          time.Duration
+	StreamPartsDialer          StreamPartsDialer
+	PendingChatAcquireInterval time.Duration
+	MaxChatsPerAcquire         int32
+	InFlightChatStaleAfter     time.Duration
+	ChatHeartbeatInterval      time.Duration
+	// StreamSilenceTimeout bounds how long a model attempt may go
+	// without receiving a stream part before it is canceled and
+	// retried. Zero uses the chatloop default.
+	StreamSilenceTimeout           time.Duration
 	AgentConn                      AgentConnFunc
 	AgentInactiveDisconnectTimeout time.Duration
 	InstructionLookupTimeout       time.Duration
@@ -3146,6 +3151,7 @@ func New(ps pubsub.Pubsub, cfg Config) *Server {
 		agentInactiveDisconnectTimeout: cfg.AgentInactiveDisconnectTimeout,
 		dialTimeout:                    defaultDialTimeout,
 		instructionLookupTimeout:       instructionLookupTimeout,
+		streamSilenceTimeout:           cfg.StreamSilenceTimeout,
 		createWorkspaceFn:              cfg.CreateWorkspace,
 		startWorkspaceFn:               cfg.StartWorkspace,
 		stopWorkspaceFn:                cfg.StopWorkspace,

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -35,8 +35,10 @@ import (
 const (
 	// defaultStreamSilenceTimeout bounds how long an individual
 	// model attempt may go without receiving a stream part before
-	// the attempt is canceled and retried.
-	defaultStreamSilenceTimeout = 10 * time.Minute
+	// the attempt is canceled and retried. Five minutes tolerates
+	// long provider thinking pauses while bounding how long a
+	// wedged provider stream can stall a turn.
+	defaultStreamSilenceTimeout = 5 * time.Minute
 	streamSilenceGuardTimerTag  = "streamSilenceGuard"
 )
 

--- a/coderd/x/chatd/generation.go
+++ b/coderd/x/chatd/generation.go
@@ -742,6 +742,7 @@ func (s *taskStarter) generateAssistant(
 		ProviderOptions:      prepared.ProviderOptions,
 		PublishMessagePart:   attempt.publish,
 		OnModelStreamStart:   attempt.startModelInvocation,
+		StreamSilenceTimeout: s.server.streamSilenceTimeout,
 		Logger:               s.opts.Logger,
 		Clock:                s.opts.Clock,
 		Metrics:              s.server.metrics,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4364,6 +4364,7 @@ Write out the current server config as YAML to stdout.`,
 			Group:       &deploymentGroupChat,
 			YAML:        "streamSilenceTimeout",
 			Hidden:      true, // Hidden because most operators should not need to modify this.
+			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
 		},
 		{
 			Name:        "Chat: Hook URL",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4355,6 +4355,17 @@ Write out the current server config as YAML to stdout.`,
 			YAML:        "debugLoggingEnabled",
 		},
 		{
+			Name:        "Chat: Stream Silence Timeout",
+			Description: "How long a chat model attempt may go without receiving a stream part before it is canceled and retried.",
+			Flag:        "chat-stream-silence-timeout",
+			Env:         "CODER_CHAT_STREAM_SILENCE_TIMEOUT",
+			Value:       &c.AI.Chat.StreamSilenceTimeout,
+			Default:     "5m",
+			Group:       &deploymentGroupChat,
+			YAML:        "streamSilenceTimeout",
+			Hidden:      true, // Hidden because most operators should not need to modify this.
+		},
+		{
 			Name:        "Chat: Hook URL",
 			Description: "HTTPS URL to receive chat agent lifecycle hook events (plain HTTP requires --chat-hook-allow-insecure). Hooks are disabled when unset. Requires the agent-lifecycle-hooks experiment.",
 			Flag:        "chat-hook-url",
@@ -5092,13 +5103,14 @@ type AIBridgeProxyConfig struct {
 }
 
 type ChatConfig struct {
-	AcquireBatchSize    serpent.Int64    `json:"acquire_batch_size" typescript:",notnull"`
-	DebugLoggingEnabled serpent.Bool     `json:"debug_logging_enabled" typescript:",notnull"`
-	HookURL             serpent.URL      `json:"hook_url" typescript:",notnull"`
-	HookSecret          serpent.String   `json:"hook_secret" typescript:",notnull"`
-	HookTimeout         serpent.Duration `json:"hook_timeout" typescript:",notnull"`
-	HookEnabled         serpent.Bool     `json:"hook_enabled" typescript:",notnull"`
-	HookAllowInsecure   serpent.Bool     `json:"hook_allow_insecure" typescript:",notnull"`
+	AcquireBatchSize     serpent.Int64    `json:"acquire_batch_size" typescript:",notnull"`
+	DebugLoggingEnabled  serpent.Bool     `json:"debug_logging_enabled" typescript:",notnull"`
+	StreamSilenceTimeout serpent.Duration `json:"stream_silence_timeout" typescript:",notnull"`
+	HookURL              serpent.URL      `json:"hook_url" typescript:",notnull"`
+	HookSecret           serpent.String   `json:"hook_secret" typescript:",notnull"`
+	HookTimeout          serpent.Duration `json:"hook_timeout" typescript:",notnull"`
+	HookEnabled          serpent.Bool     `json:"hook_enabled" typescript:",notnull"`
+	HookAllowInsecure    serpent.Bool     `json:"hook_allow_insecure" typescript:",notnull"`
 	// Deprecated: AI Gateway routing is now the only routing path. Setting this
 	// value has no effect. This option will be removed in a future release.
 	AIGatewayRoutingEnabled serpent.Bool `json:"ai_gateway_routing_enabled" typescript:",notnull" swaggerignore:"true"`

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -254,7 +254,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
           "rawQuery": "string",
           "scheme": "string",
           "user": {}
-        }
+        },
+        "stream_silence_timeout": 0
       }
     },
     "allow_workspace_renames": true,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1103,7 +1103,8 @@ title: Schemas
       "rawQuery": "string",
       "scheme": "string",
       "user": {}
-    }
+    },
+    "stream_silence_timeout": 0
   }
 }
 ```
@@ -2550,21 +2551,23 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "rawQuery": "string",
     "scheme": "string",
     "user": {}
-  }
+  },
+  "stream_silence_timeout": 0
 }
 ```
 
 ### Properties
 
-| Name                    | Type                       | Required | Restrictions | Description |
-|-------------------------|----------------------------|----------|--------------|-------------|
-| `acquire_batch_size`    | integer                    | false    |              |             |
-| `debug_logging_enabled` | boolean                    | false    |              |             |
-| `hook_allow_insecure`   | boolean                    | false    |              |             |
-| `hook_enabled`          | boolean                    | false    |              |             |
-| `hook_secret`           | string                     | false    |              |             |
-| `hook_timeout`          | integer                    | false    |              |             |
-| `hook_url`              | [serpent.URL](#serpenturl) | false    |              |             |
+| Name                     | Type                       | Required | Restrictions | Description |
+|--------------------------|----------------------------|----------|--------------|-------------|
+| `acquire_batch_size`     | integer                    | false    |              |             |
+| `debug_logging_enabled`  | boolean                    | false    |              |             |
+| `hook_allow_insecure`    | boolean                    | false    |              |             |
+| `hook_enabled`           | boolean                    | false    |              |             |
+| `hook_secret`            | string                     | false    |              |             |
+| `hook_timeout`           | integer                    | false    |              |             |
+| `hook_url`               | [serpent.URL](#serpenturl) | false    |              |             |
+| `stream_silence_timeout` | integer                    | false    |              |             |
 
 ## codersdk.ChatContext
 
@@ -6100,7 +6103,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
           "rawQuery": "string",
           "scheme": "string",
           "user": {}
-        }
+        },
+        "stream_silence_timeout": 0
       }
     },
     "allow_workspace_renames": true,
@@ -6728,7 +6732,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         "rawQuery": "string",
         "scheme": "string",
         "user": {}
-      }
+      },
+      "stream_silence_timeout": 0
     }
   },
   "allow_workspace_renames": true,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2091,6 +2091,7 @@ export const ChatComputerUseProviders: ChatComputerUseProvider[] = [
 export interface ChatConfig {
 	readonly acquire_batch_size: number;
 	readonly debug_logging_enabled: boolean;
+	readonly stream_silence_timeout: number;
 	readonly hook_url: string;
 	readonly hook_secret: string;
 	readonly hook_timeout: number;


### PR DESCRIPTION
## Stack context

MCP connect-stall incident follow-up. Below: #28400 (connect budget enforcement), #28402 (connect/prep observability). This layer tightens the stream-level resilience knob.

## Why

During the incident a wedged provider stream held a generation for the full 10-minute silence guard before the retry kicked in. Ten minutes is far slower than any legitimate provider pause; the guard exists to catch dead streams, not to give providers ten minutes of grace.

## Changes

- `defaultStreamSilenceTimeout` in chatloop drops from 10 to 5 minutes.
- The timeout is now configurable per deployment via the hidden `--chat-stream-silence-timeout` flag / `CODER_CHAT_STREAM_SILENCE_TIMEOUT` env (default 5m), wired through `chatd.Config.StreamSilenceTimeout` into `GenerateAssistantOptions`, so dogfood can tune it without a release.
- `make gen` artifacts (apidoc, typesGenerated, server config golden, docs) regenerated.

## Tests

Existing chatloop silence-guard tests pass with the new default (`go test ./coderd/x/chatd/chatloop/ ./coderd/x/chatd/`); the timeout remains injected via options in tests, so no behavior-dependent test needed changes.

> 🤖 Mux authored this PR on Mike's behalf.

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high -->
