### PR TITLE
fix(site): render change-version picker in place so it clears the dialog

### DIFF
--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
@@ -105,13 +105,16 @@ export const ChangeWorkspaceVersionDialog: FC<
 										/>
 									</ComboboxTrigger>
 									{/*
-									 * z-[1400] keeps this portalled popover above the
-									 * MUI Dialog (z-index: 1300) that still backs this
-									 * dialog on release/2.36. Without it the options
-									 * paint behind the dialog surface (DEVEX-780).
+									 * disablePortal renders the popover in place instead
+									 * of portalling to document.body. The dialog is still
+									 * an MUI Dialog (z-index: 1300) on release/2.36, so a
+									 * body portal lands behind it. Keeping the popover
+									 * inside the dialog also keeps it in the focus trap
+									 * (DEVEX-780).
 									 */}
 									<ComboboxContent
-										className="z-[1400] max-w-none min-w-[min(100%,320px)]"
+										disablePortal
+										className="max-w-none min-w-[min(100%,320px)]"
 										align="start"
 									>
 										<ComboboxInput placeholder="Search versions…" />

--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
@@ -104,14 +104,6 @@ export const ChangeWorkspaceVersionDialog: FC<
 											className="w-full min-w-0 pl-3.5"
 										/>
 									</ComboboxTrigger>
-									{/*
-									 * disablePortal renders the popover in place instead
-									 * of portalling to document.body. The dialog is still
-									 * an MUI Dialog (z-index: 1300) on release/2.36, so a
-									 * body portal lands behind it. Keeping the popover
-									 * inside the dialog also keeps it in the focus trap
-									 * (DEVEX-780).
-									 */}
 									<ComboboxContent
 										disablePortal
 										className="max-w-none min-w-[min(100%,320px)]"

--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
@@ -104,8 +104,14 @@ export const ChangeWorkspaceVersionDialog: FC<
 											className="w-full min-w-0 pl-3.5"
 										/>
 									</ComboboxTrigger>
+									{/*
+									 * z-[1400] keeps this portalled popover above the
+									 * MUI Dialog (z-index: 1300) that still backs this
+									 * dialog on release/2.36. Without it the options
+									 * paint behind the dialog surface (DEVEX-780).
+									 */}
 									<ComboboxContent
-										className="max-w-none min-w-[min(100%,320px)]"
+										className="z-[1400] max-w-none min-w-[min(100%,320px)]"
 										align="start"
 									>
 										<ComboboxInput placeholder="Search versions…" />


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Backports the [DEVEX-780](https://linear.app/codercom/issue/DEVEX-780/change-version-dialog-picker-is-inaccessible) fix to `release/2.36`. `main` is already fine, this is for shipped 2.36.x.

## Problem

In the Change version dialog, the version picker options are unclickable, painted behind the dialog surface.

The picker uses the shared Radix `Popover`, which portals to `document.body` at `z-50` (see #23374). On `release/2.36` the dialog is still an `@mui/material/Dialog` at `z-index: 1300`. Two body-level portals, `50` loses to `1300`, so the options render behind the dialog.

`main` is unaffected because #27506 moved every dialog onto Radix, but that landed **after** the 2.36 branch cut, so 2.36.x shipped broken.

<img width="646" height="386" alt="image" src="https://github.com/user-attachments/assets/f224aa43-dfc1-432a-be41-e85e16af3019"/>

## Fix

Set `disablePortal` on the dialog's `ComboboxContent` so the popover renders in place instead of portalling to `document.body`. It stays inside the dialog's stacking context and focus trap, so it paints in front and stays accessible without a z-index magic number chained to MUI's internal `1300`.

Backporting #27506 wholesale is not viable, it touches ~30 dialogs. This is the smallest scoped change.
