### PR TITLE
fix(site/src): use the browser-only bullets from the copy doc

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import type { SerpentGroup, SerpentOption } from "#/api/typesGenerated";
 import { SecuritySettingsPageView } from "./SecuritySettingsPageView";
 
@@ -55,6 +56,29 @@ export default meta;
 type Story = StoryObj<typeof SecuritySettingsPageView>;
 
 export const Page: Story = {};
+
+export const BrowserOnlyPaywall: Story = {
+	args: {
+		featureBrowserOnlyEnabled: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await expect(
+			canvas.getByText("Restrict access to web-based connections"),
+		).toBeVisible();
+		await expect(
+			canvas.getByText("Block SSH and port-forward entirely"),
+		).toBeVisible();
+		await expect(
+			canvas.getByText("Enforce browser-only compliance policies"),
+		).toBeVisible();
+		// The generic premium bullets must not leak back in.
+		await expect(
+			canvas.queryByText("24x7 global support with SLA"),
+		).not.toBeInTheDocument();
+	},
+};
 
 export const NoTLS = {
 	args: {

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
 import type { SerpentGroup, SerpentOption } from "#/api/typesGenerated";
 import { SecuritySettingsPageView } from "./SecuritySettingsPageView";
 
@@ -56,29 +55,6 @@ export default meta;
 type Story = StoryObj<typeof SecuritySettingsPageView>;
 
 export const Page: Story = {};
-
-export const BrowserOnlyPaywall: Story = {
-	args: {
-		featureBrowserOnlyEnabled: false,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-
-		await expect(
-			canvas.getByText("Restrict access to web-based connections"),
-		).toBeVisible();
-		await expect(
-			canvas.getByText("Block SSH and port-forward entirely"),
-		).toBeVisible();
-		await expect(
-			canvas.getByText("Enforce browser-only compliance policies"),
-		).toBeVisible();
-		// The generic premium bullets must not leak back in.
-		await expect(
-			canvas.queryByText("24x7 global support with SLA"),
-		).not.toBeInTheDocument();
-	},
-};
 
 export const NoTLS = {
 	args: {

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -79,8 +79,12 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 					<PremiumPaywallSmall
 						source="browser_only"
 						message="Browser-Only Connections"
-						description="Block all workspace access via SSH, port forward, and other
-						non-browser connections."
+						description="Block all workspace access via SSH, port forward, and other non-browser connections."
+						features={[
+							"Restrict access to web-based connections",
+							"Block SSH and port-forward entirely",
+							"Enforce browser-only compliance policies",
+						]}
 						canViewPremium
 					/>
 				) : null}


### PR DESCRIPTION
**TL;DR: this paywall was listing the wrong reasons to buy Premium. Now it lists the right ones.**

The [Premium Copy Updates](https://app.notion.com/p/coderhq/Premium-Copy-Updates-3c1d579be59280a59557cabd54fd8a1f) doc gained copy for the `/deployment/security` browser-only connections row after #28339 was written, so that paywall was still falling back to the generic `PREMIUM_FEATURES` list ("High availability & workspace proxies", "24x7 global support with SLA", etc.).

- Bullets now match the doc: "Restrict access to web-based connections", "Block SSH and port-forward entirely", "Enforce browser-only compliance policies".
- The description already matched the doc; it was a multi-line JSX string literal that embedded a newline and tabs, so it is now a single line.
- The section's "Read the docs" button already points at `/admin/networking#browser-only-connections`, which is the doc's Learn more URL. No change needed.

## Proof

<img src="https://raw.githubusercontent.com/david-fraley/coder/security-paywall-proof/security-browser-only.png" width="720">

From a local dev deployment with no license. DOM assertions against the same page:

```
Restrict access to web-based connections -> 1
Block SSH and port-forward entirely      -> 1
Enforce browser-only compliance policies -> 1
24x7 global support with SLA             -> 0
```

`pnpm exec tsc --noEmit`, `pnpm exec biome check src`, and the page's Storybook tests pass.

---

Generated by Coder Agents on behalf of @david-fraley.
