### PR TITLE
fix(site/src/pages/AISettingsPage/MCPServersPage): clarify disabled MCP server status

### DIFF
--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerRow.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerRow.tsx
@@ -3,6 +3,12 @@ import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Badge } from "#/components/Badge/Badge";
 import { TableCell, TableRow } from "#/components/Table/Table";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import { cn } from "#/utils/cn";
 import { MCPServerIcon } from "./MCPServerIcon";
@@ -45,7 +51,20 @@ export const MCPServerRow: FC<MCPServerRowProps> = ({ server, onClick }) => {
 				{AVAILABILITY_LABELS[server.availability] ?? server.availability}
 			</TableCell>
 			<TableCell className="w-32">
-				<Badge variant="default">{enabled ? "Enabled" : "Disabled"}</Badge>
+				{enabled ? (
+					<Badge variant="green">Enabled</Badge>
+				) : (
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Badge variant="warning">Disabled</Badge>
+							</TooltipTrigger>
+							<TooltipContent>
+								This server is disabled and won't be available to Coder Agents.
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				)}
 			</TableCell>
 			<TableCell className="w-12">
 				{onClick && (


### PR DESCRIPTION
Some MCP server rows appeared greyed out with no explanation, so their state was ambiguous. The status column also rendered both states with the same neutral badge, making a disabled server look the same as an enabled one.

Render the status as a color-coded badge (green for enabled, warning for disabled) and add a tooltip on the disabled badge explaining that the server won't be available to Coder Agents.

Closes https://linear.app/codercom/issue/ENG-3269/explain-greyed-out-labels-for-mcp-servers

<details>
<summary>Preview</summary>

The `MCPServersPageView` Default Storybook story renders a disabled server (`Image`) with the new warning badge and tooltip. Story tests in `MCPServersPageView.stories.tsx` cover the enabled and disabled states.

</details>

Generated by Coder Agents.
