### PR TITLE
feat: promote codersdk chat API methods to Client

### DIFF
--- a/cli/exp_chat.go
+++ b/cli/exp_chat.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/coder/coder/v2/agent/agentsocket"
 	"github.com/coder/coder/v2/cli/cliui"
-	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/serpent"
 )
 
@@ -293,8 +292,7 @@ func (r *RootCmd) chatContextRefreshCommand(socketPath *string) *serpent.Command
 				if err != nil {
 					return err
 				}
-				exp := codersdk.NewExperimentalClient(client)
-				chat, err := exp.RefreshChatContext(ctx, chatID)
+				chat, err := client.RefreshChatContext(ctx, chatID)
 				if err != nil {
 					return xerrors.Errorf("refresh chat context: %w", err)
 				}

--- a/cli/exp_scaletest_chat_test.go
+++ b/cli/exp_scaletest_chat_test.go
@@ -76,21 +76,20 @@ func TestScaleTestChat(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mockURL, provider.BaseURL)
 
-	expClient := codersdk.NewExperimentalClient(client)
 	defaultOrg, err := client.OrganizationByName(ctx, codersdk.DefaultOrganization)
 	require.NoError(t, err)
-	configs, err := expClient.ChatModels(ctx, defaultOrg.ID)
+	configs, err := client.ChatModels(ctx, defaultOrg.ID)
 	require.NoError(t, err)
 	matchingConfigs := scaletestModelConfigsForProvider(configs.Models, provider.ID)
 	require.Len(t, matchingConfigs, 1)
 	require.True(t, matchingConfigs[0].Enabled)
 
