### PR TITLE
feat: honor the deployment registry mirror in template builder bases

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -920,8 +920,11 @@ TEMPLATE BUILDER OPTIONS:
           When disabled, all /api/v2/templatebuilder/* endpoints return 404.
 
       --template-builder-registry-url string, $CODER_TEMPLATE_BUILDER_REGISTRY_URL (default: registry.coder.com)
-          The base URL of the module registry used by the template builder for
-          module source paths.
+          The bare host of the module registry the template builder uses for
+          module source paths, optionally with a port (for example
+          "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme
+          is stripped; a path, credentials, query, or fragment is rejected at
+          server start.
 
 USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -1193,7 +1193,9 @@ templateBuilder:
   # disabled, all /api/v2/templatebuilder/* endpoints return 404.
   # (default: <unset>, type: bool)
   disabled: false
-  # The base URL of the module registry used by the template builder for module
-  # source paths.
+  # The bare host of the module registry the template builder uses for module source
+  # paths, optionally with a port (for example "registry.coder.com" or
+  # "mirror.internal:8443"). An http(s):// scheme is stripped; a path, credentials,
+  # query, or fragment is rejected at server start.
   # (default: registry.coder.com, type: string)
   registryURL: registry.coder.com

--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -11,6 +11,8 @@ import (
 	"text/template"
 
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // BaseOS enumerates operating systems for base template filtering.
@@ -232,6 +234,7 @@ func DefaultBaseRenderContext(exampleID string) BaseRenderContext {
 
 	return BaseRenderContext{
 		ContainerImage: dc.ContainerImage,
+		RegistryBase:   codersdk.DefaultTemplateBuilderRegistryURL,
 		Variables:      vars,
 	}
 }

--- a/coderd/templatebuilder/bases/azure-linux/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/azure-linux/main.tf.tmpl
@@ -12,9 +12,9 @@ terraform {
   }
 }
 
-# See https://registry.coder.com/modules/coder/azure-region
+# Module docs (public registry): https://registry.coder.com/modules/coder/azure-region
 module "azure_region" {
-  source = "registry.coder.com/coder/azure-region/coder"
+  source = "{{ .RegistryBase }}/coder/azure-region/coder"
 
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"

--- a/coderd/templatebuilder/bases/gcp-linux/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/gcp-linux/main.tf.tmpl
@@ -16,9 +16,9 @@ variable "project_id" {
   default     = {{ .Variables.project_id }}
 }
 
-# See https://registry.coder.com/modules/coder/gcp-region
+# Module docs (public registry): https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
-  source = "registry.coder.com/coder/gcp-region/coder"
+  source = "{{ .RegistryBase }}/coder/gcp-region/coder"
 
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"

--- a/coderd/templatebuilder/bases/gcp-windows/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/gcp-windows/main.tf.tmpl
@@ -16,9 +16,9 @@ variable "project_id" {
   default     = {{ .Variables.project_id }}
 }
 
-# See https://registry.coder.com/modules/coder/gcp-region
+# Module docs (public registry): https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
-  source = "registry.coder.com/coder/gcp-region/coder"
+  source = "{{ .RegistryBase }}/coder/gcp-region/coder"
 
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"

--- a/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
@@ -151,15 +151,11 @@ resource "coder_script" "install_languages" {
 }
 
 # --- Git clone ---
-# NOTE: base templates render their module sources verbatim, so this pins the
-# public registry (registry.coder.com). Unlike wizard-composed modules, a
-# base-embedded module does not yet honor a deployment's configured module
-# registry mirror; threading that registry through base rendering is tracked as
-# a follow-up.
-
+# Module docs (public registry): https://registry.coder.com/modules/coder/git-clone
 module "git-clone" {
   count    = data.coder_workspace.me.start_count * (data.coder_parameter.git_repo.value != "" ? 1 : 0)
-  source   = "registry.coder.com/coder/git-clone/coder"
+  source   = "{{ .RegistryBase }}/coder/git-clone/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version  = "~> 2.0"
   agent_id = coder_agent.main.id
   url      = data.coder_parameter.git_repo.value

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -72,7 +72,7 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 	// HCL fails here with the parser diagnostic. Otherwise the zero-module path
 	// ships a broken main.tf unvalidated, and the module path fails with a
 	// misleading "no coder_agent resource" error instead of the real syntax error.
-	if err := validateRenderedBaseHCL(mainTF); err != nil {
+	if err := validateRenderedHCL(mainTF); err != nil {
 		return nil, err
 	}
 
@@ -104,6 +104,11 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 
 	modulesTF, err := renderModules(req.Modules, catalog, registryBase, agentName)
 	if err != nil {
+		return nil, err
+	}
+	// modulesTF is rendered from the same {{ .RegistryBase }} interpolation, so
+	// validate it too before it is bundled.
+	if err := validateRenderedHCL(modulesTF); err != nil {
 		return nil, err
 	}
 

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -57,8 +57,7 @@ type ComposeResult struct {
 func Compose(req ComposeRequest) (*ComposeResult, error) {
 	// Normalize and default the registry once here so the base and module render
 	// paths see the same canonical host. codersdk validates the same value at
-	// server start (DeploymentValues.Validate); this is the per-request defense in
-	// depth for direct callers and a belt against a value that slipped past.
+	// server start (DeploymentValues.Validate); this is per-request defense in depth.
 	registryBase, err := codersdk.NormalizeTemplateBuilderRegistryURL(req.RegistryURL)
 	if err != nil {
 		return nil, err
@@ -69,11 +68,10 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		return nil, err
 	}
 
-	// Parse the rendered base HCL once, before the module early-return, so a base
-	// that rendered to invalid HCL fails here with the parser diagnostic. Without
-	// this, the zero-module path ships a broken main.tf unvalidated, and the module
-	// path below fails with a misleading "no coder_agent resource" error from
-	// ExtractAgentResourceName instead of the real syntax error.
+	// Parse the rendered base HCL once, before the module early-return, so invalid
+	// HCL fails here with the parser diagnostic. Otherwise the zero-module path
+	// ships a broken main.tf unvalidated, and the module path fails with a
+	// misleading "no coder_agent resource" error instead of the real syntax error.
 	if err := validateRenderedBaseHCL(mainTF); err != nil {
 		return nil, err
 	}

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // ComposeRequest describes which base template and modules to render.
@@ -53,8 +55,26 @@ type ComposeResult struct {
 // source files. It extracts the coder_agent resource name from the
 // rendered base HCL and wires it into each module block.
 func Compose(req ComposeRequest) (*ComposeResult, error) {
-	mainTF, err := renderBase(req.BaseTemplateID, req.BaseVariableValues)
+	// Normalize and default the registry once here so the base and module render
+	// paths see the same canonical host. codersdk validates the same value at
+	// server start (DeploymentValues.Validate); this is the per-request defense in
+	// depth for direct callers and a belt against a value that slipped past.
+	registryBase, err := codersdk.NormalizeTemplateBuilderRegistryURL(req.RegistryURL)
 	if err != nil {
+		return nil, err
+	}
+
+	mainTF, err := renderBase(req.BaseTemplateID, req.BaseVariableValues, registryBase)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the rendered base HCL once, before the module early-return, so a base
+	// that rendered to invalid HCL fails here with the parser diagnostic. Without
+	// this, the zero-module path ships a broken main.tf unvalidated, and the module
+	// path below fails with a misleading "no coder_agent resource" error from
+	// ExtractAgentResourceName instead of the real syntax error.
+	if err := validateRenderedBaseHCL(mainTF); err != nil {
 		return nil, err
 	}
 
@@ -84,7 +104,7 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		return nil, err
 	}
 
-	modulesTF, err := renderModules(req.Modules, catalog, req.RegistryURL, agentName)
+	modulesTF, err := renderModules(req.Modules, catalog, registryBase, agentName)
 	if err != nil {
 		return nil, err
 	}
@@ -107,13 +127,15 @@ func formatHCL(src []byte) []byte {
 	return hclwrite.Format(src)
 }
 
-// renderBase renders the base template for the given example ID,
-// merging any user-supplied variable values into the render context.
-func renderBase(baseTemplateID string, baseVars map[string]string) ([]byte, error) {
+// renderBase renders the base template for the given example ID, merging any
+// user-supplied variable values into the render context. Compose has already
+// normalized registryBase, so it is threaded in unconditionally.
+func renderBase(baseTemplateID string, baseVars map[string]string, registryBase string) ([]byte, error) {
 	renderCtx := DefaultBaseRenderContext(baseTemplateID)
 	if renderCtx.Variables == nil {
 		renderCtx.Variables = make(map[string]string)
 	}
+	renderCtx.RegistryBase = registryBase
 
 	vars, err := mergeBaseVariables(baseTemplateID, baseVars)
 	if err != nil {
@@ -252,7 +274,7 @@ func validateModules(requested []ComposeModule, catalog map[string]ModuleManifes
 func renderModules(
 	requested []ComposeModule,
 	catalog map[string]ModuleManifest,
-	registryURL, agentName string,
+	registryBase, agentName string,
 ) ([]byte, error) {
 	var buf bytes.Buffer
 	for _, cm := range requested {
@@ -268,7 +290,7 @@ func renderModules(
 			return nil, xerrors.Errorf("module %q: %w", cm.ID, err)
 		}
 		modCtx := ModuleRenderContext{
-			RegistryBase:      registryURL,
+			RegistryBase:      registryBase,
 			PinnedVersion:     manifest.PinnedVersion,
 			AgentResourceName: agentName,
 			Variables:         vars,

--- a/coderd/templatebuilder/compose_internal_test.go
+++ b/coderd/templatebuilder/compose_internal_test.go
@@ -155,3 +155,24 @@ func TestMergeModuleVariables(t *testing.T) {
 		require.Equal(t, "13337", merged["port"])
 	})
 }
+
+func TestValidateRenderedBaseHCL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidHCL", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateRenderedBaseHCL([]byte(`resource "coder_agent" "main" {}`)))
+	})
+
+	t.Run("InvalidHCL", func(t *testing.T) {
+		t.Parallel()
+		// A base that rendered to invalid HCL (for example a registry value that
+		// slipped past normalization and interpolated badly) must fail with the
+		// parser diagnostic rather than being shipped as a broken main.tf. Compose
+		// relies on this backstop on the zero-module path, so the error branch
+		// needs direct coverage.
+		err := validateRenderedBaseHCL([]byte("resource {"))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "not valid HCL")
+	})
+}

--- a/coderd/templatebuilder/compose_internal_test.go
+++ b/coderd/templatebuilder/compose_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -156,20 +157,38 @@ func TestMergeModuleVariables(t *testing.T) {
 	})
 }
 
-func TestValidateRenderedBaseHCL(t *testing.T) {
+func TestValidateRenderedHCL(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ValidHCL", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, validateRenderedBaseHCL([]byte(`resource "coder_agent" "main" {}`)))
+		require.NoError(t, validateRenderedHCL([]byte(`resource "coder_agent" "main" {}`)))
 	})
 
 	t.Run("InvalidHCL", func(t *testing.T) {
 		t.Parallel()
-		// Compose relies on this backstop to reject invalid rendered HCL on the
-		// zero-module path rather than shipping a broken main.tf.
-		err := validateRenderedBaseHCL([]byte("resource {"))
+		// Compose relies on this backstop to reject invalid rendered HCL rather than
+		// shipping a broken template.
+		err := validateRenderedHCL([]byte("resource {"))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "not valid HCL")
+		// It is identifiable as a server-side fault and exposes every diagnostic.
+		require.ErrorIs(t, err, ErrRenderedHCLInvalid)
+		var diag *hcl.Diagnostic
+		require.ErrorAs(t, err, &diag)
 	})
+}
+
+func TestComposeRendersValidHCL(t *testing.T) {
+	t.Parallel()
+	// Exercise the Compose call sites that validate rendered HCL: both the base
+	// main.tf and the rendered modules.tf must parse.
+	res, err := Compose(ComposeRequest{
+		BaseTemplateID: "docker",
+		Modules:        []ComposeModule{{ID: "code-server"}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, validateRenderedHCL(res.MainTF))
+	require.NotEmpty(t, res.ModulesTF)
+	require.NoError(t, validateRenderedHCL(res.ModulesTF))
 }

--- a/coderd/templatebuilder/compose_internal_test.go
+++ b/coderd/templatebuilder/compose_internal_test.go
@@ -166,11 +166,8 @@ func TestValidateRenderedBaseHCL(t *testing.T) {
 
 	t.Run("InvalidHCL", func(t *testing.T) {
 		t.Parallel()
-		// A base that rendered to invalid HCL (for example a registry value that
-		// slipped past normalization and interpolated badly) must fail with the
-		// parser diagnostic rather than being shipped as a broken main.tf. Compose
-		// relies on this backstop on the zero-module path, so the error branch
-		// needs direct coverage.
+		// Compose relies on this backstop to reject invalid rendered HCL on the
+		// zero-module path rather than shipping a broken main.tf.
 		err := validateRenderedBaseHCL([]byte("resource {"))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "not valid HCL")

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -7,11 +7,14 @@ import (
 	"io"
 	"io/fs"
 	"regexp"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/templatebuilder"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 func TestCompose(t *testing.T) {
@@ -21,7 +24,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, result.MainTF)
@@ -34,7 +37,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{
 					ID: "code-server",
@@ -59,7 +62,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "aws-linux",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "git-commit-signing"},
 			},
@@ -72,7 +75,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "aws-linux",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.NotNil(t, result.ExtraFiles, "aws-linux should have extra files")
@@ -85,7 +88,7 @@ func TestCompose(t *testing.T) {
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID:     "gcp-linux",
 			BaseVariableValues: map[string]string{"project_id": "my-gcp-project"},
-			RegistryURL:        "https://registry.coder.com",
+			RegistryURL:        "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, result.MainTF)
@@ -100,7 +103,7 @@ func TestCompose(t *testing.T) {
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID:     "gcp-windows",
 			BaseVariableValues: map[string]string{"project_id": "my-gcp-project"},
-			RegistryURL:        "https://registry.coder.com",
+			RegistryURL:        "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, result.MainTF)
@@ -114,7 +117,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "gcp-linux",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `variable "project_id" is required`)
@@ -124,7 +127,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "azure-linux",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.Contains(t, result.ExtraFiles, "cloud-init/cloud-config.yaml.tftpl")
@@ -134,7 +137,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "claude-code"},
 			},
@@ -152,7 +155,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "code-server"},
 				{
@@ -187,7 +190,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "code-server"},
 				{ID: "code-server"},
@@ -204,7 +207,7 @@ func TestCompose(t *testing.T) {
 		// module block, so compose must reject it.
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "quickstart",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "git-clone"},
 			},
@@ -219,7 +222,7 @@ func TestCompose(t *testing.T) {
 		// code-server compose normally on top of it.
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "quickstart",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "code-server"},
 			},
@@ -232,7 +235,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "code-server"},
 				{ID: "vscode-web"},
@@ -246,7 +249,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.Empty(t, result.ExtraFiles, "docker should have no extra files")
@@ -256,7 +259,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "nonexistent",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unknown base template")
@@ -266,7 +269,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "nonexistent-module"},
 			},
@@ -279,7 +282,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{
 					ID: "code-server",
@@ -298,7 +301,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{
 					ID: "code-server",
@@ -317,7 +320,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{
 					ID: "code-server",
@@ -335,7 +338,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.NoError(t, err)
 		require.Contains(t, string(result.MainTF), `"codercom/example-base:ubuntu"`)
@@ -345,7 +348,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			BaseVariableValues: map[string]string{
 				"container_image": "myregistry/myimage:v2",
 			},
@@ -360,7 +363,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "kubernetes",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			BaseVariableValues: map[string]string{
 				"namespace": "default",
 			},
@@ -373,7 +376,7 @@ func TestCompose(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "kubernetes",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			BaseVariableValues: map[string]string{
 				"namespace":       "default",
 				"container_image": "custom/workspace:latest",
@@ -391,7 +394,7 @@ func TestCompose(t *testing.T) {
 		// Omitting it should cause a render error from missingkey=error.
 		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "git-clone"},
 			},
@@ -463,7 +466,7 @@ func TestBundleTar(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "docker",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 			Modules: []templatebuilder.ComposeModule{
 				{ID: "code-server"},
 			},
@@ -525,7 +528,7 @@ func TestBundleTar(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
 			BaseTemplateID: "aws-linux",
-			RegistryURL:    "https://registry.coder.com",
+			RegistryURL:    "registry.coder.com",
 		})
 		require.NoError(t, err)
 
@@ -598,6 +601,183 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 
 	require.ElementsMatch(t, selectorValues, dispatchNames,
 		"quickstart languages selector options must match the install script's has_language branches")
+}
+
+func TestRenderBaseHonorsRegistryMirror(t *testing.T) {
+	t.Parallel()
+
+	const mirror = "mirror.internal.example"
+
+	// resolvesThroughMirror reports whether a Terraform module source resolves
+	// through the configured registry: either the mirror host, or a local path
+	// (./ or ../) that carries no registry host at all.
+	resolvesThroughMirror := func(source string) bool {
+		return strings.HasPrefix(source, mirror+"/") ||
+			strings.HasPrefix(source, "./") ||
+			strings.HasPrefix(source, "../")
+	}
+
+	// Positive anchor: the quickstart base embeds git-clone, so a configured
+	// mirror must appear in its rendered source. This keeps the per-base sweep
+	// below from passing vacuously, since a base with no embedded catalog module
+	// satisfies the negative assertion trivially.
+	rc := testRenderContext("quickstart")
+	rc.RegistryBase = mirror
+	rendered, err := templatebuilder.RenderBaseTemplate("quickstart", "main.tf.tmpl", rc)
+	require.NoError(t, err)
+	require.Contains(t, string(rendered), mirror+"/coder/git-clone/coder",
+		"quickstart must render its embedded module source against the configured registry")
+
+	// Every base must honor the mirror: once a mirror is configured, every
+	// rendered module block's `source` must resolve through it. Reading each
+	// module's source from the parsed HCL (instead of a substring scan over the
+	// rendered text) means a hostless source ("coder/git-clone/coder"), a
+	// third-party host, or the default registry under any namespace all fail,
+	// while a `#`/`//` comment or a registry name inside a heredoc script body is
+	// never mistaken for a module source. Sorting BaseTemplateIDs() pins the
+	// otherwise map-ordered subtests.
+	ids := templatebuilder.BaseTemplateIDs()
+	slices.Sort(ids)
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			rc := testRenderContext(id)
+			rc.RegistryBase = mirror
+			rendered, err := templatebuilder.RenderBaseTemplate(id, "main.tf.tmpl", rc)
+			require.NoError(t, err)
+			for _, source := range templatebuilder.ExtractModuleSources(rendered) {
+				require.True(t, resolvesThroughMirror(source),
+					"base %q module source %q must resolve through the configured registry %q, not a hardcoded host or namespace",
+					id, source, mirror)
+			}
+		})
+	}
+}
+
+func TestComposeThreadsRegistryURLToBase(t *testing.T) {
+	t.Parallel()
+
+	const mirror = "mirror.internal.example"
+
+	// Compose threads ComposeRequest.RegistryURL into base rendering, so the
+	// quickstart base's embedded git-clone module resolves through the mirror.
+	res, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+		BaseTemplateID: "quickstart",
+		RegistryURL:    mirror,
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(res.MainTF), mirror+"/coder/git-clone/coder")
+	require.NotContains(t, string(res.MainTF),
+		codersdk.DefaultTemplateBuilderRegistryURL+"/coder/git-clone/coder")
+
+	// With RegistryURL unset, the base falls back to the canonical default
+	// instead of rendering a registry-less source.
+	resDefault, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+		BaseTemplateID: "quickstart",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(resDefault.MainTF),
+		codersdk.DefaultTemplateBuilderRegistryURL+"/coder/git-clone/coder")
+}
+
+// TestComposeNormalizesRegistryURL covers the boundary normalization Compose
+// applies to ComposeRequest.RegistryURL: a scheme and trailing slash are
+// stripped, an empty value defaults on the module path (not just the base), and
+// a value that would corrupt the Terraform source is rejected.
+func TestComposeNormalizesRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StripsSchemeAndTrailingSlash", func(t *testing.T) {
+		t.Parallel()
+		res, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "https://mirror.internal.example/",
+		})
+		require.NoError(t, err)
+		mainTF := string(res.MainTF)
+		require.Contains(t, mainTF, "mirror.internal.example/coder/git-clone/coder")
+		require.NotContains(t, mainTF, "https://mirror.internal.example")
+		require.NotContains(t, mainTF, "mirror.internal.example//coder")
+	})
+
+	t.Run("EmptyDefaultsOnModulePath", func(t *testing.T) {
+		t.Parallel()
+		// CODER_TEMPLATE_BUILDER_REGISTRY_URL= (present but empty) reaches Compose
+		// as ""; the module path must default too, not render a registry-less source.
+		res, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			Modules:        []templatebuilder.ComposeModule{{ID: "code-server"}},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, res.ModulesTF)
+		require.Contains(t, string(res.ModulesTF),
+			codersdk.DefaultTemplateBuilderRegistryURL+"/coder/code-server/coder")
+		require.NotContains(t, string(res.ModulesTF), `"/coder/code-server/coder"`)
+	})
+
+	t.Run("RejectsQuote", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    `mirror.example.com/"`,
+		})
+		require.ErrorContains(t, err, "bare host")
+	})
+
+	t.Run("StripsUppercaseScheme", func(t *testing.T) {
+		t.Parallel()
+		// A scheme is case-insensitive by RFC, so an uppercase scheme must be
+		// stripped, not left to render into the source.
+		res, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "HTTPS://mirror.internal.example",
+		})
+		require.NoError(t, err)
+		mainTF := string(res.MainTF)
+		require.Contains(t, mainTF, "mirror.internal.example/coder/git-clone/coder")
+		require.NotContains(t, mainTF, "HTTPS://")
+	})
+
+	t.Run("RejectsCredentials", func(t *testing.T) {
+		t.Parallel()
+		// Userinfo must be rejected, not silently stripped: it would otherwise
+		// render the deployment's mirror credential into the returned main.tf.
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "https://user:s3cr3t-token@mirror.example.com",
+		})
+		require.ErrorContains(t, err, "bare host")
+		// The rejection error must not echo the credential it rejected.
+		require.NotContains(t, err.Error(), "s3cr3t-token")
+	})
+
+	t.Run("RejectsInterpolation", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "mirror.example.com/${var.evil}",
+		})
+		require.ErrorContains(t, err, "bare host")
+	})
+
+	t.Run("RejectsBackslash", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    `mirror.example.com\x`,
+		})
+		require.ErrorContains(t, err, "bare host")
+	})
+
+	t.Run("RejectsDoubledScheme", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "quickstart",
+			RegistryURL:    "https://https://mirror.example.com",
+		})
+		require.ErrorContains(t, err, "bare host")
+	})
 }
 
 // extractTar reads a tar archive and returns a map of filename to content.

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -641,7 +641,13 @@ func TestRenderBaseHonorsRegistryMirror(t *testing.T) {
 			rc.RegistryBase = mirror
 			rendered, err := templatebuilder.RenderBaseTemplate(id, "main.tf.tmpl", rc)
 			require.NoError(t, err)
-			for _, source := range templatebuilder.ExtractModuleSources(rendered) {
+			// Guard against a vacuous sweep: a parse failure or a non-static source
+			// makes ExtractModuleSources drop entries, so require one extracted
+			// source per module block before asserting on them.
+			sources := templatebuilder.ExtractModuleSources(rendered)
+			require.Len(t, sources, len(templatebuilder.ExtractModuleNames(rendered)),
+				"base %q: every module block must have a static, extractable source", id)
+			for _, source := range sources {
 				require.True(t, resolvesThroughMirror(source),
 					"base %q module source %q must resolve through the configured registry %q, not a hardcoded host or namespace",
 					id, source, mirror)

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -608,19 +608,17 @@ func TestRenderBaseHonorsRegistryMirror(t *testing.T) {
 
 	const mirror = "mirror.internal.example"
 
-	// resolvesThroughMirror reports whether a Terraform module source resolves
-	// through the configured registry: either the mirror host, or a local path
-	// (./ or ../) that carries no registry host at all.
+	// resolvesThroughMirror reports whether a module source resolves through the
+	// configured registry: the mirror host, or a hostless local path (./ or ../).
 	resolvesThroughMirror := func(source string) bool {
 		return strings.HasPrefix(source, mirror+"/") ||
 			strings.HasPrefix(source, "./") ||
 			strings.HasPrefix(source, "../")
 	}
 
-	// Positive anchor: the quickstart base embeds git-clone, so a configured
-	// mirror must appear in its rendered source. This keeps the per-base sweep
-	// below from passing vacuously, since a base with no embedded catalog module
-	// satisfies the negative assertion trivially.
+	// Positive anchor: quickstart embeds git-clone, so the mirror must appear in
+	// its rendered source. This keeps the per-base sweep below from passing
+	// vacuously on a base with no embedded module.
 	rc := testRenderContext("quickstart")
 	rc.RegistryBase = mirror
 	rendered, err := templatebuilder.RenderBaseTemplate("quickstart", "main.tf.tmpl", rc)
@@ -628,14 +626,11 @@ func TestRenderBaseHonorsRegistryMirror(t *testing.T) {
 	require.Contains(t, string(rendered), mirror+"/coder/git-clone/coder",
 		"quickstart must render its embedded module source against the configured registry")
 
-	// Every base must honor the mirror: once a mirror is configured, every
-	// rendered module block's `source` must resolve through it. Reading each
-	// module's source from the parsed HCL (instead of a substring scan over the
-	// rendered text) means a hostless source ("coder/git-clone/coder"), a
-	// third-party host, or the default registry under any namespace all fail,
-	// while a `#`/`//` comment or a registry name inside a heredoc script body is
-	// never mistaken for a module source. Sorting BaseTemplateIDs() pins the
-	// otherwise map-ordered subtests.
+	// Every base must honor the mirror: every rendered module block's `source`
+	// must resolve through it. Reading each source from the parsed HCL (not a
+	// substring scan) makes a hostless, third-party, or default-registry source
+	// fail while never mistaking a comment or heredoc body for a module source.
+	// Sorting BaseTemplateIDs() pins the otherwise map-ordered subtests.
 	ids := templatebuilder.BaseTemplateIDs()
 	slices.Sort(ids)
 	for _, id := range ids {
@@ -682,9 +677,8 @@ func TestComposeThreadsRegistryURLToBase(t *testing.T) {
 }
 
 // TestComposeNormalizesRegistryURL covers the boundary normalization Compose
-// applies to ComposeRequest.RegistryURL: a scheme and trailing slash are
-// stripped, an empty value defaults on the module path (not just the base), and
-// a value that would corrupt the Terraform source is rejected.
+// applies to ComposeRequest.RegistryURL: scheme and trailing slash stripped,
+// empty defaults on the module path, and a corrupting value rejected.
 func TestComposeNormalizesRegistryURL(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -22,23 +22,18 @@ type ImageOption struct {
 type BaseRenderContext struct {
 	ContainerImage string
 	ImageOptions   []ImageOption
-	// RegistryBase is the bare host of the module registry used in rendered
-	// module source paths (e.g. "registry.coder.com"): no scheme, no trailing
-	// slash, never empty. Compose normalizes it from the deployment config
-	// (CODER_TEMPLATE_BUILDER_REGISTRY_URL) via
-	// codersdk.NormalizeTemplateBuilderRegistryURL; direct RenderBaseTemplate
-	// callers must supply an already-normalized host, or the source renders as
-	// "/coder/...".
+	// RegistryBase is the bare host (no scheme, no trailing slash, never empty)
+	// used in rendered module source paths. Compose normalizes it; direct
+	// RenderBaseTemplate callers must supply an already-normalized host.
 	RegistryBase string
 	Variables    map[string]string
 }
 
 // ModuleRenderContext is the data passed to module .tf.tmpl files.
 type ModuleRenderContext struct {
-	// RegistryBase is the bare host of the module registry used in rendered
-	// module source paths (e.g. "registry.coder.com"): no scheme, no trailing
-	// slash, never empty. renderModules passes the host Compose already
-	// normalized from CODER_TEMPLATE_BUILDER_REGISTRY_URL.
+	// RegistryBase is the bare host (no scheme, no trailing slash, never empty)
+	// used in rendered module source paths. renderModules passes the host
+	// Compose already normalized.
 	RegistryBase string
 	// PinnedVersion is the module version from the catalog manifest.
 	PinnedVersion string
@@ -168,12 +163,8 @@ func ExtractModuleNames(hcl []byte) []string {
 	return names
 }
 
-// validateRenderedBaseHCL parses rendered base HCL and returns the parser
-// diagnostic when it is malformed. Compose calls this before its module
-// early-return so a base that rendered to invalid HCL (for example, a registry
-// value that slipped past normalization and interpolated badly) fails with the
-// real syntax error instead of shipping a broken main.tf on the zero-module path
-// or failing later with a misleading missing-agent error on the module path.
+// validateRenderedBaseHCL returns a diagnostic when rendered base HCL is
+// malformed, so Compose can fail a broken main.tf instead of shipping it.
 func validateRenderedBaseHCL(hclSrc []byte) error {
 	if _, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos); diags.HasErrors() {
 		return xerrors.Errorf("rendered base template is not valid HCL: %w", diags)
@@ -181,11 +172,8 @@ func validateRenderedBaseHCL(hclSrc []byte) error {
 	return nil
 }
 
-// parseHCLBody parses rendered HCL from one of our curated base templates and
-// returns its top-level body. The input is expected to be valid HCL produced by
-// our own templates; on a parse error it returns nil so callers fail safe.
-// ExtractModuleSources turns a nil body into an empty result, which trips its
-// caller's assertions rather than passing silently.
+// parseHCLBody parses rendered base HCL and returns its top-level body, or nil
+// on a parse error.
 func parseHCLBody(hclSrc []byte) *hclsyntax.Body {
 	file, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos)
 	if diags.HasErrors() || file == nil {
@@ -198,13 +186,9 @@ func parseHCLBody(hclSrc []byte) *hclsyntax.Body {
 	return body
 }
 
-// ExtractModuleSources returns the `source` string of every top-level `module`
-// block in rendered HCL, in declaration order. A module block whose source is
-// not a static string is skipped. Parsing with hclsyntax means commented-out
-// blocks and module-like text inside strings or heredocs are ignored, so the
-// result is exactly the set of sources Terraform would resolve. The input is
-// expected to be rendered output from our own curated base templates, not
-// arbitrary user HCL.
+// ExtractModuleSources returns the source of every top-level module block in
+// rendered HCL, in declaration order, skipping any whose source is not a static
+// string.
 func ExtractModuleSources(hclSrc []byte) []string {
 	body := parseHCLBody(hclSrc)
 	if body == nil {

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 	"text/template"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/xerrors"
 )
 
@@ -19,13 +22,23 @@ type ImageOption struct {
 type BaseRenderContext struct {
 	ContainerImage string
 	ImageOptions   []ImageOption
-	Variables      map[string]string
+	// RegistryBase is the bare host of the module registry used in rendered
+	// module source paths (e.g. "registry.coder.com"): no scheme, no trailing
+	// slash, never empty. Compose normalizes it from the deployment config
+	// (CODER_TEMPLATE_BUILDER_REGISTRY_URL) via
+	// codersdk.NormalizeTemplateBuilderRegistryURL; direct RenderBaseTemplate
+	// callers must supply an already-normalized host, or the source renders as
+	// "/coder/...".
+	RegistryBase string
+	Variables    map[string]string
 }
 
 // ModuleRenderContext is the data passed to module .tf.tmpl files.
 type ModuleRenderContext struct {
-	// RegistryBase is the module registry URL from the deployment config
-	// (CODER_TEMPLATE_BUILDER_REGISTRY_URL).
+	// RegistryBase is the bare host of the module registry used in rendered
+	// module source paths (e.g. "registry.coder.com"): no scheme, no trailing
+	// slash, never empty. renderModules passes the host Compose already
+	// normalized from CODER_TEMPLATE_BUILDER_REGISTRY_URL.
 	RegistryBase string
 	// PinnedVersion is the module version from the catalog manifest.
 	PinnedVersion string
@@ -153,4 +166,72 @@ func ExtractModuleNames(hcl []byte) []string {
 		names = append(names, string(m[1]))
 	}
 	return names
+}
+
+// validateRenderedBaseHCL parses rendered base HCL and returns the parser
+// diagnostic when it is malformed. Compose calls this before its module
+// early-return so a base that rendered to invalid HCL (for example, a registry
+// value that slipped past normalization and interpolated badly) fails with the
+// real syntax error instead of shipping a broken main.tf on the zero-module path
+// or failing later with a misleading missing-agent error on the module path.
+func validateRenderedBaseHCL(hclSrc []byte) error {
+	if _, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos); diags.HasErrors() {
+		return xerrors.Errorf("rendered base template is not valid HCL: %w", diags)
+	}
+	return nil
+}
+
+// parseHCLBody parses rendered HCL from one of our curated base templates and
+// returns its top-level body. The input is expected to be valid HCL produced by
+// our own templates; on a parse error it returns nil so callers fail safe.
+// ExtractModuleSources turns a nil body into an empty result, which trips its
+// caller's assertions rather than passing silently.
+func parseHCLBody(hclSrc []byte) *hclsyntax.Body {
+	file, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos)
+	if diags.HasErrors() || file == nil {
+		return nil
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+	return body
+}
+
+// ExtractModuleSources returns the `source` string of every top-level `module`
+// block in rendered HCL, in declaration order. A module block whose source is
+// not a static string is skipped. Parsing with hclsyntax means commented-out
+// blocks and module-like text inside strings or heredocs are ignored, so the
+// result is exactly the set of sources Terraform would resolve. The input is
+// expected to be rendered output from our own curated base templates, not
+// arbitrary user HCL.
+func ExtractModuleSources(hclSrc []byte) []string {
+	body := parseHCLBody(hclSrc)
+	if body == nil {
+		return nil
+	}
+	var sources []string
+	for _, block := range body.Blocks {
+		if block.Type != "module" {
+			continue
+		}
+		attr, ok := block.Body.Attributes["source"]
+		if !ok {
+			continue
+		}
+		if s, ok := staticString(attr.Expr); ok {
+			sources = append(sources, s)
+		}
+	}
+	return sources
+}
+
+// staticString evaluates an expression expected to be a constant string (no
+// variables or functions) and reports whether it produced one.
+func staticString(expr hcl.Expression) (string, bool) {
+	val, diags := expr.Value(nil)
+	if diags.HasErrors() || val.IsNull() || val.Type() != cty.String {
+		return "", false
+	}
+	return val.AsString(), true
 }

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -2,6 +2,7 @@ package templatebuilder
 
 import (
 	"bytes"
+	"errors"
 	"io/fs"
 	"regexp"
 	"text/template"
@@ -163,13 +164,21 @@ func ExtractModuleNames(hcl []byte) []string {
 	return names
 }
 
-// validateRenderedBaseHCL returns a diagnostic when rendered base HCL is
-// malformed, so Compose can fail a broken main.tf instead of shipping it.
-func validateRenderedBaseHCL(hclSrc []byte) error {
-	if _, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos); diags.HasErrors() {
-		return xerrors.Errorf("rendered base template is not valid HCL: %w", diags)
+// ErrRenderedHCLInvalid identifies a Compose failure caused by a curated base or
+// module rendering to invalid HCL. That is a server-side fault, not bad client
+// input, so handlers map it to a 500.
+var ErrRenderedHCLInvalid = xerrors.New("rendered template is not valid HCL")
+
+// validateRenderedHCL returns an error when rendered HCL is malformed, so Compose
+// fails a broken template instead of shipping it. The result joins
+// ErrRenderedHCLInvalid with every parse diagnostic, so a caller can both
+// errors.Is it and errors.As out an *hcl.Diagnostic.
+func validateRenderedHCL(hclSrc []byte) error {
+	_, diags := hclsyntax.ParseConfig(hclSrc, "rendered.tf", hcl.InitialPos)
+	if !diags.HasErrors() {
+		return nil
 	}
-	return nil
+	return errors.Join(append([]error{ErrRenderedHCLInvalid}, diags.Errs()...)...)
 }
 
 // parseHCLBody parses rendered base HCL and returns its top-level body, or nil

--- a/coderd/templatebuilder/render_test.go
+++ b/coderd/templatebuilder/render_test.go
@@ -121,7 +121,7 @@ func TestRenderModuleTemplate(t *testing.T) {
 			},
 		}
 		ctx := templatebuilder.ModuleRenderContext{
-			RegistryBase:      "https://registry.coder.com",
+			RegistryBase:      "registry.coder.com",
 			PinnedVersion:     "1.5.0",
 			AgentResourceName: "main",
 			Variables:         map[string]string{"port": "8080"},
@@ -129,7 +129,7 @@ func TestRenderModuleTemplate(t *testing.T) {
 		out, err := templatebuilder.RenderModuleTemplate(fsys, "test.tf.tmpl", ctx)
 		require.NoError(t, err)
 		rendered := string(out)
-		require.Contains(t, rendered, `"https://registry.coder.com/coder/test/coder"`)
+		require.Contains(t, rendered, `"registry.coder.com/coder/test/coder"`)
 		require.Contains(t, rendered, `"1.5.0"`)
 		require.Contains(t, rendered, `coder_agent.main.id`)
 		require.Contains(t, rendered, `port = 8080`)
@@ -146,10 +146,10 @@ func TestRenderModuleTemplate(t *testing.T) {
 			},
 		}
 		out, err := templatebuilder.RenderModuleTemplate(fsys, "test.tf.tmpl", templatebuilder.ModuleRenderContext{
-			RegistryBase: "https://registry.coder.com",
+			RegistryBase: "registry.coder.com",
 		})
 		require.NoError(t, err)
-		require.Contains(t, string(out), "https://registry.coder.com")
+		require.Contains(t, string(out), "registry.coder.com")
 	})
 
 	t.Run("MissingKeyErrors", func(t *testing.T) {
@@ -202,7 +202,7 @@ func TestRenderModuleTemplate(t *testing.T) {
 		}
 
 		ctx := templatebuilder.ModuleRenderContext{
-			RegistryBase:      "https://registry.coder.com",
+			RegistryBase:      "registry.coder.com",
 			PinnedVersion:     csMod.PinnedVersion,
 			AgentResourceName: "main",
 			Variables:         vars,

--- a/coderd/templatebuilder/testdata/azure-linux.tf.golden
+++ b/coderd/templatebuilder/testdata/azure-linux.tf.golden
@@ -12,7 +12,7 @@ terraform {
   }
 }
 
-# See https://registry.coder.com/modules/coder/azure-region
+# Module docs (public registry): https://registry.coder.com/modules/coder/azure-region
 module "azure_region" {
   source = "registry.coder.com/coder/azure-region/coder"
 

--- a/coderd/templatebuilder/testdata/gcp-linux.tf.golden
+++ b/coderd/templatebuilder/testdata/gcp-linux.tf.golden
@@ -16,7 +16,7 @@ variable "project_id" {
   default     = "test-project_id"
 }
 
-# See https://registry.coder.com/modules/coder/gcp-region
+# Module docs (public registry): https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
   source = "registry.coder.com/coder/gcp-region/coder"
 

--- a/coderd/templatebuilder/testdata/gcp-windows.tf.golden
+++ b/coderd/templatebuilder/testdata/gcp-windows.tf.golden
@@ -16,7 +16,7 @@ variable "project_id" {
   default     = "test-project_id"
 }
 
-# See https://registry.coder.com/modules/coder/gcp-region
+# Module docs (public registry): https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
   source = "registry.coder.com/coder/gcp-region/coder"
 

--- a/coderd/templatebuilder/testdata/quickstart.tf.golden
+++ b/coderd/templatebuilder/testdata/quickstart.tf.golden
@@ -151,15 +151,11 @@ resource "coder_script" "install_languages" {
 }
 
 # --- Git clone ---
-# NOTE: base templates render their module sources verbatim, so this pins the
-# public registry (registry.coder.com). Unlike wizard-composed modules, a
-# base-embedded module does not yet honor a deployment's configured module
-# registry mirror; threading that registry through base rendering is tracked as
-# a follow-up.
-
+# Module docs (public registry): https://registry.coder.com/modules/coder/git-clone
 module "git-clone" {
   count    = data.coder_workspace.me.start_count * (data.coder_parameter.git_repo.value != "" ? 1 : 0)
   source   = "registry.coder.com/coder/git-clone/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version  = "~> 2.0"
   agent_id = coder_agent.main.id
   url      = data.coder_parameter.git_repo.value

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -226,6 +226,15 @@ func (api *API) templateBuilderCompose(rw http.ResponseWriter, r *http.Request) 
 
 	result, err := templatebuilder.Compose(composeReq)
 	if err != nil {
+		// A curated base or module rendering to invalid HCL is a server-side fault,
+		// not bad client input, so surface it as a 500.
+		if xerrors.Is(err, templatebuilder.ErrRenderedHCLInvalid) {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error composing template.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to compose template.",
 			Detail:  err.Error(),
@@ -336,6 +345,15 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 
 	result, err := templatebuilder.Compose(composeReq)
 	if err != nil {
+		// A curated base or module rendering to invalid HCL is a server-side fault,
+		// not bad client input, so surface it as a 500.
+		if xerrors.Is(err, templatebuilder.ErrRenderedHCLInvalid) {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error composing template.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to compose template.",
 			Detail:  err.Error(),

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/uuid"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"golang.org/x/mod/semver"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -4988,13 +4990,20 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Template Builder Registry URL",
-			Description: "The base URL of the module registry used by the template builder for module source paths.",
+			Description: "The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example \"registry.coder.com\" or \"mirror.internal:8443\"). An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.",
 			Flag:        "template-builder-registry-url",
 			Env:         "CODER_TEMPLATE_BUILDER_REGISTRY_URL",
-			Value:       &c.TemplateBuilder.RegistryURL,
-			Default:     "registry.coder.com",
-			Group:       &deploymentGroupTemplateBuilder,
-			YAML:        "registryURL",
+			// The value is validated once in DeploymentValues.Validate, gated on the
+			// template builder being enabled, rather than with a per-option
+			// serpent.Validate. A serpent validator only runs in Set, which the YAML
+			// path bypasses, and it cannot see whether the subsystem is disabled;
+			// validating after all sources merge covers a YAML-configured value and
+			// lets a deployment with the template builder disabled boot on an inert
+			// setting.
+			Value:   &c.TemplateBuilder.RegistryURL,
+			Default: DefaultTemplateBuilderRegistryURL,
+			Group:   &deploymentGroupTemplateBuilder,
+			YAML:    "registryURL",
 		},
 	}
 
@@ -5122,6 +5131,75 @@ type AIConfig struct {
 	Chat              ChatConfig          `json:"chat,omitempty" typescript:",notnull"`
 }
 
+// DefaultTemplateBuilderRegistryURL is the module registry the template builder
+// uses for module source paths when CODER_TEMPLATE_BUILDER_REGISTRY_URL is unset
+// or empty. It is a bare host (no scheme, no trailing slash), the shape
+// NormalizeTemplateBuilderRegistryURL enforces for any operator-supplied value.
+const DefaultTemplateBuilderRegistryURL = "registry.coder.com"
+
+// templateBuilderRegistrySchemePattern matches a leading http:// or https://
+// scheme, case-insensitively, so NormalizeTemplateBuilderRegistryURL can strip
+// it before validating the host.
+var templateBuilderRegistrySchemePattern = regexp.MustCompile(`(?i)^https?://`)
+
+// NormalizeTemplateBuilderRegistryURL canonicalizes the deployment's configured
+// module registry (CODER_TEMPLATE_BUILDER_REGISTRY_URL) into the bare host a
+// Terraform module source expects. An unset or empty value defaults to
+// DefaultTemplateBuilderRegistryURL. A leading http:// or https:// scheme (any
+// case) and trailing slashes are stripped, then the remainder is validated by
+// svchost.ForComparison, the same parser Terraform uses to read a module source
+// host: a Unicode host is normalized to punycode, a port over 65535 is
+// rejected, and userinfo, a path, a query, a fragment, a raw-punycode label,
+// whitespace, or an HCL interpolation is rejected rather than silently mangled,
+// because the value is interpolated verbatim into a module source string.
+// Delegating keeps this validator in lockstep with what `terraform init` will
+// accept instead of a hand-rolled pattern that drifts from it. The error never
+// echoes the input, so a credential in a misconfigured value is not disclosed.
+func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return DefaultTemplateBuilderRegistryURL, nil
+	}
+	host := strings.TrimRight(templateBuilderRegistrySchemePattern.ReplaceAllString(trimmed, ""), "/")
+
+	// Name the specific broken rule where we can, without echoing the input, so
+	// an operator can fix a misconfigured value without it (and any credential
+	// in it) being surfaced.
+	switch {
+	case strings.ContainsRune(host, '@'):
+		return "", newTemplateBuilderRegistryURLError("it must not contain credentials")
+	case strings.ContainsRune(host, '/'):
+		return "", newTemplateBuilderRegistryURLError("it must not contain a path")
+	case strings.ContainsRune(host, '?'):
+		return "", newTemplateBuilderRegistryURLError("it must not contain a query")
+	case strings.ContainsRune(host, '#'):
+		return "", newTemplateBuilderRegistryURLError("it must not contain a fragment")
+	case strings.HasPrefix(host, "["):
+		return "", newTemplateBuilderRegistryURLError("IPv6 address literals are not supported")
+	}
+
+	// svchost.ForComparison is the parser Terraform applies to a module source
+	// host. Its error can echo the input, so map any failure to the generic
+	// non-echoing rejection rather than surfacing it.
+	normalized, err := svchost.ForComparison(host)
+	if err != nil {
+		return "", newTemplateBuilderRegistryURLError("")
+	}
+	return string(normalized), nil
+}
+
+// newTemplateBuilderRegistryURLError builds the operator-facing rejection for a
+// bad CODER_TEMPLATE_BUILDER_REGISTRY_URL. It names the setting and the expected
+// shape (and, when known, the specific broken rule) but never echoes the input,
+// so a credential in the value is not disclosed.
+func newTemplateBuilderRegistryURLError(reason string) error {
+	msg := `template builder registry URL must be a bare host such as "registry.coder.com", optionally with a port`
+	if reason != "" {
+		msg += "; " + reason
+	}
+	return xerrors.New(msg + "; set it with the --template-builder-registry-url flag, the CODER_TEMPLATE_BUILDER_REGISTRY_URL environment variable, or the templateBuilder.registryURL YAML key")
+}
+
 type TemplateBuilderConfig struct {
 	Disabled    serpent.Bool   `json:"disabled,omitempty"`
 	RegistryURL serpent.String `json:"registry_url,omitempty"`
@@ -5196,6 +5274,19 @@ func (c *DeploymentValues) Validate() error {
 			if hookTimeout <= 0 || hookTimeout > 5*time.Second {
 				return xerrors.Errorf("chat hook timeout (%s) must be greater than zero and no more than 5s; set --chat-hook-timeout to a valid duration", hookTimeout)
 			}
+		}
+	}
+
+	// A disabled template builder must not validate an inert registry setting.
+	// This runs after all config sources merge (flag, env, and YAML), so a value
+	// set through YAML is validated too, even though the per-option serpent
+	// validator that would otherwise run only fires in Set and UnmarshalYAML
+	// bypasses it. A malformed value fails at server start naming the option,
+	// instead of surfacing as a per-request 400 on every compose blamed on the
+	// wizard user.
+	if !c.TemplateBuilder.Disabled.Value() {
+		if _, err := NormalizeTemplateBuilderRegistryURL(c.TemplateBuilder.RegistryURL.Value()); err != nil {
+			return err
 		}
 	}
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -5137,9 +5138,9 @@ var templateBuilderRegistrySchemePattern = regexp.MustCompile(`(?i)^https?://`)
 // CODER_TEMPLATE_BUILDER_REGISTRY_URL into the bare host a Terraform module
 // source expects, defaulting to DefaultTemplateBuilderRegistryURL when empty.
 // It strips an http(s):// scheme and trailing slashes, then delegates host
-// validation to svchost.ForComparison, the same parser `terraform init` uses,
-// so this stays in lockstep with what Terraform accepts. The error never echoes
-// the input, so a credential in a misconfigured value is not disclosed.
+// validation to svchost, the same parser `terraform init` uses, and returns the
+// display (Unicode) form a module source resolves through. The error names the
+// broken rule but never echoes a credential in a misconfigured value.
 func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -5147,7 +5148,7 @@ func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 	}
 	host := strings.TrimRight(templateBuilderRegistrySchemePattern.ReplaceAllString(trimmed, ""), "/")
 
-	// Name the specific broken rule where we can, without echoing the input.
+	// Reject these before svchost runs so the error cannot echo a credential.
 	switch {
 	case strings.ContainsRune(host, '@'):
 		return "", newTemplateBuilderRegistryURLError("it must not contain credentials")
@@ -5161,13 +5162,30 @@ func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 		return "", newTemplateBuilderRegistryURLError("IPv6 address literals are not supported")
 	}
 
-	// svchost.ForComparison can echo the input in its error, so map any failure
-	// to the generic non-echoing rejection rather than surfacing it.
+	// Credentials are already rejected, so svchost's diagnosis names the broken
+	// rule without disclosing a secret.
 	normalized, err := svchost.ForComparison(host)
 	if err != nil {
-		return "", newTemplateBuilderRegistryURLError("")
+		return "", newTemplateBuilderRegistryURLError(err.Error())
 	}
-	return string(normalized), nil
+	// A Terraform module source expects an IDN host in Unicode, not the punycode
+	// comparison form.
+	display := normalized.ForDisplay()
+
+	// svchost accepts shapes a module source cannot resolve: an out-of-range port
+	// and an empty label (for example from an ignorable Unicode rune). Reject them
+	// so the result is a host Terraform will actually resolve.
+	name := display
+	if h, port, splitErr := net.SplitHostPort(display); splitErr == nil {
+		name = h
+		if p, convErr := strconv.Atoi(port); convErr != nil || p < 1 || p > 65535 {
+			return "", newTemplateBuilderRegistryURLError("the port must be between 1 and 65535")
+		}
+	}
+	if strings.HasPrefix(name, ".") || strings.Contains(name, "..") {
+		return "", newTemplateBuilderRegistryURLError("it must not contain an empty label")
+	}
+	return display, nil
 }
 
 // newTemplateBuilderRegistryURLError builds the operator-facing rejection for a

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4993,13 +4993,8 @@ Write out the current server config as YAML to stdout.`,
 			Description: "The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example \"registry.coder.com\" or \"mirror.internal:8443\"). An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.",
 			Flag:        "template-builder-registry-url",
 			Env:         "CODER_TEMPLATE_BUILDER_REGISTRY_URL",
-			// The value is validated once in DeploymentValues.Validate, gated on the
-			// template builder being enabled, rather than with a per-option
-			// serpent.Validate. A serpent validator only runs in Set, which the YAML
-			// path bypasses, and it cannot see whether the subsystem is disabled;
-			// validating after all sources merge covers a YAML-configured value and
-			// lets a deployment with the template builder disabled boot on an inert
-			// setting.
+			// Validated in DeploymentValues.Validate (not a per-option
+			// serpent.Validate) so the YAML path is covered; see there for why.
 			Value:   &c.TemplateBuilder.RegistryURL,
 			Default: DefaultTemplateBuilderRegistryURL,
 			Group:   &deploymentGroupTemplateBuilder,
@@ -5131,30 +5126,20 @@ type AIConfig struct {
 	Chat              ChatConfig          `json:"chat,omitempty" typescript:",notnull"`
 }
 
-// DefaultTemplateBuilderRegistryURL is the module registry the template builder
-// uses for module source paths when CODER_TEMPLATE_BUILDER_REGISTRY_URL is unset
-// or empty. It is a bare host (no scheme, no trailing slash), the shape
-// NormalizeTemplateBuilderRegistryURL enforces for any operator-supplied value.
+// DefaultTemplateBuilderRegistryURL is the bare-host module registry the
+// template builder uses when CODER_TEMPLATE_BUILDER_REGISTRY_URL is unset.
 const DefaultTemplateBuilderRegistryURL = "registry.coder.com"
 
-// templateBuilderRegistrySchemePattern matches a leading http:// or https://
-// scheme, case-insensitively, so NormalizeTemplateBuilderRegistryURL can strip
-// it before validating the host.
+// templateBuilderRegistrySchemePattern matches a leading http(s):// scheme to strip.
 var templateBuilderRegistrySchemePattern = regexp.MustCompile(`(?i)^https?://`)
 
-// NormalizeTemplateBuilderRegistryURL canonicalizes the deployment's configured
-// module registry (CODER_TEMPLATE_BUILDER_REGISTRY_URL) into the bare host a
-// Terraform module source expects. An unset or empty value defaults to
-// DefaultTemplateBuilderRegistryURL. A leading http:// or https:// scheme (any
-// case) and trailing slashes are stripped, then the remainder is validated by
-// svchost.ForComparison, the same parser Terraform uses to read a module source
-// host: a Unicode host is normalized to punycode, a port over 65535 is
-// rejected, and userinfo, a path, a query, a fragment, a raw-punycode label,
-// whitespace, or an HCL interpolation is rejected rather than silently mangled,
-// because the value is interpolated verbatim into a module source string.
-// Delegating keeps this validator in lockstep with what `terraform init` will
-// accept instead of a hand-rolled pattern that drifts from it. The error never
-// echoes the input, so a credential in a misconfigured value is not disclosed.
+// NormalizeTemplateBuilderRegistryURL canonicalizes
+// CODER_TEMPLATE_BUILDER_REGISTRY_URL into the bare host a Terraform module
+// source expects, defaulting to DefaultTemplateBuilderRegistryURL when empty.
+// It strips an http(s):// scheme and trailing slashes, then delegates host
+// validation to svchost.ForComparison, the same parser `terraform init` uses,
+// so this stays in lockstep with what Terraform accepts. The error never echoes
+// the input, so a credential in a misconfigured value is not disclosed.
 func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -5162,9 +5147,7 @@ func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 	}
 	host := strings.TrimRight(templateBuilderRegistrySchemePattern.ReplaceAllString(trimmed, ""), "/")
 
-	// Name the specific broken rule where we can, without echoing the input, so
-	// an operator can fix a misconfigured value without it (and any credential
-	// in it) being surfaced.
+	// Name the specific broken rule where we can, without echoing the input.
 	switch {
 	case strings.ContainsRune(host, '@'):
 		return "", newTemplateBuilderRegistryURLError("it must not contain credentials")
@@ -5178,9 +5161,8 @@ func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 		return "", newTemplateBuilderRegistryURLError("IPv6 address literals are not supported")
 	}
 
-	// svchost.ForComparison is the parser Terraform applies to a module source
-	// host. Its error can echo the input, so map any failure to the generic
-	// non-echoing rejection rather than surfacing it.
+	// svchost.ForComparison can echo the input in its error, so map any failure
+	// to the generic non-echoing rejection rather than surfacing it.
 	normalized, err := svchost.ForComparison(host)
 	if err != nil {
 		return "", newTemplateBuilderRegistryURLError("")
@@ -5189,9 +5171,7 @@ func NormalizeTemplateBuilderRegistryURL(raw string) (string, error) {
 }
 
 // newTemplateBuilderRegistryURLError builds the operator-facing rejection for a
-// bad CODER_TEMPLATE_BUILDER_REGISTRY_URL. It names the setting and the expected
-// shape (and, when known, the specific broken rule) but never echoes the input,
-// so a credential in the value is not disclosed.
+// bad CODER_TEMPLATE_BUILDER_REGISTRY_URL without echoing the input.
 func newTemplateBuilderRegistryURLError(reason string) error {
 	msg := `template builder registry URL must be a bare host such as "registry.coder.com", optionally with a port`
 	if reason != "" {
@@ -5277,13 +5257,11 @@ func (c *DeploymentValues) Validate() error {
 		}
 	}
 
-	// A disabled template builder must not validate an inert registry setting.
-	// This runs after all config sources merge (flag, env, and YAML), so a value
-	// set through YAML is validated too, even though the per-option serpent
-	// validator that would otherwise run only fires in Set and UnmarshalYAML
-	// bypasses it. A malformed value fails at server start naming the option,
-	// instead of surfacing as a per-request 400 on every compose blamed on the
-	// wizard user.
+	// Validate here, gated on the builder being enabled, rather than with a
+	// per-option serpent validator: this runs after flag, env, and YAML merge
+	// (the serpent validator only fires in Set, which the YAML path bypasses),
+	// so a bad value fails at server start naming the option instead of as a
+	// per-request 400 on every compose.
 	if !c.TemplateBuilder.Disabled.Value() {
 		if _, err := NormalizeTemplateBuilderRegistryURL(c.TemplateBuilder.RegistryURL.Value()); err != nil {
 			return err

--- a/codersdk/deployment_registry_test.go
+++ b/codersdk/deployment_registry_test.go
@@ -31,11 +31,9 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 			{"UppercaseSchemeStripped", "HTTPS://mirror.example.com", "mirror.example.com"},
 			{"TrailingSlashStripped", "https://mirror.example.com/", "mirror.example.com"},
 			{"TrailingSlashesStripped", "mirror.example.com///", "mirror.example.com"},
-			// svchost.ForComparison, the parser Terraform uses, defines these:
-			// an uppercase host is lowercased, a Unicode host is normalized to
-			// punycode, a trailing dot is a valid FQDN, and :443 is the default
-			// port and is dropped. The old hand-rolled regex rejected the middle
-			// two and preserved :443, diverging from what `terraform init` does.
+			// svchost.ForComparison (the parser Terraform uses) defines these
+			// normalizations; the old hand-rolled regex diverged from `terraform
+			// init` by rejecting the Unicode/FQDN cases and preserving :443.
 			{"HostLowercased", "Registry.Coder.Com", "registry.coder.com"},
 			{"UnicodeHostPunycoded", "m\u00fcnchen.example", "xn--mnchen-3ya.example"},
 			{"TrailingDotFQDN", "registry.coder.com.", "registry.coder.com."},
@@ -69,10 +67,9 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 			{"VerticalTab", "mirror\v.example.com"},
 			{"SchemeOnly", "https://"},
 			{"LeadingDot", ".mirror.example.com"},
-			// New coverage for the over-rejection/under-rejection class: the
-			// value is validated by svchost, so it now agrees with Terraform on
-			// each of these (raw punycode and underscores are rejected, a port
-			// over 65535 is rejected, and an IPv6 literal is not a registry host).
+			// Over/under-rejection class: validating by svchost makes these agree
+			// with Terraform (raw punycode, underscores, port >65535, and IPv6
+			// literals are all rejected).
 			{"RawPunycode", "xn--mnchen-3ya.example"},
 			{"Underscore", "under_score.example"},
 			{"PortTooHigh", "mirror.example.com:99999"},
@@ -90,10 +87,9 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 
 	t.Run("ErrorNamesBrokenRuleWithoutEchoingInput", func(t *testing.T) {
 		t.Parallel()
-		// The rejection names the specific broken rule (so an operator can fix
-		// it) but never echoes the input, so a credential is not disclosed, and
-		// it no longer claims "no scheme" as a cause, since a scheme is stripped
-		// before validation and can never be the reason.
+		// The rejection names the specific broken rule so an operator can fix it,
+		// but never echoes the input, so a credential is not disclosed. It also no
+		// longer claims "no scheme", since a scheme is stripped before validation.
 		cases := []struct {
 			name, in, reason string
 		}{
@@ -119,9 +115,8 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 }
 
 // TestDeploymentValues_Validate_TemplateBuilderRegistryURL covers the config
-// boundary. A malformed CODER_TEMPLATE_BUILDER_REGISTRY_URL must fail at server
-// start naming the option, regardless of whether it was set via flag/env or
-// YAML, and must not block boot when the template builder is disabled.
+// boundary: a malformed CODER_TEMPLATE_BUILDER_REGISTRY_URL must fail at server
+// start naming the option (via flag/env or YAML), but not block boot when disabled.
 func TestDeploymentValues_Validate_TemplateBuilderRegistryURL(t *testing.T) {
 	t.Parallel()
 
@@ -148,9 +143,8 @@ func TestDeploymentValues_Validate_TemplateBuilderRegistryURL(t *testing.T) {
 			{name: "SchemeStrippedOK", url: "https://mirror.internal.example"},
 			{name: "PathRejected", url: "mirror.internal.example/coder", wantErr: "bare host"},
 			{name: "CredentialsRejected", url: "https://user:tok@mirror.example.com", wantErr: "bare host"},
-			// A disabled template builder must not block boot on an inert value,
-			// so an upgrade that tightens the shape check cannot take down a
-			// deployment that has the feature turned off.
+			// A disabled template builder must not block boot on an inert value, so
+			// tightening the shape check in an upgrade can't take down a disabled deployment.
 			{name: "DisabledSkipsValidation", url: "https://user:tok@mirror.example.com/bad", disabled: true},
 		}
 		for _, tc := range cases {
@@ -171,12 +165,10 @@ func TestDeploymentValues_Validate_TemplateBuilderRegistryURL(t *testing.T) {
 
 	t.Run("YAMLPathValidated", func(t *testing.T) {
 		t.Parallel()
-		// A serpent validator only runs in Set, which the YAML path bypasses, so
-		// validating in Set would let a YAML-configured value skip the check
-		// entirely. Validate() runs after all sources merge, so the value set
-		// here through YAML is caught. Unmarshal before applying any defaults, the
-		// order the server uses, so the YAML value is the option's source (a
-		// default-sourced option is left untouched by UnmarshalYAML).
+		// A serpent validator only runs in Set, which the YAML path bypasses;
+		// Validate() runs after all sources merge, so a YAML-set value is caught.
+		// Unmarshal before applying defaults (the server's order) so the YAML value
+		// is the option's source; a default-sourced option is left untouched.
 		dv := &codersdk.DeploymentValues{}
 		dv.Sessions.DefaultDuration = serpent.Duration(time.Hour)
 		dv.Sessions.RefreshDefaultDuration = serpent.Duration(48 * time.Hour)

--- a/codersdk/deployment_registry_test.go
+++ b/codersdk/deployment_registry_test.go
@@ -31,11 +31,12 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 			{"UppercaseSchemeStripped", "HTTPS://mirror.example.com", "mirror.example.com"},
 			{"TrailingSlashStripped", "https://mirror.example.com/", "mirror.example.com"},
 			{"TrailingSlashesStripped", "mirror.example.com///", "mirror.example.com"},
-			// svchost.ForComparison (the parser Terraform uses) defines these
-			// normalizations; the old hand-rolled regex diverged from `terraform
-			// init` by rejecting the Unicode/FQDN cases and preserving :443.
+			// svchost (the parser Terraform uses) defines these normalizations. An IDN
+			// host is returned in its Unicode display form, since that is what a
+			// Terraform module source resolves; a trailing-dot FQDN and the :443 default
+			// port match `terraform init`.
 			{"HostLowercased", "Registry.Coder.Com", "registry.coder.com"},
-			{"UnicodeHostPunycoded", "m\u00fcnchen.example", "xn--mnchen-3ya.example"},
+			{"UnicodeHostDisplayed", "m\u00fcnchen.example", "m\u00fcnchen.example"},
 			{"TrailingDotFQDN", "registry.coder.com.", "registry.coder.com."},
 			{"DefaultPortDropped", "mirror.example.com:443", "mirror.example.com"},
 		}
@@ -45,6 +46,11 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 				got, err := codersdk.NormalizeTemplateBuilderRegistryURL(tc.in)
 				require.NoError(t, err)
 				require.Equal(t, tc.want, got)
+				// Normalization is idempotent: an already-canonical value normalizes
+				// to itself, so a rendered source cannot drift on a second pass.
+				roundTrip, err := codersdk.NormalizeTemplateBuilderRegistryURL(tc.want)
+				require.NoError(t, err)
+				require.Equal(t, tc.want, roundTrip)
 			})
 		}
 	})
@@ -67,12 +73,17 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 			{"VerticalTab", "mirror\v.example.com"},
 			{"SchemeOnly", "https://"},
 			{"LeadingDot", ".mirror.example.com"},
-			// Over/under-rejection class: validating by svchost makes these agree
-			// with Terraform (raw punycode, underscores, port >65535, and IPv6
-			// literals are all rejected).
+			// Over/under-rejection class: validating by svchost makes these agree with
+			// Terraform (raw punycode, underscores, port >65535, and IPv6 literals are
+			// all rejected). An out-of-range low port and an empty label (for example
+			// from an ignorable Unicode rune) render an unresolvable source, so they are
+			// rejected too.
 			{"RawPunycode", "xn--mnchen-3ya.example"},
 			{"Underscore", "under_score.example"},
 			{"PortTooHigh", "mirror.example.com:99999"},
+			{"PortZero", "mirror.example.com:0"},
+			{"PortNegative", "mirror.example.com:-1"},
+			{"EmptyLabelFromIgnorableRune", "\u200b.example.com"},
 			{"IPv6", "[::1]:8443"},
 		}
 		for _, tc := range cases {
@@ -88,14 +99,19 @@ func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
 	t.Run("ErrorNamesBrokenRuleWithoutEchoingInput", func(t *testing.T) {
 		t.Parallel()
 		// The rejection names the specific broken rule so an operator can fix it,
-		// but never echoes the input, so a credential is not disclosed. It also no
-		// longer claims "no scheme", since a scheme is stripped before validation.
+		// forwarding svchost's diagnosis for the cases it owns, and never claims "no
+		// scheme", since a scheme is stripped before validation. Credentials are
+		// rejected before svchost runs, so no forwarded reason echoes a secret.
 		cases := []struct {
 			name, in, reason string
 		}{
 			{"Credentials", "https://user:s3cr3t-token@mirror.example.com", "credentials"},
 			{"Path", "mirror.example.com/coder", "path"},
 			{"IPv6", "[::1]:8443", "IPv6"},
+			{"Underscore", "under_score.example", "disallowed"},
+			{"RawPunycode", "xn--mnchen-3ya.example", "unicode"},
+			{"PortTooLow", "mirror.example.com:0", "port"},
+			{"EmptyLabel", "\u200b.example.com", "empty label"},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -174,12 +190,12 @@ func TestDeploymentValues_Validate_TemplateBuilderRegistryURL(t *testing.T) {
 		dv.Sessions.RefreshDefaultDuration = serpent.Duration(48 * time.Hour)
 		opts := dv.Options()
 
-		const credURL = "https://user:s3cr3t-token@mirror.example.com"
-		doc := map[string]any{"templateBuilder": map[string]any{"registryURL": credURL}}
+		const userinfoURL = "https://user:s3cr3t-token@mirror.example.com"
+		doc := map[string]any{"templateBuilder": map[string]any{"registryURL": userinfoURL}}
 		var node yaml.Node
 		require.NoError(t, node.Encode(doc))
 		require.NoError(t, opts.UnmarshalYAML(&node))
-		require.Equal(t, credURL, dv.TemplateBuilder.RegistryURL.Value(),
+		require.Equal(t, userinfoURL, dv.TemplateBuilder.RegistryURL.Value(),
 			"YAML unmarshal stores the value verbatim; validation happens in Validate()")
 
 		err := dv.Validate()

--- a/codersdk/deployment_registry_test.go
+++ b/codersdk/deployment_registry_test.go
@@ -1,0 +1,197 @@
+package codersdk_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func TestNormalizeTemplateBuilderRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Accepts", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name string
+			in   string
+			want string
+		}{
+			{"Empty", "", codersdk.DefaultTemplateBuilderRegistryURL},
+			{"Whitespaceonly", "   ", codersdk.DefaultTemplateBuilderRegistryURL},
+			{"BareHost", "registry.coder.com", "registry.coder.com"},
+			{"BareHostSurroundingSpace", "  mirror.internal.example  ", "mirror.internal.example"},
+			{"HostPort", "mirror.example.com:8443", "mirror.example.com:8443"},
+			{"HTTPSStripped", "https://mirror.example.com", "mirror.example.com"},
+			{"HTTPStripped", "http://mirror.example.com", "mirror.example.com"},
+			{"UppercaseSchemeStripped", "HTTPS://mirror.example.com", "mirror.example.com"},
+			{"TrailingSlashStripped", "https://mirror.example.com/", "mirror.example.com"},
+			{"TrailingSlashesStripped", "mirror.example.com///", "mirror.example.com"},
+			// svchost.ForComparison, the parser Terraform uses, defines these:
+			// an uppercase host is lowercased, a Unicode host is normalized to
+			// punycode, a trailing dot is a valid FQDN, and :443 is the default
+			// port and is dropped. The old hand-rolled regex rejected the middle
+			// two and preserved :443, diverging from what `terraform init` does.
+			{"HostLowercased", "Registry.Coder.Com", "registry.coder.com"},
+			{"UnicodeHostPunycoded", "m\u00fcnchen.example", "xn--mnchen-3ya.example"},
+			{"TrailingDotFQDN", "registry.coder.com.", "registry.coder.com."},
+			{"DefaultPortDropped", "mirror.example.com:443", "mirror.example.com"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				got, err := codersdk.NormalizeTemplateBuilderRegistryURL(tc.in)
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			})
+		}
+	})
+
+	t.Run("Rejects", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name string
+			in   string
+		}{
+			{"DoubledScheme", "https://https://mirror.example.com"},
+			{"Path", "mirror.example.com/coder"},
+			{"Interpolation", "mirror.example.com/${var.evil}"},
+			{"InteriorInterpolation", "mirror${var.evil}.example.com"},
+			{"Directive", "mirror.example.com/%{if true}"},
+			{"Backslash", `mirror.example.com\x`},
+			{"Quote", `mirror.example.com/"`},
+			{"InteriorSpace", "mirror .example.com"},
+			{"NonBreakingSpace", "mirror\u00a0.example.com"},
+			{"VerticalTab", "mirror\v.example.com"},
+			{"SchemeOnly", "https://"},
+			{"LeadingDot", ".mirror.example.com"},
+			// New coverage for the over-rejection/under-rejection class: the
+			// value is validated by svchost, so it now agrees with Terraform on
+			// each of these (raw punycode and underscores are rejected, a port
+			// over 65535 is rejected, and an IPv6 literal is not a registry host).
+			{"RawPunycode", "xn--mnchen-3ya.example"},
+			{"Underscore", "under_score.example"},
+			{"PortTooHigh", "mirror.example.com:99999"},
+			{"IPv6", "[::1]:8443"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				_, err := codersdk.NormalizeTemplateBuilderRegistryURL(tc.in)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "bare host")
+			})
+		}
+	})
+
+	t.Run("ErrorNamesBrokenRuleWithoutEchoingInput", func(t *testing.T) {
+		t.Parallel()
+		// The rejection names the specific broken rule (so an operator can fix
+		// it) but never echoes the input, so a credential is not disclosed, and
+		// it no longer claims "no scheme" as a cause, since a scheme is stripped
+		// before validation and can never be the reason.
+		cases := []struct {
+			name, in, reason string
+		}{
+			{"Credentials", "https://user:s3cr3t-token@mirror.example.com", "credentials"},
+			{"Path", "mirror.example.com/coder", "path"},
+			{"IPv6", "[::1]:8443", "IPv6"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				_, err := codersdk.NormalizeTemplateBuilderRegistryURL(tc.in)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "bare host")
+				require.ErrorContains(t, err, tc.reason)
+				require.NotContains(t, err.Error(), "scheme")
+			})
+		}
+
+		_, err := codersdk.NormalizeTemplateBuilderRegistryURL("https://user:s3cr3t-token@mirror.example.com")
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "s3cr3t-token")
+	})
+}
+
+// TestDeploymentValues_Validate_TemplateBuilderRegistryURL covers the config
+// boundary. A malformed CODER_TEMPLATE_BUILDER_REGISTRY_URL must fail at server
+// start naming the option, regardless of whether it was set via flag/env or
+// YAML, and must not block boot when the template builder is disabled.
+func TestDeploymentValues_Validate_TemplateBuilderRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	// mkValid returns a DeploymentValues that passes Validate() except for the
+	// template builder registry URL, so that check is what each case exercises.
+	mkValid := func() *codersdk.DeploymentValues {
+		dv := &codersdk.DeploymentValues{}
+		dv.Sessions.DefaultDuration = serpent.Duration(time.Hour)
+		dv.Sessions.RefreshDefaultDuration = serpent.Duration(48 * time.Hour)
+		return dv
+	}
+
+	t.Run("Cases", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name     string
+			url      string
+			disabled bool
+			wantErr  string
+		}{
+			{name: "EmptyOK"},
+			{name: "BareHostOK", url: "mirror.internal.example"},
+			{name: "HostPortOK", url: "mirror.internal.example:8443"},
+			{name: "SchemeStrippedOK", url: "https://mirror.internal.example"},
+			{name: "PathRejected", url: "mirror.internal.example/coder", wantErr: "bare host"},
+			{name: "CredentialsRejected", url: "https://user:tok@mirror.example.com", wantErr: "bare host"},
+			// A disabled template builder must not block boot on an inert value,
+			// so an upgrade that tightens the shape check cannot take down a
+			// deployment that has the feature turned off.
+			{name: "DisabledSkipsValidation", url: "https://user:tok@mirror.example.com/bad", disabled: true},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				dv := mkValid()
+				dv.TemplateBuilder.Disabled = serpent.Bool(tc.disabled)
+				dv.TemplateBuilder.RegistryURL = serpent.String(tc.url)
+				err := dv.Validate()
+				if tc.wantErr == "" {
+					require.NoError(t, err)
+					return
+				}
+				require.ErrorContains(t, err, tc.wantErr)
+			})
+		}
+	})
+
+	t.Run("YAMLPathValidated", func(t *testing.T) {
+		t.Parallel()
+		// A serpent validator only runs in Set, which the YAML path bypasses, so
+		// validating in Set would let a YAML-configured value skip the check
+		// entirely. Validate() runs after all sources merge, so the value set
+		// here through YAML is caught. Unmarshal before applying any defaults, the
+		// order the server uses, so the YAML value is the option's source (a
+		// default-sourced option is left untouched by UnmarshalYAML).
+		dv := &codersdk.DeploymentValues{}
+		dv.Sessions.DefaultDuration = serpent.Duration(time.Hour)
+		dv.Sessions.RefreshDefaultDuration = serpent.Duration(48 * time.Hour)
+		opts := dv.Options()
+
+		const credURL = "https://user:s3cr3t-token@mirror.example.com"
+		doc := map[string]any{"templateBuilder": map[string]any{"registryURL": credURL}}
+		var node yaml.Node
+		require.NoError(t, node.Encode(doc))
+		require.NoError(t, opts.UnmarshalYAML(&node))
+		require.Equal(t, credURL, dv.TemplateBuilder.RegistryURL.Value(),
+			"YAML unmarshal stores the value verbatim; validation happens in Validate()")
+
+		err := dv.Validate()
+		require.ErrorContains(t, err, "bare host")
+		require.NotContains(t, err.Error(), "s3cr3t-token")
+	})
+}

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -1797,7 +1797,8 @@ Disable the template builder feature for guided template creation. When disabled
 
 ### Registry URL
 
-The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.
+The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example "registry.coder.com" or "mirror.internal:8443").
+An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.
 
 - Environment variable: `CODER_TEMPLATE_BUILDER_REGISTRY_URL`
 - CLI flag: [`--template-builder-registry-url`](../../reference/cli/server.md#--template-builder-registry-url)

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -1797,8 +1797,7 @@ Disable the template builder feature for guided template creation. When disabled
 
 ### Registry URL
 
-The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example "registry.coder.com" or "mirror.internal:8443").
-An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.
+The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.
 
 - Environment variable: `CODER_TEMPLATE_BUILDER_REGISTRY_URL`
 - CLI flag: [`--template-builder-registry-url`](../../reference/cli/server.md#--template-builder-registry-url)

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -1797,7 +1797,7 @@ Disable the template builder feature for guided template creation. When disabled
 
 ### Registry URL
 
-The base URL of the module registry used by the template builder for module source paths.
+The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.
 
 - Environment variable: `CODER_TEMPLATE_BUILDER_REGISTRY_URL`
 - CLI flag: [`--template-builder-registry-url`](../../reference/cli/server.md#--template-builder-registry-url)

--- a/docs/admin/templates/creating-templates.md
+++ b/docs/admin/templates/creating-templates.md
@@ -77,7 +77,10 @@ button links to the starter templates page instead, and the
 
 Deployments using a self-hosted module registry mirror can set
 `CODER_TEMPLATE_BUILDER_REGISTRY_URL` to point generated module source paths at
-the mirror instead of `registry.coder.com`.
+the mirror instead of `registry.coder.com`. The value must be a bare host,
+optionally with a port (for example `mirror.internal:8443`); an `http(s)://`
+scheme is stripped, and a path, credentials, query, or fragment is rejected at
+server start.
 
 #### Alternative creation methods
 

--- a/docs/admin/templates/creating-templates.md
+++ b/docs/admin/templates/creating-templates.md
@@ -77,10 +77,9 @@ button links to the starter templates page instead, and the
 
 Deployments using a self-hosted module registry mirror can set
 `CODER_TEMPLATE_BUILDER_REGISTRY_URL` to point generated module source paths at
-the mirror instead of `registry.coder.com`. The value must be a bare host,
-optionally with a port (for example `mirror.internal:8443`); an `http(s)://`
-scheme is stripped, and a path, credentials, query, or fragment is rejected at
-server start.
+the mirror instead of `registry.coder.com`.
+The value must be a bare host, optionally with a port (for example `mirror.internal:8443`).
+An `http(s)://` scheme is stripped, and a path, credentials, query, or fragment is rejected at server start.
 
 #### Alternative creation methods
 

--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -259,6 +259,11 @@ CODER_TEMPLATE_BUILDER_REGISTRY_URL=registry.internal.example.com
 This makes the builder generate module source paths pointing at your mirror
 rather than `registry.coder.com`.
 
+The value must be a bare host, optionally with a port (for example
+`registry.internal.example.com` or `mirror.internal:8443`). A leading
+`http(s)://` scheme is stripped; a path, credentials, query, or fragment is
+rejected when the server starts.
+
 ## Coder Modules
 
 To use Coder modules in offline installations, you can either:

--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -259,10 +259,8 @@ CODER_TEMPLATE_BUILDER_REGISTRY_URL=registry.internal.example.com
 This makes the builder generate module source paths pointing at your mirror
 rather than `registry.coder.com`.
 
-The value must be a bare host, optionally with a port (for example
-`registry.internal.example.com` or `mirror.internal:8443`). A leading
-`http(s)://` scheme is stripped; a path, credentials, query, or fragment is
-rejected when the server starts.
+The value must be a bare host, optionally with a port (for example, `registry.internal.example.com` or `mirror.internal:8443`).
+A leading `http(s)://` scheme is stripped; a path, credentials, query, or fragment is rejected when the server starts.
 
 ## Coder Modules
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -2154,4 +2154,4 @@ Disable the template builder feature for guided template creation. When disabled
 | YAML        | <code>templateBuilder.registryURL</code>          |
 | Default     | <code>registry.coder.com</code>                   |
 
-The base URL of the module registry used by the template builder for module source paths.
+The bare host of the module registry the template builder uses for module source paths, optionally with a port (for example "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme is stripped; a path, credentials, query, or fragment is rejected at server start.

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -921,8 +921,11 @@ TEMPLATE BUILDER OPTIONS:
           When disabled, all /api/v2/templatebuilder/* endpoints return 404.
 
       --template-builder-registry-url string, $CODER_TEMPLATE_BUILDER_REGISTRY_URL (default: registry.coder.com)
-          The base URL of the module registry used by the template builder for
-          module source paths.
+          The bare host of the module registry the template builder uses for
+          module source paths, optionally with a port (for example
+          "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme
+          is stripped; a path, credentials, query, or fragment is rejected at
+          server start.
 
 USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid

--- a/go.mod
+++ b/go.mod
@@ -540,6 +540,7 @@ require (
 	github.com/elimity-com/scim v0.0.0-20260506142751-830e1caafcc3
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-git/v5 v5.19.2
+	github.com/hashicorp/terraform-svchost v0.1.1
 	github.com/invopop/jsonschema v0.14.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/nats-io/nats-server/v2 v2.14.2

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4724,6 +4724,15 @@ export const DefaultChatDebugRetentionDays = 30;
  */
 export const DefaultChatWorkspaceTTL = 0;
 
