### PR TITLE
fix(site): dispose Monaco diff models on unmount

### DIFF
--- a/site/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
+++ b/site/src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type * as Monaco from "monaco-editor";
+import * as monaco from "monaco-editor";
+import { useState } from "react";
+import { expect, userEvent, waitFor } from "storybook/test";
+import { withDashboardProvider } from "#/testHelpers/storybook";
+import { SyntaxHighlighter } from "./SyntaxHighlighter";
+
+const original = `resource "coder_agent" "main" {
+  os   = "linux"
+  arch = "amd64"
+}
+`;
+
+const modified = `resource "coder_agent" "main" {
+  os   = "linux"
+  arch = "arm64"
+}
+`;
+
+// The diff editor's gutter menu and occurrence highlighter register delayed
+// disposables whose teardown throws under jsdom (no real timers/layout) when
+// editors unmount. They are irrelevant to model disposal, so we turn them off
+// in stories to keep the test runner clean without changing production behavior.
+const stableTeardownOptions: Monaco.editor.IStandaloneDiffEditorConstructionOptions =
+	{
+		minimap: { enabled: false },
+		renderSideBySide: true,
+		readOnly: true,
+		renderGutterMenu: false,
+		occurrencesHighlight: "off",
+	};
+
+const meta: Meta<typeof SyntaxHighlighter> = {
+	title: "components/SyntaxHighlighter",
+	component: SyntaxHighlighter,
+	decorators: [withDashboardProvider],
+	args: {
+		language: "hcl",
+		editorProps: { options: stableTeardownOptions },
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof SyntaxHighlighter>;
+
+export const Plain: Story = {
+	args: {
+		value: original,
+	},
+};
+
+export const Diff: Story = {
+	args: {
+		value: modified,
+		compareWith: original,
+	},
+};
+
+// Reproduces the leak from DEVEX-736: a single SyntaxHighlighter instance that
+// stays mounted while a file switches between diff and plain across template
+// versions. Each diff editor owns two Monaco models, and they must be disposed
+// when the diff goes away. Before the fix the models were only disposed on full
+// unmount, so toggling diff -> plain -> diff leaked two models per cycle.
+const DiffToggle = () => {
+	const [showDiff, setShowDiff] = useState(true);
+	return (
+		<div>
+			<button type="button" onClick={() => setShowDiff((show) => !show)}>
+				Toggle diff
+			</button>
+			<SyntaxHighlighter
+				language="hcl"
+				value={showDiff ? modified : original}
+				compareWith={original}
+				editorProps={{ options: stableTeardownOptions }}
+			/>
+		</div>
+	);
+};
+
+export const DisposesModelsOnDiffToggle: Story = {
+	render: () => <DiffToggle />,
+	play: async ({ canvas }) => {
+		const toggle = canvas.getByRole("button", { name: "Toggle diff" });
+
+		// Wait for the diff editor to mount its original + modified models, then
+		// record the total as a baseline. Every full toggle cycle must return to
+		// this number; growth would mean abandoned models are being retained.
+		let baseline = 0;
+		await waitFor(() => {
+			baseline = monaco.editor.getModels().length;
+			expect(baseline).toBeGreaterThanOrEqual(2);
+		});
+
+		for (let cycle = 0; cycle < 3; cycle++) {
+			// Switch to plain: the diff editor unmounts and must dispose its models.
+			await userEvent.click(toggle);
+			await waitFor(() =>
+				expect(monaco.editor.getModels().length).toBeLessThan(baseline),
+			);
+
+			// Switch back to diff: a new diff editor mounts and the total must land
+			// back on the baseline rather than climbing.
+			await userEvent.click(toggle);
+			await waitFor(() =>
+				expect(monaco.editor.getModels().length).toBe(baseline),
+			);
+		}
+	},
+};

--- a/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -79,6 +79,11 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 	);
 };
 
