### PR TITLE
fix(site): show "Never" for unused tokens

### DIFF
--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
@@ -20,8 +20,10 @@ dayjs.extend(relativeTime);
 
 const lastUsedOrNever = (lastUsed: string) => {
 	const t = dayjs(lastUsed);
-	const now = dayjs();
-	return now.isBefore(t.add(100, "year")) ? t.fromNow() : "Never";
+	// Unused tokens are stamped with the Unix epoch (time.Unix(0, 0)) by the
+	// backend, so anything at or before the epoch means "never used". This also
+	// tolerates Go's zero-value time (0001-01-01), which is negative.
+	return t.valueOf() > 0 ? t.fromNow() : "Never";
 };
 
 interface TokensPageViewProps {

--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
@@ -20,9 +20,6 @@ dayjs.extend(relativeTime);
 
 const lastUsedOrNever = (lastUsed: string) => {
 	const t = dayjs(lastUsed);
-	// Unused tokens are stamped with the Unix epoch (time.Unix(0, 0)) by the
-	// backend, so anything at or before the epoch means "never used". This also
-	// tolerates Go's zero-value time (0001-01-01), which is negative.
 	return t.valueOf() > 0 ? t.fromNow() : "Never";
 };
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Closes [DEVEX-214](https://linear.app/codercom/issue/DEVEX-214/tokens-page-shows-unused-token-as-56-years-ago).

## Problem

A token that has never been used renders as `56 years ago` on the tokens page instead of `Never`.

Unused tokens are stamped with the Unix epoch (`time.Unix(0, 0)` → `1970-01-01`) by the backend (`coderd/apikey/apikey.go`). The old `lastUsedOrNever` helper tried to detect the "never used" sentinel with a 100-year window:

```ts
now.isBefore(t.add(100, "year")) ? t.fromNow() : "Never";
```

That heuristic implicitly assumed the sentinel was Go's zero-value time (year 1). It breaks for the epoch: `1970 + 100y = 2070`, which is still in the future, so the epoch falls into the `t.fromNow()` branch and displays `56 years ago`.

## Fix

Check for the sentinel directly instead of guessing a year window:

```ts
return t.valueOf() > 0 ? t.fromNow() : "Never";
```

Anything at or before the Unix epoch is treated as never used. `> 0` (rather than `=== 0`) also tolerates Go's zero-value time (`0001-01-01`, a negative value) which the frontend mock in `testHelpers/entities.ts` uses.

<details>
<summary>Why the old code used a ~100-year window</summary>

The `lastUsedOrNever` helper dates back to the original "Manage tokens in dashboard" (#5444, Jan 2023); every change since has been MUI/Tailwind refactoring that carried the logic forward untouched.

The window was a proxy for "is this the zero-value sentinel?" — deliberately huge so no legitimately-old `last_used` could be misclassified as `Never` (tokens don't live for decades). With a year-1 sentinel, `0001 + 100y = year 101`, comfortably in the past → `Never`, so it worked. It was never catching anything meaningful; it just avoided reasoning about the exact sentinel value. Once the backend sentinel became the Unix epoch, the window overshot the present day and the fallback stopped triggering. Re-tuning the number (e.g. 50 years) would fix today's symptom but rot again, so it's replaced with a direct sentinel check.
</details>

## Validation

- Unused token (`last_used = 1970-01-01`) → `Never`.
- Genuinely used token (any post-1970 date) → unchanged relative time.
- Frontend mock zero time (`0001-01-01`) → `Never`.