### PR TITLE
fix(coderd): deflake TestHealthSettings dismissal subtests

### DIFF
--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -272,8 +272,15 @@ func TestHealthSettings(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
 
-		// given
-		adminClient := coderdtest.New(t, nil)
+		// given: a stubbed healthcheck, so this test does not depend on real
+		// DERP probe timing. The stub reports nothing as dismissed, so the
+		// assertions below verify that the dismissed flags are applied per
+		// request in formatHealthcheck rather than read from the cached report.
+		adminClient := coderdtest.New(t, &coderdtest.Options{
+			HealthcheckFunc: func(context.Context, string, *healthcheck.Progress) *healthsdk.HealthcheckReport {
+				return &healthsdk.HealthcheckReport{Time: time.Now()}
+			},
+		})
 		_ = coderdtest.CreateFirstUser(t, adminClient)
 
 		expected := healthsdk.HealthSettings{
@@ -307,8 +314,13 @@ func TestHealthSettings(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
 
-		// given
-		adminClient := coderdtest.New(t, nil)
+		// given: a stubbed healthcheck, for the same reason as in
+		// "DismissSection" above.
+		adminClient := coderdtest.New(t, &coderdtest.Options{
+			HealthcheckFunc: func(context.Context, string, *healthcheck.Progress) *healthsdk.HealthcheckReport {
+				return &healthsdk.HealthcheckReport{Time: time.Now()}
+			},
+		})
 		_ = coderdtest.CreateFirstUser(t, adminClient)
 
 		initial := healthsdk.HealthSettings{

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -311,9 +311,8 @@ func TestHealthSettings(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
 
-		// given: a stubbed healthcheck, for the same reason as in
-		// "DismissSection" above.
 		adminClient := coderdtest.New(t, &coderdtest.Options{
+			// Mocked to avoid depending on DERP probe timing.
 			HealthcheckFunc: func(context.Context, string, *healthcheck.Progress) *healthsdk.HealthcheckReport {
 				return &healthsdk.HealthcheckReport{Time: time.Now()}
 			},

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -272,11 +272,8 @@ func TestHealthSettings(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
 
-		// given: a stubbed healthcheck, so this test does not depend on real
-		// DERP probe timing. The stub reports nothing as dismissed, so the
-		// assertions below verify that the dismissed flags are applied per
-		// request in formatHealthcheck rather than read from the cached report.
 		adminClient := coderdtest.New(t, &coderdtest.Options{
+			// Mocked to avoid depending on DERP probe timing.
 			HealthcheckFunc: func(context.Context, string, *healthcheck.Progress) *healthsdk.HealthcheckReport {
 				return &healthsdk.HealthcheckReport{Time: time.Now()}
 			},


### PR DESCRIPTION
Fixes https://linear.app/codercom/issue/PLAT-514/flake-testhealthsettingsdismisssection

Both TestHealthSettings dismissal subtests built their server with coderdtest.New(t, nil), so GET /api/v2/debug/health ran the real healthcheck, DERP probe included, only to assert that dismissed sections come back as dismissed.

- Raising the timeout would not fix it. The healthcheck runs on a context detached from the request (30s HealthcheckTimeout), and derphealth's 10s per-node cap is skipped whenever a deadline already exists, which is always true from that call site. Both subtests share one 10s WaitShort across setup and four round trips, so the server may spend 3x the test's entire lifetime on one request.
- Fix: inject a stub HealthcheckFunc in both subtests, as the six TestDebugHealth subtests already do.
- The stub reports nothing dismissed, so the assertions still prove the flags are applied per request in formatHealthcheck rather than read from the cached report, which is what 38ed816207 fixed.
- Endpoint drops from ~55ms to ~2ms, and three real DERP connections per health call are gone.

Out of scope: all four TestHealthSettings subtests, including the two that never call /debug/health, still budget server construction from the same 10s WaitShort. That is a separate exposure from the one PLAT-514 reported.
