### PR TITLE
feat(site): show effective user secret targets

### DIFF
--- a/site/src/hooks/useEmbeddedMetadata.test.ts
+++ b/site/src/hooks/useEmbeddedMetadata.test.ts
@@ -11,6 +11,7 @@ import {
 	MockPermissions,
 	MockUserAppearanceSettings,
 	MockUserOwner,
+	MockUserSecretFilePathEnabled,
 } from "#/testHelpers/entities";
 import {
 	DEFAULT_METADATA_KEY,
@@ -47,6 +48,7 @@ const mockDataForTags = {
 	regions: MockRegions,
 	"ai-tasks-enabled": MockAITasksEnabled,
 	"ai-gateway-enabled": MockAIGatewayEnabled,
+	"user-secret-file-path-enabled": MockUserSecretFilePathEnabled,
 	permissions: MockPermissions,
 	organizations: [MockOrganization],
 } as const satisfies Record<MetadataKey, MetadataValue>;
@@ -85,6 +87,10 @@ const emptyMetadata: RuntimeHtmlMetadata = {
 		value: undefined,
 	},
 	"ai-gateway-enabled": {
+		available: false,
+		value: undefined,
+	},
+	"user-secret-file-path-enabled": {
 		available: false,
 		value: undefined,
 	},
@@ -134,6 +140,10 @@ const populatedMetadata: RuntimeHtmlMetadata = {
 	"ai-gateway-enabled": {
 		available: true,
 		value: MockAIGatewayEnabled,
+	},
+	"user-secret-file-path-enabled": {
+		available: true,
+		value: MockUserSecretFilePathEnabled,
 	},
 	permissions: {
 		available: true,

--- a/site/src/hooks/useEmbeddedMetadata.ts
+++ b/site/src/hooks/useEmbeddedMetadata.ts
@@ -33,6 +33,7 @@ type AvailableMetadata = Readonly<{
 	"build-info": BuildInfoResponse;
 	"ai-tasks-enabled": boolean;
 	"ai-gateway-enabled": boolean;
+	"user-secret-file-path-enabled": boolean;
 	permissions: Permissions;
 	organizations: Organization[];
 }>;
@@ -98,6 +99,9 @@ export class MetadataManager implements MetadataManagerApi {
 			regions: this.registerRegionValue(),
 			"ai-tasks-enabled": this.registerValue<boolean>("ai-tasks-enabled"),
 			"ai-gateway-enabled": this.registerValue<boolean>("ai-gateway-enabled"),
+			"user-secret-file-path-enabled": this.registerValue<boolean>(
+				"user-secret-file-path-enabled",
+			),
 			permissions: this.registerValue<Permissions>("permissions"),
 			organizations: this.registerValue<Organization[]>("organizations"),
 		};
@@ -255,4 +259,13 @@ export const useEmbeddedMetadata = makeUseEmbeddedMetadata(
 export function useAIGatewayEnabled(): boolean {
 	const { metadata } = useEmbeddedMetadata();
 	return metadata["ai-gateway-enabled"].value ?? true;
+}
+
+// Mirrors the deployment setting that lets administrators block file-path user
+// secrets. A missing value means the page is served by Vite, Storybook, a test
+// runner, or a server that predates the setting, none of which block file
+// paths, so those environments fall back to allowing them.
+export function useUserSecretFilePathEnabled(): boolean {
+	const { metadata } = useEmbeddedMetadata();
+	return metadata["user-secret-file-path-enabled"].value ?? true;
 }

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
@@ -44,6 +44,7 @@ import {
 type SecretDialogProps = {
 	open: boolean;
 	secret?: UserSecret;
+	filePathEnabled: boolean;
 	isSubmitting: boolean;
 	returnFocusElement?: HTMLElement | null;
 	onClose: () => void;
@@ -71,6 +72,7 @@ export const SAVED_SECRET_VALUE_DISPLAY = "••••••••••••�
 export const SecretDialog: FC<SecretDialogProps> = ({
 	open,
 	secret,
+	filePathEnabled,
 	isSubmitting,
 	returnFocusElement,
 	onClose,
@@ -98,13 +100,14 @@ export const SecretDialog: FC<SecretDialogProps> = ({
 		enableReinitialize: true,
 		validateOnMount: true,
 		validate: (values) =>
-			isEdit ? {} : getCreateSecretRequiredFieldErrors(values),
+			isEdit ? {} : getCreateSecretRequiredFieldErrors(values, filePathEnabled),
 		onSubmit: async (values, helpers) => {
 			helpers.setStatus(undefined);
 			try {
 				if (secret) {
 					const request = buildUpdateUserSecretRequest(secret, values, {
 						clearValue: clearValueRequested,
+						filePathEnabled,
 					});
 					await onUpdateSecret(secret.name, request);
 				} else {
@@ -179,6 +182,7 @@ export const SecretDialog: FC<SecretDialogProps> = ({
 	const request = secret
 		? buildUpdateUserSecretRequest(secret, form.values, {
 				clearValue: clearValueRequested,
+				filePathEnabled,
 			})
 		: undefined;
 	const hasUpdate = request ? Object.keys(request).length > 0 : false;
@@ -230,9 +234,26 @@ export const SecretDialog: FC<SecretDialogProps> = ({
 						<>
 							<SecretFields
 								getFieldHelpers={getFieldHelpers}
+								filePathEnabled={filePathEnabled}
 								disableName
 								showValue={false}
 							/>
+							{!filePathEnabled && secret.file_path !== "" && (
+								<BlockedFilePathField
+									storedFilePath={secret.file_path}
+									isRemoved={form.values.file_path === ""}
+									onRemove={() => {
+										void form.setFieldValue("file_path", "", false);
+									}}
+									onRestore={() => {
+										void form.setFieldValue(
+											"file_path",
+											secret.file_path,
+											false,
+										);
+									}}
+								/>
+							)}
 							<SecretValueField
 								key={`${secret.name}-${open}`}
 								field={getFieldHelpers("value", {
@@ -282,6 +303,7 @@ export const SecretDialog: FC<SecretDialogProps> = ({
 							</div>
 							<SecretFields
 								getFieldHelpers={getFieldHelpers}
+								filePathEnabled={filePathEnabled}
 								showRequiredLabels
 								showValue
 							/>
@@ -306,6 +328,7 @@ export const SecretDialog: FC<SecretDialogProps> = ({
 
 type SecretFieldsProps = {
 	getFieldHelpers: ReturnType<typeof getFormHelpers<SecretFormValues>>;
+	filePathEnabled: boolean;
 	disableName?: boolean;
 	showRequiredLabels?: boolean;
 	showValue: boolean;
@@ -313,10 +336,18 @@ type SecretFieldsProps = {
 
 const SecretFields: FC<SecretFieldsProps> = ({
 	getFieldHelpers,
+	filePathEnabled,
 	disableName,
 	showRequiredLabels,
 	showValue,
 }) => {
+	const envNameRequired = Boolean(showRequiredLabels && !filePathEnabled);
+	const envNameHelperText = envNameRequired
+		? "Required. File path delivery is disabled, so the secret needs an environment variable target."
+		: filePathEnabled
+			? "Optional. Exposes the secret as an environment variable with this name in your workspace."
+			: "Environment variable delivery remains available while file path delivery is disabled.";
+
 	return (
 		<>
 			<FormField
@@ -343,30 +374,38 @@ const SecretFields: FC<SecretFieldsProps> = ({
 			/>
 			<FormField
 				field={getFieldHelpers("env_name", {
-					helperText:
-						"Optional. Exposes the secret as an environment variable with this name in your workspace.",
+					helperText: envNameHelperText,
 				})}
-				label="Environment variable"
+				label={
+					envNameRequired ? (
+						<RequiredFieldLabel>Environment variable</RequiredFieldLabel>
+					) : (
+						"Environment variable"
+					)
+				}
 				placeholder="SERVICE_TOKEN"
 				autoComplete="off"
 				className="placeholder:text-content-disabled"
+				aria-required={envNameRequired}
 				data-lpignore="true"
 				data-1p-ignore="true"
 				data-form-type="other"
 			/>
-			<FormField
-				field={getFieldHelpers("file_path", {
-					helperText:
-						"Optional. Exposes the secret as a file at this path in your workspace. Path must start with ~/ or /.",
-				})}
-				label="File path"
-				placeholder="~/api-key.txt"
-				autoComplete="off"
-				className="placeholder:text-content-disabled"
-				data-lpignore="true"
-				data-1p-ignore="true"
-				data-form-type="other"
-			/>
+			{filePathEnabled && (
+				<FormField
+					field={getFieldHelpers("file_path", {
+						helperText:
+							"Optional. Exposes the secret as a file at this path in your workspace. Path must start with ~/ or /.",
+					})}
+					label="File path"
+					placeholder="~/api-key.txt"
+					autoComplete="off"
+					className="placeholder:text-content-disabled"
+					data-lpignore="true"
+					data-1p-ignore="true"
+					data-form-type="other"
+				/>
+			)}
 			{showValue && (
 				<SecretValueField
 					field={getFieldHelpers("value")}
@@ -375,6 +414,52 @@ const SecretFields: FC<SecretFieldsProps> = ({
 				/>
 			)}
 		</>
+	);
+};
+
+type BlockedFilePathFieldProps = {
+	storedFilePath: string;
+	isRemoved: boolean;
+	onRemove: () => void;
+	onRestore: () => void;
+};
+
+const BlockedFilePathField: FC<BlockedFilePathFieldProps> = ({
+	storedFilePath,
+	isRemoved,
+	onRemove,
+	onRestore,
+}) => {
+	return (
+		<div className="flex flex-col gap-2">
+			<span className="text-sm font-medium text-content-primary">
+				File path
+			</span>
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<span
+					className={cn(
+						"flex-1 font-mono text-sm text-content-secondary",
+						isRemoved && "line-through",
+					)}
+				>
+					{storedFilePath}
+				</span>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="shrink-0"
+					onClick={isRemoved ? onRestore : onRemove}
+				>
+					{isRemoved ? "Keep file path" : "Remove file path"}
+				</Button>
+			</div>
+			<span className="text-xs text-content-secondary">
+				{isRemoved
+					? "File path will be removed when you update. If this enabled secret has no environment variable, the same update will disable it."
+					: "Your deployment administrator disabled file path secrets. This path stays saved but is not written to your workspaces, and it takes effect again if file path secrets are enabled."}
+			</span>
+		</div>
 	);
 };
 

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPage.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPage.tsx
@@ -10,12 +10,14 @@ import {
 	userSecrets,
 } from "#/api/queries/userSecrets";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useUserSecretFilePathEnabled } from "#/hooks/useEmbeddedMetadata";
 import { SecretsPageView } from "./SecretsPageView";
 import { buildImportSuccessMessage } from "./secretForm";
 
 const SecretsPage: FC = () => {
 	const { user: me } = useAuthenticated();
 	const queryClient = useQueryClient();
+	const filePathEnabled = useUserSecretFilePathEnabled();
 	const secretsQueryOptions = userSecrets(me.id);
 	const secretsQuery = useQuery(secretsQueryOptions);
 	const createSecretMutation = useMutation(
@@ -34,6 +36,7 @@ const SecretsPage: FC = () => {
 	return (
 		<SecretsPageView
 			secrets={secretsQuery.data}
+			filePathEnabled={filePathEnabled}
 			isLoading={!secretsQuery.isFetched && secretsQuery.isFetching}
 			hasLoaded={secretsQuery.isSuccess}
 			isCreating={createSecretMutation.isPending}

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from "#/api/typesGenerated";
 import { createDeferred } from "#/testHelpers/deferred";
 import {
+	MockDisabledFileOnlyUserSecret,
 	MockImportedUserSecrets,
 	MockUserSecrets,
 	mockApiError,
@@ -929,5 +930,359 @@ export const ToggleEnabledDisabledForTargetlessSecret: Story = {
 		});
 		await expect(toggle).not.toBeChecked();
 		await expect(toggle).toBeDisabled();
+	},
+};
+
+const FILE_PATH_DISABLED_NOTICE =
+	/Your deployment administrator disabled file path secrets/;
+const fileOnlySecret = findVisibleSecretByName("config-json");
+const dualTargetSecret = findVisibleSecretByName("SERVICE_API_KEY");
+const filePathDisabledSecrets = [
+	...visibleSecrets,
+	MockDisabledFileOnlyUserSecret,
+];
+
+export const FilePathEnabled: Story = {
+	args: {
+		filePathEnabled: true,
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await expect(canvas.queryByText(FILE_PATH_DISABLED_NOTICE)).toBeNull();
+		const fileOnlyRow = within(
+			canvas.getByRole("row", { name: new RegExp(fileOnlySecret.name) }),
+		);
+		await expect(fileOnlyRow.getByText("file")).toBeVisible();
+		await expect(
+			fileOnlyRow.queryByText("Saved, not written to workspaces"),
+		).toBeNull();
+		await expect(canvas.getByText("env var + file")).toBeVisible();
+
+		await user.click(canvas.getByRole("button", { name: "Add secret" }));
+		const dialog = within(await body.findByRole("dialog"));
+		await expect(dialog.getByLabelText("File path")).toBeEnabled();
+	},
+};
+
+export const FilePathFallsBackToEnabledWithoutMetadata: Story = {
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		// No `filePathEnabled` arg stands in for a deployment that does not
+		// report the setting, which must keep file paths available.
+		await expect(canvas.queryByText(FILE_PATH_DISABLED_NOTICE)).toBeNull();
+		await user.click(canvas.getByRole("button", { name: "Add secret" }));
+		const dialog = within(await body.findByRole("dialog"));
+		await expect(dialog.getByLabelText("File path")).toBeEnabled();
+	},
+};
+
+export const FilePathDisabledSecretsTable: Story = {
+	args: {
+		filePathEnabled: false,
+		secrets: filePathDisabledSecrets,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await expect(canvas.getByText(FILE_PATH_DISABLED_NOTICE)).toBeVisible();
+
+		const dualTargetRow = within(
+			canvas.getByRole("row", { name: new RegExp(dualTargetSecret.name) }),
+		);
+		await expect(dualTargetRow.getByText("env var")).toBeVisible();
+		await expect(
+			dualTargetRow.getByText(dualTargetSecret.file_path),
+		).toBeVisible();
+		await expect(
+			dualTargetRow.getByRole("switch", {
+				name: `Toggle secret ${dualTargetSecret.name}`,
+			}),
+		).toBeChecked();
+
+		const fileOnlyRow = within(
+			canvas.getByRole("row", { name: new RegExp(fileOnlySecret.name) }),
+		);
+		await expect(fileOnlyRow.getByText("not injected")).toBeVisible();
+		await expect(fileOnlyRow.getByText(fileOnlySecret.file_path)).toBeVisible();
+		await expect(
+			fileOnlyRow.getByText("Saved, not written to workspaces"),
+		).toBeVisible();
+
+		await expect(canvas.queryByText("env var + file")).toBeNull();
+		await expect(canvas.queryByText("file")).toBeNull();
+	},
+};
+
+const filePathDisabledCreateSecret = fn<
+	(request: CreateUserSecretRequest) => Promise<UserSecret>
+>(async (request) => createSecretFromRequest(request));
+
+export const FilePathDisabledAddSecretOmitsFileTarget: Story = {
+	args: {
+		filePathEnabled: false,
+		onCreateSecret: filePathDisabledCreateSecret,
+	},
+	beforeEach: () => {
+		filePathDisabledCreateSecret.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await user.click(canvas.getByRole("button", { name: "Add secret" }));
+		const dialog = within(await body.findByRole("dialog"));
+		await expect(dialog.queryByLabelText("File path")).toBeNull();
+		await expect(dialog.queryByText("File path")).toBeNull();
+		await expect(dialog.getByLabelText("Environment variable")).toBeRequired();
+
+		await user.type(dialog.getByLabelText("Name"), "example-secret");
+		await user.type(
+			dialog.getByLabelText("Environment variable"),
+			"EXAMPLE_SECRET",
+		);
+		await user.type(dialog.getByLabelText("Value"), PLACEHOLDER_INPUT);
+		await user.click(dialog.getByRole("button", { name: "Save" }));
+
+		await waitFor(() =>
+			expect(filePathDisabledCreateSecret).toHaveBeenCalledTimes(1),
+		);
+		expect(filePathDisabledCreateSecret).toHaveBeenCalledWith({
+			name: "example-secret",
+			env_name: "EXAMPLE_SECRET",
+			value: PLACEHOLDER_INPUT,
+		});
+		await waitForDialogToClose(body);
+	},
+};
+
+const filePathDisabledKeepStoredPath = fn<
+	(name: string, request: UpdateUserSecretRequest) => Promise<UserSecret>
+>(async (name) => findVisibleSecretByName(name));
+
+export const FilePathDisabledKeepsStoredPathOnUnrelatedEdit: Story = {
+	args: {
+		filePathEnabled: false,
+		onUpdateSecret: filePathDisabledKeepStoredPath,
+	},
+	beforeEach: () => {
+		filePathDisabledKeepStoredPath.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await user.click(
+			canvas.getByRole("button", {
+				name: `Open secret actions for ${fileOnlySecret.name}`,
+			}),
+		);
+		await user.click(
+			await body.findByRole("menuitem", { name: "Edit secret" }),
+		);
+
+		const dialog = within(await body.findByRole("dialog"));
+		await expect(dialog.queryByLabelText("File path")).toBeNull();
+		await waitFor(() =>
+			expect(dialog.getByText(fileOnlySecret.file_path)).toBeVisible(),
+		);
+		expect(dialog.getByText(FILE_PATH_DISABLED_NOTICE)).toBeVisible();
+		expect(
+			dialog.getByText(
+				"Environment variable delivery remains available while file path delivery is disabled.",
+			),
+		).toBeVisible();
+
+		const description = dialog.getByLabelText("Description");
+		await user.clear(description);
+		await user.type(description, "Still stored, not written");
+		await user.click(dialog.getByRole("button", { name: "Update" }));
+
+		await waitFor(() =>
+			expect(filePathDisabledKeepStoredPath).toHaveBeenCalledTimes(1),
+		);
+		expect(filePathDisabledKeepStoredPath).toHaveBeenCalledWith(
+			fileOnlySecret.name,
+			{ description: "Still stored, not written" },
+		);
+		await waitForDialogToClose(body);
+	},
+};
+
+const filePathDisabledRemoveStoredPath = fn<
+	(name: string, request: UpdateUserSecretRequest) => Promise<UserSecret>
+>(async (name) => findVisibleSecretByName(name));
+
+export const FilePathDisabledRemovesStoredPath: Story = {
+	args: {
+		filePathEnabled: false,
+		onUpdateSecret: filePathDisabledRemoveStoredPath,
+	},
+	beforeEach: () => {
+		filePathDisabledRemoveStoredPath.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await user.click(
+			canvas.getByRole("button", {
+				name: `Open secret actions for ${fileOnlySecret.name}`,
+			}),
+		);
+		await user.click(
+			await body.findByRole("menuitem", { name: "Edit secret" }),
+		);
+
+		const dialog = within(await body.findByRole("dialog"));
+		const updateButton = dialog.getByRole("button", { name: "Update" });
+		await expect(updateButton).toBeDisabled();
+
+		await user.click(dialog.getByRole("button", { name: "Remove file path" }));
+		await expect(
+			dialog.getByText(
+				"File path will be removed when you update. If this enabled secret has no environment variable, the same update will disable it.",
+			),
+		).toBeVisible();
+		await expect(updateButton).toBeEnabled();
+
+		await user.click(dialog.getByRole("button", { name: "Keep file path" }));
+		await expect(updateButton).toBeDisabled();
+
+		await user.click(dialog.getByRole("button", { name: "Remove file path" }));
+		await user.click(updateButton);
+
+		await waitFor(() =>
+			expect(filePathDisabledRemoveStoredPath).toHaveBeenCalledTimes(1),
+		);
+		expect(filePathDisabledRemoveStoredPath).toHaveBeenCalledWith(
+			fileOnlySecret.name,
+			{ file_path: "", enabled: false },
+		);
+		await waitForDialogToClose(body);
+	},
+};
+
+const filePathDisabledToggleSecret = fn<
+	(secret: UserSecret, enabled: boolean) => Promise<void>
+>(async () => {});
+
+export const FilePathDisabledBlocksEnablingFileOnlySecret: Story = {
+	args: {
+		filePathEnabled: false,
+		secrets: filePathDisabledSecrets,
+		onToggleSecretEnabled: filePathDisabledToggleSecret,
+	},
+	beforeEach: () => {
+		filePathDisabledToggleSecret.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		const toggle = canvas.getByRole("switch", {
+			name: `Toggle secret ${MockDisabledFileOnlyUserSecret.name}`,
+		});
+		await expect(toggle).not.toBeChecked();
+		await expect(toggle).toBeDisabled();
+
+		await user.click(toggle);
+		expect(filePathDisabledToggleSecret).not.toHaveBeenCalled();
+
+		await user.hover(toggle);
+		await waitFor(() => {
+			const [tooltip] = body.getAllByText(
+				"Add an environment variable before enabling this secret. Your deployment administrator disabled file path secrets.",
+			);
+			expect(tooltip).toBeVisible();
+		});
+	},
+};
+
+const filePathDisabledAddEnvName = fn<
+	(name: string, request: UpdateUserSecretRequest) => Promise<UserSecret>
+>(async () => MockDisabledFileOnlyUserSecret);
+
+export const FilePathDisabledAddsEnvNameToFileOnlySecret: Story = {
+	args: {
+		filePathEnabled: false,
+		secrets: filePathDisabledSecrets,
+		onUpdateSecret: filePathDisabledAddEnvName,
+	},
+	beforeEach: () => {
+		filePathDisabledAddEnvName.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await user.click(
+			canvas.getByRole("button", {
+				name: `Open secret actions for ${MockDisabledFileOnlyUserSecret.name}`,
+			}),
+		);
+		await user.click(
+			await body.findByRole("menuitem", { name: "Edit secret" }),
+		);
+
+		const dialog = within(await body.findByRole("dialog"));
+		const envField = dialog.getByLabelText("Environment variable");
+		await user.click(envField);
+		await user.type(envField, "LEGACY_KUBECONFIG");
+		await waitFor(() => expect(envField).toHaveValue("LEGACY_KUBECONFIG"));
+		await user.click(dialog.getByRole("button", { name: "Update" }));
+
+		await waitFor(() =>
+			expect(filePathDisabledAddEnvName).toHaveBeenCalledTimes(1),
+		);
+		expect(filePathDisabledAddEnvName).toHaveBeenCalledWith(
+			MockDisabledFileOnlyUserSecret.name,
+			{ env_name: "LEGACY_KUBECONFIG" },
+		);
+		await waitForDialogToClose(body);
+	},
+};
+
+const filePathDisabledDeleteSecret = fn<(secret: UserSecret) => void>();
+
+export const FilePathDisabledDeletesFileOnlySecret: Story = {
+	args: {
+		filePathEnabled: false,
+		secrets: filePathDisabledSecrets,
+		onDeleteSecret: filePathDisabledDeleteSecret,
+	},
+	beforeEach: () => {
+		filePathDisabledDeleteSecret.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+
+		await user.click(
+			canvas.getByRole("button", {
+				name: `Open secret actions for ${MockDisabledFileOnlyUserSecret.name}`,
+			}),
+		);
+		await user.click(await body.findByRole("menuitem", { name: "Delete" }));
+		await user.click(await body.findByRole("button", { name: "Delete" }));
+
+		await waitFor(() =>
+			expect(filePathDisabledDeleteSecret).toHaveBeenCalledTimes(1),
+		);
+		expect(filePathDisabledDeleteSecret).toHaveBeenCalledWith(
+			MockDisabledFileOnlyUserSecret,
+		);
+		await waitForDialogToClose(body);
 	},
 };

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx
@@ -19,6 +19,9 @@ import { SecretsTable } from "./SecretsTable";
 
 type SecretsPageViewProps = {
 	secrets?: readonly UserSecret[];
+	// Undefined when the deployment does not report the setting, which the page
+	// treats as file paths being allowed.
+	filePathEnabled?: boolean;
 	isLoading: boolean;
 	hasLoaded: boolean;
 	isCreating: boolean;
@@ -46,6 +49,7 @@ type SecretDialogState =
 
 export const SecretsPageView: FC<SecretsPageViewProps> = ({
 	secrets = [],
+	filePathEnabled = true,
 	isLoading,
 	hasLoaded,
 	isCreating,
@@ -106,15 +110,16 @@ export const SecretsPageView: FC<SecretsPageViewProps> = ({
 			>
 				<SettingsHeaderTitle>Secrets</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
-					Secrets with an environment variable or file path are injected into
-					workspaces you own when they start. Each environment variable and file
-					path must be unique.
+					{filePathEnabled
+						? "Secrets with an environment variable or file path are injected into workspaces you own when they start. Each environment variable and file path must be unique."
+						: "Secrets with an environment variable are injected into workspaces you own when they start. Each environment variable must be unique. Your deployment administrator disabled file path secrets, so saved file paths stay stored but are not written to your workspaces, and they take effect again if file path secrets are enabled."}
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 
 			<SecretDialog
 				open={dialogState.open}
 				secret={dialogSecret}
+				filePathEnabled={filePathEnabled}
 				isSubmitting={isCreating || isUpdating}
 				returnFocusElement={secretDialogReturnFocusElement.current}
 				onClose={closeSecretDialog}
@@ -128,6 +133,7 @@ export const SecretsPageView: FC<SecretsPageViewProps> = ({
 			<section className="flex flex-col gap-4">
 				<SecretsTable
 					secrets={secrets}
+					filePathEnabled={filePathEnabled}
 					isLoading={isLoading}
 					hasLoaded={hasLoadedSecrets}
 					isDeleting={isDeleting}

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsTable.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsTable.tsx
@@ -28,9 +28,14 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { relativeTime } from "#/utils/time";
+import {
+	getSecretInjectionSummary,
+	type SecretInjectionSummary,
+} from "./secretForm";
 
 type SecretsTableProps = {
 	secrets?: readonly UserSecret[];
+	filePathEnabled: boolean;
 	isLoading: boolean;
 	hasLoaded: boolean;
 	isDeleting: boolean;
@@ -48,6 +53,7 @@ type SecretsTableProps = {
 
 export const SecretsTable: FC<SecretsTableProps> = ({
 	secrets,
+	filePathEnabled,
 	isLoading,
 	hasLoaded,
 	isDeleting,
@@ -120,52 +126,66 @@ export const SecretsTable: FC<SecretsTableProps> = ({
 						/>
 					)}
 					{!isLoading &&
-						secrets?.map((secret) => (
-							<TableRow key={secret.id}>
-								<TableCell>
-									<EnabledToggle
-										secret={secret}
-										isPending={togglingSecretId === secret.id}
-										onToggle={handleToggle}
-									/>
-								</TableCell>
-								<TableCell className="font-semibold text-content-primary">
-									<span>{secret.name}</span>
-								</TableCell>
-								<TableCell>
-									<OptionalSecretValue value={secret.env_name} />
-								</TableCell>
-								<TableCell>
-									<OptionalSecretValue value={secret.file_path} />
-								</TableCell>
-								<TableCell>
-									<SecretTypeBadge secret={secret} />
-								</TableCell>
-								<TableCell className="max-w-0">
-									{secret.description ? (
-										<span className="block truncate" title={secret.description}>
-											{secret.description}
-										</span>
-									) : (
-										<span className="text-content-disabled">
-											No description
-										</span>
-									)}
-								</TableCell>
-								<TableCell data-pixel="ignore" className="whitespace-nowrap">
-									{relativeTime(secret.updated_at)}
-								</TableCell>
-								<TableCell>
-									<div className="flex justify-end flex-1">
-										<SecretRowActions
+						secrets?.map((secret) => {
+							const injection = getSecretInjectionSummary(
+								secret,
+								filePathEnabled,
+							);
+
+							return (
+								<TableRow key={secret.id}>
+									<TableCell>
+										<EnabledToggle
 											secret={secret}
-											onEditSecret={onEditSecret}
-											onDeleteSecret={setSecretToDelete}
+											injection={injection}
+											isPending={togglingSecretId === secret.id}
+											onToggle={handleToggle}
 										/>
-									</div>
-								</TableCell>
-							</TableRow>
-						))}
+									</TableCell>
+									<TableCell className="font-semibold text-content-primary">
+										<span>{secret.name}</span>
+									</TableCell>
+									<TableCell>
+										<OptionalSecretValue value={secret.env_name} />
+									</TableCell>
+									<TableCell>
+										<FilePathValue
+											filePath={secret.file_path}
+											isBlocked={injection.hasBlockedFilePath}
+										/>
+									</TableCell>
+									<TableCell>
+										<Badge>{injection.typeLabel}</Badge>
+									</TableCell>
+									<TableCell className="max-w-0">
+										{secret.description ? (
+											<span
+												className="block truncate"
+												title={secret.description}
+											>
+												{secret.description}
+											</span>
+										) : (
+											<span className="text-content-disabled">
+												No description
+											</span>
+										)}
+									</TableCell>
+									<TableCell data-pixel="ignore" className="whitespace-nowrap">
+										{relativeTime(secret.updated_at)}
+									</TableCell>
+									<TableCell>
+										<div className="flex justify-end flex-1">
+											<SecretRowActions
+												secret={secret}
+												onEditSecret={onEditSecret}
+												onDeleteSecret={setSecretToDelete}
+											/>
+										</div>
+									</TableCell>
+								</TableRow>
+							);
+						})}
 				</TableBody>
 			</Table>
 		</>
@@ -183,40 +203,46 @@ const OptionalSecretValue: FC<{ value?: string; fallback?: string }> = ({
 	return <span className="text-content-disabled">{fallback}</span>;
 };
 
-const SecretTypeBadge: FC<{ secret: UserSecret }> = ({ secret }) => {
-	const hasEnv = Boolean(secret.env_name);
-	const hasFile = Boolean(secret.file_path);
+type FilePathValueProps = {
+	filePath: string;
+	isBlocked: boolean;
+};
 
-	if (hasEnv && hasFile) {
-		return <Badge>env var + file</Badge>;
+const FilePathValue: FC<FilePathValueProps> = ({ filePath, isBlocked }) => {
+	if (!filePath) {
+		return <OptionalSecretValue value={filePath} />;
 	}
 
-	if (hasEnv) {
-		return <Badge>env var</Badge>;
+	if (!isBlocked) {
+		return filePath;
 	}
 
-	if (hasFile) {
-		return <Badge>file</Badge>;
-	}
-
-	return <Badge>not injected</Badge>;
+	return (
+		<div className="flex flex-col">
+			<span className="text-content-disabled">{filePath}</span>
+			<span className="text-xs text-content-disabled">
+				Saved, not written to workspaces
+			</span>
+		</div>
+	);
 };
 
 type EnabledToggleProps = {
 	secret: UserSecret;
+	injection: SecretInjectionSummary;
 	isPending: boolean;
 	onToggle: (secret: UserSecret, enabled: boolean) => void;
 };
 
 const EnabledToggle: FC<EnabledToggleProps> = ({
 	secret,
+	injection,
 	isPending,
 	onToggle,
 }) => {
-	const hasTarget = Boolean(secret.env_name) || Boolean(secret.file_path);
-	// An enabled secret must have at least one injection target. Prevent
-	// enabling a target-less secret; the user must add a target first.
-	const cannotEnable = !secret.enabled && !hasTarget;
+	// An enabled secret must have at least one effective injection target.
+	// Prevent enabling a secret that has none; the user must add a target first.
+	const cannotEnable = !secret.enabled && !injection.canEnable;
 
 	return (
 		<Tooltip>
@@ -238,7 +264,9 @@ const EnabledToggle: FC<EnabledToggleProps> = ({
 			</TooltipTrigger>
 			{cannotEnable && (
 				<TooltipContent side="top">
-					Add an environment variable or file path before enabling this secret.
+					{injection.hasBlockedFilePath
+						? "Add an environment variable before enabling this secret. Your deployment administrator disabled file path secrets."
+						: "Add an environment variable or file path before enabling this secret."}
 				</TooltipContent>
 			)}
 		</Tooltip>

--- a/site/src/pages/UserSettingsPage/SecretsPage/secretForm.test.ts
+++ b/site/src/pages/UserSettingsPage/SecretsPage/secretForm.test.ts
@@ -5,6 +5,7 @@ import {
 	buildImportSuccessMessage,
 	buildUpdateUserSecretRequest,
 	getCreateSecretRequiredFieldErrors,
+	getSecretInjectionSummary,
 	mapSecretApiErrorToFormErrors,
 	secretsFileFormatFromFilename,
 } from "./secretForm";
@@ -90,6 +91,7 @@ describe("getCreateSecretRequiredFieldErrors", () => {
 			getCreateSecretRequiredFieldErrors({
 				name: "",
 				value: "",
+				env_name: "",
 			}),
 		).toEqual({
 			name: "Name is required.",
@@ -102,10 +104,40 @@ describe("getCreateSecretRequiredFieldErrors", () => {
 			getCreateSecretRequiredFieldErrors({
 				name: "   ",
 				value: "some value",
+				env_name: "",
 			}),
 		).toEqual({
 			name: "Name is required.",
 		});
+	});
+
+	it("requires an environment variable when file path delivery is disabled", () => {
+		expect(
+			getCreateSecretRequiredFieldErrors(
+				{
+					name: "service-token",
+					value: "some value",
+					env_name: "",
+				},
+				false,
+			),
+		).toEqual({
+			env_name:
+				"Environment variable is required when file path delivery is disabled.",
+		});
+	});
+
+	it("accepts an environment variable when file path delivery is disabled", () => {
+		expect(
+			getCreateSecretRequiredFieldErrors(
+				{
+					name: "service-token",
+					value: "some value",
+					env_name: "SERVICE_TOKEN",
+				},
+				false,
+			),
+		).toEqual({});
 	});
 });
 
@@ -171,6 +203,146 @@ describe("payload builders", () => {
 			),
 		).toEqual({
 			value: "",
+		});
+	});
+
+	it("omits a stored file path that the form leaves untouched", () => {
+		expect(
+			buildUpdateUserSecretRequest(existingSecrets[1], {
+				name: "service-key",
+				value: "",
+				description: "Updated description",
+				env_name: "SERVICE_API_KEY",
+				file_path: "~/.config/service/key",
+			}),
+		).toEqual({
+			description: "Updated description",
+		});
+	});
+
+	it("disables an enabled file-only secret when its blocked path is removed", () => {
+		const secret = {
+			...existingSecrets[1],
+			env_name: "",
+			file_path: "~/.config/service/key",
+			enabled: true,
+		};
+
+		expect(
+			buildUpdateUserSecretRequest(
+				secret,
+				{
+					name: secret.name,
+					value: "",
+					description: secret.description,
+					env_name: "",
+					file_path: "",
+				},
+				{ filePathEnabled: false },
+			),
+		).toEqual({
+			file_path: "",
+			enabled: false,
+		});
+	});
+
+	it("keeps enabled intent when adding env and removing a blocked path", () => {
+		const secret = {
+			...existingSecrets[1],
+			env_name: "",
+			file_path: "~/.config/service/key",
+			enabled: true,
+		};
+
+		expect(
+			buildUpdateUserSecretRequest(
+				secret,
+				{
+					name: secret.name,
+					value: "",
+					description: secret.description,
+					env_name: "SERVICE_API_KEY",
+					file_path: "",
+				},
+				{ filePathEnabled: false },
+			),
+		).toEqual({
+			env_name: "SERVICE_API_KEY",
+			file_path: "",
+		});
+	});
+});
+
+describe("getSecretInjectionSummary", () => {
+	it("describes every target while file paths are allowed", () => {
+		expect(
+			getSecretInjectionSummary(
+				{ env_name: "SERVICE_TOKEN", file_path: "~/.config/service/key" },
+				true,
+			),
+		).toEqual({
+			injectsEnv: true,
+			injectsFile: true,
+			hasBlockedFilePath: false,
+			canEnable: true,
+			typeLabel: "env var + file",
+		});
+	});
+
+	it("keeps the environment variable of a dual-target secret effective", () => {
+		expect(
+			getSecretInjectionSummary(
+				{ env_name: "SERVICE_TOKEN", file_path: "~/.config/service/key" },
+				false,
+			),
+		).toEqual({
+			injectsEnv: true,
+			injectsFile: false,
+			hasBlockedFilePath: true,
+			canEnable: true,
+			typeLabel: "env var",
+		});
+	});
+
+	it("reports a file-only secret as ineffective while file paths are blocked", () => {
+		expect(
+			getSecretInjectionSummary(
+				{ env_name: "", file_path: "~/.config/service/key" },
+				false,
+			),
+		).toEqual({
+			injectsEnv: false,
+			injectsFile: false,
+			hasBlockedFilePath: true,
+			canEnable: false,
+			typeLabel: "not injected",
+		});
+	});
+
+	it("reports a file-only secret as a file target while file paths are allowed", () => {
+		expect(
+			getSecretInjectionSummary(
+				{ env_name: "", file_path: "~/.config/service/key" },
+				true,
+			),
+		).toEqual({
+			injectsEnv: false,
+			injectsFile: true,
+			hasBlockedFilePath: false,
+			canEnable: true,
+			typeLabel: "file",
+		});
+	});
+
+	it("reports a target-less secret as not injected", () => {
+		expect(
+			getSecretInjectionSummary({ env_name: "", file_path: "" }, false),
+		).toEqual({
+			injectsEnv: false,
+			injectsFile: false,
+			hasBlockedFilePath: false,
+			canEnable: false,
+			typeLabel: "not injected",
 		});
 	});
 });

--- a/site/src/pages/UserSettingsPage/SecretsPage/secretForm.ts
+++ b/site/src/pages/UserSettingsPage/SecretsPage/secretForm.ts
@@ -64,17 +64,68 @@ export const secretsFileFormatFromFilename = (
 };
 
 export const getCreateSecretRequiredFieldErrors = (
-	values: Pick<SecretFormValues, "name" | "value">,
+	values: Pick<SecretFormValues, "name" | "value" | "env_name">,
+	filePathEnabled = true,
 ): SecretFieldErrors => {
 	const errors: SecretFieldErrors = {};
 	if (values.name.trim() === "") {
 		errors.name = "Name is required.";
+	}
+	if (!filePathEnabled && values.env_name.trim() === "") {
+		errors.env_name =
+			"Environment variable is required when file path delivery is disabled.";
 	}
 	if (values.value === "") {
 		errors.value = "Value is required.";
 	}
 	return errors;
 };
+
+type SecretTypeLabel = "env var" | "file" | "env var + file" | "not injected";
+
+export interface SecretInjectionSummary {
+	injectsEnv: boolean;
+	injectsFile: boolean;
+	hasBlockedFilePath: boolean;
+	canEnable: boolean;
+	typeLabel: SecretTypeLabel;
+}
+
+// A deployment can disable file-path secrets. Stored file paths survive that
+// setting and become effective again once an administrator re-enables it, so
+// the effective targets are derived instead of read straight off the secret.
+export const getSecretInjectionSummary = (
+	secret: Pick<UserSecret, "env_name" | "file_path">,
+	filePathEnabled: boolean,
+): SecretInjectionSummary => {
+	const injectsEnv = secret.env_name !== "";
+	const hasFilePath = secret.file_path !== "";
+	const injectsFile = hasFilePath && filePathEnabled;
+
+	return {
+		injectsEnv,
+		injectsFile,
+		hasBlockedFilePath: hasFilePath && !filePathEnabled,
+		canEnable: injectsEnv || injectsFile,
+		typeLabel: getSecretTypeLabel(injectsEnv, injectsFile),
+	};
+};
+
+function getSecretTypeLabel(
+	injectsEnv: boolean,
+	injectsFile: boolean,
+): SecretTypeLabel {
+	if (injectsEnv && injectsFile) {
+		return "env var + file";
+	}
+	if (injectsEnv) {
+		return "env var";
+	}
+	if (injectsFile) {
+		return "file";
+	}
+	return "not injected";
+}
 
 export const buildCreateUserSecretRequest = (
 	values: SecretFormValues,
@@ -90,6 +141,7 @@ export const buildCreateUserSecretRequest = (
 
 type BuildUpdateUserSecretRequestOptions = {
 	clearValue?: boolean;
+	filePathEnabled?: boolean;
 };
 
 export const buildUpdateUserSecretRequest = (
@@ -97,6 +149,14 @@ export const buildUpdateUserSecretRequest = (
 	values: SecretFormValues,
 	options: BuildUpdateUserSecretRequestOptions = {},
 ): UpdateUserSecretRequest => {
+	const removesBlockedOnlyTarget =
+		options.filePathEnabled === false &&
+		secret.enabled &&
+		secret.file_path !== "" &&
+		values.file_path === "" &&
+		values.file_path !== secret.file_path &&
+		values.env_name === "";
+
 	return {
 		...(options.clearValue
 			? { value: "" }
@@ -112,6 +172,7 @@ export const buildUpdateUserSecretRequest = (
 		...(values.file_path !== secret.file_path
 			? { file_path: values.file_path }
 			: {}),
+		...(removesBlockedOnlyTarget ? { enabled: false } : {}),
 	};
 };
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -627,6 +627,20 @@ export const MockUserSecrets: TypesGen.UserSecret[] = [
 	},
 ];
 
+// A file-only secret that its owner disabled. While a deployment blocks
+// file-path secrets it stays ineligible for enabling until it gains an
+// environment variable target.
+export const MockDisabledFileOnlyUserSecret: TypesGen.UserSecret = {
+	id: "secret-file-only-disabled",
+	name: "legacy-kubeconfig",
+	description: "Written to a workspace file before file paths were disabled.",
+	env_name: "",
+	file_path: "~/.kube/config",
+	enabled: false,
+	created_at: "2026-04-27T16:30:00Z",
+	updated_at: "2026-05-03T20:30:00Z",
+};
+
 export const MockImportedUserSecret: TypesGen.UserSecret = {
 	id: "imported-database-url",
 	name: "DATABASE_URL",
@@ -650,6 +664,7 @@ export const MockImportedUserSecrets: TypesGen.UserSecret[] = [
 
 export const MockAITasksEnabled: boolean = false;
 export const MockAIGatewayEnabled: boolean = true;
+export const MockUserSecretFilePathEnabled: boolean = true;
 
 export const MockOrganizationMember: TypesGen.OrganizationMemberWithUserData = {
 	organization_id: MockOrganization.id,


### PR DESCRIPTION
## Summary

Updates the Secrets dashboard to present effective delivery rather than stored fields alone.

When file delivery is blocked, new secrets require an environment target and cannot create file targets. Legacy paths remain visible as stored but blocked, dual-target rows keep environment delivery, file-only rows show `not injected`, and disabled file-only rows cannot be enabled until an environment target is added. Users can explicitly remove a blocked path, add an environment target, atomically clear the sole path while disabling, or delete the secret.

## Stack

**5 of 6: dashboard behavior**

Depends on #28509 for embedded capability metadata and runtime enforcement. The final PR adds CLI copy and operator/user migration documentation.

## Validation

- 36 focused form/helper unit tests
- 37 Storybook interaction tests covering policy on/off, missing-metadata fallback, env-only creation, legacy dual/file-only states, cleanup, failed enable, environment migration, and deletion
- `pnpm check`, `pnpm lint`, and `pnpm format`
- Frontend review FE1 through FE10: all pass
- `make pre-commit`

## Rollout and compatibility

Missing metadata falls back to file delivery enabled for older servers, Storybook, and development fixtures. The server remains authoritative and no stored path or `enabled` intent changes without an explicit user action.

<details>
<summary>Decision and implementation summary</summary>

- Derive effective targets from the capability plus stored `env_name`, `file_path`, and `enabled` fields.
- Keep legacy paths visible so users can identify and remove them.
- Do not add API effective-target fields or entitlement-backed feature flags.
- Explain that preserved paths can become effective again if an administrator turns delivery back on.

</details>

Refs #27488

This PR was generated by Coder Agents on behalf of @dylanhuff-at-coder.
