### PR TITLE
feat: split public capabilities from entitlement details

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3738,6 +3738,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v2/deployment/capabilities": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "General"
+                ],
+                "summary": "Get deployment capabilities",
+                "operationId": "get-deployment-capabilities",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.DeploymentCapabilities"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/deployment/config": {
             "get": {
                 "produces": [
@@ -19201,6 +19221,20 @@ const docTemplate = `{
                 "CORSBehaviorPassthru"
             ]
         },
+        "codersdk.Capability": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "entitlement": {
+                    "$ref": "#/definitions/codersdk.Entitlement"
+                },
+                "usable": {
+                    "type": "boolean"
+                }
+            }
+        },
         "codersdk.ChangePasswordWithOneTimePasscodeRequest": {
             "type": "object",
             "required": [
@@ -22709,6 +22743,23 @@ const docTemplate = `{
                 },
                 "port": {
                     "type": "integer"
+                }
+            }
+        },
+        "codersdk.DeploymentCapabilities": {
+            "type": "object",
+            "properties": {
+                "features": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/codersdk.Capability"
+                    }
+                },
+                "has_license": {
+                    "type": "boolean"
+                },
+                "trial": {
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3301,6 +3301,22 @@
 				}
 			}
 		},
+		"/api/v2/deployment/capabilities": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["General"],
+				"summary": "Get deployment capabilities",
+				"operationId": "get-deployment-capabilities",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.DeploymentCapabilities"
+						}
+					}
+				}
+			}
+		},
 		"/api/v2/deployment/config": {
 			"get": {
 				"produces": ["application/json"],
@@ -17257,6 +17273,20 @@
 			"enum": ["simple", "passthru"],
 			"x-enum-varnames": ["CORSBehaviorSimple", "CORSBehaviorPassthru"]
 		},
+		"codersdk.Capability": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"entitlement": {
+					"$ref": "#/definitions/codersdk.Entitlement"
+				},
+				"usable": {
+					"type": "boolean"
+				}
+			}
+		},
 		"codersdk.ChangePasswordWithOneTimePasscodeRequest": {
 			"type": "object",
 			"required": ["email", "one_time_passcode", "password"],
@@ -20632,6 +20662,23 @@
 				},
 				"port": {
 					"type": "integer"
+				}
+			}
+		},
+		"codersdk.DeploymentCapabilities": {
+			"type": "object",
+			"properties": {
+				"features": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/codersdk.Capability"
+					}
+				},
+				"has_license": {
+					"type": "boolean"
+				},
+				"trial": {
+					"type": "boolean"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1435,11 +1435,14 @@ func New(options *Options) *API {
 			r.Get("/", api.derpMapUpdates)
 		})
 		r.Route("/deployment", func(r chi.Router) {
-			r.Use(apiKeyMiddleware)
-			r.Get("/config", api.deploymentValues)
-			r.Get("/stats", api.deploymentStats)
-			r.Get("/ssh", api.sshConfig)
-			r.Post("/premium-funnel-events", api.postPremiumFunnelEvent)
+			r.Get("/capabilities", api.deploymentCapabilities)
+			r.Group(func(r chi.Router) {
+				r.Use(apiKeyMiddleware)
+				r.Get("/config", api.deploymentValues)
+				r.Get("/stats", api.deploymentStats)
+				r.Get("/ssh", api.sshConfig)
+				r.Post("/premium-funnel-events", api.postPremiumFunnelEvent)
+			})
 		})
 		r.Route("/experiments", func(r chi.Router) {
 			r.Use(apiKeyMiddleware)

--- a/coderd/coderdtest/swaggerparser.go
+++ b/coderd/coderdtest/swaggerparser.go
@@ -364,6 +364,7 @@ func assertSecurityDefined(t *testing.T, comment SwaggerComment) {
 
 	if comment.router == "/api/v2/updatecheck" ||
 		comment.router == "/api/v2/buildinfo" ||
+		comment.router == "/api/v2/deployment/capabilities" ||
 		comment.router == "/api/v2/" ||
 		comment.router == "/api/v2/auth/scopes" ||
 		comment.router == "/api/v2/users/login" ||

--- a/coderd/deployment.go
+++ b/coderd/deployment.go
@@ -9,6 +9,16 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+// @Summary Get deployment capabilities
+// @ID get-deployment-capabilities
+// @Produce json
+// @Tags General
+// @Success 200 {object} codersdk.DeploymentCapabilities
+// @Router /api/v2/deployment/capabilities [get]
+func (api *API) deploymentCapabilities(rw http.ResponseWriter, r *http.Request) {
+	httpapi.Write(r.Context(), rw, http.StatusOK, api.Entitlements.AsCapabilitiesJSON())
+}
+
 // @Summary Get deployment config
 // @ID get-deployment-config
 // @Security CoderSessionToken

--- a/coderd/deployment_test.go
+++ b/coderd/deployment_test.go
@@ -2,14 +2,46 @@ package coderd_test
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
+
+func TestDeploymentCapabilities(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{})
+	capabilities, err := client.DeploymentCapabilities(t.Context())
+	require.NoError(t, err)
+	require.False(t, capabilities.HasLicense)
+	require.Len(t, capabilities.Features, len(codersdk.FeatureNames))
+	for _, capability := range capabilities.Features {
+		require.Equal(t, codersdk.EntitlementNotEntitled, capability.Entitlement)
+		require.False(t, capability.Enabled)
+		require.False(t, capability.Usable)
+	}
+
+	res, err := client.Request(t.Context(), http.MethodGet, "/api/v2/deployment/capabilities", nil)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	for _, field := range []string{
+		"\"limit\":", "\"actual\":", "\"actual_ms\":", "\"soft_limit\":",
+		"\"hard_limit\":", "\"usage_period\":", "\"warnings\":", "\"errors\":",
+		"\"require_telemetry\":", "\"refreshed_at\":",
+	} {
+		require.NotContains(t, string(body), field)
+	}
+}
 
 func TestDeploymentValues(t *testing.T) {
 	t.Parallel()

--- a/coderd/entitlements/entitlements.go
+++ b/coderd/entitlements/entitlements.go
@@ -129,6 +129,17 @@ func (l *Set) AsJSON() json.RawMessage {
 	return b
 }
 
+// AsCapabilitiesJSON returns the public capability projection without exposing
+// the entitlements for mutation.
+func (l *Set) AsCapabilitiesJSON() json.RawMessage {
+	l.entitlementsMu.RLock()
+	capabilities := l.entitlements.Capabilities()
+	l.entitlementsMu.RUnlock()
+
+	b, _ := json.Marshal(capabilities)
+	return b
+}
+
 func (l *Set) Modify(do func(entitlements *codersdk.Entitlements)) {
 	l.entitlementsMu.Lock()
 	defer l.entitlementsMu.Unlock()

--- a/coderd/entitlements/entitlements_test.go
+++ b/coderd/entitlements/entitlements_test.go
@@ -2,6 +2,7 @@ package entitlements_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -19,12 +20,22 @@ func TestModify(t *testing.T) {
 	require.False(t, set.Enabled(codersdk.FeatureMultipleOrganizations))
 
 	set.Modify(func(entitlements *codersdk.Entitlements) {
+		entitlements.HasLicense = true
 		entitlements.Features[codersdk.FeatureMultipleOrganizations] = codersdk.Feature{
 			Enabled:     true,
 			Entitlement: codersdk.EntitlementEntitled,
+			Limit:       new(int64(10)),
 		}
 	})
 	require.True(t, set.Enabled(codersdk.FeatureMultipleOrganizations))
+
+	var full codersdk.Entitlements
+	require.NoError(t, json.Unmarshal(set.AsJSON(), &full))
+	require.NotNil(t, full.Features[codersdk.FeatureMultipleOrganizations].Limit)
+	var public codersdk.DeploymentCapabilities
+	require.NoError(t, json.Unmarshal(set.AsCapabilitiesJSON(), &public))
+	require.True(t, public.Features[codersdk.FeatureMultipleOrganizations].Usable)
+	require.NotContains(t, string(set.AsCapabilitiesJSON()), "\"limit\"")
 }
 
 func TestAllowRefresh(t *testing.T) {
@@ -89,9 +100,11 @@ func TestUpdate(t *testing.T) {
 						Enabled: true,
 					},
 					codersdk.FeatureAppearance: {
-						Enabled: true,
+						Entitlement: codersdk.EntitlementEntitled,
+						Enabled:     true,
 					},
 				},
+				HasLicense: true,
 			}, nil
 		})
 		errCh <- err
@@ -103,6 +116,9 @@ func TestUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, set.Enabled(codersdk.FeatureMultipleOrganizations))
 	require.True(t, set.Enabled(codersdk.FeatureAppearance))
