### PR TITLE
fix(site): update Coder Agents license copy

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.stories.tsx
@@ -28,15 +28,17 @@ export const Default: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"16,264.3 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
-		const manageUsage = canvas.getByRole("link", { name: "Manage usage" });
-		await expect(manageUsage).toHaveAttribute("href", "/deployment/groups");
-		const agentSettings = canvas.getByRole("link", { name: "Agent settings" });
-		await expect(agentSettings).toHaveAttribute(
+		await expect(
+			canvas.queryByRole("link", { name: "Manage usage" }),
+		).not.toBeInTheDocument();
+		await expect(
+			canvas.getByRole("link", { name: "View docs" }),
+		).toHaveAttribute(
 			"href",
-			"/ai/settings/coder-agents",
+			expect.stringContaining("/ai-coder/agents/licensing-usage"),
 		);
 	},
 };
@@ -59,13 +61,13 @@ export const TooltipInteractions: Story = {
 				await expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 			});
 		});
-		await step("open the Concurrent chats tooltip on hover", async () => {
+		await step("open the Concurrent agents tooltip on hover", async () => {
 			await userEvent.hover(
-				canvas.getByRole("button", { name: "Concurrent chats information" }),
+				canvas.getByRole("button", { name: "Concurrent agents information" }),
 			);
 			await waitFor(async () => {
 				await expect(screen.getByRole("tooltip")).toHaveTextContent(
-					"Number of Coder Agents chats that can run at the same time.",
+					"Number of agents that can run at the same time.",
 				);
 			});
 		});
@@ -81,7 +83,7 @@ export const UnlimitedAllocation: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"Unlimited",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},
@@ -112,7 +114,7 @@ export const SoftLimitReached: Story = {
 		await expect(canvas.getByRole("status")).toHaveTextContent(
 			"Approaching hours limit",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},
@@ -128,7 +130,7 @@ export const Exceeded: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"21,000.0 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 		await expect(canvas.queryByRole("status")).not.toBeInTheDocument();
@@ -145,16 +147,16 @@ export const HardLimitExceeded: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"25,000.0 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"5",
 		);
 		await expect(canvas.getByRole("status")).toHaveTextContent("Limit reached");
 		await userEvent.hover(
-			canvas.getByRole("button", { name: "Concurrent chats information" }),
+			canvas.getByRole("button", { name: "Concurrent agents information" }),
 		);
 		await waitFor(async () => {
 			await expect(screen.getByRole("tooltip")).toHaveTextContent(
-				"Number of Coder Agents chats that can run at the same time. You've reached your limit: concurrent chats are now capped at 5 (down from unlimited).",
+				"Number of agents that can run at the same time. You've reached your limit: concurrent chats are now capped at 5 (down from unlimited).",
 			);
 		});
 	},
