### PR TITLE
fix(site/src): sync paywall copy with the latest copy doc

### DIFF
--- a/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.tsx
+++ b/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.tsx
@@ -77,6 +77,7 @@ export const GatewayKeysPageView: FC<GatewayKeysPageViewProps> = ({
 					features={[
 						"Authenticate without shared secrets",
 						"Works inside coderd or standalone",
+						"Independently scale, rotate, or revoke keys per deployment",
 					]}
 					canViewPremium={permissions.viewAllLicenses}
 				/>

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -64,7 +64,7 @@ export const AppearanceSettingsPageView: FC<
 				<PremiumPaywall
 					source="appearance"
 					message="Appearance"
-					description="Customize branding and announcement banners for your deployment."
+					description="Configure branding and announcement banners for your deployment."
 					features={[
 						"Custom application name and logo",
 						"Site-wide announcement banners for updates",

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
@@ -62,6 +62,7 @@ const TemplatePermissionsPage: FC = () => {
 						features={[
 							"Choose Use or Admin-level access",
 							"Prevent unauthorized template use",
+							"Let teams self-serve templates without admin bottlenecks",
 						]}
 						canViewPremium={authPermissions.viewAllLicenses}
 					/>


### PR DESCRIPTION
**TL;DR: the words on three Premium screens changed in the copy doc, so this changes them in the app too.**

Jess revised three rows in the [Premium Copy Updates](https://app.notion.com/p/coderhq/Premium-Copy-Updates-3c1d579be59280a59557cabd54fd8a1f) doc after #28339 merged. This syncs the app with them.

| Page | Change |
| --- | --- |
| Appearance | Description now reads "**Configure** branding and announcement banners for your deployment." (was "Customize") |
| AI Gateway Keys | New third bullet: "Independently scale, rotate, or revoke keys per deployment" |
| Template Permissions | New third bullet: "Let teams self-serve templates without admin bottlenecks" |

I re-checked every other row in the doc against the app. The rest match. The two rows that were blank when #28339 was written are handled separately in #28434 (browser-only connections) and #28435 (external auth).

## Proof

| Page | Screenshot |
| --- | --- |
| Appearance | <img src="https://raw.githubusercontent.com/david-fraley/coder/paywall-copy-refresh-proof/appearance.png" width="420"> |
| AI Gateway Keys | <img src="https://raw.githubusercontent.com/david-fraley/coder/paywall-copy-refresh-proof/gateway-keys.png" width="420"> |
| Template Permissions | <img src="https://raw.githubusercontent.com/david-fraley/coder/paywall-copy-refresh-proof/template-permissions.png" width="420"> |

From a local dev deployment with no license. DOM assertions against those pages:

```
appearance           1 | Configure branding and announcement banners for your deployment.
appearance           0 | Customize branding and announcement banners for your deployment.   (old copy, gone)
gateway-keys         1 | Independently scale, rotate, or revoke keys per deployment
template-permissions 1 | Let teams self-serve templates without admin bottlenecks
```

`pnpm exec tsc --noEmit`, `pnpm exec biome check src`, and the Storybook tests for the three pages pass.

---

Generated by Coder Agents on behalf of @david-fraley.
