### PR TITLE
feat(coderd): persist quickstart base language toolchains across restarts

### DIFF
--- a/coderd/templatebuilder/bases/quickstart/README.md
+++ b/coderd/templatebuilder/bases/quickstart/README.md
@@ -46,7 +46,7 @@ This template provisions:
 - **Docker container** (ephemeral) running Ubuntu with the Coder agent
 - **Docker volume** (persistent) mounted at `/home/coder`
 
-Files in your home directory (`/home/coder`) persist across workspace restarts. The language install script runs on every start and blocks login until it finishes. Most toolchains install into the ephemeral workspace container rather than your home directory, so they are reinstalled from the network on each start; the exception is Rust, whose toolchain lives under `~/.cargo` in your home directory and is detected and reused.
+Files in your home directory (`/home/coder`) persist across workspace restarts, and this template installs language toolchains there so they persist too. The language install script runs on every start and blocks login until it finishes. On the first start it downloads the selected toolchains that are not already in the base image and installs them under your home directory; on later starts it detects the persisted toolchains and reuses them instead of re-downloading. Python and C/C++ ship in the base image, while Go, Node.js, Java, and Rust are installed under `/home/coder` (Rust under `~/.cargo`, the others under `~/.local`). This template assumes the deployment has internet access, since the first install fetches toolchains from the network.
 
 ## Presets
 

--- a/coderd/templatebuilder/bases/quickstart/README.md
+++ b/coderd/templatebuilder/bases/quickstart/README.md
@@ -48,6 +48,8 @@ This template provisions:
 
 Files in your home directory (`/home/coder`) persist across workspace restarts, and this template installs language toolchains there so they persist too. The language install script runs on every start and blocks login until it finishes. On the first start it downloads the selected toolchains that are not already in the base image and installs them under your home directory; on later starts it detects the persisted toolchains and reuses them instead of re-downloading. Python and C/C++ ship in the base image, while Go, Node.js, Java, and Rust are installed under `/home/coder` (Rust under `~/.cargo`, the others under `~/.local`). This template assumes the deployment has internet access, since the first install fetches toolchains from the network.
 
+Because a toolchain is reused once it is installed, its version is effectively pinned to whatever the first start downloaded; later starts do not upgrade it, and the persistent home volume keeps it across rebuilds. To move a toolchain to a newer version, delete its directory (for example, `rm -rf ~/.local/go`, `~/.local/node`, or `~/.local/java`) and restart the workspace, which triggers a fresh install.
+
 ## Presets
 
 Select a preset to auto-fill languages for common workflows:

--- a/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
+++ b/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
@@ -1,28 +1,27 @@
 #!/bin/bash
-# persist_path_line writes literal $PATH/$HOME strings into ~/.profile, so those
-# arguments are intentionally single-quoted; suppress SC2016 for the whole file.
-# shellcheck disable=SC2016
 set -e
+set -o pipefail
 
 LANGUAGES="${LANGUAGES}"
 APT_UPDATED=false
 MACHINE="$(uname -m)"
 
-# Toolchains that are not baked into codercom/enterprise-base install under $HOME
-# so they persist on the home volume across workspace restarts. Only /home/coder
-# survives a restart, so a toolchain installed to the system (apt, /usr/local)
-# would be re-fetched from the network on every start and block login while it
-# reinstalls. Go, Node.js, and Java therefore install beneath $HOME/.local.
-# Their bin directories reach every workspace session two ways: the base sets
-# PATH in coder_agent.main.env (main.tf), which the agent applies to every
-# session regardless of login or interactivity (coder ssh -- cmd, IDE
-# terminals), and this script also appends them to $HOME/.profile as a fallback
-# for login shells the agent does not spawn. Python and C/C++ ship in the image,
-# and Rust already persists under $HOME/.cargo. This deployment is assumed to
-# have internet access: the first start still downloads the selected toolchains
-# once, then every later start detects and reuses the persisted copies.
+# Go, Node.js, and Java install under $HOME/.local so they persist on the home
+# volume; only /home/coder survives a restart, so a system-level install (apt,
+# /usr/local) would re-download and block login on every start. The -x guards
+# below detect a persisted toolchain and skip reinstalling it. Python and C/C++
+# ship in the base image and Rust persists under $HOME/.cargo. PATH reaches every
+# session through coder_agent.main.env (see main.tf for the owning rationale);
+# the ~/.profile writes here are only a fallback for login shells the agent does
+# not spawn. The first start downloads the selected toolchains once (this
+# deployment is assumed to have internet access).
 LOCAL_PREFIX="$HOME/.local"
 PROFILE="$HOME/.profile"
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
 
 apt_update() {
   if [ "$APT_UPDATED" = "false" ]; then
@@ -31,30 +30,47 @@ apt_update() {
   fi
 }
 
-# install_tarball URL DEST atomically installs a gzipped tarball at DEST. It
-# extracts into a sibling temp directory and moves it into place only after the
-# download and extraction both succeed, so an interrupted transfer never leaves a
-# half-populated DEST that the -x guards below would treat as already installed.
+# install_tarball URL DEST SHA256 atomically installs a gzipped tarball at DEST.
+# It downloads to a temp file, verifies the sha256 before unpacking (so a
+# truncated or tampered archive is never extracted), unpacks into a sibling temp
+# directory, and moves it into place only on success, so an interrupted install
+# never leaves a half-populated DEST the -x guards would treat as installed.
 # Every tarball here has a single top-level directory, so strip it.
 install_tarball() {
   local url="$1"
   local dest="$2"
+  local sha="$3"
   local tmp="$dest.tmp"
-  rm -rf "$tmp"
+  local archive="$dest.download"
+  mkdir -p "$(dirname "$dest")"
+  rm -rf "$tmp" "$archive"
+  curl -fsSL --retry 3 --retry-connrefused --retry-delay 2 -o "$archive" "$url" \
+    || fail "download failed: $url"
+  echo "$sha  $archive" | sha256sum -c - >/dev/null 2>&1 \
+    || fail "checksum mismatch for $url"
   mkdir -p "$tmp"
-  curl -fsSL "$url" | tar -C "$tmp" --strip-components=1 -xz
+  tar -C "$tmp" --strip-components=1 -xzf "$archive"
+  rm -f "$archive"
   rm -rf "$dest"
   mv "$tmp" "$dest"
 }
 
-# persist_path_line appends LINE to $HOME/.profile unless it is already present,
-# so the edit persists across restarts without being duplicated on every start.
-# ~/.profile is read by login shells only; coder_agent.main.env (main.tf) is what
-# carries PATH into the non-login, non-interactive sessions coder ssh and remote
-# IDEs use, so this write is a fallback for login shells the agent does not spawn.
-persist_path_line() {
+# persist_profile_line appends LINE to ~/.profile unless it is already present,
+# so the edit survives restarts without duplicating. ~/.profile is the
+# login-shell-only fallback; the durable PATH mechanism is coder_agent.main.env
+# (see main.tf).
+persist_profile_line() {
   local line="$1"
-  grep -qxF "$line" "$PROFILE" 2>/dev/null || echo "$line" >>"$PROFILE"
+  if grep -qxF "$line" "$PROFILE" 2>/dev/null; then
+    return 0
+  fi
+  # Guarantee a trailing newline before appending. ~/.profile lives on the
+  # user-owned home volume; an editor that strips the final newline would
+  # otherwise concatenate onto the last line and corrupt the file.
+  if [ -s "$PROFILE" ] && [ -n "$(tail -c1 "$PROFILE")" ]; then
+    echo >>"$PROFILE"
+  fi
+  echo "$line" >>"$PROFILE"
 }
 
 # has_language reports whether NAME is one of the selected languages. It matches
@@ -79,48 +95,65 @@ if has_language python; then
 fi
 
 if has_language nodejs; then
-  NODE_HOME="$LOCAL_PREFIX/node"
-  if [ -x "$NODE_HOME/bin/node" ]; then
-    echo "Node.js: $("$NODE_HOME/bin/node" --version)"
+  NODE_DIR="$LOCAL_PREFIX/node"
+  if [ -x "$NODE_DIR/bin/node" ]; then
+    echo "Node.js: $("$NODE_DIR/bin/node" --version)"
   else
     echo "Installing Node.js 22..."
     case "$MACHINE" in
       x86_64)  NODE_ARCH="x64" ;;
       aarch64) NODE_ARCH="arm64" ;;
