### PR TITLE
fix(aibridge): disable Copilot responses websockets

### DIFF
--- a/aibridge/passthrough.go
+++ b/aibridge/passthrough.go
@@ -1,18 +1,27 @@
 package aibridge
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
+	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/intercept/apidump"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/metrics"
@@ -50,6 +59,13 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			rewritePassthroughRequest(pr, provBaseURL)
 		},
+		ModifyResponse: func(resp *http.Response) error {
+			modelsPath := path.Join("/", provBaseURL.Path, "models")
+			if prov.Type() != config.ProviderCopilot || resp.Request.Method != http.MethodGet || strings.TrimSuffix(resp.Request.URL.Path, "/") != modelsPath || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return nil
+			}
+			return filterCopilotModelsResponse(resp)
+		},
 		Transport: keypool.NewKeyFailoverTransport(
 			apidump.NewPassthroughMiddleware(t, prov.APIDumpDir(), prov.Name(), logger, quartz.NewReal()),
 			prov.KeyFailoverConfig(logger),
@@ -74,6 +90,122 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 
 		proxy.ServeHTTP(w, r.WithContext(ctx))
 	}
+}
+
+func filterCopilotModelsResponse(resp *http.Response) error {
+	wireBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = resp.Body.Close()
+		return xerrors.Errorf("read Copilot models response: %w", err)
+	}
+	_ = resp.Body.Close()
+
+	body := wireBody
+	contentEncoding := resp.Header.Get("Content-Encoding")
+	if contentEncoding == "gzip" {
+		reader, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			return nil
+		}
+		decoded, err := io.ReadAll(reader)
+		_ = reader.Close()
+		if err != nil {
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			return nil
+		}
+		body = decoded
+	} else if contentEncoding != "" {
+		resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+		return nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+		return nil
+	}
+
+	var models []json.RawMessage
+	if err := json.Unmarshal(payload["data"], &models); err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+		return nil
+	}
+
+	modified := false
+	for i, rawModel := range models {
+		var model map[string]json.RawMessage
+		if err := json.Unmarshal(rawModel, &model); err != nil {
+			continue
+		}
+
+		rawEndpoints, ok := model["supported_endpoints"]
+		if !ok {
+			continue
+		}
+		var endpoints []string
+		if err := json.Unmarshal(rawEndpoints, &endpoints); err != nil {
+			continue
+		}
+
+		filtered := endpoints[:0]
+		for _, endpoint := range endpoints {
+			if endpoint != "ws:/responses" {
+				filtered = append(filtered, endpoint)
+			}
+		}
+		if len(filtered) == len(endpoints) {
+			continue
+		}
+
+		model["supported_endpoints"], err = json.Marshal(filtered)
+		if err != nil {
+			resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+			return nil
+		}
+		models[i], err = json.Marshal(model)
+		if err != nil {
+			resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+			return nil
+		}
+		modified = true
+	}
+	if !modified {
+		resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+		return nil
+	}
+
+	payload["data"], err = json.Marshal(models)
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+		return nil
+	}
+	body, err = json.Marshal(payload)
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+		return nil
+	}
+
+	if contentEncoding == "gzip" {
+		var compressed bytes.Buffer
+		writer := gzip.NewWriter(&compressed)
+		if _, err := writer.Write(body); err != nil {
+			resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+			return nil
+		}
+		if err := writer.Close(); err != nil {
+			resp.Body = io.NopCloser(bytes.NewReader(wireBody))
+			return nil
+		}
+		body = compressed.Bytes()
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	resp.Header.Del("Content-MD5")
+	resp.Header.Del("ETag")
+	return nil
 }
 
 // rewritePassthroughRequest configures the outbound request for the upstream and

--- a/aibridge/passthrough_internal_test.go
+++ b/aibridge/passthrough_internal_test.go
@@ -1,14 +1,19 @@
 package aibridge
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"encoding/json"
+	"io"
 	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
@@ -138,6 +143,201 @@ func TestPassthroughRoutes(t *testing.T) {
 			assert.Contains(t, resp.Body.String(), tc.expectRespBody)
 		})
 	}
