### PR TITLE
feat: add user secret file policy config

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -55,6 +55,13 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
+      --user-secrets-disable-file-path bool, $CODER_USER_SECRETS_DISABLE_FILE_PATH
+          Disable Coder-managed file path delivery for user secrets. Users can
+          no longer add or change a secret file path, and generated agent
+          manifests deliver user secrets only through environment variables.
+          Stored legacy paths remain visible until users explicitly clear them
+          and become effective again if this setting is turned off.
+
       --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
           Disable workspace sharing. Workspace ACL checking is disabled and only
           owners can have ssh, apps and terminal access to workspaces. Access

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -566,6 +566,13 @@ disableWorkspaceSharing: false
 # their chats.
 # (default: <unset>, type: bool)
 disableChatSharing: false
+# Disable Coder-managed file path delivery for user secrets. Users can no longer
+# add or change a secret file path, and generated agent manifests deliver user
+# secrets only through environment variables. Stored legacy paths remain visible
+# until users explicitly clear them and become effective again if this setting is
+# turned off.
+# (default: <unset>, type: bool)
+userSecretsDisableFilePath: false
 # These options change the behavior of how clients interact with the Coder.
 # Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -21719,6 +21719,9 @@ const docTemplate = `{
                 "disable_path_apps": {
                     "type": "boolean"
                 },
+                "disable_user_secret_file_path": {
+                    "type": "boolean"
+                },
                 "disable_workspace_sharing": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -19758,6 +19758,9 @@
 				"disable_path_apps": {
 					"type": "boolean"
 				},
+				"disable_user_secret_file_path": {
+					"type": "boolean"
+				},
 				"disable_workspace_sharing": {
 					"type": "boolean"
 				},

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5365,6 +5365,18 @@ func (q *querier) GetUserSecretByUserIDAndName(ctx context.Context, arg database
 	return q.db.GetUserSecretByUserIDAndName(ctx, arg)
 }
 
+func (q *querier) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	// Only the update path locks the row, so require update rather than
+	// read: a caller that may not modify the secret has no business
+	// holding a write lock on it.
+	obj := rbac.ResourceUserSecret.WithOwner(arg.UserID.String())
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, obj); err != nil {
+		return database.UserSecret{}, err
+	}
+
+	return q.db.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+}
+
 func (q *querier) GetUserSecretsTelemetrySummary(ctx context.Context) (database.GetUserSecretsTelemetrySummaryRow, error) {
 	// Telemetry queries are called from system contexts only. The
 	// query reads aggregate counts across all users' secrets, so

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6638,6 +6638,15 @@ func (s *MethodTestSuite) TestUserSecrets() {
 			Asserts(rbac.ResourceUserSecret.WithOwner(user.ID.String()), policy.ActionRead).
 			Returns(secret)
 	}))
