### PR TITLE
docs(docs/ai-coder/agents): document the chat search: full-text filter

### DIFF
--- a/docs/ai-coder/agents/chat-search-syntax.md
+++ b/docs/ai-coder/agents/chat-search-syntax.md
@@ -24,19 +24,20 @@ be combined with `title:`, `pr_title:`, or `pr:`.
 
 ## Full-text search
 
-`search:` uses token-based PostgreSQL full-text search with the
-`english` text search configuration:
+`search:` uses token-based PostgreSQL full-text search:
 
 - Matching is case-insensitive. Every word in the value must match
   (AND semantics). Quoted phrases, `OR`, and `-` negation follow
   [`websearch_to_tsquery`](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES)
   semantics.
-- English word stems match, so `refactor` matches `refactoring`. There
-  is no fuzzy, semantic, or partial-word (prefix) matching.
-- Common English stopwords (such as `the`, `or`, `and`) are dropped
-  during tokenization. A value that tokenizes to no searchable words,
-  including stopword-only or punctuation-only values, returns an empty
-  list. An empty `search:` value returns HTTP 400.
+- Chat titles and PR titles match whole words without stemming.
+- Message content matches English word stems, so `refactor` matches a
+  message containing `refactoring`, and ignores common English
+  stopwords (such as `the`, `or`, `and`).
+- There is no fuzzy, semantic, or partial-word (prefix) matching.
+- A value that tokenizes to no searchable words, such as punctuation
+  only, returns an empty list. An empty `search:` value returns HTTP
+  400.
 - A value that is a whole number also matches chats by exact PR number.
 - Results list matching conversations only; there are no match snippets
   or highlights.

--- a/docs/ai-coder/agents/chat-search-syntax.md
+++ b/docs/ai-coder/agents/chat-search-syntax.md
@@ -26,30 +26,22 @@ be combined with `title:`, `pr_title:`, or `pr:`.
 
 `search:` uses token-based PostgreSQL full-text search:
 
-- Matching is case-insensitive. Every word in the value must match
-  (AND semantics). Quoted phrases, `OR`, and `-` negation follow
+- Case-insensitive whole-word matching with AND semantics. Quoted
+  phrases, `OR`, and `-` negation follow
   [`websearch_to_tsquery`](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES)
-  semantics.
-- Chat titles and PR titles match whole words without stemming.
-- Message content matches English word stems, so `refactor` matches a
-  message containing `refactoring`, and ignores common English
-  stopwords (such as `the`, `or`, `and`).
-- There is no fuzzy, semantic, or partial-word (prefix) matching.
-- A value that tokenizes to no searchable words, such as punctuation
-  only, returns an empty list. An empty `search:` value returns HTTP
-  400.
-- A value that is a whole number also matches chats by exact PR number.
-- Results list matching conversations only; there are no match snippets
-  or highlights.
-- Results use the standard chat list ordering (pinned conversations
-  first, then most recently updated) and pagination (default page size
-  50).
-- Message content is indexed by a background job and becomes searchable
-  shortly after it is written, usually within 10 minutes. Chat titles
-  and PR titles are searchable immediately.
-
-The `title:`, `pr_title:`, and `repo:` filters are unaffected: they use
-case-insensitive `ILIKE` substring matching, not full-text search.
+  rules.
+- Message content matches English word stems (`refactor` matches
+  `refactoring`) and ignores English stopwords. Titles and PR titles
+  do not stem.
+- No fuzzy, semantic, or prefix matching.
+- Whole-number values also match exact PR numbers.
+- A value with no searchable words (punctuation only) returns an empty
+  list; an empty value returns HTTP 400.
+- Results use the standard chat list ordering (pinned first, then most
+  recently updated) and pagination, without match snippets.
+- Message content becomes searchable shortly after it is written
+  (background indexing, usually within 10 minutes). Titles and PR
+  titles are searchable immediately.
 
 ## Examples
 
@@ -82,9 +74,6 @@ case-insensitive `ILIKE` substring matching, not full-text search.
 ?q=pr_title:"fix auth bug"
 
 # Full-text search across titles, PR titles, and messages
-?q=search:deploy
-
-# Multi-word full-text search (all words must match)
 ?q=search:"kubernetes restart"
 
 # Combine full-text search with other filters

--- a/docs/ai-coder/agents/chat-search-syntax.md
+++ b/docs/ai-coder/agents/chat-search-syntax.md
@@ -2,22 +2,53 @@
 
 The chat list endpoint accepts a `q` query parameter for filtering
 conversations. All filters use `key:value` syntax. Bare search terms
-are rejected; use `title:` for title filtering.
+are rejected; use `title:` for title filtering or `search:` for
+full-text search.
 
 ## Filters
 
-| Key          | Values                              | Description                                                                                        |
-|--------------|-------------------------------------|----------------------------------------------------------------------------------------------------|
-| `title`      | substring                           | Case-insensitive substring match. Quote multi-word values.                                         |
-| `archived`   | `true`, `false`                     | Filter by archived state. Default: `false`.                                                        |
-| `has_unread` | `true`, `false`                     | Conversations with unread assistant messages.                                                      |
-| `pr_status`  | `draft`, `open`, `merged`, `closed` | Linked pull request state. Comma-separated for OR.                                                 |
-| `diff_url`   | URL                                 | Match by associated diff URL. Quote values containing colons.                                      |
-| `pr`         | positive integer                    | Exact PR number match.                                                                             |
-| `repo`       | substring                           | Case-insensitive substring match against git remote origin or URL. Quote values containing colons. |
-| `pr_title`   | substring                           | Case-insensitive PR title substring match. Quote multi-word values.                                |
+| Key          | Values                              | Description                                                                                               |
+|--------------|-------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `title`      | substring                           | Case-insensitive substring match. Quote multi-word values.                                                |
+| `archived`   | `true`, `false`                     | Filter by archived state. Default: `false`.                                                               |
+| `has_unread` | `true`, `false`                     | Conversations with unread assistant messages.                                                             |
+| `pr_status`  | `draft`, `open`, `merged`, `closed` | Linked pull request state. Comma-separated for OR.                                                        |
+| `diff_url`   | URL                                 | Match by associated diff URL. Quote values containing colons.                                             |
+| `pr`         | positive integer                    | Exact PR number match.                                                                                    |
+| `repo`       | substring                           | Case-insensitive substring match against git remote origin or URL. Quote values containing colons.        |
+| `pr_title`   | substring                           | Case-insensitive PR title substring match. Quote multi-word values.                                       |
+| `search`     | text                                | Full-text search across chat titles, PR titles, PR numbers, and message content. Quote multi-word values. |
 
