### PR TITLE
fix(site/src/pages/AISettingsPage/ModelsPage): group model provider filter by type

### DIFF
--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -4,12 +4,16 @@ import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type { ChatModel } from "#/api/typesGenerated";
 import ModelsPageView from "./ModelsPageView";
 import {
+	MockAnthropicLowercaseProviderState,
 	MockAnthropicProviderState,
+	MockAnthropicSecondaryProviderState,
 	MockBedrockProviderState,
 	MockDisabledProviderState,
 	MockOpenAIProviderState,
 	mockBedrockClaude,
 	mockClaude,
+	mockClaudeHaiku,
+	mockClaudeOpus,
 	mockDisabledModel,
 	mockGPT5,
 	mockOrphanedModel,
@@ -112,6 +116,56 @@ export const FilterByProvider: Story = {
 		await expect(canvas.getByText("Claude Sonnet 4.5")).toBeInTheDocument();
 		await expect(canvas.queryByText("GPT-5")).not.toBeInTheDocument();
 		await expect(canvas.queryByText("GPT-4o mini")).not.toBeInTheDocument();
+	},
+};
+
+// Provider names that differ only by capitalization ("anthropic" vs
+// "Anthropic") collapse into a single "Anthropic" option. A name with a
+// numeric suffix ("Anthropic 2") is treated as a distinct provider and stays
+// separate.
+export const FilterMergesCaseVariantsButKeepsNumbered: Story = {
+	args: {
+		models: [mockGPT5, mockClaude, mockClaudeOpus, mockClaudeHaiku],
+		providerStates: [
+			MockOpenAIProviderState,
+			MockAnthropicProviderState,
+			MockAnthropicLowercaseProviderState,
+			MockAnthropicSecondaryProviderState,
+		],
+		providerTypeByID: new Map<string, string>([
+			["prov-openai", "openai"],
+			["prov-anthropic", "anthropic"],
+			["prov-anthropic-lower", "anthropic"],
+			["prov-anthropic-2", "anthropic"],
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const providerFilter = canvas.getByRole("combobox", {
+			name: /filter by provider/i,
+		});
+		await userEvent.click(providerFilter);
+		const listbox = await within(document.body).findByRole("listbox");
+		// Case-only variants collapse to one "Anthropic" option...
+		await expect(
+			within(listbox).getAllByRole("option", { name: "Anthropic" }),
+		).toHaveLength(1);
+		// ...while the numbered variant stays as its own option.
+		await expect(
+			within(listbox).getByRole("option", { name: "Anthropic 2" }),
+		).toBeInTheDocument();
+
+		// Selecting "Anthropic" shows models from both case-variant configs but
+		// not the numbered "Anthropic 2" config.
+		await userEvent.click(
+			within(listbox).getByRole("option", { name: "Anthropic" }),
+		);
+		await expect(canvas.getByText("Claude Sonnet 4.5")).toBeInTheDocument();
+		await expect(canvas.getByText("Claude Opus 4.5")).toBeInTheDocument();
+		await expect(
+			canvas.queryByText("Claude Haiku 4.5"),
+		).not.toBeInTheDocument();
+		await expect(canvas.queryByText("GPT-5")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.tsx
@@ -42,11 +42,23 @@ import {
 	type ProviderState,
 } from "#/modules/aiModels/providerStates";
 import { ProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
+import { formatProviderLabel } from "#/utils/aiProviders";
 import { paginateItems } from "#/utils/paginateItems";
 import { ModelRow } from "./components/ModelRow";
 
 const MODELS_PAGE_SIZE = 10;
 const ALL_PROVIDERS_VALUE = "all";
+
+// Collapses provider names that differ only by capitalization onto one
+// canonical, capitalized label. Names that differ further (e.g. a numeric
+// suffix like "Anthropic 2") keep distinct labels and stay separate options.
+const canonicalProviderLabel = (label: string, provider: string): string => {
+	const normalized = label.trim().replace(/\s+/g, " ");
+	const brand = formatProviderLabel(provider);
+	return !normalized || normalized.toLowerCase() === brand.toLowerCase()
+		? brand
+		: `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`;
+};
 
 const AddModelDropdown: FC<{
 	providerStates: readonly ProviderState[];
@@ -115,14 +127,37 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	const [providerFilter, setProviderFilter] =
 		useState<string>(ALL_PROVIDERS_VALUE);
 
-	const providerKeyByModelId = useMemo(() => {
+	// Filter models by canonical provider name so capitalization-only variants
+	// are treated as the same provider.
+	const providerFilterKeyByModelId = useMemo(() => {
 		const map = new Map<string, string>();
 		for (const providerState of providerStates) {
+			const key = canonicalProviderLabel(
+				providerState.label,
+				providerState.provider,
+			).toLowerCase();
 			for (const providerModel of providerState.models) {
-				map.set(providerModel.id, providerState.key);
+				map.set(providerModel.id, key);
 			}
 		}
 		return map;
+	}, [providerStates]);
+
+	// One option per canonical provider name, ordered alphabetically.
+	const providerFilterOptions = useMemo(() => {
+		const seen = new Set<string>();
+		const options: { value: string; label: string; provider: string }[] = [];
+		for (const providerState of providerStates) {
+			const label = canonicalProviderLabel(
+				providerState.label,
+				providerState.provider,
+			);
+			const value = label.toLowerCase();
+			if (seen.has(value)) continue;
+			seen.add(value);
+			options.push({ value, label, provider: providerState.provider });
+		}
+		return options.sort((a, b) => a.label.localeCompare(b.label));
 	}, [providerStates]);
 
 	const providerLabelByModelId = useMemo(() => {
@@ -163,7 +198,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 		return models.filter((model) => {
 			if (
 				providerFilter !== ALL_PROVIDERS_VALUE &&
-				providerKeyByModelId.get(model.id) !== providerFilter
+				providerFilterKeyByModelId.get(model.id) !== providerFilter
 			) {
 				return false;
 			}
@@ -182,7 +217,7 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 	}, [
 		models,
 		providerFilter,
-		providerKeyByModelId,
+		providerFilterKeyByModelId,
 		providerLabelByModelId,
 		searchQuery,
 	]);
@@ -244,11 +279,11 @@ const ModelsPageView: FC<ModelsPageViewProps> = ({
 					</SelectTrigger>
 					<SelectContent>
 						<SelectItem value={ALL_PROVIDERS_VALUE}>All providers</SelectItem>
-						{providerStates.map((providerState) => (
-							<SelectItem key={providerState.key} value={providerState.key}>
+						{providerFilterOptions.map((option) => (
+							<SelectItem key={option.value} value={option.value}>
 								<span className="flex items-center gap-2">
-									<ProviderIcon provider={providerState.provider} />
-									{providerState.label}
+									<ProviderIcon provider={option.provider} />
+									{option.label}
 								</span>
 							</SelectItem>
 						))}

--- a/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
+++ b/site/src/pages/AISettingsPage/ModelsPage/testFixtures.ts
@@ -82,6 +82,40 @@ export const MockAnthropicProviderState: ProviderState = {
 	models: [mockClaude],
 };
 
+// An Anthropic config whose name differs from "Anthropic" only by
+// capitalization. The provider filter must merge the two into one option.
+export const mockClaudeOpus: ChatModel = {
+	...mockClaude,
+	id: "model-claude-opus",
+	ai_provider_id: "prov-anthropic-lower",
+	model: "claude-opus-4-5",
+	display_name: "Claude Opus 4.5",
+};
+
+export const MockAnthropicLowercaseProviderState: ProviderState = {
+	...MockAnthropicProviderState,
+	key: "prov-anthropic-lower",
+	label: "anthropic",
+	models: [mockClaudeOpus],
+};
+
+// An Anthropic config whose name adds a number. A numeric suffix is more than
+// a capitalization change, so the filter keeps it as a separate option.
+export const mockClaudeHaiku: ChatModel = {
+	...mockClaude,
+	id: "model-claude-haiku",
+	ai_provider_id: "prov-anthropic-2",
+	model: "claude-haiku-4-5",
+	display_name: "Claude Haiku 4.5",
+};
+
+export const MockAnthropicSecondaryProviderState: ProviderState = {
+	...MockAnthropicProviderState,
+	key: "prov-anthropic-2",
+	label: "Anthropic 2",
+	models: [mockClaudeHaiku],
+};
+
 const MockGoogleProviderConfig: ChatProviderConfig = {
 	...MockOpenAIProviderConfig,
 	id: "prov-google",


### PR DESCRIPTION
Closes [ENG-3268](https://linear.app/codercom/issue/ENG-3268/unify-provider-spelling-in-model-list).

## Problem

On **AI Settings > Models**, the provider filter listed one option per provider config. When configs shared a name that differed only by capitalization (e.g. `anthropic` and `Anthropic`), they showed up as separate, near-duplicate options.

## Change

- The provider filter groups options by the **case-normalized name** and displays a canonical, capitalized label. Case-only variants (`anthropic` / `Anthropic`) collapse into a single `Anthropic` option; selecting it lists models from every merged config.
- Names that differ by more than capitalization, such as a numeric suffix (`Anthropic 2`), remain distinct options.
- The models table's Provider column is unchanged: it still shows each config's own display name so admins can tell apart multiple configs of the same provider.

## Tests

- Added the `FilterMergesCaseVariantsButKeepsNumbered` Storybook story asserting case variants merge into one `Anthropic` option while `Anthropic 2` stays separate, and that selecting `Anthropic` surfaces models from both merged configs only.
- Existing `DisabledProviderModelsStillListed` story passes unchanged, confirming distinctly-named configs (`OpenAI` vs `OpenAI Secondary`) stay separate.