+}
+
+func TestPassthroughCopilotModelsResponse(t *testing.T) {
+	t.Parallel()
+
+	const modelsResponse = `{
+		"data": [
+			{
+				"id": "gpt-test",
+				"supported_endpoints": ["/chat/completions", "ws:/responses", "/responses", "ws:/responses"],
+				"unknown": {"preserved": true}
+			},
+			{
+				"id": "other-test"
+			}
+		],
+		"unknown_top_level": "preserved"
+	}`
+
+	tests := []struct {
+		name        string
+		provider    string
+		method      string
+		path        string
+		baseURLPath string
+		statusCode  int
+		body        string
+		gzip        bool
+		modified    bool
+	}{
+		{
+			name:       "copilot GET models",
+			provider:   config.ProviderCopilot,
+			method:     http.MethodGet,
+			path:       "/models",
+			statusCode: http.StatusOK,
+			body:       modelsResponse,
+			modified:   true,
+		},
+		{
+			name:       "copilot GET models trailing slash",
+			provider:   config.ProviderCopilot,
+			method:     http.MethodGet,
+			path:       "/models/",
+			statusCode: http.StatusOK,
+			body:       modelsResponse,
+			modified:   true,
+		},
+		{
+			name:        "copilot GET models with base path",
+			provider:    config.ProviderCopilot,
+			method:      http.MethodGet,
+			path:        "/models",
+			baseURLPath: "/v1",
+			statusCode:  http.StatusOK,
+			body:        modelsResponse,
+			modified:    true,
+		},
+		{
+			name:       "copilot GET compressed models",
+			provider:   config.ProviderCopilot,
+			method:     http.MethodGet,
+			path:       "/models",
+			statusCode: http.StatusOK,
+			body:       modelsResponse,
+			gzip:       true,
+			modified:   true,
+		},
+		{
+			name:       "other provider",
+			provider:   config.ProviderOpenAI,
+			method:     http.MethodGet,
+			path:       "/models",
+			statusCode: http.StatusOK,
+			body:       modelsResponse,
+		},
+		{
+			name:       "copilot POST models",
+			provider:   config.ProviderCopilot,
+			method:     http.MethodPost,
+			path:       "/models",
+			statusCode: http.StatusOK,
+			body:       modelsResponse,
+		},
+		{
+			name:       "copilot models error",
+			provider:   config.ProviderCopilot,
+			method:     http.MethodGet,
+			path:       "/models",
+			statusCode: http.StatusForbidden,
+			body:       modelsResponse,
+		},
+		{
+			name:       "copilot malformed models",
+			provider:   config.ProviderCopilot,
+			method:     http.MethodGet,
+			path:       "/models",
+			statusCode: http.StatusOK,
+			body:       `{not JSON}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tc.baseURLPath+tc.path, r.URL.Path)
+				if tc.gzip {
+					w.Header().Set("Content-Encoding", "gzip")
+				}
+				w.WriteHeader(tc.statusCode)
+				if tc.gzip {
+					var body bytes.Buffer
+					writer := gzip.NewWriter(&body)
+					_, err := writer.Write([]byte(tc.body))
+					require.NoError(t, err)
+					require.NoError(t, writer.Close())
+					_, _ = w.Write(body.Bytes())
+					return
+				}
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(upstream.Close)
+
+			logger := slogtest.Make(t, nil)
+			prov := &testutil.MockProvider{NameStr: tc.provider, URL: upstream.URL + tc.baseURLPath}
+			handler := newPassthroughRouter(prov, logger, nil, testTracer)
+
+			req := httptest.NewRequest(tc.method, "http://proxy.example.test"+tc.path, nil)
+			if tc.gzip {
+				req.Header.Set("Accept-Encoding", "gzip")
+			}
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+
+			assert.Equal(t, tc.statusCode, resp.Code)
+			if !tc.modified {
+				assert.Equal(t, tc.body, resp.Body.String())
+				return
+			}
+
+			var responseBody []byte
+			if resp.Header().Get("Content-Encoding") == "gzip" {
+				reader, err := gzip.NewReader(bytes.NewReader(resp.Body.Bytes()))
+				require.NoError(t, err)
+				responseBody, err = io.ReadAll(reader)
+				require.NoError(t, err)
+				require.NoError(t, reader.Close())
+			} else {
+				responseBody = resp.Body.Bytes()
+			}
+
+			var payload struct {
+				Data []struct {
+					ID                 string          `json:"id"`
+					SupportedEndpoints []string        `json:"supported_endpoints"`
+					Unknown            json.RawMessage `json:"unknown"`
+				} `json:"data"`
+				UnknownTopLevel string `json:"unknown_top_level"`
+			}
+			require.NoError(t, json.Unmarshal(responseBody, &payload))
+			require.Len(t, payload.Data, 2)
+			assert.Equal(t, []string{"/chat/completions", "/responses"}, payload.Data[0].SupportedEndpoints)
+			assert.JSONEq(t, `{"preserved": true}`, string(payload.Data[0].Unknown))
+			assert.Equal(t, "preserved", payload.UnknownTopLevel)
+			assert.Equal(t, strconv.Itoa(resp.Body.Len()), resp.Header().Get("Content-Length"))
+		})
+	}
+}
+
+type errorReadCloser struct {
+	closed bool
+}
+
+func (*errorReadCloser) Read(p []byte) (int, error) {
+	copy(p, "partial")
+	return len("partial"), io.ErrUnexpectedEOF
+}
+
+func (r *errorReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestFilterCopilotModelsResponseReadError(t *testing.T) {
+	t.Parallel()
+
+	body := &errorReadCloser{}
+	resp := &http.Response{Body: body, Header: http.Header{}}
+
+	err := filterCopilotModelsResponse(resp)
+
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.True(t, body.closed)
 }
 
 func TestRewritePassthroughRequest(t *testing.T) {


### PR DESCRIPTION
GitHub Copilot advertises `ws:/responses` in its `/models` response, which causes VS Code to attempt a Responses API WebSocket connection that AI Gateway does not currently support.

Remove the WebSocket endpoint from successful Copilot models responses while preserving the HTTP endpoints and all unknown response fields. Other providers, routes, methods, status codes, malformed responses, and supported content encodings remain unchanged.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents under user direction and review.
</details>