-Multiple filters in one query combine with AND logic.
+Multiple filters in one query combine with AND logic. `search:` cannot
+be combined with `title:`, `pr_title:`, or `pr:`.
+
+## Full-text search
+
+`search:` uses token-based PostgreSQL full-text search with the
+`english` text search configuration:
+
+- Matching is case-insensitive. Every word in the value must match
+  (AND semantics). Quoted phrases, `OR`, and `-` negation follow
+  [`websearch_to_tsquery`](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES)
+  semantics.
+- English word stems match, so `refactor` matches `refactoring`. There
+  is no fuzzy, semantic, or partial-word (prefix) matching.
+- Common English stopwords (such as `the`, `or`, `and`) are dropped
+  during tokenization. A value that tokenizes to no searchable words,
+  including stopword-only or punctuation-only values, returns an empty
+  list. An empty `search:` value returns HTTP 400.
+- A value that is a whole number also matches chats by exact PR number.
+- Results list matching conversations only; there are no match snippets
+  or highlights.
+- Results use the standard chat list ordering (pinned conversations
+  first, then most recently updated) and pagination (default page size
+  50).
+- Message content is indexed by a background job and becomes searchable
+  shortly after it is written, usually within 10 minutes. Chat titles
+  and PR titles are searchable immediately.
+
+The `title:`, `pr_title:`, and `repo:` filters are unaffected: they use
+case-insensitive `ILIKE` substring matching, not full-text search.
 
 ## Examples
 
@@ -48,6 +79,15 @@ Multiple filters in one query combine with AND logic.
 
 # Conversations with a specific PR title
 ?q=pr_title:"fix auth bug"
+
+# Full-text search across titles, PR titles, and messages
+?q=search:deploy
+
+# Multi-word full-text search (all words must match)
+?q=search:"kubernetes restart"
+
+# Combine full-text search with other filters
+?q=search:refactor+pr_status:open
 ```
 
 ## Notes
@@ -56,4 +96,4 @@ Multiple filters in one query combine with AND logic.
 - `pr_status:draft` means the PR is open **and** marked as a draft.
   `pr_status:open` means the PR is open and not a draft.
 - Conversations without a linked diff status are excluded when `pr_status`, `pr`, `repo`, or `pr_title` is set. The `repo:` filter also matches chats tracking a branch with no PR.
-- Unrecognized keys or bare terms return HTTP 400 with a validation error.
+- Unrecognized keys, bare terms, or combining `search:` with `title:`, `pr_title:`, or `pr:` return HTTP 400 with a validation error.


### PR DESCRIPTION
Documents the `search:` full-text filter in `docs/ai-coder/agents/chat-search-syntax.md` and drafts the release notes copy for chat history search.

Describes `main` plus #28319, which must merge first: stemming and stopword removal apply to message content only; titles and PR titles keep `simple` whole-word matching. All claims verified against the implementation. Two statements in CODAGT-727 were inaccurate and are documented as the code behaves:

- A value that tokenizes to no searchable words returns an **empty list**, not HTTP 400 (`TestListChats_Search/NoSearchableWordsReturnsEmpty`). HTTP 400 covers only an empty `search:` value, unsupported keys, bare terms, or combining `search:` with `title:`, `pr_title:`, or `pr:` (`coderd/searchquery/search.go`).
- Results are **paginated** with the standard chat list cursor (default 50), not a bounded non-paginated set (`GetChats`, `listChats`). Ordering is pinned first, then most recently updated.

Also verified: message bodies are indexed by the dbpurge sweep (10-minute tick, up to 5 x 10,000 rows, newest first) while titles and PR titles are searchable immediately; numeric values match exact PR numbers; `title:`, `pr_title:`, and `repo:` retain `ILIKE` semantics.

`pnpm run format-docs` and `pnpm run lint-docs` pass.

Closes [CODAGT-727](https://linear.app/codercom/issue/CODAGT-727/chat-search-documentation-and-release-notes)

<details>
<summary>Release notes draft</summary>

### Chat history search

You can now search your chat history by what was said, not just by title. The chat list `q` parameter accepts a new `search:` filter that performs full-text search across chat titles, pull request titles, PR numbers, and message content, for example `?q=search:"kubernetes restart"`. Matching is case-insensitive and supports quoted phrases, `OR`, and `-` negation. Message content additionally matches English word stems (`refactor` finds a message containing `refactoring`). `search:` cannot be combined with the `title:`, `pr_title:`, or `pr:` filters; the existing substring filters are unchanged.

**Upgrading with existing chat history:** the message search index is populated by a background job (every 10 minutes, up to 50,000 messages per run, newest first). Upgrades are not blocked, and chat reads and writes are unaffected while the index fills. Older messages appear in search results progressively; messages indexed before the stemming upgrade match exact word forms until re-indexed. Titles and PR titles are searchable immediately.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @f0ssel.