@@ -168,7 +170,7 @@ export const NoAllocation: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(
-			getMetricValue(canvas, "Max concurrent chats"),
+			getMetricValue(canvas, "Max concurrent agents"),
 		).toHaveTextContent("5");
 		await expect(
 			canvas.queryByText(/Agent hours used/),

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.stories.tsx
@@ -32,9 +32,6 @@ export const Default: Story = {
 			"Unlimited",
 		);
 		await expect(
-			canvas.queryByRole("link", { name: "Manage usage" }),
-		).not.toBeInTheDocument();
-		await expect(
 			canvas.getByRole("link", { name: "View docs" }),
 		).toHaveAttribute(
 			"href",

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
@@ -1,6 +1,5 @@
 import { InfoIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
-import { Link as RouterLink } from "react-router";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
@@ -10,6 +9,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { docs } from "#/utils/docs";
 
 // Allocation sentinel for unlimited agent runtime hours
 // (AgentRuntimeHoursUnlimitedAllocation in enterprise/coderd/license).
@@ -89,7 +89,7 @@ const CardContainer: FC<{
 const totalAgentHoursTooltip =
 	"Total agent runtime hours used out of the hours included in this license.";
 const concurrentChatsTooltip =
-	"Number of Coder Agents chats that can run at the same time.";
+	"Number of agents that can run at the same time.";
 const concurrentChatsHardLimitTooltip = `${concurrentChatsTooltip} You've reached your limit: concurrent chats are now capped at ${maxConcurrentChatsOverHardLimit} (down from unlimited).`;
 
 // The value is already floored to tenths, so no rounding happens here.
@@ -116,7 +116,7 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 				<div className="mt-3 flex flex-wrap gap-x-12 gap-y-3 text-xs">
 					<div>
 						<MetricLabel
-							label="Max concurrent chats"
+							label="Max concurrent agents"
 							tooltip={concurrentChatsTooltip}
 						/>
 						<div className="mt-0.5 text-sm font-medium text-content-primary">
@@ -193,7 +193,7 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 				</div>
 				<div>
 					<MetricLabel
-						label="Concurrent chats"
+						label="Concurrent agents"
 						tooltip={
 							isHardLimitExceeded
 								? concurrentChatsHardLimitTooltip
@@ -214,15 +214,9 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 					</div>
 				</div>
 			</div>
-			<div className="mt-4 flex items-center gap-2 text-sm">
-				<Link asChild size="lg" showExternalIcon={false}>
-					<RouterLink to="/deployment/groups">Manage usage</RouterLink>
-				</Link>
-				<span className="text-content-secondary" aria-hidden>
-					|
-				</span>
-				<Link asChild size="lg" showExternalIcon={false}>
-					<RouterLink to="/ai/settings/coder-agents">Agent settings</RouterLink>
+			<div className="mt-4 text-sm">
+				<Link href={docs("/ai-coder/agents/licensing-usage")} size="lg">
+					View docs
 				</Link>
 			</div>
 		</CardContainer>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.stories.tsx
@@ -157,7 +157,7 @@ export const Premium: Story = {
 			getIncludedProducts(canvas, "Workspaces + Agents"),
 		).not.toBeInTheDocument();
 		await expect(
-			getMetricValue(canvas, "Max concurrent chats"),
+			getMetricValue(canvas, "Max concurrent agents"),
 		).toHaveTextContent("5");
 		await expect(getMetricValue(canvas, "Agent hours used")).toHaveTextContent(
 			"137.3",
@@ -226,14 +226,14 @@ export const PremiumWithAgentHours: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"12,264.3 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 		await expect(
-			canvas.getByRole("link", { name: "Manage usage" }),
-		).toBeInTheDocument();
+			canvas.queryByRole("link", { name: "Manage usage" }),
+		).not.toBeInTheDocument();
 		await expect(
-			canvas.getByRole("link", { name: "Agent settings" }),
+			canvas.getByRole("link", { name: "View docs" }),
 		).toBeInTheDocument();
 	},
 };
@@ -263,7 +263,7 @@ export const PremiumWithAgentHoursSoftLimitReached: Story = {
 		await expect(canvas.getByRole("status")).toHaveTextContent(
 			"Approaching hours limit",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},
@@ -289,7 +289,7 @@ export const PremiumWithAgentHoursExceeded: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"21,000.0 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},
@@ -315,7 +315,7 @@ export const PremiumWithAgentHoursHardLimitExceeded: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"25,000.0 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"5",
 		);
 		await expect(canvas.getByRole("status")).toHaveTextContent("Limit reached");
@@ -392,7 +392,7 @@ export const PremiumWithUnlimitedAgentHours: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"Unlimited",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},
@@ -449,7 +449,7 @@ export const ReplacedDuplicateAllocationShowsNoUsage: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"\u2014 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},
@@ -488,7 +488,7 @@ export const SameIssuedAtDifferentTermEndShowsNoUsage: Story = {
 		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
 			"\u2014 / 20,000",
 		);
-		await expect(getMetricValue(canvas, "Concurrent chats")).toHaveTextContent(
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
 	},


### PR DESCRIPTION
Updates the Coder Agents license card to consistently refer to concurrent agents, removes the usage management link, and links to the licensing and usage documentation.

Updates Storybook coverage for the revised labels, tooltip, and link behavior.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents on behalf of @jaaydenh.
</details>
