### PR TITLE
fix(site/src/components/Badge): bump sm badges from text-2xs to text-xs

### DIFF
--- a/site/src/components/Badge/Badge.tsx
+++ b/site/src/components/Badge/Badge.tsx
@@ -33,7 +33,7 @@ const badgeVariants = cva(
 			},
 			size: {
 				xs: "border-0 text-2xs font-normal h-[18px] rounded",
-				sm: "text-2xs font-normal h-5.5 py-1",
+				sm: "text-xs font-normal h-6 py-1",
 				md: "text-xs font-normal py-1",
 			},
 			svgSize: {


### PR DESCRIPTION
`Badge size="sm"` renders text at `text-2xs` (10px). This was tolerable while MUI's `CssBaseline` applied a 14px body typography baseline, but since the MUI/Emotion removal (#27821) dropped that baseline, inherited text defaults to 16px and the 10px badges read as broken — e.g. the Type/Tags chips on the provisioner jobs page and the pills on the AI Gateway sessions pages.

## Changes

- `sm` size: `text-2xs` (10px) → `text-xs` (12px).
- `sm` height: `h-5.5` (22px) → `h-6` (24px) so the 1rem `text-xs` line-height plus `py-1` fits without overflowing the fixed height.

`xs` (10px, used for genuinely dense contexts) and `md` are unchanged. This affects every `size="sm"` consumer by design — that is the point: it fixes all of the too-small chips in one place (provisioner type/tags, network call pills, etc.).

## Notes for reviewers

- The 10px `sm` sizing came from the Figma-alignment pass in #22539 (and predates it); flagging for design sign-off since this intentionally diverges from that spec in response to the post-#27821 typography baseline change.
- Pixel/Storybook diffs are expected on any story containing `sm` badges.

Related: #28477 (token badge icon sizing/cleanup; its font-size aspect is superseded by this PR).

> 🤖 Generated by Coder Agents on behalf of @tracyjohnsonux