### PR TITLE
ci: map changed docs images to pages in docs-preview

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -1,54 +1,18 @@
-# This workflow posts a docs preview comment listing every navigable
-# page a pull request touches. The preview is served by coder.com's
-# branch-preview feature at /docs/@<branch>.
+# Posts a docs-preview comment on docs PRs. For every changed page with a
+# docs/manifest.json route it lists a preview link (coder.com/docs/@<branch>,
+# branch URL-encoded) and a Markdown checkbox. Checkbox state round-trips
+# across pushes but resets when a page's content changes, so a checked box
+# means "reviewed the current revision." Pages with no manifest route
+# (docs/.style/** tooling, or not-yet-navigable pages) are dropped, since
+# they 404 on the docs site. The comment is updated in place on later
+# pushes and deleted when nothing previewable remains.
 #
-# Each page in the list gets its own preview link plus a Markdown
-# task-list checkbox, so a reviewer can tick off pages as they review
-# them. State is round-tripped across pushes: a checkbox a reviewer
-# already ticked stays ticked as long as that page hasn't changed
-# since, but flips back to unchecked the moment new content lands on
-# that page, since a checked box should mean "I've reviewed the
-# current revision," not "I reviewed some earlier revision of this
-# page."
-#
-# The checkbox contract (reset-on-change) matches GitHub's native
-# per-file "Viewed" control, but Viewed tracks the raw diff and can't
-# deep-link to the rendered coder.com preview. This checklist tracks
-# review of the preview page itself, which the platform doesn't
-# provide, so the state is reimplemented here rather than reused.
-#
-# Only pages that resolve to a route in docs/manifest.json get a
-# link. Anything else (docs/.style/** contributor tooling, or a page
-# that hasn't been wired into navigation yet) is dropped from the list
-# entirely, since those pages 404 on the docs site and would confuse
-# reviewers.
-#
-# Branch names are URL-encoded so that names containing slashes or
-# other special characters produce working links.
-#
-# On subsequent pushes (synchronize) the existing comment is updated
-# rather than creating a duplicate. If a previous push had eligible
-# content but the current push has none, the stale comment is deleted
-# so readers don't follow a dead deep-link. If the PR only deletes
-# Markdown files (or only changes non-previewable files such as
-# manifest.json), no comment is posted.
-#
-# Changed images get their own section. When a PR touches an image
-# under docs/ (even with no Markdown change at all, as a screenshot
-# refresh does), the comment lists each changed image with a nested
-# list of the navigable pages that embed it, each linking to that
-# page's preview, so a reviewer can see the new image in the context
-# of every page that renders it. Image-to-page mapping reads the
-# referencing Markdown from disk, so this job checks the repo out at
-# the PR head (change detection itself still uses the PR files API).
-# Referencing pages are held to the same manifest.json allowlist as
-# the checklist: a page with no docs-site route is dropped, since its
-# preview would 404. An image that no navigable page embeds (an icon
-# wired only into docs/manifest.json, say) is still listed on its own,
-# so a screenshot- or icon-only PR always gets a comment. The image
-# list is informational only, with no review checkboxes: the image
-# changed but the pages embedding it did not, so the checklist's
-# reset-on-change contract doesn't apply.
+# Changed images get an informational section (no checkboxes: the image
+# changed, the embedding pages did not). Each image lists the manifest-
+# routed pages that embed it; mapping needs the referencing Markdown on
+# disk, so the job checks out the PR head. An image no navigable page
+# embeds (e.g. an icon referenced only from manifest.json) is still listed
+# on its own, so an image-only PR always gets a comment.
 
 name: docs-preview
 
@@ -60,10 +24,9 @@ on:
       - reopened
     paths:
       - "docs/**"
-      # docs/.style/** is contributor tooling and never deploys to coder.com.
-      # Skipping the workflow on .style-only PRs avoids posting a preview
-      # comment with an empty page list. Mixed PRs still trigger; the
-      # selection logic below filters .style files out of the preview list.
+      # docs/.style/** is contributor tooling that never deploys; skipping
+      # .style-only PRs avoids an empty preview list. Mixed PRs still run,
+      # and the selection logic below filters .style out.
       - "!docs/.style/**"
 
 concurrency:
@@ -77,20 +40,15 @@ jobs:
   docs-preview:
     runs-on: ubuntu-latest
     permissions:
-      # Job-level permissions replace (not merge with) the workflow-level
-      # defaults above, so contents: read has to be repeated here for the
-      # actions/checkout below (used to resolve image-to-page references).
+      # Job-level permissions replace the workflow defaults, so contents:
+      # read is repeated here for the checkout below.
       contents: read
       pull-requests: write # needed for commenting on PRs
     steps:
-      # Checked out only to resolve which pages embed a changed image:
-      # references are relative Markdown/HTML links, so mapping an image
-      # back to its pages needs the referencing files on disk. Pinned to
-      # the PR head sha so the references and docs/manifest.json match the
-      # commit the file list and preview links point at. Sparse-checked out
-      # to docs/ only, the sole tree this job reads (pages_for_image greps
-      # docs/**/*.md and the manifest read is docs/manifest.json), so the
-      # step doesn't pull the rest of the monorepo it never opens.
+      # Checked out only to resolve image references (relative Markdown/HTML
+      # links) to their pages. Pinned to the PR head so refs and
+      # docs/manifest.json match the file list; sparse to docs/, the only
+      # tree this job reads.
       - name: Check out docs sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -106,21 +64,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # DOCS_PREVIEW_MARKER locates this workflow's own comments.
-          # STATE_PREFIX carries the last-seen `path -> blob sha` map for
-          # change detection. Keep this script's map_doc_path, manifest
-          # filter, and carryover logic in sync with
-          # test-docs-preview-mapper.sh.
+          # DOCS_PREVIEW_MARKER locates this workflow's own comments;
+          # STATE_PREFIX carries the last-seen `path -> blob sha` map. Keep
+          # map_doc_path, the manifest filter, and the carryover logic in
+          # sync with test-docs-preview-mapper.sh.
           DOCS_PREVIEW_MARKER='<!-- docs-preview -->'
           STATE_PREFIX='docs-preview-state:'
 
-          # The image section is rendered whole rather than binary-searched
-          # like the checklist, so these caps bound its size: at most
-          # IMAGE_SECTION_BUDGET bytes, and at most IMAGE_PAGES_MAX pages
-          # listed per image, with "and N more" notes when it truncates.
-          # Realistic docs PRs never reach either; they only keep the
-          # comment under GitHub's 65536-char cap in pathological cases.
-          # Keep in sync with test-docs-preview-mapper.sh.
+          # Bound the always-rendered image section: at most
+          # IMAGE_SECTION_BUDGET bytes and IMAGE_PAGES_MAX pages per image,
+          # with "and N more" notes on overflow. Only matters in pathological
+          # cases. Keep in sync with test-docs-preview-mapper.sh.
           IMAGE_SECTION_BUDGET=20000
           IMAGE_PAGES_MAX=25
 
@@ -132,12 +86,10 @@ jobs:
               --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"${DOCS_PREVIEW_MARKER}\")) | .id"
           }
 
-          # Deletes the existing docs-preview comment (found earlier as
-          # existing_id) and exits 0, so a stale comment doesn't point
-          # readers at a dead deep-link. A failed delete is only cosmetic,
-          # so it logs and exits clean; the next push retries. The upsert
-          # path uses strict propagation instead, since silent failure
-          # there would duplicate comments.
+          # Deletes the existing comment (existing_id) and exits 0 so no
+          # stale dead-link remains. A failed delete is cosmetic: log and
+          # exit clean, next push retries. (The upsert path propagates
+          # failures instead, to avoid duplicate comments.)
           cleanup_stale_and_exit() {
             if [ -n "$existing_id" ]; then
               if gh api --method DELETE \
@@ -190,10 +142,8 @@ jobs:
             printf '%s' "$page_path"
           }
 
-          # Builds a page's preview URL from its repo path: the branch
-          # preview prefix plus the page's manifest route. Shared by the
-          # checklist and the image section so both link identically.
-          # Reads $url_prefix, set before either caller runs.
+          # Page preview URL: branch prefix ($url_prefix) plus the page's
+          # manifest route. Shared by the checklist and image section.
           page_url() {
             local filename="$1" page_path url
             page_path=$(map_doc_path "$filename")
@@ -204,16 +154,13 @@ jobs:
             printf '%s' "$url"
           }
 
-          # Extracts raw image-reference path tokens from one Markdown file,
-          # one per line: the target of every ![alt](path ...) Markdown
-          # image and every <img ... src="path"> HTML tag. Tokens are
-          # returned as written (still relative, possibly external); the
-          # resolve step decides which are repo-relative image paths. `|| true`
-          # keeps a no-match grep (exit 1) from tripping set -e.
+          # Emits the raw path token of every ![alt](path ...) and
+          # <img ... src="path"> in a Markdown file, one per line, as written
+          # (resolve_ref decides which are repo images). `|| true` keeps a
+          # no-match grep from tripping set -e.
           extract_ref_tokens() {
             local file="$1"
-            # Markdown: capture up to the first space or ) so an optional
-            # "title" after the path is dropped.
+            # Markdown: capture to the first space or ) to drop a title.
             grep -oE '!\[[^]]*\]\([^)[:space:]]+' "$file" 2>/dev/null \
               | sed -E 's/^!\[[^]]*\]\(//' || true
             # HTML: single- or double-quoted src, case-insensitive tag/attr.
@@ -221,17 +168,15 @@ jobs:
               | sed -E 's/.*src=//I; s/^["'\'']//; s/["'\'']$//' || true
           }
 
-          # Normalizes a reference found in Markdown file $1 into a repo-root-
-          # relative path, or prints nothing when the reference is external
-          # (has a scheme, or is protocol-relative) or otherwise can't be a
-          # repo path. realpath -m resolves ../ and ./ without requiring the
-          # target to exist; --relative-to makes the result comparable to the
-          # docs/... paths from the PR files API.
+          # Normalizes a ref from Markdown file $1 to a repo-root-relative
+          # path (stripping a #fragment, ?query, or <...> wrapper), or
+          # nothing when external or protocol-relative. realpath -m resolves
+          # ../ without requiring the target to exist.
           resolve_ref() {
             local file="$1" ref="$2" dir
-            ref="${ref%%#*}"   # drop #fragment
-            ref="${ref%%\?*}"  # drop ?query
-            ref="${ref#<}"     # drop an optional <...> wrapper
+            ref="${ref%%#*}"
+            ref="${ref%%\?*}"
+            ref="${ref#<}"
             ref="${ref%>}"
             [ -z "$ref" ] && return 0
             case "$ref" in
@@ -241,20 +186,15 @@ jobs:
             realpath -m --relative-to="$PWD" "${PWD}/${dir}/${ref}" 2>/dev/null || true
           }
 
-          # Prints every docs page that embeds the given repo-relative image
-          # path, one per line. A page qualifies only when one of its image
-          # references resolves to exactly this image, so a file that merely
-          # mentions the basename in prose is not matched, and two images
-          # that share a basename in different directories don't cross-match.
-          # The grep -rlF is a coarse basename pre-filter; correctness comes
-          # from the exact basename and resolved-path checks.
+          # Pages that embed the given image, one per line. A page matches
+          # only when one of its refs resolves to exactly this image, so a
+          # prose basename mention or a same-basename image in another dir
+          # won't. grep -rlF is a coarse basename pre-filter.
           pages_for_image() {
             local image="$1" base candidates file token
             base=$(basename "$image")
             # -e so a basename beginning with '-' is treated as a pattern,
-            # not as grep options: -F changes pattern interpretation, not
-            # option parsing, so grep -rlF "-foo.png" would still parse the
-            # leading dash as flags and silently match nothing.
+            # not as grep options.
             candidates=$(grep -rlF -e "$base" docs --include='*.md' 2>/dev/null \
               | grep -v '^docs/\.style/' || true)
             [ -z "$candidates" ] && return 0
@@ -271,52 +211,30 @@ jobs:
             done <<< "$candidates"
           }
 
-          # Look up the existing docs-preview comment id up front so both
-          # the cleanup path and the upsert path can reuse it without
-          # listing twice. The body is fetched later, just before state
-          # recovery, to keep the read-modify-write window small.
-          #
-          # Keep the strict list separate from the tolerant head. A real
-          # list failure (network, auth, rate-limit) must propagate under
-          # set -e; otherwise the upsert treats it as "no comment" and
-          # posts a duplicate. The `|| true` only absorbs head's SIGPIPE
-          # on the printf feeding head.
+          # Find the existing comment id once, for both the cleanup and
+          # upsert paths. The list must propagate a real failure under set -e
+          # (else the upsert sees "no comment" and posts a duplicate); the
+          # `|| true` only absorbs head's SIGPIPE.
           all_comment_ids=$(list_docs_preview_comments)
           existing_id=$(printf '%s\n' "$all_comment_ids" | head -n 1) || true
 
-          # Fetch the PR's changed files once, then derive both the Markdown
-          # and the image sets from the same payload. A single read halves
-          # this endpoint's rate-limit cost on a workflow that fires on every
-          # push, and closes a consistency gap: two separate --paginate reads
-          # of the same PR could straddle a synchronize event and describe
-          # different heads.
-          #
-          # Captured (not piped straight into jq) so that a gh-api failure
-          # (network, auth, rate-limit) propagates immediately under set -e
-          # instead of being swallowed by a downstream `|| true`. gh emits
-          # one JSON array per page; jq's `.[]` streams across the
-          # concatenated arrays, so no --slurp is needed.
-          #
-          # `pulls/files` truncates at GitHub's 3000-file ceiling, which
-          # --paginate does not lift. A PR that changes 3000+ files would
-          # list only the first 3000; docs PRs never approach that.
+          # Fetch the PR's changed files once, then derive the Markdown and
+          # image sets from the same payload: one read halves the rate-limit
+          # cost and avoids two paginated reads straddling a synchronize.
+          # Captured (not piped) so a gh failure propagates under set -e; jq
+          # `.[]` streams the per-page arrays, so no --slurp. pulls/files
+          # caps at 3000 files, which docs PRs never approach.
           files_json=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files")
 
-          # The non-removed Markdown files under docs/ (excluding
-          # docs/.style/**), one <filename>\t<sha> pair per line. `.sha` is
-          # the blob sha of the file's content at this push, which is what
-          # lets later runs detect "this page changed since it was last
-          # listed" without a full checkout.
+          # Non-removed docs/*.md (outside docs/.style/) as <filename>\t<sha>.
+          # The blob sha lets a later run detect a page changed since it was
+          # last listed.
           changed_tsv=$(printf '%s' "$files_json" \
             | jq -r '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.md$")) | select((.filename | test("^docs/\\.style/")) | not) | [.filename, .sha] | @tsv')
 
-          # The changed images under docs/ (outside docs/.style/), one
-          # filename per line. Same status and .style filtering as the
-          # Markdown query; the extension set is matched case-insensitively
-          # so .PNG etc. still count. No blob sha is tracked because the
-          # image section is stateless (no review checkboxes to carry over),
-          # unlike the checklist. Keep the extension set in sync with
-          # test-docs-preview-mapper.sh.
+          # Changed docs/ images (outside docs/.style/), extensions matched
+          # case-insensitively. No sha: the image section is stateless. Keep
+          # the extension set in sync with test-docs-preview-mapper.sh.
           changed_images=$(printf '%s' "$files_json" \
             | jq -r '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.(png|jpe?g|gif|svg|webp|avif|bmp|ico)$"; "i")) | select((.filename | test("^docs/\\.style/")) | not) | .filename')
 
