### PR TITLE
feat: report unpriced AI models to owners (standalone reporter)

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1203,6 +1203,14 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					return xerrors.Errorf("create aibridged: %w", err)
 				}
 				coderAPI.RegisterInMemoryAIBridgedHTTPHandler(aibridgeDaemon)
+				// Report models used without a price. Unpriced usage is recorded
+				// at a NULL cost, so it is neither reported nor enforced, and
+				// only an admin can close the gap by setting a price.
+				unpricedModelsReporter := aibridgedserver.NewUnpricedModelsReporter(
+					ctx, logger.Named("aigateway_unpriced_models_reporter"),
+					coderAPI.Database, options.NotificationsEnqueuer, quartz.NewReal(),
+				)
+				defer unpricedModelsReporter.Close()
 				// The handler is bound to coderAPI's lifecycle; Close() on the
 				// daemon does not affect in-flight requests but is needed to
 				// release pool/recorder resources at shutdown.

--- a/coderd/aibridgedserver/unpricedreport.go
+++ b/coderd/aibridgedserver/unpricedreport.go
@@ -1,0 +1,200 @@
+package aibridgedserver
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/notifications"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/quartz"
+)
+
+const (
+	// unpricedModelsCheckInterval is how often a replica considers reporting.
+	// The report itself is sent at most once per
+	// unpricedModelsReportFrequency; this only bounds how late a due report
+	// can be.
+	unpricedModelsCheckInterval = time.Hour
+
+	unpricedModelsReportFrequency      = 7 * 24 * time.Hour
+	unpricedModelsReportFrequencyLabel = "week"
+
+	// unpricedModelsLimit caps how many models a single report lists. A
+	// deployment can accumulate far more unpriced models than an admin can act
+	// on at once, and the remainder is reported as a count.
+	unpricedModelsLimit = 100
+)
+
+// unpricedModelsReporter periodically reports the models used without a price.
+type unpricedModelsReporter struct {
+	cancel context.CancelFunc
+	closed chan struct{}
+}
+
+// NewUnpricedModelsReporter starts a loop that notifies owners about models
+// used without a price. Usage of an unpriced model is recorded at a NULL cost,
+// so it is neither reported nor enforced against any budget, and an admin
+// cannot act on that without being told which models are missing a price.
+//
+// The set of unpriced models is derived at report time from interceptions and
+// the price table rather than tracked as usage happens, so a price set by any
+// means, including the price book shipped with an upgrade, removes a model
+// from the next report. Nothing is added to the interception path.
+func NewUnpricedModelsReporter(ctx context.Context, logger slog.Logger, db database.Store, enqueuer notifications.Enqueuer, clk quartz.Clock) io.Closer {
+	closed := make(chan struct{})
+	ctx, cancelFunc := context.WithCancel(ctx)
+	//nolint:gocritic // The system reports unpriced models without direct user input.
+	ctx = dbauthz.AsSystemRestricted(ctx)
+
+	ticker := clk.NewTicker(unpricedModelsCheckInterval)
+	doTick := func() {
+		if err := reportUnpricedModels(ctx, logger, db, enqueuer, clk); err != nil {
+			logger.Error(ctx, "failed to report unpriced AI models", slog.Error(err))
+		}
+	}
+
+	go func() {
+		defer close(closed)
+		defer ticker.Stop()
+		// Force an initial tick. On a deployment that has never run this
+		// report, it only checks in.
+		doTick()
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Debug(ctx, "closing unpriced AI models reporter")
+				return
+			case <-ticker.C:
+				doTick()
+			}
+		}
+	}()
+	return &unpricedModelsReporter{
+		cancel: cancelFunc,
+		closed: closed,
+	}
+}
+
+func (r *unpricedModelsReporter) Close() error {
+	r.cancel()
+	<-r.closed
+	return nil
+}
+
+// reportUnpricedModels sends one report to every owner covering the models used
+// without a price since the last report.
+//
+// Reporting is guarded twice. The advisory lock keeps concurrent replicas from
+// reporting the same window, and the persisted timestamp enforces the
+// frequency: the ticker cannot, because it restarts with the process and runs
+// on a different phase in each replica.
+func reportUnpricedModels(ctx context.Context, logger slog.Logger, db database.Store, enqueuer notifications.Enqueuer, clk quartz.Clock) error {
+	now := clk.Now()
+	since := now.Add(-unpricedModelsReportFrequency)
+
+	return db.InTx(func(tx database.Store) error {
+		acquired, err := tx.TryAcquireLock(ctx, database.LockIDNotifyUnpricedAIModels)
+		if err != nil {
+			return xerrors.Errorf("acquire unpriced AI models report lock: %w", err)
+		}
+		if !acquired {
+			logger.Debug(ctx, "another replica is reporting unpriced AI models, skipping")
+			return nil
+		}
+
+		// Firstly, check if this is the first run of the job ever.
+		reportLog, err := tx.GetNotificationReportGeneratorLogByTemplate(ctx, notifications.TemplateAIModelsUnpricedReport)
+		if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+			return xerrors.Errorf("read report generator log: %w", err)
+		}
+		if xerrors.Is(err, sql.ErrNoRows) {
+			// First run? Check-in the job, and get back after one week. The
+			// window before the first check-in belongs to a deployment this
+			// report has no history of.
+			logger.Info(ctx, "unpriced AI models reporter is executing the job for the first time")
+			return upsertUnpricedModelsReportLog(ctx, tx, now)
+		}
+
+		// Secondly, check if the job has not been running recently.
+		if !reportLog.LastGeneratedAt.IsZero() && reportLog.LastGeneratedAt.Add(unpricedModelsReportFrequency).After(now) {
+			return nil // reported recently, no need to report now
+		}
+
+		// Thirdly, fetch the models used without a price.
+		unpriced, err := tx.GetUnpricedAIModelsSince(ctx, dbtime.Time(since).UTC())
+		if err != nil {
+			return xerrors.Errorf("fetch unpriced AI models: %w", err)
+		}
+
+		if len(unpriced) > 0 {
+			owners, err := tx.GetUsers(ctx, database.GetUsersParams{
+				RbacRole: []string{codersdk.RoleOwner},
+			})
+			if err != nil {
+				return xerrors.Errorf("fetch owners: %w", err)
+			}
+
+			reportData := buildDataForUnpricedModelsReport(unpriced)
+			for _, owner := range owners {
+				// The enqueuer writes outside this transaction, so a failure
+				// here is logged rather than returned: rolling back would
+				// discard the timestamp and report the same window again to
+				// owners who already received it.
+				if _, err := enqueuer.EnqueueWithData(ctx, owner.ID, notifications.TemplateAIModelsUnpricedReport,
+					map[string]string{},
+					reportData,
+					"unpriced_models_reporter",
+				); err != nil {
+					logger.Warn(ctx, "failed to send a report with unpriced AI models", slog.F("user_id", owner.ID), slog.Error(err))
+				}
+			}
+		}
+
+		// Lastly, record that the window was reported. This happens even when
+		// nothing was reported, so the next report covers one week rather than
+		// every week since usage was last seen.
+		return upsertUnpricedModelsReportLog(ctx, tx, now)
+	}, nil)
+}
+
+func upsertUnpricedModelsReportLog(ctx context.Context, db database.Store, now time.Time) error {
+	if err := db.UpsertNotificationReportGeneratorLog(ctx, database.UpsertNotificationReportGeneratorLogParams{
+		NotificationTemplateID: notifications.TemplateAIModelsUnpricedReport,
+		LastGeneratedAt:        dbtime.Time(now).UTC(),
+	}); err != nil {
+		return xerrors.Errorf("update report generator log: %w", err)
+	}
+	return nil
+}
+
+// buildDataForUnpricedModelsReport renders the models most used first, so the
+// models dropped by the limit are the ones with the least unreported usage.
+// Interception counts order the list but are not reported: they count requests
+// rather than spend, and would invite reading them as one.
+func buildDataForUnpricedModelsReport(unpriced []database.GetUnpricedAIModelsSinceRow) map[string]any {
+	limit := min(len(unpriced), unpricedModelsLimit)
+	models := make([]map[string]any, 0, limit)
+	for _, row := range unpriced[:limit] {
+		models = append(models, map[string]any{
+			"provider": row.ProviderType,
+			"model":    row.Model,
+		})
+	}
+
+	data := map[string]any{
+		"report_frequency": unpricedModelsReportFrequencyLabel,
+		"models":           models,
+	}
+	if overflow := len(unpriced) - len(models); overflow > 0 {
+		data["overflow_count"] = overflow
+	}
+	return data
+}

