### PR TITLE
feat(site): add search and pagination UI for OAuth2 provider apps

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1964,13 +1964,12 @@ class ApiMethods {
 
 	getOAuth2ProviderApps = async (
 		filter?: TypesGen.OAuth2ProviderAppFilter,
+		signal?: AbortSignal,
 	): Promise<TypesGen.OAuth2ProviderAppsResponse> => {
-		const params = filter?.user_id
-			? new URLSearchParams({ user_id: filter.user_id }).toString()
-			: "";
-
+		const url = getURLWithSearchParams("/api/v2/oauth2-provider/apps", filter);
 		const resp = await this.axios.get<TypesGen.OAuth2ProviderAppsResponse>(
-			`/api/v2/oauth2-provider/apps?${params}`,
+			url,
+			{ signal },
 		);
 		return resp.data;
 	};

--- a/site/src/api/queries/oauth2.ts
+++ b/site/src/api/queries/oauth2.ts
@@ -1,6 +1,9 @@
 import type { QueryClient } from "react-query";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
+import { useFilterParamsKey } from "#/components/Filter/Filter";
+import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
+import { prepareQuery } from "#/utils/filters";
 
 const oauth2ProviderKey = ["oauth2-provider"];
 export const oauth2ProviderAppsKey = oauth2ProviderKey.concat("apps");
@@ -25,6 +28,31 @@ export const getGitHubDeviceFlowCallback = (code: string, state: string) => {
 		queryFn: () => API.getOAuth2GitHubDeviceFlowCallback(code, state),
 	};
 };
