### PR TITLE
feat: filter blocked secret file targets

### DIFF
--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -102,6 +102,7 @@ type Options struct {
 	AgentStatsRefreshInterval time.Duration
 	DisableDirectConnections  bool
 	DerpForceWebSockets       bool
+	DisableUserSecretFilePath bool
 	DerpMapUpdateFrequency    time.Duration
 	ExternalAuthConfigs       []*externalauth.Config
 	Experiments               codersdk.Experiments
@@ -120,15 +121,16 @@ func New(opts Options, workspace database.Workspace, agent database.WorkspaceAge
 	}
 
 	api.ManifestAPI = &ManifestAPI{
-		AccessURL:                opts.AccessURL,
-		AppHostname:              opts.AppHostname,
-		ExternalAuthConfigs:      opts.ExternalAuthConfigs,
-		DisableDirectConnections: opts.DisableDirectConnections,
-		DerpForceWebSockets:      opts.DerpForceWebSockets,
-		AgentFn:                  api.agent,
-		Database:                 opts.Database,
-		DerpMapFn:                opts.DerpMapFn,
-		WorkspaceID:              opts.WorkspaceID,
+		AccessURL:                 opts.AccessURL,
+		AppHostname:               opts.AppHostname,
+		ExternalAuthConfigs:       opts.ExternalAuthConfigs,
+		DisableDirectConnections:  opts.DisableDirectConnections,
+		DerpForceWebSockets:       opts.DerpForceWebSockets,
+		DisableUserSecretFilePath: opts.DisableUserSecretFilePath,
+		AgentFn:                   api.agent,
+		Database:                  opts.Database,
+		DerpMapFn:                 opts.DerpMapFn,
+		WorkspaceID:               opts.WorkspaceID,
 	}
 
 	// Don't cache details for prebuilds, though the cached fields will eventually be updated

--- a/coderd/agentapi/manifest.go
+++ b/coderd/agentapi/manifest.go
@@ -30,7 +30,12 @@ type ManifestAPI struct {
 	ExternalAuthConfigs      []*externalauth.Config
 	DisableDirectConnections bool
 	DerpForceWebSockets      bool
-	WorkspaceID              uuid.UUID
+	// DisableUserSecretFilePath suppresses the file injection target of
+	// user secrets for the whole deployment. Enforcing it here keeps the
+	// decision on the server: the agent writes whatever file targets the
+	// manifest carries, so withholding them is what stops the write.
+	DisableUserSecretFilePath bool
+	WorkspaceID               uuid.UUID
 
 	AgentFn   func(ctx context.Context) (database.WorkspaceAgent, error)
 	Database  database.Store
@@ -129,6 +134,11 @@ func (a *ManifestAPI) GetManifest(ctx context.Context, _ *agentproto.GetManifest
 		parentID = workspaceAgent.ParentID.UUID[:]
 	}
 
+	secretFilePathPolicy := userSecretFilePathAllowed
+	if a.DisableUserSecretFilePath {
+		secretFilePathPolicy = userSecretFilePathBlocked
+	}
+
 	return &agentproto.Manifest{
 		AgentId:                  workspaceAgent.ID[:],
 		AgentName:                workspaceAgent.Name,
@@ -149,7 +159,7 @@ func (a *ManifestAPI) GetManifest(ctx context.Context, _ *agentproto.GetManifest
 		Apps:          apps,
 		Metadata:      dbAgentMetadataToProtoDescription(metadata),
 		Devcontainers: dbAgentDevcontainersToProto(devcontainers),
-		Secrets:       dbUserSecretsToProto(userSecrets),
+		Secrets:       dbUserSecretsToProto(userSecrets, secretFilePathPolicy),
 	}, nil
 }
 
@@ -275,7 +285,17 @@ func dbAgentDevcontainersToProto(devcontainers []database.WorkspaceAgentDevconta
 	return ret
 }
 
-func dbUserSecretsToProto(secrets []database.UserSecret) []*agentproto.WorkspaceSecret {
+type userSecretFilePathPolicy int
+
+const (
+	userSecretFilePathAllowed userSecretFilePathPolicy = iota
+	userSecretFilePathBlocked
+)
+
+// dbUserSecretsToProto converts user secrets into the manifest
+// representation the agent injects from. The policy can drop the file
+// injection target deployment-wide.
+func dbUserSecretsToProto(secrets []database.UserSecret, policy userSecretFilePathPolicy) []*agentproto.WorkspaceSecret {
 	ret := make([]*agentproto.WorkspaceSecret, 0, len(secrets))
 	for _, s := range secrets {
 		// Skip disabled secrets so they are not injected as env vars or
@@ -285,9 +305,20 @@ func dbUserSecretsToProto(secrets []database.UserSecret) []*agentproto.Workspace
 		if !s.Enabled {
 			continue
 		}
+		filePath := s.FilePath
+		if policy == userSecretFilePathBlocked {
+			// A secret whose only target is a file has nothing left to
+			// inject, so drop the whole entry rather than send a
+			// target-less one. That also keeps its plaintext value from
+			// being transmitted to the workspace at all.
+			if s.EnvName == "" {
+				continue
+			}
+			filePath = ""
+		}
 		ret = append(ret, &agentproto.WorkspaceSecret{
 			EnvName:  s.EnvName,
-			FilePath: s.FilePath,
+			FilePath: filePath,
 			Value:    []byte(s.Value),
 		})
 	}

--- a/coderd/agentapi/manifest_internal_test.go
+++ b/coderd/agentapi/manifest_internal_test.go
@@ -7,8 +7,101 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
 )
+
+func Test_dbUserSecretsToProto(t *testing.T) {
+	t.Parallel()
+
+	// One row per injection shape, reused by every case so the
+	// expectations below differ only by policy.
+	var (
+		envOnly    = database.UserSecret{Name: "env-only", EnvName: "ENV_ONLY", Value: "env-val", Enabled: true}
+		fileOnly   = database.UserSecret{Name: "file-only", FilePath: "~/.ssh/id_rsa", Value: "file-val", Enabled: true}
+		dualTarget = database.UserSecret{Name: "dual", EnvName: "DUAL_ENV", FilePath: "/etc/dual", Value: "dual-val", Enabled: true}
+		// A disabled row is never injected regardless of policy. Its
+		// file target proves the policy is not what filters it out.
+		disabled = database.UserSecret{Name: "disabled", EnvName: "DISABLED_ENV", FilePath: "/etc/disabled", Value: "disabled-val"}
+	)
+
+	secrets := []database.UserSecret{envOnly, fileOnly, dualTarget, disabled}
+
+	cases := []struct {
+		name                      string
+		disableUserSecretFilePath bool
+		expected                  []*agentproto.WorkspaceSecret
+	}{
+		{
+			name:                      "PolicyOff",
+			disableUserSecretFilePath: false,
+			expected: []*agentproto.WorkspaceSecret{
+				{EnvName: "ENV_ONLY", FilePath: "", Value: []byte("env-val")},
+				{EnvName: "", FilePath: "~/.ssh/id_rsa", Value: []byte("file-val")},
+				{EnvName: "DUAL_ENV", FilePath: "/etc/dual", Value: []byte("dual-val")},
+			},
+		},
+		{
+			name:                      "PolicyOn",
+			disableUserSecretFilePath: true,
+			expected: []*agentproto.WorkspaceSecret{
+				// Env-only is untouched by the policy.
+				{EnvName: "ENV_ONLY", FilePath: "", Value: []byte("env-val")},
+				// The dual-target secret keeps its env injection and
+				// loses only the file target.
+				{EnvName: "DUAL_ENV", FilePath: "", Value: []byte("dual-val")},
+				// The file-only secret is dropped entirely so its
+				// plaintext value is never transmitted.
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy := userSecretFilePathAllowed
+			if c.disableUserSecretFilePath {
+				policy = userSecretFilePathBlocked
+			}
+			got := dbUserSecretsToProto(secrets, policy)
+			require.Len(t, got, len(c.expected))
+			for i, want := range c.expected {
+				require.Equal(t, want.EnvName, got[i].EnvName, "secret %d env_name", i)
+				require.Equal(t, want.FilePath, got[i].FilePath, "secret %d file_path", i)
+				require.Equal(t, want.Value, got[i].Value, "secret %d value", i)
+			}
+		})
+	}
+
+	t.Run("PolicyOnDoesNotTransmitFileOnlyValues", func(t *testing.T) {
+		t.Parallel()
+
+		// Guards the plaintext contract directly: no part of a file-only
+		// secret may reach the manifest under the policy.
+		for _, secret := range dbUserSecretsToProto(secrets, userSecretFilePathBlocked) {
+			require.NotEqual(t, []byte("file-val"), secret.Value)
+			require.Empty(t, secret.FilePath)
+		}
+	})
+
+	t.Run("PolicyOffRestoresStoredTargets", func(t *testing.T) {
+		t.Parallel()
+
+		// The policy only filters the outbound manifest, so turning it
+		// back off yields the stored targets again on the next fetch
+		// without any change to the rows.
+		before := dbUserSecretsToProto(secrets, userSecretFilePathAllowed)
+		_ = dbUserSecretsToProto(secrets, userSecretFilePathBlocked)
+		after := dbUserSecretsToProto(secrets, userSecretFilePathAllowed)
+
+		require.Equal(t, before, after)
+		require.Len(t, after, 3)
+		require.Equal(t, "~/.ssh/id_rsa", after[1].FilePath)
+		require.Equal(t, "/etc/dual", after[2].FilePath)
+	})
+}
 
 func Test_vscodeProxyURI(t *testing.T) {
 	t.Parallel()

--- a/coderd/agentapi/manifest_test.go
+++ b/coderd/agentapi/manifest_test.go
@@ -496,6 +496,69 @@ func TestGetManifest(t *testing.T) {
 		require.Equal(t, []byte("both-val"), got.Secrets[2].Value)
 	})
 
+	t.Run("SecretsFilePathDisabled", func(t *testing.T) {
+		t.Parallel()
+
+		mDB := dbmock.NewMockStore(gomock.NewController(t))
+
+		api := &agentapi.ManifestAPI{
+			AccessURL:   &url.URL{Scheme: "https", Host: "example.com"},
+			AppHostname: "*--apps.example.com",
+			ExternalAuthConfigs: []*externalauth.Config{
+				{Type: string(codersdk.EnhancedExternalAuthProviderGitHub)},
+				{Type: "some-provider"},
+				{Type: string(codersdk.EnhancedExternalAuthProviderGitLab)},
+			},
+			DisableDirectConnections:  true,
+			DerpForceWebSockets:       true,
+			DisableUserSecretFilePath: true,
+
+			AgentFn:     func(ctx context.Context) (database.WorkspaceAgent, error) { return childAgent, nil },
+			WorkspaceID: workspace.ID,
+			Database:    mDB,
+			DerpMapFn:   derpMapFn,
+		}
+
+		mDB.EXPECT().GetWorkspaceAppsByAgentID(gomock.Any(), childAgent.ID).Return([]database.WorkspaceApp{}, nil)
+		mDB.EXPECT().GetWorkspaceAgentScriptsByAgentIDs(gomock.Any(), []uuid.UUID{childAgent.ID}).Return([]database.GetWorkspaceAgentScriptsByAgentIDsRow{}, nil)
+		mDB.EXPECT().GetWorkspaceAgentMetadata(gomock.Any(), database.GetWorkspaceAgentMetadataParams{
+			WorkspaceAgentID: childAgent.ID,
+			Keys:             nil,
+		}).Return([]database.WorkspaceAgentMetadatum{}, nil)
+		mDB.EXPECT().GetWorkspaceAgentDevcontainersByAgentID(gomock.Any(), childAgent.ID).Return([]database.WorkspaceAgentDevcontainer{}, nil)
+		mDB.EXPECT().GetWorkspaceByID(gomock.Any(), workspace.ID).Return(workspace, nil)
+
+		mDB.EXPECT().ListUserSecretsWithValues(gomock.Any(), workspace.OwnerID).Return([]database.UserSecret{
+			{EnvName: "GITHUB_TOKEN", FilePath: "", Value: "ghp_xxxx", Enabled: true},
+			{EnvName: "", FilePath: "~/.ssh/id_rsa", Value: "private-key", Enabled: true},
+			{EnvName: "BOTH_ENV", FilePath: "/etc/both", Value: "both-val", Enabled: true},
+			{EnvName: "DISABLED_ENV", FilePath: "", Value: "disabled-val", Enabled: false},
+		}, nil)
+
+		got, err := api.GetManifest(context.Background(), &agentproto.GetManifestRequest{})
+		require.NoError(t, err)
+
+		// The disabled secret is filtered out as always, and the
+		// file-only secret is dropped because its sole injection
+		// target is disallowed.
+		require.Len(t, got.Secrets, 2)
+		require.Equal(t, "GITHUB_TOKEN", got.Secrets[0].EnvName)
+		require.Equal(t, "", got.Secrets[0].FilePath)
+		require.Equal(t, []byte("ghp_xxxx"), got.Secrets[0].Value)
+
+		// The dual-target secret keeps env injection with the file
+		// target cleared.
+		require.Equal(t, "BOTH_ENV", got.Secrets[1].EnvName)
+		require.Equal(t, "", got.Secrets[1].FilePath)
+		require.Equal(t, []byte("both-val"), got.Secrets[1].Value)
+
+		// The file-only secret's plaintext value must not be
+		// transmitted at all.
+		for _, secret := range got.Secrets {
+			require.NotEqual(t, []byte("private-key"), secret.Value)
+		}
+	})
+
 	t.Run("NoAppHostname", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -787,6 +787,8 @@ func New(options *Options) *API {
 		Logger:            options.Logger.Named("site"),
 		AITasksEnabled:    options.DeploymentValues.EnableAITasks.Value(),
 		AIGatewayEnabled:  options.DeploymentValues.AI.BridgeConfig.Enabled.Value(),
+
+		UserSecretFilePathEnabled: !options.DeploymentValues.DisableUserSecretFilePath.Value(),
 	})
 	if err != nil {
 		options.Logger.Fatal(ctx, "failed to initialize site handler", slog.Error(err))

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -184,6 +184,7 @@ func (api *API) workspaceAgentRPC(rw http.ResponseWriter, r *http.Request) {
 		AgentStatsRefreshInterval: api.AgentStatsRefreshInterval,
 		DisableDirectConnections:  api.DeploymentValues.DERP.Config.BlockDirect.Value(),
 		DerpForceWebSockets:       api.DeploymentValues.DERP.Config.ForceWebSockets.Value(),
+		DisableUserSecretFilePath: api.DeploymentValues.DisableUserSecretFilePath.Value(),
 		DerpMapUpdateFrequency:    api.DERPMapUpdateFrequency,
 		ExternalAuthConfigs:       api.ExternalAuthConfigs,
 		Experiments:               api.Experiments,

--- a/coderd/workspaceagentsrpc_test.go
+++ b/coderd/workspaceagentsrpc_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
@@ -168,6 +169,60 @@ func TestAgentAPI_LargeManifest(t *testing.T) {
 			require.Len(t, manifest.Scripts[0].Script, n)
 		})
 	}
+}
+
+func TestWorkspaceAgentRPCUserSecretFilePathDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	deploymentValues := coderdtest.DeploymentValues(t)
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+		DeploymentValues: deploymentValues,
+	})
+	owner := coderdtest.CreateFirstUser(t, client)
+
+	_, err := client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name:    "env-only",
+		Value:   "env-value",
+		EnvName: "ENV_ONLY",
+	})
+	require.NoError(t, err)
+	_, err = client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name:     "file-only",
+		Value:    "file-value",
+		FilePath: "~/.file-only",
+	})
+	require.NoError(t, err)
+	_, err = client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name:     "dual-target",
+		Value:    "dual-value",
+		EnvName:  "DUAL_TARGET",
+		FilePath: "~/.dual-target",
+	})
+	require.NoError(t, err)
+
+	deploymentValues.DisableUserSecretFilePath = true
+	workspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: owner.OrganizationID,
+		OwnerID:        owner.UserID,
+	}).WithAgent().Do()
+
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(workspace.AgentToken))
+	conn, err := agentClient.ConnectRPC(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	manifest, err := agentproto.NewDRPCAgentClient(conn).GetManifest(ctx, &agentproto.GetManifestRequest{})
+	require.NoError(t, err)
+	require.Len(t, manifest.Secrets, 2)
+	secretsByEnv := make(map[string]*agentproto.WorkspaceSecret, len(manifest.Secrets))
+	for _, secret := range manifest.Secrets {
+		secretsByEnv[secret.EnvName] = secret
+		require.Empty(t, secret.FilePath)
+		require.NotEqual(t, []byte("file-value"), secret.Value)
+	}
+	require.Equal(t, []byte("env-value"), secretsByEnv["ENV_ONLY"].Value)
+	require.Equal(t, []byte("dual-value"), secretsByEnv["DUAL_TARGET"].Value)
 }
 
 func TestWorkspaceAgentRPCRole(t *testing.T) {

--- a/site/index.html
+++ b/site/index.html
@@ -30,6 +30,10 @@
 	<meta property="logo-url" content="{{ .LogoURL }}" />
 	<meta property="ai-tasks-enabled" content="{{ .AITasksEnabled }}" />
 	<meta property="ai-gateway-enabled" content="{{ .AIGatewayEnabled }}" />
+	<meta
+		property="user-secret-file-path-enabled"
+		content="{{ .UserSecretFilePathEnabled }}"
+	/>
 	<meta property="permissions" content="{{ .Permissions }}" />
 	<meta property="organizations" content="{{ .Organizations }}" />
 	<link

--- a/site/site.go
+++ b/site/site.go
@@ -84,6 +84,11 @@ type Options struct {
 	Logger            slog.Logger
 	AITasksEnabled    bool
 	AIGatewayEnabled  bool
+	// UserSecretFilePathEnabled reports whether users may target a
+	// workspace file path when creating secrets. It is the positive form
+	// of the deployment's disable option so the dashboard reads a
+	// capability rather than a prohibition.
+	UserSecretFilePathEnabled bool
 }
 
 func New(opts *Options) (*Handler, error) {
@@ -269,8 +274,10 @@ type htmlState struct {
 
 	AITasksEnabled   string
 	AIGatewayEnabled string
-	Permissions      string
-	Organizations    string
+	// UserSecretFilePathEnabled is a JSON boolean rather than a struct.
+	UserSecretFilePathEnabled string
+	Permissions               string
+	Organizations             string
 }
 
 type csrfState struct {
@@ -526,6 +533,12 @@ func (h *Handler) populateHTMLState(
 		data, err := json.Marshal(h.opts.AIGatewayEnabled)
 		if err == nil {
 			state.AIGatewayEnabled = html.EscapeString(string(data))
+		}
+	})
+	wg.Go(func() {
+		data, err := json.Marshal(h.opts.UserSecretFilePathEnabled)
+		if err == nil {
+			state.UserSecretFilePathEnabled = html.EscapeString(string(data))
 		}
 	})
 	wg.Go(func() {

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -477,6 +477,57 @@ func TestOrganizationsMetadata(t *testing.T) {
 	assert.NotContains(t, memberOrgIDs, deletedOrg.ID)
 }
 
+func TestUserSecretFilePathEnabledMetadata(t *testing.T) {
+	t.Parallel()
+
+	// The dashboard reads this as a positive capability, so the
+	// metadata is the negation of the deployment's disable option.
+	for _, tc := range []struct {
+		name     string
+		enabled  bool
+		expected string
+	}{
+		{name: "Enabled", enabled: true, expected: "true"},
+		{name: "Disabled", enabled: false, expected: "false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// GIVEN: a site handler configured with the capability and a
+			// template that renders only that metadata value.
+			siteFS := fstest.MapFS{
+				"index.html": &fstest.MapFile{
+					Data: []byte("{{ .UserSecretFilePathEnabled }}"),
+				},
+			}
+			db, _ := dbtestutil.NewDB(t)
+			handler, err := site.New(&site.Options{
+				Telemetry:                 telemetry.NewNoop(),
+				Database:                  db,
+				SiteFS:                    siteFS,
+				UserSecretFilePathEnabled: tc.enabled,
+			})
+			require.NoError(t, err)
+
+			user := dbgen.User(t, db, database.User{})
+			_, token := dbgen.APIKey(t, db, database.APIKey{
+				UserID:    user.ID,
+				ExpiresAt: time.Now().Add(time.Hour),
+			})
+
+			// WHEN: an authenticated user loads the page.
+			r := httptest.NewRequest("GET", "/", nil)
+			r.Header.Set(codersdk.SessionTokenHeader, token)
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, r)
+
+			// THEN: the metadata renders as a JSON boolean.
+			require.Equal(t, http.StatusOK, rw.Code)
+			require.Equal(t, tc.expected, strings.TrimSpace(rw.Body.String()))
+		})
+	}
+}
+
 func TestCaching(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Stops blocked user-secret file targets at the agent-manifest boundary.

When the policy is enabled, env-only secrets are unchanged, dual-target secrets retain their value and environment target with an empty file path, and file-only secrets are omitted so their plaintext values do not cross DRPC. Stored paths remain untouched and return on a later manifest fetch after the deployment option is turned off.

This PR also publishes `user-secret-file-path-enabled` as positive embedded dashboard metadata with a backward-compatible `true` fallback in the consuming PR.

## Stack

**4 of 6: runtime enforcement and capability transport**

Depends on #28508. The next PR consumes the metadata in the dashboard, and the final PR updates CLI help and operational documentation.

## Validation

- Manifest conversion and full manifest-fetch tests
- End-to-end workspace agent RPC wiring test
- Positive metadata rendering tests
- Plaintext non-transmission assertion for file-only secrets
- Policy-off stored-target restoration test
- `make pre-commit`

## Rollout and compatibility

No protobuf, protocol-version, provisioner, immediate-refresh, agent-side deletion, or stale-file cleanup changes are required. Agents converge after their next manifest fetch or reconnect. Files written before convergence remain on disk.

<details>
<summary>Decision and implementation summary</summary>

- Enforce at coderd manifest generation because the agent already ignores empty targets.
- Omit file-only entries instead of transmitting a target-less secret value.
- Keep deployment configuration process-static and require reconnect or restart for manifest convergence.
- Use embedded metadata because typed deployment capabilities have not landed on `main`.

</details>

Refs #27488

This PR was generated by Coder Agents on behalf of @dylanhuff-at-coder.