--- a/coderd/aibridgedserver/unpricedreport_internal_test.go
+++ b/coderd/aibridgedserver/unpricedreport_internal_test.go
@@ -1,0 +1,353 @@
+package aibridgedserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/notifications"
+	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/quartz"
+)
+
+func TestReportUnpricedModels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FirstRun_ChecksInWithoutReporting", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		owner := seedOwner(t, db)
+		notifEnq.Clear()
+
+		// When: the job has never run, it checks in rather than reporting a
+		// window it has no history for.
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+		require.Empty(t, notifEnq.Sent())
+
+		// Then: the report arrives one week later.
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedUnpricedUsage(t, db, "anthropic", database.AIProviderTypeAnthropic, "claude-opus-4-8", clk.Now())
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+		sent := notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport))
+		require.Len(t, sent, 1)
+		require.Equal(t, owner.ID, sent[0].UserID)
+		require.Equal(t, []map[string]any{
+			{"provider": "anthropic", "model": "claude-opus-4-8"},
+		}, modelsFromPayload(t, sent[0].Data))
+	})
+
+	t.Run("ReportsOnlyOncePerFrequency", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedUnpricedUsage(t, db, "anthropic", database.AIProviderTypeAnthropic, "claude-opus-4-8", clk.Now())
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+		require.Len(t, notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport)), 1)
+
+		// When: the generator ticks again well inside the frequency window.
+		notifEnq.Clear()
+		clk.Advance(time.Hour)
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then: nothing is sent. The ticker restarts with the process and each
+		// replica runs on its own phase, so the frequency is enforced here.
+		require.Empty(t, notifEnq.Sent())
+	})
+
+	t.Run("StillUnpricedAndInUse_IsReportedAgain", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+		require.Len(t, notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport)), 1)
+
+		// Given: the admin did not price it and the model is still in use.
+		notifEnq.Clear()
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then: unreported spend is still accruing, so it is raised again.
+		require.Len(t, notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport)), 1)
+	})
+
+	t.Run("NoLongerUsed_IsNotReported", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+		seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+
+		// Given: two report windows pass with no further use of the model.
+		clk.Advance(2*unpricedModelsReportFrequency + time.Minute)
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then: a model nobody uses is not worth pricing.
+		require.Empty(t, notifEnq.Sent())
+	})
+
+	t.Run("PricedModel_IsNotReported", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+
+		// Given: a price arrives by any route. The report derives the unpriced
+		// set from the price table, so it needs no hook into how it was set.
+		seedPrice(ctx, t, db, "anthropic", "claude-opus-4-8")
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then
+		require.Empty(t, notifEnq.Sent())
+	})
+
+	t.Run("OpenAICompat_IsNotReported", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "self-hosted", database.AIProviderTypeOpenaiCompat)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedInterception(t, db, initiator, provider, "llama-4", clk.Now())
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then: openai-compat providers cannot be priced, so reporting them
+		// would be permanent noise.
+		require.Empty(t, notifEnq.Sent())
+	})
+
+	t.Run("ReportsEveryOwner", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		firstOwner := seedOwner(t, db)
+		secondOwner := seedOwner(t, db)
+		member := dbgen.User(t, db, database.User{})
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then
+		sent := notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport))
+		require.Len(t, sent, 2)
+		recipients := []uuid.UUID{sent[0].UserID, sent[1].UserID}
+		require.Contains(t, recipients, firstOwner.ID)
+		require.Contains(t, recipients, secondOwner.ID)
+		require.NotContains(t, recipients, member.ID)
+	})
+
+	t.Run("TruncatesToLimit", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+
+		// Given: more unpriced models than a single report lists. The most used
+		// model is seeded twice so its position in the report is deterministic.
+		const overflow = 5
+		seedInterception(t, db, initiator, provider, "most-used-model", clk.Now())
+		seedInterception(t, db, initiator, provider, "most-used-model", clk.Now())
+		for i := range unpricedModelsLimit + overflow - 1 {
+			seedInterception(t, db, initiator, provider, fmt.Sprintf("model-%03d", i), clk.Now())
+		}
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then: the models with the most unreported usage survive truncation.
+		sent := notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport))
+		require.Len(t, sent, 1)
+		models := modelsFromPayload(t, sent[0].Data)
+		require.Len(t, models, unpricedModelsLimit)
+		require.Equal(t, "most-used-model", models[0]["model"])
+		require.EqualValues(t, overflow, sent[0].Data["overflow_count"])
+	})
+
+	t.Run("NothingToReport_AdvancesWindow", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, logger, db, notifEnq, clk := setup(t)
+		seedOwner(t, db)
+		initiator := dbgen.User(t, db, database.User{})
+		provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+
+		checkIn(ctx, t, logger, db, notifEnq, clk)
+
+		// Given: a quiet week, then a week in which one model is used.
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+		require.Empty(t, notifEnq.Sent())
+
+		clk.Advance(unpricedModelsReportFrequency + time.Minute)
+		seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+
+		// When
+		require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+
+		// Then: the empty run still advanced the window, so this report covers
+		// one week rather than every week since usage was last seen.
+		require.Len(t, notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport)), 1)
+	})
+}
+
+// checkIn runs the first execution of the job, which records the timestamp
+// without reporting.
+func checkIn(ctx context.Context, t *testing.T, logger slog.Logger, db database.Store, notifEnq *notificationstest.FakeEnqueuer, clk quartz.Clock) {
+	t.Helper()
+	require.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+	require.Empty(t, notifEnq.Sent())
+	notifEnq.Clear()
+}
+
+func setup(t *testing.T) (context.Context, slog.Logger, database.Store, *notificationstest.FakeEnqueuer, *quartz.Mock) {
+	t.Helper()
+
+	ctx := dbauthz.AsSystemRestricted(context.Background())
+	logger := slogtest.Make(t, &slogtest.Options{})
+	db, _ := dbtestutil.NewDB(t)
+	notifyEnq := &notificationstest.FakeEnqueuer{}
+	clk := quartz.NewMock(t)
+	return ctx, logger, db, notifyEnq, clk
+}
+
+func seedOwner(t *testing.T, db database.Store) database.User {
+	t.Helper()
+	return dbgen.User(t, db, database.User{
+		RBACRoles: []string{codersdk.RoleOwner},
+	})
+}
+
+func seedProvider(t *testing.T, db database.Store, name string, providerType database.AIProviderType) database.AIProvider {
+	t.Helper()
+	return dbgen.AIProvider(t, db, database.AIProvider{
+		Name: name,
+		Type: providerType,
+	})
+}
+
+func seedInterception(t *testing.T, db database.Store, initiator database.User, provider database.AIProvider, model string, startedAt time.Time) {
+	t.Helper()
+	dbgen.AIBridgeInterception(t, db, database.InsertAIBridgeInterceptionParams{
+		InitiatorID:  initiator.ID,
+		Provider:     string(provider.Type),
+		ProviderName: provider.Name,
+		Model:        model,
+		StartedAt:    startedAt,
+	}, nil)
+}
+
+// seedUnpricedUsage records use of a model that holds no price.
+func seedUnpricedUsage(t *testing.T, db database.Store, providerName string, providerType database.AIProviderType, model string, startedAt time.Time) {
+	t.Helper()
+	seedInterception(t, db, dbgen.User(t, db, database.User{}), seedProvider(t, db, providerName, providerType), model, startedAt)
+}
+
+func seedPrice(ctx context.Context, t *testing.T, db database.Store, provider, model string) {
+	t.Helper()
+	seed, err := json.Marshal([]map[string]any{{
+		"provider":          provider,
+		"model":             model,
+		"input_price":       3_000_000,
+		"output_price":      15_000_000,
+		"cache_read_price":  nil,
+		"cache_write_price": nil,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, db.UpsertAIModelPrices(ctx, database.UpsertAIModelPricesParams{
+		Seed:   seed,
+		Source: database.AIModelPriceSourceCustom,
+	}))
+}
+
+func modelsFromPayload(t *testing.T, data map[string]any) []map[string]any {
+	t.Helper()
+	models, ok := data["models"].([]map[string]any)
+	require.True(t, ok, "models missing from report payload")
+	return models
+}
+
+func TestReportUnpricedModels_ConcurrentReplicas(t *testing.T) {
+	t.Parallel()
+
+	ctx, logger, db, notifEnq, clk := setup(t)
+	seedOwner(t, db)
+	initiator := dbgen.User(t, db, database.User{})
+	provider := seedProvider(t, db, "anthropic", database.AIProviderTypeAnthropic)
+
+	checkIn(ctx, t, logger, db, notifEnq, clk)
+	clk.Advance(unpricedModelsReportFrequency + time.Minute)
+	seedInterception(t, db, initiator, provider, "claude-opus-4-8", clk.Now())
+
+	// When: two replicas report at the same time.
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, reportUnpricedModels(ctx, logger, db, notifEnq, clk))
+		}()
+	}
+	wg.Wait()
+
+	// Then: the advisory lock makes one of them skip, and the persisted
+	// timestamp stops the loser from reporting the same window afterwards.
+	require.Len(t, notifEnq.Sent(notificationstest.WithTemplateID(notifications.TemplateAIModelsUnpricedReport)), 1)
+}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5029,6 +5029,13 @@ func (q *querier) GetUnexpiredLicenses(ctx context.Context) ([]database.License,
 	return q.db.GetUnexpiredLicenses(ctx)
 }
 