-      *)       echo "Unsupported architecture: $MACHINE"; exit 1 ;;
+      *)       fail "Unsupported architecture: $MACHINE" ;;
     esac
-    # The latest-v22.x directory always holds the newest 22.x release; read its
-    # checksum manifest to resolve the exact tarball name for this architecture.
-    NODE_FILE="$(curl -fsSL "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt" \
-      | grep -o "node-v[0-9.]*-linux-$${NODE_ARCH}.tar.gz" | head -1)"
-    if [ -z "$NODE_FILE" ]; then
-      echo "Could not resolve a Node.js 22 build for $MACHINE"; exit 1
-    fi
-    install_tarball "https://nodejs.org/dist/latest-v22.x/$${NODE_FILE}" "$NODE_HOME"
-    echo "Installed Node.js: $("$NODE_HOME/bin/node" --version)"
+    # Read the checksum manifest for the newest 22.x release to resolve the exact
+    # tarball name and its sha256, then download from the immutable per-version
+    # directory (not the moving latest-v22.x alias) so a release published
+    # between the two requests cannot 404 the download.
+    node_manifest="$(curl -fsSL --retry 3 --retry-connrefused --retry-delay 2 \
+      "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt")" \
+      || fail "could not reach nodejs.org to resolve a Node.js 22 build; check this workspace's internet access"
+    NODE_FILE="$(grep -om1 "node-v[0-9.]*-linux-$${NODE_ARCH}.tar.gz" <<<"$node_manifest")" || true
+    [ -n "$NODE_FILE" ] || fail "Could not resolve a Node.js 22 build for $MACHINE"
+    NODE_SHA="$(awk -v f="$NODE_FILE" '$2 == f { print $1 }' <<<"$node_manifest")"
+    [ -n "$NODE_SHA" ] || fail "Could not resolve the Node.js checksum for $NODE_FILE"
+    NODE_VER="$${NODE_FILE#node-}"
+    NODE_VER="$${NODE_VER%%-*}"
+    install_tarball "https://nodejs.org/dist/$${NODE_VER}/$${NODE_FILE}" "$NODE_DIR" "$NODE_SHA"
+    echo "Installed Node.js: $("$NODE_DIR/bin/node" --version)"
   fi
-  persist_path_line 'export PATH=$PATH:$HOME/.local/node/bin'
+  # shellcheck disable=SC2016 # literal $PATH/$HOME expand in ~/.profile at login, not here
+  persist_profile_line 'case ":$PATH:" in *":$HOME/.local/node/bin:"*) ;; *) export PATH="$PATH:$HOME/.local/node/bin" ;; esac'
 fi
 
 if has_language go; then
-  GO_BIN="$LOCAL_PREFIX/go/bin/go"
-  if [ -x "$GO_BIN" ]; then
-    echo "Go: $("$GO_BIN" version)"
+  GO_DIR="$LOCAL_PREFIX/go"
+  if [ -x "$GO_DIR/bin/go" ]; then
+    echo "Go: $("$GO_DIR/bin/go" version)"
   else
     echo "Installing Go..."
     case "$MACHINE" in
       x86_64)  GOARCH="amd64" ;;
       aarch64) GOARCH="arm64" ;;
-      *)       echo "Unsupported architecture: $MACHINE"; exit 1 ;;
+      *)       fail "Unsupported architecture: $MACHINE" ;;
     esac
-    GO_VERSION="$(curl -fsSL "https://go.dev/VERSION?m=text" | head -1)"
-    if [ -z "$GO_VERSION" ]; then
-      echo "Could not resolve the latest Go version"; exit 1
-    fi
-    install_tarball "https://go.dev/dl/$${GO_VERSION}.linux-$${GOARCH}.tar.gz" "$LOCAL_PREFIX/go"
-    echo "Installed Go: $("$GO_BIN" version)"
+    go_version_raw="$(curl -fsSL --retry 3 --retry-connrefused --retry-delay 2 \
+      "https://go.dev/VERSION?m=text")" \
+      || fail "could not reach go.dev to resolve the latest Go version; check this workspace's internet access"
+    GO_VERSION="$(head -1 <<<"$go_version_raw")"
+    [ -n "$GO_VERSION" ] || fail "Could not resolve the latest Go version"
+    # go.dev/dl serves an immutable per-version tarball and publishes its sha256
+    # in the release index, so verify against that rather than trusting TLS alone.
+    go_index="$(curl -fsSL --retry 3 --retry-connrefused --retry-delay 2 \
+      "https://go.dev/dl/?mode=json")" \
+      || fail "could not reach go.dev to resolve the Go checksum; check this workspace's internet access"
+    GO_SHA="$(jq -r --arg v "$GO_VERSION" --arg f "$${GO_VERSION}.linux-$${GOARCH}.tar.gz" \
+      '.[] | select(.version == $v) | .files[] | select(.filename == $f) | .sha256' <<<"$go_index")"
+    [ -n "$GO_SHA" ] || fail "Could not resolve the Go checksum for $GO_VERSION ($GOARCH)"
+    install_tarball "https://go.dev/dl/$${GO_VERSION}.linux-$${GOARCH}.tar.gz" "$GO_DIR" "$GO_SHA"
+    echo "Installed Go: $("$GO_DIR/bin/go" version)"
   fi
