### PR TITLE
feat(aibridge): introduce standalone Bedrock provider

### DIFF
--- a/aibridge/aibridgetest/aibridgetest.go
+++ b/aibridge/aibridgetest/aibridgetest.go
@@ -17,3 +17,12 @@ func NewAnthropicProvider(t testing.TB, cfg aibridge.AnthropicConfig, bedrockCfg
 	require.NoError(t, err)
 	return p
 }
+
+// NewBedrockProvider builds a Bedrock provider for tests, failing the test if
+// credential resolution fails.
+func NewBedrockProvider(t testing.TB, cfg aibridge.AnthropicConfig, bedrockCfg aibridge.AWSBedrockConfig) aibridge.Provider {
+	t.Helper()
+	p, err := aibridge.NewBedrockProvider(context.Background(), cfg, bedrockCfg)
+	require.NoError(t, err)
+	return p
+}

--- a/aibridge/api.go
+++ b/aibridge/api.go
@@ -17,6 +17,7 @@ import (
 // Const + Type + function aliases for backwards compatibility.
 const (
 	ProviderAnthropic = config.ProviderAnthropic
+	ProviderBedrock   = config.ProviderBedrock
 	ProviderOpenAI    = config.ProviderOpenAI
 	ProviderCopilot   = config.ProviderCopilot
 )
@@ -48,6 +49,10 @@ func AsActor(ctx context.Context, actorID string, metadata recorder.Metadata) co
 
 func NewAnthropicProvider(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.AWSBedrock) (provider.Provider, error) {
 	return provider.NewAnthropic(ctx, cfg, bedrockCfg)
+}
+
+func NewBedrockProvider(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWSBedrock) (provider.Provider, error) {
+	return provider.NewBedrock(ctx, cfg, bedrockCfg)
 }
 
 func NewOpenAIProvider(cfg config.OpenAI) provider.Provider {

--- a/aibridge/config/config.go
+++ b/aibridge/config/config.go
@@ -12,6 +12,7 @@ const (
 	ProviderAnthropic = "anthropic"
 	ProviderOpenAI    = "openai"
 	ProviderCopilot   = "copilot"
+	ProviderBedrock   = "bedrock"
 )
 
 // Anthropic carries configuration for an Anthropic provider.

--- a/aibridge/intercept/bedrocksig/bedrocksig.go
+++ b/aibridge/intercept/bedrocksig/bedrocksig.go
@@ -27,6 +27,17 @@ const SigningService = "bedrock-mantle"
 // header so AWS can recognize the traffic as Coder-associated Bedrock usage.
 const PRMUserAgent = "sdk-ua-app-id/APN_1.1%2Fpc_cdfmjwn8i6u8l9fwz8h82e4w3%24"
 
+// MantleConfig carries only what the OpenAI-shaped interceptors need to reach
+// Bedrock Mantle: the signing region and credentials, and the base URL that
+// BaseURLForModel rewrites per model. It deliberately excludes the InvokeModel
+// fields (Model, SmallFastModel, Protocol) that those interceptors never use;
+// the messages interceptor keeps the full messages.BedrockRuntime for those.
+type MantleConfig struct {
+	BaseURL string
+	Region  string
+	Creds   aws.CredentialsProvider
+}
+
 // AppendPRMUserAgent appends the Coder PRM attribution marker to the request's
 // User-Agent header.
 func AppendPRMUserAgent(req *http.Request) {

--- a/aibridge/intercept/bedrocksig/bedrocksig_test.go
+++ b/aibridge/intercept/bedrocksig/bedrocksig_test.go
@@ -1,0 +1,60 @@
+package bedrocksig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
+)
+
+func TestBaseURLForModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		base    string
+		model   string
+		want    string
+		wantErr bool
+	}{
+		// anthropic.* models route to the /anthropic prefix; the
+		// anthropic-go SDK appends /v1/messages itself.
+		{name: "anthropic from bare host", base: "https://bedrock-mantle.us-east-1.api.aws", model: "anthropic.claude-sonnet-5", want: "https://bedrock-mantle.us-east-1.api.aws/anthropic"},
+		{name: "anthropic keeps stored /anthropic", base: "https://bedrock-mantle.us-east-1.api.aws/anthropic", model: "anthropic.claude-opus-4-8", want: "https://bedrock-mantle.us-east-1.api.aws/anthropic"},
+
+		// openai.* models route to /openai/v1; the openai-go SDK appends
+		// /responses or /chat/completions.
+		{name: "openai from bare host", base: "https://bedrock-mantle.us-east-1.api.aws", model: "openai.gpt-5.6-luna", want: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+		{name: "openai trims stored /anthropic", base: "https://bedrock-mantle.us-east-1.api.aws/anthropic", model: "openai.gpt-5.5", want: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+		{name: "openai keeps stored /openai/v1", base: "https://bedrock-mantle.us-east-1.api.aws/openai/v1", model: "openai.gpt-5.4", want: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+
+		// Third-party models use the root /v1 prefix; Mantle serves them on
+		// /v1/chat/completions only.
+		{name: "third-party from bare host", base: "https://bedrock-mantle.us-east-1.api.aws", model: "mistral.ministral-3-3b-instruct", want: "https://bedrock-mantle.us-east-1.api.aws/v1"},
+		{name: "third-party trims stored /anthropic", base: "https://bedrock-mantle.us-east-1.api.aws/anthropic", model: "moonshotai.kimi-k2.5", want: "https://bedrock-mantle.us-east-1.api.aws/v1"},
+
+		// Trailing slashes and deeper stored prefixes are trimmed first.
+		{name: "trailing slash", base: "https://bedrock-mantle.us-east-1.api.aws/", model: "openai.gpt-5.5", want: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+		{name: "stored /anthropic/v1", base: "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1", model: "anthropic.claude-sonnet-5", want: "https://bedrock-mantle.us-east-1.api.aws/anthropic"},
+		{name: "stored /openai", base: "https://bedrock-mantle.us-east-1.api.aws/openai", model: "openai.gpt-5.4", want: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+
+		// Non-vendor path segments survive trimming.
+		{name: "proxy prefix preserved", base: "https://proxy.example.com/mantle", model: "openai.gpt-5.4", want: "https://proxy.example.com/mantle/openai/v1"},
+
+		{name: "invalid base URL", base: "://not-a-url", model: "openai.gpt-5.4", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := bedrocksig.BaseURLForModel(tc.base, tc.model)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/aibridge/intercept/chatcompletions/base.go
+++ b/aibridge/intercept/chatcompletions/base.go
@@ -15,11 +15,13 @@ import (
 	"github.com/openai/openai-go/v3/option"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/apidump"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/recorder"
@@ -33,6 +35,11 @@ type interceptionBase struct {
 
 	cfg  intercept.Config
 	cred intercept.Credential
+
+	// bedrock is nil for non-Bedrock providers. When set, upstream calls are
+	// SigV4-signed against the Bedrock Mantle endpoint instead of using a key
+	// pool or BYOK secret.
+	bedrock *bedrocksig.MantleConfig
 
 	// clientHeaders are the original HTTP headers from the client request.
 	clientHeaders http.Header
@@ -48,14 +55,34 @@ type interceptionBase struct {
 func (i *interceptionBase) newCompletionsService(ctx context.Context) openai.ChatCompletionService {
 	var opts []option.RequestOption
 	// Only BYOK sets its credential here. Centralized keys are injected
-	// per-attempt in the failover loop.
-	if byok, ok := intercept.AsBYOK(i.cred); ok {
-		i.logger.Debug(ctx, "using byok auth",
-			slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
-		)
-		opts = append(opts, option.WithAPIKey(byok.Secret))
+	// per-attempt in the failover loop. Bedrock (mantle) sets neither: it
+	// signs via SigV4 middleware installed below.
+	if i.bedrock == nil {
+		if byok, ok := intercept.AsBYOK(i.cred); ok {
+			i.logger.Debug(ctx, "using byok auth",
+				slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
+			)
+			opts = append(opts, option.WithAPIKey(byok.Secret))
+		}
 	}
-	opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
+
+	// Bedrock mantle: resolve the per-model base URL. The signing middleware
+	// is appended last (below) so it runs innermost and signs after all
+	// other headers are set.
+	if i.bedrock != nil {
+		base, err := bedrocksig.BaseURLForModel(i.bedrock.BaseURL, i.Model())
+		if err != nil {
+			// Fail the request loudly: a malformed base URL is a provider
+			// misconfiguration, not a retryable upstream error.
+			opts = append(opts, option.WithMiddleware(func(_ *http.Request, _ option.MiddlewareNext) (*http.Response, error) {
+				return nil, xerrors.Errorf("bedrock mantle base URL: %w", err)
+			}))
+			return openai.NewChatCompletionService(opts...)
+		}
+		opts = append(opts, option.WithBaseURL(base))
+	} else {
+		opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
+	}
 
 	// Forward client headers to upstream. This middleware runs after the SDK
 	// has built the request, and replaces the outgoing headers with the sanitized
@@ -70,6 +97,14 @@ func (i *interceptionBase) newCompletionsService(ctx context.Context) openai.Cha
 	// Add API dump middleware if configured
 	if mw := apidump.NewBridgeMiddleware(i.cfg.APIDumpDir, i.cfg.ProviderName, i.Model(), i.id, i.logger, quartz.NewReal()); mw != nil {
 		opts = append(opts, option.WithMiddleware(mw))
+	}
+
+	// Bedrock mantle: install the SigV4 signing middleware last so it runs
+	// innermost (right before the HTTP send) and signs the request after all
+	// other headers are set.
+	if i.bedrock != nil {
+		//nolint:bodyclose // signing middleware hands the response to the transport, which closes the body.
+		opts = append(opts, option.WithMiddleware(bedrocksig.SignMiddleware(i.bedrock.Creds, i.bedrock.Region)))
 	}
 
 	return openai.NewChatCompletionService(opts...)

--- a/aibridge/intercept/chatcompletions/base.go
+++ b/aibridge/intercept/chatcompletions/base.go
@@ -36,10 +36,10 @@ type interceptionBase struct {
 	cfg  intercept.Config
 	cred intercept.Credential
 
-	// bedrock is nil for non-Bedrock providers. When set, upstream calls are
-	// SigV4-signed against the Bedrock Mantle endpoint instead of using a key
-	// pool or BYOK secret.
-	bedrock *bedrocksig.MantleConfig
+	// bedrockMantle is nil for non-Bedrock providers. When set, upstream
+	// calls are SigV4-signed against the Bedrock Mantle endpoint instead of
+	// using a key pool or BYOK secret.
+	bedrockMantle *bedrocksig.MantleConfig
 
 	// clientHeaders are the original HTTP headers from the client request.
 	clientHeaders http.Header
@@ -54,23 +54,8 @@ type interceptionBase struct {
 // newCompletionsService builds the SDK service used for upstream calls.
 func (i *interceptionBase) newCompletionsService(ctx context.Context) openai.ChatCompletionService {
 	var opts []option.RequestOption
-	// Only BYOK sets its credential here. Centralized keys are injected
-	// per-attempt in the failover loop. Bedrock (mantle) sets neither: it
-	// signs via SigV4 middleware installed below.
-	if i.bedrock == nil {
-		if byok, ok := intercept.AsBYOK(i.cred); ok {
-			i.logger.Debug(ctx, "using byok auth",
-				slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
-			)
-			opts = append(opts, option.WithAPIKey(byok.Secret))
-		}
-	}
-
-	// Bedrock mantle: resolve the per-model base URL. The signing middleware
-	// is appended last (below) so it runs innermost and signs after all
-	// other headers are set.
-	if i.bedrock != nil {
-		base, err := bedrocksig.BaseURLForModel(i.bedrock.BaseURL, i.Model())
+	if i.bedrockMantle != nil {
+		base, err := bedrocksig.BaseURLForModel(i.bedrockMantle.BaseURL, i.Model())
 		if err != nil {
 			// Fail the request loudly: a malformed base URL is a provider
 			// misconfiguration, not a retryable upstream error.
@@ -81,6 +66,14 @@ func (i *interceptionBase) newCompletionsService(ctx context.Context) openai.Cha
 		}
 		opts = append(opts, option.WithBaseURL(base))
 	} else {
+		// Only BYOK sets its credential here. Centralized keys are injected
+		// per-attempt in the failover loop.
+		if byok, ok := intercept.AsBYOK(i.cred); ok {
+			i.logger.Debug(ctx, "using byok auth",
+				slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
+			)
+			opts = append(opts, option.WithAPIKey(byok.Secret))
+		}
 		opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
 	}
 
@@ -102,9 +95,9 @@ func (i *interceptionBase) newCompletionsService(ctx context.Context) openai.Cha
 	// Bedrock mantle: install the SigV4 signing middleware last so it runs
 	// innermost (right before the HTTP send) and signs the request after all
 	// other headers are set.
-	if i.bedrock != nil {
+	if i.bedrockMantle != nil {
 		//nolint:bodyclose // signing middleware hands the response to the transport, which closes the body.
-		opts = append(opts, option.WithMiddleware(bedrocksig.SignMiddleware(i.bedrock.Creds, i.bedrock.Region)))
+		opts = append(opts, option.WithMiddleware(bedrocksig.SignMiddleware(i.bedrockMantle.Creds, i.bedrockMantle.Region)))
 	}
 
 	return openai.NewChatCompletionService(opts...)

--- a/aibridge/intercept/chatcompletions/blocking.go
+++ b/aibridge/intercept/chatcompletions/blocking.go
@@ -48,11 +48,11 @@ func NewBedrockBlockingInterceptor(
 	req *ChatCompletionNewParamsWrapper,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingInterception {
-	return buildBlockingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildBlockingInterceptor(id, req, cfg, cred, bedrockMantle, clientHeaders, tracer)
 }
 
 func buildBlockingInterceptor(
@@ -60,7 +60,7 @@ func buildBlockingInterceptor(
 	req *ChatCompletionNewParamsWrapper,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingInterception {
@@ -69,7 +69,7 @@ func buildBlockingInterceptor(
 		req:           req,
 		cfg:           cfg,
 		cred:          cred,
-		bedrock:       bedrock,
+		bedrockMantle: bedrockMantle,
 		clientHeaders: clientHeaders,
 		tracer:        tracer,
 	}}

--- a/aibridge/intercept/chatcompletions/blocking.go
+++ b/aibridge/intercept/chatcompletions/blocking.go
@@ -19,6 +19,7 @@ import (
 	"cdr.dev/slog/v3"
 	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
@@ -39,11 +40,36 @@ func NewBlockingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingInterception {
+	return newBlockingInterceptor(id, req, cfg, cred, nil, clientHeaders, tracer)
+}
+
+func NewBedrockBlockingInterceptor(
+	id uuid.UUID,
+	req *ChatCompletionNewParamsWrapper,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *BlockingInterception {
+	return newBlockingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
+}
+
+func newBlockingInterceptor(
+	id uuid.UUID,
+	req *ChatCompletionNewParamsWrapper,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *BlockingInterception {
 	return &BlockingInterception{interceptionBase: interceptionBase{
 		id:            id,
 		req:           req,
 		cfg:           cfg,
 		cred:          cred,
+		bedrock:       bedrock,
 		clientHeaders: clientHeaders,
 		tracer:        tracer,
 	}}

--- a/aibridge/intercept/chatcompletions/blocking.go
+++ b/aibridge/intercept/chatcompletions/blocking.go
@@ -40,7 +40,7 @@ func NewBlockingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingInterception {
-	return newBlockingInterceptor(id, req, cfg, cred, nil, clientHeaders, tracer)
+	return buildBlockingInterceptor(id, req, cfg, cred, nil, clientHeaders, tracer)
 }
 
 func NewBedrockBlockingInterceptor(
@@ -52,10 +52,10 @@ func NewBedrockBlockingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingInterception {
-	return newBlockingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildBlockingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
 }
 
-func newBlockingInterceptor(
+func buildBlockingInterceptor(
 	id uuid.UUID,
 	req *ChatCompletionNewParamsWrapper,
 	cfg intercept.Config,

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -43,7 +43,7 @@ func NewStreamingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingInterception {
-	return newStreamingInterceptor(id, req, cfg, cred, nil, clientHeaders, tracer)
+	return buildStreamingInterceptor(id, req, cfg, cred, nil, clientHeaders, tracer)
 }
 
 func NewBedrockStreamingInterceptor(
@@ -55,10 +55,10 @@ func NewBedrockStreamingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingInterception {
-	return newStreamingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildStreamingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
 }
 
-func newStreamingInterceptor(
+func buildStreamingInterceptor(
 	id uuid.UUID,
 	req *ChatCompletionNewParamsWrapper,
 	cfg intercept.Config,

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -22,6 +22,7 @@ import (
 	"cdr.dev/slog/v3"
 	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
@@ -42,11 +43,36 @@ func NewStreamingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingInterception {
+	return newStreamingInterceptor(id, req, cfg, cred, nil, clientHeaders, tracer)
+}
+
+func NewBedrockStreamingInterceptor(
+	id uuid.UUID,
+	req *ChatCompletionNewParamsWrapper,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *StreamingInterception {
+	return newStreamingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
+}
+
+func newStreamingInterceptor(
+	id uuid.UUID,
+	req *ChatCompletionNewParamsWrapper,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *StreamingInterception {
 	return &StreamingInterception{interceptionBase: interceptionBase{
 		id:            id,
 		req:           req,
 		cfg:           cfg,
 		cred:          cred,
+		bedrock:       bedrock,
 		clientHeaders: clientHeaders,
 		tracer:        tracer,
 	}}

--- a/aibridge/intercept/chatcompletions/streaming.go
+++ b/aibridge/intercept/chatcompletions/streaming.go
@@ -51,11 +51,11 @@ func NewBedrockStreamingInterceptor(
 	req *ChatCompletionNewParamsWrapper,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingInterception {
-	return buildStreamingInterceptor(id, req, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildStreamingInterceptor(id, req, cfg, cred, bedrockMantle, clientHeaders, tracer)
 }
 
 func buildStreamingInterceptor(
@@ -63,7 +63,7 @@ func buildStreamingInterceptor(
 	req *ChatCompletionNewParamsWrapper,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingInterception {
@@ -72,7 +72,7 @@ func buildStreamingInterceptor(
 		req:           req,
 		cfg:           cfg,
 		cred:          cred,
-		bedrock:       bedrock,
+		bedrockMantle: bedrockMantle,
 		clientHeaders: clientHeaders,
 		tracer:        tracer,
 	}}

--- a/aibridge/intercept/responses/base.go
+++ b/aibridge/intercept/responses/base.go
@@ -47,10 +47,10 @@ type responsesInterceptionBase struct {
 
 	cfg  intercept.Config
 	cred intercept.Credential
-	// bedrock is nil for non-Bedrock providers. When set, upstream calls are
-	// SigV4-signed against the Bedrock Mantle endpoint instead of using a key
-	// pool or BYOK secret.
-	bedrock *bedrocksig.MantleConfig
+	// bedrockMantle is nil for non-Bedrock providers. When set, upstream
+	// calls are SigV4-signed against the Bedrock Mantle endpoint instead of
+	// using a key pool or BYOK secret.
+	bedrockMantle *bedrocksig.MantleConfig
 
 	// clientHeaders are the original HTTP headers from the client request.
 	clientHeaders http.Header
@@ -80,23 +80,8 @@ func sumUsage(ref responses.ResponseUsage, in responses.ResponseUsage) responses
 // newResponsesService builds the SDK service used for upstream calls.
 func (i *responsesInterceptionBase) newResponsesService(ctx context.Context) responses.ResponseService {
 	var opts []option.RequestOption
-	// Only BYOK sets its credential here. Centralized keys are injected
-	// per-attempt in the failover loop. Bedrock (mantle) sets neither: it
-	// signs via SigV4 middleware installed below.
-	if i.bedrock == nil {
-		if byok, ok := intercept.AsBYOK(i.cred); ok {
-			i.logger.Debug(ctx, "using byok auth",
-				slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
-			)
-			opts = append(opts, option.WithAPIKey(byok.Secret))
-		}
-	}
-
-	// Bedrock mantle: resolve the per-model base URL. The signing middleware
-	// is appended last (below) so it runs innermost and signs after all
-	// other headers are set.
-	if i.bedrock != nil {
-		base, err := bedrocksig.BaseURLForModel(i.bedrock.BaseURL, i.Model())
+	if i.bedrockMantle != nil {
+		base, err := bedrocksig.BaseURLForModel(i.bedrockMantle.BaseURL, i.Model())
 		if err != nil {
 			// Fail the request loudly: a malformed base URL is a provider
 			// misconfiguration, not a retryable upstream error.
@@ -107,6 +92,14 @@ func (i *responsesInterceptionBase) newResponsesService(ctx context.Context) res
 		}
 		opts = append(opts, option.WithBaseURL(base))
 	} else {
+		// Only BYOK sets its credential here. Centralized keys are injected
+		// per-attempt in the failover loop.
+		if byok, ok := intercept.AsBYOK(i.cred); ok {
+			i.logger.Debug(ctx, "using byok auth",
+				slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
+			)
+			opts = append(opts, option.WithAPIKey(byok.Secret))
+		}
 		opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
 	}
 
@@ -128,9 +121,9 @@ func (i *responsesInterceptionBase) newResponsesService(ctx context.Context) res
 	// Bedrock mantle: install the SigV4 signing middleware last so it runs
 	// innermost (right before the HTTP send) and signs the request after all
 	// other headers are set.
-	if i.bedrock != nil {
+	if i.bedrockMantle != nil {
 		//nolint:bodyclose // signing middleware hands the response to the transport, which closes the body.
-		opts = append(opts, option.WithMiddleware(bedrocksig.SignMiddleware(i.bedrock.Creds, i.bedrock.Region)))
+		opts = append(opts, option.WithMiddleware(bedrocksig.SignMiddleware(i.bedrockMantle.Creds, i.bedrockMantle.Region)))
 	}
 
 	return responses.NewResponseService(opts...)

--- a/aibridge/intercept/responses/base.go
+++ b/aibridge/intercept/responses/base.go
@@ -29,6 +29,7 @@ import (
 	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/intercept/apidump"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/recorder"
@@ -46,6 +47,10 @@ type responsesInterceptionBase struct {
 
 	cfg  intercept.Config
 	cred intercept.Credential
+	// bedrock is nil for non-Bedrock providers. When set, upstream calls are
+	// SigV4-signed against the Bedrock Mantle endpoint instead of using a key
+	// pool or BYOK secret.
+	bedrock *bedrocksig.MantleConfig
 
 	// clientHeaders are the original HTTP headers from the client request.
 	clientHeaders http.Header
@@ -76,14 +81,34 @@ func sumUsage(ref responses.ResponseUsage, in responses.ResponseUsage) responses
 func (i *responsesInterceptionBase) newResponsesService(ctx context.Context) responses.ResponseService {
 	var opts []option.RequestOption
 	// Only BYOK sets its credential here. Centralized keys are injected
-	// per-attempt in the failover loop.
-	if byok, ok := intercept.AsBYOK(i.cred); ok {
-		i.logger.Debug(ctx, "using byok auth",
-			slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
-		)
-		opts = append(opts, option.WithAPIKey(byok.Secret))
+	// per-attempt in the failover loop. Bedrock (mantle) sets neither: it
+	// signs via SigV4 middleware installed below.
+	if i.bedrock == nil {
+		if byok, ok := intercept.AsBYOK(i.cred); ok {
+			i.logger.Debug(ctx, "using byok auth",
+				slog.F("auth_header", byok.Header), slog.F("key_hint", byok.Hint()),
+			)
+			opts = append(opts, option.WithAPIKey(byok.Secret))
+		}
 	}
-	opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
+
+	// Bedrock mantle: resolve the per-model base URL. The signing middleware
+	// is appended last (below) so it runs innermost and signs after all
+	// other headers are set.
+	if i.bedrock != nil {
+		base, err := bedrocksig.BaseURLForModel(i.bedrock.BaseURL, i.Model())
+		if err != nil {
+			// Fail the request loudly: a malformed base URL is a provider
+			// misconfiguration, not a retryable upstream error.
+			opts = append(opts, option.WithMiddleware(func(_ *http.Request, _ option.MiddlewareNext) (*http.Response, error) {
+				return nil, xerrors.Errorf("bedrock mantle base URL: %w", err)
+			}))
+			return responses.NewResponseService(opts...)
+		}
+		opts = append(opts, option.WithBaseURL(base))
+	} else {
+		opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
+	}
 
 	// Forward client headers to upstream. This middleware runs after the SDK
 	// has built the request, and replaces the outgoing headers with the sanitized
@@ -98,6 +123,14 @@ func (i *responsesInterceptionBase) newResponsesService(ctx context.Context) res
 	// Add API dump middleware if configured
 	if mw := apidump.NewBridgeMiddleware(i.cfg.APIDumpDir, i.cfg.ProviderName, i.Model(), i.id, i.logger, quartz.NewReal()); mw != nil {
 		opts = append(opts, option.WithMiddleware(mw))
+	}
+
+	// Bedrock mantle: install the SigV4 signing middleware last so it runs
+	// innermost (right before the HTTP send) and signs the request after all
+	// other headers are set.
+	if i.bedrock != nil {
+		//nolint:bodyclose // signing middleware hands the response to the transport, which closes the body.
+		opts = append(opts, option.WithMiddleware(bedrocksig.SignMiddleware(i.bedrock.Creds, i.bedrock.Region)))
 	}
 
 	return responses.NewResponseService(opts...)

--- a/aibridge/intercept/responses/blocking.go
+++ b/aibridge/intercept/responses/blocking.go
@@ -44,11 +44,11 @@ func NewBedrockBlockingInterceptor(
 	reqPayload RequestPayload,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingResponsesInterceptor {
-	return buildBlockingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildBlockingInterceptor(id, reqPayload, cfg, cred, bedrockMantle, clientHeaders, tracer)
 }
 
 func buildBlockingInterceptor(
@@ -56,7 +56,7 @@ func buildBlockingInterceptor(
 	reqPayload RequestPayload,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingResponsesInterceptor {
@@ -66,7 +66,7 @@ func buildBlockingInterceptor(
 			reqPayload:    reqPayload,
 			cfg:           cfg,
 			cred:          cred,
-			bedrock:       bedrock,
+			bedrockMantle: bedrockMantle,
 			clientHeaders: clientHeaders,
 			tracer:        tracer,
 		},

--- a/aibridge/intercept/responses/blocking.go
+++ b/aibridge/intercept/responses/blocking.go
@@ -36,7 +36,7 @@ func NewBlockingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingResponsesInterceptor {
-	return newBlockingInterceptor(id, reqPayload, cfg, cred, nil, clientHeaders, tracer)
+	return buildBlockingInterceptor(id, reqPayload, cfg, cred, nil, clientHeaders, tracer)
 }
 
 func NewBedrockBlockingInterceptor(
@@ -48,10 +48,10 @@ func NewBedrockBlockingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingResponsesInterceptor {
-	return newBlockingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildBlockingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
 }
 
-func newBlockingInterceptor(
+func buildBlockingInterceptor(
 	id uuid.UUID,
 	reqPayload RequestPayload,
 	cfg intercept.Config,

--- a/aibridge/intercept/responses/blocking.go
+++ b/aibridge/intercept/responses/blocking.go
@@ -17,6 +17,7 @@ import (
 	"cdr.dev/slog/v3"
 	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/recorder"
@@ -35,12 +36,37 @@ func NewBlockingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingResponsesInterceptor {
+	return newBlockingInterceptor(id, reqPayload, cfg, cred, nil, clientHeaders, tracer)
+}
+
+func NewBedrockBlockingInterceptor(
+	id uuid.UUID,
+	reqPayload RequestPayload,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *BlockingResponsesInterceptor {
+	return newBlockingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
+}
+
+func newBlockingInterceptor(
+	id uuid.UUID,
+	reqPayload RequestPayload,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *BlockingResponsesInterceptor {
 	return &BlockingResponsesInterceptor{
 		responsesInterceptionBase: responsesInterceptionBase{
 			id:            id,
 			reqPayload:    reqPayload,
 			cfg:           cfg,
 			cred:          cred,
+			bedrock:       bedrock,
 			clientHeaders: clientHeaders,
 			tracer:        tracer,
 		},

--- a/aibridge/intercept/responses/streaming.go
+++ b/aibridge/intercept/responses/streaming.go
@@ -18,6 +18,7 @@ import (
 	"cdr.dev/slog/v3"
 	aibcontext "github.com/coder/coder/v2/aibridge/context"
 	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
@@ -42,12 +43,37 @@ func NewStreamingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingResponsesInterceptor {
+	return newStreamingInterceptor(id, reqPayload, cfg, cred, nil, clientHeaders, tracer)
+}
+
+func NewBedrockStreamingInterceptor(
+	id uuid.UUID,
+	reqPayload RequestPayload,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *StreamingResponsesInterceptor {
+	return newStreamingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
+}
+
+func newStreamingInterceptor(
+	id uuid.UUID,
+	reqPayload RequestPayload,
+	cfg intercept.Config,
+	cred intercept.Credential,
+	bedrock *bedrocksig.MantleConfig,
+	clientHeaders http.Header,
+	tracer trace.Tracer,
+) *StreamingResponsesInterceptor {
 	return &StreamingResponsesInterceptor{
 		responsesInterceptionBase: responsesInterceptionBase{
 			id:            id,
 			reqPayload:    reqPayload,
 			cfg:           cfg,
 			cred:          cred,
+			bedrock:       bedrock,
 			clientHeaders: clientHeaders,
 			tracer:        tracer,
 		},

--- a/aibridge/intercept/responses/streaming.go
+++ b/aibridge/intercept/responses/streaming.go
@@ -51,11 +51,11 @@ func NewBedrockStreamingInterceptor(
 	reqPayload RequestPayload,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingResponsesInterceptor {
-	return buildStreamingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildStreamingInterceptor(id, reqPayload, cfg, cred, bedrockMantle, clientHeaders, tracer)
 }
 
 func buildStreamingInterceptor(
@@ -63,7 +63,7 @@ func buildStreamingInterceptor(
 	reqPayload RequestPayload,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *bedrocksig.MantleConfig,
+	bedrockMantle *bedrocksig.MantleConfig,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingResponsesInterceptor {
@@ -73,7 +73,7 @@ func buildStreamingInterceptor(
 			reqPayload:    reqPayload,
 			cfg:           cfg,
 			cred:          cred,
-			bedrock:       bedrock,
+			bedrockMantle: bedrockMantle,
 			clientHeaders: clientHeaders,
 			tracer:        tracer,
 		},

--- a/aibridge/intercept/responses/streaming.go
+++ b/aibridge/intercept/responses/streaming.go
@@ -43,7 +43,7 @@ func NewStreamingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingResponsesInterceptor {
-	return newStreamingInterceptor(id, reqPayload, cfg, cred, nil, clientHeaders, tracer)
+	return buildStreamingInterceptor(id, reqPayload, cfg, cred, nil, clientHeaders, tracer)
 }
 
 func NewBedrockStreamingInterceptor(
@@ -55,10 +55,10 @@ func NewBedrockStreamingInterceptor(
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingResponsesInterceptor {
-	return newStreamingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
+	return buildStreamingInterceptor(id, reqPayload, cfg, cred, bedrock, clientHeaders, tracer)
 }
 
-func newStreamingInterceptor(
+func buildStreamingInterceptor(
 	id uuid.UUID,
 	reqPayload RequestPayload,
 	cfg intercept.Config,

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -444,6 +444,84 @@ func TestAWSBedrockIntegration(t *testing.T) {
 		bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
 	})
 
+	t.Run("mantle OpenAI routes", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name         string
+			fixture      []byte
+			model        string
+			requestPath  string
+			upstreamPath string
+		}{
+			{
+				name:         "responses",
+				fixture:      fixtures.OaiResponsesBlockingSimple,
+				model:        "openai.gpt-5.6-luna",
+				requestPath:  "/anthropic/v1/responses",
+				upstreamPath: "/openai/v1/responses",
+			},
+			{
+				name:         "chat completions",
+				fixture:      fixtures.OaiChatSimple,
+				model:        "mistral.ministral-3-3b-instruct",
+				requestPath:  "/anthropic/v1/chat/completions",
+				upstreamPath: "/v1/chat/completions",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+				t.Cleanup(cancel)
+
+				fix := fixtures.Parse(t, tc.fixture)
+				upstream := testutil.NewMockUpstream(ctx, t, testutil.NewFixtureResponse(fix))
+				bedrockCfg := config.AWSBedrock{
+					Region:          "us-west-2",
+					AccessKey:       "test-access-key",
+					AccessKeySecret: "test-secret-key",
+					BaseURL:         upstream.URL + "/anthropic",
+					Protocol:        config.BedrockProtocolMantle,
+				}
+				bridgeServer := newBridgeTestServer(ctx, t, upstream.URL,
+					withCustomProvider(aibridgetest.NewBedrockProvider(t, config.Anthropic{
+						Name:    config.ProviderAnthropic,
+						BaseURL: upstream.URL,
+					}, bedrockCfg)),
+				)
+
+				reqBody, err := sjson.SetBytes(fix.Request(), "model", tc.model)
+				require.NoError(t, err)
+				resp, err := bridgeServer.makeRequest(t, http.MethodPost, tc.requestPath, reqBody)
+				require.NoError(t, err)
+				defer resp.Body.Close()
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				_, err = io.Copy(io.Discard, resp.Body)
+				require.NoError(t, err)
+
+				received := upstream.ReceivedRequests()
+				require.Len(t, received, 1)
+				require.Equal(t, tc.upstreamPath, received[0].Path)
+				require.Equal(t, tc.model, gjson.GetBytes(received[0].Body, "model").String(),
+					"model should be forwarded unchanged")
+
+				authHeader := received[0].Header.Get("Authorization")
+				require.True(t, strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256"), "missing SigV4 auth: %q", authHeader)
+				require.Contains(t, authHeader, "/bedrock-mantle/aws4_request",
+					"signature must be scoped to the bedrock-mantle service")
+				require.Contains(t, received[0].Header.Get("User-Agent"), bedrocksig.PRMUserAgent)
+
+				interceptions := bridgeServer.Recorder.RecordedInterceptions()
+				require.Len(t, interceptions, 1)
+				require.Equal(t, tc.model, interceptions[0].Model)
+				bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
+			})
+		}
+	})
+
 	// Tests that Bedrock-incompatible fields are stripped and adaptive thinking
 	// is handled correctly per model. Different Bedrock model names trigger
 	// different behavior for beta flag filtering and field stripping.

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -458,14 +458,14 @@ func TestAWSBedrockIntegration(t *testing.T) {
 				name:         "responses",
 				fixture:      fixtures.OaiResponsesBlockingSimple,
 				model:        "openai.gpt-5.6-luna",
-				requestPath:  "/anthropic/v1/responses",
+				requestPath:  "/bedrock/v1/responses",
 				upstreamPath: "/openai/v1/responses",
 			},
 			{
 				name:         "chat completions",
 				fixture:      fixtures.OaiChatSimple,
 				model:        "mistral.ministral-3-3b-instruct",
-				requestPath:  "/anthropic/v1/chat/completions",
+				requestPath:  "/bedrock/v1/chat/completions",
 				upstreamPath: "/v1/chat/completions",
 			},
 		}
@@ -483,12 +483,12 @@ func TestAWSBedrockIntegration(t *testing.T) {
 					Region:          "us-west-2",
 					AccessKey:       "test-access-key",
 					AccessKeySecret: "test-secret-key",
-					BaseURL:         upstream.URL + "/anthropic",
+					BaseURL:         upstream.URL,
 					Protocol:        config.BedrockProtocolMantle,
 				}
 				bridgeServer := newBridgeTestServer(ctx, t, upstream.URL,
 					withCustomProvider(aibridgetest.NewBedrockProvider(t, config.Anthropic{
-						Name:    config.ProviderAnthropic,
+						Name:    config.ProviderBedrock,
 						BaseURL: upstream.URL,
 					}, bedrockCfg)),
 				)
@@ -504,7 +504,7 @@ func TestAWSBedrockIntegration(t *testing.T) {
 
 				received := upstream.ReceivedRequests()
 				require.Len(t, received, 1)
-				require.Equal(t, tc.upstreamPath, received[0].Path)
+				require.Equal(t, tc.upstreamPath, received[0].Path, "upstream path should match expected")
 				require.Equal(t, tc.model, gjson.GetBytes(received[0].Body, "model").String(),
 					"model should be forwarded unchanged")
 

--- a/aibridge/provider/bedrock_internal_test.go
+++ b/aibridge/provider/bedrock_internal_test.go
@@ -513,7 +513,6 @@ func TestNewBedrock_RegionResolution(t *testing.T) {
 			AccessKeySecret: "test-secret",
 		})
 		require.NoError(t, err)
-		require.NotNil(t, p.runtime)
 		require.Equal(t, "us-west-2", p.runtime.Cfg.Region)
 	})
 
@@ -665,4 +664,36 @@ func TestBedrock_CreateInterceptor_InvokeModelOpenAIRoutes(t *testing.T) {
 			require.Nil(t, interceptor)
 		})
 	}
+}
+
+func TestNewBedrock_BaseURLInheritance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inherits_bedrock_base_url", func(t *testing.T) {
+		t.Parallel()
+
+		const baseURL = "https://bedrock-mantle.us-west-2.api.aws/anthropic"
+		p := newTestBedrock(t, config.Anthropic{}, config.AWSBedrock{
+			Region:          "us-west-2",
+			AccessKey:       "test-key",
+			AccessKeySecret: "test-secret",
+			Model:           "m",
+			SmallFastModel:  "s",
+			BaseURL:         baseURL,
+		})
+		assert.Equal(t, baseURL, p.BaseURL())
+	})
+
+	t.Run("does_not_default_to_anthropic", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestBedrock(t, config.Anthropic{}, config.AWSBedrock{
+			Region:          "us-west-2",
+			AccessKey:       "test-key",
+			AccessKeySecret: "test-secret",
+			Model:           "m",
+			SmallFastModel:  "s",
+		})
+		assert.Empty(t, p.BaseURL())
+	})
 }

--- a/aibridge/provider/bedrock_internal_test.go
+++ b/aibridge/provider/bedrock_internal_test.go
@@ -3,11 +3,14 @@ package provider
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
+	anthropicshared "github.com/anthropics/anthropic-sdk-go/shared"
+	openai "github.com/openai/openai-go/v3/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -449,6 +452,36 @@ func newTestBedrock(t testing.TB, cfg config.Anthropic, bedrockCfg config.AWSBed
 	p, err := NewBedrock(context.Background(), cfg, bedrockCfg)
 	require.NoError(t, err)
 	return p
+}
+
+func TestBedrock_CircuitBreakerOpenErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	circuitBreaker := config.DefaultCircuitBreaker()
+	p := newTestBedrock(t, config.Anthropic{CircuitBreaker: &circuitBreaker}, config.AWSBedrock{
+		Region:          "us-west-2",
+		AccessKey:       "test-key",
+		AccessKeySecret: "test-secret",
+		Model:           "m",
+		SmallFastModel:  "s",
+	})
+	require.NotNil(t, p.cfg.CircuitBreaker.OpenErrorResponse)
+	body := p.cfg.CircuitBreaker.OpenErrorResponse()
+
+	var anthropicErr anthropicshared.ErrorResponse
+	require.NoError(t, json.Unmarshal(body, &anthropicErr))
+	assert.Equal(t, "error", string(anthropicErr.Type))
+	assert.Equal(t, "api_error", anthropicErr.Error.Type)
+	assert.Equal(t, "circuit breaker is open", anthropicErr.Error.Message)
+
+	var openAIEnvelope struct {
+		Error *openai.ErrorObject `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &openAIEnvelope))
+	require.NotNil(t, openAIEnvelope.Error)
+	assert.Equal(t, "api_error", openAIEnvelope.Error.Type)
+	assert.Equal(t, "circuit breaker is open", openAIEnvelope.Error.Message)
+	assert.Equal(t, "service_unavailable", openAIEnvelope.Error.Code)
 }
 
 func TestBedrock_TypeAndName(t *testing.T) {

--- a/aibridge/provider/bedrock_internal_test.go
+++ b/aibridge/provider/bedrock_internal_test.go
@@ -1,15 +1,20 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/aibridge/config"
+	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/internal/testutil"
 )
 
 // TestBuildBedrockCredentialsValidation covers the input validation that does
@@ -436,4 +441,228 @@ func TestBuildBedrockCredentialsAssumeRoleRegionFromEnv(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "us-west-2", awsCfg.Region)
+}
+
+// newTestBedrock is local because white-box tests need the concrete *Bedrock.
+func newTestBedrock(t testing.TB, cfg config.Anthropic, bedrockCfg config.AWSBedrock) *Bedrock {
+	t.Helper()
+	p, err := NewBedrock(context.Background(), cfg, bedrockCfg)
+	require.NoError(t, err)
+	return p
+}
+
+func TestBedrock_TypeAndName(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBedrock(t, config.Anthropic{}, config.AWSBedrock{
+		Region:          "us-west-2",
+		AccessKey:       "test-key",
+		AccessKeySecret: "test-secret",
+		Model:           "m",
+		SmallFastModel:  "s",
+	})
+	assert.Equal(t, config.ProviderBedrock, p.Type())
+	assert.Equal(t, config.ProviderBedrock, p.Name())
+
+	p2 := newTestBedrock(t, config.Anthropic{Name: "bedrock-custom"}, config.AWSBedrock{
+		Region:          "us-west-2",
+		AccessKey:       "test-key",
+		AccessKeySecret: "test-secret",
+		Model:           "m",
+		SmallFastModel:  "s",
+	})
+	assert.Equal(t, "bedrock-custom", p2.Name())
+}
+
+func TestBedrock_KeyPool(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBedrock(t, config.Anthropic{}, config.AWSBedrock{
+		Region:          "us-west-2",
+		AccessKey:       "test-key",
+		AccessKeySecret: "test-secret",
+		Model:           "m",
+		SmallFastModel:  "s",
+	})
+	assert.Nil(t, p.KeyPool(), "Bedrock has no key pool")
+}
+
+func TestBedrock_BridgedRoutes(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBedrock(t, config.Anthropic{}, config.AWSBedrock{
+		Region:          "us-west-2",
+		AccessKey:       "test-key",
+		AccessKeySecret: "test-secret",
+		Model:           "m",
+		SmallFastModel:  "s",
+	})
+	routes := p.BridgedRoutes()
+	assert.ElementsMatch(t, []string{routeMessages, routeBedrockChatCompletions, routeBedrockResponses}, routes)
+}
+
+// NOTE: no t.Parallel() because the subtests use t.Setenv.
+func TestNewBedrock_RegionResolution(t *testing.T) {
+	t.Run("mantle_region_from_env", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "us-west-2")
+
+		p, err := NewBedrock(context.Background(), config.Anthropic{}, config.AWSBedrock{
+			BaseURL:         "https://bedrock-mantle.us-west-2.api.aws/anthropic",
+			Protocol:        config.BedrockProtocolMantle,
+			AccessKey:       "test-key",
+			AccessKeySecret: "test-secret",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, p.runtime)
+		require.Equal(t, "us-west-2", p.runtime.Cfg.Region)
+	})
+
+	t.Run("mantle_no_region_anywhere", func(t *testing.T) {
+		// Clear every source the AWS SDK consults for a region so none
+		// resolves, then confirm construction rejects the mantle provider.
+		t.Setenv("AWS_REGION", "")
+		t.Setenv("AWS_DEFAULT_REGION", "")
+		t.Setenv("AWS_PROFILE", "")
+		t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+		t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+		_, err := NewBedrock(context.Background(), config.Anthropic{}, config.AWSBedrock{
+			BaseURL:         "https://proxy.internal",
+			Protocol:        config.BedrockProtocolMantle,
+			AccessKey:       "test-key",
+			AccessKeySecret: "test-secret",
+		})
+		require.ErrorContains(t, err, "region required")
+	})
+}
+
+func TestBedrock_CreateInterceptor_Credential(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// bedrockStatic configures static AWS credentials. False means
+		// dynamic mode (AWS default credential chain).
+		bedrockStatic bool
+		setHeaders    map[string]string
+		// wantErr, when set, means CreateInterceptor must fail with it. The
+		// remaining expectations are then ignored.
+		wantErr            error
+		wantCredentialKind intercept.CredentialKind
+		wantCredentialHint string
+	}{
+		{
+			// Bedrock dynamic mode: no static access key, so the hint is the
+			// AWS-credential-chain placeholder.
+			name:               "bedrock_dynamic",
+			bedrockStatic:      false,
+			setHeaders:         map[string]string{},
+			wantCredentialKind: intercept.CredentialKindCentralized,
+			wantCredentialHint: "<aws chain>",
+		},
+		{
+			// Bedrock static mode: the hint masks the access key ID.
+			name:               "bedrock_static",
+			bedrockStatic:      true,
+			setHeaders:         map[string]string{},
+			wantCredentialKind: intercept.CredentialKindCentralized,
+			wantCredentialHint: "AKIA...MPLE",
+		},
+		{
+			name:               "byok_api_key",
+			bedrockStatic:      true,
+			setHeaders:         map[string]string{"X-Api-Key": "user-api-key"},
+			wantCredentialKind: intercept.CredentialKindBYOK,
+			wantCredentialHint: "us...ey",
+		},
+		{
+			name:               "byok_bearer_token",
+			bedrockStatic:      true,
+			setHeaders:         map[string]string{"Authorization": "Bearer user-access-token"},
+			wantCredentialKind: intercept.CredentialKindBYOK,
+			wantCredentialHint: "us...en",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":"msg-123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello!"}],"model":"claude-opus-4-5","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`))
+			}))
+			t.Cleanup(mockUpstream.Close)
+
+			bcfg := config.AWSBedrock{Region: "us-west-2", Model: "m", SmallFastModel: "s", BaseURL: mockUpstream.URL}
+			if tc.bedrockStatic {
+				bcfg.AccessKey = "AKIAIOSFODNN7EXAMPLE"
+				bcfg.AccessKeySecret = "wJalrXUtnFEMI-secret-value"
+			}
+			p := newTestBedrock(t, config.Anthropic{BaseURL: mockUpstream.URL}, bcfg)
+
+			body := `{"model": "claude-opus-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "hello"}], "stream": false}`
+			req := httptest.NewRequest(http.MethodPost, routeMessages, bytes.NewBufferString(body))
+			for k, v := range tc.setHeaders {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+
+			interceptor, err := p.CreateInterceptor(w, req, testTracer)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, interceptor)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, interceptor)
+
+			cred := interceptor.Credential()
+			assert.Equal(t, tc.wantCredentialKind, cred.Kind(), "credential kind mismatch")
+			assert.Equal(t, tc.wantCredentialHint, cred.Hint(), "credential hint mismatch")
+
+			// Bedrock signs via AWS during ProcessRequest (needs real AWS
+			// credentials), covered by the integration tests.
+			interceptor.Setup(slog.Make(), &testutil.MockRecorder{}, nil)
+		})
+	}
+}
+
+// TestBedrock_CreateInterceptor_InvokeModelOpenAIRoutes verifies that an
+// invoke-model provider returns ErrUnknownRoute for the OpenAI routes, since
+// they only make sense under the mantle protocol.
+func TestBedrock_CreateInterceptor_InvokeModelOpenAIRoutes(t *testing.T) {
+	t.Parallel()
+
+	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg-123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello!"}],"model":"claude-opus-4-5","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`))
+	}))
+	t.Cleanup(mockUpstream.Close)
+
+	p := newTestBedrock(t, config.Anthropic{BaseURL: mockUpstream.URL}, config.AWSBedrock{
+		Region:          "us-west-2",
+		AccessKey:       "test-key",
+		AccessKeySecret: "test-secret",
+		Model:           "m",
+		SmallFastModel:  "s",
+		BaseURL:         mockUpstream.URL,
+	})
+	require.Equal(t, config.BedrockProtocolInvokeModel, p.runtime.Cfg.ResolvedProtocol())
+
+	for _, path := range []string{routeBedrockChatCompletions, routeBedrockResponses} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{}`))
+			w := httptest.NewRecorder()
+
+			interceptor, err := p.CreateInterceptor(w, req, testTracer)
+			require.ErrorIs(t, err, ErrUnknownRoute)
+			require.Nil(t, interceptor)
+		})
+	}
 }

--- a/aibridge/provider/bedrock_internal_test.go
+++ b/aibridge/provider/bedrock_internal_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/intercept"
-	"github.com/coder/coder/v2/aibridge/internal/testutil"
 )
 
 // TestBuildBedrockCredentialsValidation covers the input validation that does
@@ -504,6 +502,7 @@ func TestBedrock_TypeAndName(t *testing.T) {
 		Model:           "m",
 		SmallFastModel:  "s",
 	})
+	assert.Equal(t, config.ProviderBedrock, p2.Type())
 	assert.Equal(t, "bedrock-custom", p2.Name())
 }
 
@@ -621,19 +620,12 @@ func TestBedrock_CreateInterceptor_Credential(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"id":"msg-123","type":"message","role":"assistant","content":[{"type":"text","text":"Hello!"}],"model":"claude-opus-4-5","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`))
-			}))
-			t.Cleanup(mockUpstream.Close)
-
-			bcfg := config.AWSBedrock{Region: "us-west-2", Model: "m", SmallFastModel: "s", BaseURL: mockUpstream.URL}
+			bcfg := config.AWSBedrock{Region: "us-west-2", Model: "m", SmallFastModel: "s", BaseURL: "http://arbitrary.example"}
 			if tc.bedrockStatic {
 				bcfg.AccessKey = "AKIAIOSFODNN7EXAMPLE"
 				bcfg.AccessKeySecret = "wJalrXUtnFEMI-secret-value"
 			}
-			p := newTestBedrock(t, config.Anthropic{BaseURL: mockUpstream.URL}, bcfg)
+			p := newTestBedrock(t, config.Anthropic{BaseURL: "http://arbitrary.example"}, bcfg)
 
 			body := `{"model": "claude-opus-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "hello"}], "stream": false}`
 			req := httptest.NewRequest(http.MethodPost, routeMessages, bytes.NewBufferString(body))
@@ -654,10 +646,6 @@ func TestBedrock_CreateInterceptor_Credential(t *testing.T) {
 			cred := interceptor.Credential()
 			assert.Equal(t, tc.wantCredentialKind, cred.Kind(), "credential kind mismatch")
 			assert.Equal(t, tc.wantCredentialHint, cred.Hint(), "credential hint mismatch")
-
-			// Bedrock signs via AWS during ProcessRequest (needs real AWS
-			// credentials), covered by the integration tests.
-			interceptor.Setup(slog.Make(), &testutil.MockRecorder{}, nil)
 		})
 	}
 }

--- a/aibridge/provider/bedrock_provider.go
+++ b/aibridge/provider/bedrock_provider.go
@@ -34,6 +34,10 @@ const (
 	routeBedrockResponses       = "/v1/responses"
 )
 
+var bedrockOpenErrorResponse = func() []byte {
+	return []byte(`{"type":"error","error":{"type":"api_error","message":"circuit breaker is open","code":"service_unavailable"}}`)
+}
+
 var _ Provider = &Bedrock{}
 
 // Bedrock implements the Provider interface for AWS Bedrock. It serves the
@@ -58,7 +62,7 @@ func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWS
 	}
 	if cfg.CircuitBreaker != nil {
 		cfg.CircuitBreaker.IsFailure = anthropicIsFailure
-		cfg.CircuitBreaker.OpenErrorResponse = anthropicOpenErrorResponse
+		cfg.CircuitBreaker.OpenErrorResponse = bedrockOpenErrorResponse
 	}
 
 	creds, resolvedRegion, err := buildBedrockCredentials(ctx, bedrockCfg)
@@ -250,8 +254,9 @@ func (p *Bedrock) mantleConfig() *bedrocksig.MantleConfig {
 
 // bedrockInterceptConfig builds the per-request intercept.Config for Bedrock
 // mantle OpenAI routes. The effective upstream base URL is resolved per-model
-// inside the interceptor via bedrocksig.BaseURLForModel, so cfg.BaseURL is the
-// provider's base (unused for signing but kept for recording/dump).
+// inside the interceptor via bedrocksig.BaseURLForModel. cfg.BaseURL remains
+// the Bedrock runtime base URL so provider-specific request transforms inspect
+// the actual upstream.
 func (p *Bedrock) bedrockInterceptConfig() intercept.Config {
 	return intercept.Config{
 		ProviderName:     p.Name(),

--- a/aibridge/provider/bedrock_provider.go
+++ b/aibridge/provider/bedrock_provider.go
@@ -41,9 +41,8 @@ var _ Provider = &Bedrock{}
 // protocols, and the OpenAI-shaped chat-completions and responses routes under
 // mantle only. Authentication is via AWS SigV4 signing, not bearer keys.
 type Bedrock struct {
-	cfg config.Anthropic
-	// runtime is always non-nil for this provider.
-	runtime *messages.BedrockRuntime
+	cfg     config.Anthropic
+	runtime messages.BedrockRuntime
 }
 
 // NewBedrock constructs a Bedrock provider. cfg supplies the shared
@@ -55,7 +54,7 @@ func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWS
 		cfg.Name = config.ProviderBedrock
 	}
 	if cfg.BaseURL == "" {
-		cfg.BaseURL = "https://api.anthropic.com/"
+		cfg.BaseURL = bedrockCfg.BaseURL
 	}
 	if cfg.CircuitBreaker != nil {
 		cfg.CircuitBreaker.IsFailure = anthropicIsFailure
@@ -78,7 +77,7 @@ func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWS
 
 	return &Bedrock{
 		cfg:     cfg,
-		runtime: &messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds},
+		runtime: messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds},
 	}, nil
 }
 
@@ -173,9 +172,9 @@ func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, trace
 
 	var interceptor intercept.Interceptor
 	if reqPayload.Stream() {
-		interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, p.runtime, r.Header, tracer)
+		interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, &p.runtime, r.Header, tracer)
 	} else {
-		interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, p.runtime, r.Header, tracer)
+		interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, &p.runtime, r.Header, tracer)
 	}
 	span.SetAttributes(interceptor.TraceAttributes(r)...)
 	return interceptor, nil
@@ -240,8 +239,7 @@ func (p *Bedrock) createResponsesInterceptor(id uuid.UUID, r *http.Request, trac
 }
 
 // mantleConfig narrows the provider's full Bedrock runtime to the fields the
-// OpenAI-shaped interceptors use. The runtime is always non-nil for this
-// provider.
+// OpenAI-shaped interceptors use.
 func (p *Bedrock) mantleConfig() *bedrocksig.MantleConfig {
 	return &bedrocksig.MantleConfig{
 		BaseURL: p.runtime.Cfg.BaseURL,

--- a/aibridge/provider/bedrock_provider.go
+++ b/aibridge/provider/bedrock_provider.go
@@ -1,0 +1,316 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/aibridge/config"
+	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/bedrocksig"
+	"github.com/coder/coder/v2/aibridge/intercept/chatcompletions"
+	"github.com/coder/coder/v2/aibridge/intercept/messages"
+	"github.com/coder/coder/v2/aibridge/intercept/responses"
+	"github.com/coder/coder/v2/aibridge/keypool"
+	"github.com/coder/coder/v2/aibridge/recorder"
+	"github.com/coder/coder/v2/aibridge/tracing"
+	"github.com/coder/coder/v2/aibridge/utils"
+)
+
+// Bedrock Mantle OpenAI protocol routes. The Bedrock provider bridges these
+// only under the mantle protocol; the invoke-model protocol serves messages
+// only, enforced in CreateInterceptor.
+const (
+	routeBedrockChatCompletions = "/v1/chat/completions"
+	routeBedrockResponses       = "/v1/responses"
+)
+
+var _ Provider = &Bedrock{}
+
+// Bedrock implements the Provider interface for AWS Bedrock. It serves the
+// native Anthropic Messages route under both the invoke-model and mantle
+// protocols, and the OpenAI-shaped chat-completions and responses routes under
+// mantle only. Authentication is via AWS SigV4 signing, not bearer keys.
+type Bedrock struct {
+	cfg config.Anthropic
+	// runtime is always non-nil for this provider.
+	runtime *messages.BedrockRuntime
+}
+
+// NewBedrock constructs a Bedrock provider. cfg supplies the shared
+// provider-level fields (Name, BaseURL, APIDumpDir, SendActorHeaders,
+// CircuitBreaker); bedrockCfg supplies the Bedrock-specific runtime config and
+// resolves the AWS credentials provider once at construction.
+func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWSBedrock) (*Bedrock, error) {
+	if cfg.Name == "" {
+		cfg.Name = config.ProviderBedrock
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://api.anthropic.com/"
+	}
+	if cfg.CircuitBreaker != nil {
+		cfg.CircuitBreaker.IsFailure = anthropicIsFailure
+		cfg.CircuitBreaker.OpenErrorResponse = anthropicOpenErrorResponse
+	}
+
+	creds, resolvedRegion, err := buildBedrockCredentials(ctx, bedrockCfg)
+	if err != nil {
+		return nil, xerrors.Errorf("build bedrock credentials: %w", err)
+	}
+	runtimeCfg := bedrockCfg
+	// resolvedRegion is bedrockCfg.Region if provided; otherwise, it is
+	// resolved from the environment via awsconfig.LoadDefaultConfig.
+	if runtimeCfg.Region == "" {
+		runtimeCfg.Region = resolvedRegion
+	}
+	if err := runtimeCfg.Validate(); err != nil {
+		return nil, xerrors.Errorf("bedrock config: %w", err)
+	}
+
+	return &Bedrock{
+		cfg:     cfg,
+		runtime: &messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds},
+	}, nil
+}
+
+func (*Bedrock) Type() string {
+	return config.ProviderBedrock
+}
+
+func (p *Bedrock) Name() string {
+	return p.cfg.Name
+}
+
+func (*Bedrock) Enabled() bool { return true }
+
+func (p *Bedrock) RoutePrefix() string {
+	return fmt.Sprintf("/%s", p.Name())
+}
+
+// BridgedRoutes returns all three routes for mux registration. Both the
+// invoke-model and mantle protocols serve the messages route; the OpenAI
+// routes are guarded in CreateInterceptor so an invoke-model provider still
+// answers messages but returns ErrUnknownRoute for the OpenAI routes.
+func (*Bedrock) BridgedRoutes() []string {
+	return []string{routeMessages, routeBedrockChatCompletions, routeBedrockResponses}
+}
+
+func (*Bedrock) PassthroughRoutes() []string {
+	return []string{
+		"/v1/models",
+		"/v1/models/", // See https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux.
+		"/v1/messages/count_tokens",
+		"/api/event_logging/",
+	}
+}
+
+func (p *Bedrock) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tracer trace.Tracer) (_ intercept.Interceptor, outErr error) {
+	id := uuid.New()
+	_, span := tracer.Start(r.Context(), "Intercept.CreateInterceptor")
+	defer tracing.EndSpanErr(span, &outErr)
+
+	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())
+	switch path {
+	case routeMessages:
+		return p.createMessagesInterceptor(id, r, tracer, span)
+	case routeBedrockChatCompletions:
+		// The OpenAI routes only make sense for mantle. InvokeModel keeps
+		// messages-only behavior through this guard rather than BridgedRoutes,
+		// because BridgedRoutes is also used for mux registration and an
+		// invoke-model provider must still not 404 on messages.
+		//
+		if p.runtime.Cfg.ResolvedProtocol() != config.BedrockProtocolMantle {
+			span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
+			return nil, ErrUnknownRoute
+		}
+		return p.createChatCompletionsInterceptor(id, r, tracer, span)
+	case routeBedrockResponses:
+		if p.runtime.Cfg.ResolvedProtocol() != config.BedrockProtocolMantle {
+			span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
+			return nil, ErrUnknownRoute
+		}
+		return p.createResponsesInterceptor(id, r, tracer, span)
+	default:
+		span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
+		return nil, ErrUnknownRoute
+	}
+}
+
+// createMessagesInterceptor builds a messages interceptor wired to the full
+// Bedrock runtime. The runtime carries the InvokeModel remap config and the
+// SigV4 signing credentials.
+func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer, span trace.Span) (intercept.Interceptor, error) {
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, xerrors.Errorf("read body: %w", err)
+	}
+
+	reqPayload, err := messages.NewRequestPayload(payload)
+	if err != nil {
+		return nil, xerrors.Errorf("unmarshal request body: %w", err)
+	}
+
+	cfg := intercept.Config{
+		ProviderName:     p.Name(),
+		BaseURL:          p.cfg.BaseURL,
+		APIDumpDir:       p.cfg.APIDumpDir,
+		SendActorHeaders: p.cfg.SendActorHeaders,
+	}
+	cred, err := p.resolveCredential(r)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, xerrors.Errorf("resolve credential: %w", err)
+	}
+
+	var interceptor intercept.Interceptor
+	if reqPayload.Stream() {
+		interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, p.runtime, r.Header, tracer)
+	} else {
+		interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, p.runtime, r.Header, tracer)
+	}
+	span.SetAttributes(interceptor.TraceAttributes(r)...)
+	return interceptor, nil
+}
+
+// createChatCompletionsInterceptor builds a chatcompletions interceptor wired
+// to the Bedrock mantle runtime. It mirrors the OpenAI provider's dispatch:
+// decode ChatCompletionNewParamsWrapper from r.Body, then pick streaming vs
+// blocking. The bedrock runtime carries the SigV4 signing middleware.
+func (p *Bedrock) createChatCompletionsInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer, span trace.Span) (intercept.Interceptor, error) {
+	var req chatcompletions.ChatCompletionNewParamsWrapper
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, xerrors.Errorf("unmarshal request body: %w", err)
+	}
+
+	cfg := p.bedrockInterceptConfig()
+	cred, err := p.resolveCredential(r)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, xerrors.Errorf("resolve credential: %w", err)
+	}
+
+	var interceptor intercept.Interceptor
+	if req.Stream {
+		interceptor = chatcompletions.NewBedrockStreamingInterceptor(id, &req, cfg, cred, p.mantleConfig(), r.Header, tracer)
+	} else {
+		interceptor = chatcompletions.NewBedrockBlockingInterceptor(id, &req, cfg, cred, p.mantleConfig(), r.Header, tracer)
+	}
+	span.SetAttributes(interceptor.TraceAttributes(r)...)
+	return interceptor, nil
+}
+
+// createResponsesInterceptor builds a responses interceptor wired to the
+// Bedrock mantle runtime. It mirrors the OpenAI provider's dispatch: read
+// r.Body then parse via responses.NewRequestPayload, then pick streaming vs
+// blocking.
+func (p *Bedrock) createResponsesInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer, span trace.Span) (intercept.Interceptor, error) {
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, xerrors.Errorf("read body: %w", err)
+	}
+	reqPayload, err := responses.NewRequestPayload(payload)
+	if err != nil {
+		return nil, xerrors.Errorf("unmarshal request body: %w", err)
+	}
+
+	cfg := p.bedrockInterceptConfig()
+	cred, err := p.resolveCredential(r)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, xerrors.Errorf("resolve credential: %w", err)
+	}
+
+	var interceptor intercept.Interceptor
+	if reqPayload.Stream() {
+		interceptor = responses.NewBedrockStreamingInterceptor(id, reqPayload, cfg, cred, p.mantleConfig(), r.Header, tracer)
+	} else {
+		interceptor = responses.NewBedrockBlockingInterceptor(id, reqPayload, cfg, cred, p.mantleConfig(), r.Header, tracer)
+	}
+	span.SetAttributes(interceptor.TraceAttributes(r)...)
+	return interceptor, nil
+}
+
+// mantleConfig narrows the provider's full Bedrock runtime to the fields the
+// OpenAI-shaped interceptors use. The runtime is always non-nil for this
+// provider.
+func (p *Bedrock) mantleConfig() *bedrocksig.MantleConfig {
+	return &bedrocksig.MantleConfig{
+		BaseURL: p.runtime.Cfg.BaseURL,
+		Region:  p.runtime.Cfg.Region,
+		Creds:   p.runtime.Creds,
+	}
+}
+
+// bedrockInterceptConfig builds the per-request intercept.Config for Bedrock
+// mantle OpenAI routes. The effective upstream base URL is resolved per-model
+// inside the interceptor via bedrocksig.BaseURLForModel, so cfg.BaseURL is the
+// provider's base (unused for signing but kept for recording/dump).
+func (p *Bedrock) bedrockInterceptConfig() intercept.Config {
+	return intercept.Config{
+		ProviderName:     p.Name(),
+		BaseURL:          p.runtime.Cfg.BaseURL,
+		APIDumpDir:       p.cfg.APIDumpDir,
+		SendActorHeaders: p.cfg.SendActorHeaders,
+	}
+}
+
+// resolveCredential determines the upstream credential for a request. Bedrock
+// authenticates via AWS signing, so when no BYOK header is present it returns
+// the Bedrock credential backed by the runtime's access key. BYOK
+// X-Api-Key/Authorization headers are honored for users who bring their own
+// key.
+func (p *Bedrock) resolveCredential(r *http.Request) (intercept.Credential, error) {
+	if apiKey := r.Header.Get(intercept.AuthHeaderXAPIKey); apiKey != "" {
+		return intercept.BYOK{Secret: apiKey, Header: intercept.AuthHeaderXAPIKey}, nil
+	}
+	if token := utils.ExtractBearerToken(r.Header.Get(intercept.AuthHeaderAuthorization)); token != "" {
+		return intercept.BYOK{Secret: token, Header: intercept.AuthHeaderAuthorization}, nil
+	}
+	return intercept.Bedrock{AccessKey: p.runtime.Cfg.AccessKey}, nil
+}
+
+func (p *Bedrock) BaseURL() string {
+	return p.cfg.BaseURL
+}
+
+func (*Bedrock) AuthHeader() string {
+	return intercept.AuthHeaderXAPIKey
+}
+
+// KeyPool returns nil. Bedrock authenticates via AWS signing, not a key pool.
+func (*Bedrock) KeyPool() *keypool.Pool {
+	return nil
+}
+
+func (*Bedrock) KeyFailoverConfig(_ slog.Logger) keypool.KeyFailoverConfig {
+	// No key pool: the KeyFailoverTransport short-circuits. Bedrock uses AWS
+	// signing rather than bearer-key failover.
+	return keypool.KeyFailoverConfig{}
+}
+
+func (p *Bedrock) CircuitBreakerConfig() *config.CircuitBreaker {
+	return p.cfg.CircuitBreaker
+}
+
+func (p *Bedrock) APIDumpDir() string {
+	return p.cfg.APIDumpDir
+}
+
+// CategorizeError tries the Anthropic error categorizer first (the messages
+// route) and falls back to the OpenAI categorizer (the chat-completions and
+// responses routes), mirroring how copilot falls back across categorizers.
+func (*Bedrock) CategorizeError(err error) *recorder.ErrorType {
+	if t := categorizeAnthropicError(err); t != nil {
+		return t
+	}
+	return categorizeOpenAIError(err)
+}

--- a/aibridge/provider/bedrock_provider.go
+++ b/aibridge/provider/bedrock_provider.go
@@ -148,9 +148,7 @@ func (p *Bedrock) CreateInterceptor(_ http.ResponseWriter, r *http.Request, trac
 		return nil, ErrUnknownRoute
 	}
 
-	if outErr != nil {
-		span.SetStatus(codes.Error, outErr.Error())
-	} else {
+	if intr != nil {
 		span.SetAttributes(intr.TraceAttributes(r)...)
 	}
 

--- a/aibridge/provider/bedrock_provider.go
+++ b/aibridge/provider/bedrock_provider.go
@@ -65,7 +65,7 @@ func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWS
 		cfg.CircuitBreaker.OpenErrorResponse = bedrockOpenErrorResponse
 	}
 
-	creds, resolvedRegion, err := buildBedrockCredentials(ctx, bedrockCfg)
+	awsCfg, err := buildBedrockCredentials(ctx, bedrockCfg)
 	if err != nil {
 		return nil, xerrors.Errorf("build bedrock credentials: %w", err)
 	}
@@ -73,7 +73,7 @@ func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWS
 	// resolvedRegion is bedrockCfg.Region if provided; otherwise, it is
 	// resolved from the environment via awsconfig.LoadDefaultConfig.
 	if runtimeCfg.Region == "" {
-		runtimeCfg.Region = resolvedRegion
+		runtimeCfg.Region = awsCfg.Region
 	}
 	if err := runtimeCfg.Validate(); err != nil {
 		return nil, xerrors.Errorf("bedrock config: %w", err)
@@ -81,7 +81,7 @@ func NewBedrock(ctx context.Context, cfg config.Anthropic, bedrockCfg config.AWS
 
 	return &Bedrock{
 		cfg:     cfg,
-		runtime: messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds},
+		runtime: messages.BedrockRuntime{Cfg: runtimeCfg, Creds: awsCfg.Credentials},
 	}, nil
 }
 

--- a/aibridge/provider/bedrock_provider.go
+++ b/aibridge/provider/bedrock_provider.go
@@ -116,15 +116,16 @@ func (*Bedrock) PassthroughRoutes() []string {
 	}
 }
 
-func (p *Bedrock) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tracer trace.Tracer) (_ intercept.Interceptor, outErr error) {
+func (p *Bedrock) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tracer trace.Tracer) (intr intercept.Interceptor, outErr error) {
 	id := uuid.New()
 	_, span := tracer.Start(r.Context(), "Intercept.CreateInterceptor")
 	defer tracing.EndSpanErr(span, &outErr)
 
 	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())
+
 	switch path {
 	case routeMessages:
-		return p.createMessagesInterceptor(id, r, tracer, span)
+		intr, outErr = p.createMessagesInterceptor(id, r, tracer)
 	case routeBedrockChatCompletions:
 		// The OpenAI routes only make sense for mantle. InvokeModel keeps
 		// messages-only behavior through this guard rather than BridgedRoutes,
@@ -135,23 +136,31 @@ func (p *Bedrock) CreateInterceptor(_ http.ResponseWriter, r *http.Request, trac
 			span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
 			return nil, ErrUnknownRoute
 		}
-		return p.createChatCompletionsInterceptor(id, r, tracer, span)
+		intr, outErr = p.createChatCompletionsInterceptor(id, r, tracer)
 	case routeBedrockResponses:
 		if p.runtime.Cfg.ResolvedProtocol() != config.BedrockProtocolMantle {
 			span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
 			return nil, ErrUnknownRoute
 		}
-		return p.createResponsesInterceptor(id, r, tracer, span)
+		intr, outErr = p.createResponsesInterceptor(id, r, tracer)
 	default:
 		span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
 		return nil, ErrUnknownRoute
 	}
+
+	if outErr != nil {
+		span.SetStatus(codes.Error, outErr.Error())
+	} else {
+		span.SetAttributes(intr.TraceAttributes(r)...)
+	}
+
+	return intr, outErr
 }
 
 // createMessagesInterceptor builds a messages interceptor wired to the full
 // Bedrock runtime. The runtime carries the InvokeModel remap config and the
 // SigV4 signing credentials.
-func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer, span trace.Span) (intercept.Interceptor, error) {
+func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer) (intercept.Interceptor, error) {
 	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, xerrors.Errorf("read body: %w", err)
@@ -170,7 +179,6 @@ func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, trace
 	}
 	cred, err := p.resolveCredential(r)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, xerrors.Errorf("resolve credential: %w", err)
 	}
 
@@ -180,7 +188,6 @@ func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, trace
 	} else {
 		interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, &p.runtime, r.Header, tracer)
 	}
-	span.SetAttributes(interceptor.TraceAttributes(r)...)
 	return interceptor, nil
 }
 
@@ -188,7 +195,7 @@ func (p *Bedrock) createMessagesInterceptor(id uuid.UUID, r *http.Request, trace
 // to the Bedrock mantle runtime. It mirrors the OpenAI provider's dispatch:
 // decode ChatCompletionNewParamsWrapper from r.Body, then pick streaming vs
 // blocking. The bedrock runtime carries the SigV4 signing middleware.
-func (p *Bedrock) createChatCompletionsInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer, span trace.Span) (intercept.Interceptor, error) {
+func (p *Bedrock) createChatCompletionsInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer) (intercept.Interceptor, error) {
 	var req chatcompletions.ChatCompletionNewParamsWrapper
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, xerrors.Errorf("unmarshal request body: %w", err)
@@ -197,7 +204,6 @@ func (p *Bedrock) createChatCompletionsInterceptor(id uuid.UUID, r *http.Request
 	cfg := p.bedrockInterceptConfig()
 	cred, err := p.resolveCredential(r)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, xerrors.Errorf("resolve credential: %w", err)
 	}
 
@@ -207,7 +213,6 @@ func (p *Bedrock) createChatCompletionsInterceptor(id uuid.UUID, r *http.Request
 	} else {
 		interceptor = chatcompletions.NewBedrockBlockingInterceptor(id, &req, cfg, cred, p.mantleConfig(), r.Header, tracer)
 	}
-	span.SetAttributes(interceptor.TraceAttributes(r)...)
 	return interceptor, nil
 }
 
@@ -215,7 +220,7 @@ func (p *Bedrock) createChatCompletionsInterceptor(id uuid.UUID, r *http.Request
 // Bedrock mantle runtime. It mirrors the OpenAI provider's dispatch: read
 // r.Body then parse via responses.NewRequestPayload, then pick streaming vs
 // blocking.
-func (p *Bedrock) createResponsesInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer, span trace.Span) (intercept.Interceptor, error) {
+func (p *Bedrock) createResponsesInterceptor(id uuid.UUID, r *http.Request, tracer trace.Tracer) (intercept.Interceptor, error) {
 	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, xerrors.Errorf("read body: %w", err)
@@ -228,7 +233,6 @@ func (p *Bedrock) createResponsesInterceptor(id uuid.UUID, r *http.Request, trac
 	cfg := p.bedrockInterceptConfig()
 	cred, err := p.resolveCredential(r)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, xerrors.Errorf("resolve credential: %w", err)
 	}
 
@@ -238,7 +242,6 @@ func (p *Bedrock) createResponsesInterceptor(id uuid.UUID, r *http.Request, trac
 	} else {
 		interceptor = responses.NewBedrockBlockingInterceptor(id, reqPayload, cfg, cred, p.mantleConfig(), r.Header, tracer)
 	}
-	span.SetAttributes(interceptor.TraceAttributes(r)...)
 	return interceptor, nil
 }
 


### PR DESCRIPTION
Introduces a standalone Bedrock provider alongside the existing Anthropic-backed Bedrock path. The new provider implements the full `Provider` interface and supports Messages, Chat Completions, and Responses, with the OpenAI routes guarded to the Mantle protocol.

Adds Bedrock-specific OpenAI interceptor constructors so existing OpenAI, Copilot, and Anthropic call sites remain source-compatible. `bedrocksig.MantleConfig` carries only the base URL, region, and credentials required by the OpenAI-shaped interceptors. Existing provider wiring is unchanged in this PR.

Tests are scoped to the new Bedrock type and its supporting URL/signing behavior. The existing Anthropic Bedrock implementation remains intact for the follow-up migration PR.

> Generated by Coder Agents