+func (q *querier) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]database.GetUnpricedAIModelsSinceRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAiModelPrice); err != nil {
+		return nil, err
+	}
+	return q.db.GetUnpricedAIModelsSince(ctx, since)
+}
+
 func (q *querier) GetUserAIBudgetOverride(ctx context.Context, userID uuid.UUID) (database.UserAIBudgetOverride, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceUserObject(userID)); err != nil {
 		return database.UserAIBudgetOverride{}, err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6943,6 +6943,11 @@ func (s *MethodTestSuite) TestAIBridge() {
 		check.Args(database.GetAIModelPricesParams{}).Asserts(rbac.ResourceAiModelPrice, policy.ActionRead)
 	}))
 
+	s.Run("GetUnpricedAIModelsSince", s.Mocked(func(db *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		db.EXPECT().GetUnpricedAIModelsSince(gomock.Any(), gomock.Any()).Return([]database.GetUnpricedAIModelsSinceRow{}, nil).AnyTimes()
+		check.Args(time.Time{}).Asserts(rbac.ResourceAiModelPrice, policy.ActionRead)
+	}))
+
 	s.Run("GetOrganizationGroupsAISpend", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		org := testutil.Fake(s.T(), faker, database.Organization{})
 		row1 := testutil.Fake(s.T(), faker, database.GetOrganizationGroupsAISpendRow{OrganizationID: org.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3200,6 +3200,14 @@ func (m queryMetricsStore) GetUnexpiredLicenses(ctx context.Context) ([]database
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]database.GetUnpricedAIModelsSinceRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetUnpricedAIModelsSince(ctx, since)
+	m.queryLatencies.WithLabelValues("GetUnpricedAIModelsSince").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetUnpricedAIModelsSince").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetUserAIBudgetOverride(ctx context.Context, userID uuid.UUID) (database.UserAIBudgetOverride, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetUserAIBudgetOverride(ctx, userID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6013,6 +6013,21 @@ func (mr *MockStoreMockRecorder) GetUnexpiredLicenses(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnexpiredLicenses", reflect.TypeOf((*MockStore)(nil).GetUnexpiredLicenses), ctx)
 }
 
+// GetUnpricedAIModelsSince mocks base method.
+func (m *MockStore) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]database.GetUnpricedAIModelsSinceRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnpricedAIModelsSince", ctx, since)
+	ret0, _ := ret[0].([]database.GetUnpricedAIModelsSinceRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnpricedAIModelsSince indicates an expected call of GetUnpricedAIModelsSince.
+func (mr *MockStoreMockRecorder) GetUnpricedAIModelsSince(ctx, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnpricedAIModelsSince", reflect.TypeOf((*MockStore)(nil).GetUnpricedAIModelsSince), ctx, since)
+}
+
 // GetUserAIBudgetOverride mocks base method.
 func (m *MockStore) GetUserAIBudgetOverride(ctx context.Context, userID uuid.UUID) (database.UserAIBudgetOverride, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/lock.go
+++ b/coderd/database/lock.go
@@ -18,6 +18,7 @@ const (
 	LockIDAIProvidersEnvSeed
 	LockIDChatModelConfigWrites
 	LockIDChatCapacityAdmission
+	LockIDNotifyUnpricedAIModels
 )
 
 // Per-setting advisory lock IDs for the chat instruction settings. These

--- a/coderd/database/migrations/000580_unpriced_ai_models_notification.down.sql
+++ b/coderd/database/migrations/000580_unpriced_ai_models_notification.down.sql
@@ -1,0 +1,2 @@
+DELETE FROM notification_templates
+WHERE id = '1b7d9fa7-f5a8-4e46-8078-5cf53abfed94';

--- a/coderd/database/migrations/000580_unpriced_ai_models_notification.up.sql
+++ b/coderd/database/migrations/000580_unpriced_ai_models_notification.up.sql
@@ -1,0 +1,30 @@
+INSERT INTO notification_templates (
+    id,
+    name,
+    title_template,
+    body_template,
+    actions,
+    "group",
+    method,
+    kind,
+    enabled_by_default
+)
+VALUES (
+    '1b7d9fa7-f5a8-4e46-8078-5cf53abfed94',
+    'Report: Unpriced AI Models',
+    E'AI models used without a price',
+    $$The following models were used in the last {{.Data.report_frequency}} without a price. Their token usage is recorded, but it adds nothing to spend, so it is neither reported nor enforced against any budget.
+
+{{range $model := .Data.models}}
+* {{$model.provider}}/{{$model.model}}
+{{- end}}
+{{if .Data.overflow_count}}
+...and {{.Data.overflow_count}} more.
+{{end}}
+Set a price for these models to bring their usage into spend reporting.$$,
+    '[{"label": "Configure model prices", "url": "https://coder.com/docs/ai-coder/ai-gateway/cost-controls#configure-model-prices"}]'::jsonb,
+    'AI Cost Control Admin Events',
+    NULL,
+    'system'::notification_template_kind,
+    true
+);

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -895,6 +895,15 @@ type sqlcQuerier interface {
 	// rollup and accept day-granularity bounds.
 	GetTotalUsageHBAgentRuntimeV1(ctx context.Context, arg GetTotalUsageHBAgentRuntimeV1Params) (int64, error)
 	GetUnexpiredLicenses(ctx context.Context) ([]License, error)
+	// Returns the models used since the given time that hold no price, most used
+	// first. Prices are keyed by the configured provider type, so interceptions
+	// are resolved to their provider the same way cost recording resolves them:
+	// by provider name, which is unique among live providers. An interception
+	// whose provider has since been deleted cannot be resolved to a type and is
+	// excluded, matching the unknown-provider path in cost recording.
+	// openai-compat providers pass through to any upstream vendor and cannot be
+	// priced, so their models are never reported as unpriced.
+	GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]GetUnpricedAIModelsSinceRow, error)
 	GetUserAIBudgetOverride(ctx context.Context, userID uuid.UUID) (UserAIBudgetOverride, error)
 	GetUserAIProviderKeyByProviderID(ctx context.Context, arg GetUserAIProviderKeyByProviderIDParams) (UserAIProviderKey, error)
 	// GetUserAIProviderKeys is used by dbcrypt key rotation. Request paths should use

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3407,6 +3407,64 @@ func (q *sqlQuerier) GetOverBudgetUsersPerGroup(ctx context.Context, periodStart
 	return items, nil
 }
 
+const getUnpricedAIModelsSince = `-- name: GetUnpricedAIModelsSince :many
+SELECT
+	providers.type::text AS provider_type,
+	interceptions.model AS model,
+	COUNT(*)::bigint AS interceptions
+FROM aibridge_interceptions AS interceptions
+JOIN ai_providers AS providers
+	ON providers.name = interceptions.provider_name
+	AND providers.deleted = false
+WHERE interceptions.started_at >= $1::timestamptz
+	AND providers.type != 'openai-compat'
+	AND NOT EXISTS (
+		SELECT 1
+		FROM ai_model_prices AS prices
+		WHERE prices.provider = providers.type::text
+			AND prices.model = interceptions.model
+	)
+GROUP BY providers.type, interceptions.model
+ORDER BY interceptions DESC, provider_type ASC, model ASC
+`
+
+type GetUnpricedAIModelsSinceRow struct {
+	ProviderType  string `db:"provider_type" json:"provider_type"`
+	Model         string `db:"model" json:"model"`
+	Interceptions int64  `db:"interceptions" json:"interceptions"`
+}
+
+// Returns the models used since the given time that hold no price, most used
+// first. Prices are keyed by the configured provider type, so interceptions
+// are resolved to their provider the same way cost recording resolves them:
+// by provider name, which is unique among live providers. An interception
+// whose provider has since been deleted cannot be resolved to a type and is
+// excluded, matching the unknown-provider path in cost recording.
+// openai-compat providers pass through to any upstream vendor and cannot be
+// priced, so their models are never reported as unpriced.
+func (q *sqlQuerier) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]GetUnpricedAIModelsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, getUnpricedAIModelsSince, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetUnpricedAIModelsSinceRow
+	for rows.Next() {
+		var i GetUnpricedAIModelsSinceRow
+		if err := rows.Scan(&i.ProviderType, &i.Model, &i.Interceptions); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUserAIBudgetOverride = `-- name: GetUserAIBudgetOverride :one
 SELECT user_id, group_id, spend_limit_micros, created_at, updated_at
 FROM user_ai_budget_overrides

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -479,3 +479,31 @@ GROUP BY
 	ai.provider,
 	ai.provider_name
 ORDER BY ai.initiator_id, tu.effective_group_id, ai.provider, ai.provider_name, ai.model;
+
+-- name: GetUnpricedAIModelsSince :many
+-- Returns the models used since the given time that hold no price, most used
+-- first. Prices are keyed by the configured provider type, so interceptions
+-- are resolved to their provider the same way cost recording resolves them:
+-- by provider name, which is unique among live providers. An interception
+-- whose provider has since been deleted cannot be resolved to a type and is
+-- excluded, matching the unknown-provider path in cost recording.
+-- openai-compat providers pass through to any upstream vendor and cannot be
+-- priced, so their models are never reported as unpriced.
+SELECT
+	providers.type::text AS provider_type,
+	interceptions.model AS model,
+	COUNT(*)::bigint AS interceptions
+FROM aibridge_interceptions AS interceptions
+JOIN ai_providers AS providers
+	ON providers.name = interceptions.provider_name
+	AND providers.deleted = false
+WHERE interceptions.started_at >= @since::timestamptz
+	AND providers.type != 'openai-compat'
+	AND NOT EXISTS (
+		SELECT 1
+		FROM ai_model_prices AS prices
+		WHERE prices.provider = providers.type::text
+			AND prices.model = interceptions.model
+	)
+GROUP BY providers.type, interceptions.model
+ORDER BY interceptions DESC, provider_type ASC, model ASC;

--- a/coderd/notifications/events.go
+++ b/coderd/notifications/events.go
@@ -76,4 +76,5 @@ var (
 	TemplateAIBudgetLimitReachedUser  = uuid.MustParse("cdcf2ecd-f003-4169-9800-abb2661ea522")
 	TemplateAIBudgetWarningAdmin      = uuid.MustParse("2a7b0ac1-00e1-4625-9cd5-1e5933972c77")
 	TemplateAIBudgetLimitReachedAdmin = uuid.MustParse("0bafe0ea-a78b-4217-ad05-1ef12e92e025")
+	TemplateAIModelsUnpricedReport    = uuid.MustParse("1b7d9fa7-f5a8-4e46-8078-5cf53abfed94")
 )

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -1618,6 +1618,26 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 				Data: map[string]any{},
 			},
 		},
+		{
+			name: "TemplateAIModelsUnpricedReport",
+			id:   notifications.TemplateAIModelsUnpricedReport,
+			payload: types.MessagePayload{
+				UserName:     "Bobby",
+				UserEmail:    "bobby@coder.com",
+				UserUsername: "bobby",
+				Labels:       map[string]string{},
+				// We need to use floats as `json.Unmarshal` unmarshal numbers in `map[string]any` to floats.
+				Data: map[string]any{
+					"report_frequency": "week",
+					"models": []map[string]any{
+						{"provider": "anthropic", "model": "claude-opus-4-8"},
+						{"provider": "openai", "model": "gpt-5.7"},
+						{"provider": "openrouter", "model": "z-ai/glm-5.4"},
+					},
+					"overflow_count": 12.0,
+				},
+			},
+		},
 	}
 
 	// We must have a test case for every notification_template. This is enforced below:

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIModelsUnpricedReport.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateAIModelsUnpricedReport.html.golden
@@ -1,0 +1,104 @@
+From: system@coder.com
+To: bobby@coder.com
+Subject: AI models used without a price
+Message-Id: 02ee4935-73be-4fa1-a290-ff9999026b13@blush-whale-48
+Date: Fri, 11 Oct 2024 09:03:06 +0000
+Content-Type: multipart/alternative;  boundary=bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
+MIME-Version: 1.0
+
+--bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+Hi Bobby,
+
+The following models were used in the last week without a price. Their toke=
+n usage is recorded, but it adds nothing to spend, so it is neither reporte=
+d nor enforced against any budget.
+
+anthropic/claude-opus-4-8
+openai/gpt-5.7
+openrouter/z-ai/glm-5.4
+
+...and 12 more.
+
+Set a price for these models to bring their usage into spend reporting.
+
+
+Configure model prices: https://coder.com/docs/ai-coder/ai-gateway/cost-con=
+trols#configure-model-prices
+
+--bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+<!doctype html>
+<html lang=3D"en">
+  <head>
+    <meta charset=3D"UTF-8" />
+    <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
+=3D1.0" />
+    <title>AI models used without a price</title>
+  </head>
+  <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
+ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
+l', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; color: #020617=
+; background: #f8fafc;">
+    <div style=3D"max-width: 600px; margin: 20px auto; padding: 60px; borde=
+r: 1px solid #e2e8f0; border-radius: 8px; background-color: #fff; text-alig=
+n: left; font-size: 14px; line-height: 1.5;">
+      <div style=3D"text-align: center;">
+        <img src=3D"https://coder.com/coder-logo-horizontal.png" alt=3D"Cod=
+er Logo" style=3D"height: 40px;" />
+      </div>
+      <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
+argin: 8px 0 32px; line-height: 1.5;">
+        AI models used without a price
+      </h1>
+      <div style=3D"line-height: 1.5;">
+        <p>Hi Bobby,</p>
+        <p>The following models were used in the last week without a price.=
+ Their token usage is recorded, but it adds nothing to spend, so it is neit=
+her reported nor enforced against any budget.</p>
+
+<ul>
+<li>anthropic/claude-opus-4-8<br>
+</li>
+<li>openai/gpt-5.7<br>
+</li>
+<li>openrouter/z-ai/glm-5.4<br>
+</li>
+</ul>
+
+<p>&hellip;and 12 more.</p>
+
+<p>Set a price for these models to bring their usage into spend reporting.<=
+/p>
+      </div>
+      <div style=3D"text-align: center; margin-top: 32px;">
+       =20
+        <a href=3D"https://coder.com/docs/ai-coder/ai-gateway/cost-controls=
+#configure-model-prices" style=3D"display: inline-block; padding: 13px 24px=
+; background-color: #020617; color: #f8fafc; text-decoration: none; border-=
+radius: 8px; margin: 0 4px;">
+          Configure model prices
+        </a>
+       =20
+      </div>
+      <div style=3D"border-top: 1px solid #e2e8f0; color: #475569; font-siz=
+e: 12px; margin-top: 64px; padding-top: 24px; line-height: 1.6;">
+        <p>&copy;&nbsp;2024&nbsp;Coder. All rights reserved&nbsp;-&nbsp;<a =
+href=3D"http://test.com" style=3D"color: #2563eb; text-decoration: none;">h=
+ttp://test.com</a></p>
+        <p><a href=3D"http://test.com/settings/notifications" style=3D"colo=
+r: #2563eb; text-decoration: none;">Click here to manage your notification =
+settings</a></p>
+        <p><a href=3D"http://test.com/settings/notifications?disabled=3D1b7=
+d9fa7-f5a8-4e46-8078-5cf53abfed94" style=3D"color: #2563eb; text-decoration=
+: none;">Stop receiving emails like this</a></p>
+      </div>
+    </div>
+  </body>
+</html>
+
+--bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4--

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateAIModelsUnpricedReport.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateAIModelsUnpricedReport.json.golden
@@ -1,0 +1,43 @@
+{
+  "_version": "1.1",
+  "msg_id": "00000000-0000-0000-0000-000000000000",
+  "payload": {
+    "_version": "1.2",
+    "notification_name": "Report: Unpriced AI Models",
+    "notification_template_id": "00000000-0000-0000-0000-000000000000",
+    "user_id": "00000000-0000-0000-0000-000000000000",
+    "user_email": "bobby@coder.com",
+    "user_name": "Bobby",
+    "user_username": "bobby",
+    "actions": [
+      {
+        "label": "Configure model prices",
+        "url": "https://coder.com/docs/ai-coder/ai-gateway/cost-controls#configure-model-prices"
+      }
+    ],
+    "labels": {},
+    "data": {
+      "models": [
+        {
+          "model": "claude-opus-4-8",
+          "provider": "anthropic"
+        },
+        {
+          "model": "gpt-5.7",
+          "provider": "openai"
+        },
+        {
+          "model": "z-ai/glm-5.4",
+          "provider": "openrouter"
+        }
+      ],
+      "overflow_count": 12,
+      "report_frequency": "week"
+    },
+    "targets": null
+  },
+  "title": "AI models used without a price",
+  "title_markdown": "AI models used without a price",
+  "body": "The following models were used in the last week without a price. Their token usage is recorded, but it adds nothing to spend, so it is neither reported nor enforced against any budget.\n\nanthropic/claude-opus-4-8\nopenai/gpt-5.7\nopenrouter/z-ai/glm-5.4\n\n...and 12 more.\n\nSet a price for these models to bring their usage into spend reporting.",
+  "body_markdown": "The following models were used in the last week without a price. Their token usage is recorded, but it adds nothing to spend, so it is neither reported nor enforced against any budget.\n\n\n* anthropic/claude-opus-4-8\n* openai/gpt-5.7\n* openrouter/z-ai/glm-5.4\n\n...and 12 more.\n\nSet a price for these models to bring their usage into spend reporting."
+}

--- a/docs/ai-coder/ai-gateway/cost-controls.md
+++ b/docs/ai-coder/ai-gateway/cost-controls.md
@@ -234,6 +234,15 @@ value means spend is under-counted. Because the price book ships with the
 release, a newly launched model is unpriced until you upgrade Coder or set a
 price for it yourself.
 
+Owners also receive a weekly notification listing the models used without a
+price in the past week, so unpriced usage does not depend on watching metrics.
+A model that is priced by any means, including the price book shipped with an
+upgrade, stops appearing. A model that stops being used stops appearing too,
+while one that is still in use is reported every week until it is priced. The
+notification lists at most 100 models and reports the rest as a count. Models
+served by `openai-compat` providers are never listed, because they cannot be
+priced.
+
 ### Configure model prices
 
 Use the experimental `coder exp ai-model-prices` command to set model prices

--- a/mise.lock
+++ b/mise.lock
@@ -707,7 +707,6 @@ url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-linux-arm64.tar.gz"
 [tools.node."platforms.linux-arm64-musl"]
 checksum = "sha256:4cea680423f98abc6a2a5ca127fb34c5f6586c24217f57749be6ea886c9be9a6"
 url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0.tar.gz"
-install = "source"
 
 [tools.node."platforms.linux-x64"]
 checksum = "sha256:d36e56998220085782c0ca965f9d51b7726335aed2f5fc7321c6c0ad233aa96d"


### PR DESCRIPTION
Alternative to #28419. Same feature, same query, same notification template, different host for the periodic job. Open both, merge one.

Closes [AIGOV-568](https://linear.app/codercom/issue/AIGOV-568/notify-admins-about-unpriced-ai-models).

## What differs from #28419

| | #28419 | This PR |
|---|---|---|
| Loop | Sibling function in `coderd/notifications/reports` | Own loop in `coderd/aibridgedserver` |
| Lock | Shares `LockIDNotificationsReportGenerator` | Own `LockIDNotifyUnpricedAIModels` |
| Transaction | Shared with the failed-builds report | Own |
| Tick interval | 15m (inherited) | 1h |
| Started | Always | Only when AI Bridge is enabled |
| Extra code | ~0 scheduling | ~60 lines of scheduling |

Everything else is identical: `GetUnpricedAIModelsSince`, the notification template and its golden files, the 100-model cap, the openai-compat exclusion, and the docs.

## Why this shape

Reusing the report generator meant AI cost-control logic living in the generic notifications package, and it created three couplings that do not reflect any real dependency between the two reports:

- **Ordering.** The failed-builds report runs first and returns its error, so a failure there prevents the unpriced report from running at all.
- **Shared transaction.** The enqueuer writes outside the tick transaction, so a rollback caused by the *other* report discards our timestamp while the emails have already been sent. Owners would receive the same report again 15 minutes later.
- **Shared lock.** A replica that cannot acquire the lock because another replica is generating the failed-builds report skips the unpriced report too, despite the two being independent.

Here each of those disappears by construction. The reporter owns its loop, its lock and its transaction, and it inherits the AI Bridge enablement check from where it is started.

## What is still shared

`notification_report_generator_logs` still holds the timestamp. It is keyed by `notification_template_id`, not by report type, so it is generic bookkeeping rather than something owned by the reports package. Adding a second one-row table for the same purpose would be strictly worse.

## Design (unchanged from #28419)

**Derived, not tracked.** The unpriced set is computed at report time by joining `aibridge_interceptions` to `ai_model_prices`. A price set by any means removes a model from the next report with no hook into the write path, and nothing is added to the interception hot path. Prices are keyed by configured provider type, so the query resolves interceptions through `ai_providers` by name, exactly as `cost.go` does.

**Two guards, not one.** The advisory lock prevents concurrent replicas from reporting the same window. The persisted timestamp enforces the weekly frequency, which the ticker cannot: it restarts with the process and runs on a different phase in each replica. Without it, the forced initial tick would report on every restart.

## Behaviour

| Situation | Outcome |
|---|---|
| Model used without a price | Listed in the next weekly report |
| Price set by any means | Disappears from the next report |
| Still unpriced and still in use | Reported again each week |
| Model stops being used | Drops out of the report |
| Nothing unpriced | No notification; window still advances |
| More than 100 unpriced models | Top 100 by usage, rest reported as a count |
| openai-compat models | Excluded, they cannot be priced |
| Many replicas | Exactly one report per week |
| First ever run | Checks in, reports one week later |

## Follow-up

The unpriced info log in `cost.go` can drop to debug once this is verified in practice. Not done here: deployments with no SMTP or webhook configured would otherwise lose their only signal.

<details>
<summary>Implementation plan and decision log</summary>

The plan below records the design discussion that produced both PRs, including the approaches that were rejected.

### Rejected: enqueue per interception and rely on notification dedupe

The original proposal was to notify once per unpriced model per day using the notification system's daily dedupe. Rejected because:

- The dedupe hash is per recipient, per calendar day, and dedupes in the database. Every request for an unpriced model would still round-trip the database once per admin only to be rejected, moving the log-spam problem rather than fixing it.
- It makes correctness depend on an implicit "never put a volatile value in the payload" rule that nothing enforces.
- Fan-out is per user, so it cannot collapse to one message.

### Rejected: a sightings table written on the hot path

An `ai_unpriced_model_sightings` table with `last_seen_at` and `last_notified_at`, garbage collected against `ai_model_prices`. Rejected because it is a denormalised cache of what `aibridge_interceptions` already records, and it added a migration, a hot-path write, GC and staleness pruning for no gain.

An earlier variant called a delete from the price write path. Rejected because prices arrive from several places (seeder, price book refresh, CLI, API, future endpoints), and missing one would produce notifications about models that are already priced.

### Rejected: notify once per new model, never repeat

Considered notifying only about newly detected models. Rejected in favour of reporting everything currently unpriced and still in use: a model that keeps accruing unreported spend is worth raising again, and "still in use" is a better filter than "not seen before".

### Notes on synchronization

Every replica runs these loops; coderd has no leader election. Two patterns apply: `TryAcquireLock` for periodic singletons where a skipped run is fine, and `FOR UPDATE SKIP LOCKED` for work sharing. This is the former. The advisory lock prevents concurrency but holds no memory, which is why the weekly cadence needs a durable timestamp as well.

### Open item resolved during implementation

Model ID granularity: the price book contains versioned IDs such as `anthropic/claude-opus-4-1-20250805`, so snapshot releases are priced normally and no normalisation is needed.

</details>

---

Created by Coder Agents on behalf of @evgeniy-scherbina.
