### PR TITLE
feat(site): use /api/v2 chat API paths

### DIFF
--- a/site/e2e/tests/agents/chatSearch.spec.ts
+++ b/site/e2e/tests/agents/chatSearch.spec.ts
@@ -17,7 +17,7 @@ test("searches chats with backend full-text search", async ({ page }) => {
 	const searchResponse = page.waitForResponse((response) => {
 		const url = new URL(response.url());
 		return (
-			url.pathname === "/api/experimental/chats" &&
+			url.pathname === "/api/v2/chats" &&
 			url.searchParams.get("q") === 'search:"full-text-smoke"'
 		);
 	});

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -437,7 +437,7 @@ describe("api.ts", () => {
 
 		it.each<[string, () => Promise<unknown>, unknown]>([
 			[
-				"/api/experimental/organizations/organization%2Fid/chats/models",
+				"/api/v2/organizations/organization%2Fid/chats/models",
 				() => API.experimental.getChatModels(organizationId),
 				{ models: [], providers: [], unsupported_providers: [] },
 			],
@@ -466,7 +466,7 @@ describe("api.ts", () => {
 
 		it.each<[string, () => Promise<unknown>]>([
 			[
-				"/api/experimental/organizations/organization%2Fid/chats/models",
+				"/api/v2/organizations/organization%2Fid/chats/models",
 				() => API.experimental.getChatModels(organizationId),
 			],
 		])("rethrows axios errors for %s", async (path, request) => {
@@ -501,7 +501,7 @@ describe("api.ts", () => {
 			).resolves.toBeUndefined();
 
 			const itemPath =
-				"/api/experimental/organizations/organization%2Fid/chats/models/model%2Fid";
+				"/api/v2/organizations/organization%2Fid/chats/models/model%2Fid";
 			expect(axiosInstance.get).toHaveBeenCalledWith(itemPath);
 			expect(axiosInstance.patch).toHaveBeenCalledWith(itemPath, {
 				enabled: true,
@@ -523,7 +523,7 @@ describe("api.ts", () => {
 			).resolves.toBeUndefined();
 
 			const aclPath =
-				"/api/experimental/organizations/organization%2Fid/chats/models/model%2Fid/acl";
+				"/api/v2/organizations/organization%2Fid/chats/models/model%2Fid/acl";
 			expect(axiosInstance.get).toHaveBeenCalledWith(aclPath);
 			expect(axiosInstance.patch).toHaveBeenCalledWith(aclPath, acl);
 		});
@@ -645,7 +645,7 @@ describe("api.ts", () => {
 			const result = await API.experimental.getChatACL(chatId);
 
 			expect(axiosInstance.get).toHaveBeenCalledWith(
-				`/api/experimental/chats/${chatId}/acl`,
+				`/api/v2/chats/${chatId}/acl`,
 			);
 			expect(result).toStrictEqual(chatACL);
 		});
@@ -660,7 +660,7 @@ describe("api.ts", () => {
 			await API.experimental.updateChatACL(chatId, request);
 
 			expect(axiosInstance.patch).toHaveBeenCalledWith(
-				`/api/experimental/chats/${chatId}/acl`,
+				`/api/v2/chats/${chatId}/acl`,
 				request,
 			);
 		});

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -81,7 +81,7 @@ export const watchChat = (
 		params.set(SessionTokenCookie, token);
 	}
 	const query = params.toString();
-	const route = `/api/experimental/chats/${chatId}/stream${query ? `?${query}` : ""}`;
+	const route = `/api/v2/chats/${chatId}/stream${query ? `?${query}` : ""}`;
 	return new OneWayWebSocket({
 		apiRoute: route,
 	});
@@ -94,13 +94,13 @@ export const watchChats = (): OneWayWebSocket<TypesGen.ChatWatchEvent> => {
 		searchParams[SessionTokenCookie] = token;
 	}
 	return new OneWayWebSocket({
-		apiRoute: "/api/experimental/chats/watch",
+		apiRoute: "/api/v2/chats/watch",
 		searchParams,
 	});
 };
 
 export const watchChatGit = (chatId: string): WebSocket => {
-	return createWebSocket(`/api/experimental/chats/${chatId}/stream/git`);
+	return createWebSocket(`/api/v2/chats/${chatId}/stream/git`);
 };
 
 export const watchChatDesktop = (chatId: string): WebSocket => {
@@ -353,7 +353,7 @@ const aiSpendBatchSize = 100;
 const aiProviderConfigsPath = "/api/v2/ai/providers";
 const aiGatewayPath = "/api/v2/ai-gateway";
 const chatModelsPath = (organizationId: string) =>
-	`/api/experimental/organizations/${encodeURIComponent(organizationId)}/chats/models`;
+	`/api/v2/organizations/${encodeURIComponent(organizationId)}/chats/models`;
 const chatModelPath = (organizationId: string, modelId: string) =>
 	`${chatModelsPath(organizationId)}/${encodeURIComponent(modelId)}`;
 const chatModelACLPath = (organizationId: string, modelId: string) =>
@@ -363,15 +363,15 @@ const userSkillsPath = (user: string) =>
 const userSkillPath = (user: string, name: string) =>
 	`${userSkillsPath(user)}/${encodeURIComponent(name)}`;
 const userAIProviderKeysPath = (user = "me") =>
-	`/api/experimental/users/${encodeURIComponent(user)}/ai-provider-keys`;
+	`/api/v2/users/${encodeURIComponent(user)}/ai-provider-keys`;
 const mcpServerConfigsPath = (organization: string) =>
-	`/api/experimental/organizations/${encodeURIComponent(organization)}/mcp-servers`;
+	`/api/v2/organizations/${encodeURIComponent(organization)}/mcp-servers`;
 const mcpServerConfigPath = (organization: string, id: string) =>
 	`${mcpServerConfigsPath(organization)}/${encodeURIComponent(id)}`;
 export const mcpServerOAuth2ConnectPath = (organization: string, id: string) =>
 	`${mcpServerConfigPath(organization, id)}/oauth2/connect`;
 const mcpServerOAuth2DisconnectPath = (id: string) =>
-	`/api/experimental/mcp/servers/${encodeURIComponent(id)}/oauth2/disconnect`;
+	`/api/v2/mcp/servers/${encodeURIComponent(id)}/oauth2/disconnect`;
 
 type Claims = {
 	license_expires: number;
@@ -3272,8 +3272,8 @@ type UpdateChatRequestWithClearablePlanMode = Omit<
 	readonly plan_mode?: ChatPlanModeOrClear;
 };
 
-// Experimental API methods call endpoints under the /api/experimental/ prefix.
-// These endpoints are not stable and may change or be removed at any time.
+// These API methods span stable and experimental endpoints. Routes that remain
+// experimental are not stable and may change or be removed at any time.
 //
 // All methods must be defined with arrow function syntax. See the docstring
 // above the ApiMethods class for a full explanation.
@@ -3283,7 +3283,7 @@ class ExperimentalApiMethods {
 	getChatsByWorkspace = async (
 		workspaceIds: readonly string[],
 	): Promise<Record<string, string>> => {
-		const res = await this.axios.get("/api/experimental/chats/by-workspace", {
+		const res = await this.axios.get("/api/v2/chats/by-workspace", {
 			params: { workspace_ids: workspaceIds.join(",") },
 		});
 		return res.data;
@@ -3294,7 +3294,7 @@ class ExperimentalApiMethods {
 		organizationId: string,
 	): Promise<TypesGen.UploadChatFileResponse> => {
 		const response = await this.axios.post(
-			`/api/experimental/chats/files?organization=${organizationId}`,
+			`/api/v2/chats/files?organization=${organizationId}`,
 			file,
 			{
 				headers: {
@@ -3311,17 +3311,16 @@ class ExperimentalApiMethods {
 	};
 
 	getChatFileText = async (fileId: string): Promise<string> => {
-		const response = await this.axios.get(
-			`/api/experimental/chats/files/${fileId}`,
-			{ responseType: "text" },
-		);
+		const response = await this.axios.get(`/api/v2/chats/files/${fileId}`, {
+			responseType: "text",
+		});
 		return response.data as string;
 	};
 
 	// Chat API methods
 	getChatACL = async (chatId: string): Promise<TypesGen.ChatACL> => {
 		const response = await this.axios.get<TypesGen.ChatACL>(
-			`/api/experimental/chats/${chatId}/acl`,
+			`/api/v2/chats/${chatId}/acl`,
 		);
 		return response.data;
 	};
@@ -3330,7 +3329,7 @@ class ExperimentalApiMethods {
 		chatId: string,
 		req: TypesGen.UpdateChatACL,
 	): Promise<void> => {
-		await this.axios.patch(`/api/experimental/chats/${chatId}/acl`, req);
+		await this.axios.patch(`/api/v2/chats/${chatId}/acl`, req);
 	};
 
 	getChats = async (req?: {
@@ -3340,19 +3339,19 @@ class ExperimentalApiMethods {
 		q?: string;
 	}): Promise<TypesGen.Chat[]> => {
 		const response = await this.axios.get<TypesGen.Chat[]>(
-			getURLWithSearchParams("/api/experimental/chats", req),
+			getURLWithSearchParams("/api/v2/chats", req),
 		);
 		return response.data;
 	};
 	getChat = async (chatId: string): Promise<TypesGen.Chat> => {
 		const response = await this.axios.get<TypesGen.Chat>(
-			`/api/experimental/chats/${chatId}`,
+			`/api/v2/chats/${chatId}`,
 		);
 		return response.data;
 	};
 	getChatCost = async (chatId: string): Promise<TypesGen.ChatCost> => {
 		const response = await this.axios.get<TypesGen.ChatCost>(
-			`/api/experimental/chats/${chatId}/cost`,
+			`/api/v2/chats/${chatId}/cost`,
 		);
 		return response.data;
 	};
@@ -3371,7 +3370,7 @@ class ExperimentalApiMethods {
 			params.set("limit", opts.limit.toString());
 		}
 		const query = params.toString();
-		const url = `/api/experimental/chats/${chatId}/messages${query ? `?${query}` : ""}`;
+		const url = `/api/v2/chats/${chatId}/messages${query ? `?${query}` : ""}`;
 		const response = await this.axios.get<TypesGen.ChatMessagesResponse>(url);
 		return response.data;
 	};
@@ -3384,10 +3383,7 @@ class ExperimentalApiMethods {
 		chatId: string,
 		opts?: { limit?: number },
 	): Promise<TypesGen.ChatPromptsResponse> => {
-		const url = getURLWithSearchParams(
-			`/api/experimental/chats/${chatId}/prompts`,
-			opts,
-		);
+		const url = getURLWithSearchParams(`/api/v2/chats/${chatId}/prompts`, opts);
 		const response = await this.axios.get<TypesGen.ChatPromptsResponse>(url);
 		return response.data;
 	};
@@ -3395,10 +3391,7 @@ class ExperimentalApiMethods {
 	createChat = async (
 		req: TypesGen.CreateChatRequest,
 	): Promise<TypesGen.Chat> => {
-		const response = await this.axios.post<TypesGen.Chat>(
-			"/api/experimental/chats",
-			req,
-		);
+		const response = await this.axios.post<TypesGen.Chat>("/api/v2/chats", req);
 		return response.data;
 	};
 
@@ -3406,12 +3399,12 @@ class ExperimentalApiMethods {
 		chatId: string,
 		req: UpdateChatRequestWithClearablePlanMode,
 	): Promise<void> => {
-		await this.axios.patch(`/api/experimental/chats/${chatId}`, req);
+		await this.axios.patch(`/api/v2/chats/${chatId}`, req);
 	};
 
 	proposeChatTitle = async (chatId: string): Promise<{ title: string }> => {
 		const response = await this.axios.post<{ title: string }>(
-			`/api/experimental/chats/${chatId}/title/propose`,
+			`/api/v2/chats/${chatId}/title/propose`,
 		);
 		return response.data;
 	};
@@ -3421,7 +3414,7 @@ class ExperimentalApiMethods {
 		req: CreateChatMessageRequestWithClearablePlanMode,
 	): Promise<TypesGen.CreateChatMessageResponse> => {
 		const response = await this.axios.post<TypesGen.CreateChatMessageResponse>(
-			`/api/experimental/chats/${chatId}/messages`,
+			`/api/v2/chats/${chatId}/messages`,
 			req,
 		);
 		return response.data;
@@ -3433,14 +3426,14 @@ class ExperimentalApiMethods {
 		req: TypesGen.EditChatMessageRequest,
 	): Promise<TypesGen.EditChatMessageResponse> => {
 		const response = await this.axios.patch<TypesGen.EditChatMessageResponse>(
-			`/api/experimental/chats/${chatId}/messages/${messageId}`,
+			`/api/v2/chats/${chatId}/messages/${messageId}`,
 			req,
 		);
 		return response.data;
 	};
 	interruptChat = async (chatId: string): Promise<TypesGen.Chat> => {
 		const response = await this.axios.post<TypesGen.Chat>(
-			`/api/experimental/chats/${chatId}/interrupt`,
+			`/api/v2/chats/${chatId}/interrupt`,
 		);
 		return response.data;
 	};
@@ -3452,7 +3445,7 @@ class ExperimentalApiMethods {
 	 */
 	compactChat = async (chatId: string): Promise<TypesGen.Chat> => {
 		const response = await this.axios.post<TypesGen.Chat>(
-			`/api/experimental/chats/${chatId}/compact`,
+			`/api/v2/chats/${chatId}/compact`,
 		);
 		return response.data;
 	};
@@ -3463,7 +3456,7 @@ class ExperimentalApiMethods {
 	 */
 	refreshChatContext = async (chatId: string): Promise<TypesGen.Chat> => {
 		const response = await this.axios.put<TypesGen.Chat>(
-			`/api/experimental/chats/${chatId}/context`,
+			`/api/v2/chats/${chatId}/context`,
 		);
 		return response.data;
 	};
@@ -3472,9 +3465,7 @@ class ExperimentalApiMethods {
 		chatId: string,
 		queuedMessageId: number,
 	): Promise<void> => {
-		await this.axios.delete(
-			`/api/experimental/chats/${chatId}/queue/${queuedMessageId}`,
-		);
+		await this.axios.delete(`/api/v2/chats/${chatId}/queue/${queuedMessageId}`);
 	};
 
 	promoteChatQueuedMessage = async (
@@ -3482,7 +3473,7 @@ class ExperimentalApiMethods {
 		queuedMessageId: number,
 	): Promise<void> => {
 		await this.axios.post(
-			`/api/experimental/chats/${chatId}/queue/${queuedMessageId}/promote`,
+			`/api/v2/chats/${chatId}/queue/${queuedMessageId}/promote`,
 		);
 	};
 
@@ -3490,7 +3481,7 @@ class ExperimentalApiMethods {
 		chatId: string,
 	): Promise<TypesGen.ChatDiffContents> => {
 		const response = await this.axios.get<TypesGen.ChatDiffContents>(
-			`/api/experimental/chats/${chatId}/diff`,
+			`/api/v2/chats/${chatId}/diff`,
 		);
 		return response.data;
 	};
@@ -3569,7 +3560,7 @@ class ExperimentalApiMethods {
 	getChatSystemPrompt =
 		async (): Promise<TypesGen.ChatSystemPromptResponse> => {
 			const response = await this.axios.get<TypesGen.ChatSystemPromptResponse>(
-				"/api/experimental/chats/config/system-prompt",
+				"/api/v2/chats/config/system-prompt",
 			);
 			return response.data;
 		};
@@ -3577,14 +3568,14 @@ class ExperimentalApiMethods {
 	updateChatSystemPrompt = async (
 		req: TypesGen.UpdateChatSystemPromptRequest,
 	): Promise<void> => {
-		await this.axios.put("/api/experimental/chats/config/system-prompt", req);
+		await this.axios.put("/api/v2/chats/config/system-prompt", req);
 	};
 
 	getChatPlanModeInstructions =
 		async (): Promise<TypesGen.ChatPlanModeInstructionsResponse> => {
 			const response =
 				await this.axios.get<TypesGen.ChatPlanModeInstructionsResponse>(
-					"/api/experimental/chats/config/plan-mode-instructions",
+					"/api/v2/chats/config/plan-mode-instructions",
 				);
 			return response.data;
 		};
@@ -3592,17 +3583,14 @@ class ExperimentalApiMethods {
 	updateChatPlanModeInstructions = async (
 		req: TypesGen.UpdateChatPlanModeInstructionsRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			"/api/experimental/chats/config/plan-mode-instructions",
-			req,
-		);
+		await this.axios.put("/api/v2/chats/config/plan-mode-instructions", req);
 	};
 
 	getOrganizationChatModelOverrides = async (
 		organizationId: string,
 	): Promise<TypesGen.ChatModelOverridesResponse> => {
 		const response = await this.axios.get<TypesGen.ChatModelOverridesResponse>(
-			`/api/experimental/organizations/${encodeURIComponent(organizationId)}/chats/model-overrides`,
+			`/api/v2/organizations/${encodeURIComponent(organizationId)}/chats/model-overrides`,
 		);
 		return response.data;
 	};
@@ -3613,7 +3601,7 @@ class ExperimentalApiMethods {
 		req: TypesGen.UpdateChatModelOverrideRequest,
 	): Promise<TypesGen.ChatModelOverrideResponse> => {
 		const response = await this.axios.put<TypesGen.ChatModelOverrideResponse>(
-			`/api/experimental/organizations/${encodeURIComponent(organizationId)}/chats/model-overrides/${encodeURIComponent(context)}`,
+			`/api/v2/organizations/${encodeURIComponent(organizationId)}/chats/model-overrides/${encodeURIComponent(context)}`,
 			req,
 		);
 		return response.data;
@@ -3623,7 +3611,7 @@ class ExperimentalApiMethods {
 		async (): Promise<TypesGen.ChatPersonalModelOverridesAdminSettings> => {
 			const response =
 				await this.axios.get<TypesGen.ChatPersonalModelOverridesAdminSettings>(
-					"/api/experimental/chats/config/personal-model-overrides",
+					"/api/v2/chats/config/personal-model-overrides",
 				);
 			return response.data;
 		};
@@ -3631,17 +3619,14 @@ class ExperimentalApiMethods {
 	updateChatPersonalModelOverridesAdminSettings = async (
 		req: TypesGen.UpdateChatPersonalModelOverridesAdminSettingsRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			"/api/experimental/chats/config/personal-model-overrides",
-			req,
-		);
+		await this.axios.put("/api/v2/chats/config/personal-model-overrides", req);
 	};
 
 	getChatDebugLogging =
 		async (): Promise<TypesGen.ChatDebugLoggingAdminSettings> => {
 			const response =
 				await this.axios.get<TypesGen.ChatDebugLoggingAdminSettings>(
-					"/api/experimental/chats/config/debug-logging",
+					"/api/v2/chats/config/debug-logging",
 				);
 			return response.data;
 		};
@@ -3649,14 +3634,14 @@ class ExperimentalApiMethods {
 	updateChatDebugLogging = async (
 		req: TypesGen.UpdateChatDebugLoggingAllowUsersRequest,
 	): Promise<void> => {
-		await this.axios.put("/api/experimental/chats/config/debug-logging", req);
+		await this.axios.put("/api/v2/chats/config/debug-logging", req);
 	};
 
 	getUserChatDebugLogging =
 		async (): Promise<TypesGen.UserChatDebugLoggingSettings> => {
 			const response =
 				await this.axios.get<TypesGen.UserChatDebugLoggingSettings>(
-					"/api/experimental/chats/config/user-debug-logging",
+					"/api/v2/chats/config/user-debug-logging",
 				);
 			return response.data;
 		};
@@ -3664,10 +3649,7 @@ class ExperimentalApiMethods {
 	updateUserChatDebugLogging = async (
 		req: TypesGen.UpdateUserChatDebugLoggingRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			"/api/experimental/chats/config/user-debug-logging",
-			req,
-		);
+		await this.axios.put("/api/v2/chats/config/user-debug-logging", req);
 	};
 
 	getUserChatPersonalModelOverrides = async (
@@ -3676,7 +3658,7 @@ class ExperimentalApiMethods {
 	): Promise<TypesGen.UserChatPersonalModelOverridesResponse> => {
 		const response =
 			await this.axios.get<TypesGen.UserChatPersonalModelOverridesResponse>(
-				`/api/experimental/organizations/${encodeURIComponent(organizationId)}/members/${encodeURIComponent(user)}/chats/model-overrides`,
+				`/api/v2/organizations/${encodeURIComponent(organizationId)}/members/${encodeURIComponent(user)}/chats/model-overrides`,
 			);
 		return response.data;
 	};
@@ -3688,7 +3670,7 @@ class ExperimentalApiMethods {
 		req: TypesGen.UpdateUserChatPersonalModelOverrideRequest,
 	): Promise<void> => {
 		await this.axios.put(
-			`/api/experimental/organizations/${encodeURIComponent(organizationId)}/members/${encodeURIComponent(user)}/chats/model-overrides/${encodeURIComponent(context)}`,
+			`/api/v2/organizations/${encodeURIComponent(organizationId)}/members/${encodeURIComponent(user)}/chats/model-overrides/${encodeURIComponent(context)}`,
 			req,
 		);
 	};
@@ -3746,7 +3728,7 @@ class ExperimentalApiMethods {
 	getChatWorkspaceTTL =
 		async (): Promise<TypesGen.ChatWorkspaceTTLResponse> => {
 			const response = await this.axios.get<TypesGen.ChatWorkspaceTTLResponse>(
-				"/api/experimental/chats/config/workspace-ttl",
+				"/api/v2/chats/config/workspace-ttl",
 			);
 			return response.data;
 		};
@@ -3754,13 +3736,13 @@ class ExperimentalApiMethods {
 	updateChatWorkspaceTTL = async (
 		req: TypesGen.UpdateChatWorkspaceTTLRequest,
 	): Promise<void> => {
-		await this.axios.put("/api/experimental/chats/config/workspace-ttl", req);
+		await this.axios.put("/api/v2/chats/config/workspace-ttl", req);
 	};
 
 	getChatRetentionDays =
 		async (): Promise<TypesGen.ChatRetentionDaysResponse> => {
 			const response = await this.axios.get<TypesGen.ChatRetentionDaysResponse>(
-				"/api/experimental/chats/config/retention-days",
+				"/api/v2/chats/config/retention-days",
 			);
 			return response.data;
 		};
@@ -3768,14 +3750,14 @@ class ExperimentalApiMethods {
 	updateChatRetentionDays = async (
 		req: TypesGen.UpdateChatRetentionDaysRequest,
 	): Promise<void> => {
-		await this.axios.put("/api/experimental/chats/config/retention-days", req);
+		await this.axios.put("/api/v2/chats/config/retention-days", req);
 	};
 
 	getChatDebugRetentionDays =
 		async (): Promise<TypesGen.ChatDebugRetentionDaysResponse> => {
 			const response =
 				await this.axios.get<TypesGen.ChatDebugRetentionDaysResponse>(
-					"/api/experimental/chats/config/debug-retention-days",
+					"/api/v2/chats/config/debug-retention-days",
 				);
 			return response.data;
 		};
@@ -3783,17 +3765,14 @@ class ExperimentalApiMethods {
 	updateChatDebugRetentionDays = async (
 		req: TypesGen.UpdateChatDebugRetentionDaysRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			"/api/experimental/chats/config/debug-retention-days",
-			req,
-		);
+		await this.axios.put("/api/v2/chats/config/debug-retention-days", req);
 	};
 
 	getChatAutoArchiveDays =
 		async (): Promise<TypesGen.ChatAutoArchiveDaysResponse> => {
 			const response =
 				await this.axios.get<TypesGen.ChatAutoArchiveDaysResponse>(
-					"/api/experimental/chats/config/auto-archive-days",
+					"/api/v2/chats/config/auto-archive-days",
 				);
 			return response.data;
 		};
@@ -3801,16 +3780,13 @@ class ExperimentalApiMethods {
 	updateChatAutoArchiveDays = async (
 		req: TypesGen.UpdateChatAutoArchiveDaysRequest,
 	): Promise<void> => {
-		await this.axios.put(
-			"/api/experimental/chats/config/auto-archive-days",
-			req,
-		);
+		await this.axios.put("/api/v2/chats/config/auto-archive-days", req);
 	};
 
 	getUserChatCustomPrompt =
 		async (): Promise<TypesGen.UserChatCustomPrompt> => {
 			const response = await this.axios.get<TypesGen.UserChatCustomPrompt>(
-				"/api/experimental/chats/config/user-prompt",
+				"/api/v2/chats/config/user-prompt",
 			);
 			return response.data;
 		};
@@ -3818,7 +3794,7 @@ class ExperimentalApiMethods {
 		req: TypesGen.UserChatCustomPrompt,
 	): Promise<TypesGen.UserChatCustomPrompt> => {
 		const response = await this.axios.put<TypesGen.UserChatCustomPrompt>(
-			"/api/experimental/chats/config/user-prompt",
+			"/api/v2/chats/config/user-prompt",
 			req,
 		);
 		return response.data;
@@ -3874,7 +3850,7 @@ class ExperimentalApiMethods {
 		async (): Promise<TypesGen.UserChatCompactionThresholds> => {
 			const response =
 				await this.axios.get<TypesGen.UserChatCompactionThresholds>(
-					"/api/experimental/chats/config/user-compaction-thresholds",
+					"/api/v2/chats/config/user-compaction-thresholds",
 				);
 			return response.data;
 		};
@@ -3883,7 +3859,7 @@ class ExperimentalApiMethods {
 		req: TypesGen.UpdateUserChatCompactionThresholdRequest,
 	): Promise<TypesGen.UserChatCompactionThreshold> => {
 		const response = await this.axios.put<TypesGen.UserChatCompactionThreshold>(
-			`/api/experimental/chats/config/user-compaction-thresholds/${encodeURIComponent(modelId)}`,
+			`/api/v2/chats/config/user-compaction-thresholds/${encodeURIComponent(modelId)}`,
 			req,
 		);
 		return response.data;
@@ -3892,7 +3868,7 @@ class ExperimentalApiMethods {
 		modelId: string,
 	): Promise<void> => {
 		await this.axios.delete(
-			`/api/experimental/chats/config/user-compaction-thresholds/${encodeURIComponent(modelId)}`,
+			`/api/v2/chats/config/user-compaction-thresholds/${encodeURIComponent(modelId)}`,
 		);
 	};
 

--- a/site/src/pages/AgentsPage/AgentsPageLayout.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.test.ts
@@ -341,7 +341,7 @@ describe("useFileAttachments persistence", () => {
 		expect(state).toEqual({ status: "uploaded", fileId: "file-1" });
 
 		const previewUrl = result.current.previewUrls.get(file);
-		expect(previewUrl).toBe("/api/experimental/chats/files/file-1");
+		expect(previewUrl).toBe("/api/v2/chats/files/file-1");
 		unmount();
 	});
 

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -805,7 +805,7 @@ export const WithMCPNeedingAuth: Story = {
 		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
 		await userEvent.click(body.getByRole("button", { name: "Auth" }));
 		expect(window.open).toHaveBeenCalledWith(
-			"/api/experimental/organizations/org-1/mcp-servers/mcp-github/oauth2/connect",
+			"/api/v2/organizations/org-1/mcp-servers/mcp-github/oauth2/connect",
 			"_blank",
 			"width=900,height=600",
 		);
@@ -827,7 +827,7 @@ export const MCPAutoEnablesAfterOAuthCompletes: Story = {
 	play: async ({ args, canvasElement }) => {
 		await startMCPOAuthFlow(canvasElement);
 		expect(window.open).toHaveBeenCalledWith(
-			`/api/experimental/organizations/org-1/mcp-servers/${githubMCP.id}/oauth2/connect`,
+			`/api/v2/organizations/org-1/mcp-servers/${githubMCP.id}/oauth2/connect`,
 			"_blank",
 			"width=900,height=600",
 		);

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1229,7 +1229,7 @@ export const UserMessageWithDownloadableFile: Story = {
 		});
 		expect(downloadLink).toHaveAttribute(
 			"href",
-			"/api/experimental/chats/files/storybook-user-deployment-report",
+			"/api/v2/chats/files/storybook-user-deployment-report",
 		);
 		expect(canvas.getByText("deployment-report.pdf")).toBeInTheDocument();
 		expect(

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -146,7 +146,7 @@ const createMockSocket = (): MockSocket => {
 	}) as WatchChatSocket["removeEventListener"];
 
 	return {
-		url: "ws://example.test/api/experimental/chats/mock-stream",
+		url: "ws://example.test/api/v2/chats/mock-stream",
 		addEventListener,
 		removeEventListener,
 		close: vi.fn(),

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.stories.tsx
@@ -193,7 +193,7 @@ export const OAuthNeedsAuth: Story = {
 			body.getByRole("button", { name: "Authenticate with GitHub" }),
 		);
 		expect(window.open).toHaveBeenCalledWith(
-			"/api/experimental/organizations/org-1/mcp-servers/mcp-github/oauth2/connect",
+			"/api/v2/organizations/org-1/mcp-servers/mcp-github/oauth2/connect",
 			"_blank",
 			"width=900,height=600",
 		);

--- a/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.test.ts
@@ -19,7 +19,7 @@ describe("handleAttachmentDownloadClick", () => {
 	const iPhoneUserAgent =
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
 	const target = {
-		href: "/api/experimental/chats/files/file-1",
+		href: "/api/v2/chats/files/file-1",
 		fileName: "01-agents-list.png",
 		mediaType: "image/png",
 	};

--- a/site/src/pages/AgentsPage/utils/chatAttachments.ts
+++ b/site/src/pages/AgentsPage/utils/chatAttachments.ts
@@ -10,7 +10,7 @@ export type AttachmentFailure =
 	| { kind: "failed"; detail?: string };
 
 export const getChatFileURL = (fileId: string) =>
-	`/api/experimental/chats/files/${encodeURIComponent(fileId)}`;
+	`/api/v2/chats/files/${encodeURIComponent(fileId)}`;
 
 export const isAbortError = (error: unknown): error is Error =>
 	error instanceof Error && error.name === "AbortError";

--- a/site/src/pages/AgentsPage/utils/fetchTextAttachment.test.ts
+++ b/site/src/pages/AgentsPage/utils/fetchTextAttachment.test.ts
@@ -69,7 +69,7 @@ describe("fetchTextAttachmentContent", () => {
 			content: "hello from the server",
 		});
 		expect(globalThis.fetch).toHaveBeenCalledWith(
-			"/api/experimental/chats/files/folder%2Ffile-1%3Fpreview%3Dyes",
+			"/api/v2/chats/files/folder%2Ffile-1%3Fpreview%3Dyes",
 			expect.anything(),
 		);
 	});

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -85,7 +85,7 @@ type CallbackFn = (ev?: MessageEvent) => void;
 //   Record keyed by URL substring — events are delivered only to
 //   sockets whose URL contains the key:
 //     webSocket: {
-//       "/api/experimental/chats/": [{ event: "message", data: "..." }],
+//       "/api/v2/chats/": [{ event: "message", data: "..." }],
 //       "/api/experimental/workspaceagents/": [{ event: "message", data: "..." }],
 //     }
 export const withWebSocket = (Story: FC, { parameters }: StoryContext) => {


### PR DESCRIPTION
## Stack context

This is the final PR in the 3-PR chat API promotion stack: server compatibility mounts (#28496), codersdk promotion (#28497), and frontend path updates (this PR).

## Summary

Switch promoted frontend chat and MCP REST and WebSocket calls to `/api/v2`. Debug runs, virtual desktop streaming, advisor, and computer-use provider routes remain on `/api/experimental` because those surfaces were not promoted.

Update the matching tests, stories, helpers, and end-to-end route expectations. Remote dogfood UAT passed with chat traffic verified on the v2 routes.

> [!NOTE]
> Xum acted on Mike's behalf in this pull request.
<!-- xum-attribution: model=claude-fable-5 thinking=high -->