+
+function oauth2AppsKey(req: TypesGen.OAuth2ProviderAppFilter) {
+	return [...oauth2ProviderAppsKey, req] as const;
+}
+
+export function paginatedApps(
+	searchParams: URLSearchParams,
+): UsePaginatedQueryOptions<
+	TypesGen.OAuth2ProviderAppsResponse,
+	TypesGen.OAuth2ProviderAppFilter
+> {
+	return {
+		searchParams,
+		queryPayload: ({ limit, offset }) => {
+			return {
+				limit,
+				offset,
+				q: prepareQuery(searchParams.get(useFilterParamsKey) ?? ""),
+			};
+		},
+		queryKey: ({ payload }) => oauth2AppsKey(payload),
+		queryFn: ({ payload, signal }) =>
+			API.getOAuth2ProviderApps(payload, signal),
+	};
+}
 
 export const getApps = (userId?: string) => {
 	return {

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPage.tsx
@@ -1,13 +1,23 @@
 import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { getApps, getSettings, putSettings } from "#/api/queries/oauth2";
+import { useSearchParams } from "react-router";
+import { getSettings, paginatedApps, putSettings } from "#/api/queries/oauth2";
+import { useFilter } from "#/components/Filter/Filter";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
 import { pageTitle } from "#/utils/page";
 import OAuth2AppsSettingsPageView from "./OAuth2AppsSettingsPageView";
 
 const OAuth2AppsSettingsPage: FC = () => {
 	const { permissions } = useAuthenticated();
 	const queryClient = useQueryClient();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const appsQuery = usePaginatedQuery(paginatedApps(searchParams));
+	const filter = useFilter({
+		searchParams,
+		onSearchParamsChange: setSearchParams,
+		onUpdate: appsQuery.goToFirstPage,
+	});
 
 	const canCreateApp = permissions.createOAuth2App;
 	// Gates the query and the prop below. Spelled once because a disabled query
@@ -17,7 +27,6 @@ const OAuth2AppsSettingsPage: FC = () => {
 	const canViewSettings = permissions.viewDeploymentConfig;
 	const canEditSettings = permissions.editDeploymentConfig;
 
-	const appsQuery = useQuery(getApps());
 	const settingsQuery = useQuery({
 		...getSettings(),
 		enabled: canViewSettings,
@@ -30,6 +39,8 @@ const OAuth2AppsSettingsPage: FC = () => {
 
 			<OAuth2AppsSettingsPageView
 				apps={appsQuery.data?.apps}
+				appsQuery={appsQuery}
+				filter={filter}
 				isLoadingApps={appsQuery.isLoading}
 				appsError={appsQuery.error}
 				canCreateApp={canCreateApp}

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
@@ -1,8 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import type { OAuth2ProviderAppsResponse } from "#/api/typesGenerated";
+import type { UseFilterResult } from "#/components/Filter/Filter";
+import type { PaginationResult } from "#/components/PaginationWidget/PaginationContainer";
+import {
+	mockInitialRenderResult,
+	mockSuccessResult,
+} from "#/components/PaginationWidget/PaginationContainer.mocks";
 import { MockOAuth2ProviderApps } from "#/testHelpers/entities";
 import OAuth2AppsSettingsPageView from "./OAuth2AppsSettingsPageView";
+
+const defaultFilter: UseFilterResult = {
+	query: "",
+	values: {},
+	update: () => {},
+	debounceUpdate: () => {},
+	cancelDebounce: () => {},
+	used: false,
+};
+
+const appsQuerySuccess: PaginationResult<OAuth2ProviderAppsResponse> = {
+	...mockSuccessResult,
+	totalRecords: MockOAuth2ProviderApps.length,
+	data: {
+		apps: MockOAuth2ProviderApps,
+		count: MockOAuth2ProviderApps.length,
+	},
+};
 
 // Spread and override per story. Omitting `settings` entirely is how a viewer
 // without deployment config read access is expressed.
@@ -22,9 +47,15 @@ const meta: Meta<typeof OAuth2AppsSettingsPageView> = {
 	component: OAuth2AppsSettingsPageView,
 	args: {
 		canCreateApp: true,
+		filter: defaultFilter,
+		apps: MockOAuth2ProviderApps,
+		appsQuery: appsQuerySuccess,
+		isLoadingApps: false,
+		appsError: undefined,
 		settings: MockSettingsTab,
 	},
 };
+
 export default meta;
 
 type Story = StoryObj<typeof OAuth2AppsSettingsPageView>;
@@ -32,6 +63,11 @@ type Story = StoryObj<typeof OAuth2AppsSettingsPageView>;
 export const Loading: Story = {
 	args: {
 		isLoadingApps: true,
+		apps: undefined,
+		appsQuery: {
+			...mockInitialRenderResult,
+			data: undefined,
+		},
 	},
 };
 
@@ -43,7 +79,12 @@ export const Loading: Story = {
 export const WithError: Story = {
 	args: {
 		isLoadingApps: false,
+		apps: undefined,
 		appsError: "some error",
+		appsQuery: {
+			...mockInitialRenderResult,
+			data: undefined,
+		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -57,22 +98,77 @@ export const WithError: Story = {
 	},
 };
 
-export const Apps: Story = {
-	args: {
-		isLoadingApps: false,
-		apps: MockOAuth2ProviderApps,
-	},
-};
+// Rendering assertions are left to Storybook snapshots; only stories that
+// exercise real interactions keep a play function.
+export const Apps: Story = {};
 
 export const Empty: Story = {
 	args: {
 		isLoadingApps: false,
+		apps: [],
+		appsQuery: {
+			...mockSuccessResult,
+			totalRecords: 0,
+			data: {
+				apps: [],
+				count: 0,
+			},
+		},
+	},
+};
+
+export const EmptySearch: Story = {
+	args: {
+		isLoadingApps: false,
+		apps: [],
+		filter: {
+			...defaultFilter,
+			query: "nonexistent",
+			used: true,
+		},
+		appsQuery: {
+			...mockSuccessResult,
+			totalRecords: 0,
+			data: {
+				apps: [],
+				count: 0,
+			},
+		},
 	},
 };
 
 export const NoCreatePermissions: Story = {
 	args: {
 		canCreateApp: false,
+		apps: [],
+		appsQuery: {
+			...mockSuccessResult,
+			totalRecords: 0,
+			data: {
+				apps: [],
+				count: 0,
+			},
+		},
+	},
+};
+
+export const Paginated: Story = {
+	args: {
+		apps: MockOAuth2ProviderApps.slice(0, 2),
+		appsQuery: {
+			...mockSuccessResult,
+			currentPage: 1,
+			totalPages: 2,
+			totalRecords: 5,
+			hasNextPage: true,
+			hasPreviousPage: false,
+			currentOffsetStart: 1,
+			limit: 2,
+			data: {
+				apps: MockOAuth2ProviderApps.slice(0, 2),
+				count: 5,
+			},
+		},
 	},
 };
 

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
@@ -6,7 +6,12 @@ import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Button } from "#/components/Button/Button";
+import { Filter, type UseFilterResult } from "#/components/Filter/Filter";
 import { Loader } from "#/components/Loader/Loader";
+import {
+	PaginationContainer,
+	type PaginationResult,
+} from "#/components/PaginationWidget/PaginationContainer";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -66,6 +71,8 @@ type SettingsTab = {
 
 type OAuth2AppsSettingsProps = {
 	apps?: readonly TypesGen.OAuth2ProviderApp[];
+	appsQuery: PaginationResult<TypesGen.OAuth2ProviderAppsResponse>;
+	filter: UseFilterResult;
 	isLoadingApps: boolean;
 	appsError: unknown;
 	canCreateApp: boolean;
@@ -126,6 +133,8 @@ const AddApplicationButton: FC = () => (
 
 const OAuth2AppsSettingsPageView: FC<OAuth2AppsSettingsProps> = ({
 	apps,
+	appsQuery,
+	filter,
 	isLoadingApps,
 	appsError,
 	canCreateApp,
@@ -138,6 +147,9 @@ const OAuth2AppsSettingsPageView: FC<OAuth2AppsSettingsProps> = ({
 	// A value matching no trigger would leave no tab selected.
 	const activeTab =
 		tabState.value === "settings" && settings ? "settings" : "applications";
+
+	const isFiltered = filter.used;
+	const isEmpty = !isLoadingApps && !appsError && (!apps || apps.length === 0);
 
 	return (
 		<div>
@@ -189,30 +201,56 @@ const OAuth2AppsSettingsPageView: FC<OAuth2AppsSettingsProps> = ({
 							<ErrorAlert error={appsError} />
 						</div>
 					)}
-					<Table className="table-fixed" aria-label="OAuth2 applications">
-						<TableHeader>
-							<TableRow>
-								<TableHead className="w-1/3">Name</TableHead>
-								<TableHead className="w-1/3">Callback URL</TableHead>
-								<TableHead className="w-12">
-									<span className="sr-only">Open</span>
-								</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody size="lg">
-							{isLoadingApps ? (
-								<TableLoader />
-							) : !appsError && (!apps || apps.length === 0) ? (
-								<TableEmpty
-									message="No OAuth2 applications configured"
-									description="Add an application to use Coder as an OAuth2 provider."
-									cta={canCreateApp ? <AddApplicationButton /> : undefined}
-								/>
-							) : (
-								apps?.map((app) => <OAuth2AppRow key={app.id} app={app} />)
-							)}
-						</TableBody>
-					</Table>
+
+					<Filter
+						filter={filter}
+						error={appsError}
+						isLoading={isLoadingApps}
+						presets={[{ query: "", name: "All applications" }]}
+						optionsSkeleton={null}
+					/>
+
+					<PaginationContainer
+						query={appsQuery}
+						paginationUnitLabel="applications"
+					>
+						<Table className="table-fixed" aria-label="OAuth2 applications">
+							<TableHeader>
+								<TableRow>
+									<TableHead className="w-1/3">Name</TableHead>
+									<TableHead className="w-1/3">Callback URL</TableHead>
+									<TableHead className="w-12">
+										<span className="sr-only">Open</span>
+									</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody size="lg">
+								{isLoadingApps ? (
+									<TableLoader />
+								) : isEmpty ? (
+									<TableEmpty
+										message={
+											isFiltered
+												? "No OAuth2 applications match your search"
+												: "No OAuth2 applications configured"
+										}
+										description={
+											isFiltered
+												? "Try adjusting your search query."
+												: "Add an application to use Coder as an OAuth2 provider."
+										}
+										cta={
+											!isFiltered && canCreateApp ? (
+												<AddApplicationButton />
+											) : undefined
+										}
+									/>
+								) : (
+									apps?.map((app) => <OAuth2AppRow key={app.id} app={app} />)
+								)}
+							</TableBody>
+						</Table>
+					</PaginationContainer>
 				</TabsContent>
 
 				{settings && (

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -4918,6 +4918,30 @@ export const MockOAuth2ProviderApps: TypesGen.OAuth2ProviderApp[] = [
 			token_revoke: "http://127.0.0.1:3001/oauth2/revoke",
 		},
 	},
+	{
+		id: "2",
+		name: "bar",
+		callback_url: "http://127.0.0.1:3002/callback",
+		icon: "/icon/gitlab.svg",
+		endpoints: {
+			authorization: "http://127.0.0.1:3001/oauth2/authorize",
+			token: "http://127.0.0.1:3001/oauth2/token",
+			device_authorization: "",
+			token_revoke: "http://127.0.0.1:3001/oauth2/revoke",
+		},
+	},
+	{
+		id: "3",
+		name: "baz",
+		callback_url: "https://example.com/oauth/callback",
+		icon: "",
+		endpoints: {
+			authorization: "http://127.0.0.1:3001/oauth2/authorize",
+			token: "http://127.0.0.1:3001/oauth2/token",
+			device_authorization: "",
+			token_revoke: "http://127.0.0.1:3001/oauth2/revoke",
+		},
+	},
 ];
 
 export const MockOAuth2ProviderSettings: TypesGen.OAuth2ProviderSettings = {


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Frontend half of the OAuth2 provider apps search + pagination work, split out from #27652 per review feedback. Stacked on the backend PR #27652 (base branch `jakehwll/oauth2app-pagination`); rebase onto `main` once that merges.

Adds the Filter + paginated table to the OAuth2 applications settings page, wired to the wrapped `{ apps, count }` response and the `q` / `limit` / `offset` query params.

## Changes

- `paginatedApps` query + `usePaginatedQuery`/`useFilter` on the settings page
- Filter input and `PaginationContainer` in the applications tab
- Empty vs. no-results states; extra mock apps for stories

## Preview

| <img width="1466" alt="OAuth2 apps" src="https://github.com/user-attachments/assets/d301d058-5322-4785-b217-f232af954481"/> | <img width="1466" alt="Pagination" src="https://github.com/user-attachments/assets/ccb466ac-bf3e-4aeb-bc55-d577de182760"/> |
| - | - |
| <img width="1466" alt="Search" src="https://github.com/user-attachments/assets/c8c806b0-31be-4b39-99d8-d2d9b5dbced4"/> | |

## Review feedback addressed

- Dropped the presence-only "is it in the UI?" `play` functions from the new stories and rely on Storybook snapshots; `play` functions are kept only where they exercise real interactions.

<details><summary>Notes</summary>

- `useFilterParamsKey` is imported from the `Filter` component. This is an existing repo pattern (other query files do the same), so it is left as-is rather than reshaped in this PR.
- Validation run locally: `tsc -p .` and Biome pass on the touched files.

</details>