-  persist_path_line 'export PATH=$PATH:$HOME/.local/go/bin:$HOME/go/bin'
+  # shellcheck disable=SC2016 # literal $PATH/$HOME expand in ~/.profile at login, not here
+  persist_profile_line 'case ":$PATH:" in *":$HOME/.local/go/bin:"*) ;; *) export PATH="$PATH:$HOME/.local/go/bin:$HOME/go/bin" ;; esac'
 fi
 
 if has_language rust; then
@@ -136,21 +169,31 @@ if has_language rust; then
 fi
 
 if has_language java; then
-  JAVA_HOME_DIR="$LOCAL_PREFIX/java"
-  if [ -x "$JAVA_HOME_DIR/bin/java" ]; then
-    echo "Java: $("$JAVA_HOME_DIR/bin/java" --version 2>&1 | head -1)"
+  JAVA_DIR="$LOCAL_PREFIX/java"
+  if [ -x "$JAVA_DIR/bin/java" ]; then
+    echo "Java: $("$JAVA_DIR/bin/java" --version 2>&1 | head -1)"
   else
     echo "Installing Java (Temurin 21)..."
     case "$MACHINE" in
       x86_64)  JAVA_ARCH="x64" ;;
       aarch64) JAVA_ARCH="aarch64" ;;
-      *)       echo "Unsupported architecture: $MACHINE"; exit 1 ;;
+      *)       fail "Unsupported architecture: $MACHINE" ;;
     esac
-    install_tarball "https://api.adoptium.net/v3/binary/latest/21/ga/linux/$${JAVA_ARCH}/jdk/hotspot/normal/eclipse" "$JAVA_HOME_DIR"
-    echo "Installed Java: $("$JAVA_HOME_DIR/bin/java" --version 2>&1 | head -1)"
+    # The Adoptium assets API returns the download link and its sha256 in one
+    # response, so the tarball and its checksum come from the same source.
+    java_asset="$(curl -fsSL --retry 3 --retry-connrefused --retry-delay 2 \
+      "https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=$${JAVA_ARCH}&image_type=jdk&vendor=eclipse")" \
+      || fail "could not reach api.adoptium.net to resolve the Temurin 21 build; check this workspace's internet access"
+    JAVA_URL="$(jq -r '.[0].binary.package.link // empty' <<<"$java_asset")"
+    JAVA_SHA="$(jq -r '.[0].binary.package.checksum // empty' <<<"$java_asset")"
+    { [ -n "$JAVA_URL" ] && [ -n "$JAVA_SHA" ]; } || fail "Could not resolve a Temurin 21 build for $MACHINE"
+    install_tarball "$JAVA_URL" "$JAVA_DIR" "$JAVA_SHA"
+    echo "Installed Java: $("$JAVA_DIR/bin/java" --version 2>&1 | head -1)"
   fi
-  persist_path_line 'export JAVA_HOME=$HOME/.local/java'
-  persist_path_line 'export PATH=$PATH:$HOME/.local/java/bin'
+  # shellcheck disable=SC2016 # literal $HOME expands in ~/.profile at login, not here
+  persist_profile_line 'export JAVA_HOME=$HOME/.local/java'
+  # shellcheck disable=SC2016 # literal $PATH/$HOME expand in ~/.profile at login, not here
+  persist_profile_line 'case ":$PATH:" in *":$HOME/.local/java/bin:"*) ;; *) export PATH="$PATH:$HOME/.local/java/bin" ;; esac'
 fi
 
 if has_language cpp; then

--- a/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
+++ b/coderd/templatebuilder/bases/quickstart/install-languages.sh.tftpl
@@ -1,14 +1,60 @@
 #!/bin/bash
+# persist_path_line writes literal $PATH/$HOME strings into ~/.profile, so those
+# arguments are intentionally single-quoted; suppress SC2016 for the whole file.
+# shellcheck disable=SC2016
 set -e
 
 LANGUAGES="${LANGUAGES}"
 APT_UPDATED=false
+MACHINE="$(uname -m)"
+
+# Toolchains that are not baked into codercom/enterprise-base install under $HOME
+# so they persist on the home volume across workspace restarts. Only /home/coder
+# survives a restart, so a toolchain installed to the system (apt, /usr/local)
+# would be re-fetched from the network on every start and block login while it
+# reinstalls. Go, Node.js, and Java therefore install beneath $HOME/.local.
+# Their bin directories reach every workspace session two ways: the base sets
+# PATH in coder_agent.main.env (main.tf), which the agent applies to every
+# session regardless of login or interactivity (coder ssh -- cmd, IDE
+# terminals), and this script also appends them to $HOME/.profile as a fallback
+# for login shells the agent does not spawn. Python and C/C++ ship in the image,
+# and Rust already persists under $HOME/.cargo. This deployment is assumed to
+# have internet access: the first start still downloads the selected toolchains
+# once, then every later start detects and reuses the persisted copies.
+LOCAL_PREFIX="$HOME/.local"
+PROFILE="$HOME/.profile"
 
 apt_update() {
   if [ "$APT_UPDATED" = "false" ]; then
     sudo apt-get update -qq
     APT_UPDATED=true
   fi
+}
+
+# install_tarball URL DEST atomically installs a gzipped tarball at DEST. It
+# extracts into a sibling temp directory and moves it into place only after the
+# download and extraction both succeed, so an interrupted transfer never leaves a
+# half-populated DEST that the -x guards below would treat as already installed.
+# Every tarball here has a single top-level directory, so strip it.
+install_tarball() {
+  local url="$1"
+  local dest="$2"
+  local tmp="$dest.tmp"
+  rm -rf "$tmp"
+  mkdir -p "$tmp"
+  curl -fsSL "$url" | tar -C "$tmp" --strip-components=1 -xz
+  rm -rf "$dest"
+  mv "$tmp" "$dest"
+}
+
+# persist_path_line appends LINE to $HOME/.profile unless it is already present,
+# so the edit persists across restarts without being duplicated on every start.
+# ~/.profile is read by login shells only; coder_agent.main.env (main.tf) is what
+# carries PATH into the non-login, non-interactive sessions coder ssh and remote
+# IDEs use, so this write is a fallback for login shells the agent does not spawn.
+persist_path_line() {
+  local line="$1"
+  grep -qxF "$line" "$PROFILE" 2>/dev/null || echo "$line" >>"$PROFILE"
 }
 
 # has_language reports whether NAME is one of the selected languages. It matches
@@ -33,55 +79,78 @@ if has_language python; then
 fi
 
 if has_language nodejs; then