+	var public codersdk.DeploymentCapabilities
+	require.NoError(t, json.Unmarshal(set.AsCapabilitiesJSON(), &public))
+	require.True(t, public.Features[codersdk.FeatureAppearance].Usable)
 }
 
 func TestUpdate_LicenseRequiresTelemetry(t *testing.T) {
@@ -111,8 +127,10 @@ func TestUpdate_LicenseRequiresTelemetry(t *testing.T) {
 	set := entitlements.New()
 	set.Modify(func(entitlements *codersdk.Entitlements) {
 		entitlements.Errors = []string{"some error"}
+		entitlements.HasLicense = true
 		entitlements.Features[codersdk.FeatureAppearance] = codersdk.Feature{
-			Enabled: true,
+			Entitlement: codersdk.EntitlementEntitled,
+			Enabled:     true,
 		}
 	})
 	err := set.Update(ctx, func(_ context.Context) (codersdk.Entitlements, error) {
@@ -121,4 +139,8 @@ func TestUpdate_LicenseRequiresTelemetry(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, set.Enabled(codersdk.FeatureAppearance))
 	require.Equal(t, []string{entitlements.ErrLicenseRequiresTelemetry.Error()}, set.Errors())
+	var public codersdk.DeploymentCapabilities
+	require.NoError(t, json.Unmarshal(set.AsCapabilitiesJSON(), &public))
+	require.True(t, public.Features[codersdk.FeatureAppearance].Usable)
+	require.NotContains(t, string(set.AsCapabilitiesJSON()), entitlements.ErrLicenseRequiresTelemetry.Error())
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -537,6 +537,21 @@ func (f Feature) Capable() bool {
 	return true
 }
 
+// Capability is the public state needed to decide whether a deployment
+// feature can be used.
+type Capability struct {
+	Entitlement Entitlement `json:"entitlement"`
+	Enabled     bool        `json:"enabled"`
+	Usable      bool        `json:"usable"`
+}
+
+// DeploymentCapabilities contains public deployment feature state.
+type DeploymentCapabilities struct {
+	Features   map[FeatureName]Capability `json:"features"`
+	HasLicense bool                       `json:"has_license"`
+	Trial      bool                       `json:"trial"`
+}
+
 type Entitlements struct {
 	Features         map[FeatureName]Feature `json:"features"`
 	Warnings         []string                `json:"warnings"`
@@ -545,6 +560,28 @@ type Entitlements struct {
 	Trial            bool                    `json:"trial"`
 	RequireTelemetry bool                    `json:"require_telemetry"`
 	RefreshedAt      time.Time               `json:"refreshed_at" format:"date-time"`
+}
+
+// Capabilities returns the public deployment feature state derived from the
+// full entitlements.
+func (e Entitlements) Capabilities() DeploymentCapabilities {
+	features := make(map[FeatureName]Capability, len(FeatureNames))
+	for _, name := range FeatureNames {
+		feature, ok := e.Features[name]
+		if !ok {
+			feature.Entitlement = EntitlementNotEntitled
+		}
+		features[name] = Capability{
+			Entitlement: feature.Entitlement,
+			Enabled:     feature.Enabled,
+			Usable:      e.HasLicense && feature.Entitlement.Entitled() && feature.Enabled && feature.Capable(),
+		}
+	}
+	return DeploymentCapabilities{
+		Features:   features,
+		HasLicense: e.HasLicense,
+		Trial:      e.Trial,
+	}
 }
 
 // AddFeature will add the feature to the entitlements iff it expands
@@ -585,6 +622,20 @@ func (e *Entitlements) AddFeature(name FeatureName, add Feature) {
 		e.Features[name] = add
 		return
 	}
+}
+
+// DeploymentCapabilities returns public deployment feature state.
+func (c *Client) DeploymentCapabilities(ctx context.Context) (DeploymentCapabilities, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/deployment/capabilities", nil)
+	if err != nil {
+		return DeploymentCapabilities{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return DeploymentCapabilities{}, ReadBodyAsError(res)
+	}
+	var capabilities DeploymentCapabilities
+	return capabilities, ReadBodyAsJSON(res, &capabilities)
 }
 
 func (c *Client) Entitlements(ctx context.Context) (Entitlements, error) {

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -5,9 +5,11 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1060,6 +1062,85 @@ func TestExternalAuthYAMLConfig(t *testing.T) {
 	// Because we only marshal the 1 section, the correct section name is not applied.
 	output := strings.Replace(out.String(), "value:", "externalAuthProviders:", 1)
 	require.Equal(t, inputYAML, output, "re-marshaled is the same as input")
+}
+
+func TestEntitlementsCapabilities(t *testing.T) {
+	t.Parallel()
+
+	entitlements := codersdk.Entitlements{
+		Features: map[codersdk.FeatureName]codersdk.Feature{
+			codersdk.FeatureAuditLog: {
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     true,
+				Limit:       ptr.Ref(int64(10)),
+				Actual:      ptr.Ref(int64(5)),
+			},
+			codersdk.FeatureSCIM: {
+				Entitlement: codersdk.EntitlementGracePeriod,
+				Enabled:     true,
+			},
+			codersdk.FeatureUserLimit: {
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     true,
+				Limit:       ptr.Ref(int64(1)),
+				Actual:      ptr.Ref(int64(2)),
+			},
+			codersdk.FeatureBrowserOnly: {
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     false,
+			},
+			codersdk.FeatureAppearance: {
+				Entitlement: codersdk.EntitlementNotEntitled,
+				Enabled:     true,
+				SoftLimit:   ptr.Ref(int64(3)),
+				HardLimit:   ptr.Ref(int64(4)),
+				ActualMs:    ptr.Ref(int64(5)),
+				UsagePeriod: &codersdk.UsagePeriod{IssuedAt: time.Now()},
+			},
+		},
+		Warnings:         []string{"sensitive warning"},
+		Errors:           []string{"sensitive error"},
+		HasLicense:       true,
+		Trial:            true,
+		RequireTelemetry: true,
+		RefreshedAt:      time.Now(),
+	}
+
+	capabilities := entitlements.Capabilities()
+	require.Len(t, capabilities.Features, len(codersdk.FeatureNames))
+	require.True(t, capabilities.HasLicense)
+	require.True(t, capabilities.Trial)
+	require.Equal(t, codersdk.Capability{
+		Entitlement: codersdk.EntitlementEntitled,
+		Enabled:     true,
+		Usable:      true,
+	}, capabilities.Features[codersdk.FeatureAuditLog])
+	require.True(t, capabilities.Features[codersdk.FeatureSCIM].Usable)
+	require.False(t, capabilities.Features[codersdk.FeatureUserLimit].Usable)
+	require.False(t, capabilities.Features[codersdk.FeatureBrowserOnly].Usable)
+	require.False(t, capabilities.Features[codersdk.FeatureAppearance].Usable)
+	require.Equal(t, codersdk.Capability{
+		Entitlement: codersdk.EntitlementNotEntitled,
+	}, capabilities.Features[codersdk.FeatureBoundary])
+
+	capabilities.Features[codersdk.FeatureAuditLog] = codersdk.Capability{}
+	require.True(t, entitlements.Features[codersdk.FeatureAuditLog].Enabled)
+
+	publicJSON, err := json.Marshal(entitlements.Capabilities())
+	require.NoError(t, err)
+	require.NotContains(t, string(publicJSON), "sensitive warning")
+	require.NotContains(t, string(publicJSON), "sensitive error")
+	var publicFields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(publicJSON, &publicFields))
+	require.ElementsMatch(t, []string{"features", "has_license", "trial"}, slices.Collect(maps.Keys(publicFields)))
+	var featureFields map[string]map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(publicFields["features"], &featureFields))
+	for _, fields := range featureFields {
+		require.ElementsMatch(t, []string{"entitlement", "enabled", "usable"}, slices.Collect(maps.Keys(fields)))
+	}
+
+	entitlements.HasLicense = false
+	require.False(t, entitlements.Capabilities().Features[codersdk.FeatureAuditLog].Usable)
 }
 
 func TestFeatureComparison(t *testing.T) {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -118,6 +118,47 @@ curl -X POST http://coder-server:8080/api/v2/csp/reports \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get deployment capabilities
+
+### Code samples
+
+```sh
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/deployment/capabilities \
+  -H 'Accept: application/json'
+```
+
+`GET /api/v2/deployment/capabilities`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "features": {
+    "property1": {
+      "enabled": true,
+      "entitlement": "entitled",
+      "usable": true
+    },
+    "property2": {
+      "enabled": true,
+      "entitlement": "entitled",
+      "usable": true
+    }
+  },
+  "has_license": true,
+  "trial": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                       |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.DeploymentCapabilities](schemas.md#codersdkdeploymentcapabilities) |
+
 ## Get deployment config
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2246,6 +2246,24 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |----------------------|
 | `passthru`, `simple` |
 
+## codersdk.Capability
+
+```json
+{
+  "enabled": true,
+  "entitlement": "entitled",
+  "usable": true
+}
+```
+
+### Properties
+
+| Name          | Type                                         | Required | Restrictions | Description |
+|---------------|----------------------------------------------|----------|--------------|-------------|
+| `enabled`     | boolean                                      | false    |              |             |
+| `entitlement` | [codersdk.Entitlement](#codersdkentitlement) | false    |              |             |
+| `usable`      | boolean                                      | false    |              |             |
+
 ## codersdk.ChangePasswordWithOneTimePasscodeRequest
 
 ```json
@@ -7400,6 +7418,36 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 |--------------|---------|----------|--------------|-------------|
 | `agent_name` | string  | false    |              |             |
 | `port`       | integer | false    |              |             |
+
+## codersdk.DeploymentCapabilities
+
+```json
+{
+  "features": {
+    "property1": {
+      "enabled": true,
+      "entitlement": "entitled",
+      "usable": true
+    },
+    "property2": {
+      "enabled": true,
+      "entitlement": "entitled",
+      "usable": true
+    }
+  },
+  "has_license": true,
+  "trial": true
+}
+```
+
+### Properties
+
+| Name               | Type                                       | Required | Restrictions | Description |
+|--------------------|--------------------------------------------|----------|--------------|-------------|
+| `features`         | object                                     | false    |              |             |
+| » `[any property]` | [codersdk.Capability](#codersdkcapability) | false    |              |             |
+| `has_license`      | boolean                                    | false    |              |             |
+| `trial`            | boolean                                    | false    |              |             |
 
 ## codersdk.DeploymentConfig
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -350,7 +350,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 	})
 
 	api.AGPL.APIHandler.Group(func(r chi.Router) {
-		r.Get("/entitlements", api.serveEntitlements)
+		r.With(apiKeyMiddleware).Get("/entitlements", api.serveEntitlements)
 		// /regions overrides the AGPL /regions endpoint
 		r.Group(func(r chi.Router) {
 			r.Use(apiKeyMiddleware)

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -68,6 +68,21 @@ func TestMain(m *testing.M) {
 
 func TestEntitlements(t *testing.T) {
 	t.Parallel()
+	t.Run("Authentication", func(t *testing.T) {
+		t.Parallel()
+		adminClient, _ := coderdenttest.New(t, &coderdenttest.Options{DontAddLicense: true})
+		anonymous := codersdk.New(adminClient.URL)
+
+		res, err := anonymous.Request(t.Context(), http.MethodGet, "/api/v2/entitlements", nil)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+		capabilities, err := anonymous.DeploymentCapabilities(t.Context())
+		require.NoError(t, err)
+		require.False(t, capabilities.HasLicense)
+		require.Len(t, capabilities.Features, len(codersdk.FeatureNames))
+	})
 	t.Run("NoLicense", func(t *testing.T) {
 		t.Parallel()
 		adminClient, _, api, adminUser := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
@@ -84,10 +99,11 @@ func TestEntitlements(t *testing.T) {
 	})
 	t.Run("FullLicense", func(t *testing.T) {
 		t.Parallel()
-		adminClient, _ := coderdenttest.New(t, &coderdenttest.Options{
+		adminClient, adminUser := coderdenttest.New(t, &coderdenttest.Options{
 			AuditLogging:   true,
 			DontAddLicense: true,
 		})
+		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, adminUser.OrganizationID)
 		// Enable all features
 		features := make(license.Features)
 		for _, feature := range codersdk.FeatureNames {
@@ -99,22 +115,22 @@ func TestEntitlements(t *testing.T) {
 			}
 			features[feature] = 1
 		}
-		features[codersdk.FeatureUserLimit] = 100
+		features[codersdk.FeatureUserLimit] = 1
 		coderdenttest.AddLicense(t, adminClient, coderdenttest.LicenseOptions{
 			Features: features,
 			Addons:   []codersdk.Addon{codersdk.AddonAIGovernance},
 			GraceAt:  time.Now().Add(59 * 24 * time.Hour),
 		})
-		res, err := adminClient.Entitlements(context.Background()) //nolint:gocritic // adding another user would put us over user limit
+		res, err := adminClient.Entitlements(context.Background()) //nolint:gocritic // Verify owner access to full entitlement details.
 		require.NoError(t, err)
 		assert.True(t, res.HasLicense)
 		ul := res.Features[codersdk.FeatureUserLimit]
 		assert.Equal(t, codersdk.EntitlementEntitled, ul.Entitlement)
 		if assert.NotNil(t, ul.Limit) {
-			assert.Equal(t, int64(100), *ul.Limit)
+			assert.Equal(t, int64(1), *ul.Limit)
 		}
 		if assert.NotNil(t, ul.Actual) {
-			assert.Equal(t, int64(1), *ul.Actual)
+			assert.Equal(t, int64(2), *ul.Actual)
 		}
 		assert.True(t, ul.Enabled)
 		al := res.Features[codersdk.FeatureAuditLog]
@@ -122,7 +138,33 @@ func TestEntitlements(t *testing.T) {
 		assert.True(t, al.Enabled)
 		assert.Nil(t, al.Limit)
 		assert.Nil(t, al.Actual)
-		assert.Empty(t, res.Warnings)
+		const userLimitWarning = "Your deployment has 2 active users but is only licensed for 1."
+		assert.Contains(t, res.Warnings, userLimitWarning)
+		runtime := res.Features[codersdk.FeatureAgentRuntimeHours]
+		require.NotNil(t, runtime.Limit)
+		require.NotNil(t, runtime.Actual)
+		require.NotNil(t, runtime.ActualMs)
+		require.NotNil(t, runtime.UsagePeriod)
+
+		anonymous := codersdk.New(adminClient.URL)
+		capabilities, err := anonymous.DeploymentCapabilities(t.Context())
+		require.NoError(t, err)
+		require.True(t, capabilities.HasLicense)
+		require.True(t, capabilities.Features[codersdk.FeatureAuditLog].Usable)
+		resPublic, err := anonymous.Request(t.Context(), http.MethodGet, "/api/v2/deployment/capabilities", nil)
+		require.NoError(t, err)
+		defer resPublic.Body.Close()
+		publicBody, err := io.ReadAll(resPublic.Body)
+		require.NoError(t, err)
+		require.NotContains(t, string(publicBody), userLimitWarning)
+		for _, field := range []string{"\"limit\":", "\"actual\":", "\"actual_ms\":", "\"warnings\":"} {
+			require.NotContains(t, string(publicBody), field)
+		}
+
+		memberEntitlements, err := memberClient.Entitlements(t.Context())
+		require.NoError(t, err)
+		require.True(t, memberEntitlements.HasLicense)
+		require.Equal(t, int64(1), *memberEntitlements.Features[codersdk.FeatureUserLimit].Limit)
 	})
 
 	// TestEntitlements/MultiplePrebuildsLicenseUpdates verifies that uploading

--- a/site/index.html
+++ b/site/index.html
@@ -21,7 +21,7 @@
 	<meta property="csrf-token" content="{{ .CSRF.Token }}" />
 	<meta property="build-info" content="{{ .BuildInfo }}" />
 	<meta property="user" content="{{ .User }}" />
-	<meta property="entitlements" content="{{ .Entitlements }}" />
+	<meta property="deployment-capabilities" content="{{ .DeploymentCapabilities }}" />
 	<meta property="appearance" content="{{ .Appearance }}" />
 	<meta property="userAppearance" content="{{ .UserAppearance }}" />
 	<meta property="experiments" content="{{ .Experiments }}" />

--- a/site/site.go
+++ b/site/site.go
@@ -171,7 +171,6 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		BuildInfo: h.buildInfoJSON,
 		DocsURL:   h.opts.DocsURL,
 	}
-
 	// First check if it's a file we have in our templates
 	if h.serveHTML(rw, r, reqFile, state) {
 		return
@@ -258,14 +257,14 @@ type htmlState struct {
 	ApplicationName string
 	LogoURL         string
 
-	BuildInfo      string
-	User           string
-	Entitlements   string
-	Appearance     string
-	UserAppearance string
-	Experiments    string
-	Regions        string
-	DocsURL        string
+	BuildInfo              string
+	User                   string
+	DeploymentCapabilities string
+	Appearance             string
+	UserAppearance         string
+	Experiments            string
+	Regions                string
+	DocsURL                string
 
 	AITasksEnabled   string
 	AIGatewayEnabled string
@@ -378,6 +377,10 @@ func (h *Handler) renderHTMLWithState(r *http.Request, filePath string, state ht
 		return nil, xerrors.Errorf("template %q not found", filePath)
 	}
 
+	if h.Entitlements != nil {
+		state.DeploymentCapabilities = html.EscapeString(string(h.Entitlements.AsCapabilitiesJSON()))
+	}
+
 	// Cookies are sent when requesting HTML, so we can get the user
 	// and pre-populate the state for the frontend to reduce requests.
 	// We use a noop response writer because we don't want to write
@@ -480,11 +483,6 @@ func (h *Handler) populateHTMLState(
 			state.UserAppearance = html.EscapeString(string(data))
 		}
 	})
-	if h.Entitlements != nil {
-		wg.Go(func() {
-			state.Entitlements = html.EscapeString(string(h.Entitlements.AsJSON()))
-		})
-	}
 	wg.Go(func() {
 		cfg, err := af.Fetch(ctx)
 		if err == nil {

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/telemetry"
@@ -376,6 +377,68 @@ func TestInjectionFailureProducesCleanHTML(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rw.Code)
 	body := rw.Body.String()
 	assert.Equal(t, "<html></html>", body)
+}
+
+func TestDeploymentCapabilitiesMetadataHidesEntitlementDetails(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	user := dbgen.User(t, db, database.User{})
+	_, token := dbgen.APIKey(t, db, database.APIKey{
+		UserID:    user.ID,
+		ExpiresAt: dbtime.Now().Add(time.Hour),
+	})
+	set := entitlements.New()
+	set.Modify(func(entitlements *codersdk.Entitlements) {
+		entitlements.HasLicense = true
+		entitlements.Trial = true
+		entitlements.Warnings = []string{"obvious warning"}
+		entitlements.Errors = []string{"obvious error"}
+		entitlements.RequireTelemetry = true
+		entitlements.RefreshedAt = time.Now()
+		entitlements.Features[codersdk.FeatureAgentRuntimeHours] = codersdk.Feature{
+			Entitlement: codersdk.EntitlementEntitled,
+			Enabled:     true,
+			Limit:       new(int64(100)),
+			SoftLimit:   new(int64(80)),
+			HardLimit:   new(int64(120)),
+			Actual:      new(int64(10)),
+			ActualMs:    new(int64(36_000_000)),
+			UsagePeriod: &codersdk.UsagePeriod{
+				IssuedAt: time.Now().Add(-time.Hour),
+				Start:    time.Now().Add(-time.Hour),
+				End:      time.Now().Add(time.Hour),
+			},
+		}
+	})
+
+	handler, err := site.New(&site.Options{
+		Telemetry:    telemetry.NewNoop(),
+		Database:     db,
+		Entitlements: set,
+		SiteFS: fstest.MapFS{
+			"index.html": &fstest.MapFile{Data: []byte(`<meta property="deployment-capabilities" content="{{ .DeploymentCapabilities }}">`)},
+		},
+	})
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(codersdk.SessionTokenHeader, token)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, r)
+	require.Equal(t, http.StatusOK, rw.Code)
+	body := html.UnescapeString(rw.Body.String())
+	require.Contains(t, body, `property="deployment-capabilities"`)
+	require.Contains(t, body, `"has_license":true`)
+	require.Contains(t, body, `"trial":true`)
+	for _, sensitive := range []string{
+		`property="entitlements"`, `"limit":`, `"soft_limit":`,
+		`"hard_limit":`, `"actual":`, `"actual_ms":`, `"usage_period":`,
+		`"warnings":`, `"errors":`, `"require_telemetry":`,
+		`"refreshed_at":`, "obvious warning", "obvious error",
+	} {
+		require.NotContains(t, body, sensitive)
+	}
 }
 
 func TestOrganizationsMetadata(t *testing.T) {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -172,6 +172,22 @@ export const withDefaultFeatures = (
 	return fs as TypesGen.Entitlements["features"];
 };
 
+export const withDefaultCapabilities = (
+	capabilities: Partial<TypesGen.DeploymentCapabilities["features"]>,
+): TypesGen.DeploymentCapabilities["features"] => {
+	for (const feature of TypesGen.FeatureNames) {
+		if (capabilities[feature] !== undefined) {
+			continue;
+		}
+		capabilities[feature] = {
+			enabled: false,
+			entitlement: "not_entitled",
+			usable: false,
+		};
+	}
+	return capabilities as TypesGen.DeploymentCapabilities["features"];
+};
+
 type WatchBuildLogsByTemplateVersionIdOptions = {
 	after?: number;
 	onMessage: (log: TypesGen.ProvisionerJobLog) => void;
@@ -1853,6 +1869,14 @@ class ApiMethods {
 	refreshEntitlements = async (): Promise<void> => {
 		await this.axios.post("/api/v2/licenses/refresh-entitlements");
 	};
+
+	getDeploymentCapabilities =
+		async (): Promise<TypesGen.DeploymentCapabilities> => {
+			const response = await this.axios.get<TypesGen.DeploymentCapabilities>(
+				"/api/v2/deployment/capabilities",
+			);
+			return response.data;
+		};
 
 	getEntitlements = async (): Promise<TypesGen.Entitlements> => {
 		try {

--- a/site/src/api/queries/entitlements.ts
+++ b/site/src/api/queries/entitlements.ts
@@ -1,26 +1,39 @@
 import type { QueryClient } from "react-query";
 import { API } from "#/api/api";
-import type { Entitlements } from "#/api/typesGenerated";
+import type {
+	DeploymentCapabilities,
+	Entitlements,
+} from "#/api/typesGenerated";
 import type { MetadataState } from "#/hooks/useEmbeddedMetadata";
 import { cachedQuery } from "./util";
 
-export const entitlementsQueryKey = ["entitlements"] as const;
+export const deploymentCapabilitiesQueryKey = [
+	"deployment-capabilities",
+] as const;
+export const entitlementDetailsQueryKey = ["entitlements", "details"] as const;
 
-export const entitlements = (metadata: MetadataState<Entitlements>) => {
-	return cachedQuery({
+export const deploymentCapabilities = (
+	metadata: MetadataState<DeploymentCapabilities>,
+) =>
+	cachedQuery({
 		metadata,
-		queryKey: entitlementsQueryKey,
-		queryFn: () => API.getEntitlements(),
+		queryKey: deploymentCapabilitiesQueryKey,
+		queryFn: () => API.getDeploymentCapabilities(),
 	});
-};
 
-export const refreshEntitlements = (queryClient: QueryClient) => {
-	return {
-		mutationFn: API.refreshEntitlements,
-		onSuccess: async () => {
-			await queryClient.invalidateQueries({
-				queryKey: entitlementsQueryKey,
-			});
-		},
-	};
-};
+export const entitlementDetails = () => ({
+	queryKey: entitlementDetailsQueryKey,
+	queryFn: (): Promise<Entitlements> => API.getEntitlements(),
+});
+
+export const refreshEntitlements = (queryClient: QueryClient) => ({
+	mutationFn: API.refreshEntitlements,
+	onSuccess: async () => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: deploymentCapabilitiesQueryKey,
+			}),
+			queryClient.invalidateQueries({ queryKey: entitlementDetailsQueryKey }),
+		]);
+	},
+});

--- a/site/src/api/queries/licenses.ts
+++ b/site/src/api/queries/licenses.ts
@@ -1,6 +1,9 @@
 import type { QueryClient } from "react-query";
 import { API } from "#/api/api";
-import { entitlementsQueryKey } from "./entitlements";
+import {
+	deploymentCapabilitiesQueryKey,
+	entitlementDetailsQueryKey,
+} from "./entitlements";
 
 export const licensesKey = ["licenses"] as const;
 
@@ -13,7 +16,10 @@ export const createTrialLicense = (queryClient: QueryClient) => ({
 	mutationFn: API.createTrialLicense,
 	onSuccess: async () => {
 		await Promise.all([
-			queryClient.invalidateQueries({ queryKey: entitlementsQueryKey }),
+			queryClient.invalidateQueries({
+				queryKey: deploymentCapabilitiesQueryKey,
+			}),
+			queryClient.invalidateQueries({ queryKey: entitlementDetailsQueryKey }),
 			queryClient.invalidateQueries({ queryKey: licensesKey }),
 		]);
 	},

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1948,6 +1948,17 @@ export const CancelWorkspaceBuildStatuses: CancelWorkspaceBuildStatus[] = [
 	"running",
 ];
 
+// From codersdk/deployment.go
+/**
+ * Capability is the public state needed to decide whether a deployment
+ * feature can be used.
+ */
+export interface Capability {
+	readonly entitlement: Entitlement;
+	readonly enabled: boolean;
+	readonly usable: boolean;
+}
+
 // From codersdk/users.go
 /**
  * ChangePasswordWithOneTimePasscodeRequest enables callers to change their password when they've forgotten it.
@@ -4742,6 +4753,16 @@ export interface DeleteWebpushSubscription {
 export interface DeleteWorkspaceAgentPortShareRequest {
 	readonly agent_name: string;
 	readonly port: number;
+}
+
+// From codersdk/deployment.go
+/**
+ * DeploymentCapabilities contains public deployment feature state.
+ */
+export interface DeploymentCapabilities {
+	readonly features: Record<FeatureName, Capability>;
+	readonly has_license: boolean;
+	readonly trial: boolean;
 }
 
 // From codersdk/deployment.go

--- a/site/src/hooks/useEmbeddedMetadata.test.ts
+++ b/site/src/hooks/useEmbeddedMetadata.test.ts
@@ -5,7 +5,7 @@ import {
 	MockAITasksEnabled,
 	MockAppearanceConfig,
 	MockBuildInfo,
-	MockEntitlements,
+	MockDeploymentCapabilities,
 	MockExperiments,
 	MockOrganization,
 	MockPermissions,
@@ -40,7 +40,7 @@ const MockRegions: readonly Region[] = [];
 const mockDataForTags = {
 	appearance: MockAppearanceConfig,
 	"build-info": MockBuildInfo,
-	entitlements: MockEntitlements,
+	"deployment-capabilities": MockDeploymentCapabilities,
 	experiments: MockExperiments,
 	user: MockUserOwner,
 	userAppearance: MockUserAppearanceSettings,
@@ -60,7 +60,7 @@ const emptyMetadata: RuntimeHtmlMetadata = {
 		available: false,
 		value: undefined,
 	},
-	entitlements: {
+	"deployment-capabilities": {
 		available: false,
 		value: undefined,
 	},
@@ -107,9 +107,9 @@ const populatedMetadata: RuntimeHtmlMetadata = {
 		available: true,
 		value: MockBuildInfo,
 	},
-	entitlements: {
+	"deployment-capabilities": {
 		available: true,
-		value: MockEntitlements,
+		value: MockDeploymentCapabilities,
 	},
 	experiments: {
 		available: true,
@@ -275,7 +275,7 @@ describe(useEmbeddedMetadata.name, () => {
 
 	it("Will not notify subscribers if you try deleting a metadata value that does not exist (or has already been deleted)", () => {
 		const key = "giraffe";
-		const tagToDelete: MetadataKey = "entitlements";
+		const tagToDelete: MetadataKey = "deployment-capabilities";
 
 		const cleanupTags = seedInitialMetadata(key);
 		const { result } = renderMetadataHook(key);

--- a/site/src/hooks/useEmbeddedMetadata.ts
+++ b/site/src/hooks/useEmbeddedMetadata.ts
@@ -2,7 +2,7 @@ import { useMemo, useSyncExternalStore } from "react";
 import type {
 	AppearanceConfig,
 	BuildInfoResponse,
-	Entitlements,
+	DeploymentCapabilities,
 	Experiment,
 	Organization,
 	Region,
@@ -28,7 +28,7 @@ type AvailableMetadata = Readonly<{
 	experiments: Experiment[];
 	appearance: AppearanceConfig;
 	userAppearance: UserAppearanceSettings;
-	entitlements: Entitlements;
+	"deployment-capabilities": DeploymentCapabilities;
 	regions: readonly Region[];
 	"build-info": BuildInfoResponse;
 	"ai-tasks-enabled": boolean;
@@ -92,7 +92,9 @@ export class MetadataManager implements MetadataManagerApi {
 			appearance: this.registerValue<AppearanceConfig>("appearance"),
 			userAppearance:
 				this.registerValue<UserAppearanceSettings>("userAppearance"),
-			entitlements: this.registerValue<Entitlements>("entitlements"),
+			"deployment-capabilities": this.registerValue<DeploymentCapabilities>(
+				"deployment-capabilities",
+			),
 			experiments: this.registerValue<Experiment[]>("experiments"),
 			"build-info": this.registerValue<BuildInfoResponse>("build-info"),
 			regions: this.registerRegionValue(),

--- a/site/src/modules/dashboard/DashboardLayout.test.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.test.tsx
@@ -91,10 +91,26 @@ test("shows AI Governance over-limit warning in LicenseBanner for admin users", 
 	});
 
 	expect(
-		screen.getByText(
+		await screen.findByText(
 			/110 of 100 AI Governance add-on seats \(10 over the limit\)/,
 		),
 	).toBeInTheDocument();
+});
+
+test("renders the dashboard when entitlement details fail", async () => {
+	server.use(
+		http.get("/api/v2/entitlements", () =>
+			HttpResponse.json({ message: "unavailable" }, { status: 500 }),
+		),
+	);
+
+	renderWithAuth(<DashboardLayout />, {
+		children: [{ element: <h1>Test page</h1> }],
+	});
+	await waitForLoaderToBeRemoved();
+
+	expect(screen.getByRole("main")).toBeVisible();
+	expect(screen.queryByText("unavailable")).not.toBeInTheDocument();
 });
 
 test("renders a skip link before navigation content", async () => {

--- a/site/src/modules/dashboard/DashboardProvider.tsx
+++ b/site/src/modules/dashboard/DashboardProvider.tsx
@@ -2,13 +2,13 @@ import { createContext, type FC, type PropsWithChildren } from "react";
 import { useQuery } from "react-query";
 import { appearance } from "#/api/queries/appearance";
 import { buildInfo } from "#/api/queries/buildInfo";
-import { entitlements } from "#/api/queries/entitlements";
+import { deploymentCapabilities } from "#/api/queries/entitlements";
 import { experiments } from "#/api/queries/experiments";
 import { organizations } from "#/api/queries/organizations";
 import type {
 	AppearanceConfig,
 	BuildInfoResponse,
-	Entitlements,
+	DeploymentCapabilities,
 	Experiment,
 	Organization,
 } from "#/api/typesGenerated";
@@ -20,7 +20,7 @@ import { canViewAnyOrganization } from "#/modules/permissions";
 import { selectFeatureVisibility } from "./entitlements";
 
 export interface DashboardValue {
-	entitlements: Entitlements;
+	entitlements: DeploymentCapabilities;
 	experiments: Experiment[];
 	appearance: AppearanceConfig;
 	buildInfo: BuildInfoResponse;
@@ -36,7 +36,9 @@ export const DashboardContext = createContext<DashboardValue | undefined>(
 export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
 	const { metadata } = useEmbeddedMetadata();
 	const { permissions } = useAuthenticated();
-	const entitlementsQuery = useQuery(entitlements(metadata.entitlements));
+	const entitlementsQuery = useQuery(
+		deploymentCapabilities(metadata["deployment-capabilities"]),
+	);
 	const experimentsQuery = useQuery(experiments(metadata.experiments));
 	const appearanceQuery = useQuery(appearance(metadata.appearance));
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBanner.tsx
@@ -1,5 +1,8 @@
 import type { FC } from "react";
+import { useQuery } from "react-query";
+import { entitlementDetails } from "#/api/queries/entitlements";
 import {
+	type Feature,
 	LicenseAgentRuntimeHoursClaimsIgnoredWarningText,
 	LicenseAgentRuntimeHoursSoftLimitWarningText,
 	LicenseAgentRuntimeUsageUnavailableErrorText,
@@ -8,7 +11,6 @@ import {
 	LicenseManagedAgentLimitExceededWarningText,
 	LicenseTelemetryRequiredErrorText,
 } from "#/api/typesGenerated";
-import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { docs } from "#/utils/docs";
 import {
 	type LicenseBannerLink,
@@ -59,9 +61,7 @@ const isAdvisoryMessage = (message: string): boolean =>
 	message.startsWith(agentRuntimeSoftLimitWarningPrefix);
 
 const aiGovernanceOverLimitMessage = (
-	feature: ReturnType<
-		typeof useDashboard
-	>["entitlements"]["features"]["ai_governance_user_limit"],
+	feature: Feature | undefined,
 ): string | null => {
 	if (!feature) {
 		return null;
@@ -88,9 +88,7 @@ const aiGovernanceOverLimitMessage = (
 };
 
 const aiGovernanceNearLimitMessage = (
-	feature: ReturnType<
-		typeof useDashboard
-	>["entitlements"]["features"]["ai_governance_user_limit"],
+	feature: Feature | undefined,
 ): string | null => {
 	if (!feature) {
 		return null;
@@ -119,9 +117,7 @@ const aiGovernanceNearLimitMessage = (
 
 const normalizeAIGovernanceWarning = (
 	message: string,
-	feature: ReturnType<
-		typeof useDashboard
-	>["entitlements"]["features"]["ai_governance_user_limit"],
+	feature: Feature | undefined,
 ): string => {
 	if (message !== LicenseAIGovernance90PercentWarningText) {
 		return message;
@@ -185,7 +181,10 @@ const toBannerMessage = (
 };
 
 export const LicenseBanner: FC = () => {
-	const { entitlements } = useDashboard();
+	const { data: entitlements } = useQuery(entitlementDetails());
+	if (!entitlements) {
+		return null;
+	}
 	const { errors } = entitlements;
 	const warnings = [...entitlements.warnings];
 	const aiGovernanceUserLimitFeature =

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useQueryClient } from "react-query";
 import { expect, within } from "storybook/test";
+import { entitlementDetailsQueryKey } from "#/api/queries/entitlements";
 import {
 	type Entitlements,
 	LicenseAgentRuntimeHoursAllocationReachedWarningText,
@@ -10,15 +12,8 @@ import {
 	LicenseManagedAgentLimitExceededWarningText,
 	LicenseTelemetryRequiredErrorText,
 } from "#/api/typesGenerated";
-import {
-	MockAppearanceConfig,
-	MockBuildInfo,
-	MockDefaultOrganization,
-	MockEntitlements,
-	MockExperiments,
-} from "#/testHelpers/entities";
+import { MockEntitlements } from "#/testHelpers/entities";
 import { docs } from "#/utils/docs";
-import { DashboardContext, type DashboardValue } from "../DashboardProvider";
 import { formatLicenseMessage, LicenseBanner } from "./LicenseBanner";
 import { LicenseBannerView } from "./LicenseBannerView";
 
@@ -198,30 +193,23 @@ const renderLicenseBanner = ({
 	warnings?: string[];
 	features?: Partial<Entitlements["features"]>;
 }) => {
-	const mockDashboardValue: DashboardValue = {
-		entitlements: {
-			...MockEntitlements,
-			has_license: true,
-			errors,
-			warnings,
-			features: {
-				...MockEntitlements.features,
-				...features,
-			},
+	const entitlementDetails: Entitlements = {
+		...MockEntitlements,
+		has_license: true,
+		errors,
+		warnings,
+		features: {
+			...MockEntitlements.features,
+			...features,
 		},
-		experiments: MockExperiments,
-		appearance: MockAppearanceConfig,
-		buildInfo: MockBuildInfo,
-		organizations: [MockDefaultOrganization],
-		showOrganizations: false,
-		canViewOrganizationSettings: false,
 	};
 
-	return (
-		<DashboardContext value={mockDashboardValue}>
-			<LicenseBanner />
-		</DashboardContext>
-	);
+	const Banner = () => {
+		const queryClient = useQueryClient();
+		queryClient.setQueryData(entitlementDetailsQueryKey, entitlementDetails);
+		return <LicenseBanner />;
+	};
+	return <Banner />;
 };
 
 const renderLicenseBannerWithAIGovernance = ({

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -9,7 +9,7 @@ import {
 	MockAppearanceConfig,
 	MockBuildInfo,
 	MockDefaultOrganization,
-	MockEntitlements,
+	MockDeploymentCapabilities,
 	MockNoPermissions,
 	MockTasks,
 	MockUserMember,
@@ -34,7 +34,7 @@ const AISettingsIndexRedirectWithProviders = () => (
 	<AuthProvider>
 		<DashboardContext.Provider
 			value={{
-				entitlements: MockEntitlements,
+				entitlements: MockDeploymentCapabilities,
 				experiments: [],
 				appearance: MockAppearanceConfig,
 				buildInfo: MockBuildInfo,

--- a/site/src/modules/dashboard/entitlements.test.ts
+++ b/site/src/modules/dashboard/entitlements.test.ts
@@ -1,34 +1,29 @@
 import { getFeatureVisibility } from "./entitlements";
 
 describe("getFeatureVisibility", () => {
-	it("returns empty object if there is no license", () => {
-		const result = getFeatureVisibility(false, {
-			audit_log: { entitlement: "entitled", enabled: true },
+	it("uses the backend-computed usable state", () => {
+		const result = getFeatureVisibility({
+			audit_log: {
+				entitlement: "entitled",
+				enabled: true,
+				usable: true,
+			},
+			user_limit: {
+				entitlement: "entitled",
+				enabled: true,
+				usable: false,
+			},
+			browser_only: {
+				entitlement: "not_entitled",
+				enabled: false,
+				usable: false,
+			},
 		});
-		expect(result).toEqual(expect.objectContaining({}));
-	});
-	it("returns false for a feature that is not enabled", () => {
-		const result = getFeatureVisibility(true, {
-			audit_log: { entitlement: "entitled", enabled: false },
+
+		expect(result).toEqual({
+			audit_log: true,
+			user_limit: false,
+			browser_only: false,
 		});
-		expect(result).toEqual(expect.objectContaining({ audit_log: false }));
-	});
-	it("returns false for a feature that is not entitled", () => {
-		const result = getFeatureVisibility(true, {
-			audit_log: { entitlement: "not_entitled", enabled: true },
-		});
-		expect(result).toEqual(expect.objectContaining({ audit_log: false }));
-	});
-	it("returns true for a feature that is in grace period", () => {
-		const result = getFeatureVisibility(true, {
-			audit_log: { entitlement: "grace_period", enabled: true },
-		});
-		expect(result).toEqual(expect.objectContaining({ audit_log: true }));
-	});
-	it("returns true for a feature that is in entitled", () => {
-		const result = getFeatureVisibility(true, {
-			audit_log: { entitlement: "entitled", enabled: true },
-		});
-		expect(result).toEqual(expect.objectContaining({ audit_log: true }));
 	});
 });

--- a/site/src/modules/dashboard/entitlements.ts
+++ b/site/src/modules/dashboard/entitlements.ts
@@ -1,30 +1,19 @@
-import type { Entitlements, Feature, FeatureName } from "#/api/typesGenerated";
+import type {
+	Capability,
+	DeploymentCapabilities,
+	FeatureName,
+} from "#/api/typesGenerated";
 
-/**
- * @param hasLicense true if Enterprise edition
- * @param features record from feature name to feature object
- * @returns record from feature name whether to show the feature
- */
 export const getFeatureVisibility = (
-	hasLicense: boolean,
-	features: Record<string, Feature>,
-): Record<string, boolean> => {
-	if (!hasLicense) {
-		return {};
-	}
-
-	const permissionPairs = Object.entries(features).map(
-		([feature, { entitlement, limit, actual, enabled }]) => {
-			const entitled = ["entitled", "grace_period"].includes(entitlement);
-			const limitCompliant = limit && actual ? limit >= actual : true;
-			return [feature, entitled && limitCompliant && enabled];
-		},
+	features: Record<string, Capability>,
+): Record<string, boolean> =>
+	Object.fromEntries(
+		Object.entries(features).map(([feature, capability]) => [
+			feature,
+			capability.usable,
+		]),
 	);
-	return Object.fromEntries(permissionPairs);
-};
 
 export const selectFeatureVisibility = (
-	entitlements: Entitlements,
-): Record<FeatureName, boolean> => {
-	return getFeatureVisibility(entitlements.has_license, entitlements.features);
-};
+	capabilities: DeploymentCapabilities,
+): Record<FeatureName, boolean> => getFeatureVisibility(capabilities.features);

--- a/site/src/pages/AIBridgePage/getAIBridgePermissions.ts
+++ b/site/src/pages/AIBridgePage/getAIBridgePermissions.ts
@@ -1,4 +1,4 @@
-import type { Entitlements } from "#/api/typesGenerated";
+import type { DeploymentCapabilities } from "#/api/typesGenerated";
 import type { Permissions } from "#/modules/permissions";
 
 // Users are allowed to view their own request logs via the API,
@@ -6,7 +6,7 @@ import type { Permissions } from "#/modules/permissions";
 // the user has the `viewAnyAIBridgeInterception` permission. (as it's
 // defined in the Admin settings dropdown).
 export const getAIBridgePermissions = (
-	entitlements: Entitlements,
+	entitlements: DeploymentCapabilities,
 	permissions: Permissions,
 ) => {
 	// the user is entitled if they have either "entitled" or "grace_period"

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -7,9 +7,10 @@ import {
 	useEffect,
 	useState,
 } from "react";
-import { useQueryClient } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
 import { invalidateChatDiffContents } from "#/api/queries/chats";
+import { entitlementDetails } from "#/api/queries/entitlements";
 import type * as TypesGen from "#/api/typesGenerated";
 import type {
 	AgentChatSendShortcut,
@@ -402,6 +403,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const queryClient = useQueryClient();
 	const { proxy } = useProxy();
 	const { entitlements } = useDashboard();
+	const entitlementDetailsQuery = useQuery(entitlementDetails());
 	const { permissions } = useAuthenticated();
 	const wildcardHostname = proxy.preferredWildcardHostname;
 
@@ -841,9 +843,10 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 
 	const hasLicense = entitlements.has_license;
 	const canManageLicenses = permissions.viewAllLicenses;
-	const runtimeHours = entitlements.features.agent_runtime_hours;
+	const runtimeHours =
+		entitlementDetailsQuery.data?.features.agent_runtime_hours;
 	const agentHoursHardLimit =
-		runtimeHours.enabled &&
+		runtimeHours?.enabled &&
 		runtimeHours.hard_limit !== undefined &&
 		runtimeHours.actual !== undefined &&
 		runtimeHours.actual >= runtimeHours.hard_limit

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
@@ -15,7 +15,7 @@ import {
 	MockAppearanceConfig,
 	MockBuildInfo,
 	MockDefaultOrganization,
-	MockEntitlements,
+	MockDeploymentCapabilities,
 	MockUserOwner,
 } from "#/testHelpers/entities";
 import { createTestQueryClient } from "#/testHelpers/renderHelpers";
@@ -67,7 +67,7 @@ const buildChat = (overrides: Partial<Chat> = {}): Chat => ({
 });
 
 const dashboardValue = {
-	entitlements: MockEntitlements,
+	entitlements: MockDeploymentCapabilities,
 	experiments: [] as TypesGen.Experiment[],
 	appearance: MockAppearanceConfig,
 	buildInfo: MockBuildInfo,

--- a/site/src/pages/AuditPage/AuditPage.test.tsx
+++ b/site/src/pages/AuditPage/AuditPage.test.tsx
@@ -13,7 +13,7 @@ import { DEFAULT_RECORDS_PER_PAGE } from "#/components/PaginationWidget/utils";
 import {
 	MockAuditLog,
 	MockAuditLog2,
-	MockEntitlementsWithAuditLog,
+	MockDeploymentCapabilitiesWithAuditLog,
 } from "#/testHelpers/entities";
 import {
 	renderWithAuth,
@@ -59,8 +59,8 @@ describe("AuditPage", () => {
 
 		// Mock the entitlements
 		server.use(
-			http.get("/api/v2/entitlements", () => {
-				return HttpResponse.json(MockEntitlementsWithAuditLog);
+			http.get("/api/v2/deployment/capabilities", () => {
+				return HttpResponse.json(MockDeploymentCapabilitiesWithAuditLog);
 			}),
 		);
 	});

--- a/site/src/pages/ConnectionLogPage/ConnectionLogPage.test.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogPage.test.tsx
@@ -5,8 +5,8 @@ import { API } from "#/api/api";
 import { DEFAULT_RECORDS_PER_PAGE } from "#/components/PaginationWidget/utils";
 import {
 	MockConnectedSSHConnectionLog,
+	MockDeploymentCapabilitiesWithConnectionLog,
 	MockDisconnectedSSHConnectionLog,
-	MockEntitlementsWithConnectionLog,
 } from "#/testHelpers/entities";
 import {
 	renderWithAuth,
@@ -52,8 +52,8 @@ describe("ConnectionLogPage", () => {
 
 		// Mock the entitlements
 		server.use(
-			http.get("/api/v2/entitlements", () => {
-				return HttpResponse.json(MockEntitlementsWithConnectionLog);
+			http.get("/api/v2/deployment/capabilities", () => {
+				return HttpResponse.json(MockDeploymentCapabilitiesWithConnectionLog);
 			}),
 		);
 	});

--- a/site/src/pages/CreateTemplatePage/utils.ts
+++ b/site/src/pages/CreateTemplatePage/utils.ts
@@ -1,7 +1,7 @@
 import type { CreateTemplateOptions } from "#/api/queries/templates";
 import type {
 	CreateTemplateVersionRequest,
-	Entitlements,
+	DeploymentCapabilities,
 	ProvisionerType,
 	TemplateExample,
 	VariableValue,
@@ -46,7 +46,7 @@ export const newTemplate = (
 	};
 };
 
-export const getFormPermissions = (entitlements: Entitlements) => {
+export const getFormPermissions = (entitlements: DeploymentCapabilities) => {
 	const allowAdvancedScheduling =
 		entitlements.features.advanced_template_scheduling.enabled;
 

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import dayjs from "dayjs";
 import { expect, within } from "storybook/test";
+import { entitlementDetailsQueryKey } from "#/api/queries/entitlements";
 import { MockEntitlements, MockLicenseResponse } from "#/testHelpers/entities";
 import LicensesSettingsPage from "./LicensesSettingsPage";
 
@@ -33,7 +34,7 @@ const withBaseQueries = ({
 	licenses?: typeof MockLicenseResponse | unknown[];
 }) => ({
 	queries: [
-		{ key: ["entitlements"], data: entitlements },
+		{ key: entitlementDetailsQueryKey, data: entitlements },
 		{ key: ["licenses"], data: licenses },
 		USER_STATUS_COUNTS_QUERY,
 	],

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
@@ -4,10 +4,12 @@ import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { API } from "#/api/api";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
-import { entitlements, refreshEntitlements } from "#/api/queries/entitlements";
+import {
+	entitlementDetails,
+	refreshEntitlements,
+} from "#/api/queries/entitlements";
 import { insightsUserStatusCounts } from "#/api/queries/insights";
 import { licenses, licensesKey } from "#/api/queries/licenses";
-import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
 import { pageTitle } from "#/utils/page";
 import LicensesSettingsPageView from "./LicensesSettingsPageView";
 
@@ -17,8 +19,7 @@ const LicensesSettingsPage: FC = () => {
 	const success = searchParams.get("success");
 	const [confettiOn, setConfettiOn] = useState(false);
 
-	const { metadata } = useEmbeddedMetadata();
-	const entitlementsQuery = useQuery(entitlements(metadata.entitlements));
+	const entitlementsQuery = useQuery(entitlementDetails());
 
 	const { data: userStatusCount } = useQuery(insightsUserStatusCounts());
 

--- a/site/src/pages/HealthPage/storybook.tsx
+++ b/site/src/pages/HealthPage/storybook.tsx
@@ -8,6 +8,7 @@ import {
 	HEALTH_QUERY_KEY,
 	HEALTH_QUERY_SETTINGS_KEY,
 } from "#/api/queries/debug";
+import { entitlementDetailsQueryKey } from "#/api/queries/entitlements";
 import {
 	MockAppearanceConfig,
 	MockBuildInfo,
@@ -38,7 +39,7 @@ export const generateMeta = ({ element, path, params }: MetaOptions) => {
 				{ key: HEALTH_QUERY_KEY, data: MockHealth },
 				{ key: HEALTH_QUERY_SETTINGS_KEY, data: MockHealthSettings },
 				{ key: ["buildInfo"], data: MockBuildInfo },
-				{ key: ["entitlements"], data: MockEntitlements },
+				{ key: entitlementDetailsQueryKey, data: MockEntitlements },
 				{ key: ["experiments"], data: MockExperiments },
 				{ key: ["appearance"], data: MockAppearanceConfig },
 			],

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.test.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { SlimRole } from "#/api/typesGenerated";
 import {
-	MockEntitlementsWithMultiOrg,
+	MockDeploymentCapabilitiesWithMultiOrg,
 	MockOrganization,
 	MockOrganizationAuditorRole,
 	MockOrganizationPermissions,
@@ -20,8 +20,8 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
 	server.use(
-		http.get("/api/v2/entitlements", () => {
-			return HttpResponse.json(MockEntitlementsWithMultiOrg);
+		http.get("/api/v2/deployment/capabilities", () => {
+			return HttpResponse.json(MockDeploymentCapabilitiesWithMultiOrg);
 		}),
 		http.post("/api/v2/authcheck", async () => {
 			return HttpResponse.json(

--- a/site/src/pages/OrganizationSettingsPage/OrganizationRedirect.test.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationRedirect.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import {
 	MockDefaultOrganization,
-	MockEntitlementsWithMultiOrg,
+	MockDeploymentCapabilitiesWithMultiOrg,
 	MockOrganization2,
 } from "#/testHelpers/entities";
 import {
@@ -35,8 +35,8 @@ const renderPage = async () => {
 describe("OrganizationRedirect", () => {
 	it("has no editable organizations", async () => {
 		server.use(
-			http.get("/api/v2/entitlements", () => {
-				return HttpResponse.json(MockEntitlementsWithMultiOrg);
+			http.get("/api/v2/deployment/capabilities", () => {
+				return HttpResponse.json(MockDeploymentCapabilitiesWithMultiOrg);
 			}),
 			http.get("/api/v2/organizations", () => {
 				return HttpResponse.json([MockDefaultOrganization, MockOrganization2]);
@@ -51,8 +51,8 @@ describe("OrganizationRedirect", () => {
 
 	it("redirects to default organization", async () => {
 		server.use(
-			http.get("/api/v2/entitlements", () => {
-				return HttpResponse.json(MockEntitlementsWithMultiOrg);
+			http.get("/api/v2/deployment/capabilities", () => {
+				return HttpResponse.json(MockDeploymentCapabilitiesWithMultiOrg);
 			}),
 			http.get("/api/v2/organizations", () => {
 				// Default always preferred regardless of order.
@@ -78,8 +78,8 @@ describe("OrganizationRedirect", () => {
 
 	it("redirects to non-default organization", async () => {
 		server.use(
-			http.get("/api/v2/entitlements", () => {
-				return HttpResponse.json(MockEntitlementsWithMultiOrg);
+			http.get("/api/v2/deployment/capabilities", () => {
+				return HttpResponse.json(MockDeploymentCapabilitiesWithMultiOrg);
 			}),
 			http.get("/api/v2/organizations", () => {
 				return HttpResponse.json([MockDefaultOrganization, MockOrganization2]);

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { API } from "#/api/api";
 import {
-	MockEntitlementsWithScheduling,
+	MockDeploymentCapabilitiesWithScheduling,
 	MockTemplate,
 } from "#/testHelpers/entities";
 import {
@@ -121,8 +121,8 @@ function waitForWithCutoff(callback: () => void | Promise<void>) {
 
 describe("TemplateSchedulePage", () => {
 	beforeEach(() => {
-		vi.spyOn(API, "getEntitlements").mockResolvedValue(
-			MockEntitlementsWithScheduling,
+		vi.spyOn(API, "getDeploymentCapabilities").mockResolvedValue(
+			MockDeploymentCapabilitiesWithScheduling,
 		);
 	});
 

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -5,6 +5,7 @@ import {
 	reactRouterParameters,
 } from "storybook-addon-remix-react-router";
 import { getAuthorizationKey } from "#/api/queries/authCheck";
+import { entitlementDetailsQueryKey } from "#/api/queries/entitlements";
 import { workspaceByOwnerAndNameKey } from "#/api/queries/workspaces";
 import type { Workspace, WorkspaceAgentLifecycle } from "#/api/typesGenerated";
 import { AuthProvider } from "#/contexts/auth/AuthProvider";
@@ -72,7 +73,7 @@ const meta = {
 			{ key: ["authMethods"], data: MockAuthMethodsAll },
 			{ key: ["hasFirstUser"], data: true },
 			{ key: ["buildInfo"], data: MockBuildInfo },
-			{ key: ["entitlements"], data: MockEntitlements },
+			{ key: entitlementDetailsQueryKey, data: MockEntitlements },
 			{ key: ["experiments"], data: MockExperiments },
 			{ key: ["appearance"], data: MockAppearanceConfig },
 			{ key: ["organizations"], data: [MockDefaultOrganization] },

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -14,8 +14,8 @@ import type { WorkspacePermissions } from "#/modules/workspaces/permissions";
 import {
 	MockAppearanceConfig,
 	MockBuildInfo,
+	MockDeploymentCapabilities,
 	MockDeploymentConfig,
-	MockEntitlements,
 	MockFailedWorkspace,
 	MockOrganization,
 	MockOutdatedWorkspace,
@@ -402,7 +402,7 @@ describe("WorkspacePage", () => {
 				<DashboardContext.Provider
 					value={{
 						appearance: MockAppearanceConfig,
-						entitlements: MockEntitlements,
+						entitlements: MockDeploymentCapabilities,
 						experiments: [],
 						buildInfo: {
 							...MockBuildInfo,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2,6 +2,7 @@ import range from "lodash/range";
 import {
 	type DeploymentConfig,
 	type GetLicensesResponse,
+	withDefaultCapabilities,
 	withDefaultFeatures,
 } from "#/api/api";
 import type { FieldError } from "#/api/errors";
@@ -2706,6 +2707,64 @@ export const MockAgentRuntimeHoursFeature: TypesGen.Feature = {
 	},
 };
 
+export const MockDeploymentCapabilities: TypesGen.DeploymentCapabilities = {
+	has_license: false,
+	trial: false,
+	features: withDefaultCapabilities({}),
+};
+
+export const MockDeploymentCapabilitiesWithAuditLog: TypesGen.DeploymentCapabilities =
+	{
+		...MockDeploymentCapabilities,
+		has_license: true,
+		features: withDefaultCapabilities({
+			audit_log: {
+				enabled: true,
+				entitlement: "entitled",
+				usable: true,
+			},
+		}),
+	};
+
+export const MockDeploymentCapabilitiesWithConnectionLog: TypesGen.DeploymentCapabilities =
+	{
+		...MockDeploymentCapabilities,
+		has_license: true,
+		features: withDefaultCapabilities({
+			connection_log: {
+				enabled: true,
+				entitlement: "entitled",
+				usable: true,
+			},
+		}),
+	};
+
+export const MockDeploymentCapabilitiesWithScheduling: TypesGen.DeploymentCapabilities =
+	{
+		...MockDeploymentCapabilities,
+		has_license: true,
+		features: withDefaultCapabilities({
+			advanced_template_scheduling: {
+				enabled: true,
+				entitlement: "entitled",
+				usable: true,
+			},
+		}),
+	};
+
+export const MockDeploymentCapabilitiesWithMultiOrg: TypesGen.DeploymentCapabilities =
+	{
+		...MockDeploymentCapabilities,
+		has_license: true,
+		features: withDefaultCapabilities({
+			multiple_organizations: {
+				enabled: true,
+				entitlement: "entitled",
+				usable: true,
+			},
+		}),
+	};
+
 export const MockEntitlements: TypesGen.Entitlements = {
 	errors: [],
 	warnings: [],
@@ -2750,51 +2809,6 @@ const _MockEntitlementsWithWarnings: TypesGen.Entitlements = {
 	}),
 };
 
-export const MockEntitlementsWithAuditLog: TypesGen.Entitlements = {
-	errors: [],
-	warnings: [],
-	has_license: true,
-	require_telemetry: false,
-	trial: false,
-	refreshed_at: "2022-05-20T16:45:57.122Z",
-	features: withDefaultFeatures({
-		audit_log: {
-			enabled: true,
-			entitlement: "entitled",
-		},
-	}),
-};
-
-export const MockEntitlementsWithConnectionLog: TypesGen.Entitlements = {
-	errors: [],
-	warnings: [],
-	has_license: true,
-	require_telemetry: false,
-	trial: false,
-	refreshed_at: "2022-05-20T16:45:57.122Z",
-	features: withDefaultFeatures({
-		connection_log: {
-			enabled: true,
-			entitlement: "entitled",
-		},
-	}),
-};
-
-export const MockEntitlementsWithScheduling: TypesGen.Entitlements = {
-	errors: [],
-	warnings: [],
-	has_license: true,
-	require_telemetry: false,
-	trial: false,
-	refreshed_at: "2022-05-20T16:45:57.122Z",
-	features: withDefaultFeatures({
-		advanced_template_scheduling: {
-			enabled: true,
-			entitlement: "entitled",
-		},
-	}),
-};
-
 const _MockEntitlementsWithUserLimit: TypesGen.Entitlements = {
 	errors: [],
 	warnings: [],
@@ -2807,17 +2821,6 @@ const _MockEntitlementsWithUserLimit: TypesGen.Entitlements = {
 			enabled: true,
 			entitlement: "entitled",
 			limit: 25,
-		},
-	}),
-};
-
-export const MockEntitlementsWithMultiOrg: TypesGen.Entitlements = {
-	...MockEntitlements,
-	has_license: true,
-	features: withDefaultFeatures({
-		multiple_organizations: {
-			enabled: true,
-			entitlement: "entitled",
 		},
 	}),
 };

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -333,6 +333,9 @@ export const handlers = [
 	http.get("/api/v2/workspacebuilds/:workspaceBuildId/logs", () => {
 		return HttpResponse.json(M.MockWorkspaceBuildLogs);
 	}),
+	http.get("/api/v2/deployment/capabilities", () => {
+		return HttpResponse.json(M.MockDeploymentCapabilities);
+	}),
 	http.get("/api/v2/entitlements", () => {
 		return HttpResponse.json(M.MockEntitlements);
 	}),

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -1,10 +1,14 @@
 import type { StoryContext } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useQueryClient } from "react-query";
-import { withDefaultFeatures } from "#/api/api";
+import { withDefaultCapabilities, withDefaultFeatures } from "#/api/api";
 import { getAuthorizationKey } from "#/api/queries/authCheck";
+import { entitlementDetailsQueryKey } from "#/api/queries/entitlements";
 import { hasFirstUserKey, meKey } from "#/api/queries/users";
-import type { Entitlements } from "#/api/typesGenerated";
+import type {
+	DeploymentCapabilities,
+	Entitlements,
+} from "#/api/typesGenerated";
 import { Toaster } from "#/components/Toaster/Toaster";
 import { AuthProvider } from "#/contexts/auth/AuthProvider";
 import {
@@ -20,6 +24,7 @@ import {
 	MockAppearanceConfig,
 	MockBuildInfo,
 	MockDefaultOrganization,
+	MockDeploymentCapabilities,
 	MockDeploymentConfig,
 	MockEntitlements,
 	MockOrganizationPermissions,
@@ -30,6 +35,7 @@ export const withDashboardProvider = (
 	Story: FC,
 	{ parameters }: StoryContext,
 ) => {
+	const queryClient = useQueryClient();
 	const {
 		features = [],
 		experiments = [],
@@ -38,7 +44,7 @@ export const withDashboardProvider = (
 		canViewOrganizationSettings = false,
 	} = parameters;
 
-	const entitlements: Entitlements = {
+	const entitlementDetails: Entitlements = {
 		...MockEntitlements,
 		has_license: features.length > 0,
 		features: withDefaultFeatures(
@@ -49,6 +55,32 @@ export const withDashboardProvider = (
 					}
 					const { name, ...values } = feature;
 					return [name, { enabled: true, entitlement: "entitled", ...values }];
+				}),
+			),
+		),
+	};
+	queryClient.setQueryData(entitlementDetailsQueryKey, entitlementDetails);
+
+	const entitlements: DeploymentCapabilities = {
+		...MockDeploymentCapabilities,
+		has_license: features.length > 0,
+		features: withDefaultCapabilities(
+			Object.fromEntries(
+				features.map((feature) => {
+					if (typeof feature === "string") {
+						return [
+							feature,
+							{ enabled: true, entitlement: "entitled", usable: true },
+						];
+					}
+					return [
+						feature.name,
+						{
+							enabled: feature.enabled ?? true,
+							entitlement: feature.entitlement ?? "entitled",
+							usable: true,
+						},
+					];
 				}),
 			),
 		),


### PR DESCRIPTION
## Summary
Split public deployment capability state from authenticated entitlement details.

## Problem
The public entitlements endpoint and embedded HTML metadata exposed complete entitlement data, including limits, actual usage, runtime milliseconds, usage periods, warnings, and errors. The dashboard also depended on those details to decide feature visibility.

## Fix
Add a public capability-only deployment endpoint with backend-computed feature usability, require authentication for the existing full entitlements endpoint, and embed only the sanitized capability projection in the HTML shell. The frontend now uses separate capability and detail queries so detail failures remain local while authenticated SDK, CLI, and support callers retain the existing full contract.

Part 1 of a 2-PR stack. Followed by #28489. Refs CODAGT-890.