+type DiffFileProps = CommonEditorProps & {
+	original: string;
+	modified: string;
+};
+
 // Renders the diff editor and owns its model cleanup. Scoping this to its own
 // component means the cleanup effect runs whenever the diff editor unmounts,
 // including when SyntaxHighlighter stays mounted but switches diff -> plain for
@@ -88,9 +93,12 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 // the models mid-teardown (which throws), so we dispose them ourselves after
 // React has torn the editor down. Without this the models accumulate unbounded
 // as users open template versions until the tab runs out of memory.
-const DiffFile: FC<
-	{ original: string; modified: string } & CommonEditorProps
-> = ({ original, modified, onMount, ...editorProps }) => {
+const DiffFile: FC<DiffFileProps> = ({
+	original,
+	modified,
+	onMount,
+	...editorProps
+}) => {
 	const diffModelsRef = useRef<{
 		original: Monaco.editor.ITextModel;
 		modified: Monaco.editor.ITextModel;

--- a/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -111,7 +111,6 @@ const DiffFile: FC<DiffFileProps> = ({
 		) => {
 			onMount?.(editor, monacoInstance);
 
-			// Capture the models so the cleanup effect can dispose them.
 			const diffModel = editor.getModel();
 			diffModelsRef.current = diffModel
 				? { original: diffModel.original, modified: diffModel.modified }

--- a/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,7 +1,13 @@
 import Editor, { DiffEditor, loader } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import * as monaco from "monaco-editor";
-import { type ComponentProps, type FC, useCallback } from "react";
+import {
+	type ComponentProps,
+	type FC,
+	useCallback,
+	useEffect,
+	useRef,
+} from "react";
 import { useTheme } from "#/theme/context";
 import { useCoderTheme } from "./coderTheme";
 
@@ -38,40 +44,6 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 	const theme = useTheme();
 	const coderTheme = useCoderTheme();
 
-	// Auto-scroll to first diff when the diff editor mounts and diffs are computed.
-	const handleDiffEditorMount = useCallback(
-		(
-			editor: Monaco.editor.IStandaloneDiffEditor,
-			monacoInstance: typeof Monaco,
-		) => {
-			// Call any existing onMount handler from editorProps.
-			editorProps?.onMount?.(editor, monacoInstance);
-
-			// Diffs may already be computed by the time onMount fires,
-			// so check immediately first. If not ready yet, fall back
-			// to waiting for the onDidUpdateDiff event.
-			const scrollToFirstDiff = () => {
-				editor.goToDiff("next");
-			};
-
-			const changes = editor.getLineChanges();
-			if (changes && changes.length > 0) {
-				scrollToFirstDiff();
-				return;
-			}
-
-			const disposable = editor.onDidUpdateDiff(() => {
-				const updatedChanges = editor.getLineChanges();
-				if (!updatedChanges || updatedChanges.length === 0) {
-					return;
-				}
-				disposable.dispose();
-				scrollToFirstDiff();
-			});
-		},
-		[editorProps],
-	);
-
 	const commonProps = {
 		language,
 		theme: coderTheme.name,
@@ -99,20 +71,95 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 			}}
 		>
 			{hasDiff ? (
-				<DiffEditor
-					original={compareWith}
-					modified={value}
-					{...commonProps}
-					// Let the editor handle model cleanup. Without this,
-					// @monaco-editor/react disposes models before the
-					// DiffEditorWidget and throws an error.
-					keepCurrentOriginalModel
-					keepCurrentModifiedModel
-					onMount={handleDiffEditorMount}
-				/>
+				<DiffFile original={compareWith} modified={value} {...commonProps} />
 			) : (
 				<Editor value={value} {...commonProps} />
 			)}
 		</div>
+	);
+};
+
+// Renders the diff editor and owns its model cleanup. Scoping this to its own
+// component means the cleanup effect runs whenever the diff editor unmounts,
+// including when SyntaxHighlighter stays mounted but switches diff -> plain for
+// a file that stopped changing between versions.
+//
+// keepCurrent{Original,Modified}Model stops @monaco-editor/react from disposing
+// the models mid-teardown (which throws), so we dispose them ourselves after
+// React has torn the editor down. Without this the models accumulate unbounded
+// as users open template versions until the tab runs out of memory.
+const DiffFile: FC<
+	{ original: string; modified: string } & CommonEditorProps
+> = ({ original, modified, onMount, ...editorProps }) => {
+	const diffModelsRef = useRef<{
+		original: Monaco.editor.ITextModel;
+		modified: Monaco.editor.ITextModel;
+	} | null>(null);
+
+	const handleMount = useCallback(
+		(
+			editor: Monaco.editor.IStandaloneDiffEditor,
+			monacoInstance: typeof Monaco,
+		) => {
+			onMount?.(editor, monacoInstance);
+
+			// Capture the models so the cleanup effect can dispose them.
+			const diffModel = editor.getModel();
+			diffModelsRef.current = diffModel
+				? { original: diffModel.original, modified: diffModel.modified }
+				: null;
+
+			// Auto-scroll to the first diff. Diffs may already be computed by the
+			// time onMount fires, so check immediately and otherwise wait for the
+			// onDidUpdateDiff event.
+			const scrollToFirstDiff = () => {
+				editor.goToDiff("next");
+			};
+
+			const changes = editor.getLineChanges();
+			if (changes && changes.length > 0) {
+				scrollToFirstDiff();
+				return;
+			}
+
+			const disposable = editor.onDidUpdateDiff(() => {
+				const updatedChanges = editor.getLineChanges();
+				if (!updatedChanges || updatedChanges.length === 0) {
+					return;
+				}
+				disposable.dispose();
+				scrollToFirstDiff();
+			});
+		},
+		[onMount],
+	);
+
+	useEffect(() => {
+		return () => {
+			const models = diffModelsRef.current;
+			if (!models) {
+				return;
+			}
+			diffModelsRef.current = null;
+			// Defer disposal until after React's commit finishes. @monaco-editor/
+			// react disposes the diff widget in its own unmount cleanup; freeing
+			// the models in the same synchronous teardown makes the widget throw
+			// "TextModel got disposed before DiffEditorWidget model got reset".
+			queueMicrotask(() => {
+				models.original.dispose();
+				models.modified.dispose();
+			});
+		};
+	}, []);
+
+	return (
+		<DiffEditor
+			original={original}
+			modified={modified}
+			{...editorProps}
+			keepCurrentOriginalModel
+			keepCurrentModifiedModel
+			onMount={handleMount}
+		/>
 	);
 };


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Fixes [DEVEX-736](https://linear.app/codercom/issue/DEVEX-736/template-editor-crashes-becomes-unusable-when-opening-versions).

## Problem

Opening template versions in the template editor leaks Monaco text models. Each version renders one `DiffEditor` per changed file, and `SyntaxHighlighter` sets `keepCurrentOriginalModel` / `keepCurrentModifiedModel`, which tells `@monaco-editor/react` **not** to dispose the underlying text models when the editor unmounts. Because no stable model paths are supplied, every visit creates fresh anonymous models that are never freed. Navigating between versions accumulates models without bound until the tab lags, spins, and eventually OOMs — matching the customer reports on 2.34.5.

The flags themselves are still required: removing them makes the library dispose the models mid-teardown (before the `DiffEditorWidget` is torn down), which throws.

## Fix

Keep the `keepCurrent*Model` flags, but move the diff editor into its own `DiffFile` component that owns the model cleanup:

- `DiffFile` captures the `original`/`modified` models in `onMount` and disposes them in its own unmount effect. Because the effect lives with the diff editor, it runs whenever the diff editor unmounts — **including when a file switches diff → plain across versions while `SyntaxHighlighter` stays mounted** (the `key={filename}` case raised in review), not only on full unmount.
- Disposal is deferred with `queueMicrotask` so it runs after React's commit and after `@monaco-editor/react` disposes the widget. Freeing the models in the same synchronous teardown throws `TextModel got disposed before DiffEditorWidget model got reset`.

Non-diff files use the plain `Editor`, which already disposes its own model, so they are unaffected. No editor options or UI behavior change.

## Evidence

Reproduced locally on a template with 32 versions (9 `.tf` files each), driving 192 in-app version navigations (single SPA session, no page reloads) and reading `monaco.editor.getModels().length` via temporary instrumentation.

| | before (pass 1 → pass 6) | after (pass 1 → pass 6) |
|---|---|---|
| retained Monaco models | 532 → **3,142** (unbounded) | ~10–19 (flat) |
| per-navigation render latency | 206ms → **611ms** | ~120–270ms (flat) |

Before: models climb ~520 per full pass and never release (a sample taken with zero editors on screen still showed 522 live models). After: model count and render latency stay flat across the same workload.

## Testing

Added `SyntaxHighlighter.stories.tsx` with a `play` regression test (`DisposesModelsOnDiffToggle`) that reproduces the exact leak: it toggles a single surviving `SyntaxHighlighter` between diff and plain three times and asserts `monaco.editor.getModels().length` drops when the diff is removed and returns to the baseline each cycle (no accumulation).

- The test **fails on the unfixed behavior** (disposal removed): `expected 5 to be less than 4` — models grow instead of being freed.
- With the fix it passes with **zero Monaco teardown errors**:

  ```
  $ pnpm test:storybook src/components/SyntaxHighlighter/SyntaxHighlighter.stories.tsx
   Test Files  1 passed (1)
        Tests  3 passed (3)
       Errors  0
  ```

- `pnpm check` (biome) — pass
- `pnpm lint:types` (`tsc --noEmit`) — pass
- Manual stress test: model count and render latency stay flat across 192 navigations (see Evidence).

<details>
<summary>Investigation & decision log</summary>

**Root cause trace**
- `site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx` → `TemplateFiles` renders every template file at once.
- Each changed file → `SyntaxHighlighter` → a full Monaco `DiffEditor`.
- `@monaco-editor/react@4.7.0` unmount cleanup does, in effect:
  ```js
  const model = editor.getModel();
  keepCurrentOriginalModel || model.original.dispose();
  keepCurrentModifiedModel || model.modified.dispose();
  editor.dispose();
  ```
  With both `keepCurrent*` flags set, neither model is disposed, so they leak.
- The flags exist to stop a storybook hang caused by that same disposal-order error, so they cannot simply be removed.

**Options considered**
1. Remove the flags — fixes the leak but re-introduces the mid-teardown throw. Rejected.
2. Supply stable `originalModelPath`/`modifiedModelPath` so models are reused — the library reuses by URI, but its value-sync effect is skipped on the first render, so a reused model renders **stale content** for the new version. Rejected.
3. Keep the flags and dispose the captured models when the diff editor unmounts — targeted and correct for the diff → plain → diff case. **Chosen.**

**Why the cleanup is scoped to a child component**
The first iteration kept the effect in `SyntaxHighlighter` with an empty dependency array, so it only ran on full unmount. Review correctly flagged that a surviving instance switching diff → plain would then orphan the previous model pair. Scoping the effect to the `DiffFile` child ties it to the diff editor's own lifecycle, closing that gap.

**Why `queueMicrotask`**
Disposing synchronously in the effect cleanup races Monaco's own widget teardown and throws `TextModel got disposed before DiffEditorWidget model got reset`. Deferring one microtask lets the widget finish tearing down first.

**Test-only editor options**
The stories pass `renderGutterMenu: false` / `occurrencesHighlight: "off"` through `editorProps`. Those Monaco features register delayed disposables whose teardown throws under jsdom on unmount; disabling them keeps the test runner clean. They do not affect model count, and production keeps Monaco's default options unchanged.
</details>