-  if command -v node >/dev/null 2>&1; then
-    echo "Node.js: $(node --version)"
+  NODE_HOME="$LOCAL_PREFIX/node"
+  if [ -x "$NODE_HOME/bin/node" ]; then
+    echo "Node.js: $("$NODE_HOME/bin/node" --version)"
   else
     echo "Installing Node.js 22..."
-    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-    sudo apt-get install -y -qq nodejs
-    echo "Installed Node.js: $(node --version)"
+    case "$MACHINE" in
+      x86_64)  NODE_ARCH="x64" ;;
+      aarch64) NODE_ARCH="arm64" ;;
+      *)       echo "Unsupported architecture: $MACHINE"; exit 1 ;;
+    esac
+    # The latest-v22.x directory always holds the newest 22.x release; read its
+    # checksum manifest to resolve the exact tarball name for this architecture.
+    NODE_FILE="$(curl -fsSL "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt" \
+      | grep -o "node-v[0-9.]*-linux-$${NODE_ARCH}.tar.gz" | head -1)"
+    if [ -z "$NODE_FILE" ]; then
+      echo "Could not resolve a Node.js 22 build for $MACHINE"; exit 1
+    fi
+    install_tarball "https://nodejs.org/dist/latest-v22.x/$${NODE_FILE}" "$NODE_HOME"
+    echo "Installed Node.js: $("$NODE_HOME/bin/node" --version)"
   fi
+  persist_path_line 'export PATH=$PATH:$HOME/.local/node/bin'
 fi
 
 if has_language go; then
-  if command -v /usr/local/go/bin/go >/dev/null 2>&1; then
-    echo "Go: $(/usr/local/go/bin/go version)"
+  GO_BIN="$LOCAL_PREFIX/go/bin/go"
+  if [ -x "$GO_BIN" ]; then
+    echo "Go: $("$GO_BIN" version)"
   else
     echo "Installing Go..."
-    ARCH=$(uname -m)
-    case $ARCH in
+    case "$MACHINE" in
       x86_64)  GOARCH="amd64" ;;
       aarch64) GOARCH="arm64" ;;
-      *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+      *)       echo "Unsupported architecture: $MACHINE"; exit 1 ;;
     esac
-    GO_VERSION=$(curl -fsSL "https://go.dev/VERSION?m=text" | head -1)
-    curl -fsSL "https://go.dev/dl/$${GO_VERSION}.linux-$${GOARCH}.tar.gz" | sudo tar -C /usr/local -xz
-    echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' | sudo tee /etc/profile.d/go.sh >/dev/null
-    echo "Installed Go: $(/usr/local/go/bin/go version)"
+    GO_VERSION="$(curl -fsSL "https://go.dev/VERSION?m=text" | head -1)"
+    if [ -z "$GO_VERSION" ]; then
+      echo "Could not resolve the latest Go version"; exit 1
+    fi
+    install_tarball "https://go.dev/dl/$${GO_VERSION}.linux-$${GOARCH}.tar.gz" "$LOCAL_PREFIX/go"
+    echo "Installed Go: $("$GO_BIN" version)"
   fi
+  persist_path_line 'export PATH=$PATH:$HOME/.local/go/bin:$HOME/go/bin'
 fi
 
 if has_language rust; then
   if command -v rustc >/dev/null 2>&1 || [ -f "$HOME/.cargo/bin/rustc" ]; then
     RUSTC=$${HOME}/.cargo/bin/rustc
     command -v rustc >/dev/null 2>&1 && RUSTC=rustc
-    echo "Rust: $($RUSTC --version)"
+    echo "Rust: $("$RUSTC" --version)"
   else
     echo "Installing Rust..."
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    echo "Installed Rust: $($HOME/.cargo/bin/rustc --version)"
+    echo "Installed Rust: $("$HOME/.cargo/bin/rustc" --version)"
   fi
 fi
 
 if has_language java; then
-  if command -v java >/dev/null 2>&1; then
-    echo "Java: $(java --version 2>&1 | head -1)"
+  JAVA_HOME_DIR="$LOCAL_PREFIX/java"
+  if [ -x "$JAVA_HOME_DIR/bin/java" ]; then
+    echo "Java: $("$JAVA_HOME_DIR/bin/java" --version 2>&1 | head -1)"
   else
-    echo "Installing Java (OpenJDK 21)..."
-    apt_update
-    sudo apt-get install -y -qq openjdk-21-jdk
-    echo "Installed Java: $(java --version 2>&1 | head -1)"
+    echo "Installing Java (Temurin 21)..."
+    case "$MACHINE" in
+      x86_64)  JAVA_ARCH="x64" ;;
+      aarch64) JAVA_ARCH="aarch64" ;;
+      *)       echo "Unsupported architecture: $MACHINE"; exit 1 ;;
+    esac
+    install_tarball "https://api.adoptium.net/v3/binary/latest/21/ga/linux/$${JAVA_ARCH}/jdk/hotspot/normal/eclipse" "$JAVA_HOME_DIR"
+    echo "Installed Java: $("$JAVA_HOME_DIR/bin/java" --version 2>&1 | head -1)"
   fi
+  persist_path_line 'export JAVA_HOME=$HOME/.local/java'
+  persist_path_line 'export PATH=$PATH:$HOME/.local/java/bin'
 fi
 
 if has_language cpp; then