@@ -327,27 +245,16 @@ jobs:
             cleanup_stale_and_exit
           fi
 
-          # Read docs/manifest.json from the checked-out PR head and collect
-          # every object with a "path" key, which in the manifest is always
-          # a navigable page entry. Manifest paths are written "./foo/bar.md"
-          # or "foo/bar.md" relative to docs/; normalize both to
-          # "docs/foo/bar.md" so they compare directly against the PR-files
-          # filenames above and the resolved image references below.
-          #
-          # This makes the manifest an implicit hard dependency of comment
-          # persistence: if the manifest schema ever drops or renames the
-          # "path" key, the read still succeeds but allowed_paths comes back
-          # empty, no page is eligible, and the run takes
-          # cleanup_stale_and_exit, deleting the comment and its checkbox
-          # state. "Parsed fine, zero matches" is indistinguishable from
-          # "format changed," so a future manifest refactor must keep this
-          # extraction in step.
+          # Navigable pages from the PR-head manifest: every object with a
+          # "path" key, normalized to docs/... to compare against the PR-file
+          # and resolved-image paths. This makes the manifest a hard
+          # dependency: rename the "path" key and allowed_paths comes back
+          # empty, nothing is eligible, and the comment is deleted, so a
+          # future manifest refactor must keep this extraction in step.
           allowed_paths=$(jq -r '[.. | objects | select(has("path")) | .path] | .[]' docs/manifest.json \
             | sed -E 's#^\./##; s#^#docs/#')
 
-          # Intersect the changed-files set with the manifest allowlist.
-          # A file with no manifest route 404s on the docs site, so drop
-          # it from the list rather than link to a broken preview.
+          # Keep only changed pages with a manifest route; the rest 404.
           eligible_tsv=$(printf '%s\n' "$changed_tsv" | while IFS=$'\t' read -r filename sha; do
             [ -z "$filename" ] && continue
             if printf '%s\n' "$allowed_paths" | grep -qxF "$filename"; then
@@ -356,11 +263,8 @@ jobs:
           done)
 
           # Map each changed image to the manifest-routed pages that embed
-          # it, one "<image>\t<page>" pair per line. Pages that resolve but
-          # aren't in the manifest are dropped for the same reason as the
-          # checklist: their preview would 404. An image that ends up with
-          # no eligible page yields no pair here, but is still listed on its
-          # own (without page links) by the image_section_json step below.
+          # it, one "<image>\t<page>" per line. An image with no such page
+          # yields no pair but is still listed (link-less) below.
           image_pairs_tsv=$(printf '%s\n' "$changed_images" | while IFS= read -r image; do
             [ -z "$image" ] && continue
             pages_for_image "$image" | while IFS= read -r page; do
@@ -371,11 +275,9 @@ jobs:
             done
           done)
 
-          # Nothing to preview: no changed page on a manifest route and no
-          # changed image at all. A changed image that no navigable page
-          # embeds is still listed on its own, so any changed image keeps the
-          # comment alive; only a Markdown-only PR with nothing manifest-
-          # routed falls through here. Drop any stale comment and stop.
+          # Nothing to preview: no manifest-routed changed page and no
+          # changed image (a changed image always renders, so only a
+          # Markdown-only PR with nothing routed lands here). Drop and stop.
           if [ -z "$eligible_tsv" ] && [ -z "$changed_images" ]; then
             echo "No changed Markdown pages resolve to a docs/manifest.json route, and no images changed under docs/ (outside docs/.style/)."
             echo "(If pages you expect are missing, check docs/manifest.json's schema: an empty allowlist looks identical to no eligible pages.)"
@@ -388,14 +290,11 @@ jobs:
           eligible_json=$(printf '%s\n' "$eligible_tsv" \
             | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {filename: .[0], sha: .[1]}]')
 
-          # Combine every changed image with the manifest-routed pages that
-          # embed it, as [{image, pages:[...]}] sorted by image, each image's
-          # pages de-duplicated and sorted (jq unique sorts). An image with
-          # no embedding page keeps an empty pages list so it still renders
-          # (on its own line, no sub-links): icons live only in the
-          # manifest's icon_path and match no Markdown, and some images are
-          # embedded only by non-navigable pages. No changed image yields [],
-          # and then no image section is rendered. Keep in sync with
+          # [{image, pages:[...]}] sorted by image, pages per image deduped
+          # and sorted. An image with no embedding page keeps pages:[] so it
+          # still renders link-less (icons live only in manifest icon_path;
+          # some images are embedded only by non-navigable pages). No changed
+          # image yields [], so no image section. Keep in sync with
           # test-docs-preview-mapper.sh.
           image_section_json=$(jq -n \
             --argjson images "$(printf '%s\n' "$changed_images" | jq -R -s '[splits("\n") | select(length > 0)]')" \
@@ -404,48 +303,40 @@ jobs:
              | [$images[] | {image: ., pages: ($by[.] // [])}]
              | sort_by(.image)')
 
-          # Fetch the existing comment body now, right before reading its
-          # checkbox state, so a reviewer's toggle isn't overwritten by a
-          # stale read taken several API calls earlier. `|| true` keeps a
-          # transient API error from failing the run; state recovery then
-          # just treats every page as new.
-          #
-          # A reviewer toggle that lands in the small window between this
-          # read and the PATCH below is lost, but reappears correctly on
-          # the next push. Accepted limitation, not a bug.
+          # Fetch the body right before reading its checkbox state, so a
+          # reviewer's toggle isn't overwritten by a stale read from several
+          # API calls earlier. `|| true`: a transient error degrades to
+          # treating every page as new. A toggle landing between this read
+          # and the PATCH below is lost but reappears on the next push.
           existing_body=""
           if [ -n "$existing_id" ]; then
             existing_body=$(gh api "repos/${REPO}/issues/comments/${existing_id}" --jq '.body' || true)
             if [ -z "$existing_body" ]; then
-              # A docs-preview comment always contains its body, so an
-              # empty read against a known id is a transient fetch
-              # failure, not a legitimately empty comment. State recovery
-              # will reset every checkbox this push; log a breadcrumb so
-              # the reset isn't silent (it self-heals on the next push).
+              # A docs-preview comment always has a body, so an empty read
+              # against a known id is a transient fetch failure. Log the
+              # resulting checkbox reset so it isn't silent; self-heals next
+              # push.
               echo "Could not read existing comment ${existing_id}; checkbox state resets this push (transient, self-heals)." >&2
             fi
           fi
 
           # Recover state from the existing comment, if any:
-          #   - old_state: the path -> sha map this workflow wrote the
-          #     last time it updated the comment (hidden marker).
-          #   - old_checked: the path -> checked map read from the
-          #     *live* checkbox glyphs in the comment body, which is
-          #     where a reviewer's manual clicks land (GitHub persists a
-          #     checkbox toggle as an edit to the comment body).
+          #   - old_state: path -> sha map this workflow wrote last time
+          #     (hidden marker).
+          #   - old_checked: path -> checked map from the live checkbox
+          #     glyphs, where a reviewer's clicks land (GitHub persists a
+          #     toggle as a comment-body edit).
           old_state_json="{}"
           old_checked_json="{}"
           if [ -n "$existing_body" ]; then
             old_state_b64=$(printf '%s\n' "$existing_body" | grep -oE "${STATE_PREFIX}[A-Za-z0-9+/=]+" | sed "s/^${STATE_PREFIX}//") || true
             if [ -n "$old_state_b64" ]; then
-              # Guard the decode: a truncated or corrupted marker must
-              # degrade to "treat every page as new", not kill the run
-              # (base64 -d and jq both run under set -e). Reject an empty
-              # decode before the type check: on jq < 1.7 `jq -e` exits 0
-              # on empty input, so the type check alone would accept an
-              # empty string and `--argjson old_state ""` would abort the
-              # run. Require a non-empty result that parses as a JSON
-              # object, else keep {}.
+              # Guard the decode: a truncated/corrupt marker must degrade to
+              # "treat every page as new", not kill the run (base64 -d and jq
+              # run under set -e). The non-empty check matters because on
+              # jq < 1.7 `jq -e` exits 0 on empty input, so the type check
+              # alone would accept "" and `--argjson old_state ""` would
+              # abort. Else keep {}.
               decoded=$(printf '%s' "$old_state_b64" | base64 -d 2>/dev/null || true)
               if [ -n "$decoded" ] && printf '%s' "$decoded" | jq -e 'type == "object"' >/dev/null 2>&1; then
                 old_state_json="$decoded"
@@ -459,10 +350,9 @@ jobs:
               | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {(.[1]): (.[0] | test("x"; "i"))}] | add // {}') || true
           fi
 
-          # Decide each page's checked state: carry the live checkbox
-          # value forward only if the page's blob sha hasn't changed
-          # since the last time this workflow wrote the state marker.
-          # New pages, and pages whose sha moved, start unchecked.
+          # Each page's checked state: carry the live checkbox forward only
+          # if its blob sha is unchanged since the last state marker. New
+          # pages, and pages whose sha moved, start unchecked.
           final_rows=$(jq -n \
             --argjson eligible "$eligible_json" \
             --argjson old_state "$old_state_json" \
@@ -477,26 +367,22 @@ jobs:
               {filename: $f.filename, sha: $f.sha, checked: $checked}
             ] | sort_by(.filename)')
 
-          # URL-encode the branch name so slashes and special
-          # characters don't break the preview URL. The page path is
-          # left as-is because its components are simple ASCII path
-          # segments and the slashes between them must be preserved.
+          # URL-encode the branch so slashes and special characters don't
+          # break the preview URL. The page path is left as-is: its slashes
+          # are real path separators that must be preserved.
           encoded_branch=$(jq -rn --arg b "$BRANCH" '$b | @uri')
           url_prefix="https://coder.com/docs/@${encoded_branch}"
 
           total_pages=$(printf '%s' "$final_rows" | jq 'length')
 
-          # Render the "Changed images" section from image_section_json:
-          # each changed image as a bullet with, nested under it, the
-          # preview link for every page that embeds it. An image with no
-          # embedding page renders as a bare line with no sub-links. Unlike
-          # the checklist this isn't binary-searched, so it self-limits to a
-          # byte budget at image granularity (always emitting at least the
-          # first image) and to IMAGE_PAGES_MAX pages per image, appending
-          # "and N more" notes when it truncates. Prints nothing only when no
-          # image changed. Reads $image_section_json, $url_prefix (via
-          # page_url), REPO, PR_NUMBER, and the IMAGE_* caps. Keep in sync
-          # with test-docs-preview-mapper.sh.
+          # Render the "Changed images" section from image_section_json: each
+          # image as a bullet with a nested preview link per embedding page
+          # (an image with no page renders link-less). Self-limits to a byte
+          # budget at image granularity (always emits the first image) and to
+          # IMAGE_PAGES_MAX pages per image, with "and N more" notes on
+          # overflow. Reads $image_section_json, $url_prefix (via page_url),
+          # REPO, PR_NUMBER, IMAGE_* caps. Keep in sync with
+          # test-docs-preview-mapper.sh.
           render_image_section() {
             local budget="$1" count intro header out="" shown=0 i=0
             local image page_count entry j page url dropped candidate
@@ -521,10 +407,9 @@ jobs:
               if [ "$page_count" -gt "$IMAGE_PAGES_MAX" ]; then
                 entry="${entry}  - _and $((page_count - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
               fi
-              # Keep the first image unconditionally (an empty section under
-              # a header would be self-contradicting); for every later image
-              # measure the would-be section first so the rendered block
-              # stays under budget.
+              # Keep the first image unconditionally (an empty section under a
+              # header is self-contradicting); measure each later image's
+              # would-be section and stop before it exceeds budget.
               if [ "$shown" -gt 0 ]; then
                 candidate="${header}${out}${entry}"
                 if [ "$(printf '%s' "$candidate" | LC_ALL=C wc -c)" -gt "$budget" ]; then
@@ -542,18 +427,15 @@ jobs:
             printf '%s%s' "$header" "$out"
           }
 
-          # Rendered once (it doesn't depend on the page count) so the
-          # checklist binary search below sizes the page list against a body
-          # that already includes it.
+          # Rendered once (independent of page count) so the checklist binary
+          # search below sizes pages against a body that already includes it.
           image_section=$(render_image_section "$IMAGE_SECTION_BUDGET")
 
-          # Assemble the comment body for the first N pages: the optional
-          # checklist, the optional image section, and the hidden base64
-          # state marker. The checklist and the marker derive from the same
-          # N rows, so this prints exactly the bytes that get posted, which
-          # is what lets the caller size the comment by measuring rather
-          # than estimating. An image-only PR has zero pages, so the
-          # checklist and its intro are omitted and only images render.
+          # Assemble the body for the first N pages: optional checklist,
+          # optional image section, hidden base64 state marker. Checklist and
+          # marker derive from the same N rows, so this prints exactly the
+          # posted bytes, letting the caller size by measuring not estimating.
+          # An image-only PR has zero pages: only images render.
           build_comment_body() {
             local n="$1" rows state_json state_b64 checklist="" intro page_block=""
             local filename checked url box omitted
@@ -583,9 +465,8 @@ jobs:
               page_block="${intro}"$'\n\n'"${checklist}"
             fi
 
-            # Emit only the sections that have content. The identity marker
-            # and the state marker are always present so the comment stays
-            # discoverable and round-trippable, even on an image-only PR
+            # The identity and state markers are always present so the comment
+            # stays discoverable and round-trippable, even on an image-only PR
             # whose state map is {}.
             {
               printf '## Docs preview\n\n'
@@ -600,14 +481,11 @@ jobs:
             }
           }
 
-          # GitHub caps a comment body at 65536 characters. Estimating the
-          # per-page cost drifts from the real size (each page adds a
-          # checklist line and a base64 state entry whose combined length
-          # depends on the path), so assemble the real body and measure it
-          # instead. Keep every page if they all fit; otherwise binary
-          # search for the largest leading prefix that stays under budget.
-          # Body size grows monotonically with the page count, so the
-          # search is well defined. 65000 leaves headroom under the limit.
+          # GitHub caps a comment body at 65536 chars. Per-page cost varies
+          # with path length, so measure the real body instead of estimating:
+          # keep every page if all fit, else binary search the largest leading
+          # prefix under budget (body size grows monotonically with page
+          # count, so the search is well defined). 65000 leaves headroom.
           comment_budget=65000
           body_bytes() { LC_ALL=C wc -c; }
 
@@ -628,12 +506,11 @@ jobs:
             done
           fi
 
-          # Always list at least one page when the PR changed any page. The
-          # binary search can floor at 0 only if a single line exceeds the
-          # budget (impossible at real path lengths), and an empty list
-          # under an "and N more" summary would be self-contradicting; a
-          # floor of 1 makes that unreachable. An image-only PR legitimately
-          # has zero pages, so the floor is gated on total_pages.
+          # List at least one page when any page changed: the search floors at
+          # 0 only if a single line exceeds budget (impossible at real path
+          # lengths), and an empty list under an "and N more" summary is
+          # self-contradicting. Gated on total_pages so an image-only PR keeps
+          # its legitimate zero.
           if [ "$total_pages" -ge 1 ] && [ "$keep_pages" -lt 1 ]; then
             keep_pages=1
           fi
@@ -642,16 +519,12 @@ jobs:
           echo "Listing ${keep_pages} of ${total_pages} changed page(s); ${omitted_pages} omitted for comment size."
           comment_body=$(build_comment_body "$keep_pages")
 
-          # Upsert: PATCH the existing comment if we found one, else
-          # create it. existing_id is re-derived from a live list on
-          # every run (never persisted), so a genuinely deleted comment
-          # isn't found and lands in the create branch below.
-          #
-          # Therefore a PATCH failure against a known existing_id almost
-          # always means the comment still exists and the error is
-          # transient: never create in that case, or we post a permanent
-          # duplicate (the write-path sibling of the guarded list
-          # failure). Fail instead; the next push retries.
+          # Upsert: PATCH the existing comment if found, else create.
+          # existing_id is re-derived from a live list each run (never
+          # persisted), so a deleted comment lands in the create branch. A
+          # PATCH failure against a known id therefore almost always means the
+          # comment still exists and the error is transient: fail instead of
+          # creating a duplicate; the next push retries.
           if [ -n "$existing_id" ]; then
             if gh api --method PATCH \
               "repos/${REPO}/issues/comments/${existing_id}" \

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -28,10 +28,24 @@
 #
 # On subsequent pushes (synchronize) the existing comment is updated
 # rather than creating a duplicate. If a previous push had eligible
-# Markdown files but the current push has none, the stale comment is
-# deleted so readers don't follow a dead deep-link. If the PR only
-# deletes Markdown files (or only changes non-Markdown files such as
-# images or manifest.json), no comment is posted.
+# content but the current push has none, the stale comment is deleted
+# so readers don't follow a dead deep-link. If the PR only deletes
+# Markdown files (or only changes non-previewable files such as
+# manifest.json), no comment is posted.
+#
+# Changed images get their own section. When a PR touches an image
+# under docs/ (even with no Markdown change at all, as a screenshot
+# refresh does), the comment lists each changed image with a nested
+# list of the navigable pages that embed it, each linking to that
+# page's preview, so a reviewer can see the new image in the context
+# of every page that renders it. Image-to-page mapping reads the
+# referencing Markdown from disk, so this job checks the repo out at
+# the PR head (change detection itself still uses the PR files API).
+# Referencing pages are held to the same manifest.json allowlist as
+# the checklist: a page with no docs-site route is dropped, since its
+# preview would 404. The image list is informational only, with no
+# review checkboxes: the image changed but the pages embedding it did
+# not, so the checklist's reset-on-change contract doesn't apply.
 
 name: docs-preview
 
@@ -62,15 +76,24 @@ jobs:
     permissions:
       # Job-level permissions replace (not merge with) the workflow-level
       # defaults above, so contents: read has to be repeated here for the
-      # docs/manifest.json contents-API read below.
+      # actions/checkout below (used to resolve image-to-page references).
       contents: read
       pull-requests: write # needed for commenting on PRs
     steps:
+      # Checked out only to resolve which pages embed a changed image:
+      # references are relative Markdown/HTML links, so mapping an image
+      # back to its pages needs the referencing files on disk. Pinned to
+      # the PR head sha so the references and docs/manifest.json match the
+      # commit the file list and preview links point at.
+      - name: Check out docs sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Post docs preview comment
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -83,6 +106,16 @@ jobs:
           # test-docs-preview-mapper.sh.
           DOCS_PREVIEW_MARKER='<!-- docs-preview -->'
           STATE_PREFIX='docs-preview-state:'
+
+          # The image section is rendered whole rather than binary-searched
+          # like the checklist, so these caps bound its size: at most
+          # IMAGE_SECTION_BUDGET bytes, and at most IMAGE_PAGES_MAX pages
+          # listed per image, with "and N more" notes when it truncates.
+          # Realistic docs PRs never reach either; they only keep the
+          # comment under GitHub's 65536-char cap in pathological cases.
+          # Keep in sync with test-docs-preview-mapper.sh.
+          IMAGE_SECTION_BUDGET=20000
+          IMAGE_PAGES_MAX=25
 
           # Returns IDs of github-actions[bot] comments on the PR whose
           # body contains DOCS_PREVIEW_MARKER.
@@ -150,6 +183,83 @@ jobs:
             printf '%s' "$page_path"
           }
 
+          # Builds a page's preview URL from its repo path: the branch
+          # preview prefix plus the page's manifest route. Shared by the
+          # checklist and the image section so both link identically.
+          # Reads $url_prefix, set before either caller runs.
+          page_url() {
+            local filename="$1" page_path url
+            page_path=$(map_doc_path "$filename")
+            url="$url_prefix"
+            if [ -n "$page_path" ]; then
+              url="${url}/${page_path}"
+            fi
+            printf '%s' "$url"
+          }
+
+          # Extracts raw image-reference path tokens from one Markdown file,
+          # one per line: the target of every ![alt](path ...) Markdown
+          # image and every <img ... src="path"> HTML tag. Tokens are
+          # returned as written (still relative, possibly external); the
+          # resolve step decides which are repo-relative image paths. `|| true`
+          # keeps a no-match grep (exit 1) from tripping set -e.
+          extract_ref_tokens() {
+            local file="$1"
+            # Markdown: capture up to the first space or ) so an optional
+            # "title" after the path is dropped.
+            grep -oE '!\[[^]]*\]\([^)[:space:]]+' "$file" 2>/dev/null \
+              | sed -E 's/^!\[[^]]*\]\(//' || true
+            # HTML: single- or double-quoted src, case-insensitive tag/attr.
+            grep -oiE '<img[^>]+src=("[^"]+"|'\''[^'\'']+'\'')' "$file" 2>/dev/null \
+              | sed -E 's/.*src=//I; s/^["'\'']//; s/["'\'']$//' || true
+          }
+
+          # Normalizes a reference found in Markdown file $1 into a repo-root-
+          # relative path, or prints nothing when the reference is external
+          # (has a scheme, or is protocol-relative) or otherwise can't be a
+          # repo path. realpath -m resolves ../ and ./ without requiring the
+          # target to exist; --relative-to makes the result comparable to the
+          # docs/... paths from the PR files API.
+          resolve_ref() {
+            local file="$1" ref="$2" dir
+            ref="${ref%%#*}"   # drop #fragment
+            ref="${ref%%\?*}"  # drop ?query
+            ref="${ref#<}"     # drop an optional <...> wrapper
+            ref="${ref%>}"
+            [ -z "$ref" ] && return 0
+            case "$ref" in
+            *://* | //* | mailto:* | data:*) return 0 ;;
+            esac
+            dir=$(dirname "$file")
+            realpath -m --relative-to="$PWD" "${PWD}/${dir}/${ref}" 2>/dev/null || true
+          }
+
+          # Prints every docs page that embeds the given repo-relative image
+          # path, one per line. A page qualifies only when one of its image
+          # references resolves to exactly this image, so a file that merely
+          # mentions the basename in prose is not matched, and two images
+          # that share a basename in different directories don't cross-match.
+          # The grep -rlF is a coarse basename pre-filter; correctness comes
+          # from the exact basename and resolved-path checks.
+          pages_for_image() {
+            local image="$1" base candidates file token
+            base=$(basename "$image")
+            candidates=$(grep -rlF "$base" docs --include='*.md' 2>/dev/null \
+              | grep -v '^docs/\.style/' || true)
+            [ -z "$candidates" ] && return 0
+            while IFS= read -r file; do
+              [ -z "$file" ] && continue
+              while IFS= read -r token; do
+                [ -z "$token" ] && continue
+                [ "$(basename "$token")" = "$base" ] || continue
+                if [ "$(resolve_ref "$file" "$token")" = "$image" ]; then
+                  printf '%s\n' "$file"
+                  break
+                fi
+              done < <(extract_ref_tokens "$file")
+            done <<< "$candidates"
+          }
+
           # Look up the existing docs-preview comment id up front so both
           # the cleanup path and the upsert path can reuse it without
           # listing twice. The body is fetched later, just before state
@@ -180,33 +290,40 @@ jobs:
             "repos/${REPO}/pulls/${PR_NUMBER}/files" \
             --jq '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.md$")) | select((.filename | test("^docs/\\.style/")) | not) | [.filename, .sha] | @tsv')
 
