### PR TITLE
fix(site/src/pages/AgentsPage): rename "This Week" group to "Past 7 days"

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -740,7 +740,7 @@ export const SectionHeadersCollapse: Story = {
 		await expect(canvas.getByText("Pinned (2)")).toBeInTheDocument();
 		await expect(canvas.getByText("Today (2)")).toBeInTheDocument();
 		await expect(canvas.getByText("Yesterday (1)")).toBeInTheDocument();
-		await expect(canvas.getByText("This Week (1)")).toBeInTheDocument();
+		await expect(canvas.getByText("Past 7 days (1)")).toBeInTheDocument();
 
 		const pinnedToggle = canvas.getByRole("button", {
 			name: "Collapse Pinned section",

--- a/site/src/pages/AgentsPage/utils/timeGroups.test.ts
+++ b/site/src/pages/AgentsPage/utils/timeGroups.test.ts
@@ -14,7 +14,7 @@ describe("getTimeGroup", () => {
 	});
 
 	it("exports the expected group labels in order", () => {
-		expect(TIME_GROUPS).toEqual(["Today", "Yesterday", "This Week", "Older"]);
+		expect(TIME_GROUPS).toEqual(["Today", "Yesterday", "Past 7 days", "Older"]);
 	});
 
 	it('returns "Today" for a date later today', () => {
@@ -37,19 +37,19 @@ describe("getTimeGroup", () => {
 		expect(getTimeGroup("2025-07-14T00:00:00.000Z")).toBe("Yesterday");
 	});
 
-	it('returns "This Week" for a date 2 days ago', () => {
-		expect(getTimeGroup("2025-07-13T12:00:00.000Z")).toBe("This Week");
+	it('returns "Past 7 days" for a date 2 days ago', () => {
+		expect(getTimeGroup("2025-07-13T12:00:00.000Z")).toBe("Past 7 days");
 	});
 
-	it('returns "This Week" for a date 6 days ago', () => {
-		expect(getTimeGroup("2025-07-09T12:00:00.000Z")).toBe("This Week");
+	it('returns "Past 7 days" for a date 6 days ago', () => {
+		expect(getTimeGroup("2025-07-09T12:00:00.000Z")).toBe("Past 7 days");
 	});
 
-	it('returns "This Week" for exactly 7 days ago at midnight', () => {
+	it('returns "Past 7 days" for exactly 7 days ago at midnight', () => {
 		// weekAgo = today - 7 days = 2025-07-08T00:00:00 local.
-		// A date at exactly that boundary should be "This Week"
+		// A date at exactly that boundary should be "Past 7 days"
 		// because the comparison is date >= weekAgo.
-		expect(getTimeGroup("2025-07-08T00:00:00.000Z")).toBe("This Week");
+		expect(getTimeGroup("2025-07-08T00:00:00.000Z")).toBe("Past 7 days");
 	});
 
 	it('returns "Older" for a date 8 days ago', () => {

--- a/site/src/pages/AgentsPage/utils/timeGroups.ts
+++ b/site/src/pages/AgentsPage/utils/timeGroups.ts
@@ -1,11 +1,15 @@
 /**
  * Time-based grouping utility used by the sidebar to categorize
- * chats into "Today", "Yesterday", "This Week", and "Older".
+ * chats into "Today", "Yesterday", "Past 7 days", and "Older".
+ *
+ * "Past 7 days" is a rolling window (today minus 7 days), not the
+ * current calendar week, so the label stays accurate on Mondays
+ * when calendar-week grouping would misfile items from last week.
  */
 export const TIME_GROUPS = [
 	"Today",
 	"Yesterday",
-	"This Week",
+	"Past 7 days",
 	"Older",
 ] as const;
 type TimeGroup = (typeof TIME_GROUPS)[number];
@@ -21,6 +25,6 @@ export function getTimeGroup(dateStr: string): TimeGroup {
 
 	if (date >= today) return "Today";
 	if (date >= yesterday) return "Yesterday";
-	if (date >= weekAgo) return "This Week";
+	if (date >= weekAgo) return "Past 7 days";
 	return "Older";
 }


### PR DESCRIPTION
## Problem

The agents sidebar groups chats with `getTimeGroup`, which labels anything within a rolling `today - 7 days` window as **"This Week"**. Because it is a rolling 7-day window rather than the current calendar week, on Mondays items from the *previous* calendar week (e.g. a chat updated "3d" ago on Friday) are still filed under "This Week", which reads as wrong. See [CODAGT-964](https://linear.app/codercom/issue/CODAGT-964/this-week-grouping-mislabels-items-on-monday).

## Fix

Rename the bucket label to **"Past 7 days"**, which accurately describes the existing rolling-window behavior. This matches the engineer's suggestion on the issue. The bucketing logic itself is unchanged (it was already correct as a 7-day window); only the label was misleading.

### Changes
- `timeGroups.ts`: rename the `TIME_GROUPS` entry and clarify the doc comment on why it is a rolling window.
- `timeGroups.test.ts`: update the label assertions and test names.
- `ChatsSidebar.stories.tsx`: update the `SectionHeadersCollapse` play-function assertion.

## Proof

Storybook `pages/AgentsPage/ChatsSidebar` → `SectionHeadersCollapse`, showing the renamed header:

![Past 7 days section header](https://raw.githubusercontent.com/coder/coder/dfraley/codagt-964-proof/proof/past-7-days.png)

## Testing
- `pnpm vitest run --project=unit src/pages/AgentsPage/utils/timeGroups.test.ts` — 15 passed
- `pnpm vitest run --project=storybook src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx` — 56 passed
- `biome check` on the changed files — clean

<details>
<summary>Decision log</summary>

- The reported symptom is a labeling problem, not a bucketing bug: `getTimeGroup` intentionally uses `weekAgo = today - 7 days` and compares `date >= weekAgo`, i.e. a rolling 7-day window. On a Monday, last week's items legitimately fall in that window but the "This Week" label implies the current calendar week, so it looks mislabeled.
- Two options were considered: (a) change the logic to true calendar-week semantics (`startOf("week")`), or (b) rename the label to match the existing rolling-window behavior. Per the issue author's suggestion ("We should probably name it 'Past 7 days'"), option (b) was chosen. It is the smaller, lower-risk change and avoids shrinking the group near the start of a week.
- The group string is used both as the display label and as the React key / section-toggle test id, so renaming the single constant keeps display and keys consistent. No test referenced the old week-specific test id.

</details>

---

> Generated by Coder Agents on behalf of @david-fraley.