+// From codersdk/deployment.go
+/**
+ * DefaultTemplateBuilderRegistryURL is the module registry the template builder
+ * uses for module source paths when CODER_TEMPLATE_BUILDER_REGISTRY_URL is unset
+ * or empty. It is a bare host (no scheme, no trailing slash), the shape
+ * NormalizeTemplateBuilderRegistryURL enforces for any operator-supplied value.
+ */
+export const DefaultTemplateBuilderRegistryURL = "registry.coder.com";
+
 // From codersdk/externalauth.go
 export interface DeleteExternalAuthByIDResponse {
 	/**

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4726,10 +4726,8 @@ export const DefaultChatWorkspaceTTL = 0;
 
 // From codersdk/deployment.go
 /**
- * DefaultTemplateBuilderRegistryURL is the module registry the template builder
- * uses for module source paths when CODER_TEMPLATE_BUILDER_REGISTRY_URL is unset
- * or empty. It is a bare host (no scheme, no trailing slash), the shape
- * NormalizeTemplateBuilderRegistryURL enforces for any operator-supplied value.
+ * DefaultTemplateBuilderRegistryURL is the bare-host module registry the
+ * template builder uses when CODER_TEMPLATE_BUILDER_REGISTRY_URL is unset.
  */
 export const DefaultTemplateBuilderRegistryURL = "registry.coder.com";
 


### PR DESCRIPTION
## Summary

Threads the deployment's configured module registry (`CODER_TEMPLATE_BUILDER_REGISTRY_URL`) into template-builder **base** rendering, so a base that embeds a catalog module resolves its `source` through a registry mirror the same way wizard-composed modules already do. Previously, base-embedded module sources hardcoded `registry.coder.com`: on a mirror or private-registry deployment, the same module resolved through the mirror when the wizard rendered it but reached the public registry when a base embedded it.

This closes the base-layer registry-hardcode class, not only the quickstart instance.

## What changed

- **`BaseRenderContext.RegistryBase`** (new field), mirroring `ModuleRenderContext.RegistryBase`. `renderBase` threads the normalized registry host into it so base-embedded module sources honor the deployment mirror. Both field docs and the `DefaultTemplateBuilderRegistryURL` const doc state the bare-host, never-empty contract a direct `RenderBaseTemplate` caller must satisfy.
- **Registry validation via Terraform's own parser.** The value is a bare host interpolated verbatim into a Terraform module `source`, so `codersdk.NormalizeTemplateBuilderRegistryURL` defaults an unset/empty value, strips an `http(s)://` scheme (any case) and trailing slashes, then validates the remainder with `svchost` from `github.com/hashicorp/terraform-svchost`, the same parser `terraform init` uses to read a module-source host. It returns the host in svchost's **Unicode display form** (the form a module source resolves), matching Terraform on IDN, the `:443` default port, and trailing-dot FQDNs, and rejects userinfo, a path, a query, a fragment, raw punycode, an empty label, an out-of-range port, whitespace, and HCL interpolation. The error names the specific broken rule (forwarding svchost's diagnosis where it owns the check) and never echoes a credential in a misconfigured value.
- **Validated at the config boundary, gated on the feature.** The check runs in `DeploymentValues.Validate()` (after flag, env, and YAML sources merge), gated on `!TemplateBuilder.Disabled`, matching the chat-hook `HookEnabled` precedent. A YAML/Helm-configured value is validated (a per-option `serpent.Validate` only runs in `Set`, which the YAML path bypasses), and a deployment with the template builder disabled still boots on an inert value. `Compose` runs the same normalizer for the base and module render paths as defense in depth.
  - **Rollout decision (open):** a malformed value currently **fails at server start** (gated on enabled), rather than log-and-default. Silently defaulting to the public registry on a mirror/air-gapped deployment would leak module fetches to the internet, the exact failure this feature prevents; failing at boot names the option where the operator set it instead of surfacing as a per-request 400. A log-at-startup + disable-the-feature alternative (raised in review) is under discussion as a lower-blast-radius option; see the open review thread.
- **HCL backstop.** `Compose` parses the rendered `main.tf` once before its module early-return, and validates the rendered `modules.tf` too, so a template that rendered to invalid HCL fails with the parser diagnostic instead of shipping broken Terraform or failing later with a misleading missing-agent error. An invalid-HCL failure is the exported sentinel `templatebuilder.ErrRenderedHCLInvalid` (joining every diagnostic), which the compose handlers map to a **500** — a curated-template fault is a server error, not a client 400.
- **Single source of truth for the default.** Exported `codersdk.DefaultTemplateBuilderRegistryURL`, used for both the deployment option default and the normalization default, so they cannot drift.
- **Templatized the four hardcoded base module sources** to `{{ .RegistryBase }}/...`: `quickstart` (git-clone), `azure-linux` (azure-region), `gcp-linux` and `gcp-windows` (gcp-region). Because the default normalizes back to `registry.coder.com`, the rendered module `source` values stay byte-identical; the goldens change only in the `# Module docs (public registry): ...` comments.
- **Operator-facing docs.** Reworded the option `Description` to the bare-host shape and regenerated the CLI `--help`/`--write-config` goldens, `docs/reference/cli/server.md`, and `docs/admin/setup/configuration-reference.md`; added a format sentence to `docs/install/airgap.md` and `docs/admin/templates/creating-templates.md`. Regenerated `site/src/api/typesGenerated.ts` for the new exported constant.

## Tests

- `codersdk`: `TestNormalizeTemplateBuilderRegistryURL` is an accept/reject matrix (scheme strip incl. uppercase, trailing slash, `host:port`, IDN to Unicode display form, `:443` drop, trailing-dot FQDN, with an idempotency round-trip check; rejects userinfo, path, interpolation/directive, backslash, quote, whitespace incl. NBSP and vertical tab, doubled scheme, raw punycode, underscore label, empty label, out-of-range low/high port, IPv6 literal), plus `ErrorNamesBrokenRuleWithoutEchoingInput`. `TestDeploymentValues_Validate_TemplateBuilderRegistryURL` covers the config boundary, including a disabled-skips-validation case and a `YAMLPathValidated` case that drives `opts.UnmarshalYAML` and asserts the value is caught at `Validate()` without echoing the credential.
- `templatebuilder`: `TestRenderBaseHonorsRegistryMirror` iterates every base via `BaseTemplateIDs()` (sorted), renders each against a mirror, and asserts every module `source` parsed from the rendered HCL (`ExtractModuleSources`) resolves through the mirror or a local path; a per-module-block source count guards the sweep from passing vacuously, and a positive quickstart anchor is kept. `TestValidateRenderedHCL` covers the invalid-HCL backstop (including `errors.Is`/`errors.As`), and `TestComposeRendersValidHCL` parses both rendered files end-to-end.

## Stacking

Was stacked on #27247 (the quickstart base and base helpers this builds on). #27247 has merged, so this PR is now rebased onto `main` and targets `main` directly.

---

Linear: [DOCS-610](https://linear.app/codercom/issue/DOCS-610/template-builder-base-embedded-modules-should-honor-the-deployment)

> This PR was created with AI assistance (Coder Agents).