-          if [ -z "$changed_tsv" ]; then
-            echo "No added/modified Markdown files under docs/ (outside docs/.style/) on this push."
+          # The changed images under docs/ (outside docs/.style/), one
+          # filename per line. Same status and .style filtering as the
+          # Markdown query; the extension set is matched case-insensitively
+          # so .PNG etc. still count. No blob sha is tracked because the
+          # image section is stateless (no review checkboxes to carry over),
+          # unlike the checklist. Keep the extension set in sync with
+          # test-docs-preview-mapper.sh.
+          changed_images=$(gh api --paginate \
+            "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.(png|jpe?g|gif|svg|webp|avif|bmp|ico)$"; "i")) | select((.filename | test("^docs/\\.style/")) | not) | .filename')
+
+          # Nothing previewable changed at all: drop any stale comment and
+          # stop before the manifest read and reference resolution below.
+          if [ -z "$changed_tsv" ] && [ -z "$changed_images" ]; then
+            echo "No added/modified Markdown or image files under docs/ (outside docs/.style/) on this push."
             cleanup_stale_and_exit
           fi
 
-          # Fetch docs/manifest.json at the PR head sha (this job never
-          # checks the repo out) and collect every object with a "path"
-          # key, which in the manifest is always a navigable page entry.
-          # Manifest paths are written "./foo/bar.md" or "foo/bar.md"
-          # relative to docs/; normalize both to "docs/foo/bar.md" so
-          # they compare directly against the PR-files filenames above.
-          #
-          # Request the raw blob rather than the JSON envelope so the
-          # read has no 1MB inline-body ceiling, which would otherwise
-          # return an empty body and silently drop every page.
+          # Read docs/manifest.json from the checked-out PR head and collect
+          # every object with a "path" key, which in the manifest is always
+          # a navigable page entry. Manifest paths are written "./foo/bar.md"
+          # or "foo/bar.md" relative to docs/; normalize both to
+          # "docs/foo/bar.md" so they compare directly against the PR-files
+          # filenames above and the resolved image references below.
           #
           # This makes the manifest an implicit hard dependency of comment
           # persistence: if the manifest schema ever drops or renames the
-          # "path" key, the fetch still succeeds but allowed_paths comes
-          # back empty, no page is eligible, and the run takes
+          # "path" key, the read still succeeds but allowed_paths comes back
+          # empty, no page is eligible, and the run takes
           # cleanup_stale_and_exit, deleting the comment and its checkbox
           # state. "Parsed fine, zero matches" is indistinguishable from
           # "format changed," so a future manifest refactor must keep this
           # extraction in step.
-          manifest_content=$(gh api -H "Accept: application/vnd.github.raw" "repos/${REPO}/contents/docs/manifest.json?ref=${HEAD_SHA}")
-          allowed_paths=$(printf '%s' "$manifest_content" \
-            | jq -r '[.. | objects | select(has("path")) | .path] | .[]' \
+          allowed_paths=$(jq -r '[.. | objects | select(has("path")) | .path] | .[]' docs/manifest.json \
             | sed -E 's#^\./##; s#^#docs/#')
 
           # Intersect the changed-files set with the manifest allowlist.
@@ -219,14 +336,41 @@ jobs:
             fi
           done)
 
-          if [ -z "$eligible_tsv" ]; then
-            echo "No changed Markdown files resolve to a docs/manifest.json route."
+          # Map each changed image to the manifest-routed pages that embed
+          # it, one "<image>\t<page>" pair per line. Pages that resolve but
+          # aren't in the manifest are dropped for the same reason as the
+          # checklist: their preview would 404. An image that ends up with
+          # no eligible page contributes nothing and is not listed.
+          image_pairs_tsv=$(printf '%s\n' "$changed_images" | while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            pages_for_image "$image" | while IFS= read -r page; do
+              [ -z "$page" ] && continue
+              if printf '%s\n' "$allowed_paths" | grep -qxF "$page"; then
+                printf '%s\t%s\n' "$image" "$page"
+              fi
+            done
+          done)
+
+          # Nothing resolves to a preview: neither a changed page on a
+          # manifest route nor a changed image embedded by one. Drop any
+          # stale comment and stop.
+          if [ -z "$eligible_tsv" ] && [ -z "$image_pairs_tsv" ]; then
+            echo "No changed Markdown pages or referenced images resolve to a docs/manifest.json route."
             echo "(If pages you expect are missing, check docs/manifest.json's schema: an empty allowlist looks identical to no eligible pages.)"
             cleanup_stale_and_exit
           fi
 
+          # May be an empty array: an image-only PR has no changed pages,
+          # in which case the checklist section is omitted and only the
+          # image section renders.
           eligible_json=$(printf '%s\n' "$eligible_tsv" \
             | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {filename: .[0], sha: .[1]}]')
+
+          # Group the image/page pairs into [{image, pages:[...]}], pages
+          # de-duplicated and sorted (jq unique sorts), images sorted. Empty
+          # input yields [], and then no image section is rendered.
+          image_section_json=$(printf '%s\n' "$image_pairs_tsv" \
+            | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {image: .[0], page: .[1]}] | group_by(.image) | map({image: .[0].image, pages: (map(.page) | unique)}) | sort_by(.image)')
 
           # Fetch the existing comment body now, right before reading its
           # checkbox state, so a reviewer's toggle isn't overwritten by a
@@ -310,44 +454,117 @@ jobs:
 
           total_pages=$(printf '%s' "$final_rows" | jq 'length')
 
