### PR TITLE
fix(site): point queued-capacity trial link to /deployment/premium

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/QueuedForCapacityCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/QueuedForCapacityCallout.tsx
@@ -1,4 +1,5 @@
 import type { FC, ReactNode } from "react";
+import { Link as RouterLink } from "react-router";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Link } from "#/components/Link/Link";
 import { docs } from "#/utils/docs";
@@ -54,13 +55,10 @@ export const QueuedForCapacityCallout: FC<QueuedForCapacityCalloutProps> = ({
 	} else if (canManageLicenses) {
 		action = (
 			<>
-				<Link
-					href="https://coder.com/trial"
-					target="_blank"
-					rel="noreferrer"
-					size="sm"
-				>
-					Start an unlimited trial
+				<Link asChild showExternalIcon={false} size="sm">
+					<RouterLink to="/deployment/premium">
+						Start an unlimited trial
+					</RouterLink>
 				</Link>{" "}
 				or{" "}
 				<Link

--- a/site/src/pages/AgentsPage/components/ChatConversation/QueuedForCapacityCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/QueuedForCapacityCallout.tsx
@@ -31,12 +31,7 @@ export const QueuedForCapacityCallout: FC<QueuedForCapacityCalloutProps> = ({
 
 	let action: ReactNode = (
 		<>
-			<Link
-				href={concurrencyDocsUrl}
-				target="_blank"
-				rel="noreferrer"
-				size="sm"
-			>
+			<Link href={concurrencyDocsUrl} target="_blank" rel="noreferrer">
 				Learn more
 			</Link>
 			.
@@ -46,7 +41,7 @@ export const QueuedForCapacityCallout: FC<QueuedForCapacityCalloutProps> = ({
 		action = (
 			<>
 				Contact your Coder account team or{" "}
-				<Link href="mailto:sales@coder.com" size="sm" showExternalIcon={false}>
+				<Link href="mailto:sales@coder.com" showExternalIcon={false}>
 					sales@coder.com
 				</Link>{" "}
 				to upgrade to unlimited concurrent agents.
@@ -55,18 +50,13 @@ export const QueuedForCapacityCallout: FC<QueuedForCapacityCalloutProps> = ({
 	} else if (canManageLicenses) {
 		action = (
 			<>
-				<Link asChild showExternalIcon={false} size="sm">
+				<Link asChild showExternalIcon={false}>
 					<RouterLink to="/deployment/premium">
 						Start an unlimited trial
 					</RouterLink>
 				</Link>{" "}
 				or{" "}
-				<Link
-					href={concurrencyDocsUrl}
-					target="_blank"
-					rel="noreferrer"
-					size="sm"
-				>
+				<Link href={concurrencyDocsUrl} target="_blank" rel="noreferrer">
 					learn more
 				</Link>
 				.


### PR DESCRIPTION
Points the "Start an unlimited trial" link in the concurrency-limit queued callout (`QueuedForCapacityCallout`) to the internal `/deployment/premium` route instead of the external `https://coder.com/trial` URL, matching the convention used elsewhere in the app (e.g. `LicensesSettingsPageView`, `Paywall`).

Uses `Link asChild` + `RouterLink` so navigation is client-side (SPA) instead of a full page reload.

Also fixes all four links in the callout (`Start an unlimited trial`, both `learn more` links, and the `sales@coder.com` mailto) rendering at 12px (`size="sm"`) while the surrounding message text is 14px. Dropping the explicit `size="sm"` lets the links fall back to `Link`'s default size, matching `AlertDescription`'s `text-sm` (14px).

<details>
<summary>Decision log</summary>

- Confirmed `/deployment/premium` is an existing internal route (`PREMIUM_PAGE_PATH` constant in `Paywall.tsx`), not an external link.
- Existing pattern for internal links elsewhere in the codebase is `<Link asChild showExternalIcon={false}><RouterLink to="..." /></Link>`, so this change follows that convention rather than using a plain `<a href>`.
- Only the admin-on-Community-license path (`canManageLicenses && !hasLicense`) is affected by the route change; the member and paid-license admin messages are unchanged.
- Verified in a local `develop.sh` dev instance: HMR picked up the change cleanly, TypeScript reports 0 errors, and the links now render at 14px matching the message body.

</details>

---
PR generated with Coder Agents.