### PR TITLE
fix(site): right-align DateTimeRangePicker dropdown to match other dropdowns

### DIFF
--- a/site/src/components/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/site/src/components/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -219,7 +219,7 @@ export const DateTimeRangePicker: FC<DateTimeRangePickerProps> = ({
 			</PopoverTrigger>
 			<PopoverContent
 				className="w-auto p-0 overflow-x-hidden overflow-y-auto"
-				align="start"
+				align="end"
 				onOpenAutoFocus={(e) => e.preventDefault()}
 			>
 				<div className="flex">


### PR DESCRIPTION
Follow-up to #28392. The `DateTimeRangePicker` popover opened with `align="start"` (left-aligned to the trigger), while the other dropdowns on the page use `align="end"`. This changes the `PopoverContent` alignment to `align="end"` for consistency.

One-line change; no behavior or layout changes inside the dropdown itself.

---

Generated by Coder Agents on behalf of @tracyjohnsonux.