-          # Assemble the comment body for the first N pages: the checklist,
-          # the hidden base64 state marker, and (when N < total_pages) the
-          # omitted-pages summary line. Both the checklist and the marker
-          # derive from the same N rows, so this prints exactly the bytes
-          # that get posted, which is what lets the caller size the comment
-          # by measuring rather than estimating.
+          # Render the "Changed images" section from image_section_json:
+          # each changed image as a bullet with, nested under it, the
+          # preview link for every page that embeds it. Unlike the checklist
+          # this isn't binary-searched, so it self-limits to a byte budget
+          # at image granularity (always emitting at least the first image)
+          # and to IMAGE_PAGES_MAX pages per image, appending "and N more"
+          # notes when it truncates. Prints nothing when no image maps to an
+          # eligible page. Reads $image_section_json, $url_prefix (via
+          # page_url), and the IMAGE_* caps. Keep in sync with
+          # test-docs-preview-mapper.sh.
+          render_image_section() {
+            local budget="$1" count intro header out="" shown=0 i=0
+            local image np entry j pg url dropped candidate
+            count=$(printf '%s' "$image_section_json" | jq 'length')
+            if [ "$count" -eq 0 ]; then
+              return 0
+            fi
+            intro="These images changed. Each is listed with the page(s) that embed it so you can open the preview and see the new image in context. These links are informational and separate from the checklist above."
+            header="#### Changed images"$'\n\n'"${intro}"$'\n\n'
+            while [ "$i" -lt "$count" ]; do
+              image=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" '.[$i].image')
+              np=$(printf '%s' "$image_section_json" | jq --argjson i "$i" '.[$i].pages | length')
+              # The backticks are literal Markdown code-span delimiters.
+              entry="- \`${image}\`"$'\n'
+              j=0
+              while [ "$j" -lt "$np" ] && [ "$j" -lt "$IMAGE_PAGES_MAX" ]; do
+                pg=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" --argjson j "$j" '.[$i].pages[$j]')
+                url=$(page_url "$pg")
+                entry="${entry}  - [\`${pg}\`](${url})"$'\n'
+                j=$((j + 1))
+              done
+              if [ "$np" -gt "$IMAGE_PAGES_MAX" ]; then
+                entry="${entry}  - _and $((np - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
+              fi
+              # Keep the first image unconditionally (an empty section under
+              # a header would be self-contradicting); for every later image
+              # measure the would-be section first so the rendered block
+              # stays under budget.
+              if [ "$shown" -gt 0 ]; then
+                candidate="${header}${out}${entry}"
+                if [ "$(printf '%s' "$candidate" | LC_ALL=C wc -c)" -gt "$budget" ]; then
+                  break
+                fi
+              fi
+              out="${out}${entry}"
+              shown=$((shown + 1))
+              i=$((i + 1))
+            done
+            dropped=$((count - shown))
+            if [ "$dropped" -gt 0 ]; then
+              out="${out}"$'\n'"_and ${dropped} more changed image(s) not listed to stay under GitHub's comment size limit._"$'\n'
+            fi
+            printf '%s%s' "$header" "$out"
+          }
+
+          # Rendered once (it doesn't depend on the page count) so the
+          # checklist binary search below sizes the page list against a body
+          # that already includes it.
+          image_section=$(render_image_section "$IMAGE_SECTION_BUDGET")
+
+          # Assemble the comment body for the first N pages: the optional
+          # checklist, the optional image section, and the hidden base64
+          # state marker. The checklist and the marker derive from the same
+          # N rows, so this prints exactly the bytes that get posted, which
+          # is what lets the caller size the comment by measuring rather
+          # than estimating. An image-only PR has zero pages, so the
+          # checklist and its intro are omitted and only images render.
           build_comment_body() {
-            local n="$1" rows state_json state_b64 checklist="" intro
-            local filename checked page_path url box omitted
+            local n="$1" rows state_json state_b64 checklist="" intro page_block=""
+            local filename checked url box omitted
 
             rows=$(printf '%s' "$final_rows" | jq -c --argjson n "$n" '.[:$n]')
             state_json=$(printf '%s' "$rows" | jq -c 'map({(.filename): .sha}) | add // {}')
             state_b64=$(printf '%s' "$state_json" | base64 -w0)
 
-            while IFS=$'\t' read -r filename checked; do
-              [ -z "$filename" ] && continue
-              page_path=$(map_doc_path "$filename")
-              url="$url_prefix"
-              if [ -n "$page_path" ]; then
-                url="${url}/${page_path}"
-              fi
-              box=" "
-              if [ "$checked" = "true" ]; then
-                box="x"
-              fi
-              # The backticks are literal Markdown code-span delimiters.
-              checklist="${checklist}- [${box}] [\`${filename}\`](${url})"$'\n'
-            done < <(printf '%s' "$rows" | jq -r '.[] | [.filename, (.checked | tostring)] | @tsv')
+            if [ "$total_pages" -gt 0 ]; then
+              while IFS=$'\t' read -r filename checked; do
+                [ -z "$filename" ] && continue
+                url=$(page_url "$filename")
+                box=" "
+                if [ "$checked" = "true" ]; then
+                  box="x"
+                fi
+                # The backticks are literal Markdown code-span delimiters.
+                checklist="${checklist}- [${box}] [\`${filename}\`](${url})"$'\n'
+              done < <(printf '%s' "$rows" | jq -r '.[] | [.filename, (.checked | tostring)] | @tsv')
 
-            omitted=$((total_pages - n))
-            if [ "$omitted" -gt 0 ]; then
-              checklist="${checklist}"$'\n'"_and ${omitted} more changed page(s) not listed to stay under GitHub's comment size limit. See the [Files tab](https://github.com/${REPO}/pull/${PR_NUMBER}/files) for the full list._"$'\n'
+              omitted=$((total_pages - n))
+              if [ "$omitted" -gt 0 ]; then
+                checklist="${checklist}"$'\n'"_and ${omitted} more changed page(s) not listed to stay under GitHub's comment size limit. See the [Files tab](https://github.com/${REPO}/pull/${PR_NUMBER}/files) for the full list._"$'\n'
+              fi
+
+              intro="Check off each page once it's been reviewed. If a page changes in a later push, its checkbox clears automatically so it gets a fresh look. Pages not yet wired into the docs navigation aren't listed here."
+              page_block="${intro}"$'\n\n'"${checklist}"
             fi
 
-            intro="Check off each page once it's been reviewed. If a page changes in a later push, its checkbox clears automatically so it gets a fresh look. Pages not yet wired into the docs navigation aren't listed here."
-
-            printf '## Docs preview\n\n%s\n\n%s\n%s\n<!-- %s%s -->' \
-              "$intro" "$checklist" "$DOCS_PREVIEW_MARKER" "$STATE_PREFIX" "$state_b64"
+            # Emit only the sections that have content. The identity marker
+            # and the state marker are always present so the comment stays
+            # discoverable and round-trippable, even on an image-only PR
+            # whose state map is {}.
+            {
+              printf '## Docs preview\n\n'
+              if [ -n "$page_block" ]; then
+                printf '%s\n' "$page_block"
+              fi
+              if [ -n "$image_section" ]; then
+                printf '%s\n' "$image_section"
+              fi
+              printf '%s\n' "$DOCS_PREVIEW_MARKER"
+              printf '<!-- %s%s -->' "$STATE_PREFIX" "$state_b64"
+            }
           }
 
           # GitHub caps a comment body at 65536 characters. Estimating the
@@ -378,12 +595,13 @@ jobs:
             done
           fi
 
-          # Always list at least one page. The binary search can floor at
-          # 0 only if a single line exceeds the budget (impossible at real
-          # path lengths), and an empty list under an "and N more" summary
-          # would be self-contradicting; a floor of 1 makes that
-          # unreachable state impossible.
-          if [ "$keep_pages" -lt 1 ]; then
+          # Always list at least one page when the PR changed any page. The
+          # binary search can floor at 0 only if a single line exceeds the
+          # budget (impossible at real path lengths), and an empty list
+          # under an "and N more" summary would be self-contradicting; a
+          # floor of 1 makes that unreachable. An image-only PR legitimately
+          # has zero pages, so the floor is gated on total_pages.
+          if [ "$total_pages" -ge 1 ] && [ "$keep_pages" -lt 1 ]; then
             keep_pages=1
           fi
 

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -43,9 +43,12 @@
 # the PR head (change detection itself still uses the PR files API).
 # Referencing pages are held to the same manifest.json allowlist as
 # the checklist: a page with no docs-site route is dropped, since its
-# preview would 404. The image list is informational only, with no
-# review checkboxes: the image changed but the pages embedding it did
-# not, so the checklist's reset-on-change contract doesn't apply.
+# preview would 404. An image that no navigable page embeds (an icon
+# wired only into docs/manifest.json, say) is still listed on its own,
+# so a screenshot- or icon-only PR always gets a comment. The image
+# list is informational only, with no review checkboxes: the image
+# changed but the pages embedding it did not, so the checklist's
+# reset-on-change contract doesn't apply.
 
 name: docs-preview
 
@@ -84,12 +87,16 @@ jobs:
       # references are relative Markdown/HTML links, so mapping an image
       # back to its pages needs the referencing files on disk. Pinned to
       # the PR head sha so the references and docs/manifest.json match the
-      # commit the file list and preview links point at.
+      # commit the file list and preview links point at. Sparse-checked out
+      # to docs/ only, the sole tree this job reads (pages_for_image greps
+      # docs/**/*.md and the manifest read is docs/manifest.json), so the
+      # step doesn't pull the rest of the monorepo it never opens.
       - name: Check out docs sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          sparse-checkout: docs
       - name: Post docs preview comment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -244,7 +251,11 @@ jobs:
           pages_for_image() {
             local image="$1" base candidates file token
             base=$(basename "$image")
-            candidates=$(grep -rlF "$base" docs --include='*.md' 2>/dev/null \
+            # -e so a basename beginning with '-' is treated as a pattern,
+            # not as grep options: -F changes pattern interpretation, not
+            # option parsing, so grep -rlF "-foo.png" would still parse the
+            # leading dash as flags and silently match nothing.
+            candidates=$(grep -rlF -e "$base" docs --include='*.md' 2>/dev/null \
               | grep -v '^docs/\.style/' || true)
             [ -z "$candidates" ] && return 0
             while IFS= read -r file; do
@@ -273,22 +284,31 @@ jobs:
           all_comment_ids=$(list_docs_preview_comments)
           existing_id=$(printf '%s\n' "$all_comment_ids" | head -n 1) || true
 
-          # Fetch the non-removed Markdown files under docs/ (excluding
-          # docs/.style/**) this PR currently touches, one <filename>\t<sha>
-          # pair per line. `.sha` is the blob sha of the file's content at
-          # this push, which is what lets later runs detect "this page
-          # changed since it was last listed" without a full checkout.
+          # Fetch the PR's changed files once, then derive both the Markdown
+          # and the image sets from the same payload. A single read halves
+          # this endpoint's rate-limit cost on a workflow that fires on every
+          # push, and closes a consistency gap: two separate --paginate reads
+          # of the same PR could straddle a synchronize event and describe
+          # different heads.
           #
-          # This is intentionally not piped into grep so that a gh-api
-          # failure (network, auth, rate-limit) propagates immediately
-          # instead of being swallowed by `|| true`.
+          # Captured (not piped straight into jq) so that a gh-api failure
+          # (network, auth, rate-limit) propagates immediately under set -e
+          # instead of being swallowed by a downstream `|| true`. gh emits
+          # one JSON array per page; jq's `.[]` streams across the
+          # concatenated arrays, so no --slurp is needed.
           #
           # `pulls/files` truncates at GitHub's 3000-file ceiling, which
           # --paginate does not lift. A PR that changes 3000+ files would
           # list only the first 3000; docs PRs never approach that.
-          changed_tsv=$(gh api --paginate \
-            "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            --jq '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.md$")) | select((.filename | test("^docs/\\.style/")) | not) | [.filename, .sha] | @tsv')
+          files_json=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files")
+
+          # The non-removed Markdown files under docs/ (excluding
+          # docs/.style/**), one <filename>\t<sha> pair per line. `.sha` is
+          # the blob sha of the file's content at this push, which is what
+          # lets later runs detect "this page changed since it was last
+          # listed" without a full checkout.
+          changed_tsv=$(printf '%s' "$files_json" \
+            | jq -r '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.md$")) | select((.filename | test("^docs/\\.style/")) | not) | [.filename, .sha] | @tsv')
 
           # The changed images under docs/ (outside docs/.style/), one
           # filename per line. Same status and .style filtering as the
@@ -297,9 +317,8 @@ jobs:
           # image section is stateless (no review checkboxes to carry over),
           # unlike the checklist. Keep the extension set in sync with
           # test-docs-preview-mapper.sh.
-          changed_images=$(gh api --paginate \
-            "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            --jq '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.(png|jpe?g|gif|svg|webp|avif|bmp|ico)$"; "i")) | select((.filename | test("^docs/\\.style/")) | not) | .filename')
+          changed_images=$(printf '%s' "$files_json" \
+            | jq -r '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.(png|jpe?g|gif|svg|webp|avif|bmp|ico)$"; "i")) | select((.filename | test("^docs/\\.style/")) | not) | .filename')
 
           # Nothing previewable changed at all: drop any stale comment and
           # stop before the manifest read and reference resolution below.
@@ -340,7 +359,8 @@ jobs:
           # it, one "<image>\t<page>" pair per line. Pages that resolve but
           # aren't in the manifest are dropped for the same reason as the
           # checklist: their preview would 404. An image that ends up with
-          # no eligible page contributes nothing and is not listed.
+          # no eligible page yields no pair here, but is still listed on its
+          # own (without page links) by the image_section_json step below.
           image_pairs_tsv=$(printf '%s\n' "$changed_images" | while IFS= read -r image; do
             [ -z "$image" ] && continue
             pages_for_image "$image" | while IFS= read -r page; do
@@ -351,11 +371,13 @@ jobs:
             done
           done)
 
-          # Nothing resolves to a preview: neither a changed page on a
-          # manifest route nor a changed image embedded by one. Drop any
-          # stale comment and stop.
-          if [ -z "$eligible_tsv" ] && [ -z "$image_pairs_tsv" ]; then
-            echo "No changed Markdown pages or referenced images resolve to a docs/manifest.json route."
+          # Nothing to preview: no changed page on a manifest route and no
+          # changed image at all. A changed image that no navigable page
+          # embeds is still listed on its own, so any changed image keeps the
+          # comment alive; only a Markdown-only PR with nothing manifest-
+          # routed falls through here. Drop any stale comment and stop.
+          if [ -z "$eligible_tsv" ] && [ -z "$changed_images" ]; then
+            echo "No changed Markdown pages resolve to a docs/manifest.json route, and no images changed under docs/ (outside docs/.style/)."
             echo "(If pages you expect are missing, check docs/manifest.json's schema: an empty allowlist looks identical to no eligible pages.)"
             cleanup_stale_and_exit
           fi
@@ -366,11 +388,21 @@ jobs:
           eligible_json=$(printf '%s\n' "$eligible_tsv" \
             | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {filename: .[0], sha: .[1]}]')
 
