### PR TITLE
feat(site): return a queued chat message to the composer

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -3488,6 +3488,92 @@ export const QueuedSendPromotesPreviousHead: Story = {
 	},
 };
 
+const queuedEditChat: TypesGen.Chat = {
+	id: CHAT_ID,
+	...baseChatFields,
+	title: "Queued message edit",
+	status: "running",
+};
+
+const queuedEditMessages: TypesGen.ChatMessagesResponse = {
+	messages: compactCommandMessages.messages,
+	queued_messages: [
+		{
+			...MockChatQueuedMessage,
+			id: 61,
+			chat_id: CHAT_ID,
+			content: [{ type: "text", text: "Queued prompt" }],
+		},
+	],
+	has_more: false,
+};
+
+export const EditQueuedMessageReturnsItToComposer: Story = {
+	parameters: {
+		queries: buildQueries(queuedEditChat, queuedEditMessages, {
+			diffUrl: undefined,
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getUserSkills").mockResolvedValue([]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const deleteSpy = spyOn(
+			API.experimental,
+			"deleteChatQueuedMessage",
+		).mockResolvedValue(undefined);
+		// The delete invalidates the messages query; the refetch must show
+		// the drained queue.
+		spyOn(API.experimental, "getChatMessages").mockResolvedValue({
+			...queuedEditMessages,
+			queued_messages: [],
+		});
+		const sendSpy = spyOn(
+			API.experimental,
+			"createChatMessage",
+		).mockResolvedValue({
+			queued: true,
+			messages: [],
+			queued_message: {
+				...MockChatQueuedMessage,
+				id: 62,
+				chat_id: CHAT_ID,
+				content: [{ type: "text", text: "Queued prompt edited" }],
+			},
+		});
+
+		await userEvent.click(
+			await canvas.findByRole("button", { name: "Edit queued message" }),
+		);
+
+		await waitFor(() => {
+			expect(deleteSpy).toHaveBeenCalledWith(CHAT_ID, 61);
+		});
+		const editor = await canvas.findByTestId("chat-message-input");
+		await waitFor(() => expect(editor).toHaveTextContent("Queued prompt"));
+		expect(
+			canvas.queryByRole("button", { name: "Cancel editing" }),
+		).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", { name: "Edit queued message" }),
+		).not.toBeInTheDocument();
+
+		await userEvent.click(editor);
+		await userEvent.type(editor, " edited");
+		await userEvent.keyboard("{Enter}");
+
+		await waitFor(() => {
+			expect(sendSpy).toHaveBeenCalledWith(
+				CHAT_ID,
+				expect.objectContaining({
+					content: [{ type: "text", text: "Queued prompt edited" }],
+				}),
+			);
+		});
+	},
+};
+
 const switchedChat: TypesGen.Chat = {
 	id: SWITCHED_CHAT_ID,
 	...baseChatFields,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -101,6 +101,7 @@ import {
 	useChatSelector,
 	useChatStore,
 } from "./components/ChatConversation/chatStore";
+import { getEditableContentPayload } from "./components/ChatConversation/messageParsing";
 import { useChatToolInvalidations } from "./components/ChatConversation/useChatToolInvalidations";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { workspaceSkillsFromChat } from "./components/ChatPageContent";
@@ -585,6 +586,30 @@ export function useConversationEditingState(deps: {
 		setEditingFileBlocks(fileBlocks ?? []);
 	};
 
+	const loadDraftIntoComposer = (text: string) => {
+		setDraftState({
+			editorInitialValue: text,
+			initialEditorState: undefined,
+		});
+		serializedEditorStateRef.current = undefined;
+		setRemountKey((k) => k + 1);
+		inputValueRef.current = text;
+		if (draftStorageKey) {
+			try {
+				// Plain text is the legacy draft format parseStoredDraft still reads.
+				localStorage.setItem(draftStorageKey, text);
+			} catch {
+				// QuotaExceededError, silently discard the draft.
+			}
+		}
+		// Focus after the remount swaps in the new editor instance.
+		setTimeout(() => {
+			if (!isMobileViewport()) {
+				chatInputRef.current?.focus();
+			}
+		}, 0);
+	};
+
 	const handleCancelHistoryEdit = () => {
 		const savedText = draftBeforeHistoryEdit?.text ?? "";
 		const savedState = draftBeforeHistoryEdit?.editorState;
@@ -725,6 +750,7 @@ export function useConversationEditingState(deps: {
 		editingMessageId,
 		editingFileBlocks,
 		handleEditUserMessage,
+		loadDraftIntoComposer,
 		handleCancelHistoryEdit,
 		handleSendFromInput,
 		handleContentChange,
@@ -1498,6 +1524,28 @@ const AgentChatPage: FC = () => {
 		editing.handleEditUserMessage(...args);
 	};
 
+	const handleEditQueuedMessage = async (id: number) => {
+		const queuedMessage = store
+			.getSnapshot()
+			.queuedMessages.find((message) => message.id === id);
+		if (!queuedMessage) {
+			return;
+		}
+		const { text, fileBlocks } = getEditableContentPayload(
+			queuedMessage.content,
+		);
+		if (fileBlocks && fileBlocks.length > 0) {
+			return;
+		}
+		try {
+			await handleDeleteQueuedMessage(id);
+		} catch (error) {
+			toast.error(getErrorMessage(error, "Failed to edit queued message."));
+			throw error;
+		}
+		editing.loadDraftIntoComposer(text);
+	};
+
 	const chatTitle = chatQuery.data?.title;
 
 	const titleElement = (
@@ -2062,6 +2110,7 @@ const AgentChatPage: FC = () => {
 			handleInterrupt={handleInterrupt}
 			handleDeleteQueuedMessage={handleDeleteQueuedMessage}
 			handlePromoteQueuedMessage={handlePromoteQueuedMessage}
+			handleEditQueuedMessage={handleEditQueuedMessage}
 			onImplementPlan={handleImplementPlan}
 			onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
 			handleArchiveAgentAction={handleArchiveAgentAction}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -165,6 +165,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		handleInterrupt: fn(),
 		handleDeleteQueuedMessage: fn(),
 		handlePromoteQueuedMessage: fn(),
+		handleEditQueuedMessage: fn(),
 		handleArchiveAgentAction: fn(),
 		handleUnarchiveAgentAction: fn(),
 		handleArchiveAndDeleteWorkspaceAction: fn(),

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -192,6 +192,7 @@ interface AgentChatPageViewProps {
 	handleInterrupt: () => void;
 	handleDeleteQueuedMessage: (id: number) => Promise<void>;
 	handlePromoteQueuedMessage: (id: number) => Promise<void>;
+	handleEditQueuedMessage: (id: number) => Promise<void>;
 
 	onImplementPlan?: () => Promise<void> | void;
 	onSendAskUserQuestionResponse?: (message: string) => Promise<void> | void;
@@ -373,6 +374,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	handleInterrupt,
 	handleDeleteQueuedMessage,
 	handlePromoteQueuedMessage,
+	handleEditQueuedMessage,
 	onImplementPlan,
 	onSendAskUserQuestionResponse,
 	handleArchiveAgentAction,
@@ -999,6 +1001,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								onSend={editing.handleSendFromInput}
 								onDeleteQueuedMessage={handleDeleteQueuedMessage}
 								onPromoteQueuedMessage={handlePromoteQueuedMessage}
+								onEditQueuedMessage={handleEditQueuedMessage}
 								onInterrupt={handleInterrupt}
 								isInputDisabled={isInputDisabled}
 								isSendPending={isSubmissionPending}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -153,6 +153,7 @@ interface AgentChatInputProps {
 	queuedMessages?: readonly ChatQueuedMessage[];
 	onDeleteQueuedMessage?: (id: number) => Promise<void> | void;
 	onPromoteQueuedMessage?: (id: number) => Promise<void> | void;
+	onEditQueuedMessage?: (id: number) => Promise<void> | void;
 	// History editing state, owned by the parent.
 	isEditingHistoryMessage?: boolean;
 	onCancelHistoryEdit?: () => void;
@@ -376,6 +377,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	queuedMessages = [],
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
+	onEditQueuedMessage,
 	isEditingHistoryMessage = false,
 	onCancelHistoryEdit,
 	userPromptHistory = [],
@@ -1062,6 +1064,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 					messages={queuedMessages}
 					onDelete={(id) => onDeleteQueuedMessage?.(id)}
 					onPromote={(id) => onPromoteQueuedMessage?.(id)}
+					onEdit={onEditQueuedMessage}
+					editDisabledReason={
+						isComposerEffectivelyEmpty
+							? undefined
+							: "Send or clear the composer to edit a queued message."
+					}
 					className="mb-2"
 				/>
 			)}

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
@@ -325,14 +325,21 @@ export const getEditableUserMessagePayload = (
 ): {
 	text: string;
 	fileBlocks: readonly TypesGen.ChatMessagePart[] | undefined;
+} => getEditableContentPayload(message.content);
+
+export const getEditableContentPayload = (
+	content: readonly TypesGen.ChatMessagePart[] | undefined,
+): {
+	text: string;
+	fileBlocks: readonly TypesGen.ChatMessagePart[] | undefined;
 } => {
 	// Concatenate text parts verbatim to match the server-side string_agg in
 	// GetChatUserPromptsByChatID; parseMessageContent/appendText is for streaming and drops whitespace-only chunks.
-	const text = (message.content ?? [])
+	const text = (content ?? [])
 		.filter((part): part is TypesGen.ChatTextPart => part.type === "text")
 		.map((part) => part.text)
 		.join("");
-	const parsed = parseMessageContent(message.content);
+	const parsed = parseMessageContent(content);
 	const fileBlocks = parsed.blocks.filter(isEditableUserMessageFileBlock);
 	return {
 		text,

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -249,6 +249,7 @@ interface ChatPageInputProps {
 	sendShortcut: AgentChatSendShortcut;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
+	onEditQueuedMessage?: (id: number) => Promise<void>;
 	onInterrupt: () => void;
 	isInputDisabled: boolean;
 	isSendPending: boolean;
@@ -317,6 +318,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	sendShortcut,
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
+	onEditQueuedMessage,
 	onInterrupt,
 	isInputDisabled,
 	isSendPending,
@@ -567,6 +569,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			queuedMessages={queuedMessages}
 			onDeleteQueuedMessage={onDeleteQueuedMessage}
 			onPromoteQueuedMessage={onPromoteQueuedMessage}
+			onEditQueuedMessage={onEditQueuedMessage}
 			isEditingHistoryMessage={isEditing}
 			onCancelHistoryEdit={onCancelHistoryEdit}
 			userPromptHistory={userPromptHistory}

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.stories.tsx
@@ -119,6 +119,38 @@ export const MultiLineTextTruncation: Story = {
 	},
 };
 
+export const ExpandAndCollapseText: Story = {
+	args: {
+		messages: [
+			buildMessage(
+				1,
+				textContent(
+					"First line of the message\nSecond line that should be hidden",
+				),
+			),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = canvas.getByRole("button", {
+			name: /First line of the message/,
+		});
+		expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+		await userEvent.click(toggle);
+		await waitFor(() =>
+			expect(
+				canvas.getByRole("button", { name: /Second line/ }),
+			).toHaveAttribute("aria-expanded", "true"),
+		);
+
+		await userEvent.click(canvas.getByRole("button", { name: /Second line/ }));
+		await waitFor(() =>
+			expect(canvas.queryByText(/Second line/)).not.toBeInTheDocument(),
+		);
+	},
+};
+
 // A message with both text and a file attachment shows the ImageIcon badge.
 export const WithAttachments: Story = {
 	args: {
@@ -155,8 +187,86 @@ export const ActionsExcludeEdit: Story = {
 			canvas.getByRole("button", { name: "Remove from queue" }),
 		).toBeVisible();
 		expect(
-			canvas.queryByRole("button", { name: "Edit" }),
+			canvas.queryByRole("button", { name: "Edit queued message" }),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const EditAction: Story = {
+	args: {
+		messages: [
+			buildMessage(1, textContent("Run the linter")),
+			buildMessage(2, textContent("Run the formatter")),
+		],
+		onEdit: fn(),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		const editButtons = canvas.getAllByRole("button", {
+			name: "Edit queued message",
+		});
+		await userEvent.click(editButtons[1]);
+		expect(args.onEdit).toHaveBeenCalledWith(2);
+	},
+};
+
+export const EditDisabledWhileComposerHasDraft: Story = {
+	args: {
+		messages: [buildMessage(1, textContent("Run the linter"))],
+		onEdit: fn(),
+		editDisabledReason: "Send or clear the composer to edit a queued message.",
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("button", { name: "Edit queued message" }),
+		).toBeDisabled();
+		expect(args.onEdit).not.toHaveBeenCalled();
+	},
+};
+
+export const EditDisabledForAttachments: Story = {
+	args: {
+		messages: [
+			buildMessage(1, [
+				{ type: "text", text: "Look at this" },
+				{ type: "file", file_id: "file-1", media_type: "image/png" },
+			]),
+			buildMessage(2, textContent("Plain text prompt")),
+		],
+		onEdit: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const editButtons = canvas.getAllByRole("button", {
+			name: "Edit queued message",
+		});
+		expect(editButtons[0]).toBeDisabled();
+		expect(editButtons[1]).toBeEnabled();
+	},
+};
+
+let rejectQueuedEdit: ((error: Error) => void) | undefined;
+
+export const EditRejectionRestoresRow: Story = {
+	args: {
+		messages: [buildMessage(1, textContent("First queued"))],
+		onEdit: () =>
+			new Promise<void>((_, reject) => {
+				rejectQueuedEdit = reject;
+			}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Edit queued message" }),
+		);
+		await waitFor(() =>
+			expect(canvas.queryByText("First queued")).not.toBeInTheDocument(),
+		);
+
+		rejectQueuedEdit?.(new Error("nope"));
+		await waitFor(() => expect(canvas.getByText("First queued")).toBeVisible());
 	},
 };
 
@@ -230,6 +340,8 @@ export const HookNotice: Story = {
 		const trigger = canvas.getByRole("button", {
 			name: "Lifecycle hook notice: Deployment prompts are audited.",
 		});
+		// The expand/collapse control takes the first tab stop.
+		await userEvent.tab();
 		await userEvent.tab();
 		expect(trigger).toHaveFocus();
 		const tooltip = await within(document.body).findByRole("tooltip");

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -3,6 +3,7 @@ import {
 	CornerDownLeftIcon,
 	ImageIcon,
 	InfoIcon,
+	PencilIcon,
 	Trash2Icon,
 } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
@@ -20,6 +21,9 @@ interface QueuedMessagesListProps {
 	messages: readonly ChatQueuedMessage[];
 	onDelete: (id: number) => Promise<void> | void;
 	onPromote: (id: number) => Promise<void> | void;
+	// Removes the message from the queue and returns its text to the composer.
+	onEdit?: (id: number) => Promise<void> | void;
+	editDisabledReason?: string;
 	className?: string;
 }
 
@@ -57,6 +61,8 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 	messages,
 	onDelete,
 	onPromote,
+	onEdit,
+	editDisabledReason,
 	className,
 }) => {
 	const items = messages.map((message) => {
@@ -66,10 +72,23 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 	});
 
 	const [hoveredID, setHoveredID] = useState<number | null>(null);
+	const [expandedIDs, setExpandedIDs] = useState<ReadonlySet<number>>(
+		new Set(),
+	);
+
+	const toggleExpanded = (id: number) => {
+		setExpandedIDs((current) => {
+			const next = new Set(current);
+			if (!next.delete(id)) {
+				next.add(id);
+			}
+			return next;
+		});
+	};
 	// Tracks which item has an async action in flight and what kind.
 	const [busyItem, setBusyItem] = useState<{
 		id: number;
-		action: "delete" | "promote";
+		action: "delete" | "promote" | "edit";
 	} | null>(null);
 	const [optimisticallyHiddenIDs, setOptimisticallyHiddenIDs] = useState<
 		ReadonlySet<number>
@@ -140,6 +159,21 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 		}
 	};
 
+	const handleEdit = async (id: number) => {
+		if (!onEdit) {
+			return;
+		}
+		setBusyItem({ id, action: "edit" });
+		hideItemOptimistically(id);
+		try {
+			await onEdit(id);
+			setBusyItem((current) => (current?.id === id ? null : current));
+		} catch {
+			restoreHiddenItem(id);
+			setBusyItem((current) => (current?.id === id ? null : current));
+		}
+	};
+
 	const visibleItems = items.filter(
 		(item) => !optimisticallyHiddenIDs.has(item.id),
 	);
@@ -162,6 +196,13 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 				const isItemBusy = busyItem !== null && busyItem.id === item.id;
 				const isHovered = hoveredID === item.id;
 				const showActions = isHovered || (isFirst && hoveredID === null);
+				const isExpanded = expandedIDs.has(item.id);
+				const hasMoreLines = item.displayText.includes("\n");
+				// Composer drafts cannot hold files uploaded in an earlier session.
+				const itemEditDisabledReason =
+					item.attachmentCount > 0
+						? "Queued messages with attachments cannot be edited."
+						: editDisabledReason;
 
 				return (
 					<div
@@ -173,10 +214,24 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 						}
 					>
 						<div className="flex items-center gap-2 rounded-lg border border-solid border-border-default bg-surface-secondary px-3 py-2 font-sans text-sm leading-relaxed text-content-primary shadow-sm">
-							<span className="min-w-0 flex-1 truncate">
-								{item.displayText.split("\n")[0]}
-								{item.displayText.includes("\n") ? "…" : ""}
-							</span>
+							<button
+								type="button"
+								aria-expanded={isExpanded}
+								onClick={() => toggleExpanded(item.id)}
+								className={cn(
+									"min-w-0 flex-1 cursor-pointer border-none bg-transparent p-0 text-left font-sans text-sm leading-relaxed text-content-primary",
+									isExpanded ? "whitespace-pre-wrap break-words" : "truncate",
+								)}
+							>
+								{isExpanded ? (
+									item.displayText
+								) : (
+									<>
+										{item.displayText.split("\n")[0]}
+										{hasMoreLines ? "…" : ""}
+									</>
+								)}
+							</button>
 							{item.attachmentCount > 0 && (
 								<span
 									role="img"
@@ -239,6 +294,31 @@ export const QueuedMessagesList: FC<QueuedMessagesListProps> = ({
 									</TooltipTrigger>
 									<TooltipContent side="top">Send now</TooltipContent>
 								</Tooltip>
+								{onEdit && (
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												variant="subtle"
+												size="icon"
+												aria-label="Edit queued message"
+												disabled={
+													isBusy || itemEditDisabledReason !== undefined
+												}
+												onClick={() => void handleEdit(item.id)}
+												className="size-6 rounded text-content-secondary hover:bg-surface-tertiary hover:text-content-primary"
+											>
+												{isItemBusy && busyItem.action === "edit" ? (
+													<Spinner className="h-3.5 w-3.5" loading />
+												) : (
+													<PencilIcon className="size-3.5" />
+												)}
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent side="top">
+											{itemEditDisabledReason ?? "Edit in composer"}
+										</TooltipContent>
+									</Tooltip>
+								)}
 								<Tooltip>
 									<TooltipTrigger asChild>
 										<Button


### PR DESCRIPTION
Queued messages could only be sent now or removed, so fixing a typo meant deleting the message and retyping it. Queued text was also always clipped to its first line.

The queued text is now a button that toggles between the truncated first line and the full content. A pencil action **returns the message to the composer**: the queue row is deleted and its text becomes an ordinary draft, persisted like typed input so it survives a reload. From there it is just a prompt being written, so the next Enter takes the normal send path, which queues it at the tail while the chat is busy or sends it immediately when the chat is idle. There is no edit mode, no banner, and nothing enters the chat stream.

The action is disabled, with the reason in its tooltip, when:

- the composer already holds a draft, since returning a message would overwrite what is being written; or
- the queued message carries attachments, because composer drafts cannot be seeded with files uploaded in an earlier session (only the file IDs are available, not the bytes).

A failed removal restores the row and leaves the composer untouched.

<details>
<summary>Implementation notes</summary>

- `QueuedMessagesList`: per-item expanded state with `aria-expanded`, plus an optional `onEdit` action that hides the row optimistically and restores it if the handler rejects, mirroring the existing delete and promote actions. `editDisabledReason` disables the action and supplies the tooltip.
- `AgentChatInput` derives the composer-draft reason from its existing `isComposerEffectivelyEmpty` state.
- `AgentChatPage.handleEditQueuedMessage` reuses `handleDeleteQueuedMessage` (optimistic queue removal with rollback) and then loads the text through `loadDraftIntoComposer`, which writes the plain-text draft to the same localStorage key the composer uses and focuses the editor after the remount.
- `getEditableUserMessagePayload` now delegates to a content-level `getEditableContentPayload` shared with queued messages.
- Frontend only: no API, SDK, database, or state-machine changes.

</details>

<details>
<summary>Design history</summary>

Earlier revisions of this branch added `PATCH /api/experimental/chats/{chat}/queue/{queuedMessage}` with a `chatstate.UpdateQueuedMessage` transition so a queued message could be edited in place, and later tried to hold a queued message while it was being edited. The hold is not expressible in the current chat state machine: `ClassifyExecutionState` maps `waiting` with a non-empty queue to `StateInvalid`, `FinishTurn` promotes the queue head in the same transaction as the status write, and a chat parked in an invalid state refuses every transition until a user-triggered reconcile forces it to `error`. Returning the message to the composer needs no backend change at all, so the endpoint, transition, SDK method, and their tests were dropped and this branch is now a single frontend commit.

</details>

---

Generated by Coder Agents on behalf of @tracyjohnsonux.
