### PR TITLE
fix(site/src/pages/AgentsPage/components/ChatElements/tools): stop completed process_output rows animating forever

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -14,13 +14,23 @@ import {
 	resolveAgentDisplayState,
 } from "./displayMode";
 import { ToolCall } from "./ToolCall";
-import { sanitizeExecuteModelIntent, signalTooltipLabel } from "./utils";
+import {
+	sanitizeExecuteModelIntent,
+	signalTooltipLabel,
+	type ToolStatus,
+} from "./utils";
 
 type ProcessOutputToolProps = {
 	output: string;
 	command?: string;
 	modelIntent?: string;
-	isRunning: boolean;
+	status: ToolStatus;
+	/**
+	 * Whether the result snapshot saw the process still alive. This only
+	 * affects label tense and signal badges; the row must not animate for
+	 * it, because the snapshot never updates once the poll completes.
+	 */
+	processRunning?: boolean;
 	exitCode: number | null;
 	isError: boolean;
 	errorMessage?: string;
@@ -59,7 +69,8 @@ export const ProcessOutputTool: React.FC<ProcessOutputToolProps> = ({
 	output,
 	command,
 	modelIntent,
-	isRunning,
+	status,
+	processRunning = false,
 	exitCode,
 	isError,
 	errorMessage,
@@ -73,6 +84,7 @@ export const ProcessOutputTool: React.FC<ProcessOutputToolProps> = ({
 		autoDisplayState,
 	);
 
+	const isRunning = status === "running" || processRunning;
 	// A clean exit is the expected outcome of a check, so only
 	// failures earn a badge. The label verb carries the rest.
 	const isFailed = exitCode !== null && exitCode !== 0;
@@ -83,7 +95,7 @@ export const ProcessOutputTool: React.FC<ProcessOutputToolProps> = ({
 		<ToolCall.Root
 			key={`${shellToolDisplayMode ?? "auto"}:${autoDisplayState}`}
 			className="group/proc w-full"
-			status={isRunning ? "running" : isError ? "error" : "completed"}
+			status={status}
 			isError={isError}
 			errorMessage={errorMessage || "Failed to read process output"}
 			hasContent={hasOutput}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -717,10 +717,17 @@ export const ProcessOutputModelIntent: Story = {
 			canvas.getByText("Waiting for the dev server to be ready"),
 		).toBeVisible();
 		expect(canvas.queryByText(/npm start/)).not.toBeInTheDocument();
+		expect(
+			canvas.getByRole("img", { name: "Tool call running" }),
+		).toBeVisible();
 	},
 };
 
-/** Wait timed out while the process lives on: running:true in the result. */
+/**
+ * Wait timed out while the process lives on: running:true in the result.
+ * The label keeps the present tense, but the row must not keep animating
+ * (spinner/shimmer) once the poll itself has completed.
+ */
 export const ProcessOutputStillRunningResult: Story = {
 	args: {
 		name: "process_output",
@@ -737,6 +744,9 @@ export const ProcessOutputStillRunningResult: Story = {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("Checking npm start")).toBeVisible();
 		expect(canvas.queryByText(/Checked/)).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("img", { name: "Tool call running" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -268,7 +268,8 @@ const ProcessOutputRenderer: FC<ToolRendererProps> = ({
 			output={output}
 			command={command || undefined}
 			modelIntent={modelIntent}
-			isRunning={status === "running" || processRunning}
+			status={status}
+			processRunning={processRunning}
 			exitCode={exitCode}
 			isError={isError}
 			errorMessage={errorMessage || undefined}


### PR DESCRIPTION
Since #28300, `process_output` tool rows in the Agents chat transcript fed the result payload's `running: true` flag into the row's active state. That flag is a frozen snapshot of whether the polled process was still alive, so for long-lived background processes (a dev server that never exits) every completed poll kept its shimmer label and spinner animating forever, even after the agent went idle.

`ToolCall.Root` now receives the actual tool-call status, so the shimmer and spinner stop when the poll completes. The `running: true` snapshot still controls what it was meant to: label tense ("Checking npm start" while alive vs "Checked npm start" after exit) and kill-signal badge visibility. The existing `ProcessOutputStillRunningResult` story now also asserts the running spinner is absent on a completed poll (verified red-green: reintroducing the bug fails exactly that story), and the intent story asserts the spinner is present while the tool call is genuinely running.

> [!NOTE]
> Mux (AI agent) authored this PR on behalf of @ibetitsmike.

<!-- mux-attribution: model=claude-opus-4-6 thinking=high -->