-          # Group the image/page pairs into [{image, pages:[...]}], pages
-          # de-duplicated and sorted (jq unique sorts), images sorted. Empty
-          # input yields [], and then no image section is rendered.
-          image_section_json=$(printf '%s\n' "$image_pairs_tsv" \
-            | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {image: .[0], page: .[1]}] | group_by(.image) | map({image: .[0].image, pages: (map(.page) | unique)}) | sort_by(.image)')
+          # Combine every changed image with the manifest-routed pages that
+          # embed it, as [{image, pages:[...]}] sorted by image, each image's
+          # pages de-duplicated and sorted (jq unique sorts). An image with
+          # no embedding page keeps an empty pages list so it still renders
+          # (on its own line, no sub-links): icons live only in the
+          # manifest's icon_path and match no Markdown, and some images are
+          # embedded only by non-navigable pages. No changed image yields [],
+          # and then no image section is rendered. Keep in sync with
+          # test-docs-preview-mapper.sh.
+          image_section_json=$(jq -n \
+            --argjson images "$(printf '%s\n' "$changed_images" | jq -R -s '[splits("\n") | select(length > 0)]')" \
+            --argjson pairs "$(printf '%s\n' "$image_pairs_tsv" | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {image: .[0], page: .[1]}]')" \
+            '($pairs | group_by(.image) | map({key: .[0].image, value: (map(.page) | unique)}) | from_entries) as $by
+             | [$images[] | {image: ., pages: ($by[.] // [])}]
+             | sort_by(.image)')
 
           # Fetch the existing comment body now, right before reading its
           # checkbox state, so a reviewer's toggle isn't overwritten by a
@@ -456,37 +488,38 @@ jobs:
 
           # Render the "Changed images" section from image_section_json:
           # each changed image as a bullet with, nested under it, the
-          # preview link for every page that embeds it. Unlike the checklist
-          # this isn't binary-searched, so it self-limits to a byte budget
-          # at image granularity (always emitting at least the first image)
-          # and to IMAGE_PAGES_MAX pages per image, appending "and N more"
-          # notes when it truncates. Prints nothing when no image maps to an
-          # eligible page. Reads $image_section_json, $url_prefix (via
-          # page_url), and the IMAGE_* caps. Keep in sync with
-          # test-docs-preview-mapper.sh.
+          # preview link for every page that embeds it. An image with no
+          # embedding page renders as a bare line with no sub-links. Unlike
+          # the checklist this isn't binary-searched, so it self-limits to a
+          # byte budget at image granularity (always emitting at least the
+          # first image) and to IMAGE_PAGES_MAX pages per image, appending
+          # "and N more" notes when it truncates. Prints nothing only when no
+          # image changed. Reads $image_section_json, $url_prefix (via
+          # page_url), REPO, PR_NUMBER, and the IMAGE_* caps. Keep in sync
+          # with test-docs-preview-mapper.sh.
           render_image_section() {
             local budget="$1" count intro header out="" shown=0 i=0
-            local image np entry j pg url dropped candidate
+            local image page_count entry j page url dropped candidate
             count=$(printf '%s' "$image_section_json" | jq 'length')
             if [ "$count" -eq 0 ]; then
               return 0
             fi
-            intro="These images changed. Each is listed with the page(s) that embed it so you can open the preview and see the new image in context. These links are informational and separate from the checklist above."
+            intro="These images changed. Each is listed with the navigable page(s) that embed it, so you can open the preview and see the new image in context. An image with no page listed isn't embedded by any navigable docs page. These links are informational and have no review checkboxes."
             header="#### Changed images"$'\n\n'"${intro}"$'\n\n'
             while [ "$i" -lt "$count" ]; do
               image=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" '.[$i].image')
-              np=$(printf '%s' "$image_section_json" | jq --argjson i "$i" '.[$i].pages | length')
+              page_count=$(printf '%s' "$image_section_json" | jq --argjson i "$i" '.[$i].pages | length')
               # The backticks are literal Markdown code-span delimiters.
               entry="- \`${image}\`"$'\n'
               j=0
-              while [ "$j" -lt "$np" ] && [ "$j" -lt "$IMAGE_PAGES_MAX" ]; do
-                pg=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" --argjson j "$j" '.[$i].pages[$j]')
-                url=$(page_url "$pg")
-                entry="${entry}  - [\`${pg}\`](${url})"$'\n'
+              while [ "$j" -lt "$page_count" ] && [ "$j" -lt "$IMAGE_PAGES_MAX" ]; do
+                page=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" --argjson j "$j" '.[$i].pages[$j]')
+                url=$(page_url "$page")
+                entry="${entry}  - [\`${page}\`](${url})"$'\n'
                 j=$((j + 1))
               done
-              if [ "$np" -gt "$IMAGE_PAGES_MAX" ]; then
-                entry="${entry}  - _and $((np - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
+              if [ "$page_count" -gt "$IMAGE_PAGES_MAX" ]; then
+                entry="${entry}  - _and $((page_count - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
               fi
               # Keep the first image unconditionally (an empty section under
               # a header would be self-contradicting); for every later image
@@ -504,7 +537,7 @@ jobs:
             done
             dropped=$((count - shown))
             if [ "$dropped" -gt 0 ]; then
-              out="${out}"$'\n'"_and ${dropped} more changed image(s) not listed to stay under GitHub's comment size limit._"$'\n'
+              out="${out}"$'\n'"_and ${dropped} more changed image(s) not listed to stay under GitHub's comment size limit. See the [Files tab](https://github.com/${REPO}/pull/${PR_NUMBER}/files) for the full list._"$'\n'
             fi
             printf '%s%s' "$header" "$out"
           }

--- a/.github/workflows/test-docs-preview-mapper.sh
+++ b/.github/workflows/test-docs-preview-mapper.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
-# Regression tests for the path-mapping logic in docs-preview.yaml.
-# The mapper converts a repo-relative docs path into the URL path
-# used by the docs site preview. Five distinct branches exist in the
-# case block; every branch must be covered here.
-#
-# Also covers the other logic-dense pieces of docs-preview.yaml:
-# extracting page paths from docs/manifest.json, filtering the PR's
-# changed files, intersecting the two into the eligible set, parsing
-# checkbox state out of the rendered checklist, and the checked-state
-# carryover. Where the workflow runs jq, these tests run the same jq
-# against fixtures rather than a shell mirror. Keep them in sync with
-# docs-preview.yaml.
+# Regression tests for the logic-dense pieces of docs-preview.yaml: the
+# path mapper (five case branches, all covered here), manifest path
+# extraction, changed-file/image filtering, the eligible-set intersection,
+# checkbox-state parsing, and the checked-state carryover. Where the
+# workflow runs jq, these run the same jq against fixtures rather than a
+# shell mirror. Keep in sync with docs-preview.yaml.
 
 set -euo pipefail
 
@@ -87,12 +81,10 @@ assert_maps_to "docs/about/contributing/CONTRIBUTING.md" "about/contributing/CON
 assert_maps_to "docs/admin/groups.md" "admin/groups"
 assert_maps_to "docs/tutorials/best-practices/index.md" "tutorials/best-practices"
 
-# normalize_manifest_path replicates the sed pipeline docs-preview.yaml
-# runs over `jq -r '[.. | objects | select(has("path")) | .path]'`
-# output. manifest.json paths are written either "./foo/bar.md" or
-# "foo/bar.md" relative to docs/; both forms must normalize to the
-# same "docs/foo/bar.md" so they compare directly against the
-# filenames returned by the PR-files API.
+# normalize_manifest_path replicates the sed pipeline docs-preview.yaml runs
+# over the manifest paths. Entries are written "./foo/bar.md" or "foo/bar.md"
+# relative to docs/; both must normalize to "docs/foo/bar.md" to compare
+# against the PR-files API filenames.
 normalize_manifest_path() {
 	printf '%s' "$1" | sed -E 's#^\./##; s#^#docs/#'
 }
@@ -120,11 +112,10 @@ assert_normalizes_to "reference/cli/whoami.md" "docs/reference/cli/whoami.md"
 # Branch C: top-level README, no subdirectory.
 assert_normalizes_to "./README.md" "docs/README.md"
 
-# parse_checkbox_line replicates the sed extraction docs-preview.yaml
-# runs over the existing comment body to recover the *live* checked
-# state a reviewer's clicks land in (GitHub persists a checkbox toggle
-# as a comment-body edit). Emits "<x-or-space>\t<path>", matching the
-# workflow's intermediate TSV format.
+# parse_checkbox_line replicates the sed extraction docs-preview.yaml runs
+# over the comment body to recover the live checked state a reviewer's clicks
+# land in (GitHub persists a toggle as a comment-body edit). Emits
+# "<x-or-space>\t<path>", the workflow's intermediate TSV.
 parse_checkbox_line() {
 	# shellcheck disable=SC2016 # backticks are literal Markdown code-span delimiters, not command substitution.
 	printf '%s\n' "$1" | grep -oE '^[[:space:]]*- \[[ xX]\] \[`[^`]+`\]' | sed -E 's/^[[:space:]]*- \[([ xX])\] \[`([^`]+)`\]/\1\t\2/' || true
@@ -159,24 +150,15 @@ assert_checkbox_parses_to '- [X] [`docs/foo/qux.md`](https://coder.com/docs/@b/f
 # must not match at all.
 assert_checkbox_parses_to '## Docs preview' ""
 
-# decide_checked removed: round_trip_state below covers the carryover
-# rule through the workflow's real jq, so the hand-written shell mirror
-# only added a green check that guarded nothing.
-
-# round_trip_state exercises the *actual* jq/grep/sed/base64 expressions
-# from docs-preview.yaml end to end, which a hand-written shell mirror of
-# the carryover rule could not: it drives the jq null-coalescing
-# (// false, // null) and the base64 state marker directly. A path->sha
-# map is encoded into the hidden marker, read back, the live checkbox
-# glyphs are parsed, and the carryover jq decides each page's final
-# checked state.
+# round_trip_state exercises the actual jq/grep/sed/base64 from
+# docs-preview.yaml end to end: a path->sha map is encoded into the hidden
+# marker, read back, the live checkbox glyphs parsed, and the carryover jq
+# decides each page's final checked state.
 STATE_PREFIX='docs-preview-state:'
 
-# Recovers the {path: sha} state map from the hidden marker, a faithful
-# copy of the guarded block in docs-preview.yaml: decode under
-# `2>/dev/null || true` and adopt the result only if it is non-empty and
-# parses as a JSON object, else degrade to {} so a corrupt marker can't
-# kill the run. The non-empty check keeps the guard's outcome the same on
+# Recovers the {path: sha} map from the hidden marker, mirroring the guarded
+# block in docs-preview.yaml: adopt the decode only if non-empty and a JSON
+# object, else {}. The non-empty check keeps the outcome the same on
 # jq < 1.7, where `jq -e` exits 0 on empty input.
 recover_old_state() {
 	local body="$1" b64 decoded
@@ -260,9 +242,8 @@ assert_round_trip_state() {
 
 assert_round_trip_state
 
-# The malformed-marker path the decode guard added must recover to {} with
-# the run surviving. Feed markers that clear the charset grep but fail the
-# decode or the object-type gate.
+# A malformed marker must recover to {} with the run surviving. Feed markers
+# that clear the charset grep but fail the decode or the object-type gate.
 assert_marker_recovers() {
 	local marker="$1" expected="$2" desc="$3" body actual
 	body=$(printf '## Docs preview\n<!-- docs-preview -->\n<!-- %s%s -->' "$STATE_PREFIX" "$marker")
@@ -285,10 +266,8 @@ assert_marker_recovers "$(printf '"hello"' | base64 -w0)" "{}" "valid base64 non
 assert_marker_recovers "$(printf '\xff\xfe\xfd' | base64 -w0)" "{}" "valid base64 non-JSON bytes"
 
 # extract_manifest_paths runs the real jq + sed pipeline from
-# docs-preview.yaml against manifest JSON on stdin, emitting one
-# normalized repo-relative path per line. Guards the recursive
-# `[.. | objects | select(has("path")) | .path]` extraction that
-# normalize_manifest_path above does not reach.
+# docs-preview.yaml against manifest JSON on stdin, guarding the recursive
+# path extraction that normalize_manifest_path above does not reach.
 extract_manifest_paths() {
 	jq -r '[.. | objects | select(has("path")) | .path] | .[]' |
 		sed -E 's#^\./##; s#^#docs/#'
@@ -339,9 +318,8 @@ else
 fi
 
 # intersect_eligible replicates the grep -qxF intersection from
-# docs-preview.yaml: keep only changed files whose path is in the
-# manifest allowlist. This is the single decision the feature exists to
-# make, so cover it directly.
+# docs-preview.yaml: keep only changed files whose path is in the manifest
+# allowlist.
 intersect_eligible() {
 	local changed="$1" allowed="$2"
 	printf '%s\n' "$changed" | while IFS=$'\t' read -r filename sha; do
@@ -363,11 +341,9 @@ else
 	failures=$((failures + 1))
 fi
 
-# filter_changed_images runs the real image filter jq from
-# docs-preview.yaml over the pulls/files payload: keep non-removed docs/
-# image files outside docs/.style/, matching the extension set case-
-# insensitively, emitting one filename per line (no sha; the image
-# section is stateless). Mirror of the changed_images query.
+# filter_changed_images runs the real image filter jq from docs-preview.yaml:
+# keep non-removed docs/ images outside docs/.style/, extensions matched
+# case-insensitively (no sha; the image section is stateless).
 filter_changed_images() {
 	jq -r '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.(png|jpe?g|gif|svg|webp|avif|bmp|ico)$"; "i")) | select((.filename | test("^docs/\\.style/")) | not) | .filename'
 }
@@ -400,12 +376,11 @@ else
 	failures=$((failures + 1))
 fi
 
-# extract_ref_tokens, resolve_ref, and pages_for_image are spliced in here
+# extract_ref_tokens, resolve_ref, and pages_for_image are spliced in
 # verbatim from docs-preview.yaml so the mirror can't drift; the assertions
-# below drive them against a throwaway docs tree (not the real repo) so the
-# expectations stay stable. A page embeds an image only when one of its
-# Markdown/HTML references resolves to exactly that repo path, so prose
-# mentions and same-basename collisions in other directories don't match.
+# below drive them against a throwaway docs tree. A page embeds an image only
+# when a Markdown/HTML reference resolves to exactly that repo path, so prose
+# mentions and same-basename collisions elsewhere don't match.
 extract_ref_tokens() {
 	local file="$1"
 	# Markdown: capture up to the first space or ) so an optional
@@ -419,9 +394,9 @@ extract_ref_tokens() {
 
 resolve_ref() {
 	local file="$1" ref="$2" dir
-	ref="${ref%%#*}"  # drop #fragment
-	ref="${ref%%\?*}" # drop ?query
-	ref="${ref#<}"    # drop an optional <...> wrapper
+	ref="${ref%%#*}"
+	ref="${ref%%\?*}"
+	ref="${ref#<}"
 	ref="${ref%>}"
 	[ -z "$ref" ] && return 0
 	case "$ref" in
@@ -514,12 +489,10 @@ fi
 cd "$img_orig_pwd"
 rm -rf "$img_fixture_root"
 
-# resolve_ref branch coverage: the ref-normalization steps (strip a
-# #fragment, a ?query, and a <...> wrapper; reject external and
-# protocol-relative refs) each have a case, so deleting any one changes a
-# result and fails the suite. resolve_ref is spliced from docs-preview.yaml
-# above; path math is relative to $PWD, so these are independent of the
-# real tree.
+# resolve_ref branch coverage: each normalization step (strip #fragment,
+# ?query, <...> wrapper; reject external and protocol-relative refs) has a
+# case, so deleting any one fails the suite. Path math is relative to $PWD,
+# so these are independent of the real tree.
 assert_resolves_ref() {
 	local ref="$1" expected="$2" desc="$3" actual
 	actual=$(resolve_ref "docs/user-guides/page.md" "$ref")
@@ -539,10 +512,9 @@ assert_resolves_ref "//cdn.example.com/shared.png" "" "protocol-relative ignored
 assert_resolves_ref "mailto:docs@coder.com" "" "mailto ignored"
 assert_resolves_ref "" "" "empty ref"
 
-# extract_ref_tokens branch coverage: a titled Markdown ref (the space
-# before the title stops the path capture), an uppercase <IMG SRC="...">
-# (the HTML grep is case-insensitive), and a single-quoted src. Each drives
-# a distinct part of the extractor spliced from docs-preview.yaml above.
+# extract_ref_tokens branch coverage: a titled Markdown ref (the space stops
+# the path capture), an uppercase <IMG SRC="..."> (case-insensitive grep),
+# and a single-quoted src.
 ert_root=$(mktemp -d)
 cat >"$ert_root/titled.md" <<'MD'
 ![shot](../images/shared.png "Optional title")
@@ -569,11 +541,10 @@ assert_extracts "$ert_root/single.md" "../images/shared.png|" "single-quoted src
 rm -rf "$ert_root"
 
 # build_image_section runs the real image_section_json jq from
-# docs-preview.yaml: combine every changed image (a newline list) with the
-# "<image>\t<page>" pairs into [{image, pages:[...]}], images sorted, each
-# image's pages de-duplicated and sorted (jq unique sorts). An image with
-# no pair keeps an empty pages list, so an icon- or screenshot-only PR
-# whose images embed no navigable page still renders (and posts a comment).
+# docs-preview.yaml: combine the changed-image list and "<image>\t<page>"
+# pairs into [{image, pages:[...]}], images sorted, pages per image deduped
+# and sorted. An image with no pair keeps pages:[], so an icon- or
+# screenshot-only PR still renders.
 build_image_section() {
 	local images_list="$1" pairs_tsv="$2"
 	jq -n \
@@ -596,13 +567,12 @@ else
 	failures=$((failures + 1))
 fi
 
-# build_comment_body and render_image_section mirror the body assembler
-# in docs-preview.yaml: they render $final_rows and $image_section_json
-# into the exact comment body the workflow posts, so the comment can be
-# sized by measuring the real bytes instead of estimating a per-page
-# cost. Read the $final_rows, $total_pages, $url_prefix, $image_section,
-# $image_section_json, $DOCS_PREVIEW_MARKER, $STATE_PREFIX, and IMAGE_*
-# globals set before each case below. Keep in sync with docs-preview.yaml.
+# build_comment_body and render_image_section mirror the body assembler in
+# docs-preview.yaml, rendering the exact comment body the workflow posts so
+# it can be sized by measuring real bytes not estimating. Read the
+# $final_rows, $total_pages, $url_prefix, $image_section, $image_section_json,
+# $DOCS_PREVIEW_MARKER, $STATE_PREFIX, and IMAGE_* globals set before each
+# case below. Keep in sync with docs-preview.yaml.
 DOCS_PREVIEW_MARKER='<!-- docs-preview -->'
 STATE_PREFIX='docs-preview-state:'
 # Representative values for the Files-tab link in the omitted-pages
@@ -650,10 +620,9 @@ render_image_section() {
 		if [ "$page_count" -gt "$IMAGE_PAGES_MAX" ]; then
 			entry="${entry}  - _and $((page_count - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
 		fi
-		# Keep the first image unconditionally (an empty section under
-		# a header would be self-contradicting); for every later image
-		# measure the would-be section first so the rendered block
-		# stays under budget.
+		# Keep the first image unconditionally (an empty section under a
+		# header is self-contradicting); measure each later image's
+		# would-be section and stop before it exceeds budget.
 		if [ "$shown" -gt 0 ]; then
 			candidate="${header}${out}${entry}"
 			if [ "$(printf '%s' "$candidate" | LC_ALL=C wc -c)" -gt "$budget" ]; then
@@ -700,9 +669,8 @@ build_comment_body() {
 		page_block="${intro}"$'\n\n'"${checklist}"
 	fi
 
-	# Emit only the sections that have content. The identity marker
-	# and the state marker are always present so the comment stays
-	# discoverable and round-trippable, even on an image-only PR
+	# The identity and state markers are always present so the comment
+	# stays discoverable and round-trippable, even on an image-only PR
 	# whose state map is {}.
 	{
 		printf '## Docs preview\n\n'
@@ -745,10 +713,9 @@ budget=65000
 # GitHub's hard comment-body limit; the budget above leaves headroom under it.
 github_comment_limit=65536
 
-# Repo-scale worst case: a docs migration touching 400 pages on a long
-# ticket-prefixed branch, ~60-char paths, the shape reviewers measured
-# overflowing the old per-page estimate. The cap must keep the real body
-# under GitHub's 65536-char limit while still listing as many pages as fit.
+# Repo-scale worst case: a 400-page docs migration on a long branch with
+# ~60-char paths. The cap must keep the real body under GitHub's 65536-char
+# limit while still listing as many pages as fit.
 url_prefix="https://coder.com/docs/@feature-team-very-long-branch-name-docs-migration-2024"
 final_rows=$(jq -nc '[range(400) | {
 	filename: ("docs/reference/generated/section-\(. + 1000)/really-long-page-name-\(. + 1000).md"),
@@ -875,9 +842,8 @@ else
 fi
 
 # Icon-only PR: the only changed image embeds no navigable page, so
-# image_section_json carries it with pages: []. The comment must still
-# render, listing the image on its own line with no sub-links, so an icon
-# refresh no longer falls through to no comment.
+# image_section_json carries it with pages:[]. The comment must still render,
+# listing the image on its own line with no sub-links.
 final_rows='[]'
 total_pages=0
 url_prefix="https://coder.com/docs/@branch"
@@ -896,10 +862,9 @@ else
 	failures=$((failures + 1))
 fi
 
-# build_comment_body with both changed pages and changed images: the
-# checklist and the image section both render. A page that is both changed
-# (checklist) and an image referrer (image section) appears in both, and
-# the image sub-link (no checkbox glyph) never pollutes carried-over
+# build_comment_body with both changed pages and images: both sections
+# render. A page that is both changed and an image referrer appears in both,
+# and the image sub-link (no checkbox glyph) never pollutes carried-over
 # checkbox state.
 final_rows='[{"filename":"docs/a.md","sha":"s1","checked":true},{"filename":"docs/b.md","sha":"s2","checked":false}]'
 total_pages=2

--- a/.github/workflows/test-docs-preview-mapper.sh
+++ b/.github/workflows/test-docs-preview-mapper.sh
@@ -375,6 +375,13 @@ filter_changed_images() {
 images_fixture='[
   {"filename":"docs/images/a.png","sha":"a1","status":"modified"},
   {"filename":"docs/images/user-guides/b.SVG","sha":"b1","status":"added"},
+  {"filename":"docs/images/c.jpg","sha":"c1","status":"added"},
+  {"filename":"docs/images/d.jpeg","sha":"d1","status":"added"},
+  {"filename":"docs/images/e.gif","sha":"e1","status":"added"},
+  {"filename":"docs/images/f.webp","sha":"f1","status":"added"},
+  {"filename":"docs/images/g.avif","sha":"g2","status":"added"},
+  {"filename":"docs/images/h.bmp","sha":"h1","status":"added"},
+  {"filename":"docs/images/i.ico","sha":"i1","status":"added"},
   {"filename":"docs/images/old.gif","sha":"g1","status":"removed"},
   {"filename":"docs/.style/logo.png","sha":"s1","status":"modified"},
   {"filename":"docs/admin/notes.md","sha":"m1","status":"modified"},
@@ -382,9 +389,12 @@ images_fixture='[
   {"filename":"site/logo.png","sha":"x1","status":"modified"}
 ]'
 actual_images=$(printf '%s' "$images_fixture" | filter_changed_images | LC_ALL=C sort | tr '\n' '|')
-expected_images="docs/images/a.png|docs/images/user-guides/b.SVG|"
+# Every extension in the workflow regex (png, jpg, jpeg, gif, svg, webp,
+# avif, bmp, ico) has a matching entry, so trimming any one from the regex
+# fails this assertion. b.SVG also proves the match is case-insensitive.
+expected_images="docs/images/a.png|docs/images/c.jpg|docs/images/d.jpeg|docs/images/e.gif|docs/images/f.webp|docs/images/g.avif|docs/images/h.bmp|docs/images/i.ico|docs/images/user-guides/b.SVG|"
 if [ "$actual_images" = "$expected_images" ]; then
-	echo "PASS: filter_changed_images (removed/.style/md/non-docs/video excluded, case-insensitive)"
+	echo "PASS: filter_changed_images (every extension matches; removed/.style/md/non-docs/video excluded, case-insensitive)"
 else
 	echo "FAIL: filter_changed_images -> $actual_images (expected $expected_images)"
 	failures=$((failures + 1))
@@ -504,19 +514,85 @@ fi
 cd "$img_orig_pwd"
 rm -rf "$img_fixture_root"
 
-# group_image_pairs runs the real grouping jq from docs-preview.yaml over
-# "<image>\t<page>" pairs: [{image, pages:[...]}] with images sorted and
-# each image's pages de-duplicated and sorted (jq unique sorts).
-group_image_pairs() {
-	jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {image: .[0], page: .[1]}] | group_by(.image) | map({image: .[0].image, pages: (map(.page) | unique)}) | sort_by(.image)'
+# resolve_ref branch coverage: the ref-normalization steps (strip a
+# #fragment, a ?query, and a <...> wrapper; reject external and
+# protocol-relative refs) each have a case, so deleting any one changes a
+# result and fails the suite. resolve_ref is spliced from docs-preview.yaml
+# above; path math is relative to $PWD, so these are independent of the
+# real tree.
+assert_resolves_ref() {
+	local ref="$1" expected="$2" desc="$3" actual
+	actual=$(resolve_ref "docs/user-guides/page.md" "$ref")
+	if [ "$actual" = "$expected" ]; then
+		echo "PASS: resolve_ref ($desc)"
+	else
+		echo "FAIL: resolve_ref ($desc) -> \"$actual\" (expected \"$expected\")"
+		failures=$((failures + 1))
+	fi
 }
+assert_resolves_ref "../images/shared.png" "docs/images/shared.png" "relative path"
+assert_resolves_ref "../images/shared.png#top" "docs/images/shared.png" "strips #fragment"
+assert_resolves_ref "../images/shared.png?v=1" "docs/images/shared.png" "strips ?query"
+assert_resolves_ref "<../images/shared.png>" "docs/images/shared.png" "strips <...> wrapper"
+assert_resolves_ref "https://example.com/shared.png" "" "external URL ignored"
+assert_resolves_ref "//cdn.example.com/shared.png" "" "protocol-relative ignored"
+assert_resolves_ref "mailto:docs@coder.com" "" "mailto ignored"
+assert_resolves_ref "" "" "empty ref"
+
+# extract_ref_tokens branch coverage: a titled Markdown ref (the space
+# before the title stops the path capture), an uppercase <IMG SRC="...">
+# (the HTML grep is case-insensitive), and a single-quoted src. Each drives
+# a distinct part of the extractor spliced from docs-preview.yaml above.
+ert_root=$(mktemp -d)
+cat >"$ert_root/titled.md" <<'MD'
+![shot](../images/shared.png "Optional title")
+MD
+cat >"$ert_root/upper.md" <<'MD'
+<IMG SRC="../images/shared.png" alt="x">
+MD
+cat >"$ert_root/single.md" <<'MD'
+<img src='../images/shared.png'>
+MD
+assert_extracts() {
+	local file="$1" expected="$2" desc="$3" actual
+	actual=$(extract_ref_tokens "$file" | tr '\n' '|')
+	if [ "$actual" = "$expected" ]; then
+		echo "PASS: extract_ref_tokens ($desc)"
+	else
+		echo "FAIL: extract_ref_tokens ($desc) -> \"$actual\" (expected \"$expected\")"
+		failures=$((failures + 1))
+	fi
+}
+assert_extracts "$ert_root/titled.md" "../images/shared.png|" "titled Markdown ref drops the title"
+assert_extracts "$ert_root/upper.md" "../images/shared.png|" "uppercase <IMG SRC> matches case-insensitively"
+assert_extracts "$ert_root/single.md" "../images/shared.png|" "single-quoted src"
+rm -rf "$ert_root"
+
+# build_image_section runs the real image_section_json jq from
+# docs-preview.yaml: combine every changed image (a newline list) with the
+# "<image>\t<page>" pairs into [{image, pages:[...]}], images sorted, each
+# image's pages de-duplicated and sorted (jq unique sorts). An image with
+# no pair keeps an empty pages list, so an icon- or screenshot-only PR
+# whose images embed no navigable page still renders (and posts a comment).
+build_image_section() {
+	local images_list="$1" pairs_tsv="$2"
+	jq -n \
+		--argjson images "$(printf '%s\n' "$images_list" | jq -R -s '[splits("\n") | select(length > 0)]')" \
+		--argjson pairs "$(printf '%s\n' "$pairs_tsv" | jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {image: .[0], page: .[1]}]')" \
+		'($pairs | group_by(.image) | map({key: .[0].image, value: (map(.page) | unique)}) | from_entries) as $by
+		 | [$images[] | {image: ., pages: ($by[.] // [])}]
+		 | sort_by(.image)'
+}
+# c.png is a changed image with no pair (the icon-only case); it must still
+# appear, with pages: [].
+images_list_fixture=$(printf 'docs/images/b.png\ndocs/images/a.png\ndocs/images/c.png')
 pairs_fixture=$(printf 'docs/images/b.png\tdocs/z.md\ndocs/images/a.png\tdocs/p2.md\ndocs/images/a.png\tdocs/p1.md\ndocs/images/a.png\tdocs/p1.md')
-actual_group=$(printf '%s\n' "$pairs_fixture" | group_image_pairs | jq -c .)
-expected_group='[{"image":"docs/images/a.png","pages":["docs/p1.md","docs/p2.md"]},{"image":"docs/images/b.png","pages":["docs/z.md"]}]'
+actual_group=$(build_image_section "$images_list_fixture" "$pairs_fixture" | jq -c .)
+expected_group='[{"image":"docs/images/a.png","pages":["docs/p1.md","docs/p2.md"]},{"image":"docs/images/b.png","pages":["docs/z.md"]},{"image":"docs/images/c.png","pages":[]}]'
 if [ "$actual_group" = "$expected_group" ]; then
-	echo "PASS: group_image_pairs (sorted images, de-duped sorted pages)"
+	echo "PASS: build_image_section (sorted images, de-duped sorted pages, unmapped image kept with empty pages)"
 else
-	echo "FAIL: group_image_pairs -> $actual_group (expected $expected_group)"
+	echo "FAIL: build_image_section -> $actual_group (expected $expected_group)"
 	failures=$((failures + 1))
 fi
 
@@ -552,27 +628,27 @@ page_url() {
 
 render_image_section() {
 	local budget="$1" count intro header out="" shown=0 i=0
-	local image np entry j pg url dropped candidate
+	local image page_count entry j page url dropped candidate
 	count=$(printf '%s' "$image_section_json" | jq 'length')
 	if [ "$count" -eq 0 ]; then
 		return 0
 	fi
-	intro="These images changed. Each is listed with the page(s) that embed it so you can open the preview and see the new image in context. These links are informational and separate from the checklist above."
+	intro="These images changed. Each is listed with the navigable page(s) that embed it, so you can open the preview and see the new image in context. An image with no page listed isn't embedded by any navigable docs page. These links are informational and have no review checkboxes."
 	header="#### Changed images"$'\n\n'"${intro}"$'\n\n'
 	while [ "$i" -lt "$count" ]; do
 		image=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" '.[$i].image')
-		np=$(printf '%s' "$image_section_json" | jq --argjson i "$i" '.[$i].pages | length')
+		page_count=$(printf '%s' "$image_section_json" | jq --argjson i "$i" '.[$i].pages | length')
 		# The backticks are literal Markdown code-span delimiters.
 		entry="- \`${image}\`"$'\n'
 		j=0
-		while [ "$j" -lt "$np" ] && [ "$j" -lt "$IMAGE_PAGES_MAX" ]; do
-			pg=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" --argjson j "$j" '.[$i].pages[$j]')
-			url=$(page_url "$pg")
-			entry="${entry}  - [\`${pg}\`](${url})"$'\n'
+		while [ "$j" -lt "$page_count" ] && [ "$j" -lt "$IMAGE_PAGES_MAX" ]; do
+			page=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" --argjson j "$j" '.[$i].pages[$j]')
+			url=$(page_url "$page")
+			entry="${entry}  - [\`${page}\`](${url})"$'\n'
 			j=$((j + 1))
 		done
-		if [ "$np" -gt "$IMAGE_PAGES_MAX" ]; then
-			entry="${entry}  - _and $((np - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
+		if [ "$page_count" -gt "$IMAGE_PAGES_MAX" ]; then
+			entry="${entry}  - _and $((page_count - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
 		fi
 		# Keep the first image unconditionally (an empty section under
 		# a header would be self-contradicting); for every later image
@@ -590,7 +666,7 @@ render_image_section() {
 	done
 	dropped=$((count - shown))
 	if [ "$dropped" -gt 0 ]; then
-		out="${out}"$'\n'"_and ${dropped} more changed image(s) not listed to stay under GitHub's comment size limit._"$'\n'
+		out="${out}"$'\n'"_and ${dropped} more changed image(s) not listed to stay under GitHub's comment size limit. See the [Files tab](https://github.com/${REPO}/pull/${PR_NUMBER}/files) for the full list._"$'\n'
 	fi
 	printf '%s%s' "$header" "$out"
 }
@@ -752,7 +828,7 @@ many_pages=$(jq -nc '[range(5) | "docs/p\(.).md"]')
 image_section_json=$(jq -nc --argjson p "$many_pages" '[{image: "docs/images/big.png", pages: $p}]')
 section=$(render_image_section "$IMAGE_SECTION_BUDGET")
 shown_links=$(printf '%s\n' "$section" | grep -cE '^  - \[')
-if [ "$shown_links" -eq 2 ] && printf '%s' "$section" | grep -qF 'more page(s) embedding this image'; then
+if [ "$shown_links" -eq 2 ] && printf '%s' "$section" | grep -qF 'and 3 more page(s) embedding this image'; then
 	echo "PASS: render_image_section (per-image page cap keeps 2 with an overflow note)"
 else
 	echo "FAIL: render_image_section page cap -> shown_links=$shown_links"
@@ -768,7 +844,7 @@ image_section_json='[{"image":"docs/images/aaaaaaaaaa.png","pages":["docs/one.md
 section=$(render_image_section 1)
 # shellcheck disable=SC2016 # backtick is a literal Markdown delimiter.
 imgs_shown=$(printf '%s\n' "$section" | grep -cE '^- `docs/images/')
-if [ "$imgs_shown" -eq 1 ] && printf '%s' "$section" | grep -qF 'more changed image(s) not listed'; then
+if [ "$imgs_shown" -eq 1 ] && printf '%s' "$section" | grep -qF 'and 2 more changed image(s) not listed'; then
 	echo "PASS: render_image_section (byte-budget truncation keeps first image + note)"
 else
 	echo "FAIL: render_image_section truncation -> imgs_shown=$imgs_shown"
@@ -787,12 +863,36 @@ image_section=$(render_image_section "$IMAGE_SECTION_BUDGET")
 image_only_body=$(build_comment_body 0)
 if printf '%s' "$image_only_body" | grep -qF '#### Changed images' &&
 	! printf '%s' "$image_only_body" | grep -qF 'Check off each page' &&
+	printf '%s' "$image_only_body" | grep -qF 'These links are informational and have no review checkboxes.' &&
+	! printf '%s' "$image_only_body" | grep -qF 'separate from the checklist above' &&
 	printf '%s' "$image_only_body" | grep -qF '<!-- docs-preview -->' &&
 	[ "$(recover_old_state "$image_only_body")" = '{}' ]; then
 	echo "PASS: build_comment_body (image-only PR: image section, no checklist, empty state)"
 else
 	echo "FAIL: build_comment_body image-only ->"
 	printf '%s\n' "$image_only_body"
+	failures=$((failures + 1))
+fi
+
+# Icon-only PR: the only changed image embeds no navigable page, so
+# image_section_json carries it with pages: []. The comment must still
+# render, listing the image on its own line with no sub-links, so an icon
+# refresh no longer falls through to no comment.
+final_rows='[]'
+total_pages=0
+url_prefix="https://coder.com/docs/@branch"
+image_section_json='[{"image":"docs/images/icons/system.svg","pages":[]}]'
+image_section=$(render_image_section "$IMAGE_SECTION_BUDGET")
+icon_only_body=$(build_comment_body 0)
+# shellcheck disable=SC2016 # backtick-quoted path is literal Markdown.
+if printf '%s' "$icon_only_body" | grep -qF '#### Changed images' &&
+	printf '%s' "$icon_only_body" | grep -qF -- '- `docs/images/icons/system.svg`' &&
+	! printf '%s' "$icon_only_body" | grep -qF 'Check off each page' &&
+	[ "$(printf '%s\n' "$icon_only_body" | grep -cE '^  - \[')" -eq 0 ]; then
+	echo "PASS: build_comment_body (icon-only PR: unmapped image still produces a comment)"
+else
+	echo "FAIL: build_comment_body icon-only ->"
+	printf '%s\n' "$icon_only_body"
 	failures=$((failures + 1))
 fi
 

--- a/.github/workflows/test-docs-preview-mapper.sh
+++ b/.github/workflows/test-docs-preview-mapper.sh
@@ -363,50 +363,282 @@ else
 	failures=$((failures + 1))
 fi
 
-# build_comment_body mirrors the body assembler in docs-preview.yaml:
-# it renders the first N pages of $final_rows into the exact
-# comment body the workflow posts, so the comment can be sized by
-# measuring the real bytes instead of estimating a per-page cost. Reads
-# the $final_rows, $total_pages, $url_prefix, $DOCS_PREVIEW_MARKER, and
-# $STATE_PREFIX globals set before each case below. Keep in sync with
-# docs-preview.yaml.
+# filter_changed_images runs the real image filter jq from
+# docs-preview.yaml over the pulls/files payload: keep non-removed docs/
+# image files outside docs/.style/, matching the extension set case-
+# insensitively, emitting one filename per line (no sha; the image
+# section is stateless). Mirror of the changed_images query.
+filter_changed_images() {
+	jq -r '.[] | select(.status != "removed") | select(.filename | test("^docs/.*\\.(png|jpe?g|gif|svg|webp|avif|bmp|ico)$"; "i")) | select((.filename | test("^docs/\\.style/")) | not) | .filename'
+}
+
+images_fixture='[
+  {"filename":"docs/images/a.png","sha":"a1","status":"modified"},
+  {"filename":"docs/images/user-guides/b.SVG","sha":"b1","status":"added"},
+  {"filename":"docs/images/old.gif","sha":"g1","status":"removed"},
+  {"filename":"docs/.style/logo.png","sha":"s1","status":"modified"},
+  {"filename":"docs/admin/notes.md","sha":"m1","status":"modified"},
+  {"filename":"docs/images/clip.mp4","sha":"v1","status":"added"},
+  {"filename":"site/logo.png","sha":"x1","status":"modified"}
+]'
+actual_images=$(printf '%s' "$images_fixture" | filter_changed_images | LC_ALL=C sort | tr '\n' '|')
+expected_images="docs/images/a.png|docs/images/user-guides/b.SVG|"
+if [ "$actual_images" = "$expected_images" ]; then
+	echo "PASS: filter_changed_images (removed/.style/md/non-docs/video excluded, case-insensitive)"
+else
+	echo "FAIL: filter_changed_images -> $actual_images (expected $expected_images)"
+	failures=$((failures + 1))
+fi
+
+# extract_ref_tokens, resolve_ref, and pages_for_image are spliced in here
+# verbatim from docs-preview.yaml so the mirror can't drift; the assertions
+# below drive them against a throwaway docs tree (not the real repo) so the
+# expectations stay stable. A page embeds an image only when one of its
+# Markdown/HTML references resolves to exactly that repo path, so prose
+# mentions and same-basename collisions in other directories don't match.
+extract_ref_tokens() {
+	local file="$1"
+	# Markdown: capture up to the first space or ) so an optional
+	# "title" after the path is dropped.
+	grep -oE '!\[[^]]*\]\([^)[:space:]]+' "$file" 2>/dev/null |
+		sed -E 's/^!\[[^]]*\]\(//' || true
+	# HTML: single- or double-quoted src, case-insensitive tag/attr.
+	grep -oiE '<img[^>]+src=("[^"]+"|'\''[^'\'']+'\'')' "$file" 2>/dev/null |
+		sed -E 's/.*src=//I; s/^["'\'']//; s/["'\'']$//' || true
+}
+
+resolve_ref() {
+	local file="$1" ref="$2" dir
+	ref="${ref%%#*}"  # drop #fragment
+	ref="${ref%%\?*}" # drop ?query
+	ref="${ref#<}"    # drop an optional <...> wrapper
+	ref="${ref%>}"
+	[ -z "$ref" ] && return 0
+	case "$ref" in
+	*://* | //* | mailto:* | data:*) return 0 ;;
+	esac
+	dir=$(dirname "$file")
+	realpath -m --relative-to="$PWD" "${PWD}/${dir}/${ref}" 2>/dev/null || true
+}
+
+pages_for_image() {
+	local image="$1" base candidates file token
+	base=$(basename "$image")
+	candidates=$(grep -rlF "$base" docs --include='*.md' 2>/dev/null |
+		grep -v '^docs/\.style/' || true)
+	[ -z "$candidates" ] && return 0
+	while IFS= read -r file; do
+		[ -z "$file" ] && continue
+		while IFS= read -r token; do
+			[ -z "$token" ] && continue
+			[ "$(basename "$token")" = "$base" ] || continue
+			if [ "$(resolve_ref "$file" "$token")" = "$image" ]; then
+				printf '%s\n' "$file"
+				break
+			fi
+		done < <(extract_ref_tokens "$file")
+	done <<<"$candidates"
+}
+
+img_fixture_root=$(mktemp -d)
+img_orig_pwd=$PWD
+mkdir -p \
+	"$img_fixture_root/docs/user-guides" \
+	"$img_fixture_root/docs/admin/sub" \
+	"$img_fixture_root/docs/images/other" \
+	"$img_fixture_root/docs/.style"
+# Two pages embed docs/images/shared.png at different depths (one Markdown,
+# one HTML): the nested-list case.
+cat >"$img_fixture_root/docs/user-guides/page.md" <<'MD'
+# UG
+
+![shot](../images/shared.png)
+MD
+cat >"$img_fixture_root/docs/admin/sub/deep.md" <<'MD'
+# Sub
+
+<img src="../../images/shared.png" alt="x">
+MD
+# A different shared.png in another dir must not cross-match.
+cat >"$img_fixture_root/docs/admin/collide.md" <<'MD'
+# Other
+
+![o](../images/other/shared.png)
+MD
+# Only a prose mention of the basename must not match.
+cat >"$img_fixture_root/docs/admin/prose.md" <<'MD'
+# Prose
+
+We refreshed shared.png last week.
+MD
+# An external image with the same basename must be ignored.
+cat >"$img_fixture_root/docs/admin/ext.md" <<'MD'
+# Ext
+
+![e](https://example.com/shared.png)
+MD
+# A .style page that references it is excluded by pages_for_image.
+cat >"$img_fixture_root/docs/.style/tool.md" <<'MD'
+# Style
+
+![s](../images/shared.png)
+MD
+
+cd "$img_fixture_root"
+actual_pfi=$(pages_for_image "docs/images/shared.png" | LC_ALL=C sort | tr '\n' '|')
+expected_pfi="docs/admin/sub/deep.md|docs/user-guides/page.md|"
+if [ "$actual_pfi" = "$expected_pfi" ]; then
+	echo "PASS: pages_for_image (md+html refs match; prose/external/.style excluded)"
+else
+	echo "FAIL: pages_for_image -> $actual_pfi (expected $expected_pfi)"
+	failures=$((failures + 1))
+fi
+actual_collide=$(pages_for_image "docs/images/other/shared.png" | LC_ALL=C sort | tr '\n' '|')
+expected_collide="docs/admin/collide.md|"
+if [ "$actual_collide" = "$expected_collide" ]; then
+	echo "PASS: pages_for_image (same-basename images in different dirs don't cross-match)"
+else
+	echo "FAIL: pages_for_image collision -> $actual_collide (expected $expected_collide)"
+	failures=$((failures + 1))
+fi
+cd "$img_orig_pwd"
+rm -rf "$img_fixture_root"
+
+# group_image_pairs runs the real grouping jq from docs-preview.yaml over
+# "<image>\t<page>" pairs: [{image, pages:[...]}] with images sorted and
+# each image's pages de-duplicated and sorted (jq unique sorts).
+group_image_pairs() {
+	jq -R -s '[splits("\n") | select(length > 0) | split("\t") | {image: .[0], page: .[1]}] | group_by(.image) | map({image: .[0].image, pages: (map(.page) | unique)}) | sort_by(.image)'
+}
+pairs_fixture=$(printf 'docs/images/b.png\tdocs/z.md\ndocs/images/a.png\tdocs/p2.md\ndocs/images/a.png\tdocs/p1.md\ndocs/images/a.png\tdocs/p1.md')
+actual_group=$(printf '%s\n' "$pairs_fixture" | group_image_pairs | jq -c .)
+expected_group='[{"image":"docs/images/a.png","pages":["docs/p1.md","docs/p2.md"]},{"image":"docs/images/b.png","pages":["docs/z.md"]}]'
+if [ "$actual_group" = "$expected_group" ]; then
+	echo "PASS: group_image_pairs (sorted images, de-duped sorted pages)"
+else
+	echo "FAIL: group_image_pairs -> $actual_group (expected $expected_group)"
+	failures=$((failures + 1))
+fi
+
+# build_comment_body and render_image_section mirror the body assembler
+# in docs-preview.yaml: they render $final_rows and $image_section_json
+# into the exact comment body the workflow posts, so the comment can be
+# sized by measuring the real bytes instead of estimating a per-page
+# cost. Read the $final_rows, $total_pages, $url_prefix, $image_section,
+# $image_section_json, $DOCS_PREVIEW_MARKER, $STATE_PREFIX, and IMAGE_*
+# globals set before each case below. Keep in sync with docs-preview.yaml.
 DOCS_PREVIEW_MARKER='<!-- docs-preview -->'
 STATE_PREFIX='docs-preview-state:'
 # Representative values for the Files-tab link in the omitted-pages
 # summary; the workflow supplies these from the GitHub Actions env.
 REPO='owner/repo'
 PR_NUMBER='123'
+# Caps that bound the image section, mirrored from docs-preview.yaml.
+IMAGE_SECTION_BUDGET=20000
+IMAGE_PAGES_MAX=25
+# Default so the page-only cases below can call build_comment_body under
+# set -u; the image cases set it via render_image_section.
+image_section=""
+
+page_url() {
+	local filename="$1" page_path url
+	page_path=$(map_doc_path "$filename")
+	url="$url_prefix"
+	if [ -n "$page_path" ]; then
+		url="${url}/${page_path}"
+	fi
+	printf '%s' "$url"
+}
+
+render_image_section() {
+	local budget="$1" count intro header out="" shown=0 i=0
+	local image np entry j pg url dropped candidate
+	count=$(printf '%s' "$image_section_json" | jq 'length')
+	if [ "$count" -eq 0 ]; then
+		return 0
+	fi
+	intro="These images changed. Each is listed with the page(s) that embed it so you can open the preview and see the new image in context. These links are informational and separate from the checklist above."
+	header="#### Changed images"$'\n\n'"${intro}"$'\n\n'
+	while [ "$i" -lt "$count" ]; do
+		image=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" '.[$i].image')
+		np=$(printf '%s' "$image_section_json" | jq --argjson i "$i" '.[$i].pages | length')
+		# The backticks are literal Markdown code-span delimiters.
+		entry="- \`${image}\`"$'\n'
+		j=0
+		while [ "$j" -lt "$np" ] && [ "$j" -lt "$IMAGE_PAGES_MAX" ]; do
+			pg=$(printf '%s' "$image_section_json" | jq -r --argjson i "$i" --argjson j "$j" '.[$i].pages[$j]')
+			url=$(page_url "$pg")
+			entry="${entry}  - [\`${pg}\`](${url})"$'\n'
+			j=$((j + 1))
+		done
+		if [ "$np" -gt "$IMAGE_PAGES_MAX" ]; then
+			entry="${entry}  - _and $((np - IMAGE_PAGES_MAX)) more page(s) embedding this image_"$'\n'
+		fi
+		# Keep the first image unconditionally (an empty section under
+		# a header would be self-contradicting); for every later image
+		# measure the would-be section first so the rendered block
+		# stays under budget.
+		if [ "$shown" -gt 0 ]; then
+			candidate="${header}${out}${entry}"
+			if [ "$(printf '%s' "$candidate" | LC_ALL=C wc -c)" -gt "$budget" ]; then
+				break
+			fi
+		fi
+		out="${out}${entry}"
+		shown=$((shown + 1))
+		i=$((i + 1))
+	done
+	dropped=$((count - shown))
+	if [ "$dropped" -gt 0 ]; then
+		out="${out}"$'\n'"_and ${dropped} more changed image(s) not listed to stay under GitHub's comment size limit._"$'\n'
+	fi
+	printf '%s%s' "$header" "$out"
+}
+
 build_comment_body() {
-	local n="$1" rows state_json state_b64 checklist="" intro
-	local filename checked page_path url box omitted
+	local n="$1" rows state_json state_b64 checklist="" intro page_block=""
+	local filename checked url box omitted
 
 	rows=$(printf '%s' "$final_rows" | jq -c --argjson n "$n" '.[:$n]')
 	state_json=$(printf '%s' "$rows" | jq -c 'map({(.filename): .sha}) | add // {}')
 	state_b64=$(printf '%s' "$state_json" | base64 -w0)
 
-	while IFS=$'\t' read -r filename checked; do
-		[ -z "$filename" ] && continue
-		page_path=$(map_doc_path "$filename")
-		url="$url_prefix"
-		if [ -n "$page_path" ]; then
-			url="${url}/${page_path}"
-		fi
-		box=" "
-		if [ "$checked" = "true" ]; then
-			box="x"
-		fi
-		checklist="${checklist}- [${box}] [\`${filename}\`](${url})"$'\n'
-	done < <(printf '%s' "$rows" | jq -r '.[] | [.filename, (.checked | tostring)] | @tsv')
+	if [ "$total_pages" -gt 0 ]; then
+		while IFS=$'\t' read -r filename checked; do
+			[ -z "$filename" ] && continue
+			url=$(page_url "$filename")
+			box=" "
+			if [ "$checked" = "true" ]; then
+				box="x"
+			fi
+			# The backticks are literal Markdown code-span delimiters.
+			checklist="${checklist}- [${box}] [\`${filename}\`](${url})"$'\n'
+		done < <(printf '%s' "$rows" | jq -r '.[] | [.filename, (.checked | tostring)] | @tsv')
 
-	omitted=$((total_pages - n))
-	if [ "$omitted" -gt 0 ]; then
-		checklist="${checklist}"$'\n'"_and ${omitted} more changed page(s) not listed to stay under GitHub's comment size limit. See the [Files tab](https://github.com/${REPO}/pull/${PR_NUMBER}/files) for the full list._"$'\n'
+		omitted=$((total_pages - n))
+		if [ "$omitted" -gt 0 ]; then
+			checklist="${checklist}"$'\n'"_and ${omitted} more changed page(s) not listed to stay under GitHub's comment size limit. See the [Files tab](https://github.com/${REPO}/pull/${PR_NUMBER}/files) for the full list._"$'\n'
+		fi
+
+		intro="Check off each page once it's been reviewed. If a page changes in a later push, its checkbox clears automatically so it gets a fresh look. Pages not yet wired into the docs navigation aren't listed here."
+		page_block="${intro}"$'\n\n'"${checklist}"
 	fi
 
-	intro="Check off each page once it's been reviewed. If a page changes in a later push, its checkbox clears automatically so it gets a fresh look. Pages not yet wired into the docs navigation aren't listed here."
-
-	printf '## Docs preview\n\n%s\n\n%s\n%s\n<!-- %s%s -->' \
-		"$intro" "$checklist" "$DOCS_PREVIEW_MARKER" "$STATE_PREFIX" "$state_b64"
+	# Emit only the sections that have content. The identity marker
+	# and the state marker are always present so the comment stays
+	# discoverable and round-trippable, even on an image-only PR
+	# whose state map is {}.
+	{
+		printf '## Docs preview\n\n'
+		if [ -n "$page_block" ]; then
+			printf '%s\n' "$page_block"
+		fi
+		if [ -n "$image_section" ]; then
+			printf '%s\n' "$image_section"
+		fi
+		printf '%s\n' "$DOCS_PREVIEW_MARKER"
+		printf '<!-- %s%s -->' "$STATE_PREFIX" "$state_b64"
+	}
 }
 
 # cap_pages mirrors the measure-and-binary-search cap in docs-preview.yaml:
@@ -490,6 +722,105 @@ if [ "$emitted_state" = "$expected_state" ]; then
 	echo "PASS: emitted marker round-trips through recovery"
 else
 	echo "FAIL: emitted marker round-trip -> $emitted_state (expected $expected_state)"
+	failures=$((failures + 1))
+fi
+
+# render_image_section renders a nested list of each changed image with a
+# preview link for every page that embeds it. A docs-root page
+# (docs/README.md) links to the branch root with no trailing path.
+url_prefix="https://coder.com/docs/@branch"
+IMAGE_PAGES_MAX=25
+image_section_json='[{"image":"docs/images/a.png","pages":["docs/user-guides/x.md","docs/y.md"]},{"image":"docs/images/b.png","pages":["docs/README.md"]}]'
+section=$(render_image_section "$IMAGE_SECTION_BUDGET")
+# shellcheck disable=SC2016 # backtick-quoted paths are literal Markdown.
+if printf '%s' "$section" | grep -qF '#### Changed images' &&
+	printf '%s' "$section" | grep -qF -- '- `docs/images/a.png`' &&
+	printf '%s' "$section" | grep -qF -- '  - [`docs/user-guides/x.md`](https://coder.com/docs/@branch/user-guides/x)' &&
+	printf '%s' "$section" | grep -qF -- '  - [`docs/README.md`](https://coder.com/docs/@branch)'; then
+	echo "PASS: render_image_section (nested preview links; README maps to docs root)"
+else
+	echo "FAIL: render_image_section basic ->"
+	printf '%s\n' "$section"
+	failures=$((failures + 1))
+fi
+
+# Per-image page cap: at most IMAGE_PAGES_MAX links, then an "and N more"
+# note. Page-link lines start with two spaces, a dash and a bracket; the
+# note line starts with an underscore, so ^  - \[ counts only the links.
+IMAGE_PAGES_MAX=2
+many_pages=$(jq -nc '[range(5) | "docs/p\(.).md"]')
+image_section_json=$(jq -nc --argjson p "$many_pages" '[{image: "docs/images/big.png", pages: $p}]')
+section=$(render_image_section "$IMAGE_SECTION_BUDGET")
+shown_links=$(printf '%s\n' "$section" | grep -cE '^  - \[')
+if [ "$shown_links" -eq 2 ] && printf '%s' "$section" | grep -qF 'more page(s) embedding this image'; then
+	echo "PASS: render_image_section (per-image page cap keeps 2 with an overflow note)"
+else
+	echo "FAIL: render_image_section page cap -> shown_links=$shown_links"
+	printf '%s\n' "$section"
+	failures=$((failures + 1))
+fi
+IMAGE_PAGES_MAX=25
+
+# Byte-budget truncation across images: with a 1-byte budget only the
+# first image (always kept) renders, and a trailing "and N more image(s)"
+# note reports the rest.
+image_section_json='[{"image":"docs/images/aaaaaaaaaa.png","pages":["docs/one.md"]},{"image":"docs/images/bbbbbbbbbb.png","pages":["docs/two.md"]},{"image":"docs/images/cccccccccc.png","pages":["docs/three.md"]}]'
+section=$(render_image_section 1)
+# shellcheck disable=SC2016 # backtick is a literal Markdown delimiter.
+imgs_shown=$(printf '%s\n' "$section" | grep -cE '^- `docs/images/')
+if [ "$imgs_shown" -eq 1 ] && printf '%s' "$section" | grep -qF 'more changed image(s) not listed'; then
+	echo "PASS: render_image_section (byte-budget truncation keeps first image + note)"
+else
+	echo "FAIL: render_image_section truncation -> imgs_shown=$imgs_shown"
+	printf '%s\n' "$section"
+	failures=$((failures + 1))
+fi
+
+# build_comment_body on an image-only PR (zero changed pages): the
+# checklist and its intro are omitted, the image section renders, both
+# hidden markers are present, and the state map is {}.
+final_rows='[]'
+total_pages=0
+url_prefix="https://coder.com/docs/@branch"
+image_section_json='[{"image":"docs/images/a.png","pages":["docs/user-guides/x.md"]}]'
+image_section=$(render_image_section "$IMAGE_SECTION_BUDGET")
+image_only_body=$(build_comment_body 0)
+if printf '%s' "$image_only_body" | grep -qF '#### Changed images' &&
+	! printf '%s' "$image_only_body" | grep -qF 'Check off each page' &&
+	printf '%s' "$image_only_body" | grep -qF '<!-- docs-preview -->' &&
+	[ "$(recover_old_state "$image_only_body")" = '{}' ]; then
+	echo "PASS: build_comment_body (image-only PR: image section, no checklist, empty state)"
+else
+	echo "FAIL: build_comment_body image-only ->"
+	printf '%s\n' "$image_only_body"
+	failures=$((failures + 1))
+fi
+
+# build_comment_body with both changed pages and changed images: the
+# checklist and the image section both render. A page that is both changed
+# (checklist) and an image referrer (image section) appears in both, and
+# the image sub-link (no checkbox glyph) never pollutes carried-over
+# checkbox state.
+final_rows='[{"filename":"docs/a.md","sha":"s1","checked":true},{"filename":"docs/b.md","sha":"s2","checked":false}]'
+total_pages=2
+image_section_json='[{"image":"docs/images/a.png","pages":["docs/a.md"]}]'
+image_section=$(render_image_section "$IMAGE_SECTION_BUDGET")
+both_body=$(build_comment_body 2)
+# shellcheck disable=SC2016 # backtick-quoted paths are literal Markdown.
+if printf '%s' "$both_body" | grep -qF 'Check off each page' &&
+	printf '%s' "$both_body" | grep -qF -- '- [x] [`docs/a.md`]' &&
+	printf '%s' "$both_body" | grep -qF '#### Changed images' &&
+	printf '%s' "$both_body" | grep -qF -- '  - [`docs/a.md`](https://coder.com/docs/@branch/a)'; then
+	echo "PASS: build_comment_body (pages and images both render)"
+else
+	echo "FAIL: build_comment_body pages+images ->"
+	printf '%s\n' "$both_body"
+	failures=$((failures + 1))
+fi
+if [ "$(recover_old_checked "$both_body" | jq -cS .)" = '{"docs/a.md":true,"docs/b.md":false}' ]; then
+	echo "PASS: build_comment_body (image sub-links excluded from checkbox state)"
+else
+	echo "FAIL: image sub-links polluted checkbox state -> $(recover_old_checked "$both_body")"
 	failures=$((failures + 1))
 fi
 


### PR DESCRIPTION
## Problem

The `docs-preview` workflow only inspected changed **Markdown** files. A PR that changes only images under `docs/images/` (for example a screenshot refresh with no `.md` edits) produced **no preview comment at all**: the changed-files list was filtered to `^docs/.*\.md$`, so an image-only PR fell through to `cleanup_stale_and_exit` and posted nothing.

Motivating example: #28356 changed 6 screenshots under `docs/images/` with zero Markdown changes, so reviewers got no preview link to see the new images in context.

## Change

- Map each changed image to the docs pages that embed it, and render a nested list in the comment: every changed image, then each page that references it, each with its own preview link.
- An image that no navigable page embeds (an icon wired only into `docs/manifest.json`'s `icon_path`, or an image referenced only from a non-navigable page) is still listed on its own line with no sub-links, so a screenshot- or icon-only PR always posts a comment.
- Image references in docs are **relative** Markdown (`![](../images/…)`) and HTML (`<img src="…">`) at varying `../` depths. Resolving them needs each page's directory, so the job now checks out the PR head (`actions/checkout`, commit-pinned, `persist-credentials: false`, `sparse-checkout: docs` since `docs/` is the only tree it reads) and resolves refs against the working tree. External `<img>` URLs are ignored.
- The manifest read moves from the contents API to reading `docs/manifest.json` from the checkout (the now-unused `HEAD_SHA` env is dropped). A page is still only linked if it has a `docs/manifest.json` route, so image sub-links never point at un-navigable pages.
- The image section is **informational (no checkboxes)**. The pages themselves did not change, so the checklist's reset-on-change contract does not apply. Sub-links deliberately use `  - [` + a code span (no `[ ]` glyph) so the existing checkbox-state parser cannot pick them up, and the hidden state marker is unchanged.
- Bounded by `IMAGE_SECTION_BUDGET` (20000) and `IMAGE_PAGES_MAX` (25) so the always-rendered section stays under GitHub's comment size limit. Image extensions matched: `png|jpe?g|gif|svg|webp|avif|bmp|ico` (case-insensitive); `mp4` is excluded (video, not image).
- The PR's changed-file list is fetched once and filtered into the Markdown and image sets from the same payload, rather than paginating the same endpoint twice.

## Example rendered section (paths illustrative)

The comment gains a section that renders like this:

```
#### Changed images

These images changed. Each is listed with the navigable page(s) that embed it, so you can open the preview and see the new image in context. An image with no page listed isn't embedded by any navigable docs page. These links are informational and have no review checkboxes.

- `docs/images/user-guides/desktop/coder-desktop-mac.png`
  - [`docs/user-guides/desktop/index.md`](https://coder.com/docs/@my-branch/user-guides/desktop)
- `docs/images/templates/icons.png`
  - [`docs/admin/templates/managing-templates/index.md`](https://coder.com/docs/@my-branch/admin/templates/managing-templates)
  - [`docs/tutorials/best-practices/index.md`](https://coder.com/docs/@my-branch/tutorials/best-practices)
- `docs/images/icons/cloud.svg`
```

A shared image lists every page that embeds it; a page with no manifest route is dropped, and an image that no navigable page embeds (like the icon above) is listed on its own with no sub-links.

## Testing

- `.github/workflows/test-docs-preview-mapper.sh` passes (50 cases), covering image extraction (every matched extension, plus `extract_ref_tokens` and `resolve_ref` branch cases), relative-ref resolution, page grouping (including an image with no embedding page), section rendering with exact overflow counts, an icon-only comment, and a guard that image sub-links do not pollute checkbox-state recovery.
- `actionlint` (with embedded shellcheck) on the workflow; `shellcheck` and `shfmt -d` on the test script; `typos`; `scripts/check_emdash.sh`. All clean.
- End-to-end sanity check against the current repo for #28356's images: the nested links resolve to the embedding, manifest-routed pages.

## Follow-up

`test-docs-preview-mapper.sh` is not yet invoked by any CI job. The script exists but nothing runs it, so a regression in this logic would not be caught automatically. That is a pre-existing gap (it predates this PR) and is tracked separately in DOCS-689; it is intentionally left out here to keep this diff focused.

## CI notes

<details>
<summary>Initial CI red was a transient Go module-proxy flake (green after re-run)</summary>

The first run of this commit had `gen`, `test-go-pg (ubuntu-latest)`, and `test-go-race-pg` fail with `stream error: ... INTERNAL_ERROR; received from peer` while fetching modules from `proxy.golang.org` (e.g. `go-openapi/swag`, `coder/serpent`, `unrolled/secure`), so the Go builds hit `[setup failed]` before any test ran. `test-go-pg` on macOS and Windows passed in the same run. This PR only touches `.github/workflows/` (no Go, `go.mod`, or `go.sum`), so it cannot cause module-download failures. Re-running the failed jobs cleared it; all checks are now green.
</details>

Linear: DOCS-687

> This PR was created with AI assistance (Coder Agents).