-	chats, err := expClient.ListChats(ctx, &codersdk.ListChatsOptions{Query: "archived:true"})
+	chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{Query: "archived:true"})
 	require.NoError(t, err)
 
 	var scaletestMessages []codersdk.ChatMessage
 	for _, chat := range chats {
-		resp, err := expClient.GetChatMessages(ctx, chat.ID, nil)
+		resp, err := client.GetChatMessages(ctx, chat.ID, nil)
 		require.NoError(t, err)
 		if userText, ok := chatMessageText(resp.Messages, codersdk.ChatMessageRoleUser); ok &&
 			strings.Contains(userText, scaletestChatPrompt) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -700,7 +700,7 @@ type ChatMessagesResponse struct {
 }
 
 // ChatPrompt is a single user-authored prompt in a chat, returned by
-// GET /api/experimental/chats/{chat}/prompts. The text field contains
+// GET /api/v2/chats/{chat}/prompts. The text field contains
 // the concatenated text payload of the underlying chat message; non-text
 // parts (tool calls, files, attachments) are omitted by the server.
 type ChatPrompt struct {
@@ -709,7 +709,7 @@ type ChatPrompt struct {
 }
 
 // ChatPromptsResponse is the payload of
-// GET /api/experimental/chats/{chat}/prompts. Prompts are returned
+// GET /api/v2/chats/{chat}/prompts. Prompts are returned
 // newest first so the client can index directly into the slice for
 // up/down arrow history cycling.
 type ChatPromptsResponse struct {
@@ -1623,7 +1623,7 @@ type ChatDiffContents struct {
 
 // Chat git watch error messages. These are the user-visible messages
 // the server returns in 400 responses from
-// /api/experimental/chats/{id}/stream/git when the chat cannot be
+// /api/v2/chats/{id}/stream/git when the chat cannot be
 // observed through a workspace agent. They are exported so the CLI
 // (and any future consumer) can match them structurally via
 // IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -1640,14 +1640,14 @@ const (
 )
 
 // ChatGitWatchAgentStateMessage is the user-visible error message
-// returned from /api/experimental/chats/{id}/stream/git when the
+// returned from /api/v2/chats/{id}/stream/git when the
 // chat workspace's agent is not in the connected state.
 func ChatGitWatchAgentStateMessage(actual WorkspaceAgentStatus) string {
 	return fmt.Sprintf("%s%q, it must be in the %q state.", ChatGitWatchAgentStatePrefix, actual, WorkspaceAgentConnected)
 }
 
 // IsChatGitWatchFallbackMessage reports whether msg matches one of
-// the 400-response messages /api/experimental/chats/{id}/stream/git
+// the 400-response messages /api/v2/chats/{id}/stream/git
 // emits when the chat cannot be observed through a workspace agent.
 // Clients should treat these cases as "no diff available" and fall
 // back to the empty remote diff instead of surfacing a hard error.
@@ -1983,7 +1983,7 @@ type ListChatsOptions struct {
 }
 
 // ListChats returns all chats for the authenticated user.
-func (c *ExperimentalClient) ListChats(ctx context.Context, opts *ListChatsOptions) ([]Chat, error) {
+func (c *Client) ListChats(ctx context.Context, opts *ListChatsOptions) ([]Chat, error) {
 	var reqOpts []RequestOption
 	if opts != nil {
 		reqOpts = append(reqOpts, opts.asRequestOption())
@@ -2011,7 +2011,7 @@ func (c *ExperimentalClient) ListChats(ctx context.Context, opts *ListChatsOptio
 			})
 		}
 	}
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats", nil, reqOpts...)
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats", nil, reqOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2082,7 +2082,7 @@ func (c *ExperimentalClient) DeleteChatProvider(ctx context.Context, providerID 
 }
 
 // ListUserAIProviderKeyConfigs returns user-scoped AI provider key configs.
-func (c *ExperimentalClient) ListUserAIProviderKeyConfigs(ctx context.Context, user string) ([]UserAIProviderKeyConfig, error) {
+func (c *Client) ListUserAIProviderKeyConfigs(ctx context.Context, user string) ([]UserAIProviderKeyConfig, error) {
 	res, err := c.Request(ctx, http.MethodGet, userAIProviderKeysPath(user), nil)
 	if err != nil {
 		return nil, xerrors.Errorf("list user AI provider key configs: %w", err)
@@ -2096,7 +2096,7 @@ func (c *ExperimentalClient) ListUserAIProviderKeyConfigs(ctx context.Context, u
 }
 
 // UpsertUserAIProviderKey creates or replaces a user API key for an AI provider.
-func (c *ExperimentalClient) UpsertUserAIProviderKey(ctx context.Context, user string, providerID uuid.UUID, req CreateUserAIProviderKeyRequest) (UserAIProviderKeyConfig, error) {
+func (c *Client) UpsertUserAIProviderKey(ctx context.Context, user string, providerID uuid.UUID, req CreateUserAIProviderKeyRequest) (UserAIProviderKeyConfig, error) {
 	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("%s/%s", userAIProviderKeysPath(user), providerID), req)
 	if err != nil {
 		return UserAIProviderKeyConfig{}, xerrors.Errorf("upsert user AI provider key: %w", err)
@@ -2110,7 +2110,7 @@ func (c *ExperimentalClient) UpsertUserAIProviderKey(ctx context.Context, user s
 }
 
 // DeleteUserAIProviderKey deletes a user API key for an AI provider.
-func (c *ExperimentalClient) DeleteUserAIProviderKey(ctx context.Context, user string, providerID uuid.UUID) error {
+func (c *Client) DeleteUserAIProviderKey(ctx context.Context, user string, providerID uuid.UUID) error {
 	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", userAIProviderKeysPath(user), providerID), nil)
 	if err != nil {
 		return xerrors.Errorf("delete user AI provider key: %w", err)
@@ -2123,7 +2123,7 @@ func (c *ExperimentalClient) DeleteUserAIProviderKey(ctx context.Context, user s
 }
 
 func userAIProviderKeysPath(user string) string {
-	return fmt.Sprintf("/api/experimental/users/%s/ai-provider-keys", url.PathEscape(user))
+	return fmt.Sprintf("/api/v2/users/%s/ai-provider-keys", url.PathEscape(user))
 }
 
 // ListUserChatProviderConfigs returns user-scoped chat provider configs.
@@ -2170,8 +2170,8 @@ func (c *ExperimentalClient) DeleteUserChatProviderKey(ctx context.Context, prov
 // ChatModels returns the chat model configs the caller can read in one
 // organization, plus the redacted provider descriptors the authoring page
 // needs, for org-scoped management and picker surfaces.
-func (c *ExperimentalClient) ChatModels(ctx context.Context, organizationID uuid.UUID) (OrganizationChatModelsResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chats/models", organizationID), nil)
+func (c *Client) ChatModels(ctx context.Context, organizationID uuid.UUID) (OrganizationChatModelsResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/chats/models", organizationID), nil)
 	if err != nil {
 		return OrganizationChatModelsResponse{}, err
 	}
@@ -2185,8 +2185,8 @@ func (c *ExperimentalClient) ChatModels(ctx context.Context, organizationID uuid
 }
 
 // ChatModel fetches one chat model config by ID in an organization.
-func (c *ExperimentalClient) ChatModel(ctx context.Context, organizationID, modelConfigID uuid.UUID) (ChatModel, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chats/models/%s", organizationID, modelConfigID), nil)
+func (c *Client) ChatModel(ctx context.Context, organizationID, modelConfigID uuid.UUID) (ChatModel, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/chats/models/%s", organizationID, modelConfigID), nil)
 	if err != nil {
 		return ChatModel{}, err
 	}
@@ -2200,8 +2200,8 @@ func (c *ExperimentalClient) ChatModel(ctx context.Context, organizationID, mode
 }
 
 // CreateChatModel creates a chat model config in the given organization.
-func (c *ExperimentalClient) CreateChatModel(ctx context.Context, organizationID uuid.UUID, req CreateChatModelRequest) (ChatModel, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/organizations/%s/chats/models", organizationID), req)
+func (c *Client) CreateChatModel(ctx context.Context, organizationID uuid.UUID, req CreateChatModelRequest) (ChatModel, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/organizations/%s/chats/models", organizationID), req)
 	if err != nil {
 		return ChatModel{}, err
 	}
@@ -2215,8 +2215,8 @@ func (c *ExperimentalClient) CreateChatModel(ctx context.Context, organizationID
 }
 
 // UpdateChatModel updates a ChatModel in an organization.
-func (c *ExperimentalClient) UpdateChatModel(ctx context.Context, organizationID, modelID uuid.UUID, req UpdateChatModelRequest) (ChatModel, error) {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/organizations/%s/chats/models/%s", organizationID, modelID), req)
+func (c *Client) UpdateChatModel(ctx context.Context, organizationID, modelID uuid.UUID, req UpdateChatModelRequest) (ChatModel, error) {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/organizations/%s/chats/models/%s", organizationID, modelID), req)
 	if err != nil {
 		return ChatModel{}, err
 	}
@@ -2231,8 +2231,8 @@ func (c *ExperimentalClient) UpdateChatModel(ctx context.Context, organizationID
 
 // ChatModelACL returns the access control list for a chat model in an
 // organization.
-func (c *ExperimentalClient) ChatModelACL(ctx context.Context, organizationID, modelID uuid.UUID) (ChatModelACL, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/chats/models/%s/acl", organizationID, modelID), nil)
+func (c *Client) ChatModelACL(ctx context.Context, organizationID, modelID uuid.UUID) (ChatModelACL, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/chats/models/%s/acl", organizationID, modelID), nil)
 	if err != nil {
 		return ChatModelACL{}, err
 	}
@@ -2247,8 +2247,8 @@ func (c *ExperimentalClient) ChatModelACL(ctx context.Context, organizationID, m
 
 // UpdateChatModelACL applies a sparse access control list update to a chat
 // model in an organization.
-func (c *ExperimentalClient) UpdateChatModelACL(ctx context.Context, organizationID, modelID uuid.UUID, req UpdateChatModelACLRequest) error {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/organizations/%s/chats/models/%s/acl", organizationID, modelID), req)
+func (c *Client) UpdateChatModelACL(ctx context.Context, organizationID, modelID uuid.UUID, req UpdateChatModelACLRequest) error {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/organizations/%s/chats/models/%s/acl", organizationID, modelID), req)
 	if err != nil {
 		return err
 	}
@@ -2260,8 +2260,8 @@ func (c *ExperimentalClient) UpdateChatModelACL(ctx context.Context, organizatio
 }
 
 // DeleteChatModel deletes a ChatModel in an organization.
-func (c *ExperimentalClient) DeleteChatModel(ctx context.Context, organizationID, modelID uuid.UUID) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/organizations/%s/chats/models/%s", organizationID, modelID), nil)
+func (c *Client) DeleteChatModel(ctx context.Context, organizationID, modelID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/organizations/%s/chats/models/%s", organizationID, modelID), nil)
 	if err != nil {
 		return err
 	}
@@ -2275,7 +2275,7 @@ func (c *ExperimentalClient) DeleteChatModel(ctx context.Context, organizationID
 // ChatModelProviderDescriptor is the redacted view of an AI provider carried
 // on the org model collection response. It carries only the capability
 // metadata the Models UI needs; key material, base URLs, and headers are
-// never exposed. The fields mirror what /api/experimental/chats/models
+// never exposed. The fields mirror what /api/v2/chats/models
 // already discloses to any authenticated caller.
 type ChatModelProviderDescriptor struct {
 	ID                 uuid.UUID                          `json:"id" format:"uuid"`
@@ -2302,8 +2302,8 @@ type OrganizationChatModelsResponse struct {
 
 // GetChatCost returns the AI Gateway cost for the whole chat tree that
 // contains chatID.
-func (c *ExperimentalClient) GetChatCost(ctx context.Context, chatID uuid.UUID) (ChatCost, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/cost", chatID), nil)
+func (c *Client) GetChatCost(ctx context.Context, chatID uuid.UUID) (ChatCost, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s/cost", chatID), nil)
 	if err != nil {
 		return ChatCost{}, err
 	}
@@ -2316,8 +2316,8 @@ func (c *ExperimentalClient) GetChatCost(ctx context.Context, chatID uuid.UUID) 
 }
 
 // GetChatSystemPrompt returns the deployment-wide chat system prompt.
-func (c *ExperimentalClient) GetChatSystemPrompt(ctx context.Context) (ChatSystemPromptResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/system-prompt", nil)
+func (c *Client) GetChatSystemPrompt(ctx context.Context) (ChatSystemPromptResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/system-prompt", nil)
 	if err != nil {
 		return ChatSystemPromptResponse{}, err
 	}
@@ -2330,8 +2330,8 @@ func (c *ExperimentalClient) GetChatSystemPrompt(ctx context.Context) (ChatSyste
 }
 
 // UpdateChatSystemPrompt updates the deployment-wide chat system prompt.
-func (c *ExperimentalClient) UpdateChatSystemPrompt(ctx context.Context, req UpdateChatSystemPromptRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/system-prompt", req)
+func (c *Client) UpdateChatSystemPrompt(ctx context.Context, req UpdateChatSystemPromptRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/system-prompt", req)
 	if err != nil {
 		return err
 	}
@@ -2343,8 +2343,8 @@ func (c *ExperimentalClient) UpdateChatSystemPrompt(ctx context.Context, req Upd
 }
 
 // GetChatPlanModeInstructions returns the deployment-wide plan mode instructions.
-func (c *ExperimentalClient) GetChatPlanModeInstructions(ctx context.Context) (ChatPlanModeInstructionsResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/plan-mode-instructions", nil)
+func (c *Client) GetChatPlanModeInstructions(ctx context.Context) (ChatPlanModeInstructionsResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/plan-mode-instructions", nil)
 	if err != nil {
 		return ChatPlanModeInstructionsResponse{}, err
 	}
@@ -2357,8 +2357,8 @@ func (c *ExperimentalClient) GetChatPlanModeInstructions(ctx context.Context) (C
 }
 
 // UpdateChatPlanModeInstructions updates the deployment-wide plan mode instructions.
-func (c *ExperimentalClient) UpdateChatPlanModeInstructions(ctx context.Context, req UpdateChatPlanModeInstructionsRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/plan-mode-instructions", req)
+func (c *Client) UpdateChatPlanModeInstructions(ctx context.Context, req UpdateChatPlanModeInstructionsRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/plan-mode-instructions", req)
 	if err != nil {
 		return err
 	}
@@ -2370,8 +2370,8 @@ func (c *ExperimentalClient) UpdateChatPlanModeInstructions(ctx context.Context,
 }
 
 // OrganizationChatModelOverrides returns the configured chat model overrides for an organization.
-func (c *ExperimentalClient) OrganizationChatModelOverrides(ctx context.Context, organizationID uuid.UUID) (ChatModelOverridesResponse, error) {
-	path := fmt.Sprintf("/api/experimental/organizations/%s/chats/model-overrides", organizationID)
+func (c *Client) OrganizationChatModelOverrides(ctx context.Context, organizationID uuid.UUID) (ChatModelOverridesResponse, error) {
+	path := fmt.Sprintf("/api/v2/organizations/%s/chats/model-overrides", organizationID)
 	res, err := c.Request(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return ChatModelOverridesResponse{}, err
@@ -2385,9 +2385,9 @@ func (c *ExperimentalClient) OrganizationChatModelOverrides(ctx context.Context,
 }
 
 // UpdateOrganizationChatModelOverride updates or clears a chat model override for an organization.
-func (c *ExperimentalClient) UpdateOrganizationChatModelOverride(ctx context.Context, organizationID uuid.UUID, override ChatModelOverrideContext, req UpdateChatModelOverrideRequest) (ChatModelOverrideResponse, error) {
+func (c *Client) UpdateOrganizationChatModelOverride(ctx context.Context, organizationID uuid.UUID, override ChatModelOverrideContext, req UpdateChatModelOverrideRequest) (ChatModelOverrideResponse, error) {
 	path := fmt.Sprintf(
-		"/api/experimental/organizations/%s/chats/model-overrides/%s",
+		"/api/v2/organizations/%s/chats/model-overrides/%s",
 		organizationID,
 		url.PathEscape(string(override)),
 	)
@@ -2405,8 +2405,8 @@ func (c *ExperimentalClient) UpdateOrganizationChatModelOverride(ctx context.Con
 
 // GetChatPersonalModelOverridesAdminSettings returns the deployment-wide
 // personal model override admin settings.
-func (c *ExperimentalClient) GetChatPersonalModelOverridesAdminSettings(ctx context.Context) (ChatPersonalModelOverridesAdminSettings, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/personal-model-overrides", nil)
+func (c *Client) GetChatPersonalModelOverridesAdminSettings(ctx context.Context) (ChatPersonalModelOverridesAdminSettings, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/personal-model-overrides", nil)
 	if err != nil {
 		return ChatPersonalModelOverridesAdminSettings{}, err
 	}
@@ -2420,8 +2420,8 @@ func (c *ExperimentalClient) GetChatPersonalModelOverridesAdminSettings(ctx cont
 
 // UpdateChatPersonalModelOverridesAdminSettings updates the deployment-wide
 // personal model override admin settings.
-func (c *ExperimentalClient) UpdateChatPersonalModelOverridesAdminSettings(ctx context.Context, req UpdateChatPersonalModelOverridesAdminSettingsRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/personal-model-overrides", req)
+func (c *Client) UpdateChatPersonalModelOverridesAdminSettings(ctx context.Context, req UpdateChatPersonalModelOverridesAdminSettingsRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/personal-model-overrides", req)
 	if err != nil {
 		return err
 	}
@@ -2433,9 +2433,9 @@ func (c *ExperimentalClient) UpdateChatPersonalModelOverridesAdminSettings(ctx c
 }
 
 // UserChatPersonalModelOverrides returns a user's personal model overrides in an organization.
-func (c *ExperimentalClient) UserChatPersonalModelOverrides(ctx context.Context, organizationID uuid.UUID, user string) (UserChatPersonalModelOverridesResponse, error) {
+func (c *Client) UserChatPersonalModelOverrides(ctx context.Context, organizationID uuid.UUID, user string) (UserChatPersonalModelOverridesResponse, error) {
 	path := fmt.Sprintf(
-		"/api/experimental/organizations/%s/members/%s/chats/model-overrides",
+		"/api/v2/organizations/%s/members/%s/chats/model-overrides",
 		organizationID,
 		url.PathEscape(user),
 	)
@@ -2452,9 +2452,9 @@ func (c *ExperimentalClient) UserChatPersonalModelOverrides(ctx context.Context,
 }
 
 // UpdateUserChatPersonalModelOverride updates a user's personal model override in an organization.
-func (c *ExperimentalClient) UpdateUserChatPersonalModelOverride(ctx context.Context, organizationID uuid.UUID, user string, override ChatPersonalModelOverrideContext, req UpdateUserChatPersonalModelOverrideRequest) error {
+func (c *Client) UpdateUserChatPersonalModelOverride(ctx context.Context, organizationID uuid.UUID, user string, override ChatPersonalModelOverrideContext, req UpdateUserChatPersonalModelOverrideRequest) error {
 	path := fmt.Sprintf(
-		"/api/experimental/organizations/%s/members/%s/chats/model-overrides/%s",
+		"/api/v2/organizations/%s/members/%s/chats/model-overrides/%s",
 		organizationID,
 		url.PathEscape(user),
 		url.PathEscape(string(override)),
@@ -2471,8 +2471,8 @@ func (c *ExperimentalClient) UpdateUserChatPersonalModelOverride(ctx context.Con
 }
 
 // GetUserChatCustomPrompt fetches the user's custom chat prompt.
-func (c *ExperimentalClient) GetUserChatCustomPrompt(ctx context.Context) (UserChatCustomPrompt, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/user-prompt", nil)
+func (c *Client) GetUserChatCustomPrompt(ctx context.Context) (UserChatCustomPrompt, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/user-prompt", nil)
 	if err != nil {
 		return UserChatCustomPrompt{}, err
 	}
@@ -2540,8 +2540,8 @@ func (c *ExperimentalClient) UpdateChatComputerUseProvider(ctx context.Context, 
 }
 
 // GetChatWorkspaceTTL returns the configured chat workspace TTL.
-func (c *ExperimentalClient) GetChatWorkspaceTTL(ctx context.Context) (ChatWorkspaceTTLResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/workspace-ttl", nil)
+func (c *Client) GetChatWorkspaceTTL(ctx context.Context) (ChatWorkspaceTTLResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/workspace-ttl", nil)
 	if err != nil {
 		return ChatWorkspaceTTLResponse{}, err
 	}
@@ -2554,8 +2554,8 @@ func (c *ExperimentalClient) GetChatWorkspaceTTL(ctx context.Context) (ChatWorks
 }
 
 // UpdateChatWorkspaceTTL updates the chat workspace TTL setting.
-func (c *ExperimentalClient) UpdateChatWorkspaceTTL(ctx context.Context, req UpdateChatWorkspaceTTLRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/workspace-ttl", req)
+func (c *Client) UpdateChatWorkspaceTTL(ctx context.Context, req UpdateChatWorkspaceTTLRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/workspace-ttl", req)
 	if err != nil {
 		return err
 	}
@@ -2567,8 +2567,8 @@ func (c *ExperimentalClient) UpdateChatWorkspaceTTL(ctx context.Context, req Upd
 }
 
 // GetChatRetentionDays returns the configured chat retention period.
-func (c *ExperimentalClient) GetChatRetentionDays(ctx context.Context) (ChatRetentionDaysResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/retention-days", nil)
+func (c *Client) GetChatRetentionDays(ctx context.Context) (ChatRetentionDaysResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/retention-days", nil)
 	if err != nil {
 		return ChatRetentionDaysResponse{}, err
 	}
@@ -2581,8 +2581,8 @@ func (c *ExperimentalClient) GetChatRetentionDays(ctx context.Context) (ChatRete
 }
 
 // UpdateChatRetentionDays updates the chat retention period.
-func (c *ExperimentalClient) UpdateChatRetentionDays(ctx context.Context, req UpdateChatRetentionDaysRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/retention-days", req)
+func (c *Client) UpdateChatRetentionDays(ctx context.Context, req UpdateChatRetentionDaysRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/retention-days", req)
 	if err != nil {
 		return err
 	}
@@ -2595,8 +2595,8 @@ func (c *ExperimentalClient) UpdateChatRetentionDays(ctx context.Context, req Up
 
 // GetChatDebugRetentionDays returns the configured chat debug run
 // retention period.
-func (c *ExperimentalClient) GetChatDebugRetentionDays(ctx context.Context) (ChatDebugRetentionDaysResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/debug-retention-days", nil)
+func (c *Client) GetChatDebugRetentionDays(ctx context.Context) (ChatDebugRetentionDaysResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/debug-retention-days", nil)
 	if err != nil {
 		return ChatDebugRetentionDaysResponse{}, err
 	}
@@ -2609,8 +2609,8 @@ func (c *ExperimentalClient) GetChatDebugRetentionDays(ctx context.Context) (Cha
 }
 
 // UpdateChatDebugRetentionDays updates the chat debug run retention period.
-func (c *ExperimentalClient) UpdateChatDebugRetentionDays(ctx context.Context, req UpdateChatDebugRetentionDaysRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/debug-retention-days", req)
+func (c *Client) UpdateChatDebugRetentionDays(ctx context.Context, req UpdateChatDebugRetentionDaysRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/debug-retention-days", req)
 	if err != nil {
 		return err
 	}
@@ -2622,8 +2622,8 @@ func (c *ExperimentalClient) UpdateChatDebugRetentionDays(ctx context.Context, r
 }
 
 // GetChatAutoArchiveDays returns the configured chat auto-archive period.
-func (c *ExperimentalClient) GetChatAutoArchiveDays(ctx context.Context) (ChatAutoArchiveDaysResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/auto-archive-days", nil)
+func (c *Client) GetChatAutoArchiveDays(ctx context.Context) (ChatAutoArchiveDaysResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/auto-archive-days", nil)
 	if err != nil {
 		return ChatAutoArchiveDaysResponse{}, err
 	}
@@ -2636,8 +2636,8 @@ func (c *ExperimentalClient) GetChatAutoArchiveDays(ctx context.Context) (ChatAu
 }
 
 // UpdateChatAutoArchiveDays updates the chat auto-archive period.
-func (c *ExperimentalClient) UpdateChatAutoArchiveDays(ctx context.Context, req UpdateChatAutoArchiveDaysRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/auto-archive-days", req)
+func (c *Client) UpdateChatAutoArchiveDays(ctx context.Context, req UpdateChatAutoArchiveDaysRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/auto-archive-days", req)
 	if err != nil {
 		return err
 	}
@@ -2649,8 +2649,8 @@ func (c *ExperimentalClient) UpdateChatAutoArchiveDays(ctx context.Context, req 
 }
 
 // UpdateUserChatCustomPrompt updates the user's custom chat prompt.
-func (c *ExperimentalClient) UpdateUserChatCustomPrompt(ctx context.Context, req UserChatCustomPrompt) (UserChatCustomPrompt, error) {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/user-prompt", req)
+func (c *Client) UpdateUserChatCustomPrompt(ctx context.Context, req UserChatCustomPrompt) (UserChatCustomPrompt, error) {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/user-prompt", req)
 	if err != nil {
 		return UserChatCustomPrompt{}, err
 	}
@@ -2664,8 +2664,8 @@ func (c *ExperimentalClient) UpdateUserChatCustomPrompt(ctx context.Context, req
 
 // GetUserChatCompactionThresholds fetches the user's per-model chat
 // compaction thresholds.
-func (c *ExperimentalClient) GetUserChatCompactionThresholds(ctx context.Context) (UserChatCompactionThresholds, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/user-compaction-thresholds", nil)
+func (c *Client) GetUserChatCompactionThresholds(ctx context.Context) (UserChatCompactionThresholds, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/user-compaction-thresholds", nil)
 	if err != nil {
 		return UserChatCompactionThresholds{}, err
 	}
@@ -2679,8 +2679,8 @@ func (c *ExperimentalClient) GetUserChatCompactionThresholds(ctx context.Context
 
 // UpdateUserChatCompactionThreshold updates the user's per-model chat
 // compaction threshold.
-func (c *ExperimentalClient) UpdateUserChatCompactionThreshold(ctx context.Context, modelID uuid.UUID, req UpdateUserChatCompactionThresholdRequest) (UserChatCompactionThreshold, error) {
-	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/experimental/chats/config/user-compaction-thresholds/%s", modelID), req)
+func (c *Client) UpdateUserChatCompactionThreshold(ctx context.Context, modelID uuid.UUID, req UpdateUserChatCompactionThresholdRequest) (UserChatCompactionThreshold, error) {
+	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/v2/chats/config/user-compaction-thresholds/%s", modelID), req)
 	if err != nil {
 		return UserChatCompactionThreshold{}, err
 	}
@@ -2694,8 +2694,8 @@ func (c *ExperimentalClient) UpdateUserChatCompactionThreshold(ctx context.Conte
 
 // DeleteUserChatCompactionThreshold deletes the user's per-model chat
 // compaction threshold override.
-func (c *ExperimentalClient) DeleteUserChatCompactionThreshold(ctx context.Context, modelID uuid.UUID) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/config/user-compaction-thresholds/%s", modelID), nil)
+func (c *Client) DeleteUserChatCompactionThreshold(ctx context.Context, modelID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/chats/config/user-compaction-thresholds/%s", modelID), nil)
 	if err != nil {
 		return err
 	}
@@ -2707,8 +2707,8 @@ func (c *ExperimentalClient) DeleteUserChatCompactionThreshold(ctx context.Conte
 }
 
 // CreateChat creates a new chat.
-func (c *ExperimentalClient) CreateChat(ctx context.Context, req CreateChatRequest) (Chat, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/chats", req)
+func (c *Client) CreateChat(ctx context.Context, req CreateChatRequest) (Chat, error) {
+	res, err := c.Request(ctx, http.MethodPost, "/api/v2/chats", req)
 	if err != nil {
 		return Chat{}, err
 	}
@@ -2734,8 +2734,8 @@ type StreamChatOptions struct {
 // The returned channel includes initial snapshot events first, followed by
 // live updates. Callers must close the returned io.Closer to release the
 // websocket connection when done.
-func (c *ExperimentalClient) StreamChat(ctx context.Context, chatID uuid.UUID, opts *StreamChatOptions) (<-chan ChatStreamEvent, io.Closer, error) {
-	path := fmt.Sprintf("/api/experimental/chats/%s/stream", chatID)
+func (c *Client) StreamChat(ctx context.Context, chatID uuid.UUID, opts *StreamChatOptions) (<-chan ChatStreamEvent, io.Closer, error) {
+	path := fmt.Sprintf("/api/v2/chats/%s/stream", chatID)
 	if opts != nil && opts.AfterID != nil {
 		path += fmt.Sprintf("?after_id=%d", *opts.AfterID)
 	}
@@ -2811,10 +2811,10 @@ func (c *ExperimentalClient) StreamChat(ctx context.Context, chatID uuid.UUID, o
 // deletion, diff-status changes, and action-required notifications.
 // Callers must close the returned io.Closer to release the websocket
 // connection when done.
-func (c *ExperimentalClient) WatchChats(ctx context.Context) (<-chan ChatWatchEvent, io.Closer, error) {
+func (c *Client) WatchChats(ctx context.Context) (<-chan ChatWatchEvent, io.Closer, error) {
 	conn, err := c.Dial(
 		ctx,
-		"/api/experimental/chats/watch",
+		"/api/v2/chats/watch",
 		&websocket.DialOptions{CompressionMode: websocket.CompressionDisabled},
 	)
 	if err != nil {
@@ -2861,8 +2861,8 @@ func (c *ExperimentalClient) WatchChats(ctx context.Context) (<-chan ChatWatchEv
 
 // GetChatDebugLogging returns the runtime admin setting that allows
 // users to opt into chat debug logging.
-func (c *ExperimentalClient) GetChatDebugLogging(ctx context.Context) (ChatDebugLoggingAdminSettings, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/debug-logging", nil)
+func (c *Client) GetChatDebugLogging(ctx context.Context) (ChatDebugLoggingAdminSettings, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/debug-logging", nil)
 	if err != nil {
 		return ChatDebugLoggingAdminSettings{}, err
 	}
@@ -2876,8 +2876,8 @@ func (c *ExperimentalClient) GetChatDebugLogging(ctx context.Context) (ChatDebug
 
 // UpdateChatDebugLogging updates the runtime admin setting that allows
 // users to opt into chat debug logging.
-func (c *ExperimentalClient) UpdateChatDebugLogging(ctx context.Context, req UpdateChatDebugLoggingAllowUsersRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/debug-logging", req)
+func (c *Client) UpdateChatDebugLogging(ctx context.Context, req UpdateChatDebugLoggingAllowUsersRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/debug-logging", req)
 	if err != nil {
 		return err
 	}
@@ -2890,8 +2890,8 @@ func (c *ExperimentalClient) UpdateChatDebugLogging(ctx context.Context, req Upd
 
 // GetUserChatDebugLogging returns whether chat debug logging is active
 // for the current user and whether the user may change it.
-func (c *ExperimentalClient) GetUserChatDebugLogging(ctx context.Context) (UserChatDebugLoggingSettings, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/user-debug-logging", nil)
+func (c *Client) GetUserChatDebugLogging(ctx context.Context) (UserChatDebugLoggingSettings, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/chats/config/user-debug-logging", nil)
 	if err != nil {
 		return UserChatDebugLoggingSettings{}, err
 	}
@@ -2905,8 +2905,8 @@ func (c *ExperimentalClient) GetUserChatDebugLogging(ctx context.Context) (UserC
 
 // UpdateUserChatDebugLogging updates the current user's chat debug
 // logging preference.
-func (c *ExperimentalClient) UpdateUserChatDebugLogging(ctx context.Context, req UpdateUserChatDebugLoggingRequest) error {
-	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/user-debug-logging", req)
+func (c *Client) UpdateUserChatDebugLogging(ctx context.Context, req UpdateUserChatDebugLoggingRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/v2/chats/config/user-debug-logging", req)
 	if err != nil {
 		return err
 	}
@@ -2947,8 +2947,8 @@ func (c *ExperimentalClient) GetChatDebugRun(ctx context.Context, chatID uuid.UU
 }
 
 // GetChat returns a chat by ID.
-func (c *ExperimentalClient) GetChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s", chatID), nil)
+func (c *Client) GetChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s", chatID), nil)
 	if err != nil {
 		return Chat{}, err
 	}
@@ -2962,8 +2962,8 @@ func (c *ExperimentalClient) GetChat(ctx context.Context, chatID uuid.UUID) (Cha
 
 // RefreshChatContext re-pins the chat to its agent's latest context snapshot
 // and clears the dirty marker. The request takes no body.
-func (c *ExperimentalClient) RefreshChatContext(ctx context.Context, chatID uuid.UUID) (Chat, error) {
-	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/experimental/chats/%s/context", chatID), nil)
+func (c *Client) RefreshChatContext(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/v2/chats/%s/context", chatID), nil)
 	if err != nil {
 		return Chat{}, err
 	}
@@ -2975,8 +2975,8 @@ func (c *ExperimentalClient) RefreshChatContext(ctx context.Context, chatID uuid
 	return chat, ReadBodyAsJSON(res, &chat)
 }
 
-func (c *ExperimentalClient) GetChatACL(ctx context.Context, chatID uuid.UUID) (ChatACL, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/acl", chatID), nil)
+func (c *Client) GetChatACL(ctx context.Context, chatID uuid.UUID) (ChatACL, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s/acl", chatID), nil)
 	if err != nil {
 		return ChatACL{}, err
 	}
@@ -2988,8 +2988,8 @@ func (c *ExperimentalClient) GetChatACL(ctx context.Context, chatID uuid.UUID) (
 	return acl, ReadBodyAsJSON(res, &acl)
 }
 
-func (c *ExperimentalClient) UpdateChatACL(ctx context.Context, chatID uuid.UUID, req UpdateChatACL) error {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/%s/acl", chatID), req)
+func (c *Client) UpdateChatACL(ctx context.Context, chatID uuid.UUID, req UpdateChatACL) error {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/chats/%s/acl", chatID), req)
 	if err != nil {
 		return err
 	}
@@ -3016,7 +3016,7 @@ type ChatMessagesPaginationOptions struct {
 }
 
 // GetChatMessages returns the messages and queued messages for a chat.
-func (c *ExperimentalClient) GetChatMessages(ctx context.Context, chatID uuid.UUID, opts *ChatMessagesPaginationOptions) (ChatMessagesResponse, error) {
+func (c *Client) GetChatMessages(ctx context.Context, chatID uuid.UUID, opts *ChatMessagesPaginationOptions) (ChatMessagesResponse, error) {
 	reqOpts := []RequestOption{}
 	if opts != nil {
 		reqOpts = append(reqOpts, func(r *http.Request) {
@@ -3033,7 +3033,7 @@ func (c *ExperimentalClient) GetChatMessages(ctx context.Context, chatID uuid.UU
 			r.URL.RawQuery = q.Encode()
 		})
 	}
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/messages", chatID), nil, reqOpts...)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s/messages", chatID), nil, reqOpts...)
 	if err != nil {
 		return ChatMessagesResponse{}, err
 	}
@@ -3059,7 +3059,7 @@ type ChatPromptsOptions struct {
 // only their text parts (concatenated in the original order) are
 // returned. Whitespace-only prompts are filtered server-side so the
 // caller never has to skip blank entries while cycling.
-func (c *ExperimentalClient) GetChatPrompts(ctx context.Context, chatID uuid.UUID, opts *ChatPromptsOptions) (ChatPromptsResponse, error) {
+func (c *Client) GetChatPrompts(ctx context.Context, chatID uuid.UUID, opts *ChatPromptsOptions) (ChatPromptsResponse, error) {
 	reqOpts := []RequestOption{}
 	if opts != nil && opts.Limit > 0 {
 		reqOpts = append(reqOpts, func(r *http.Request) {
@@ -3068,7 +3068,7 @@ func (c *ExperimentalClient) GetChatPrompts(ctx context.Context, chatID uuid.UUI
 			r.URL.RawQuery = q.Encode()
 		})
 	}
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/prompts", chatID), nil, reqOpts...)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s/prompts", chatID), nil, reqOpts...)
 	if err != nil {
 		return ChatPromptsResponse{}, err
 	}
@@ -3081,8 +3081,8 @@ func (c *ExperimentalClient) GetChatPrompts(ctx context.Context, chatID uuid.UUI
 }
 
 // UpdateChat patches a chat resource.
-func (c *ExperimentalClient) UpdateChat(ctx context.Context, chatID uuid.UUID, req UpdateChatRequest) error {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/%s", chatID), req)
+func (c *Client) UpdateChat(ctx context.Context, chatID uuid.UUID, req UpdateChatRequest) error {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/chats/%s", chatID), req)
 	if err != nil {
 		return err
 	}
@@ -3094,8 +3094,8 @@ func (c *ExperimentalClient) UpdateChat(ctx context.Context, chatID uuid.UUID, r
 }
 
 // CreateChatMessage adds a message to a chat.
-func (c *ExperimentalClient) CreateChatMessage(ctx context.Context, chatID uuid.UUID, req CreateChatMessageRequest) (CreateChatMessageResponse, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/messages", chatID), req)
+func (c *Client) CreateChatMessage(ctx context.Context, chatID uuid.UUID, req CreateChatMessageRequest) (CreateChatMessageResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/%s/messages", chatID), req)
 	if err != nil {
 		return CreateChatMessageResponse{}, err
 	}
@@ -3108,7 +3108,7 @@ func (c *ExperimentalClient) CreateChatMessage(ctx context.Context, chatID uuid.
 }
 
 // EditChatMessage edits an existing user message in a chat and re-runs from there.
-func (c *ExperimentalClient) EditChatMessage(
+func (c *Client) EditChatMessage(
 	ctx context.Context,
 	chatID uuid.UUID,
 	messageID int64,
@@ -3117,7 +3117,7 @@ func (c *ExperimentalClient) EditChatMessage(
 	res, err := c.Request(
 		ctx,
 		http.MethodPatch,
-		fmt.Sprintf("/api/experimental/chats/%s/messages/%d", chatID, messageID),
+		fmt.Sprintf("/api/v2/chats/%s/messages/%d", chatID, messageID),
 		req,
 	)
 	if err != nil {
@@ -3132,8 +3132,8 @@ func (c *ExperimentalClient) EditChatMessage(
 }
 
 // InterruptChat cancels an in-flight chat run and leaves it waiting.
-func (c *ExperimentalClient) InterruptChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/interrupt", chatID), nil)
+func (c *Client) InterruptChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/%s/interrupt", chatID), nil)
 	if err != nil {
 		return Chat{}, err
 	}
@@ -3149,8 +3149,8 @@ func (c *ExperimentalClient) InterruptChat(ctx context.Context, chatID uuid.UUID
 // errored chat, clearing any stored error. The compaction runs
 // asynchronously through the chat worker and bypasses the automatic
 // usage threshold.
-func (c *ExperimentalClient) CompactChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/compact", chatID), nil)
+func (c *Client) CompactChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/%s/compact", chatID), nil)
 	if err != nil {
 		return Chat{}, err
 	}
@@ -3165,8 +3165,8 @@ func (c *ExperimentalClient) CompactChat(ctx context.Context, chatID uuid.UUID) 
 // ReconcileInvalidChatState recovers a chat stuck in an invalid
 // execution state, moving it into an error state from which the caller
 // can send a new message or edit history to continue.
-func (c *ExperimentalClient) ReconcileInvalidChatState(ctx context.Context, chatID uuid.UUID) (Chat, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/reconcile-invalid", chatID), nil)
+func (c *Client) ReconcileInvalidChatState(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/%s/reconcile-invalid", chatID), nil)
 	if err != nil {
 		return Chat{}, err
 	}
@@ -3184,8 +3184,8 @@ type ProposeChatTitleResponse struct {
 }
 
 // ProposeChatTitle requests the server to generate a suggested chat title without persisting it.
-func (c *ExperimentalClient) ProposeChatTitle(ctx context.Context, chatID uuid.UUID) (ProposeChatTitleResponse, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/title/propose", chatID), nil)
+func (c *Client) ProposeChatTitle(ctx context.Context, chatID uuid.UUID) (ProposeChatTitleResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/%s/title/propose", chatID), nil)
 	if err != nil {
 		return ProposeChatTitleResponse{}, err
 	}
@@ -3198,8 +3198,8 @@ func (c *ExperimentalClient) ProposeChatTitle(ctx context.Context, chatID uuid.U
 }
 
 // GetChatDiffContents returns resolved diff contents for a chat.
-func (c *ExperimentalClient) GetChatDiffContents(ctx context.Context, chatID uuid.UUID) (ChatDiffContents, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/diff", chatID), nil)
+func (c *Client) GetChatDiffContents(ctx context.Context, chatID uuid.UUID) (ChatDiffContents, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s/diff", chatID), nil)
 	if err != nil {
 		return ChatDiffContents{}, err
 	}
@@ -3212,8 +3212,8 @@ func (c *ExperimentalClient) GetChatDiffContents(ctx context.Context, chatID uui
 }
 
 // UploadChatFile uploads a file for use in chat messages.
-func (c *ExperimentalClient) UploadChatFile(ctx context.Context, organizationID uuid.UUID, contentType string, filename string, rd io.Reader) (UploadChatFileResponse, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/files?organization=%s", organizationID), rd, func(r *http.Request) {
+func (c *Client) UploadChatFile(ctx context.Context, organizationID uuid.UUID, contentType string, filename string, rd io.Reader) (UploadChatFileResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/files?organization=%s", organizationID), rd, func(r *http.Request) {
 		r.Header.Set("Content-Type", contentType)
 		if filename != "" {
 			r.Header.Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": filename}))
@@ -3231,8 +3231,8 @@ func (c *ExperimentalClient) UploadChatFile(ctx context.Context, organizationID 
 }
 
 // ChatFileDownloadURL creates a short-lived download URL for a chat file.
-func (c *ExperimentalClient) ChatFileDownloadURL(ctx context.Context, fileID uuid.UUID) (ChatFileDownloadURLResponse, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/files/%s/download-url", fileID), nil)
+func (c *Client) ChatFileDownloadURL(ctx context.Context, fileID uuid.UUID) (ChatFileDownloadURLResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/files/%s/download-url", fileID), nil)
 	if err != nil {
 		return ChatFileDownloadURLResponse{}, err
 	}
@@ -3245,8 +3245,8 @@ func (c *ExperimentalClient) ChatFileDownloadURL(ctx context.Context, fileID uui
 }
 
 // GetChatFile retrieves a previously uploaded chat file by ID.
-func (c *ExperimentalClient) GetChatFile(ctx context.Context, fileID uuid.UUID) ([]byte, string, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/files/%s", fileID), nil)
+func (c *Client) GetChatFile(ctx context.Context, fileID uuid.UUID) ([]byte, string, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/files/%s", fileID), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -3263,8 +3263,8 @@ func (c *ExperimentalClient) GetChatFile(ctx context.Context, fileID uuid.UUID) 
 
 // SubmitToolResults submits the results of dynamic tool calls for a chat
 // that is in requires_action status.
-func (c *ExperimentalClient) SubmitToolResults(ctx context.Context, chatID uuid.UUID, req SubmitToolResultsRequest) error {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/tool-results", chatID), req)
+func (c *Client) SubmitToolResults(ctx context.Context, chatID uuid.UUID, req SubmitToolResultsRequest) error {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/chats/%s/tool-results", chatID), req)
 	if err != nil {
 		return err
 	}
@@ -3278,12 +3278,12 @@ func (c *ExperimentalClient) SubmitToolResults(ctx context.Context, chatID uuid.
 // GetChatsByWorkspace returns a mapping of workspace ID to the latest
 // non-archived chat ID for each requested workspace. Workspaces with
 // no chats are omitted from the response.
-func (c *ExperimentalClient) GetChatsByWorkspace(ctx context.Context, workspaceIDs []uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
+func (c *Client) GetChatsByWorkspace(ctx context.Context, workspaceIDs []uuid.UUID) (map[uuid.UUID]uuid.UUID, error) {
 	ids := make([]string, 0, len(workspaceIDs))
 	for _, id := range workspaceIDs {
 		ids = append(ids, id.String())
 	}
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/by-workspace?workspace_ids=%s", strings.Join(ids, ",")), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/by-workspace?workspace_ids=%s", strings.Join(ids, ",")), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -2275,7 +2275,7 @@ func (c *Client) DeleteChatModel(ctx context.Context, organizationID, modelID uu
 // ChatModelProviderDescriptor is the redacted view of an AI provider carried
 // on the org model collection response. It carries only the capability
 // metadata the Models UI needs; key material, base URLs, and headers are
-// never exposed. The fields mirror what /api/v2/chats/models
+// never exposed. The fields mirror what /api/experimental/chats/models
 // already discloses to any authenticated caller.
 type ChatModelProviderDescriptor struct {
 	ID                 uuid.UUID                          `json:"id" format:"uuid"`

--- a/codersdk/chats_model_acl_test.go
+++ b/codersdk/chats_model_acl_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func TestExperimentalClientChatModelACL(t *testing.T) {
+func TestClientChatModelACL(t *testing.T) {
 	t.Parallel()
 
 	organizationID := uuid.New()
@@ -25,14 +25,14 @@ func TestExperimentalClientChatModelACL(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "/api/experimental/organizations/"+organizationID.String()+"/chats/models/"+modelID.String()+"/acl", r.URL.Path)
+		require.Equal(t, "/api/v2/organizations/"+organizationID.String()+"/chats/models/"+modelID.String()+"/acl", r.URL.Path)
 		http.Error(rw, `{"user_roles":{"`+userID.String()+`":"read"},"group_roles":{"`+groupID.String()+`":"read"}}`, http.StatusOK)
 	}))
 	defer server.Close()
 
 	serverURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
-	client := codersdk.NewExperimentalClient(codersdk.New(serverURL))
+	client := codersdk.New(serverURL)
 
 	modelACL, err := client.ChatModelACL(context.Background(), organizationID, modelID)
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestExperimentalClientChatModelACL(t *testing.T) {
 	require.Equal(t, map[string]codersdk.ChatRole{groupID.String(): codersdk.ChatRoleRead}, modelACL.GroupRoles)
 }
 
-func TestExperimentalClientUpdateChatModelACL(t *testing.T) {
+func TestClientUpdateChatModelACL(t *testing.T) {
 	t.Parallel()
 
 	organizationID := uuid.New()
@@ -50,7 +50,7 @@ func TestExperimentalClientUpdateChatModelACL(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPatch, r.Method)
-		require.Equal(t, "/api/experimental/organizations/"+organizationID.String()+"/chats/models/"+modelID.String()+"/acl", r.URL.Path)
+		require.Equal(t, "/api/v2/organizations/"+organizationID.String()+"/chats/models/"+modelID.String()+"/acl", r.URL.Path)
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		var payload map[string]json.RawMessage
@@ -63,7 +63,7 @@ func TestExperimentalClientUpdateChatModelACL(t *testing.T) {
 
 	serverURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
-	client := codersdk.NewExperimentalClient(codersdk.New(serverURL))
+	client := codersdk.New(serverURL)
 
 	err = client.UpdateChatModelACL(context.Background(), organizationID, modelID, codersdk.UpdateChatModelACLRequest{
 		UserRoles:  map[string]codersdk.ChatRole{userID.String(): codersdk.ChatRoleRead},

--- a/codersdk/mcp.go
+++ b/codersdk/mcp.go
@@ -13,7 +13,7 @@ import (
 // start the OAuth2 flow for an MCP server. The frontend opens this
 // in a new window/popup.
 func (c *Client) MCPServerOAuth2ConnectURL(organizationID, id uuid.UUID) string {
-	return fmt.Sprintf("%s/api/experimental/organizations/%s/mcp-servers/%s/oauth2/connect", c.URL.String(), organizationID, id)
+	return fmt.Sprintf("%s/api/v2/organizations/%s/mcp-servers/%s/oauth2/connect", c.URL.String(), organizationID, id)
 }
 
 // MCPServerOAuth2DisconnectResponse reports whether the removed token
@@ -34,7 +34,7 @@ func (c *Client) MCPServerOAuth2Disconnect(ctx context.Context, id uuid.UUID) er
 // MCPServerOAuth2DisconnectWithResponse removes the user's OAuth2
 // token for an MCP server and reports the provider revocation outcome.
 func (c *Client) MCPServerOAuth2DisconnectWithResponse(ctx context.Context, id uuid.UUID) (MCPServerOAuth2DisconnectResponse, error) {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/disconnect", id), nil)
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/mcp/servers/%s/oauth2/disconnect", id), nil)
 	if err != nil {
 		return MCPServerOAuth2DisconnectResponse{}, err
 	}
@@ -213,7 +213,7 @@ type UpdateMCPServerConfigRequest struct {
 }
 
 func (c *Client) MCPServerConfigs(ctx context.Context, organizationID uuid.UUID) ([]MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers", organizationID), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers", organizationID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (c *Client) MCPServerConfigs(ctx context.Context, organizationID uuid.UUID)
 }
 
 func (c *Client) MCPServerConfigByID(ctx context.Context, organizationID, id uuid.UUID) (MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers/%s", organizationID, id), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers/%s", organizationID, id), nil)
 	if err != nil {
 		return MCPServerConfig{}, err
 	}
@@ -240,7 +240,7 @@ func (c *Client) MCPServerConfigByID(ctx context.Context, organizationID, id uui
 
 // MCPServerConfigACL returns the resolved ACL of an MCP server config.
 func (c *Client) MCPServerConfigACL(ctx context.Context, organizationID, id uuid.UUID) (MCPServerConfigACL, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers/%s/acl", organizationID, id), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers/%s/acl", organizationID, id), nil)
 	if err != nil {
 		return MCPServerConfigACL{}, err
 	}
@@ -255,7 +255,7 @@ func (c *Client) MCPServerConfigACL(ctx context.Context, organizationID, id uuid
 // UpdateMCPServerConfigACL applies a sparse ACL update to an MCP server
 // config.
 func (c *Client) UpdateMCPServerConfigACL(ctx context.Context, organizationID, id uuid.UUID, req UpdateMCPServerConfigACLRequest) error {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers/%s/acl", organizationID, id), req)
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers/%s/acl", organizationID, id), req)
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func (c *Client) UpdateMCPServerConfigACL(ctx context.Context, organizationID, i
 }
 
 func (c *Client) CreateMCPServerConfig(ctx context.Context, organizationID uuid.UUID, req CreateMCPServerConfigRequest) (MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers", organizationID), req)
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers", organizationID), req)
 	if err != nil {
 		return MCPServerConfig{}, err
 	}
@@ -280,7 +280,7 @@ func (c *Client) CreateMCPServerConfig(ctx context.Context, organizationID uuid.
 }
 
 func (c *Client) UpdateMCPServerConfig(ctx context.Context, organizationID, id uuid.UUID, req UpdateMCPServerConfigRequest) (MCPServerConfig, error) {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers/%s", organizationID, id), req)
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers/%s", organizationID, id), req)
 	if err != nil {
 		return MCPServerConfig{}, err
 	}
@@ -293,7 +293,7 @@ func (c *Client) UpdateMCPServerConfig(ctx context.Context, organizationID, id u
 }
 
 func (c *Client) DeleteMCPServerConfig(ctx context.Context, organizationID, id uuid.UUID) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/organizations/%s/mcp-servers/%s", organizationID, id), nil)
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/organizations/%s/mcp-servers/%s", organizationID, id), nil)
 	if err != nil {
 		return err
 	}

--- a/codersdk/toolsdk/chats_test.go
+++ b/codersdk/toolsdk/chats_test.go
@@ -506,7 +506,7 @@ func TestChatTools(t *testing.T) {
 		getSeen := make(chan struct{})
 		getRelease := make(chan struct{})
 		transport := &signalPathTransport{
-			path:    "/api/experimental/chats/" + running.ID.String(),
+			path:    "/api/v2/chats/" + running.ID.String(),
 			seen:    getSeen,
 			release: getRelease,
 		}
@@ -592,7 +592,7 @@ func TestChatTools(t *testing.T) {
 		sharedAwaitClient := codersdk.New(sharedClient.URL)
 		sharedAwaitClient.SetSessionToken(sharedClient.SessionToken())
 		sharedAwaitClient.HTTPClient = &http.Client{Transport: &signalPathTransport{
-			path:    "/api/experimental/chats/" + sharedRunning.ID.String(),
+			path:    "/api/v2/chats/" + sharedRunning.ID.String(),
 			seen:    sharedGetSeen,
 			release: sharedGetRelease,
 		}}

--- a/enterprise/coderd/x/chatd/chatd.go
+++ b/enterprise/coderd/x/chatd/chatd.go
@@ -123,7 +123,7 @@ func buildRelayURL(address string, chatID uuid.UUID) (string, error) {
 	default:
 		return "", xerrors.Errorf("unsupported relay address scheme %q", u.Scheme)
 	}
-	u.Path = "/api/experimental/chats/" + chatID.String() + "/stream/parts"
+	u.Path = "/api/v2/chats/" + chatID.String() + "/stream/parts"
 	u.RawQuery = ""
 	return u.String(), nil
 }

--- a/enterprise/coderd/x/chatd/chatd.go
+++ b/enterprise/coderd/x/chatd/chatd.go
@@ -123,11 +123,7 @@ func buildRelayURL(address string, chatID uuid.UUID) (string, error) {
 	default:
 		return "", xerrors.Errorf("unsupported relay address scheme %q", u.Scheme)
 	}
-	// Peer replicas may still run a pre-promotion release during a
-	// rolling upgrade, so the internal relay dial stays on the
-	// experimental path for the compatibility window.
-	// TODO(CODAGT-922): switch to /api/v2 with the experimental removal.
-	u.Path = "/api/experimental/chats/" + chatID.String() + "/stream/parts"
+	u.Path = "/api/v2/chats/" + chatID.String() + "/stream/parts"
 	u.RawQuery = ""
 	return u.String(), nil
 }

--- a/enterprise/coderd/x/chatd/chatd.go
+++ b/enterprise/coderd/x/chatd/chatd.go
@@ -123,7 +123,11 @@ func buildRelayURL(address string, chatID uuid.UUID) (string, error) {
 	default:
 		return "", xerrors.Errorf("unsupported relay address scheme %q", u.Scheme)
 	}
-	u.Path = "/api/v2/chats/" + chatID.String() + "/stream/parts"
+	// Peer replicas may still run a pre-promotion release during a
+	// rolling upgrade, so the internal relay dial stays on the
+	// experimental path for the compatibility window.
+	// TODO(CODAGT-922): switch to /api/v2 with the experimental removal.
+	u.Path = "/api/experimental/chats/" + chatID.String() + "/stream/parts"
 	u.RawQuery = ""
 	return u.String(), nil
 }

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -90,7 +90,7 @@ func TestStreamPartsDialerDialsPartsEndpoint(t *testing.T) {
 	received := make(chan http.Header, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v2/chats/"+chatID.String()+"/stream/parts", r.URL.Path)
+		require.Equal(t, "/api/experimental/chats/"+chatID.String()+"/stream/parts", r.URL.Path)
 		require.Empty(t, r.URL.RawQuery)
 		received <- r.Header.Clone()
 		conn, err := websocket.Accept(rw, r, nil)

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -90,7 +90,7 @@ func TestStreamPartsDialerDialsPartsEndpoint(t *testing.T) {
 	received := make(chan http.Header, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/experimental/chats/"+chatID.String()+"/stream/parts", r.URL.Path)
+		require.Equal(t, "/api/v2/chats/"+chatID.String()+"/stream/parts", r.URL.Path)
 		require.Empty(t, r.URL.RawQuery)
 		received <- r.Header.Clone()
 		conn, err := websocket.Accept(rw, r, nil)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3050,7 +3050,7 @@ export interface ChatModelOverridesResponse {
  * ChatModelProviderDescriptor is the redacted view of an AI provider carried
  * on the org model collection response. It carries only the capability
  * metadata the Models UI needs; key material, base URLs, and headers are
- * never exposed. The fields mirror what /api/v2/chats/models
+ * never exposed. The fields mirror what /api/experimental/chats/models
  * already discloses to any authenticated caller.
  */
 export interface ChatModelProviderDescriptor {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2575,7 +2575,7 @@ export interface ChatGitChange {
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2591,7 +2591,7 @@ export const ChatGitWatchAgentStatePrefix = "Agent state is ";
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2604,7 +2604,7 @@ export const ChatGitWatchNoEligibleAgentMessage =
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2616,7 +2616,7 @@ export const ChatGitWatchNoWorkspaceMessage = "Chat has no workspace to watch.";
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -3050,7 +3050,7 @@ export interface ChatModelOverridesResponse {
  * ChatModelProviderDescriptor is the redacted view of an AI provider carried
  * on the org model collection response. It carries only the capability
  * metadata the Models UI needs; key material, base URLs, and headers are
- * never exposed. The fields mirror what /api/experimental/chats/models
+ * never exposed. The fields mirror what /api/v2/chats/models
  * already discloses to any authenticated caller.
  */
 export interface ChatModelProviderDescriptor {
@@ -3247,7 +3247,7 @@ export const ChatPlanModes: ChatPlanMode[] = ["plan"];
 // From codersdk/chats.go
 /**
  * ChatPrompt is a single user-authored prompt in a chat, returned by
- * GET /api/experimental/chats/{chat}/prompts. The text field contains
+ * GET /api/v2/chats/{chat}/prompts. The text field contains
  * the concatenated text payload of the underlying chat message; non-text
  * parts (tool calls, files, attachments) are omitted by the server.
  */
@@ -3272,7 +3272,7 @@ export interface ChatPromptsOptions {
 // From codersdk/chats.go
 /**
  * ChatPromptsResponse is the payload of
- * GET /api/experimental/chats/{chat}/prompts. Prompts are returned
+ * GET /api/v2/chats/{chat}/prompts. Prompts are returned
  * newest first so the client can index directly into the slice for
  * up/down arrow history cycling.
  */


### PR DESCRIPTION
## Stack context

This is the second PR in the 3-PR chat API promotion stack: server compatibility mounts (#28496), codersdk promotion (this PR), and frontend path updates (#28498).

## Summary

Move the promoted chat and MCP SDK methods from `ExperimentalClient` to `Client` and update them to use `/api/v2`. Methods for routes that remain experimental stay on `ExperimentalClient`.

Update in-repository callers and generated types. The multi-replica chat stream relay dials `/api/v2` directly: mixed-version replica sets are not a supported upgrade path, so no experimental-path fallback is kept (per review). Remote dogfood UAT passed for the composed stack.

> [!NOTE]
> Xum acted on Mike's behalf in this pull request.
<!-- xum-attribution: model=claude-fable-5 thinking=high -->