--- a/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
@@ -107,6 +107,11 @@ resource "coder_agent" "main" {
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
     GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
+    # Persisted toolchains (see install-languages.sh.tftpl) install under
+    # $HOME/.local. Put their bin directories on PATH here so every session the
+    # agent spawns sees them regardless of login or interactivity; the agent
+    # expands $PATH/$HOME at apply time.
+    PATH = "$PATH:$HOME/.local/go/bin:$HOME/go/bin:$HOME/.local/node/bin:$HOME/.local/java/bin"
   }
 
   metadata {

--- a/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
+++ b/coderd/templatebuilder/bases/quickstart/main.tf.tmpl
@@ -102,17 +102,26 @@ resource "coder_agent" "main" {
     fi
   EOT
 
-  env = {
+  env = merge({
     GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
     GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
-    # Persisted toolchains (see install-languages.sh.tftpl) install under
-    # $HOME/.local. Put their bin directories on PATH here so every session the
-    # agent spawns sees them regardless of login or interactivity; the agent
-    # expands $PATH/$HOME at apply time.
-    PATH = "$PATH:$HOME/.local/go/bin:$HOME/go/bin:$HOME/.local/node/bin:$HOME/.local/java/bin"
-  }
+    # Durable PATH for persisted toolchains. Toolchains that survive a restart
+    # install under $HOME (see install-languages.sh.tftpl); their bin directories
+    # go on PATH here because the agent applies coder_agent.main.env to every
+    # session it spawns regardless of login or interactivity (coder ssh -- cmd,
+    # IDE terminals, remote-IDE exec), which ~/.profile alone does not reach. The
+    # agent expands $PATH/$HOME at apply time. $HOME/.local/bin and
+    # $HOME/.cargo/bin cover pip --user and rustup, which otherwise stay
+    # login-shell-only.
+    PATH = "$PATH:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.local/go/bin:$HOME/go/bin:$HOME/.local/node/bin:$HOME/.local/java/bin"
+    }, contains(local.languages, "java") ? {
+    # Java tooling (Gradle, Maven, IDE SDK detection) keys off JAVA_HOME, so set
+    # it in the same durable env, but only when Java is selected: an
+    # unconditional value would point at a missing directory everywhere else.
+    JAVA_HOME = "$HOME/.local/java"
+  } : {})
 
   metadata {
     display_name = "CPU Usage"

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"os/exec"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -601,6 +603,142 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 
 	require.ElementsMatch(t, selectorValues, dispatchNames,
 		"quickstart languages selector options must match the install script's has_language branches")
+}
+
+// TestQuickstartToolchainsPersistUnderHome guards the fix for the every-start
+// reinstall: Go, Node.js, and Java must install under $HOME (the persistent home
+// volume) instead of into the ephemeral container, so a workspace restart reuses
+// them rather than re-fetching them from the network. It asserts the system-level
+// install mechanisms this change removed do not creep back in, and that each of
+// the three toolchains still puts its bin directory under $HOME on PATH, exposed
+// both through the coder_agent env (which reaches every agent-spawned session)
+// and a ~/.profile fallback. Python and C/C++ come from the base image and Rust
+// already persists under ~/.cargo, so they are out of scope here.
+func TestQuickstartToolchainsPersistUnderHome(t *testing.T) {
+	t.Parallel()
+
+	fsys, err := templatebuilder.BaseTemplateFS("quickstart")
+	require.NoError(t, err)
+	raw, err := fs.ReadFile(fsys, "install-languages.sh.tftpl")
+	require.NoError(t, err)
+	script := string(raw)
+
+	// System-level installs that landed in the ephemeral container and so
+	// re-downloaded on every start. None of these may return.
+	for _, ephemeral := range []string{
+		"/usr/local/go",                 // Go unpacked into the system prefix
+		"deb.nodesource.com",            // Node.js installed via apt
+		"apt-get install -y -qq nodejs", // Node.js installed via apt
+		"openjdk",                       // Java installed via apt
+	} {
+		require.NotContains(t, script, ephemeral,
+			"Go/Node.js/Java must persist under $HOME, not reinstall into the ephemeral container")
+	}
+
+	// Each network toolchain must put its bin directory under the persistent home
+	// volume on PATH, so it survives a restart.
+	for _, persisted := range []string{
+		"$HOME/.local/go/bin",   // Go
+		"$HOME/.local/node/bin", // Node.js
+		"$HOME/.local/java/bin", // Java
+	} {
+		require.Contains(t, script, persisted,
+			"expected the toolchain to install under the persistent home volume")
+	}
+
+	// PATH must reach every session, including the non-login, non-interactive
+	// shells coder ssh and remote IDEs use. The durable mechanism is the
+	// coder_agent env, which the agent applies to every session it spawns
+	// regardless of login or interactivity; ~/.profile (login shells only) is a
+	// fallback for shells the agent does not spawn. Assert the agent env carries
+	// each toolchain bin dir on PATH.
+	rc := testRenderContext("quickstart")
+	mainTF, err := templatebuilder.RenderBaseTemplate("quickstart", "main.tf.tmpl", rc)
+	require.NoError(t, err)
+	require.Regexp(t, `PATH\s*=\s*"\$PATH:`, string(mainTF),
+		"coder_agent env must prepend the existing PATH")
+	for _, binDir := range []string{
+		"$HOME/.local/go/bin",
+		"$HOME/go/bin",
+		"$HOME/.local/node/bin",
+		"$HOME/.local/java/bin",
+	} {
+		require.Contains(t, string(mainTF), binDir,
+			"coder_agent env PATH must include %s so every agent session sees the toolchain", binDir)
+	}
+
+	// Keep a ~/.profile fallback for login shells the agent does not spawn, and
+	// do not rely on ~/.bashrc, which returns early in non-interactive shells.
+	require.Contains(t, script, "$HOME/.profile",
+		"the install script should persist PATH to ~/.profile as a login-shell fallback")
+	require.NotContains(t, script, ".bashrc",
+		"~/.bashrc returns early in non-interactive shells; use ~/.profile plus the agent env")
+}
+
+// TestQuickstartInstallScriptRendersValidBash renders the quickstart language
+// install template the way Terraform's templatefile() does, then syntax-checks
+// the result with `bash -n` and lints it with `shellcheck`. The .sh.tftpl
+// extension hides this base from lint/shellcheck and fmt/shfmt (both match only
+// *.sh), so without this test the script has no mechanical coverage: a template
+// edit that renders to broken shell, or a quoting/expansion defect `bash -n`
+// cannot see, would ship silently. This guards the whole file, including the
+// PATH and atomic-install logic other tests only assert on as text.
+func TestQuickstartInstallScriptRendersValidBash(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("bash is not available on Windows runners")
+	}
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not found in PATH")
+	}
+
+	fsys, err := templatebuilder.BaseTemplateFS("quickstart")
+	require.NoError(t, err)
+	raw, err := fs.ReadFile(fsys, "install-languages.sh.tftpl")
+	require.NoError(t, err)
+
+	// Emulate Terraform templatefile(): the only interpolation token in this
+	// file is ${LANGUAGES}, and every shell brace expansion is escaped as
+	// $${...}, which Terraform unescapes to ${...}. Substitute all selectable
+	// languages so every install branch is present in the checked script.
+	rendered := strings.ReplaceAll(string(raw), "${LANGUAGES}", "python,nodejs,go,rust,java,cpp")
+	rendered = strings.ReplaceAll(rendered, "$${", "${")
+
+	cmd := exec.Command(bashPath, "-n")
+	cmd.Stdin = strings.NewReader(rendered)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "rendered install script failed `bash -n`:\n%s", out)
+
+	// shellcheck catches quoting and expansion defects that are valid bash
+	// syntax (so `bash -n` passes) but wrong at runtime, e.g. an unquoted
+	// expansion that word-splits. Skip when the linter is absent so the test
+	// stays hermetic on runners without it.
+	shellcheckPath, err := exec.LookPath("shellcheck")
+	if err != nil {
+		t.Skip("shellcheck not found in PATH")
+	}
+	scCmd := exec.Command(shellcheckPath, "-s", "bash", "-")
+	scCmd.Stdin = strings.NewReader(rendered)
+	scOut, err := scCmd.CombinedOutput()
+	require.NoErrorf(t, err, "rendered install script failed shellcheck:\n%s", scOut)
+}
+
+// stripHCLCommentLines drops whole-line "#" comments so a registry host left in
+// a module source is caught while the "# Module docs (public registry):
+// registry.coder.com/modules/..." links, which legitimately name the public
+// registry, are excluded by construction.
+func stripHCLCommentLines(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		_, _ = b.WriteString(line)
+		_ = b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 func TestRenderBaseHonorsRegistryMirror(t *testing.T) {

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/templatebuilder"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestCompose(t *testing.T) {
@@ -605,15 +606,11 @@ func TestQuickstartLanguageSelectorMatchesInstallScript(t *testing.T) {
 		"quickstart languages selector options must match the install script's has_language branches")
 }
 
-// TestQuickstartToolchainsPersistUnderHome guards the fix for the every-start
-// reinstall: Go, Node.js, and Java must install under $HOME (the persistent home
-// volume) instead of into the ephemeral container, so a workspace restart reuses
-// them rather than re-fetching them from the network. It asserts the system-level
-// install mechanisms this change removed do not creep back in, and that each of
-// the three toolchains still puts its bin directory under $HOME on PATH, exposed
-// both through the coder_agent env (which reaches every agent-spawned session)
-// and a ~/.profile fallback. Python and C/C++ come from the base image and Rust
-// already persists under ~/.cargo, so they are out of scope here.
+// TestQuickstartToolchainsPersistUnderHome guards the every-start reinstall fix:
+// Go, Node.js, and Java must install under $HOME (the persistent home volume)
+// and reach every session, so a restart reuses them instead of re-fetching from
+// the network. The assertions encode those invariants rather than a blocklist of
+// yesterday's strings, so reintroducing the regression another way still fails.
 func TestQuickstartToolchainsPersistUnderHome(t *testing.T) {
 	t.Parallel()
 
@@ -623,122 +620,155 @@ func TestQuickstartToolchainsPersistUnderHome(t *testing.T) {
 	require.NoError(t, err)
 	script := string(raw)
 
-	// System-level installs that landed in the ephemeral container and so
-	// re-downloaded on every start. None of these may return.
-	for _, ephemeral := range []string{
-		"/usr/local/go",                 // Go unpacked into the system prefix
-		"deb.nodesource.com",            // Node.js installed via apt
-		"apt-get install -y -qq nodejs", // Node.js installed via apt
-		"openjdk",                       // Java installed via apt
-	} {
-		require.NotContains(t, script, ephemeral,
-			"Go/Node.js/Java must persist under $HOME, not reinstall into the ephemeral container")
-	}
+	// The persistent root must be under $HOME, so moving it off the home volume
+	// (e.g. LOCAL_PREFIX="/opt/toolchains") fails here instead of slipping past a
+	// blocklist that only named the old system paths.
+	require.Contains(t, script, `LOCAL_PREFIX="$HOME/.local"`,
+		"network toolchains must root under $HOME so they persist across restarts")
 
-	// Each network toolchain must put its bin directory under the persistent home
-	// volume on PATH, so it survives a restart.
-	for _, persisted := range []string{
-		"$HOME/.local/go/bin",   // Go
-		"$HOME/.local/node/bin", // Node.js
-		"$HOME/.local/java/bin", // Java
+	// Each network toolchain must define its dir under $LOCAL_PREFIX and install
+	// into it via install_tarball. Asserting the install_tarball call (not the
+	// absence of apt) fails a swap to `apt-get install` even with flags the old
+	// blocklist never enumerated.
+	for _, tc := range []struct {
+		name   string
+		dirDef string
+	}{
+		{"NODE_DIR", `NODE_DIR="$LOCAL_PREFIX/node"`},
+		{"GO_DIR", `GO_DIR="$LOCAL_PREFIX/go"`},
+		{"JAVA_DIR", `JAVA_DIR="$LOCAL_PREFIX/java"`},
 	} {
-		require.Contains(t, script, persisted,
-			"expected the toolchain to install under the persistent home volume")
+		require.Contains(t, script, tc.dirDef,
+			"%s must be defined under $LOCAL_PREFIX", tc.name)
+		require.Regexp(t, `install_tarball\s+"[^"]+"\s+"\$`+tc.name+`"`, script,
+			"%s toolchain must install via install_tarball into $%s", tc.name, tc.name)
 	}
 
 	// PATH must reach every session, including the non-login, non-interactive
 	// shells coder ssh and remote IDEs use. The durable mechanism is the
-	// coder_agent env, which the agent applies to every session it spawns
-	// regardless of login or interactivity; ~/.profile (login shells only) is a
-	// fallback for shells the agent does not spawn. Assert the agent env carries
-	// each toolchain bin dir on PATH.
+	// coder_agent env (see main.tf). Parse the PATH value and assert each bin dir
+	// is a real ":"-separated element, so dropping one while mentioning it in a
+	// nearby comment (which a substring match would accept) fails.
 	rc := testRenderContext("quickstart")
 	mainTF, err := templatebuilder.RenderBaseTemplate("quickstart", "main.tf.tmpl", rc)
 	require.NoError(t, err)
-	require.Regexp(t, `PATH\s*=\s*"\$PATH:`, string(mainTF),
-		"coder_agent env must prepend the existing PATH")
+	pathElems := strings.Split(extractAgentEnvPATH(t, string(mainTF)), ":")
+	require.Equal(t, "$PATH", pathElems[0], "coder_agent env PATH must prepend the existing $PATH")
 	for _, binDir := range []string{
-		"$HOME/.local/go/bin",
-		"$HOME/go/bin",
-		"$HOME/.local/node/bin",
-		"$HOME/.local/java/bin",
+		"$HOME/.local/bin",      // pip install --user
+		"$HOME/.cargo/bin",      // rustup
+		"$HOME/.local/go/bin",   // Go
+		"$HOME/go/bin",          // go install targets
+		"$HOME/.local/node/bin", // Node.js
+		"$HOME/.local/java/bin", // Java
 	} {
-		require.Contains(t, string(mainTF), binDir,
-			"coder_agent env PATH must include %s so every agent session sees the toolchain", binDir)
+		require.Contains(t, pathElems, binDir,
+			"coder_agent env PATH must include %s as a path element", binDir)
 	}
 
-	// Keep a ~/.profile fallback for login shells the agent does not spawn, and
-	// do not rely on ~/.bashrc, which returns early in non-interactive shells.
-	require.Contains(t, script, "$HOME/.profile",
-		"the install script should persist PATH to ~/.profile as a login-shell fallback")
+	// JAVA_HOME goes in the same durable env, conditional on Java so it never
+	// points at a missing dir, with a ~/.profile export as the login-shell
+	// fallback.
+	require.Regexp(t, `contains\(local\.languages, "java"\)\s*\?\s*\{[^}]*JAVA_HOME\s*=\s*"\$HOME/\.local/java"`, string(mainTF),
+		"JAVA_HOME must be set in the agent env, conditional on Java being selected")
+	require.Contains(t, script, `export JAVA_HOME=$HOME/.local/java`,
+		"the install script should also persist JAVA_HOME to ~/.profile for login shells")
+
+	// The install script keeps a ~/.profile fallback and must not rely on
+	// ~/.bashrc, which returns early in non-interactive shells.
+	require.Contains(t, script, `PROFILE="$HOME/.profile"`,
+		"the install script should persist to ~/.profile as a login-shell fallback")
 	require.NotContains(t, script, ".bashrc",
 		"~/.bashrc returns early in non-interactive shells; use ~/.profile plus the agent env")
 }
 
-// TestQuickstartInstallScriptRendersValidBash renders the quickstart language
-// install template the way Terraform's templatefile() does, then syntax-checks
-// the result with `bash -n` and lints it with `shellcheck`. The .sh.tftpl
-// extension hides this base from lint/shellcheck and fmt/shfmt (both match only
-// *.sh), so without this test the script has no mechanical coverage: a template
-// edit that renders to broken shell, or a quoting/expansion defect `bash -n`
-// cannot see, would ship silently. This guards the whole file, including the
-// PATH and atomic-install logic other tests only assert on as text.
+// extractAgentEnvPATH returns the value of the PATH assignment in the rendered
+// coder_agent env block.
+func extractAgentEnvPATH(t *testing.T, mainTF string) string {
+	t.Helper()
+	m := regexp.MustCompile(`(?m)^\s*PATH\s*=\s*"([^"]*)"`).FindStringSubmatch(mainTF)
+	require.Len(t, m, 2, "expected a PATH assignment in the rendered coder_agent env")
+	return m[1]
+}
+
+// unescapedInterpolationPattern matches a Terraform ${name} interpolation that
+// is not escaped as $${name}; the char before ${ is captured and must not be $.
+var unescapedInterpolationPattern = regexp.MustCompile(`(^|[^$])\$\{([A-Za-z0-9_]+)\}`)
+
+// TestQuickstartInstallScriptRendersValidBash gives the quickstart install
+// template the mechanical coverage its .sh.tftpl extension hides from
+// lint/shellcheck and fmt/shfmt (both match only *.sh): it verifies the
+// Terraform escaping, then renders the script and checks it with `bash -n` and
+// shellcheck, guarding the whole file including the PATH and atomic-install
+// logic other tests only assert on as text.
 func TestQuickstartInstallScriptRendersValidBash(t *testing.T) {
 	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("bash is not available on Windows runners")
-	}
-	bashPath, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skip("bash not found in PATH")
-	}
 
 	fsys, err := templatebuilder.BaseTemplateFS("quickstart")
 	require.NoError(t, err)
 	raw, err := fs.ReadFile(fsys, "install-languages.sh.tftpl")
 	require.NoError(t, err)
 
-	// Emulate Terraform templatefile(): the only interpolation token in this
-	// file is ${LANGUAGES}, and every shell brace expansion is escaped as
-	// $${...}, which Terraform unescapes to ${...}. Substitute all selectable
-	// languages so every install branch is present in the checked script.
+	// Verify the escaping on the raw template rather than emulating it: the only
+	// interpolation this file passes to templatefile() is ${LANGUAGES}, so every
+	// other ${...} must be escaped as $${...}. An unescaped ${FOO} renders fine
+	// but fails templatefile() at every workspace build, which bash -n cannot see.
+	for _, m := range unescapedInterpolationPattern.FindAllStringSubmatch(string(raw), -1) {
+		require.Equalf(t, "LANGUAGES", m[2],
+			"unescaped Terraform interpolation ${%s}; write shell brace expansions as $${%s}", m[2], m[2])
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("bash and shellcheck are not available on Windows runners")
+	}
+
+	// Emulate Terraform templatefile(): substitute ${LANGUAGES} with every
+	// selectable language so all install branches are present, then unescape
+	// $${ to ${.
 	rendered := strings.ReplaceAll(string(raw), "${LANGUAGES}", "python,nodejs,go,rust,java,cpp")
 	rendered = strings.ReplaceAll(rendered, "$${", "${")
 
-	cmd := exec.Command(bashPath, "-n")
-	cmd.Stdin = strings.NewReader(rendered)
-	out, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "rendered install script failed `bash -n`:\n%s", out)
-
-	// shellcheck catches quoting and expansion defects that are valid bash
-	// syntax (so `bash -n` passes) but wrong at runtime, e.g. an unquoted
-	// expansion that word-splits. Skip when the linter is absent so the test
-	// stays hermetic on runners without it.
-	shellcheckPath, err := exec.LookPath("shellcheck")
-	if err != nil {
-		t.Skip("shellcheck not found in PATH")
-	}
-	scCmd := exec.Command(shellcheckPath, "-s", "bash", "-")
-	scCmd.Stdin = strings.NewReader(rendered)
-	scOut, err := scCmd.CombinedOutput()
-	require.NoErrorf(t, err, "rendered install script failed shellcheck:\n%s", scOut)
-}
-
-// stripHCLCommentLines drops whole-line "#" comments so a registry host left in
-// a module source is caught while the "# Module docs (public registry):
-// registry.coder.com/modules/..." links, which legitimately name the public
-// registry, are excluded by construction.
-func stripHCLCommentLines(s string) string {
-	var b strings.Builder
-	for _, line := range strings.Split(s, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
-			continue
+	t.Run("bash -n", func(t *testing.T) {
+		t.Parallel()
+		bashPath, err := exec.LookPath("bash")
+		if err != nil {
+			t.Skip("bash not found in PATH")
 		}
-		_, _ = b.WriteString(line)
-		_ = b.WriteByte('\n')
-	}
-	return b.String()
+		cmd := exec.CommandContext(t.Context(), bashPath, "-n")
+		cmd.Stdin = strings.NewReader(rendered)
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "rendered install script failed `bash -n`:\n%s", out)
+	})
+
+	t.Run("shellcheck", func(t *testing.T) {
+		t.Parallel()
+		shellcheckPath, err := exec.LookPath("shellcheck")
+		if err != nil {
+			// shellcheck is pre-installed on the Linux CI runners (the lint job's
+			// lint/shellcheck relies on the same ambient binary), so require it
+			// there to keep this coverage from silently vanishing. It is not
+			// guaranteed on the macOS runner image, so skip rather than fail when
+			// it is absent off Linux.
+			if testutil.InCI() && runtime.GOOS == "linux" {
+				t.Fatal("shellcheck must be installed on Linux CI so this coverage cannot silently vanish")
+			}
+			t.Skip("shellcheck not found in PATH")
+		}
+		cmd := exec.CommandContext(t.Context(), shellcheckPath, "-s", "bash", "-")
+		cmd.Stdin = strings.NewReader(rendered)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			return
+		}
+		// Distinguish a lint finding (exit 1) from a tool or launch failure (any
+		// other exit code), so a broken shellcheck invocation is not misreported
+		// as a defect in the script.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			t.Fatalf("rendered install script failed shellcheck:\n%s", out)
+		}
+		t.Fatalf("could not run shellcheck (%v):\n%s", err, out)
+	})
 }
 
 func TestRenderBaseHonorsRegistryMirror(t *testing.T) {

--- a/coderd/templatebuilder/testdata/quickstart.tf.golden
+++ b/coderd/templatebuilder/testdata/quickstart.tf.golden
@@ -107,6 +107,11 @@ resource "coder_agent" "main" {
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
     GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
+    # Persisted toolchains (see install-languages.sh.tftpl) install under
+    # $HOME/.local. Put their bin directories on PATH here so every session the
+    # agent spawns sees them regardless of login or interactivity; the agent
+    # expands $PATH/$HOME at apply time.
+    PATH = "$PATH:$HOME/.local/go/bin:$HOME/go/bin:$HOME/.local/node/bin:$HOME/.local/java/bin"
   }
 
   metadata {

--- a/coderd/templatebuilder/testdata/quickstart.tf.golden
+++ b/coderd/templatebuilder/testdata/quickstart.tf.golden
@@ -102,17 +102,26 @@ resource "coder_agent" "main" {
     fi
   EOT
 
-  env = {
+  env = merge({
     GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
     GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
-    # Persisted toolchains (see install-languages.sh.tftpl) install under
-    # $HOME/.local. Put their bin directories on PATH here so every session the
-    # agent spawns sees them regardless of login or interactivity; the agent
-    # expands $PATH/$HOME at apply time.
-    PATH = "$PATH:$HOME/.local/go/bin:$HOME/go/bin:$HOME/.local/node/bin:$HOME/.local/java/bin"
-  }
+    # Durable PATH for persisted toolchains. Toolchains that survive a restart
+    # install under $HOME (see install-languages.sh.tftpl); their bin directories
+    # go on PATH here because the agent applies coder_agent.main.env to every
+    # session it spawns regardless of login or interactivity (coder ssh -- cmd,
+    # IDE terminals, remote-IDE exec), which ~/.profile alone does not reach. The
+    # agent expands $PATH/$HOME at apply time. $HOME/.local/bin and
+    # $HOME/.cargo/bin cover pip --user and rustup, which otherwise stay
+    # login-shell-only.
+    PATH = "$PATH:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.local/go/bin:$HOME/go/bin:$HOME/.local/node/bin:$HOME/.local/java/bin"
+    }, contains(local.languages, "java") ? {
+    # Java tooling (Gradle, Maven, IDE SDK detection) keys off JAVA_HOME, so set
+    # it in the same durable env, but only when Java is selected: an
+    # unconditional value would point at a missing directory everywhere else.
+    JAVA_HOME = "$HOME/.local/java"
+  } : {})
 
   metadata {
     display_name = "CPU Usage"


### PR DESCRIPTION
## What

The Coder Quickstart base installed Go, Node.js, and Java into the ephemeral workspace container, so every workspace start re-downloaded them from the network and blocked login while they reinstalled. Only Rust (`~/.cargo`) persisted; Python and C/C++ ship in the base image.

This change installs Go, Node.js, and Java under `$HOME/.local` so they persist on the home volume across restarts:

- **Go**: official tarball unpacked to `~/.local/go` (was `/usr/local`).
- **Node.js**: official 22.x tarball unpacked to `~/.local/node` (was NodeSource apt).
- **Java**: Eclipse Temurin 21 JDK tarball unpacked to `~/.local/java` (was `apt install openjdk`).

The durable PATH mechanism is `coder_agent.main.env` in `main.tf.tmpl`: the agent applies that env to every session it spawns regardless of login or interactivity (`coder ssh` commands, IDE terminals, remote-IDE exec), which `~/.profile` alone does not reach. The env PATH also covers `~/.local/bin` (pip user installs) and `~/.cargo/bin` (rustup), and sets `JAVA_HOME` conditional on Java being selected. `install-languages.sh.tftpl` still appends guarded, idempotent exports to `~/.profile` as a fallback for the login shells the agent does not spawn.

Each toolchain is fetched over an immutable, version-pinned URL and its download is checksum-verified (sha256) before an atomic install, so a truncated or tampered archive is never persisted under `~/.local`. The first start downloads the selected toolchains once; every later start detects and reuses the persisted copies, so login is no longer blocked on a network reinstall. A persisted toolchain version is frozen after that first install; the README documents this and the `rm -rf ~/.local/<toolchain>` escape hatch to move to a newer version.

Python and C/C++ remain image-provided, and Rust already persisted under `~/.cargo`, so those branches are unchanged.

## Why

Follow-up from the coder/coder#27247 review: the quickstart base's language install runs on every start with `start_blocks_login = true`, and the non-persisted toolchains reinstalled from the network each time, which is slow on every start and broken on network-restricted deployments.

## Scope

This base assumes the deployment has internet access; the first install fetches toolchains from the network. Fully air-gapped installs are explicitly out of scope and would warrant a dedicated quickstart.

## Testing

- `go test ./coderd/templatebuilder/ -race -shuffle=on` and `go build ./coderd/`.
- `TestQuickstartToolchainsPersistUnderHome` asserts the persistence invariants (toolchains rooted under `$HOME/.local`, installed via `install_tarball`, and each bin dir present as a real `:`-separated element of the rendered `coder_agent.main.env` PATH, plus the conditional `JAVA_HOME`), so a regression that moves a toolchain off the home volume or drops a PATH entry fails even if it avoids the old strings. Mutation-tested.
- `TestQuickstartInstallScriptRendersValidBash` verifies the Terraform `${...}` escaping on the raw template, then renders the script and checks it with `bash -n` and `shellcheck` (shellcheck required in CI). I also rendered the template through the real Terraform `templatefile()` (terraform 1.15.5) and confirmed the output passes `bash -n` and `shellcheck`.
- Installed Node.js, Go, and Java end to end in `codercom/enterprise-base:ubuntu`: all checksums verify, a re-run reuses the persisted toolchains, and `~/.profile` stays deduplicated.

## Stacked PR

Stacked on #28480 (registry mirror). #27247 (the quickstart base) has merged; #28480 remains open, so this PR targets the #28480 branch and will be re-targeted to `main` once #28480 merges.

Tracked in DOCS-614. Pre-existing follow-up filed as DOCS-736 (cpp branch never installs `cmake`).

> This PR was created with AI assistance (Coder Agents).