+	s.Run("GetUserSecretByUserIDAndNameForUpdate", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		user := testutil.Fake(s.T(), faker, database.User{})
+		secret := testutil.Fake(s.T(), faker, database.UserSecret{UserID: user.ID})
+		arg := database.GetUserSecretByUserIDAndNameForUpdateParams{UserID: user.ID, Name: secret.Name}
+		dbm.EXPECT().GetUserSecretByUserIDAndNameForUpdate(gomock.Any(), arg).Return(secret, nil).AnyTimes()
+		check.Args(arg).
+			Asserts(rbac.ResourceUserSecret.WithOwner(user.ID.String()), policy.ActionUpdate).
+			Returns(secret)
+	}))
 	s.Run("ListUserSecrets", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		user := testutil.Fake(s.T(), faker, database.User{})
 		row := testutil.Fake(s.T(), faker, database.ListUserSecretsRow{UserID: user.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3432,6 +3432,14 @@ func (m queryMetricsStore) GetUserSecretByUserIDAndName(ctx context.Context, arg
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetUserSecretByUserIDAndNameForUpdate").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetUserSecretByUserIDAndNameForUpdate").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetUserSecretsTelemetrySummary(ctx context.Context) (database.GetUserSecretsTelemetrySummaryRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetUserSecretsTelemetrySummary(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6464,6 +6464,21 @@ func (mr *MockStoreMockRecorder) GetUserSecretByUserIDAndName(ctx, arg any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretByUserIDAndName", reflect.TypeOf((*MockStore)(nil).GetUserSecretByUserIDAndName), ctx, arg)
 }
 
+// GetUserSecretByUserIDAndNameForUpdate mocks base method.
+func (m *MockStore) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserSecretByUserIDAndNameForUpdate", ctx, arg)
+	ret0, _ := ret[0].(database.UserSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserSecretByUserIDAndNameForUpdate indicates an expected call of GetUserSecretByUserIDAndNameForUpdate.
+func (mr *MockStoreMockRecorder) GetUserSecretByUserIDAndNameForUpdate(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretByUserIDAndNameForUpdate", reflect.TypeOf((*MockStore)(nil).GetUserSecretByUserIDAndNameForUpdate), ctx, arg)
+}
+
 // GetUserSecretsTelemetrySummary mocks base method.
 func (m *MockStore) GetUserSecretsTelemetrySummary(ctx context.Context) (database.GetUserSecretsTelemetrySummaryRow, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -958,6 +958,15 @@ type sqlcQuerier interface {
 	GetUserNotificationPreferences(ctx context.Context, userID uuid.UUID) ([]NotificationPreference, error)
 	GetUserSecretByID(ctx context.Context, id uuid.UUID) (UserSecret, error)
 	GetUserSecretByUserIDAndName(ctx context.Context, arg GetUserSecretByUserIDAndNameParams) (UserSecret, error)
+	// Row-locking variant of GetUserSecretByUserIDAndName, used by PATCH.
+	//
+	// The update handler validates the post-update state against the row it
+	// just read. Without the lock, two concurrent PATCHes both read the
+	// pre-update row, so each one validates against a state the other is
+	// about to invalidate. Taking the lock here makes the second transaction
+	// wait and re-read the winner's row, so the post-state check is evaluated
+	// against what will actually be updated.
+	GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg GetUserSecretByUserIDAndNameForUpdateParams) (UserSecret, error)
 	// Returns deployment-wide aggregates for the telemetry snapshot.
 	//
 	// The denominator for both user-level counts and the per-user

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -30473,6 +30473,45 @@ func (q *sqlQuerier) GetUserSecretByUserIDAndName(ctx context.Context, arg GetUs
 	return i, err
 }
 
+const getUserSecretByUserIDAndNameForUpdate = `-- name: GetUserSecretByUserIDAndNameForUpdate :one
+SELECT id, user_id, name, description, value, env_name, file_path, created_at, updated_at, value_key_id, enabled
+FROM user_secrets
+WHERE user_id = $1 AND name = $2
+FOR UPDATE
+`
+
+type GetUserSecretByUserIDAndNameForUpdateParams struct {
+	UserID uuid.UUID `db:"user_id" json:"user_id"`
+	Name   string    `db:"name" json:"name"`
+}
+
+// Row-locking variant of GetUserSecretByUserIDAndName, used by PATCH.
+//
+// The update handler validates the post-update state against the row it
+// just read. Without the lock, two concurrent PATCHes both read the
+// pre-update row, so each one validates against a state the other is
+// about to invalidate. Taking the lock here makes the second transaction
+// wait and re-read the winner's row, so the post-state check is evaluated
+// against what will actually be updated.
+func (q *sqlQuerier) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg GetUserSecretByUserIDAndNameForUpdateParams) (UserSecret, error) {
+	row := q.db.QueryRowContext(ctx, getUserSecretByUserIDAndNameForUpdate, arg.UserID, arg.Name)
+	var i UserSecret
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.Description,
+		&i.Value,
+		&i.EnvName,
+		&i.FilePath,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ValueKeyID,
+		&i.Enabled,
+	)
+	return i, err
+}
+
 const getUserSecretsTelemetrySummary = `-- name: GetUserSecretsTelemetrySummary :one
 WITH active_users AS (
     SELECT id AS user_id

--- a/coderd/database/queries/user_secrets.sql
+++ b/coderd/database/queries/user_secrets.sql
@@ -8,6 +8,20 @@ SELECT *
 FROM user_secrets
 WHERE id = @id;
 
+-- name: GetUserSecretByUserIDAndNameForUpdate :one
+-- Row-locking variant of GetUserSecretByUserIDAndName, used by PATCH.
+--
+-- The update handler validates the post-update state against the row it
+-- just read. Without the lock, two concurrent PATCHes both read the
+-- pre-update row, so each one validates against a state the other is
+-- about to invalidate. Taking the lock here makes the second transaction
+-- wait and re-read the winner's row, so the post-state check is evaluated
+-- against what will actually be updated.
+SELECT *
+FROM user_secrets
+WHERE user_id = @user_id AND name = @name
+FOR UPDATE;
+
 -- name: ListUserSecrets :many
 -- Returns metadata only (no value or value_key_id) for the
 -- REST API list and get endpoints.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -736,6 +736,7 @@ type DeploymentValues struct {
 	DisableOwnerWorkspaceExec               serpent.Bool                         `json:"disable_owner_workspace_exec,omitempty" typescript:",notnull"`
 	DisableWorkspaceSharing                 serpent.Bool                         `json:"disable_workspace_sharing,omitempty" typescript:",notnull"`
 	DisableChatSharing                      serpent.Bool                         `json:"disable_chat_sharing,omitempty" typescript:",notnull"`
+	DisableUserSecretFilePath               serpent.Bool                         `json:"disable_user_secret_file_path,omitempty" typescript:",notnull"`
 	ProxyHealthStatusInterval               serpent.Duration                     `json:"proxy_health_status_interval,omitempty" typescript:",notnull"`
 	EnableTerraformDebugMode                serpent.Bool                         `json:"enable_terraform_debug_mode,omitempty" typescript:",notnull"`
 	UserQuietHoursSchedule                  UserQuietHoursScheduleConfig         `json:"user_quiet_hours_schedule,omitempty" typescript:",notnull"`
@@ -3780,6 +3781,17 @@ communicating directly.`,
 
 			Value: &c.DisableChatSharing,
 			YAML:  "disableChatSharing",
+		},
+		{
+			Name: "Disable User Secret File Path",
+			Description: "Disable Coder-managed file path delivery for user secrets. Users can no longer add or change " +
+				"a secret file path, and generated agent manifests deliver user secrets only through environment variables. " +
+				"Stored legacy paths remain visible until users explicitly clear them and become effective again if this setting is turned off.",
+			Flag: "user-secrets-disable-file-path",
+			Env:  "CODER_USER_SECRETS_DISABLE_FILE_PATH",
+
+			Value: &c.DisableUserSecretFilePath,
+			YAML:  "userSecretsDisableFilePath",
 		},
 		{
 			Name:        "Session Duration",

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -1429,6 +1429,75 @@ func TestRetentionConfigParsing(t *testing.T) {
 	}
 }
 
+func TestUserSecretsDisableFilePath(t *testing.T) {
+	t.Parallel()
+
+	findOption := func(t *testing.T, dv *codersdk.DeploymentValues) serpent.Option {
+		t.Helper()
+		opts := dv.Options()
+		for _, opt := range opts {
+			if opt.Value == &dv.DisableUserSecretFilePath {
+				return opt
+			}
+		}
+		t.Fatal("DisableUserSecretFilePath is not registered as a deployment option")
+		return serpent.Option{}
+	}
+
+	t.Run("DefaultsToFalse", func(t *testing.T) {
+		t.Parallel()
+
+		dv := codersdk.DeploymentValues{}
+		opts := dv.Options()
+		require.NoError(t, opts.SetDefaults())
+		require.False(t, dv.DisableUserSecretFilePath.Value())
+	})
+
+	t.Run("Naming", func(t *testing.T) {
+		t.Parallel()
+
+		dv := codersdk.DeploymentValues{}
+		opt := findOption(t, &dv)
+		assert.Equal(t, "user-secrets-disable-file-path", opt.Flag)
+		assert.Equal(t, "CODER_USER_SECRETS_DISABLE_FILE_PATH", opt.Env)
+		assert.Equal(t, "userSecretsDisableFilePath", opt.YAML)
+	})
+
+	t.Run("ParsesEnv", func(t *testing.T) {
+		t.Parallel()
+
+		dv := codersdk.DeploymentValues{}
+		opts := dv.Options()
+		require.NoError(t, opts.SetDefaults())
+		require.NoError(t, opts.ParseEnv([]serpent.EnvVar{
+			{Name: "CODER_USER_SECRETS_DISABLE_FILE_PATH", Value: "true"},
+		}))
+		require.True(t, dv.DisableUserSecretFilePath.Value())
+	})
+
+	t.Run("ParsesYAML", func(t *testing.T) {
+		t.Parallel()
+
+		dv := codersdk.DeploymentValues{}
+		opts := dv.Options()
+		var node yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte("userSecretsDisableFilePath: true\n"), &node))
+		require.NoError(t, node.Decode(&opts))
+		require.True(t, dv.DisableUserSecretFilePath.Value())
+	})
+
+	t.Run("PreservedWithoutSecrets", func(t *testing.T) {
+		t.Parallel()
+
+		dv := codersdk.DeploymentValues{
+			DisableUserSecretFilePath: true,
+		}
+		withoutSecrets, err := dv.WithoutSecrets()
+		require.NoError(t, err)
+		require.True(t, withoutSecrets.DisableUserSecretFilePath.Value())
+	})
+}
+
 func TestChatAIGatewayRoutingEnabledDefault(t *testing.T) {
 	t.Parallel()
 

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -82,6 +82,14 @@ Disable workspace apps that are not served from subdomains. Path-based apps can 
 - CLI flag: [`--disable-path-apps`](../../reference/cli/server.md#--disable-path-apps)
 - YAML key: `disablePathApps`
 
+### Disable user secret file path
+
+Disable Coder-managed file path delivery for user secrets. Users can no longer add or change a secret file path, and generated agent manifests deliver user secrets only through environment variables. Stored legacy paths remain visible until users explicitly clear them and become effective again if this setting is turned off.
+
+- Environment variable: `CODER_USER_SECRETS_DISABLE_FILE_PATH`
+- CLI flag: [`--user-secrets-disable-file-path`](../../reference/cli/server.md#--user-secrets-disable-file-path)
+- YAML key: `userSecretsDisableFilePath`
+
 ### Disable workspace sharing
 
 Disable workspace sharing. Workspace ACL checking is disabled and only owners can have ssh, apps and terminal access to workspaces. Access based on the 'owner' role is also allowed unless disabled via --disable-owner-workspace-access.

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -311,6 +311,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
+    "disable_user_secret_file_path": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7418,6 +7418,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
+    "disable_user_secret_file_path": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -8046,6 +8047,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "disable_owner_workspace_exec": true,
   "disable_password_auth": true,
   "disable_path_apps": true,
+  "disable_user_secret_file_path": true,
   "disable_workspace_sharing": true,
   "docs_url": {
     "forceQuery": true,
@@ -8441,6 +8443,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                    |
 | `disable_password_auth`                        | boolean                                                                                              | false    |              |                                                                    |
 | `disable_path_apps`                            | boolean                                                                                              | false    |              |                                                                    |
+| `disable_user_secret_file_path`                | boolean                                                                                              | false    |              |                                                                    |
 | `disable_workspace_sharing`                    | boolean                                                                                              | false    |              |                                                                    |
 | `docs_url`                                     | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
 | `enable_ai_tasks`                              | boolean                                                                                              | false    |              |                                                                    |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1216,6 +1216,16 @@ Disable workspace sharing. Workspace ACL checking is disabled and only owners ca
 
 Disable chat sharing. Chat ACL checking is disabled and only owners can access their chats.
 
+### --user-secrets-disable-file-path
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>bool</code>                                  |
+| Environment | <code>$CODER_USER_SECRETS_DISABLE_FILE_PATH</code> |
+| YAML        | <code>userSecretsDisableFilePath</code>            |
+
+Disable Coder-managed file path delivery for user secrets. Users can no longer add or change a secret file path, and generated agent manifests deliver user secrets only through environment variables. Stored legacy paths remain visible until users explicitly clear them and become effective again if this setting is turned off.
+
 ### --session-duration
 
 |             |                                              |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -56,6 +56,13 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
+      --user-secrets-disable-file-path bool, $CODER_USER_SECRETS_DISABLE_FILE_PATH
+          Disable Coder-managed file path delivery for user secrets. Users can
+          no longer add or change a secret file path, and generated agent
+          manifests deliver user secrets only through environment variables.
+          Stored legacy paths remain visible until users explicitly clear them
+          and become effective again if this setting is turned off.
+
       --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
           Disable workspace sharing. Workspace ACL checking is disabled and only
           owners can have ssh, apps and terminal access to workspaces. Access

--- a/enterprise/dbcrypt/dbcrypt.go
+++ b/enterprise/dbcrypt/dbcrypt.go
@@ -939,6 +939,17 @@ func (db *dbCrypt) GetUserSecretByUserIDAndName(ctx context.Context, arg databas
 	return secret, nil
 }
 
+func (db *dbCrypt) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	secret, err := db.Store.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+	if err != nil {
+		return database.UserSecret{}, err
+	}
+	if err := db.decryptField(&secret.Value, secret.ValueKeyID); err != nil {
+		return database.UserSecret{}, err
+	}
+	return secret, nil
+}
+
 func (db *dbCrypt) ListUserSecretsWithValues(ctx context.Context, userID uuid.UUID) ([]database.UserSecret, error) {
 	secrets, err := db.Store.ListUserSecretsWithValues(ctx, userID)
 	if err != nil {

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -1886,6 +1886,50 @@ func TestUserSecrets(t *testing.T) {
 		require.Equal(t, rawBefore.ValueKeyID, rawAfter.ValueKeyID)
 	})
 
+	t.Run("GetUserSecretForUpdateDecryptsValue", func(t *testing.T) {
+		t.Parallel()
+		db, crypt, ciphers := setup(t)
+		secret := insertUserSecret(t, crypt, ciphers)
+
+		// The row-locking variant PATCH uses must decrypt exactly like the
+		// plain read, otherwise a locked read would hand the handler
+		// ciphertext.
+		got, err := crypt.GetUserSecretByUserIDAndNameForUpdate(ctx, database.GetUserSecretByUserIDAndNameForUpdateParams{
+			UserID: secret.UserID,
+			Name:   secret.Name,
+		})
+		require.NoError(t, err)
+		require.Equal(t, initialValue, got.Value)
+
+		raw, err := db.GetUserSecretByUserIDAndNameForUpdate(ctx, database.GetUserSecretByUserIDAndNameForUpdateParams{
+			UserID: secret.UserID,
+			Name:   secret.Name,
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, initialValue, raw.Value)
+		requireEncryptedEquals(t, ciphers[0], raw.Value, initialValue)
+	})
+
+	t.Run("GetUserSecretForUpdateDecryptErr", func(t *testing.T) {
+		t.Parallel()
+		db, crypt, ciphers := setup(t)
+		user := dbgen.User(t, db, database.User{})
+		dbgen.UserSecret(t, db, database.UserSecret{
+			UserID:     user.ID,
+			Name:       "corrupt-for-update-secret",
+			Value:      fakeBase64RandomData(t, 32),
+			ValueKeyID: sql.NullString{String: ciphers[0].HexDigest(), Valid: true},
+		})
+
+		_, err := crypt.GetUserSecretByUserIDAndNameForUpdate(ctx, database.GetUserSecretByUserIDAndNameForUpdateParams{
+			UserID: user.ID,
+			Name:   "corrupt-for-update-secret",
+		})
+		require.Error(t, err)
+		var derr *DecryptFailedError
+		require.ErrorAs(t, err, &derr)
+	})
+
 	t.Run("GetUserSecretDecryptErr", func(t *testing.T) {
 		t.Parallel()
 		db, crypt, ciphers := setup(t)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4830,6 +4830,7 @@ export interface DeploymentValues {
 	readonly disable_owner_workspace_exec?: boolean;
 	readonly disable_workspace_sharing?: boolean;
 	readonly disable_chat_sharing?: boolean;
+	readonly disable_user_secret_file_path?: boolean;
 	readonly proxy_health_status_interval?: number;
 	readonly enable_terraform_debug_mode?: boolean;
 	readonly user_quiet_hours_schedule?: UserQuietHoursScheduleConfig;


### PR DESCRIPTION
## Summary

Adds the deployment configuration and database foundation for #27488.

The new `DisableUserSecretFilePath` option defaults to `false` and is available as `--user-secrets-disable-file-path`, `CODER_USER_SECRETS_DISABLE_FILE_PATH`, and `userSecretsDisableFilePath`. This PR also adds the generated configuration/help artifacts and the `FOR UPDATE` user-secret query and database wrappers used by the next PR.

## Stack

**1 of 6: configuration and locking foundation**

The row-locking query is inert until the API enforcement in #28507. Later PRs add policy tests, runtime manifest filtering, dashboard behavior, and CLI/documentation updates.

## Validation

- `make gen`
- Deployment option default, flag, environment, YAML, and sanitized telemetry-preservation tests
- Database authorization and encrypted-value wrapper tests
- `make pre-commit`

## Rollout and compatibility

The default preserves existing behavior. This PR does not enforce the policy by itself and does not change stored user secrets.

<details>
<summary>Decision and implementation summary</summary>

- Keep the control deployment-scoped and outside entitlement feature maps.
- Preserve stored legacy paths rather than migrating or clearing them.
- Lock the secret row before policy validation so later PATCH enforcement can validate and update the same serialized state.
- Generate all configuration, API type, CLI help, and reference artifacts from repository generators.

</details>

Refs #27488

This PR was generated by Coder Agents on behalf of @dylanhuff-at-coder.
