### PR TITLE
feat: enforce user secret file policy

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -17,13 +17,6 @@ SUBCOMMANDS:
                                 PostgreSQL deployment.
 
 OPTIONS:
-      --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
-          Allow users to rename their workspaces. WARNING: Renaming a workspace
-          can cause Terraform resources that depend on the workspace name to be
-          destroyed and recreated, potentially causing data loss. Only enable
-          this if your templates do not use workspace names in resource
-          identifiers, or if you understand the risks.
-
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and
           $CACHE_DIRECTORY is set, it will be used for compatibility with
@@ -59,6 +52,13 @@ OPTIONS:
           Disable Coder-managed file path delivery for user secrets. Stored
           paths remain until users clear them and resume if this setting is
           turned off.
+
+      --disable-workspace-agent-context-sync bool, $CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC
+          Stop persisting workspace agent context snapshots (instructions,
+          skills, and MCP state used for pinned chat context). When set, coderd
+          rejects agent context pushes as unimplemented and agents stop sending
+          them; chats cannot pin workspace context. Use this to shed the
+          database write load of context sync on large deployments.
 
       --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
           Disable workspace sharing. Workspace ACL checking is disabled and only
@@ -451,6 +451,13 @@ INTROSPECTION / PPROF OPTIONS:
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
+
+MCP OPTIONS: 
+      --mcp-allowed-private-cidrs string-array, $CODER_MCP_ALLOWED_PRIVATE_CIDRS
+          MCP server destinations in private or reserved IP ranges are blocked
+          by default for SSRF protection. This applies to OAuth2 discovery,
+          OAuth2 token and revocation exchanges, and runtime MCP connections
+          from coderd. This option exempts specific CIDRs.
 
 NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
@@ -925,8 +932,10 @@ TEMPLATE BUILDER OPTIONS:
           When disabled, all /api/v2/templatebuilder/* endpoints return 404.
 
       --template-builder-registry-url string, $CODER_TEMPLATE_BUILDER_REGISTRY_URL (default: registry.coder.com)
-          The base URL of the module registry used by the template builder for
-          module source paths.
+          The module registry host the template builder uses for module source
+          paths (for example, "registry.coder.com" or "mirror.internal:8443").
+          An http(s):// scheme and trailing slash are stripped; a path, query,
+          fragment, or credentials is rejected.
 
 USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -17,6 +17,13 @@ SUBCOMMANDS:
                                 PostgreSQL deployment.
 
 OPTIONS:
+      --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
+          Allow users to rename their workspaces. WARNING: Renaming a workspace
+          can cause Terraform resources that depend on the workspace name to be
+          destroyed and recreated, potentially causing data loss. Only enable
+          this if your templates do not use workspace names in resource
+          identifiers, or if you understand the risks.
+
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and
           $CACHE_DIRECTORY is set, it will be used for compatibility with
@@ -48,12 +55,10 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
-      --disable-workspace-agent-context-sync bool, $CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC
-          Stop persisting workspace agent context snapshots (instructions,
-          skills, and MCP state used for pinned chat context). When set, coderd
-          rejects agent context pushes as unimplemented and agents stop sending
-          them; chats cannot pin workspace context. Use this to shed the
-          database write load of context sync on large deployments.
+      --user-secrets-disable-file-path bool, $CODER_USER_SECRETS_DISABLE_FILE_PATH
+          Disable Coder-managed file path delivery for user secrets. Stored
+          paths remain until users clear them and resume if this setting is
+          turned off.
 
       --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
           Disable workspace sharing. Workspace ACL checking is disabled and only
@@ -446,13 +451,6 @@ INTROSPECTION / PPROF OPTIONS:
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
-
-MCP OPTIONS: 
-      --mcp-allowed-private-cidrs string-array, $CODER_MCP_ALLOWED_PRIVATE_CIDRS
-          MCP server destinations in private or reserved IP ranges are blocked
-          by default for SSRF protection. This applies to OAuth2 discovery,
-          OAuth2 token and revocation exchanges, and runtime MCP connections
-          from coderd. This option exempts specific CIDRs.
 
 NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
@@ -927,10 +925,8 @@ TEMPLATE BUILDER OPTIONS:
           When disabled, all /api/v2/templatebuilder/* endpoints return 404.
 
       --template-builder-registry-url string, $CODER_TEMPLATE_BUILDER_REGISTRY_URL (default: registry.coder.com)
-          The module registry host the template builder uses for module source
-          paths (for example, "registry.coder.com" or "mirror.internal:8443").
-          An http(s):// scheme and trailing slash are stripped; a path, query,
-          fragment, or credentials is rejected.
+          The base URL of the module registry used by the template builder for
+          module source paths.
 
 USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -48,7 +48,7 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
-      --user-secrets-disable-file-path bool, $CODER_USER_SECRETS_DISABLE_FILE_PATH
+      --disable-user-secret-file-path bool, $CODER_DISABLE_USER_SECRET_FILE_PATH
           Disable Coder-managed file path delivery for user secrets. Stored
           paths remain until users clear them and resume if this setting is
           turned off.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -1,3 +1,10 @@
+mcp:
+  # MCP server destinations in private or reserved IP ranges are blocked by default
+  # for SSRF protection. This applies to OAuth2 discovery, OAuth2 token and
+  # revocation exchanges, and runtime MCP connections from coderd. This option
+  # exempts specific CIDRs.
+  # (default: <unset>, type: string-array)
+  allowed_private_cidrs: []
 networking:
   # The URL that users will use to access the Coder deployment.
   # (default: <unset>, type: url)
@@ -566,6 +573,13 @@ disableWorkspaceSharing: false
 # their chats.
 # (default: <unset>, type: bool)
 disableChatSharing: false
+# Stop persisting workspace agent context snapshots (instructions, skills, and MCP
+# state used for pinned chat context). When set, coderd rejects agent context
+# pushes as unimplemented and agents stop sending them; chats cannot pin workspace
+# context. Use this to shed the database write load of context sync on large
+# deployments.
+# (default: <unset>, type: bool)
+disableWorkspaceAgentContextSync: false
 # Disable Coder-managed file path delivery for user secrets. Stored paths remain
 # until users clear them and resume if this setting is turned off.
 # (default: <unset>, type: bool)
@@ -632,10 +646,10 @@ userQuietHoursSchedule:
   # change their quiet hours schedule and the site default is always used.
   # (default: true, type: bool)
   allowCustomQuietHours: true
-# Allow users to rename their workspaces. WARNING: Renaming a workspace can cause
-# Terraform resources that depend on the workspace name to be destroyed and
-# recreated, potentially causing data loss. Only enable this if your templates do
-# not use workspace names in resource identifiers, or if you understand the risks.
+# Deprecated: use the per-template "Allow workspace renames" setting instead.
+# While set, it force-enables renames for every template in the deployment.
+# WARNING: Renaming a workspace can cause Terraform resources that depend on the
+# workspace name to be destroyed and recreated, potentially causing data loss.
 # (default: false, type: bool)
 allowWorkspaceRenames: false
 # Configure how emails are sent.
@@ -1190,7 +1204,9 @@ templateBuilder:
   # disabled, all /api/v2/templatebuilder/* endpoints return 404.
   # (default: <unset>, type: bool)
   disabled: false
-  # The base URL of the module registry used by the template builder for module
-  # source paths.
+  # The module registry host the template builder uses for module source paths (for
+  # example, "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme
+  # and trailing slash are stripped; a path, query, fragment, or credentials is
+  # rejected.
   # (default: registry.coder.com, type: string)
   registryURL: registry.coder.com

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -1,10 +1,3 @@
-mcp:
-  # MCP server destinations in private or reserved IP ranges are blocked by default
-  # for SSRF protection. This applies to OAuth2 discovery, OAuth2 token and
-  # revocation exchanges, and runtime MCP connections from coderd. This option
-  # exempts specific CIDRs.
-  # (default: <unset>, type: string-array)
-  allowed_private_cidrs: []
 networking:
   # The URL that users will use to access the Coder deployment.
   # (default: <unset>, type: url)
@@ -573,13 +566,10 @@ disableWorkspaceSharing: false
 # their chats.
 # (default: <unset>, type: bool)
 disableChatSharing: false
-# Stop persisting workspace agent context snapshots (instructions, skills, and MCP
-# state used for pinned chat context). When set, coderd rejects agent context
-# pushes as unimplemented and agents stop sending them; chats cannot pin workspace
-# context. Use this to shed the database write load of context sync on large
-# deployments.
+# Disable Coder-managed file path delivery for user secrets. Stored paths remain
+# until users clear them and resume if this setting is turned off.
 # (default: <unset>, type: bool)
-disableWorkspaceAgentContextSync: false
+userSecretsDisableFilePath: false
 # These options change the behavior of how clients interact with the Coder.
 # Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:
@@ -642,10 +632,10 @@ userQuietHoursSchedule:
   # change their quiet hours schedule and the site default is always used.
   # (default: true, type: bool)
   allowCustomQuietHours: true
-# Deprecated: use the per-template "Allow workspace renames" setting instead.
-# While set, it force-enables renames for every template in the deployment.
-# WARNING: Renaming a workspace can cause Terraform resources that depend on the
-# workspace name to be destroyed and recreated, potentially causing data loss.
+# Allow users to rename their workspaces. WARNING: Renaming a workspace can cause
+# Terraform resources that depend on the workspace name to be destroyed and
+# recreated, potentially causing data loss. Only enable this if your templates do
+# not use workspace names in resource identifiers, or if you understand the risks.
 # (default: false, type: bool)
 allowWorkspaceRenames: false
 # Configure how emails are sent.
@@ -1200,9 +1190,7 @@ templateBuilder:
   # disabled, all /api/v2/templatebuilder/* endpoints return 404.
   # (default: <unset>, type: bool)
   disabled: false
-  # The module registry host the template builder uses for module source paths (for
-  # example, "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme
-  # and trailing slash are stripped; a path, query, fragment, or credentials is
-  # rejected.
+  # The base URL of the module registry used by the template builder for module
+  # source paths.
   # (default: registry.coder.com, type: string)
   registryURL: registry.coder.com

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -583,7 +583,7 @@ disableWorkspaceAgentContextSync: false
 # Disable Coder-managed file path delivery for user secrets. Stored paths remain
 # until users clear them and resume if this setting is turned off.
 # (default: <unset>, type: bool)
-userSecretsDisableFilePath: false
+disableUserSecretFilePath: false
 # These options change the behavior of how clients interact with the Coder.
 # Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -154,970 +154,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/experimental/chats": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chats",
-                "operationId": "list-chats",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search query. Supports ` + "`" + `title:\u003csubstring\u003e` + "`" + ` (case-insensitive, quote multi-word values), ` + "`" + `archived:bool` + "`" + `, ` + "`" + `has_unread:bool` + "`" + `, ` + "`" + `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` + "`" + ` as repeated or comma-separated values, ` + "`" + `source:\u003ccreated_by_me\\|shared_with_me\u003e` + "`" + `, ` + "`" + `diff_url:\u003curl\u003e` + "`" + ` (quote values containing colons), ` + "`" + `pr:\u003cnumber\u003e` + "`" + ` (exact PR number match), ` + "`" + `repo:\u003cowner/repo\u003e` + "`" + ` (case-insensitive substring match against git remote origin or URL), ` + "`" + `pr_title:\u003ctext\u003e` + "`" + ` (case-insensitive PR title substring), ` + "`" + `search:\u003ctext\u003e` + "`" + ` (full-text search across chat titles, PR titles, PR numbers, and message bodies; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words returns an empty list). Bare terms are not supported; use ` + "`" + `title:\u003cvalue\u003e` + "`" + ` or ` + "`" + `search:\u003cvalue\u003e` + "`" + `.",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by label as key:value. Repeat for multiple (AND logic).",
-                        "name": "label",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.Chat"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create chat",
-                "operationId": "create-chat",
-                "parameters": [
-                    {
-                        "description": "Create chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    },
-                    "413": {
-                        "description": "Request body exceeds 256 KiB",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Response"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/config/retention-days": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat retention days",
-                "operationId": "get-chat-retention-days",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat retention days",
-                "operationId": "update-chat-retention-days",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chats/files": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Upload chat file",
-                "operationId": "upload-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UploadChatFileResponse"
-                        }
-                    },
-                    "413": {
-                        "description": "Request body exceeds 10 MiB",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Response"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/files/{file}": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat file",
-                "operationId": "get-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/files/{file}/download": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Download chat file with signed token",
-                "operationId": "download-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Signed download token",
-                        "name": "token",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chats/files/{file}/download-url": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create chat file download URL",
-                "operationId": "create-chat-file-download-url",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chats/watch": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat events for a user via WebSockets",
-                "operationId": "watch-chat-events-for-a-user-via-websockets",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatWatchEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat by ID",
-                "operationId": "get-chat-by-id",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "patch": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat",
-                "operationId": "update-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/acl": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat ACLs",
-                "operationId": "get-chat-acls",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatACL"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat ACL",
-                "operationId": "update-chat-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update chat ACL request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatACL"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chats/{chat}/compact": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.\nRequests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Compact chat",
-                "operationId": "compact-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chats/{chat}/context": {
-            "put": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Refresh chat context",
-                "operationId": "refresh-chat-context",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/cost": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.\n\nCost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat cost",
-                "operationId": "get-chat-cost",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatCost"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/diff": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat diff contents",
-                "operationId": "get-chat-diff-contents",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatDiffContents"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/interrupt": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Interrupt chat",
-                "operationId": "interrupt-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/messages": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat messages",
-                "operationId": "list-chat-messages",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Return messages with id \u003c before_id",
-                        "name": "before_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Return messages with id \u003e after_id",
-                        "name": "after_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 1 to 200. Defaults to 50.",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatMessagesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Send chat message",
-                "operationId": "send-chat-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Create chat message request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatMessageResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/messages/{message}": {
-            "patch": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Edit chat message",
-                "operationId": "edit-chat-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Message ID",
-                        "name": "message",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Edit chat message request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.EditChatMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.EditChatMessageResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/prompts": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.\n\nReturns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat user prompts",
-                "operationId": "list-chat-user-prompts",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatPromptsResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/reconcile-invalid": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Reconcile invalid chat state",
-                "operationId": "reconcile-invalid-chat-state",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/stream": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Stream chat events via WebSockets",
-                "operationId": "stream-chat-events-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatStreamEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
         "/api/experimental/chats/{chat}/stream/desktop": {
             "get": {
                 "description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
@@ -1142,117 +178,6 @@ const docTemplate = `{
                 "responses": {
                     "101": {
                         "description": "Switching Protocols"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/stream/git": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat workspace git state via WebSockets",
-                "operationId": "watch-chat-workspace-git-state-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/experimental/chats/{chat}/stream/parts": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Stream chat parts via WebSockets",
-                "operationId": "stream-chat-parts-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatStreamEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/chats/{chat}/title/regenerate": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Regenerate chat title",
-                "operationId": "regenerate-chat-title",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
                     }
                 },
                 "security": [
@@ -1309,927 +234,6 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/mcp/servers/{mcpServer}/oauth2/disconnect": {
-            "delete": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Disconnect MCP server OAuth2 token",
-                "operationId": "disconnect-mcp-server-oauth2-token",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpServer",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/chats/model-overrides": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List organization chat model overrides",
-                "operationId": "list-organization-chat-model-overrides",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/chats/model-overrides/{context}": {
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update organization chat model override",
-                "operationId": "update-organization-chat-model-override",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "general",
-                            "explore",
-                            "title_generation",
-                            "compaction",
-                            "advisor"
-                        ],
-                        "type": "string",
-                        "description": "Override context",
-                        "name": "context",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Model override",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/chats/models": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List AI models and provider descriptors in an organization",
-                "operationId": "list-ai-models-by-organization",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create an AI model in an organization",
-                "operationId": "create-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Model",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatModelRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModel"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/chats/models/{model}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get an AI model",
-                "operationId": "get-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModel"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Delete an AI model",
-                "operationId": "delete-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update an AI model",
-                "operationId": "update-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Model updates",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModel"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/chats/models/{model}/acl": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get an AI model ACL",
-                "operationId": "get-ai-model-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelACL"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update an AI model ACL",
-                "operationId": "update-ai-model-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Sparse model ACL update",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/mcp-servers": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "List MCP server configs",
-                "operationId": "list-mcp-server-configs",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.MCPServerConfig"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Create MCP server config",
-                "operationId": "create-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Create MCP server config request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Get MCP server config",
-                "operationId": "get-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "delete": {
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Delete MCP server config",
-                "operationId": "delete-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Update MCP server config",
-                "operationId": "update-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update MCP server config request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Get MCP server config ACL",
-                "operationId": "get-mcp-server-config-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfigACL"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Update MCP server config ACL",
-                "operationId": "update-mcp-server-config-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update MCP server config ACL request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
-            "get": {
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Initiate MCP server OAuth2 connect",
-                "operationId": "initiate-mcp-server-oauth2-connect",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Temporary Redirect"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get organization member chat model overrides",
-                "operationId": "get-organization-member-chat-model-overrides",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "User name, ID, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update organization member chat model override",
-                "operationId": "update-organization-member-chat-model-override",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "User name, ID, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "root",
-                            "general",
-                            "explore"
-                        ],
-                        "type": "string",
-                        "description": "Override context",
-                        "name": "context",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Personal model override",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     }
                 },
                 "security": [
@@ -3357,6 +1361,1923 @@ const docTemplate = `{
                         }
                     }
                 }
+            }
+        },
+        "/api/v2/chats": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chats",
+                "operationId": "list-chats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query. Supports ` + "`" + `title:\u003csubstring\u003e` + "`" + ` (case-insensitive, quote multi-word values), ` + "`" + `archived:bool` + "`" + `, ` + "`" + `has_unread:bool` + "`" + `, ` + "`" + `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` + "`" + ` as repeated or comma-separated values, ` + "`" + `source:\u003ccreated_by_me\\|shared_with_me\u003e` + "`" + `, ` + "`" + `diff_url:\u003curl\u003e` + "`" + ` (quote values containing colons), ` + "`" + `pr:\u003cnumber\u003e` + "`" + ` (exact PR number match), ` + "`" + `repo:\u003cowner/repo\u003e` + "`" + ` (case-insensitive substring match against git remote origin or URL), ` + "`" + `pr_title:\u003ctext\u003e` + "`" + ` (case-insensitive PR title substring), ` + "`" + `search:\u003ctext\u003e` + "`" + ` (full-text search across chat titles, PR titles, PR numbers, and message bodies; message bodies match English word stems, e.g. ` + "`" + `refactor` + "`" + ` matches ` + "`" + `refactoring` + "`" + `, and ignore English stopwords; titles and PR titles match whole words case-insensitively without stemming; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words, e.g. punctuation only, returns an empty list). Bare terms are not supported; use ` + "`" + `title:\u003cvalue\u003e` + "`" + ` or ` + "`" + `search:\u003cvalue\u003e` + "`" + `.",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Filter by label as key:value. Repeat for multiple (AND logic).",
+                        "name": "label",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "After ID",
+                        "name": "after_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page limit",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.Chat"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat",
+                "operationId": "create-chat",
+                "parameters": [
+                    {
+                        "description": "Create chat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    },
+                    "413": {
+                        "description": "Request body exceeds 256 KiB",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/by-workspace": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chats by workspace",
+                "operationId": "list-chats-by-workspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated workspace IDs",
+                        "name": "workspace_ids",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/coderd.chatsByWorkspaceResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/auto-archive-days": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat auto archive days",
+                "operationId": "get-chat-auto-archive-days",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatAutoArchiveDaysResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat auto archive days",
+                "operationId": "update-chat-auto-archive-days",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatAutoArchiveDaysRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/debug-logging": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat debug logging setting",
+                "operationId": "get-chat-debug-logging-setting",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDebugLoggingAdminSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat debug logging setting",
+                "operationId": "update-chat-debug-logging-setting",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatDebugLoggingAllowUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/debug-retention-days": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat debug retention days",
+                "operationId": "get-chat-debug-retention-days",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDebugRetentionDaysResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat debug retention days",
+                "operationId": "update-chat-debug-retention-days",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatDebugRetentionDaysRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/personal-model-overrides": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat personal model override settings",
+                "operationId": "get-chat-personal-model-override-settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatPersonalModelOverridesAdminSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat personal model override settings",
+                "operationId": "update-chat-personal-model-override-settings",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/plan-mode-instructions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat plan mode instructions",
+                "operationId": "get-chat-plan-mode-instructions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatPlanModeInstructionsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat plan mode instructions",
+                "operationId": "update-chat-plan-mode-instructions",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatPlanModeInstructionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/retention-days": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat retention days",
+                "operationId": "get-chat-retention-days",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat retention days",
+                "operationId": "update-chat-retention-days",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/config/system-prompt": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat system prompt",
+                "operationId": "get-chat-system-prompt",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatSystemPromptResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat system prompt",
+                "operationId": "update-chat-system-prompt",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatSystemPromptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/user-compaction-thresholds": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get user chat compaction thresholds",
+                "operationId": "get-user-chat-compaction-thresholds",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCompactionThresholds"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/config/user-compaction-thresholds/{modelConfig}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user chat compaction threshold",
+                "operationId": "update-user-chat-compaction-threshold",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserChatCompactionThresholdRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete user chat compaction threshold",
+                "operationId": "delete-user-chat-compaction-threshold",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/config/user-debug-logging": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get user chat debug logging setting",
+                "operationId": "get-user-chat-debug-logging-setting",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatDebugLoggingSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user chat debug logging setting",
+                "operationId": "update-user-chat-debug-logging-setting",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserChatDebugLoggingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/user-prompt": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get user chat custom prompt",
+                "operationId": "get-user-chat-custom-prompt",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user chat custom prompt",
+                "operationId": "update-user-chat-custom-prompt",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/config/workspace-ttl": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat workspace time to live",
+                "operationId": "get-chat-workspace-time-to-live",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatWorkspaceTTLResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat workspace time to live",
+                "operationId": "update-chat-workspace-time-to-live",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatWorkspaceTTLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/files": {
+            "post": {
+                "consumes": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Upload chat file",
+                "operationId": "upload-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "attachment; filename=\"image.png\"",
+                        "description": "Attachment disposition carrying the file name",
+                        "name": "Content-Disposition",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Raw file binary data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UploadChatFileResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request body exceeds 10 MiB",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "rawBodyFile": "image.png"
+                }
+            }
+        },
+        "/api/v2/chats/files/{file}": {
+            "get": {
+                "produces": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat file",
+                "operationId": "get-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/files/{file}/download": {
+            "get": {
+                "produces": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Download chat file with signed token",
+                "operationId": "download-chat-file-with-signed-token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Signed download token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/files/{file}/download-url": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat file download URL",
+                "operationId": "create-chat-file-download-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/watch": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Watch chat events for a user via WebSockets",
+                "operationId": "watch-chat-events-for-a-user-via-websockets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatWatchEvent"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat by ID",
+                "operationId": "get-chat-by-id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat",
+                "operationId": "update-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update chat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/acl": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat ACLs",
+                "operationId": "get-chat-acls",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatACL"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat ACL",
+                "operationId": "update-chat-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update chat ACL request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatACL"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/{chat}/clear": {
+            "post": {
+                "description": "Resets the model context of an idle or errored chat,\nclearing any stored error. The reset commits\nsynchronously with no model call: the transcript is\npreserved and the next prompt starts from a fresh\ncontext.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Clear chat context",
+                "operationId": "clear-chat-context",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/{chat}/compact": {
+            "post": {
+                "description": "Requests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Compact chat",
+                "operationId": "compact-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/{chat}/context": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Refresh chat context",
+                "operationId": "refresh-chat-context",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/cost": {
+            "get": {
+                "description": "Cost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat cost",
+                "operationId": "get-chat-cost",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatCost"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/diff": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat diff contents",
+                "operationId": "get-chat-diff-contents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDiffContents"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/interrupt": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Interrupt chat",
+                "operationId": "interrupt-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/messages": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat messages",
+                "operationId": "list-chat-messages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return messages with id \u003c before_id",
+                        "name": "before_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return messages with id \u003e after_id",
+                        "name": "after_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1 to 200. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatMessagesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Send chat message",
+                "operationId": "send-chat-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Create chat message request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatMessageResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/messages/{message}": {
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Edit chat message",
+                "operationId": "edit-chat-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Message ID",
+                        "name": "message",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Edit chat message request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.EditChatMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.EditChatMessageResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/prompts": {
+            "get": {
+                "description": "Returns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat user prompts",
+                "operationId": "list-chat-user-prompts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatPromptsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/queue/{queuedMessage}": {
+            "delete": {
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete chat queued message",
+                "operationId": "delete-chat-queued-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Queued message ID",
+                        "name": "queuedMessage",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/queue/{queuedMessage}/promote": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Promote chat queued message",
+                "operationId": "promote-chat-queued-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Queued message ID",
+                        "name": "queuedMessage",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/reconcile-invalid": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Reconcile invalid chat state",
+                "operationId": "reconcile-invalid-chat-state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/stream": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Stream chat events via WebSockets",
+                "operationId": "stream-chat-events-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Skip snapshot messages with id at or before this cursor",
+                        "name": "after_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatStreamEvent"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/stream/git": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Watch chat workspace git state via WebSockets",
+                "operationId": "watch-chat-workspace-git-state-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/stream/parts": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Stream chat parts via WebSockets",
+                "operationId": "stream-chat-parts-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatStreamEvent"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/chats/{chat}/title/propose": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Propose chat title",
+                "operationId": "propose-chat-title",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ProposeChatTitleResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/chats/{chat}/tool-results": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Submit chat tool results",
+                "operationId": "submit-chat-tool-results",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.SubmitToolResultsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
             }
         },
         "/api/v2/connectionlog": {
@@ -5155,6 +5076,44 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/mcp/servers/{mcpServer}/oauth2/disconnect": {
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Disconnect MCP server OAuth2 token",
+                "operationId": "disconnect-mcp-server-oauth2-token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpServer",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/api/v2/notifications/custom": {
             "post": {
                 "consumes": [
@@ -6152,6 +6111,485 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/organizations/{organization}/chats/model-overrides": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List organization chat model overrides",
+                "operationId": "list-organization-chat-model-overrides",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/chats/model-overrides/{context}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update organization chat model override",
+                "operationId": "update-organization-chat-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "general",
+                            "explore",
+                            "title_generation",
+                            "compaction",
+                            "advisor"
+                        ],
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/chats/models": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List AI models and provider descriptors in an organization",
+                "operationId": "list-ai-models-and-provider-descriptors-in-an-organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create an AI model in an organization",
+                "operationId": "create-an-ai-model-in-an-organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatModelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/organizations/{organization}/chats/models/{model}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get an AI model",
+                "operationId": "get-an-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete an AI model",
+                "operationId": "delete-an-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update an AI model",
+                "operationId": "update-an-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model updates",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/chats/models/{model}/acl": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get an AI model ACL",
+                "operationId": "get-an-ai-model-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelACL"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update an AI model ACL",
+                "operationId": "update-an-ai-model-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sparse model ACL update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/chats/models/{model}/acl/available": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get available AI model ACL users and groups",
+                "operationId": "get-available-ai-model-acl-users-and-groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User search query; free-text search also applies to groups",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "User after ID",
+                        "name": "after_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page limit for users and groups, if 0 returns all candidates",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "User page offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ACLAvailable"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/api/v2/organizations/{organization}/groups": {
             "get": {
                 "produces": [
@@ -6434,6 +6872,433 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ]
+            }
+        },
+        "/api/v2/organizations/{organization}/mcp-servers": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "List MCP server configs",
+                "operationId": "list-mcp-server-configs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.MCPServerConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Create MCP server config",
+                "operationId": "create-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Create MCP server config request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Get MCP server config",
+                "operationId": "get-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Delete MCP server config",
+                "operationId": "delete-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Update MCP server config",
+                "operationId": "update-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update MCP server config request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Get MCP server config ACL",
+                "operationId": "get-mcp-server-config-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfigACL"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Update MCP server config ACL",
+                "operationId": "update-mcp-server-config-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update MCP server config ACL request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl/available": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Get available MCP server config ACL users and groups",
+                "operationId": "get-available-mcp-server-config-acl-users-and-groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User search query; free-text search also applies to groups",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "User after ID",
+                        "name": "after_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page limit for users and groups, if 0 returns all candidates",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "User page offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ACLAvailable"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
+            "get": {
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Initiate MCP server OAuth2 connect",
+                "operationId": "initiate-mcp-server-oauth2-connect",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "307": {
+                        "description": "Temporary Redirect"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
             }
         },
         "/api/v2/organizations/{organization}/members": {
@@ -6764,6 +7629,112 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ]
+            }
+        },
+        "/api/v2/organizations/{organization}/members/{user}/chats/model-overrides": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get organization member chat model overrides",
+                "operationId": "get-organization-member-chat-model-overrides",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User name, ID, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/v2/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update organization member chat model override",
+                "operationId": "update-organization-member-chat-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User name, ID, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "root",
+                            "general",
+                            "explore"
+                        ],
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Personal model override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
             }
         },
         "/api/v2/organizations/{organization}/members/{user}/roles": {
@@ -7160,7 +8131,7 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "object",
+                        "type": "string",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
                         "in": "query"
@@ -7271,7 +8242,7 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "object",
+                        "type": "string",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
                         "in": "query"
@@ -10848,6 +11819,131 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/users/{user}/ai-provider-keys": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List user AI provider key configurations",
+                "operationId": "list-user-ai-provider-key-configurations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID, username, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v2/users/{user}/ai-provider-keys/{aiProvider}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user AI provider key",
+                "operationId": "update-user-ai-provider-key",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID, username, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "AI provider ID",
+                        "name": "aiProvider",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateUserAIProviderKeyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete user AI provider key",
+                "operationId": "delete-user-ai-provider-key",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID, username, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "AI provider ID",
+                        "name": "aiProvider",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     }
                 },
                 "security": [
@@ -15453,7 +16549,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Token scopes (currently ignored)",
+                        "description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
                         "name": "scope",
                         "in": "query"
                     }
@@ -15509,7 +16605,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Token scopes (currently ignored)",
+                        "description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
                         "name": "scope",
                         "in": "query"
                     }
@@ -15710,7 +16806,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Client secret, required if grant_type=authorization_code",
+                        "description": "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.",
                         "name": "client_secret",
                         "in": "formData"
                     },
@@ -15718,6 +16814,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Authorization code, required if grant_type=authorization_code",
                         "name": "code",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636.",
+                        "name": "code_verifier",
                         "in": "formData"
                     },
                     {
@@ -16161,6 +17263,12 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "ReinitializeReasonPrebuildClaimed"
             ]
+        },
+        "coderd.chatsByWorkspaceResponse": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "coderd.cspViolation": {
             "type": "object",
@@ -16950,6 +18058,33 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "codersdk.AIProviderSummary": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/codersdk.AIProviderType"
                 }
             }
         },
@@ -18377,6 +19512,14 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatAutoArchiveDaysResponse": {
+            "type": "object",
+            "properties": {
+                "auto_archive_days": {
+                    "type": "integer"
+                }
+            }
+        },
         "codersdk.ChatBusyBehavior": {
             "type": "string",
             "enum": [
@@ -18551,6 +19694,25 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "unpriced_request_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatDebugLoggingAdminSettings": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                },
+                "forced_by_deployment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatDebugRetentionDaysResponse": {
+            "type": "object",
+            "properties": {
+                "debug_retention_days": {
                     "type": "integer"
                 }
             }
@@ -18921,12 +20083,8 @@ const docTemplate = `{
                 },
                 "context_file_agent_id": {
                     "description": "ContextFileAgentID is the workspace agent that provided\nthis context file. Used to detect when the agent changes\n(e.g. workspace rebuilt) so instruction files can be\nre-persisted with fresh content.",
-                    "format": "uuid",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/uuid.NullUUID"
-                        }
-                    ]
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "context_file_content": {
                     "description": "ContextFileContent holds the file content sent to the LLM.\nInternal only: stripped before API responses to keep\npayloads small. The backend reads it when building the\nprompt via partsToMessageParts.",
@@ -18967,12 +20125,8 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "file_id": {
-                    "format": "uuid",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/uuid.NullUUID"
-                        }
-                    ]
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "file_name": {
                     "type": "string"
@@ -18988,12 +20142,8 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "mcp_server_config_id": {
-                    "format": "uuid",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/uuid.NullUUID"
-                        }
-                    ]
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "media_type": {
                     "type": "string"
@@ -19218,16 +20368,16 @@ const docTemplate = `{
         "codersdk.ChatModelACL": {
             "type": "object",
             "properties": {
-                "group_roles": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/codersdk.ChatRole"
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatGroup"
                     }
                 },
-                "user_roles": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/codersdk.ChatRole"
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatUser"
                     }
                 }
             }
@@ -19779,6 +20929,14 @@ const docTemplate = `{
                 "ChatPersonalModelOverrideModeModel"
             ]
         },
+        "codersdk.ChatPersonalModelOverridesAdminSettings": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                }
+            }
+        },
         "codersdk.ChatPlanMode": {
             "type": "string",
             "enum": [
@@ -19787,6 +20945,14 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "ChatPlanModePlan"
             ]
+        },
+        "codersdk.ChatPlanModeInstructionsResponse": {
+            "type": "object",
+            "properties": {
+                "plan_mode_instructions": {
+                    "type": "string"
+                }
+            }
         },
         "codersdk.ChatPrompt": {
             "type": "object",
@@ -20024,6 +21190,20 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatSystemPromptResponse": {
+            "type": "object",
+            "properties": {
+                "default_system_prompt": {
+                    "type": "string"
+                },
+                "include_default_system_prompt": {
+                    "type": "boolean"
+                },
+                "system_prompt": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatUnsupportedProvider": {
             "type": "object",
             "properties": {
@@ -20110,6 +21290,15 @@ const docTemplate = `{
                 "ChatWatchEventKindActionRequired",
                 "ChatWatchEventKindContextDirty"
             ]
+        },
+        "codersdk.ChatWorkspaceTTLResponse": {
+            "type": "object",
+            "properties": {
+                "workspace_ttl_ms": {
+                    "description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
+                    "type": "integer"
+                }
+            }
         },
         "codersdk.ClusterConfig": {
             "type": "object",
@@ -20777,6 +21966,10 @@ const docTemplate = `{
                     "description": "Allow users to cancel in-progress workspace jobs.\n*bool as the default value is \"true\".",
                     "type": "boolean"
                 },
+                "allow_workspace_renames": {
+                    "description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name, so this defaults to false.",
+                    "type": "boolean"
+                },
                 "autostart_requirement": {
                     "description": "AutostartRequirement allows optionally specifying the autostart allowed days\nfor workspaces created from this template. This is an enterprise feature.",
                     "allOf": [
@@ -21108,6 +22301,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/codersdk.PremiumFunnelSource"
                         }
                     ]
+                }
+            }
+        },
+        "codersdk.CreateUserAIProviderKeyRequest": {
+            "type": "object",
+            "properties": {
+                "api_key": {
+                    "type": "string"
                 }
             }
         },
@@ -21702,6 +22903,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.AIConfig"
                 },
                 "allow_workspace_renames": {
+                    "description": "Deprecated: Use the per-template allow_workspace_renames setting instead.",
                     "type": "boolean"
                 },
                 "autobuild_poll_interval": {
@@ -21744,6 +22946,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "disable_user_secret_file_path": {
+                    "type": "boolean"
+                },
+                "disable_workspace_agent_context_sync": {
                     "type": "boolean"
                 },
                 "disable_workspace_sharing": {
@@ -21797,6 +23002,12 @@ const docTemplate = `{
                 },
                 "logging": {
                     "$ref": "#/definitions/codersdk.LoggingConfig"
+                },
+                "mcp_allowed_private_cidrs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "metrics_cache_refresh_interval": {
                     "type": "integer"
@@ -22661,13 +23872,21 @@ const docTemplate = `{
         "codersdk.GroupMemberAISpend": {
             "type": "object",
             "properties": {
+                "effective_budget": {
+                    "description": "EffectiveBudget is the spend limit that currently applies to the user.\nNull when no budget applies or the effective group belongs to a different\norganization than the queried group.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.AIBudgetLimit"
+                        }
+                    ]
+                },
                 "effective_group_id": {
                     "description": "EffectiveGroupID is the user's effective budget group within the queried\ngroup's organization, falling back to the Everyone group when no budget\napplies. Null when the effective group belongs to a different organization\nthan the queried group.",
                     "type": "string",
                     "format": "uuid"
                 },
                 "group_budget": {
-                    "description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. Null when the user's budget resolves to another\ngroup or no budget applies to the user.",
+                    "description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. When populated, it matches EffectiveBudget. Null\nwhen the user's budget resolves to another group or no budget applies.\nDeprecated: Use EffectiveBudget instead.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/codersdk.AIBudgetLimit"
@@ -25218,6 +26437,14 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ProposeChatTitleResponse": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ProvisionerConfig": {
             "type": "object",
             "properties": {
@@ -26452,6 +27679,17 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.SubmitToolResultsRequest": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ToolResult"
+                    }
+                }
+            }
+        },
         "codersdk.SupportConfig": {
             "type": "object",
             "properties": {
@@ -26557,6 +27795,10 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "allow_user_cancel_workspace_jobs": {
+                    "type": "boolean"
+                },
+                "allow_workspace_renames": {
+                    "description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
                     "type": "boolean"
                 },
                 "autostart_requirement": {
@@ -27692,6 +28934,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ToolResult": {
+            "type": "object",
+            "properties": {
+                "is_error": {
+                    "type": "boolean"
+                },
+                "output": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "tool_call_id": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.TraceConfig": {
             "type": "object",
             "properties": {
@@ -27802,6 +29061,30 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.UpdateChatAutoArchiveDaysRequest": {
+            "type": "object",
+            "properties": {
+                "auto_archive_days": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.UpdateChatDebugLoggingAllowUsersRequest": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UpdateChatDebugRetentionDaysRequest": {
+            "type": "object",
+            "properties": {
+                "debug_retention_days": {
+                    "type": "integer"
+                }
+            }
+        },
         "codersdk.UpdateChatModelACLRequest": {
             "type": "object",
             "properties": {
@@ -27860,6 +29143,22 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UpdateChatPlanModeInstructionsRequest": {
+            "type": "object",
+            "properties": {
+                "plan_mode_instructions": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.UpdateChatRequest": {
             "type": "object",
             "properties": {
@@ -27897,6 +29196,26 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "retention_days": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.UpdateChatSystemPromptRequest": {
+            "type": "object",
+            "properties": {
+                "include_default_system_prompt": {
+                    "type": "boolean"
+                },
+                "system_prompt": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateChatWorkspaceTTLRequest": {
+            "type": "object",
+            "properties": {
+                "workspace_ttl_ms": {
+                    "description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
                     "type": "integer"
                 }
             }
@@ -28118,6 +29437,10 @@ const docTemplate = `{
                 "allow_user_cancel_workspace_jobs": {
                     "type": "boolean"
                 },
+                "allow_workspace_renames": {
+                    "description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
+                    "type": "boolean"
+                },
                 "autostart_requirement": {
                     "$ref": "#/definitions/codersdk.TemplateAutostartRequirement"
                 },
@@ -28241,6 +29564,24 @@ const docTemplate = `{
                 },
                 "theme_preference": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateUserChatCompactionThresholdRequest": {
+            "type": "object",
+            "properties": {
+                "threshold_percent": {
+                    "type": "integer",
+                    "maximum": 100,
+                    "minimum": 0
+                }
+            }
+        },
+        "codersdk.UpdateUserChatDebugLoggingRequest": {
+            "type": "object",
+            "properties": {
+                "debug_logging_enabled": {
+                    "type": "boolean"
                 }
             }
         },
@@ -28691,6 +30032,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.UserAIProviderKeyConfig": {
+            "type": "object",
+            "properties": {
+                "byok_enabled": {
+                    "type": "boolean"
+                },
+                "has_provider_api_key": {
+                    "type": "boolean"
+                },
+                "has_user_api_key": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "$ref": "#/definitions/codersdk.AIProviderSummary"
+                }
+            }
+        },
         "codersdk.UserAISpendStatus": {
             "type": "object",
             "properties": {
@@ -28808,6 +30166,51 @@ const docTemplate = `{
                 "theme_preference": {
                     "description": "ThemePreference is the legacy single-field appearance setting. In\n\"single\" mode it mirrors the active theme. In \"sync\" mode modern\nclients normally mirror the active OS slot, but older clients can\nupdate only this field, so it may diverge from ThemeLight or\nThemeDark until a modern client saves the full appearance state\nagain.",
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.UserChatCompactionThreshold": {
+            "type": "object",
+            "properties": {
+                "model_config_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "threshold_percent": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.UserChatCompactionThresholds": {
+            "type": "object",
+            "properties": {
+                "thresholds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
+                    }
+                }
+            }
+        },
+        "codersdk.UserChatCustomPrompt": {
+            "type": "object",
+            "properties": {
+                "custom_prompt": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UserChatDebugLoggingSettings": {
+            "type": "object",
+            "properties": {
+                "debug_logging_enabled": {
+                    "type": "boolean"
+                },
+                "forced_by_deployment": {
+                    "type": "boolean"
+                },
+                "user_toggle_allowed": {
+                    "type": "boolean"
                 }
             }
         },
@@ -28981,7 +30384,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "enabled": {
-                    "description": "Enabled is stored intent. Deployment policy may block a stored target.",
+                    "description": "Enabled controls whether the secret is injected into workspaces.\nDisabled secrets remain visible and editable, but are not added\nto the agent manifest, so they are not exposed as environment\nvariables or written to secret files.",
                     "type": "boolean"
                 },
                 "env_name": {
@@ -29155,6 +30558,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "allow_renames": {
+                    "description": "AllowRenames is the effective rename permission for this workspace,\nderived from the template's allow_workspace_renames setting and the\ndeprecated deployment-wide flag.",
                     "type": "boolean"
                 },
                 "automatic_updates": {
@@ -29250,11 +30654,7 @@ const docTemplate = `{
                 },
                 "task_id": {
                     "description": "TaskID, if set, indicates that the workspace is relevant to the given codersdk.Task.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/uuid.NullUUID"
-                        }
-                    ]
+                    "type": "string"
                 },
                 "template_active_version_id": {
                     "type": "string",
@@ -29411,12 +30811,8 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "parent_id": {
-                    "format": "uuid",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/uuid.NullUUID"
-                        }
-                    ]
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "ready_at": {
                     "type": "string",
@@ -29571,12 +30967,8 @@ const docTemplate = `{
                     ]
                 },
                 "subagent_id": {
-                    "format": "uuid",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/uuid.NullUUID"
-                        }
-                    ]
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "workspace_folder": {
                     "type": "string"
@@ -31429,10 +32821,6 @@ const docTemplate = `{
                     "description": "[ip]:port of global IPv6",
                     "type": "string"
                 },
-                "hairPinning": {
-                    "description": "HairPinning is whether the router supports communicating\nbetween two local devices through the NATted public IP address\n(on IPv4).",
-                    "type": "string"
-                },
                 "icmpv4": {
                     "description": "an ICMPv4 round trip completed",
                     "type": "boolean"
@@ -31858,18 +33246,6 @@ const docTemplate = `{
         },
         "url.Userinfo": {
             "type": "object"
-        },
-        "uuid.NullUUID": {
-            "type": "object",
-            "properties": {
-                "uuid": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if UUID is not NULL",
-                    "type": "boolean"
-                }
-            }
         },
         "workspaceapps.AccessMethod": {
             "type": "string",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -154,6 +154,970 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/chats": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chats",
+                "operationId": "list-chats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query. Supports ` + "`" + `title:\u003csubstring\u003e` + "`" + ` (case-insensitive, quote multi-word values), ` + "`" + `archived:bool` + "`" + `, ` + "`" + `has_unread:bool` + "`" + `, ` + "`" + `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` + "`" + ` as repeated or comma-separated values, ` + "`" + `source:\u003ccreated_by_me\\|shared_with_me\u003e` + "`" + `, ` + "`" + `diff_url:\u003curl\u003e` + "`" + ` (quote values containing colons), ` + "`" + `pr:\u003cnumber\u003e` + "`" + ` (exact PR number match), ` + "`" + `repo:\u003cowner/repo\u003e` + "`" + ` (case-insensitive substring match against git remote origin or URL), ` + "`" + `pr_title:\u003ctext\u003e` + "`" + ` (case-insensitive PR title substring), ` + "`" + `search:\u003ctext\u003e` + "`" + ` (full-text search across chat titles, PR titles, PR numbers, and message bodies; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words returns an empty list). Bare terms are not supported; use ` + "`" + `title:\u003cvalue\u003e` + "`" + ` or ` + "`" + `search:\u003cvalue\u003e` + "`" + `.",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by label as key:value. Repeat for multiple (AND logic).",
+                        "name": "label",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.Chat"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat",
+                "operationId": "create-chat",
+                "parameters": [
+                    {
+                        "description": "Create chat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    },
+                    "413": {
+                        "description": "Request body exceeds 256 KiB",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/retention-days": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat retention days",
+                "operationId": "get-chat-retention-days",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat retention days",
+                "operationId": "update-chat-retention-days",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chats/files": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Upload chat file",
+                "operationId": "upload-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UploadChatFileResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request body exceeds 10 MiB",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/files/{file}": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat file",
+                "operationId": "get-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/files/{file}/download": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Download chat file with signed token",
+                "operationId": "download-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Signed download token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chats/files/{file}/download-url": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat file download URL",
+                "operationId": "create-chat-file-download-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chats/watch": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Watch chat events for a user via WebSockets",
+                "operationId": "watch-chat-events-for-a-user-via-websockets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatWatchEvent"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat by ID",
+                "operationId": "get-chat-by-id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat",
+                "operationId": "update-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update chat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/acl": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat ACLs",
+                "operationId": "get-chat-acls",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatACL"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat ACL",
+                "operationId": "update-chat-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update chat ACL request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatACL"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chats/{chat}/compact": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.\nRequests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Compact chat",
+                "operationId": "compact-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chats/{chat}/context": {
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Refresh chat context",
+                "operationId": "refresh-chat-context",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/cost": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.\n\nCost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat cost",
+                "operationId": "get-chat-cost",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatCost"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/diff": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat diff contents",
+                "operationId": "get-chat-diff-contents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDiffContents"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/interrupt": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Interrupt chat",
+                "operationId": "interrupt-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/messages": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat messages",
+                "operationId": "list-chat-messages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return messages with id \u003c before_id",
+                        "name": "before_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return messages with id \u003e after_id",
+                        "name": "after_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1 to 200. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatMessagesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Send chat message",
+                "operationId": "send-chat-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Create chat message request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatMessageResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/messages/{message}": {
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Edit chat message",
+                "operationId": "edit-chat-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Message ID",
+                        "name": "message",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Edit chat message request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.EditChatMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.EditChatMessageResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/prompts": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.\n\nReturns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat user prompts",
+                "operationId": "list-chat-user-prompts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatPromptsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/reconcile-invalid": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Reconcile invalid chat state",
+                "operationId": "reconcile-invalid-chat-state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/stream": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Stream chat events via WebSockets",
+                "operationId": "stream-chat-events-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatStreamEvent"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/{chat}/stream/desktop": {
             "get": {
                 "description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
@@ -178,6 +1142,117 @@ const docTemplate = `{
                 "responses": {
                     "101": {
                         "description": "Switching Protocols"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/stream/git": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Watch chat workspace git state via WebSockets",
+                "operationId": "watch-chat-workspace-git-state-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/stream/parts": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Stream chat parts via WebSockets",
+                "operationId": "stream-chat-parts-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatStreamEvent"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/chats/{chat}/title/regenerate": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Regenerate chat title",
+                "operationId": "regenerate-chat-title",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
                     }
                 },
                 "security": [
@@ -234,6 +1309,927 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/mcp/servers/{mcpServer}/oauth2/disconnect": {
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Disconnect MCP server OAuth2 token",
+                "operationId": "disconnect-mcp-server-oauth2-token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpServer",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/model-overrides": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List organization chat model overrides",
+                "operationId": "list-organization-chat-model-overrides",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/model-overrides/{context}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update organization chat model override",
+                "operationId": "update-organization-chat-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "general",
+                            "explore",
+                            "title_generation",
+                            "compaction",
+                            "advisor"
+                        ],
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/models": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List AI models and provider descriptors in an organization",
+                "operationId": "list-ai-models-by-organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create an AI model in an organization",
+                "operationId": "create-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatModelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/models/{model}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get an AI model",
+                "operationId": "get-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete an AI model",
+                "operationId": "delete-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update an AI model",
+                "operationId": "update-ai-model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Model updates",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModel"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/chats/models/{model}/acl": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get an AI model ACL",
+                "operationId": "get-ai-model-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelACL"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update an AI model ACL",
+                "operationId": "update-ai-model-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model ID",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sparse model ACL update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/mcp-servers": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "List MCP server configs",
+                "operationId": "list-mcp-server-configs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.MCPServerConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Create MCP server config",
+                "operationId": "create-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Create MCP server config request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Get MCP server config",
+                "operationId": "get-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Delete MCP server config",
+                "operationId": "delete-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Update MCP server config",
+                "operationId": "update-mcp-server-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update MCP server config request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Get MCP server config ACL",
+                "operationId": "get-mcp-server-config-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.MCPServerConfigACL"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Update MCP server config ACL",
+                "operationId": "update-mcp-server-config-acl",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update MCP server config ACL request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
+            "get": {
+                "tags": [
+                    "MCP"
+                ],
+                "summary": "Initiate MCP server OAuth2 connect",
+                "operationId": "initiate-mcp-server-oauth2-connect",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "MCP server config ID",
+                        "name": "mcpserverconfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "307": {
+                        "description": "Temporary Redirect"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get organization member chat model overrides",
+                "operationId": "get-organization-member-chat-model-overrides",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User name, ID, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
+        "/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update organization member chat model override",
+                "operationId": "update-organization-member-chat-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization name or ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User name, ID, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "root",
+                            "general",
+                            "explore"
+                        ],
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Personal model override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     }
                 },
                 "security": [
@@ -1361,1923 +3357,6 @@ const docTemplate = `{
                         }
                     }
                 }
-            }
-        },
-        "/api/v2/chats": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chats",
-                "operationId": "list-chats",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search query. Supports ` + "`" + `title:\u003csubstring\u003e` + "`" + ` (case-insensitive, quote multi-word values), ` + "`" + `archived:bool` + "`" + `, ` + "`" + `has_unread:bool` + "`" + `, ` + "`" + `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` + "`" + ` as repeated or comma-separated values, ` + "`" + `source:\u003ccreated_by_me\\|shared_with_me\u003e` + "`" + `, ` + "`" + `diff_url:\u003curl\u003e` + "`" + ` (quote values containing colons), ` + "`" + `pr:\u003cnumber\u003e` + "`" + ` (exact PR number match), ` + "`" + `repo:\u003cowner/repo\u003e` + "`" + ` (case-insensitive substring match against git remote origin or URL), ` + "`" + `pr_title:\u003ctext\u003e` + "`" + ` (case-insensitive PR title substring), ` + "`" + `search:\u003ctext\u003e` + "`" + ` (full-text search across chat titles, PR titles, PR numbers, and message bodies; message bodies match English word stems, e.g. ` + "`" + `refactor` + "`" + ` matches ` + "`" + `refactoring` + "`" + `, and ignore English stopwords; titles and PR titles match whole words case-insensitively without stemming; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words, e.g. punctuation only, returns an empty list). Bare terms are not supported; use ` + "`" + `title:\u003cvalue\u003e` + "`" + ` or ` + "`" + `search:\u003cvalue\u003e` + "`" + `.",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "collectionFormat": "multi",
-                        "description": "Filter by label as key:value. Repeat for multiple (AND logic).",
-                        "name": "label",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "After ID",
-                        "name": "after_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page limit",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page offset",
-                        "name": "offset",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.Chat"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create chat",
-                "operationId": "create-chat",
-                "parameters": [
-                    {
-                        "description": "Create chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    },
-                    "413": {
-                        "description": "Request body exceeds 256 KiB",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Response"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/by-workspace": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chats by workspace",
-                "operationId": "list-chats-by-workspace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Comma-separated workspace IDs",
-                        "name": "workspace_ids",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/coderd.chatsByWorkspaceResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/auto-archive-days": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat auto archive days",
-                "operationId": "get-chat-auto-archive-days",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatAutoArchiveDaysResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat auto archive days",
-                "operationId": "update-chat-auto-archive-days",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatAutoArchiveDaysRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/debug-logging": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat debug logging setting",
-                "operationId": "get-chat-debug-logging-setting",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatDebugLoggingAdminSettings"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat debug logging setting",
-                "operationId": "update-chat-debug-logging-setting",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatDebugLoggingAllowUsersRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/debug-retention-days": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat debug retention days",
-                "operationId": "get-chat-debug-retention-days",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatDebugRetentionDaysResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat debug retention days",
-                "operationId": "update-chat-debug-retention-days",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatDebugRetentionDaysRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/personal-model-overrides": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat personal model override settings",
-                "operationId": "get-chat-personal-model-override-settings",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatPersonalModelOverridesAdminSettings"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat personal model override settings",
-                "operationId": "update-chat-personal-model-override-settings",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/plan-mode-instructions": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat plan mode instructions",
-                "operationId": "get-chat-plan-mode-instructions",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatPlanModeInstructionsResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat plan mode instructions",
-                "operationId": "update-chat-plan-mode-instructions",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatPlanModeInstructionsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/retention-days": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat retention days",
-                "operationId": "get-chat-retention-days",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat retention days",
-                "operationId": "update-chat-retention-days",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/config/system-prompt": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat system prompt",
-                "operationId": "get-chat-system-prompt",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatSystemPromptResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat system prompt",
-                "operationId": "update-chat-system-prompt",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatSystemPromptRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/user-compaction-thresholds": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get user chat compaction thresholds",
-                "operationId": "get-user-chat-compaction-thresholds",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatCompactionThresholds"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/config/user-compaction-thresholds/{modelConfig}": {
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update user chat compaction threshold",
-                "operationId": "update-user-chat-compaction-threshold",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model config ID",
-                        "name": "modelConfig",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateUserChatCompactionThresholdRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Delete user chat compaction threshold",
-                "operationId": "delete-user-chat-compaction-threshold",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model config ID",
-                        "name": "modelConfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/config/user-debug-logging": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get user chat debug logging setting",
-                "operationId": "get-user-chat-debug-logging-setting",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatDebugLoggingSettings"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update user chat debug logging setting",
-                "operationId": "update-user-chat-debug-logging-setting",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateUserChatDebugLoggingRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/user-prompt": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get user chat custom prompt",
-                "operationId": "get-user-chat-custom-prompt",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update user chat custom prompt",
-                "operationId": "update-user-chat-custom-prompt",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/config/workspace-ttl": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat workspace time to live",
-                "operationId": "get-chat-workspace-time-to-live",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatWorkspaceTTLResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat workspace time to live",
-                "operationId": "update-chat-workspace-time-to-live",
-                "parameters": [
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatWorkspaceTTLRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/files": {
-            "post": {
-                "consumes": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Upload chat file",
-                "operationId": "upload-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "example": "attachment; filename=\"image.png\"",
-                        "description": "Attachment disposition carrying the file name",
-                        "name": "Content-Disposition",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "description": "Raw file binary data",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UploadChatFileResponse"
-                        }
-                    },
-                    "413": {
-                        "description": "Request body exceeds 10 MiB",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Response"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "rawBodyFile": "image.png"
-                }
-            }
-        },
-        "/api/v2/chats/files/{file}": {
-            "get": {
-                "produces": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat file",
-                "operationId": "get-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/files/{file}/download": {
-            "get": {
-                "produces": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Download chat file with signed token",
-                "operationId": "download-chat-file-with-signed-token",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Signed download token",
-                        "name": "token",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/files/{file}/download-url": {
-            "post": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create chat file download URL",
-                "operationId": "create-chat-file-download-url",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/watch": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat events for a user via WebSockets",
-                "operationId": "watch-chat-events-for-a-user-via-websockets",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatWatchEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat by ID",
-                "operationId": "get-chat-by-id",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat",
-                "operationId": "update-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/acl": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat ACLs",
-                "operationId": "get-chat-acls",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatACL"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat ACL",
-                "operationId": "update-chat-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update chat ACL request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatACL"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/{chat}/clear": {
-            "post": {
-                "description": "Resets the model context of an idle or errored chat,\nclearing any stored error. The reset commits\nsynchronously with no model call: the transcript is\npreserved and the next prompt starts from a fresh\ncontext.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Clear chat context",
-                "operationId": "clear-chat-context",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/{chat}/compact": {
-            "post": {
-                "description": "Requests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Compact chat",
-                "operationId": "compact-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/{chat}/context": {
-            "put": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Refresh chat context",
-                "operationId": "refresh-chat-context",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/cost": {
-            "get": {
-                "description": "Cost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat cost",
-                "operationId": "get-chat-cost",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatCost"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/diff": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat diff contents",
-                "operationId": "get-chat-diff-contents",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatDiffContents"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/interrupt": {
-            "post": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Interrupt chat",
-                "operationId": "interrupt-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/messages": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat messages",
-                "operationId": "list-chat-messages",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Return messages with id \u003c before_id",
-                        "name": "before_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Return messages with id \u003e after_id",
-                        "name": "after_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 1 to 200. Defaults to 50.",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatMessagesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Send chat message",
-                "operationId": "send-chat-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Create chat message request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatMessageResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/messages/{message}": {
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Edit chat message",
-                "operationId": "edit-chat-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Message ID",
-                        "name": "message",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Edit chat message request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.EditChatMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.EditChatMessageResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/prompts": {
-            "get": {
-                "description": "Returns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat user prompts",
-                "operationId": "list-chat-user-prompts",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatPromptsResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/queue/{queuedMessage}": {
-            "delete": {
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Delete chat queued message",
-                "operationId": "delete-chat-queued-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Queued message ID",
-                        "name": "queuedMessage",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/queue/{queuedMessage}/promote": {
-            "post": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Promote chat queued message",
-                "operationId": "promote-chat-queued-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Queued message ID",
-                        "name": "queuedMessage",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "description": "Accepted",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Response"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/reconcile-invalid": {
-            "post": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Reconcile invalid chat state",
-                "operationId": "reconcile-invalid-chat-state",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/stream": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Stream chat events via WebSockets",
-                "operationId": "stream-chat-events-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Skip snapshot messages with id at or before this cursor",
-                        "name": "after_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.ChatStreamEvent"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/stream/git": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat workspace git state via WebSockets",
-                "operationId": "watch-chat-workspace-git-state-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/stream/parts": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Stream chat parts via WebSockets",
-                "operationId": "stream-chat-parts-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.ChatStreamEvent"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/chats/{chat}/title/propose": {
-            "post": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Propose chat title",
-                "operationId": "propose-chat-title",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ProposeChatTitleResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/chats/{chat}/tool-results": {
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Submit chat tool results",
-                "operationId": "submit-chat-tool-results",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.SubmitToolResultsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
             }
         },
         "/api/v2/connectionlog": {
@@ -5076,44 +5155,6 @@ const docTemplate = `{
                 ]
             }
         },
-        "/api/v2/mcp/servers/{mcpServer}/oauth2/disconnect": {
-            "delete": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Disconnect MCP server OAuth2 token",
-                "operationId": "disconnect-mcp-server-oauth2-token",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpServer",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
         "/api/v2/notifications/custom": {
             "post": {
                 "consumes": [
@@ -6111,485 +6152,6 @@ const docTemplate = `{
                 ]
             }
         },
-        "/api/v2/organizations/{organization}/chats/model-overrides": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List organization chat model overrides",
-                "operationId": "list-organization-chat-model-overrides",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/chats/model-overrides/{context}": {
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update organization chat model override",
-                "operationId": "update-organization-chat-model-override",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "general",
-                            "explore",
-                            "title_generation",
-                            "compaction",
-                            "advisor"
-                        ],
-                        "type": "string",
-                        "description": "Override context",
-                        "name": "context",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Model override",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/chats/models": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List AI models and provider descriptors in an organization",
-                "operationId": "list-ai-models-and-provider-descriptors-in-an-organization",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create an AI model in an organization",
-                "operationId": "create-an-ai-model-in-an-organization",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Model",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatModelRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModel"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/organizations/{organization}/chats/models/{model}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get an AI model",
-                "operationId": "get-an-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModel"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Delete an AI model",
-                "operationId": "delete-an-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update an AI model",
-                "operationId": "update-an-ai-model",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Model updates",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModel"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/chats/models/{model}/acl": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get an AI model ACL",
-                "operationId": "get-an-ai-model-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelACL"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update an AI model ACL",
-                "operationId": "update-an-ai-model-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Sparse model ACL update",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/chats/models/{model}/acl/available": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get available AI model ACL users and groups",
-                "operationId": "get-available-ai-model-acl-users-and-groups",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Model ID",
-                        "name": "model",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "User search query; free-text search also applies to groups",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User after ID",
-                        "name": "after_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page limit for users and groups, if 0 returns all candidates",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "User page offset",
-                        "name": "offset",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ACLAvailable"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
         "/api/v2/organizations/{organization}/groups": {
             "get": {
                 "produces": [
@@ -6872,433 +6434,6 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ]
-            }
-        },
-        "/api/v2/organizations/{organization}/mcp-servers": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "List MCP server configs",
-                "operationId": "list-mcp-server-configs",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.MCPServerConfig"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Create MCP server config",
-                "operationId": "create-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Create MCP server config request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Get MCP server config",
-                "operationId": "get-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "delete": {
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Delete MCP server config",
-                "operationId": "delete-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Update MCP server config",
-                "operationId": "update-mcp-server-config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update MCP server config request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Get MCP server config ACL",
-                "operationId": "get-mcp-server-config-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.MCPServerConfigACL"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            },
-            "patch": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Update MCP server config ACL",
-                "operationId": "update-mcp-server-config-acl",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update MCP server config ACL request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl/available": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Get available MCP server config ACL users and groups",
-                "operationId": "get-available-mcp-server-config-acl-users-and-groups",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "User search query; free-text search also applies to groups",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User after ID",
-                        "name": "after_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page limit for users and groups, if 0 returns all candidates",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "User page offset",
-                        "name": "offset",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ACLAvailable"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
-            "get": {
-                "tags": [
-                    "MCP"
-                ],
-                "summary": "Initiate MCP server OAuth2 connect",
-                "operationId": "initiate-mcp-server-oauth2-connect",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "MCP server config ID",
-                        "name": "mcpserverconfig",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Temporary Redirect"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
             }
         },
         "/api/v2/organizations/{organization}/members": {
@@ -7629,112 +6764,6 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ]
-            }
-        },
-        "/api/v2/organizations/{organization}/members/{user}/chats/model-overrides": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get organization member chat model overrides",
-                "operationId": "get-organization-member-chat-model-overrides",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "User name, ID, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
-            }
-        },
-        "/api/v2/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update organization member chat model override",
-                "operationId": "update-organization-member-chat-model-override",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization name or ID",
-                        "name": "organization",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "User name, ID, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "root",
-                            "general",
-                            "explore"
-                        ],
-                        "type": "string",
-                        "description": "Override context",
-                        "name": "context",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Personal model override",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "x-apidocgen": {
-                    "skip": true
-                }
             }
         },
         "/api/v2/organizations/{organization}/members/{user}/roles": {
@@ -8131,7 +7160,7 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "string",
+                        "type": "object",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
                         "in": "query"
@@ -8242,7 +7271,7 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
-                        "type": "string",
+                        "type": "object",
                         "description": "Provisioner tags to filter by (JSON of the form ` + "`" + `{'tag1':'value1','tag2':'value2'}` + "`" + `)",
                         "name": "tags",
                         "in": "query"
@@ -11828,131 +10857,6 @@ const docTemplate = `{
                 ]
             }
         },
-        "/api/v2/users/{user}/ai-provider-keys": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List user AI provider key configurations",
-                "operationId": "list-user-ai-provider-key-configurations",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID, username, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v2/users/{user}/ai-provider-keys/{aiProvider}": {
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update user AI provider key",
-                "operationId": "update-user-ai-provider-key",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID, username, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "AI provider ID",
-                        "name": "aiProvider",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Request body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateUserAIProviderKeyRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "delete": {
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Delete user AI provider key",
-                "operationId": "delete-user-ai-provider-key",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User ID, username, or me",
-                        "name": "user",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "AI provider ID",
-                        "name": "aiProvider",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
         "/api/v2/users/{user}/ai/budget/override": {
             "get": {
                 "produces": [
@@ -13242,6 +12146,18 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/codersdk.UserSecret"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
                     }
                 },
                 "security": [
@@ -13433,6 +12349,18 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/codersdk.UserSecret"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
                         }
                     }
                 },
@@ -16525,7 +15453,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
+                        "description": "Token scopes (currently ignored)",
                         "name": "scope",
                         "in": "query"
                     }
@@ -16581,7 +15509,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
+                        "description": "Token scopes (currently ignored)",
                         "name": "scope",
                         "in": "query"
                     }
@@ -16782,7 +15710,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.",
+                        "description": "Client secret, required if grant_type=authorization_code",
                         "name": "client_secret",
                         "in": "formData"
                     },
@@ -16790,12 +15718,6 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Authorization code, required if grant_type=authorization_code",
                         "name": "code",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "description": "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636.",
-                        "name": "code_verifier",
                         "in": "formData"
                     },
                     {
@@ -17239,12 +16161,6 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "ReinitializeReasonPrebuildClaimed"
             ]
-        },
-        "coderd.chatsByWorkspaceResponse": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
         },
         "coderd.cspViolation": {
             "type": "object",
@@ -18034,33 +16950,6 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
-                }
-            }
-        },
-        "codersdk.AIProviderSummary": {
-            "type": "object",
-            "properties": {
-                "deleted": {
-                    "type": "boolean"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "icon": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/codersdk.AIProviderType"
                 }
             }
         },
@@ -19488,14 +18377,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.ChatAutoArchiveDaysResponse": {
-            "type": "object",
-            "properties": {
-                "auto_archive_days": {
-                    "type": "integer"
-                }
-            }
-        },
         "codersdk.ChatBusyBehavior": {
             "type": "string",
             "enum": [
@@ -19670,25 +18551,6 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "unpriced_request_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "codersdk.ChatDebugLoggingAdminSettings": {
-            "type": "object",
-            "properties": {
-                "allow_users": {
-                    "type": "boolean"
-                },
-                "forced_by_deployment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "codersdk.ChatDebugRetentionDaysResponse": {
-            "type": "object",
-            "properties": {
-                "debug_retention_days": {
                     "type": "integer"
                 }
             }
@@ -20059,8 +18921,12 @@ const docTemplate = `{
                 },
                 "context_file_agent_id": {
                     "description": "ContextFileAgentID is the workspace agent that provided\nthis context file. Used to detect when the agent changes\n(e.g. workspace rebuilt) so instruction files can be\nre-persisted with fresh content.",
-                    "type": "string",
-                    "format": "uuid"
+                    "format": "uuid",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/uuid.NullUUID"
+                        }
+                    ]
                 },
                 "context_file_content": {
                     "description": "ContextFileContent holds the file content sent to the LLM.\nInternal only: stripped before API responses to keep\npayloads small. The backend reads it when building the\nprompt via partsToMessageParts.",
@@ -20101,8 +18967,12 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "file_id": {
-                    "type": "string",
-                    "format": "uuid"
+                    "format": "uuid",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/uuid.NullUUID"
+                        }
+                    ]
                 },
                 "file_name": {
                     "type": "string"
@@ -20118,8 +18988,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "mcp_server_config_id": {
-                    "type": "string",
-                    "format": "uuid"
+                    "format": "uuid",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/uuid.NullUUID"
+                        }
+                    ]
                 },
                 "media_type": {
                     "type": "string"
@@ -20344,16 +19218,16 @@ const docTemplate = `{
         "codersdk.ChatModelACL": {
             "type": "object",
             "properties": {
-                "groups": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.ChatGroup"
+                "group_roles": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/codersdk.ChatRole"
                     }
                 },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.ChatUser"
+                "user_roles": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/codersdk.ChatRole"
                     }
                 }
             }
@@ -20905,14 +19779,6 @@ const docTemplate = `{
                 "ChatPersonalModelOverrideModeModel"
             ]
         },
-        "codersdk.ChatPersonalModelOverridesAdminSettings": {
-            "type": "object",
-            "properties": {
-                "allow_users": {
-                    "type": "boolean"
-                }
-            }
-        },
         "codersdk.ChatPlanMode": {
             "type": "string",
             "enum": [
@@ -20921,14 +19787,6 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "ChatPlanModePlan"
             ]
-        },
-        "codersdk.ChatPlanModeInstructionsResponse": {
-            "type": "object",
-            "properties": {
-                "plan_mode_instructions": {
-                    "type": "string"
-                }
-            }
         },
         "codersdk.ChatPrompt": {
             "type": "object",
@@ -21166,20 +20024,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.ChatSystemPromptResponse": {
-            "type": "object",
-            "properties": {
-                "default_system_prompt": {
-                    "type": "string"
-                },
-                "include_default_system_prompt": {
-                    "type": "boolean"
-                },
-                "system_prompt": {
-                    "type": "string"
-                }
-            }
-        },
         "codersdk.ChatUnsupportedProvider": {
             "type": "object",
             "properties": {
@@ -21266,15 +20110,6 @@ const docTemplate = `{
                 "ChatWatchEventKindActionRequired",
                 "ChatWatchEventKindContextDirty"
             ]
-        },
-        "codersdk.ChatWorkspaceTTLResponse": {
-            "type": "object",
-            "properties": {
-                "workspace_ttl_ms": {
-                    "description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
-                    "type": "integer"
-                }
-            }
         },
         "codersdk.ClusterConfig": {
             "type": "object",
@@ -21942,10 +20777,6 @@ const docTemplate = `{
                     "description": "Allow users to cancel in-progress workspace jobs.\n*bool as the default value is \"true\".",
                     "type": "boolean"
                 },
-                "allow_workspace_renames": {
-                    "description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name, so this defaults to false.",
-                    "type": "boolean"
-                },
                 "autostart_requirement": {
                     "description": "AutostartRequirement allows optionally specifying the autostart allowed days\nfor workspaces created from this template. This is an enterprise feature.",
                     "allOf": [
@@ -22277,14 +21108,6 @@ const docTemplate = `{
                             "$ref": "#/definitions/codersdk.PremiumFunnelSource"
                         }
                     ]
-                }
-            }
-        },
-        "codersdk.CreateUserAIProviderKeyRequest": {
-            "type": "object",
-            "properties": {
-                "api_key": {
-                    "type": "string"
                 }
             }
         },
@@ -22879,7 +21702,6 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.AIConfig"
                 },
                 "allow_workspace_renames": {
-                    "description": "Deprecated: Use the per-template allow_workspace_renames setting instead.",
                     "type": "boolean"
                 },
                 "autobuild_poll_interval": {
@@ -22921,7 +21743,7 @@ const docTemplate = `{
                 "disable_path_apps": {
                     "type": "boolean"
                 },
-                "disable_workspace_agent_context_sync": {
+                "disable_user_secret_file_path": {
                     "type": "boolean"
                 },
                 "disable_workspace_sharing": {
@@ -22975,12 +21797,6 @@ const docTemplate = `{
                 },
                 "logging": {
                     "$ref": "#/definitions/codersdk.LoggingConfig"
-                },
-                "mcp_allowed_private_cidrs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 },
                 "metrics_cache_refresh_interval": {
                     "type": "integer"
@@ -23845,21 +22661,13 @@ const docTemplate = `{
         "codersdk.GroupMemberAISpend": {
             "type": "object",
             "properties": {
-                "effective_budget": {
-                    "description": "EffectiveBudget is the spend limit that currently applies to the user.\nNull when no budget applies or the effective group belongs to a different\norganization than the queried group.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/codersdk.AIBudgetLimit"
-                        }
-                    ]
-                },
                 "effective_group_id": {
                     "description": "EffectiveGroupID is the user's effective budget group within the queried\ngroup's organization, falling back to the Everyone group when no budget\napplies. Null when the effective group belongs to a different organization\nthan the queried group.",
                     "type": "string",
                     "format": "uuid"
                 },
                 "group_budget": {
-                    "description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. When populated, it matches EffectiveBudget. Null\nwhen the user's budget resolves to another group or no budget applies.\nDeprecated: Use EffectiveBudget instead.",
+                    "description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. Null when the user's budget resolves to another\ngroup or no budget applies to the user.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/codersdk.AIBudgetLimit"
@@ -26410,14 +25218,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.ProposeChatTitleResponse": {
-            "type": "object",
-            "properties": {
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
         "codersdk.ProvisionerConfig": {
             "type": "object",
             "properties": {
@@ -27652,17 +26452,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.SubmitToolResultsRequest": {
-            "type": "object",
-            "properties": {
-                "results": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.ToolResult"
-                    }
-                }
-            }
-        },
         "codersdk.SupportConfig": {
             "type": "object",
             "properties": {
@@ -27768,10 +26557,6 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "allow_user_cancel_workspace_jobs": {
-                    "type": "boolean"
-                },
-                "allow_workspace_renames": {
-                    "description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
                     "type": "boolean"
                 },
                 "autostart_requirement": {
@@ -28907,23 +27692,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.ToolResult": {
-            "type": "object",
-            "properties": {
-                "is_error": {
-                    "type": "boolean"
-                },
-                "output": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "tool_call_id": {
-                    "type": "string"
-                }
-            }
-        },
         "codersdk.TraceConfig": {
             "type": "object",
             "properties": {
@@ -29034,30 +27802,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.UpdateChatAutoArchiveDaysRequest": {
-            "type": "object",
-            "properties": {
-                "auto_archive_days": {
-                    "type": "integer"
-                }
-            }
-        },
-        "codersdk.UpdateChatDebugLoggingAllowUsersRequest": {
-            "type": "object",
-            "properties": {
-                "allow_users": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "codersdk.UpdateChatDebugRetentionDaysRequest": {
-            "type": "object",
-            "properties": {
-                "debug_retention_days": {
-                    "type": "integer"
-                }
-            }
-        },
         "codersdk.UpdateChatModelACLRequest": {
             "type": "object",
             "properties": {
@@ -29116,22 +27860,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest": {
-            "type": "object",
-            "properties": {
-                "allow_users": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "codersdk.UpdateChatPlanModeInstructionsRequest": {
-            "type": "object",
-            "properties": {
-                "plan_mode_instructions": {
-                    "type": "string"
-                }
-            }
-        },
         "codersdk.UpdateChatRequest": {
             "type": "object",
             "properties": {
@@ -29169,26 +27897,6 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "retention_days": {
-                    "type": "integer"
-                }
-            }
-        },
-        "codersdk.UpdateChatSystemPromptRequest": {
-            "type": "object",
-            "properties": {
-                "include_default_system_prompt": {
-                    "type": "boolean"
-                },
-                "system_prompt": {
-                    "type": "string"
-                }
-            }
-        },
-        "codersdk.UpdateChatWorkspaceTTLRequest": {
-            "type": "object",
-            "properties": {
-                "workspace_ttl_ms": {
-                    "description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
                     "type": "integer"
                 }
             }
@@ -29410,10 +28118,6 @@ const docTemplate = `{
                 "allow_user_cancel_workspace_jobs": {
                     "type": "boolean"
                 },
-                "allow_workspace_renames": {
-                    "description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
-                    "type": "boolean"
-                },
                 "autostart_requirement": {
                     "$ref": "#/definitions/codersdk.TemplateAutostartRequirement"
                 },
@@ -29537,24 +28241,6 @@ const docTemplate = `{
                 },
                 "theme_preference": {
                     "type": "string"
-                }
-            }
-        },
-        "codersdk.UpdateUserChatCompactionThresholdRequest": {
-            "type": "object",
-            "properties": {
-                "threshold_percent": {
-                    "type": "integer",
-                    "maximum": 100,
-                    "minimum": 0
-                }
-            }
-        },
-        "codersdk.UpdateUserChatDebugLoggingRequest": {
-            "type": "object",
-            "properties": {
-                "debug_logging_enabled": {
-                    "type": "boolean"
                 }
             }
         },
@@ -30005,23 +28691,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.UserAIProviderKeyConfig": {
-            "type": "object",
-            "properties": {
-                "byok_enabled": {
-                    "type": "boolean"
-                },
-                "has_provider_api_key": {
-                    "type": "boolean"
-                },
-                "has_user_api_key": {
-                    "type": "boolean"
-                },
-                "provider": {
-                    "$ref": "#/definitions/codersdk.AIProviderSummary"
-                }
-            }
-        },
         "codersdk.UserAISpendStatus": {
             "type": "object",
             "properties": {
@@ -30139,51 +28808,6 @@ const docTemplate = `{
                 "theme_preference": {
                     "description": "ThemePreference is the legacy single-field appearance setting. In\n\"single\" mode it mirrors the active theme. In \"sync\" mode modern\nclients normally mirror the active OS slot, but older clients can\nupdate only this field, so it may diverge from ThemeLight or\nThemeDark until a modern client saves the full appearance state\nagain.",
                     "type": "string"
-                }
-            }
-        },
-        "codersdk.UserChatCompactionThreshold": {
-            "type": "object",
-            "properties": {
-                "model_config_id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "threshold_percent": {
-                    "type": "integer"
-                }
-            }
-        },
-        "codersdk.UserChatCompactionThresholds": {
-            "type": "object",
-            "properties": {
-                "thresholds": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
-                    }
-                }
-            }
-        },
-        "codersdk.UserChatCustomPrompt": {
-            "type": "object",
-            "properties": {
-                "custom_prompt": {
-                    "type": "string"
-                }
-            }
-        },
-        "codersdk.UserChatDebugLoggingSettings": {
-            "type": "object",
-            "properties": {
-                "debug_logging_enabled": {
-                    "type": "boolean"
-                },
-                "forced_by_deployment": {
-                    "type": "boolean"
-                },
-                "user_toggle_allowed": {
-                    "type": "boolean"
                 }
             }
         },
@@ -30357,7 +28981,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "enabled": {
-                    "description": "Enabled controls whether the secret is injected into workspaces.\nDisabled secrets remain visible and editable, but are not added\nto the agent manifest, so they are not exposed as environment\nvariables or written to secret files.",
+                    "description": "Enabled is stored intent. Deployment policy may block a stored target.",
                     "type": "boolean"
                 },
                 "env_name": {
@@ -30531,7 +29155,6 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "allow_renames": {
-                    "description": "AllowRenames is the effective rename permission for this workspace,\nderived from the template's allow_workspace_renames setting and the\ndeprecated deployment-wide flag.",
                     "type": "boolean"
                 },
                 "automatic_updates": {
@@ -30627,7 +29250,11 @@ const docTemplate = `{
                 },
                 "task_id": {
                     "description": "TaskID, if set, indicates that the workspace is relevant to the given codersdk.Task.",
-                    "type": "string"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/uuid.NullUUID"
+                        }
+                    ]
                 },
                 "template_active_version_id": {
                     "type": "string",
@@ -30784,8 +29411,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "parent_id": {
-                    "type": "string",
-                    "format": "uuid"
+                    "format": "uuid",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/uuid.NullUUID"
+                        }
+                    ]
                 },
                 "ready_at": {
                     "type": "string",
@@ -30940,8 +29571,12 @@ const docTemplate = `{
                     ]
                 },
                 "subagent_id": {
-                    "type": "string",
-                    "format": "uuid"
+                    "format": "uuid",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/uuid.NullUUID"
+                        }
+                    ]
                 },
                 "workspace_folder": {
                     "type": "string"
@@ -32794,6 +31429,10 @@ const docTemplate = `{
                     "description": "[ip]:port of global IPv6",
                     "type": "string"
                 },
+                "hairPinning": {
+                    "description": "HairPinning is whether the router supports communicating\nbetween two local devices through the NATted public IP address\n(on IPv4).",
+                    "type": "string"
+                },
                 "icmpv4": {
                     "description": "an ICMPv4 round trip completed",
                     "type": "boolean"
@@ -33219,6 +31858,18 @@ const docTemplate = `{
         },
         "url.Userinfo": {
             "type": "object"
+        },
+        "uuid.NullUUID": {
+            "type": "object",
+            "properties": {
+                "uuid": {
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "Valid is true if UUID is not NULL",
+                    "type": "boolean"
+                }
+            }
         },
         "workspaceapps.AccessMethod": {
             "type": "string",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3885,6 +3885,31 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/deployment/user-secrets/capabilities": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "General"
+                ],
+                "summary": "Get user secrets capabilities",
+                "operationId": "get-user-secrets-capabilities",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserSecretsCapabilities"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/v2/derp-map": {
             "get": {
                 "tags": [
@@ -30403,6 +30428,15 @@ const docTemplate = `{
                 "updated_at": {
                     "type": "string",
                     "format": "date-time"
+                }
+            }
+        },
+        "codersdk.UserSecretsCapabilities": {
+            "type": "object",
+            "properties": {
+                "file_path_delivery_enabled": {
+                    "description": "FilePathDeliveryEnabled reports whether Coder writes stored file paths\ninto workspaces. Stored paths are preserved either way.",
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -127,872 +127,6 @@
 				}
 			}
 		},
-		"/api/experimental/chats": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chats",
-				"operationId": "list-chats",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Search query. Supports `title:\u003csubstring\u003e` (case-insensitive, quote multi-word values), `archived:bool`, `has_unread:bool`, `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` as repeated or comma-separated values, `source:\u003ccreated_by_me\\|shared_with_me\u003e`, `diff_url:\u003curl\u003e` (quote values containing colons), `pr:\u003cnumber\u003e` (exact PR number match), `repo:\u003cowner/repo\u003e` (case-insensitive substring match against git remote origin or URL), `pr_title:\u003ctext\u003e` (case-insensitive PR title substring), `search:\u003ctext\u003e` (full-text search across chat titles, PR titles, PR numbers, and message bodies; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words returns an empty list). Bare terms are not supported; use `title:\u003cvalue\u003e` or `search:\u003cvalue\u003e`.",
-						"name": "q",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"description": "Filter by label as key:value. Repeat for multiple (AND logic).",
-						"name": "label",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.Chat"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create chat",
-				"operationId": "create-chat",
-				"parameters": [
-					{
-						"description": "Create chat request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					},
-					"413": {
-						"description": "Request body exceeds 256 KiB",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Response"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/config/retention-days": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat retention days",
-				"operationId": "get-chat-retention-days",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat retention days",
-				"operationId": "update-chat-retention-days",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chats/files": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Upload chat file",
-				"operationId": "upload-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "query",
-						"required": true
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UploadChatFileResponse"
-						}
-					},
-					"413": {
-						"description": "Request body exceeds 10 MiB",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Response"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/files/{file}": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"tags": ["Chats"],
-				"summary": "Get chat file",
-				"operationId": "get-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/files/{file}/download": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"tags": ["Chats"],
-				"summary": "Download chat file with signed token",
-				"operationId": "download-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "Signed download token",
-						"name": "token",
-						"in": "query",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					}
-				},
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chats/files/{file}/download-url": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create chat file download URL",
-				"operationId": "create-chat-file-download-url",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chats/watch": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Watch chat events for a user via WebSockets",
-				"operationId": "watch-chat-events-for-a-user-via-websockets",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatWatchEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat by ID",
-				"operationId": "get-chat-by-id",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"patch": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat",
-				"operationId": "update-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update chat request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/acl": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat ACLs",
-				"operationId": "get-chat-acls",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatACL"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat ACL",
-				"operationId": "update-chat-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update chat ACL request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatACL"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chats/{chat}/compact": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.\nRequests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Compact chat",
-				"operationId": "compact-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chats/{chat}/context": {
-			"put": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Refresh chat context",
-				"operationId": "refresh-chat-context",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/cost": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.\n\nCost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat cost",
-				"operationId": "get-chat-cost",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatCost"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/diff": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat diff contents",
-				"operationId": "get-chat-diff-contents",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatDiffContents"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/interrupt": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Interrupt chat",
-				"operationId": "interrupt-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/messages": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat messages",
-				"operationId": "list-chat-messages",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Return messages with id \u003c before_id",
-						"name": "before_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Return messages with id \u003e after_id",
-						"name": "after_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page size, 1 to 200. Defaults to 50.",
-						"name": "limit",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatMessagesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Send chat message",
-				"operationId": "send-chat-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Create chat message request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatMessageRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatMessageResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/messages/{message}": {
-			"patch": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Edit chat message",
-				"operationId": "edit-chat-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Message ID",
-						"name": "message",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Edit chat message request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.EditChatMessageRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.EditChatMessageResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/prompts": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.\n\nReturns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat user prompts",
-				"operationId": "list-chat-user-prompts",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
-						"name": "limit",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatPromptsResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/reconcile-invalid": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Reconcile invalid chat state",
-				"operationId": "reconcile-invalid-chat-state",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/stream": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Stream chat events via WebSockets",
-				"operationId": "stream-chat-events-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatStreamEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
 		"/api/experimental/chats/{chat}/stream/desktop": {
 			"get": {
 				"description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
@@ -1013,105 +147,6 @@
 				"responses": {
 					"101": {
 						"description": "Switching Protocols"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/stream/git": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Watch chat workspace git state via WebSockets",
-				"operationId": "watch-chat-workspace-git-state-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/experimental/chats/{chat}/stream/parts": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Stream chat parts via WebSockets",
-				"operationId": "stream-chat-parts-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatStreamEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/chats/{chat}/title/regenerate": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Regenerate chat title",
-				"operationId": "regenerate-chat-title",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
 					}
 				},
 				"security": [
@@ -1164,839 +199,6 @@
 				"responses": {
 					"200": {
 						"description": "OK"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/mcp/servers/{mcpServer}/oauth2/disconnect": {
-			"delete": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Disconnect MCP server OAuth2 token",
-				"operationId": "disconnect-mcp-server-oauth2-token",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpServer",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/chats/model-overrides": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List organization chat model overrides",
-				"operationId": "list-organization-chat-model-overrides",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/chats/model-overrides/{context}": {
-			"put": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update organization chat model override",
-				"operationId": "update-organization-chat-model-override",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"enum": [
-							"general",
-							"explore",
-							"title_generation",
-							"compaction",
-							"advisor"
-						],
-						"type": "string",
-						"description": "Override context",
-						"name": "context",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Model override",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/chats/models": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List AI models and provider descriptors in an organization",
-				"operationId": "list-ai-models-by-organization",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"post": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create an AI model in an organization",
-				"operationId": "create-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Model",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatModelRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModel"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/chats/models/{model}": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get an AI model",
-				"operationId": "get-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModel"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"delete": {
-				"tags": ["Chats"],
-				"summary": "Delete an AI model",
-				"operationId": "delete-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update an AI model",
-				"operationId": "update-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Model updates",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModel"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/chats/models/{model}/acl": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get an AI model ACL",
-				"operationId": "get-ai-model-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelACL"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update an AI model ACL",
-				"operationId": "update-ai-model-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Sparse model ACL update",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/mcp-servers": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "List MCP server configs",
-				"operationId": "list-mcp-server-configs",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.MCPServerConfig"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"post": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Create MCP server config",
-				"operationId": "create-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Create MCP server config request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Get MCP server config",
-				"operationId": "get-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"delete": {
-				"tags": ["MCP"],
-				"summary": "Delete MCP server config",
-				"operationId": "delete-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Update MCP server config",
-				"operationId": "update-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update MCP server config request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Get MCP server config ACL",
-				"operationId": "get-mcp-server-config-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfigACL"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Update MCP server config ACL",
-				"operationId": "update-mcp-server-config-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update MCP server config ACL request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
-			"get": {
-				"tags": ["MCP"],
-				"summary": "Initiate MCP server OAuth2 connect",
-				"operationId": "initiate-mcp-server-oauth2-connect",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"307": {
-						"description": "Temporary Redirect"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get organization member chat model overrides",
-				"operationId": "get-organization-member-chat-model-overrides",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "User name, ID, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update organization member chat model override",
-				"operationId": "update-organization-member-chat-model-override",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "User name, ID, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					},
-					{
-						"enum": ["root", "general", "explore"],
-						"type": "string",
-						"description": "Override context",
-						"name": "context",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Personal model override",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
 					}
 				},
 				"security": [
@@ -2990,6 +1192,1709 @@
 						}
 					}
 				}
+			}
+		},
+		"/api/v2/chats": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chats",
+				"operationId": "list-chats",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Search query. Supports `title:\u003csubstring\u003e` (case-insensitive, quote multi-word values), `archived:bool`, `has_unread:bool`, `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` as repeated or comma-separated values, `source:\u003ccreated_by_me\\|shared_with_me\u003e`, `diff_url:\u003curl\u003e` (quote values containing colons), `pr:\u003cnumber\u003e` (exact PR number match), `repo:\u003cowner/repo\u003e` (case-insensitive substring match against git remote origin or URL), `pr_title:\u003ctext\u003e` (case-insensitive PR title substring), `search:\u003ctext\u003e` (full-text search across chat titles, PR titles, PR numbers, and message bodies; message bodies match English word stems, e.g. `refactor` matches `refactoring`, and ignore English stopwords; titles and PR titles match whole words case-insensitively without stemming; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words, e.g. punctuation only, returns an empty list). Bare terms are not supported; use `title:\u003cvalue\u003e` or `search:\u003cvalue\u003e`.",
+						"name": "q",
+						"in": "query"
+					},
+					{
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"collectionFormat": "multi",
+						"description": "Filter by label as key:value. Repeat for multiple (AND logic).",
+						"name": "label",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "After ID",
+						"name": "after_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page limit",
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page offset",
+						"name": "offset",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.Chat"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat",
+				"operationId": "create-chat",
+				"parameters": [
+					{
+						"description": "Create chat request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					},
+					"413": {
+						"description": "Request body exceeds 256 KiB",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/by-workspace": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chats by workspace",
+				"operationId": "list-chats-by-workspace",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Comma-separated workspace IDs",
+						"name": "workspace_ids",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/coderd.chatsByWorkspaceResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/auto-archive-days": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat auto archive days",
+				"operationId": "get-chat-auto-archive-days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatAutoArchiveDaysResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat auto archive days",
+				"operationId": "update-chat-auto-archive-days",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatAutoArchiveDaysRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/debug-logging": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat debug logging setting",
+				"operationId": "get-chat-debug-logging-setting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDebugLoggingAdminSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat debug logging setting",
+				"operationId": "update-chat-debug-logging-setting",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatDebugLoggingAllowUsersRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/debug-retention-days": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat debug retention days",
+				"operationId": "get-chat-debug-retention-days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDebugRetentionDaysResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat debug retention days",
+				"operationId": "update-chat-debug-retention-days",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatDebugRetentionDaysRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/personal-model-overrides": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat personal model override settings",
+				"operationId": "get-chat-personal-model-override-settings",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatPersonalModelOverridesAdminSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat personal model override settings",
+				"operationId": "update-chat-personal-model-override-settings",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/plan-mode-instructions": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat plan mode instructions",
+				"operationId": "get-chat-plan-mode-instructions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatPlanModeInstructionsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat plan mode instructions",
+				"operationId": "update-chat-plan-mode-instructions",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatPlanModeInstructionsRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/retention-days": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat retention days",
+				"operationId": "get-chat-retention-days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat retention days",
+				"operationId": "update-chat-retention-days",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/config/system-prompt": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat system prompt",
+				"operationId": "get-chat-system-prompt",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatSystemPromptResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat system prompt",
+				"operationId": "update-chat-system-prompt",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatSystemPromptRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/user-compaction-thresholds": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get user chat compaction thresholds",
+				"operationId": "get-user-chat-compaction-thresholds",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCompactionThresholds"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/config/user-compaction-thresholds/{modelConfig}": {
+			"put": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user chat compaction threshold",
+				"operationId": "update-user-chat-compaction-threshold",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateUserChatCompactionThresholdRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"delete": {
+				"tags": ["Chats"],
+				"summary": "Delete user chat compaction threshold",
+				"operationId": "delete-user-chat-compaction-threshold",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/config/user-debug-logging": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get user chat debug logging setting",
+				"operationId": "get-user-chat-debug-logging-setting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatDebugLoggingSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user chat debug logging setting",
+				"operationId": "update-user-chat-debug-logging-setting",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateUserChatDebugLoggingRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/user-prompt": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get user chat custom prompt",
+				"operationId": "get-user-chat-custom-prompt",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user chat custom prompt",
+				"operationId": "update-user-chat-custom-prompt",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/config/workspace-ttl": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat workspace time to live",
+				"operationId": "get-chat-workspace-time-to-live",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatWorkspaceTTLResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat workspace time to live",
+				"operationId": "update-chat-workspace-time-to-live",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatWorkspaceTTLRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/files": {
+			"post": {
+				"consumes": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Upload chat file",
+				"operationId": "upload-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "query",
+						"required": true
+					},
+					{
+						"type": "string",
+						"example": "attachment; filename=\"image.png\"",
+						"description": "Attachment disposition carrying the file name",
+						"name": "Content-Disposition",
+						"in": "header",
+						"required": true
+					},
+					{
+						"description": "Raw file binary data",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UploadChatFileResponse"
+						}
+					},
+					"413": {
+						"description": "Request body exceeds 10 MiB",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"rawBodyFile": "image.png"
+				}
+			}
+		},
+		"/api/v2/chats/files/{file}": {
+			"get": {
+				"produces": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"tags": ["Chats"],
+				"summary": "Get chat file",
+				"operationId": "get-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/files/{file}/download": {
+			"get": {
+				"produces": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"tags": ["Chats"],
+				"summary": "Download chat file with signed token",
+				"operationId": "download-chat-file-with-signed-token",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Signed download token",
+						"name": "token",
+						"in": "query",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/files/{file}/download-url": {
+			"post": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat file download URL",
+				"operationId": "create-chat-file-download-url",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/watch": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Watch chat events for a user via WebSockets",
+				"operationId": "watch-chat-events-for-a-user-via-websockets",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatWatchEvent"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat by ID",
+				"operationId": "get-chat-by-id",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat",
+				"operationId": "update-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update chat request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/acl": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat ACLs",
+				"operationId": "get-chat-acls",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatACL"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat ACL",
+				"operationId": "update-chat-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update chat ACL request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatACL"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/{chat}/clear": {
+			"post": {
+				"description": "Resets the model context of an idle or errored chat,\nclearing any stored error. The reset commits\nsynchronously with no model call: the transcript is\npreserved and the next prompt starts from a fresh\ncontext.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Clear chat context",
+				"operationId": "clear-chat-context",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/{chat}/compact": {
+			"post": {
+				"description": "Requests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Compact chat",
+				"operationId": "compact-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/{chat}/context": {
+			"put": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Refresh chat context",
+				"operationId": "refresh-chat-context",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/cost": {
+			"get": {
+				"description": "Cost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat cost",
+				"operationId": "get-chat-cost",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatCost"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/diff": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat diff contents",
+				"operationId": "get-chat-diff-contents",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDiffContents"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/interrupt": {
+			"post": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Interrupt chat",
+				"operationId": "interrupt-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/messages": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat messages",
+				"operationId": "list-chat-messages",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Return messages with id \u003c before_id",
+						"name": "before_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Return messages with id \u003e after_id",
+						"name": "after_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page size, 1 to 200. Defaults to 50.",
+						"name": "limit",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatMessagesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Send chat message",
+				"operationId": "send-chat-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Create chat message request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatMessageRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatMessageResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/messages/{message}": {
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Edit chat message",
+				"operationId": "edit-chat-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Message ID",
+						"name": "message",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Edit chat message request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.EditChatMessageRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.EditChatMessageResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/prompts": {
+			"get": {
+				"description": "Returns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat user prompts",
+				"operationId": "list-chat-user-prompts",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
+						"name": "limit",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatPromptsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/queue/{queuedMessage}": {
+			"delete": {
+				"tags": ["Chats"],
+				"summary": "Delete chat queued message",
+				"operationId": "delete-chat-queued-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Queued message ID",
+						"name": "queuedMessage",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/queue/{queuedMessage}/promote": {
+			"post": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Promote chat queued message",
+				"operationId": "promote-chat-queued-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Queued message ID",
+						"name": "queuedMessage",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"202": {
+						"description": "Accepted",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/reconcile-invalid": {
+			"post": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Reconcile invalid chat state",
+				"operationId": "reconcile-invalid-chat-state",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/stream": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Stream chat events via WebSockets",
+				"operationId": "stream-chat-events-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Skip snapshot messages with id at or before this cursor",
+						"name": "after_id",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatStreamEvent"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/stream/git": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Watch chat workspace git state via WebSockets",
+				"operationId": "watch-chat-workspace-git-state-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/stream/parts": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Stream chat parts via WebSockets",
+				"operationId": "stream-chat-parts-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatStreamEvent"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/chats/{chat}/title/propose": {
+			"post": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Propose chat title",
+				"operationId": "propose-chat-title",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ProposeChatTitleResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/chats/{chat}/tool-results": {
+			"post": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Submit chat tool results",
+				"operationId": "submit-chat-tool-results",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.SubmitToolResultsRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
 			}
 		},
 		"/api/v2/connectionlog": {
@@ -4581,6 +4486,40 @@
 				]
 			}
 		},
+		"/api/v2/mcp/servers/{mcpServer}/oauth2/disconnect": {
+			"delete": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Disconnect MCP server OAuth2 token",
+				"operationId": "disconnect-mcp-server-oauth2-token",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpServer",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/api/v2/notifications/custom": {
 			"post": {
 				"consumes": ["application/json"],
@@ -5457,6 +5396,441 @@
 				]
 			}
 		},
+		"/api/v2/organizations/{organization}/chats/model-overrides": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List organization chat model overrides",
+				"operationId": "list-organization-chat-model-overrides",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/chats/model-overrides/{context}": {
+			"put": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update organization chat model override",
+				"operationId": "update-organization-chat-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"enum": [
+							"general",
+							"explore",
+							"title_generation",
+							"compaction",
+							"advisor"
+						],
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model override",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/chats/models": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List AI models and provider descriptors in an organization",
+				"operationId": "list-ai-models-and-provider-descriptors-in-an-organization",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create an AI model in an organization",
+				"operationId": "create-an-ai-model-in-an-organization",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatModelRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/organizations/{organization}/chats/models/{model}": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get an AI model",
+				"operationId": "get-an-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"delete": {
+				"tags": ["Chats"],
+				"summary": "Delete an AI model",
+				"operationId": "delete-an-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update an AI model",
+				"operationId": "update-an-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model updates",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/chats/models/{model}/acl": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get an AI model ACL",
+				"operationId": "get-an-ai-model-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelACL"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update an AI model ACL",
+				"operationId": "update-an-ai-model-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Sparse model ACL update",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/chats/models/{model}/acl/available": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get available AI model ACL users and groups",
+				"operationId": "get-available-ai-model-acl-users-and-groups",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User search query; free-text search also applies to groups",
+						"name": "q",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "User after ID",
+						"name": "after_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page limit for users and groups, if 0 returns all candidates",
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "User page offset",
+						"name": "offset",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ACLAvailable"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/api/v2/organizations/{organization}/groups": {
 			"get": {
 				"produces": ["application/json"],
@@ -5713,6 +6087,397 @@
 						"CoderSessionToken": []
 					}
 				]
+			}
+		},
+		"/api/v2/organizations/{organization}/mcp-servers": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "List MCP server configs",
+				"operationId": "list-mcp-server-configs",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.MCPServerConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Create MCP server config",
+				"operationId": "create-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Create MCP server config request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Get MCP server config",
+				"operationId": "get-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"delete": {
+				"tags": ["MCP"],
+				"summary": "Delete MCP server config",
+				"operationId": "delete-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Update MCP server config",
+				"operationId": "update-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update MCP server config request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Get MCP server config ACL",
+				"operationId": "get-mcp-server-config-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfigACL"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Update MCP server config ACL",
+				"operationId": "update-mcp-server-config-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update MCP server config ACL request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl/available": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Get available MCP server config ACL users and groups",
+				"operationId": "get-available-mcp-server-config-acl-users-and-groups",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User search query; free-text search also applies to groups",
+						"name": "q",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "User after ID",
+						"name": "after_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page limit for users and groups, if 0 returns all candidates",
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "User page offset",
+						"name": "offset",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ACLAvailable"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
+			"get": {
+				"tags": ["MCP"],
+				"summary": "Initiate MCP server OAuth2 connect",
+				"operationId": "initiate-mcp-server-oauth2-connect",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"307": {
+						"description": "Temporary Redirect"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
 			}
 		},
 		"/api/v2/organizations/{organization}/members": {
@@ -6009,6 +6774,100 @@
 						"CoderSessionToken": []
 					}
 				]
+			}
+		},
+		"/api/v2/organizations/{organization}/members/{user}/chats/model-overrides": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get organization member chat model overrides",
+				"operationId": "get-organization-member-chat-model-overrides",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User name, ID, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/v2/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update organization member chat model override",
+				"operationId": "update-organization-member-chat-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User name, ID, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"enum": ["root", "general", "explore"],
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Personal model override",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
 			}
 		},
 		"/api/v2/organizations/{organization}/members/{user}/roles": {
@@ -6373,7 +7232,7 @@
 						"in": "query"
 					},
 					{
-						"type": "object",
+						"type": "string",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
 						"in": "query"
@@ -6478,7 +7337,7 @@
 						"in": "query"
 					},
 					{
-						"type": "object",
+						"type": "string",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
 						"in": "query"
@@ -9637,6 +10496,119 @@
 				"responses": {
 					"200": {
 						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/users/{user}/ai-provider-keys": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List user AI provider key configurations",
+				"operationId": "list-user-ai-provider-key-configurations",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "User ID, username, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/v2/users/{user}/ai-provider-keys/{aiProvider}": {
+			"put": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user AI provider key",
+				"operationId": "update-user-ai-provider-key",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "User ID, username, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "AI provider ID",
+						"name": "aiProvider",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateUserAIProviderKeyRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"delete": {
+				"tags": ["Chats"],
+				"summary": "Delete user AI provider key",
+				"operationId": "delete-user-ai-provider-key",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "User ID, username, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "AI provider ID",
+						"name": "aiProvider",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
 					}
 				},
 				"security": [
@@ -13740,7 +14712,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Token scopes (currently ignored)",
+						"description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
 						"name": "scope",
 						"in": "query"
 					}
@@ -13791,7 +14763,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Token scopes (currently ignored)",
+						"description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
 						"name": "scope",
 						"in": "query"
 					}
@@ -13964,7 +14936,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Client secret, required if grant_type=authorization_code",
+						"description": "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.",
 						"name": "client_secret",
 						"in": "formData"
 					},
@@ -13972,6 +14944,12 @@
 						"type": "string",
 						"description": "Authorization code, required if grant_type=authorization_code",
 						"name": "code",
+						"in": "formData"
+					},
+					{
+						"type": "string",
+						"description": "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636.",
+						"name": "code_verifier",
 						"in": "formData"
 					},
 					{
@@ -14377,6 +15355,12 @@
 			"type": "string",
 			"enum": ["prebuild_claimed"],
 			"x-enum-varnames": ["ReinitializeReasonPrebuildClaimed"]
+		},
+		"coderd.chatsByWorkspaceResponse": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "string"
+			}
 		},
 		"coderd.cspViolation": {
 			"type": "object",
@@ -15160,6 +16144,33 @@
 					"items": {
 						"type": "string"
 					}
+				}
+			}
+		},
+		"codersdk.AIProviderSummary": {
+			"type": "object",
+			"properties": {
+				"deleted": {
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"name": {
+					"type": "string"
+				},
+				"type": {
+					"$ref": "#/definitions/codersdk.AIProviderType"
 				}
 			}
 		},
@@ -16545,6 +17556,14 @@
 				}
 			}
 		},
+		"codersdk.ChatAutoArchiveDaysResponse": {
+			"type": "object",
+			"properties": {
+				"auto_archive_days": {
+					"type": "integer"
+				}
+			}
+		},
 		"codersdk.ChatBusyBehavior": {
 			"type": "string",
 			"enum": ["queue", "interrupt"],
@@ -16696,6 +17715,25 @@
 					"type": "integer"
 				},
 				"unpriced_request_count": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatDebugLoggingAdminSettings": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				},
+				"forced_by_deployment": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatDebugRetentionDaysResponse": {
+			"type": "object",
+			"properties": {
+				"debug_retention_days": {
 					"type": "integer"
 				}
 			}
@@ -17060,12 +18098,8 @@
 				},
 				"context_file_agent_id": {
 					"description": "ContextFileAgentID is the workspace agent that provided\nthis context file. Used to detect when the agent changes\n(e.g. workspace rebuilt) so instruction files can be\nre-persisted with fresh content.",
-					"format": "uuid",
-					"allOf": [
-						{
-							"$ref": "#/definitions/uuid.NullUUID"
-						}
-					]
+					"type": "string",
+					"format": "uuid"
 				},
 				"context_file_content": {
 					"description": "ContextFileContent holds the file content sent to the LLM.\nInternal only: stripped before API responses to keep\npayloads small. The backend reads it when building the\nprompt via partsToMessageParts.",
@@ -17106,12 +18140,8 @@
 					"type": "integer"
 				},
 				"file_id": {
-					"format": "uuid",
-					"allOf": [
-						{
-							"$ref": "#/definitions/uuid.NullUUID"
-						}
-					]
+					"type": "string",
+					"format": "uuid"
 				},
 				"file_name": {
 					"type": "string"
@@ -17127,12 +18157,8 @@
 					"type": "boolean"
 				},
 				"mcp_server_config_id": {
-					"format": "uuid",
-					"allOf": [
-						{
-							"$ref": "#/definitions/uuid.NullUUID"
-						}
-					]
+					"type": "string",
+					"format": "uuid"
 				},
 				"media_type": {
 					"type": "string"
@@ -17352,16 +18378,16 @@
 		"codersdk.ChatModelACL": {
 			"type": "object",
 			"properties": {
-				"group_roles": {
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/codersdk.ChatRole"
+				"groups": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatGroup"
 					}
 				},
-				"user_roles": {
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/codersdk.ChatRole"
+				"users": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatUser"
 					}
 				}
 			}
@@ -17901,10 +18927,26 @@
 				"ChatPersonalModelOverrideModeModel"
 			]
 		},
+		"codersdk.ChatPersonalModelOverridesAdminSettings": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				}
+			}
+		},
 		"codersdk.ChatPlanMode": {
 			"type": "string",
 			"enum": ["plan"],
 			"x-enum-varnames": ["ChatPlanModePlan"]
+		},
+		"codersdk.ChatPlanModeInstructionsResponse": {
+			"type": "object",
+			"properties": {
+				"plan_mode_instructions": {
+					"type": "string"
+				}
+			}
 		},
 		"codersdk.ChatPrompt": {
 			"type": "object",
@@ -18136,6 +19178,20 @@
 				}
 			}
 		},
+		"codersdk.ChatSystemPromptResponse": {
+			"type": "object",
+			"properties": {
+				"default_system_prompt": {
+					"type": "string"
+				},
+				"include_default_system_prompt": {
+					"type": "boolean"
+				},
+				"system_prompt": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ChatUnsupportedProvider": {
 			"type": "object",
 			"properties": {
@@ -18217,6 +19273,15 @@
 				"ChatWatchEventKindActionRequired",
 				"ChatWatchEventKindContextDirty"
 			]
+		},
+		"codersdk.ChatWorkspaceTTLResponse": {
+			"type": "object",
+			"properties": {
+				"workspace_ttl_ms": {
+					"description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
+					"type": "integer"
+				}
+			}
 		},
 		"codersdk.ClusterConfig": {
 			"type": "object",
@@ -18852,6 +19917,10 @@
 					"description": "Allow users to cancel in-progress workspace jobs.\n*bool as the default value is \"true\".",
 					"type": "boolean"
 				},
+				"allow_workspace_renames": {
+					"description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name, so this defaults to false.",
+					"type": "boolean"
+				},
 				"autostart_requirement": {
 					"description": "AutostartRequirement allows optionally specifying the autostart allowed days\nfor workspaces created from this template. This is an enterprise feature.",
 					"allOf": [
@@ -19165,6 +20234,14 @@
 							"$ref": "#/definitions/codersdk.PremiumFunnelSource"
 						}
 					]
+				}
+			}
+		},
+		"codersdk.CreateUserAIProviderKeyRequest": {
+			"type": "object",
+			"properties": {
+				"api_key": {
+					"type": "string"
 				}
 			}
 		},
@@ -19741,6 +20818,7 @@
 					"$ref": "#/definitions/codersdk.AIConfig"
 				},
 				"allow_workspace_renames": {
+					"description": "Deprecated: Use the per-template allow_workspace_renames setting instead.",
 					"type": "boolean"
 				},
 				"autobuild_poll_interval": {
@@ -19783,6 +20861,9 @@
 					"type": "boolean"
 				},
 				"disable_user_secret_file_path": {
+					"type": "boolean"
+				},
+				"disable_workspace_agent_context_sync": {
 					"type": "boolean"
 				},
 				"disable_workspace_sharing": {
@@ -19836,6 +20917,12 @@
 				},
 				"logging": {
 					"$ref": "#/definitions/codersdk.LoggingConfig"
+				},
+				"mcp_allowed_private_cidrs": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				},
 				"metrics_cache_refresh_interval": {
 					"type": "integer"
@@ -20693,13 +21780,21 @@
 		"codersdk.GroupMemberAISpend": {
 			"type": "object",
 			"properties": {
+				"effective_budget": {
+					"description": "EffectiveBudget is the spend limit that currently applies to the user.\nNull when no budget applies or the effective group belongs to a different\norganization than the queried group.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.AIBudgetLimit"
+						}
+					]
+				},
 				"effective_group_id": {
 					"description": "EffectiveGroupID is the user's effective budget group within the queried\ngroup's organization, falling back to the Everyone group when no budget\napplies. Null when the effective group belongs to a different organization\nthan the queried group.",
 					"type": "string",
 					"format": "uuid"
 				},
 				"group_budget": {
-					"description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. Null when the user's budget resolves to another\ngroup or no budget applies to the user.",
+					"description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. When populated, it matches EffectiveBudget. Null\nwhen the user's budget resolves to another group or no budget applies.\nDeprecated: Use EffectiveBudget instead.",
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.AIBudgetLimit"
@@ -23143,6 +24238,14 @@
 				}
 			}
 		},
+		"codersdk.ProposeChatTitleResponse": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ProvisionerConfig": {
 			"type": "object",
 			"properties": {
@@ -24314,6 +25417,17 @@
 				}
 			}
 		},
+		"codersdk.SubmitToolResultsRequest": {
+			"type": "object",
+			"properties": {
+				"results": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ToolResult"
+					}
+				}
+			}
+		},
 		"codersdk.SupportConfig": {
 			"type": "object",
 			"properties": {
@@ -24419,6 +25533,10 @@
 					"type": "boolean"
 				},
 				"allow_user_cancel_workspace_jobs": {
+					"type": "boolean"
+				},
+				"allow_workspace_renames": {
+					"description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
 					"type": "boolean"
 				},
 				"autostart_requirement": {
@@ -25481,6 +26599,23 @@
 				}
 			}
 		},
+		"codersdk.ToolResult": {
+			"type": "object",
+			"properties": {
+				"is_error": {
+					"type": "boolean"
+				},
+				"output": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				},
+				"tool_call_id": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.TraceConfig": {
 			"type": "object",
 			"properties": {
@@ -25589,6 +26724,30 @@
 				}
 			}
 		},
+		"codersdk.UpdateChatAutoArchiveDaysRequest": {
+			"type": "object",
+			"properties": {
+				"auto_archive_days": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UpdateChatDebugLoggingAllowUsersRequest": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UpdateChatDebugRetentionDaysRequest": {
+			"type": "object",
+			"properties": {
+				"debug_retention_days": {
+					"type": "integer"
+				}
+			}
+		},
 		"codersdk.UpdateChatModelACLRequest": {
 			"type": "object",
 			"properties": {
@@ -25647,6 +26806,22 @@
 				}
 			}
 		},
+		"codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UpdateChatPlanModeInstructionsRequest": {
+			"type": "object",
+			"properties": {
+				"plan_mode_instructions": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.UpdateChatRequest": {
 			"type": "object",
 			"properties": {
@@ -25684,6 +26859,26 @@
 			"type": "object",
 			"properties": {
 				"retention_days": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UpdateChatSystemPromptRequest": {
+			"type": "object",
+			"properties": {
+				"include_default_system_prompt": {
+					"type": "boolean"
+				},
+				"system_prompt": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateChatWorkspaceTTLRequest": {
+			"type": "object",
+			"properties": {
+				"workspace_ttl_ms": {
+					"description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
 					"type": "integer"
 				}
 			}
@@ -25892,6 +27087,10 @@
 				"allow_user_cancel_workspace_jobs": {
 					"type": "boolean"
 				},
+				"allow_workspace_renames": {
+					"description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
+					"type": "boolean"
+				},
 				"autostart_requirement": {
 					"$ref": "#/definitions/codersdk.TemplateAutostartRequirement"
 				},
@@ -26009,6 +27208,24 @@
 				},
 				"theme_preference": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateUserChatCompactionThresholdRequest": {
+			"type": "object",
+			"properties": {
+				"threshold_percent": {
+					"type": "integer",
+					"maximum": 100,
+					"minimum": 0
+				}
+			}
+		},
+		"codersdk.UpdateUserChatDebugLoggingRequest": {
+			"type": "object",
+			"properties": {
+				"debug_logging_enabled": {
+					"type": "boolean"
 				}
 			}
 		},
@@ -26426,6 +27643,23 @@
 				}
 			}
 		},
+		"codersdk.UserAIProviderKeyConfig": {
+			"type": "object",
+			"properties": {
+				"byok_enabled": {
+					"type": "boolean"
+				},
+				"has_provider_api_key": {
+					"type": "boolean"
+				},
+				"has_user_api_key": {
+					"type": "boolean"
+				},
+				"provider": {
+					"$ref": "#/definitions/codersdk.AIProviderSummary"
+				}
+			}
+		},
 		"codersdk.UserAISpendStatus": {
 			"type": "object",
 			"properties": {
@@ -26543,6 +27777,51 @@
 				"theme_preference": {
 					"description": "ThemePreference is the legacy single-field appearance setting. In\n\"single\" mode it mirrors the active theme. In \"sync\" mode modern\nclients normally mirror the active OS slot, but older clients can\nupdate only this field, so it may diverge from ThemeLight or\nThemeDark until a modern client saves the full appearance state\nagain.",
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.UserChatCompactionThreshold": {
+			"type": "object",
+			"properties": {
+				"model_config_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"threshold_percent": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UserChatCompactionThresholds": {
+			"type": "object",
+			"properties": {
+				"thresholds": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
+					}
+				}
+			}
+		},
+		"codersdk.UserChatCustomPrompt": {
+			"type": "object",
+			"properties": {
+				"custom_prompt": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UserChatDebugLoggingSettings": {
+			"type": "object",
+			"properties": {
+				"debug_logging_enabled": {
+					"type": "boolean"
+				},
+				"forced_by_deployment": {
+					"type": "boolean"
+				},
+				"user_toggle_allowed": {
+					"type": "boolean"
 				}
 			}
 		},
@@ -26716,7 +27995,7 @@
 					"type": "string"
 				},
 				"enabled": {
-					"description": "Enabled is stored intent. Deployment policy may block a stored target.",
+					"description": "Enabled controls whether the secret is injected into workspaces.\nDisabled secrets remain visible and editable, but are not added\nto the agent manifest, so they are not exposed as environment\nvariables or written to secret files.",
 					"type": "boolean"
 				},
 				"env_name": {
@@ -26878,6 +28157,7 @@
 			"type": "object",
 			"properties": {
 				"allow_renames": {
+					"description": "AllowRenames is the effective rename permission for this workspace,\nderived from the template's allow_workspace_renames setting and the\ndeprecated deployment-wide flag.",
 					"type": "boolean"
 				},
 				"automatic_updates": {
@@ -26970,11 +28250,7 @@
 				},
 				"task_id": {
 					"description": "TaskID, if set, indicates that the workspace is relevant to the given codersdk.Task.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/uuid.NullUUID"
-						}
-					]
+					"type": "string"
 				},
 				"template_active_version_id": {
 					"type": "string",
@@ -27131,12 +28407,8 @@
 					"type": "string"
 				},
 				"parent_id": {
-					"format": "uuid",
-					"allOf": [
-						{
-							"$ref": "#/definitions/uuid.NullUUID"
-						}
-					]
+					"type": "string",
+					"format": "uuid"
 				},
 				"ready_at": {
 					"type": "string",
@@ -27291,12 +28563,8 @@
 					]
 				},
 				"subagent_id": {
-					"format": "uuid",
-					"allOf": [
-						{
-							"$ref": "#/definitions/uuid.NullUUID"
-						}
-					]
+					"type": "string",
+					"format": "uuid"
 				},
 				"workspace_folder": {
 					"type": "string"
@@ -29017,10 +30285,6 @@
 					"description": "[ip]:port of global IPv6",
 					"type": "string"
 				},
-				"hairPinning": {
-					"description": "HairPinning is whether the router supports communicating\nbetween two local devices through the NATted public IP address\n(on IPv4).",
-					"type": "string"
-				},
 				"icmpv4": {
 					"description": "an ICMPv4 round trip completed",
 					"type": "boolean"
@@ -29440,18 +30704,6 @@
 		},
 		"url.Userinfo": {
 			"type": "object"
-		},
-		"uuid.NullUUID": {
-			"type": "object",
-			"properties": {
-				"uuid": {
-					"type": "string"
-				},
-				"valid": {
-					"description": "Valid is true if UUID is not NULL",
-					"type": "boolean"
-				}
-			}
 		},
 		"workspaceapps.AccessMethod": {
 			"type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -127,6 +127,872 @@
 				}
 			}
 		},
+		"/api/experimental/chats": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chats",
+				"operationId": "list-chats",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Search query. Supports `title:\u003csubstring\u003e` (case-insensitive, quote multi-word values), `archived:bool`, `has_unread:bool`, `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` as repeated or comma-separated values, `source:\u003ccreated_by_me\\|shared_with_me\u003e`, `diff_url:\u003curl\u003e` (quote values containing colons), `pr:\u003cnumber\u003e` (exact PR number match), `repo:\u003cowner/repo\u003e` (case-insensitive substring match against git remote origin or URL), `pr_title:\u003ctext\u003e` (case-insensitive PR title substring), `search:\u003ctext\u003e` (full-text search across chat titles, PR titles, PR numbers, and message bodies; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words returns an empty list). Bare terms are not supported; use `title:\u003cvalue\u003e` or `search:\u003cvalue\u003e`.",
+						"name": "q",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "Filter by label as key:value. Repeat for multiple (AND logic).",
+						"name": "label",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.Chat"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat",
+				"operationId": "create-chat",
+				"parameters": [
+					{
+						"description": "Create chat request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					},
+					"413": {
+						"description": "Request body exceeds 256 KiB",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/retention-days": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat retention days",
+				"operationId": "get-chat-retention-days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat retention days",
+				"operationId": "update-chat-retention-days",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chats/files": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Upload chat file",
+				"operationId": "upload-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "query",
+						"required": true
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UploadChatFileResponse"
+						}
+					},
+					"413": {
+						"description": "Request body exceeds 10 MiB",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/files/{file}": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"tags": ["Chats"],
+				"summary": "Get chat file",
+				"operationId": "get-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/files/{file}/download": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"tags": ["Chats"],
+				"summary": "Download chat file with signed token",
+				"operationId": "download-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Signed download token",
+						"name": "token",
+						"in": "query",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chats/files/{file}/download-url": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat file download URL",
+				"operationId": "create-chat-file-download-url",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chats/watch": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Watch chat events for a user via WebSockets",
+				"operationId": "watch-chat-events-for-a-user-via-websockets",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatWatchEvent"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat by ID",
+				"operationId": "get-chat-by-id",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat",
+				"operationId": "update-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update chat request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/acl": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat ACLs",
+				"operationId": "get-chat-acls",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatACL"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat ACL",
+				"operationId": "update-chat-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update chat ACL request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatACL"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chats/{chat}/compact": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.\nRequests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Compact chat",
+				"operationId": "compact-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chats/{chat}/context": {
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Refresh chat context",
+				"operationId": "refresh-chat-context",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/cost": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.\n\nCost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat cost",
+				"operationId": "get-chat-cost",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatCost"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/diff": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat diff contents",
+				"operationId": "get-chat-diff-contents",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDiffContents"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/interrupt": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Interrupt chat",
+				"operationId": "interrupt-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/messages": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat messages",
+				"operationId": "list-chat-messages",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Return messages with id \u003c before_id",
+						"name": "before_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Return messages with id \u003e after_id",
+						"name": "after_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page size, 1 to 200. Defaults to 50.",
+						"name": "limit",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatMessagesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Send chat message",
+				"operationId": "send-chat-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Create chat message request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatMessageRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatMessageResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/messages/{message}": {
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Edit chat message",
+				"operationId": "edit-chat-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Message ID",
+						"name": "message",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Edit chat message request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.EditChatMessageRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.EditChatMessageResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/prompts": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.\n\nReturns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat user prompts",
+				"operationId": "list-chat-user-prompts",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
+						"name": "limit",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatPromptsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/reconcile-invalid": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Reconcile invalid chat state",
+				"operationId": "reconcile-invalid-chat-state",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/stream": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Stream chat events via WebSockets",
+				"operationId": "stream-chat-events-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatStreamEvent"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/{chat}/stream/desktop": {
 			"get": {
 				"description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
@@ -147,6 +1013,105 @@
 				"responses": {
 					"101": {
 						"description": "Switching Protocols"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/stream/git": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Watch chat workspace git state via WebSockets",
+				"operationId": "watch-chat-workspace-git-state-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/stream/parts": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Stream chat parts via WebSockets",
+				"operationId": "stream-chat-parts-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatStreamEvent"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/chats/{chat}/title/regenerate": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Regenerate chat title",
+				"operationId": "regenerate-chat-title",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
 					}
 				},
 				"security": [
@@ -199,6 +1164,839 @@
 				"responses": {
 					"200": {
 						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/mcp/servers/{mcpServer}/oauth2/disconnect": {
+			"delete": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Disconnect MCP server OAuth2 token",
+				"operationId": "disconnect-mcp-server-oauth2-token",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpServer",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/model-overrides": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List organization chat model overrides",
+				"operationId": "list-organization-chat-model-overrides",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/model-overrides/{context}": {
+			"put": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update organization chat model override",
+				"operationId": "update-organization-chat-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"enum": [
+							"general",
+							"explore",
+							"title_generation",
+							"compaction",
+							"advisor"
+						],
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model override",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/models": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List AI models and provider descriptors in an organization",
+				"operationId": "list-ai-models-by-organization",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create an AI model in an organization",
+				"operationId": "create-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatModelRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/models/{model}": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get an AI model",
+				"operationId": "get-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"delete": {
+				"tags": ["Chats"],
+				"summary": "Delete an AI model",
+				"operationId": "delete-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update an AI model",
+				"operationId": "update-ai-model",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Model updates",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModel"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/chats/models/{model}/acl": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get an AI model ACL",
+				"operationId": "get-ai-model-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelACL"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update an AI model ACL",
+				"operationId": "update-ai-model-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model ID",
+						"name": "model",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Sparse model ACL update",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/mcp-servers": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "List MCP server configs",
+				"operationId": "list-mcp-server-configs",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.MCPServerConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Create MCP server config",
+				"operationId": "create-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Create MCP server config request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Get MCP server config",
+				"operationId": "get-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"delete": {
+				"tags": ["MCP"],
+				"summary": "Delete MCP server config",
+				"operationId": "delete-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Update MCP server config",
+				"operationId": "update-mcp-server-config",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update MCP server config request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Get MCP server config ACL",
+				"operationId": "get-mcp-server-config-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.MCPServerConfigACL"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"tags": ["MCP"],
+				"summary": "Update MCP server config ACL",
+				"operationId": "update-mcp-server-config-acl",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update MCP server config ACL request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
+			"get": {
+				"tags": ["MCP"],
+				"summary": "Initiate MCP server OAuth2 connect",
+				"operationId": "initiate-mcp-server-oauth2-connect",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "MCP server config ID",
+						"name": "mcpserverconfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"307": {
+						"description": "Temporary Redirect"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get organization member chat model overrides",
+				"operationId": "get-organization-member-chat-model-overrides",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User name, ID, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
+		"/api/experimental/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
+			"put": {
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update organization member chat model override",
+				"operationId": "update-organization-member-chat-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Organization name or ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User name, ID, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"enum": ["root", "general", "explore"],
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Personal model override",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
 					}
 				},
 				"security": [
@@ -1192,1709 +2990,6 @@
 						}
 					}
 				}
-			}
-		},
-		"/api/v2/chats": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chats",
-				"operationId": "list-chats",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Search query. Supports `title:\u003csubstring\u003e` (case-insensitive, quote multi-word values), `archived:bool`, `has_unread:bool`, `pr_status:\u003cdraft\\|open\\|merged\\|closed\u003e` as repeated or comma-separated values, `source:\u003ccreated_by_me\\|shared_with_me\u003e`, `diff_url:\u003curl\u003e` (quote values containing colons), `pr:\u003cnumber\u003e` (exact PR number match), `repo:\u003cowner/repo\u003e` (case-insensitive substring match against git remote origin or URL), `pr_title:\u003ctext\u003e` (case-insensitive PR title substring), `search:\u003ctext\u003e` (full-text search across chat titles, PR titles, PR numbers, and message bodies; message bodies match English word stems, e.g. `refactor` matches `refactoring`, and ignore English stopwords; titles and PR titles match whole words case-insensitively without stemming; quote multi-word values; cannot be combined with title, pr_title, or pr; a value that tokenizes to no searchable words, e.g. punctuation only, returns an empty list). Bare terms are not supported; use `title:\u003cvalue\u003e` or `search:\u003cvalue\u003e`.",
-						"name": "q",
-						"in": "query"
-					},
-					{
-						"type": "array",
-						"items": {
-							"type": "string"
-						},
-						"collectionFormat": "multi",
-						"description": "Filter by label as key:value. Repeat for multiple (AND logic).",
-						"name": "label",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "After ID",
-						"name": "after_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page limit",
-						"name": "limit",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page offset",
-						"name": "offset",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.Chat"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create chat",
-				"operationId": "create-chat",
-				"parameters": [
-					{
-						"description": "Create chat request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					},
-					"413": {
-						"description": "Request body exceeds 256 KiB",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Response"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/by-workspace": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chats by workspace",
-				"operationId": "list-chats-by-workspace",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Comma-separated workspace IDs",
-						"name": "workspace_ids",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/coderd.chatsByWorkspaceResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/auto-archive-days": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat auto archive days",
-				"operationId": "get-chat-auto-archive-days",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatAutoArchiveDaysResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat auto archive days",
-				"operationId": "update-chat-auto-archive-days",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatAutoArchiveDaysRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/debug-logging": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat debug logging setting",
-				"operationId": "get-chat-debug-logging-setting",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatDebugLoggingAdminSettings"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat debug logging setting",
-				"operationId": "update-chat-debug-logging-setting",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatDebugLoggingAllowUsersRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/debug-retention-days": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat debug retention days",
-				"operationId": "get-chat-debug-retention-days",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatDebugRetentionDaysResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat debug retention days",
-				"operationId": "update-chat-debug-retention-days",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatDebugRetentionDaysRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/personal-model-overrides": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat personal model override settings",
-				"operationId": "get-chat-personal-model-override-settings",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatPersonalModelOverridesAdminSettings"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat personal model override settings",
-				"operationId": "update-chat-personal-model-override-settings",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/plan-mode-instructions": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat plan mode instructions",
-				"operationId": "get-chat-plan-mode-instructions",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatPlanModeInstructionsResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat plan mode instructions",
-				"operationId": "update-chat-plan-mode-instructions",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatPlanModeInstructionsRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/retention-days": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat retention days",
-				"operationId": "get-chat-retention-days",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatRetentionDaysResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat retention days",
-				"operationId": "update-chat-retention-days",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatRetentionDaysRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/config/system-prompt": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat system prompt",
-				"operationId": "get-chat-system-prompt",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatSystemPromptResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat system prompt",
-				"operationId": "update-chat-system-prompt",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatSystemPromptRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/user-compaction-thresholds": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get user chat compaction thresholds",
-				"operationId": "get-user-chat-compaction-thresholds",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatCompactionThresholds"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/config/user-compaction-thresholds/{modelConfig}": {
-			"put": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update user chat compaction threshold",
-				"operationId": "update-user-chat-compaction-threshold",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model config ID",
-						"name": "modelConfig",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateUserChatCompactionThresholdRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"delete": {
-				"tags": ["Chats"],
-				"summary": "Delete user chat compaction threshold",
-				"operationId": "delete-user-chat-compaction-threshold",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model config ID",
-						"name": "modelConfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/config/user-debug-logging": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get user chat debug logging setting",
-				"operationId": "get-user-chat-debug-logging-setting",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatDebugLoggingSettings"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update user chat debug logging setting",
-				"operationId": "update-user-chat-debug-logging-setting",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateUserChatDebugLoggingRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/user-prompt": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get user chat custom prompt",
-				"operationId": "get-user-chat-custom-prompt",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update user chat custom prompt",
-				"operationId": "update-user-chat-custom-prompt",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/config/workspace-ttl": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat workspace time to live",
-				"operationId": "get-chat-workspace-time-to-live",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatWorkspaceTTLResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat workspace time to live",
-				"operationId": "update-chat-workspace-time-to-live",
-				"parameters": [
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatWorkspaceTTLRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/files": {
-			"post": {
-				"consumes": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Upload chat file",
-				"operationId": "upload-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "query",
-						"required": true
-					},
-					{
-						"type": "string",
-						"example": "attachment; filename=\"image.png\"",
-						"description": "Attachment disposition carrying the file name",
-						"name": "Content-Disposition",
-						"in": "header",
-						"required": true
-					},
-					{
-						"description": "Raw file binary data",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UploadChatFileResponse"
-						}
-					},
-					"413": {
-						"description": "Request body exceeds 10 MiB",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Response"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"rawBodyFile": "image.png"
-				}
-			}
-		},
-		"/api/v2/chats/files/{file}": {
-			"get": {
-				"produces": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"tags": ["Chats"],
-				"summary": "Get chat file",
-				"operationId": "get-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/files/{file}/download": {
-			"get": {
-				"produces": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"tags": ["Chats"],
-				"summary": "Download chat file with signed token",
-				"operationId": "download-chat-file-with-signed-token",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "Signed download token",
-						"name": "token",
-						"in": "query",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					}
-				},
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/files/{file}/download-url": {
-			"post": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create chat file download URL",
-				"operationId": "create-chat-file-download-url",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatFileDownloadURLResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/watch": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Watch chat events for a user via WebSockets",
-				"operationId": "watch-chat-events-for-a-user-via-websockets",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatWatchEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat by ID",
-				"operationId": "get-chat-by-id",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat",
-				"operationId": "update-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update chat request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/acl": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat ACLs",
-				"operationId": "get-chat-acls",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatACL"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat ACL",
-				"operationId": "update-chat-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update chat ACL request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatACL"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/{chat}/clear": {
-			"post": {
-				"description": "Resets the model context of an idle or errored chat,\nclearing any stored error. The reset commits\nsynchronously with no model call: the transcript is\npreserved and the next prompt starts from a fresh\ncontext.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Clear chat context",
-				"operationId": "clear-chat-context",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/{chat}/compact": {
-			"post": {
-				"description": "Requests a manual context compaction on an idle or errored\nchat, clearing any stored error. The compaction runs\nasynchronously through the chat worker and bypasses the\nautomatic usage threshold.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Compact chat",
-				"operationId": "compact-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/{chat}/context": {
-			"put": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Refresh chat context",
-				"operationId": "refresh-chat-context",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/cost": {
-			"get": {
-				"description": "Cost covers the whole chat tree: the root chat plus every\nsubagent chat beneath it. Requesting cost for a subagent chat\nreturns that same total.\n\nCost is derived from AI Gateway data, which is subject to its\nown retention period, 60 days by default, configured\nindependently of chat retention. Spend for requests older than\nthat period is no longer reported, so a chat whose requests\nhave all been purged reports zero cost.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat cost",
-				"operationId": "get-chat-cost",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatCost"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/diff": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat diff contents",
-				"operationId": "get-chat-diff-contents",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatDiffContents"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/interrupt": {
-			"post": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Interrupt chat",
-				"operationId": "interrupt-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/messages": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat messages",
-				"operationId": "list-chat-messages",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Return messages with id \u003c before_id",
-						"name": "before_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Return messages with id \u003e after_id",
-						"name": "after_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page size, 1 to 200. Defaults to 50.",
-						"name": "limit",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatMessagesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Send chat message",
-				"operationId": "send-chat-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Create chat message request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatMessageRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatMessageResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/messages/{message}": {
-			"patch": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Edit chat message",
-				"operationId": "edit-chat-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Message ID",
-						"name": "message",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Edit chat message request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.EditChatMessageRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.EditChatMessageResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/prompts": {
-			"get": {
-				"description": "Returns the user-authored prompts in a chat, newest first,\nwith each prompt's text parts concatenated in the order they\nwere authored. Used by the composer to power the up/down\narrow prompt-history cycle without paging through every\nmessage in the chat.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat user prompts",
-				"operationId": "list-chat-user-prompts",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Page size, 0 to 2000. 0 (the default) means the server-side default of 500.",
-						"name": "limit",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatPromptsResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/queue/{queuedMessage}": {
-			"delete": {
-				"tags": ["Chats"],
-				"summary": "Delete chat queued message",
-				"operationId": "delete-chat-queued-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Queued message ID",
-						"name": "queuedMessage",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/queue/{queuedMessage}/promote": {
-			"post": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Promote chat queued message",
-				"operationId": "promote-chat-queued-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Queued message ID",
-						"name": "queuedMessage",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"202": {
-						"description": "Accepted",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Response"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/reconcile-invalid": {
-			"post": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Reconcile invalid chat state",
-				"operationId": "reconcile-invalid-chat-state",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/stream": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Stream chat events via WebSockets",
-				"operationId": "stream-chat-events-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Skip snapshot messages with id at or before this cursor",
-						"name": "after_id",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.ChatStreamEvent"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/stream/git": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Watch chat workspace git state via WebSockets",
-				"operationId": "watch-chat-workspace-git-state-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/stream/parts": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Stream chat parts via WebSockets",
-				"operationId": "stream-chat-parts-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.ChatStreamEvent"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/chats/{chat}/title/propose": {
-			"post": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Propose chat title",
-				"operationId": "propose-chat-title",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ProposeChatTitleResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/chats/{chat}/tool-results": {
-			"post": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Submit chat tool results",
-				"operationId": "submit-chat-tool-results",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.SubmitToolResultsRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
 			}
 		},
 		"/api/v2/connectionlog": {
@@ -4486,40 +4581,6 @@
 				]
 			}
 		},
-		"/api/v2/mcp/servers/{mcpServer}/oauth2/disconnect": {
-			"delete": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Disconnect MCP server OAuth2 token",
-				"operationId": "disconnect-mcp-server-oauth2-token",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpServer",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerOAuth2DisconnectResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
 		"/api/v2/notifications/custom": {
 			"post": {
 				"consumes": ["application/json"],
@@ -5396,441 +5457,6 @@
 				]
 			}
 		},
-		"/api/v2/organizations/{organization}/chats/model-overrides": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List organization chat model overrides",
-				"operationId": "list-organization-chat-model-overrides",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelOverridesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/chats/model-overrides/{context}": {
-			"put": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update organization chat model override",
-				"operationId": "update-organization-chat-model-override",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"enum": [
-							"general",
-							"explore",
-							"title_generation",
-							"compaction",
-							"advisor"
-						],
-						"type": "string",
-						"description": "Override context",
-						"name": "context",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Model override",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/chats/models": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List AI models and provider descriptors in an organization",
-				"operationId": "list-ai-models-and-provider-descriptors-in-an-organization",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.OrganizationChatModelsResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create an AI model in an organization",
-				"operationId": "create-an-ai-model-in-an-organization",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Model",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatModelRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModel"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/organizations/{organization}/chats/models/{model}": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get an AI model",
-				"operationId": "get-an-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModel"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"delete": {
-				"tags": ["Chats"],
-				"summary": "Delete an AI model",
-				"operationId": "delete-an-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update an AI model",
-				"operationId": "update-an-ai-model",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Model updates",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModel"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/chats/models/{model}/acl": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get an AI model ACL",
-				"operationId": "get-an-ai-model-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelACL"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update an AI model ACL",
-				"operationId": "update-an-ai-model-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Sparse model ACL update",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatModelACLRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/chats/models/{model}/acl/available": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get available AI model ACL users and groups",
-				"operationId": "get-available-ai-model-acl-users-and-groups",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Model ID",
-						"name": "model",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "User search query; free-text search also applies to groups",
-						"name": "q",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "User after ID",
-						"name": "after_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page limit for users and groups, if 0 returns all candidates",
-						"name": "limit",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "User page offset",
-						"name": "offset",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ACLAvailable"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
 		"/api/v2/organizations/{organization}/groups": {
 			"get": {
 				"produces": ["application/json"],
@@ -6087,397 +5713,6 @@
 						"CoderSessionToken": []
 					}
 				]
-			}
-		},
-		"/api/v2/organizations/{organization}/mcp-servers": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "List MCP server configs",
-				"operationId": "list-mcp-server-configs",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.MCPServerConfig"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"post": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Create MCP server config",
-				"operationId": "create-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Create MCP server config request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateMCPServerConfigRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Get MCP server config",
-				"operationId": "get-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"delete": {
-				"tags": ["MCP"],
-				"summary": "Delete MCP server config",
-				"operationId": "delete-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Update MCP server config",
-				"operationId": "update-mcp-server-config",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update MCP server config request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Get MCP server config ACL",
-				"operationId": "get-mcp-server-config-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.MCPServerConfigACL"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			},
-			"patch": {
-				"consumes": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Update MCP server config ACL",
-				"operationId": "update-mcp-server-config-acl",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update MCP server config ACL request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateMCPServerConfigACLRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/acl/available": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["MCP"],
-				"summary": "Get available MCP server config ACL users and groups",
-				"operationId": "get-available-mcp-server-config-acl-users-and-groups",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "User search query; free-text search also applies to groups",
-						"name": "q",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "User after ID",
-						"name": "after_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page limit for users and groups, if 0 returns all candidates",
-						"name": "limit",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "User page offset",
-						"name": "offset",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ACLAvailable"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/mcp-servers/{mcpserverconfig}/oauth2/connect": {
-			"get": {
-				"tags": ["MCP"],
-				"summary": "Initiate MCP server OAuth2 connect",
-				"operationId": "initiate-mcp-server-oauth2-connect",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "MCP server config ID",
-						"name": "mcpserverconfig",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"307": {
-						"description": "Temporary Redirect"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
 			}
 		},
 		"/api/v2/organizations/{organization}/members": {
@@ -6774,100 +6009,6 @@
 						"CoderSessionToken": []
 					}
 				]
-			}
-		},
-		"/api/v2/organizations/{organization}/members/{user}/chats/model-overrides": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get organization member chat model overrides",
-				"operationId": "get-organization-member-chat-model-overrides",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "User name, ID, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
-			}
-		},
-		"/api/v2/organizations/{organization}/members/{user}/chats/model-overrides/{context}": {
-			"put": {
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update organization member chat model override",
-				"operationId": "update-organization-member-chat-model-override",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Organization name or ID",
-						"name": "organization",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"description": "User name, ID, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					},
-					{
-						"enum": ["root", "general", "explore"],
-						"type": "string",
-						"description": "Override context",
-						"name": "context",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Personal model override",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"x-apidocgen": {
-					"skip": true
-				}
 			}
 		},
 		"/api/v2/organizations/{organization}/members/{user}/roles": {
@@ -7232,7 +6373,7 @@
 						"in": "query"
 					},
 					{
-						"type": "string",
+						"type": "object",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
 						"in": "query"
@@ -7337,7 +6478,7 @@
 						"in": "query"
 					},
 					{
-						"type": "string",
+						"type": "object",
 						"description": "Provisioner tags to filter by (JSON of the form `{'tag1':'value1','tag2':'value2'}`)",
 						"name": "tags",
 						"in": "query"
@@ -10505,119 +9646,6 @@
 				]
 			}
 		},
-		"/api/v2/users/{user}/ai-provider-keys": {
-			"get": {
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List user AI provider key configurations",
-				"operationId": "list-user-ai-provider-key-configurations",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "User ID, username, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/api/v2/users/{user}/ai-provider-keys/{aiProvider}": {
-			"put": {
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update user AI provider key",
-				"operationId": "update-user-ai-provider-key",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "User ID, username, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "AI provider ID",
-						"name": "aiProvider",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Request body",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateUserAIProviderKeyRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UserAIProviderKeyConfig"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"delete": {
-				"tags": ["Chats"],
-				"summary": "Delete user AI provider key",
-				"operationId": "delete-user-ai-provider-key",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "User ID, username, or me",
-						"name": "user",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "AI provider ID",
-						"name": "aiProvider",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
 		"/api/v2/users/{user}/ai/budget/override": {
 			"get": {
 				"produces": ["application/json"],
@@ -11761,6 +10789,18 @@
 						"schema": {
 							"$ref": "#/definitions/codersdk.UserSecret"
 						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
 					}
 				},
 				"security": [
@@ -11934,6 +10974,18 @@
 						"description": "OK",
 						"schema": {
 							"$ref": "#/definitions/codersdk.UserSecret"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
 						}
 					}
 				},
@@ -14688,7 +13740,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
+						"description": "Token scopes (currently ignored)",
 						"name": "scope",
 						"in": "query"
 					}
@@ -14739,7 +13791,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Space-separated scopes to request. Each must be supported by this deployment, and the app's allowlist, when it has one, must cover the permissions requested rather than name each scope. Defaults to that allowlist, or to coder:all for an app with no allowlist",
+						"description": "Token scopes (currently ignored)",
 						"name": "scope",
 						"in": "query"
 					}
@@ -14912,7 +13964,7 @@
 					},
 					{
 						"type": "string",
-						"description": "Client secret, required if grant_type=authorization_code and the client is confidential. Public clients (token_endpoint_auth_method=none) send no secret.",
+						"description": "Client secret, required if grant_type=authorization_code",
 						"name": "client_secret",
 						"in": "formData"
 					},
@@ -14920,12 +13972,6 @@
 						"type": "string",
 						"description": "Authorization code, required if grant_type=authorization_code",
 						"name": "code",
-						"in": "formData"
-					},
-					{
-						"type": "string",
-						"description": "PKCE code verifier, required if grant_type=authorization_code. 43-128 characters per RFC 7636.",
-						"name": "code_verifier",
 						"in": "formData"
 					},
 					{
@@ -15331,12 +14377,6 @@
 			"type": "string",
 			"enum": ["prebuild_claimed"],
 			"x-enum-varnames": ["ReinitializeReasonPrebuildClaimed"]
-		},
-		"coderd.chatsByWorkspaceResponse": {
-			"type": "object",
-			"additionalProperties": {
-				"type": "string"
-			}
 		},
 		"coderd.cspViolation": {
 			"type": "object",
@@ -16120,33 +15160,6 @@
 					"items": {
 						"type": "string"
 					}
-				}
-			}
-		},
-		"codersdk.AIProviderSummary": {
-			"type": "object",
-			"properties": {
-				"deleted": {
-					"type": "boolean"
-				},
-				"display_name": {
-					"type": "string"
-				},
-				"enabled": {
-					"type": "boolean"
-				},
-				"icon": {
-					"type": "string"
-				},
-				"id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"name": {
-					"type": "string"
-				},
-				"type": {
-					"$ref": "#/definitions/codersdk.AIProviderType"
 				}
 			}
 		},
@@ -17532,14 +16545,6 @@
 				}
 			}
 		},
-		"codersdk.ChatAutoArchiveDaysResponse": {
-			"type": "object",
-			"properties": {
-				"auto_archive_days": {
-					"type": "integer"
-				}
-			}
-		},
 		"codersdk.ChatBusyBehavior": {
 			"type": "string",
 			"enum": ["queue", "interrupt"],
@@ -17691,25 +16696,6 @@
 					"type": "integer"
 				},
 				"unpriced_request_count": {
-					"type": "integer"
-				}
-			}
-		},
-		"codersdk.ChatDebugLoggingAdminSettings": {
-			"type": "object",
-			"properties": {
-				"allow_users": {
-					"type": "boolean"
-				},
-				"forced_by_deployment": {
-					"type": "boolean"
-				}
-			}
-		},
-		"codersdk.ChatDebugRetentionDaysResponse": {
-			"type": "object",
-			"properties": {
-				"debug_retention_days": {
 					"type": "integer"
 				}
 			}
@@ -18074,8 +17060,12 @@
 				},
 				"context_file_agent_id": {
 					"description": "ContextFileAgentID is the workspace agent that provided\nthis context file. Used to detect when the agent changes\n(e.g. workspace rebuilt) so instruction files can be\nre-persisted with fresh content.",
-					"type": "string",
-					"format": "uuid"
+					"format": "uuid",
+					"allOf": [
+						{
+							"$ref": "#/definitions/uuid.NullUUID"
+						}
+					]
 				},
 				"context_file_content": {
 					"description": "ContextFileContent holds the file content sent to the LLM.\nInternal only: stripped before API responses to keep\npayloads small. The backend reads it when building the\nprompt via partsToMessageParts.",
@@ -18116,8 +17106,12 @@
 					"type": "integer"
 				},
 				"file_id": {
-					"type": "string",
-					"format": "uuid"
+					"format": "uuid",
+					"allOf": [
+						{
+							"$ref": "#/definitions/uuid.NullUUID"
+						}
+					]
 				},
 				"file_name": {
 					"type": "string"
@@ -18133,8 +17127,12 @@
 					"type": "boolean"
 				},
 				"mcp_server_config_id": {
-					"type": "string",
-					"format": "uuid"
+					"format": "uuid",
+					"allOf": [
+						{
+							"$ref": "#/definitions/uuid.NullUUID"
+						}
+					]
 				},
 				"media_type": {
 					"type": "string"
@@ -18354,16 +17352,16 @@
 		"codersdk.ChatModelACL": {
 			"type": "object",
 			"properties": {
-				"groups": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.ChatGroup"
+				"group_roles": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/codersdk.ChatRole"
 					}
 				},
-				"users": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.ChatUser"
+				"user_roles": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/codersdk.ChatRole"
 					}
 				}
 			}
@@ -18903,26 +17901,10 @@
 				"ChatPersonalModelOverrideModeModel"
 			]
 		},
-		"codersdk.ChatPersonalModelOverridesAdminSettings": {
-			"type": "object",
-			"properties": {
-				"allow_users": {
-					"type": "boolean"
-				}
-			}
-		},
 		"codersdk.ChatPlanMode": {
 			"type": "string",
 			"enum": ["plan"],
 			"x-enum-varnames": ["ChatPlanModePlan"]
-		},
-		"codersdk.ChatPlanModeInstructionsResponse": {
-			"type": "object",
-			"properties": {
-				"plan_mode_instructions": {
-					"type": "string"
-				}
-			}
 		},
 		"codersdk.ChatPrompt": {
 			"type": "object",
@@ -19154,20 +18136,6 @@
 				}
 			}
 		},
-		"codersdk.ChatSystemPromptResponse": {
-			"type": "object",
-			"properties": {
-				"default_system_prompt": {
-					"type": "string"
-				},
-				"include_default_system_prompt": {
-					"type": "boolean"
-				},
-				"system_prompt": {
-					"type": "string"
-				}
-			}
-		},
 		"codersdk.ChatUnsupportedProvider": {
 			"type": "object",
 			"properties": {
@@ -19249,15 +18217,6 @@
 				"ChatWatchEventKindActionRequired",
 				"ChatWatchEventKindContextDirty"
 			]
-		},
-		"codersdk.ChatWorkspaceTTLResponse": {
-			"type": "object",
-			"properties": {
-				"workspace_ttl_ms": {
-					"description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
-					"type": "integer"
-				}
-			}
 		},
 		"codersdk.ClusterConfig": {
 			"type": "object",
@@ -19893,10 +18852,6 @@
 					"description": "Allow users to cancel in-progress workspace jobs.\n*bool as the default value is \"true\".",
 					"type": "boolean"
 				},
-				"allow_workspace_renames": {
-					"description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name, so this defaults to false.",
-					"type": "boolean"
-				},
 				"autostart_requirement": {
 					"description": "AutostartRequirement allows optionally specifying the autostart allowed days\nfor workspaces created from this template. This is an enterprise feature.",
 					"allOf": [
@@ -20210,14 +19165,6 @@
 							"$ref": "#/definitions/codersdk.PremiumFunnelSource"
 						}
 					]
-				}
-			}
-		},
-		"codersdk.CreateUserAIProviderKeyRequest": {
-			"type": "object",
-			"properties": {
-				"api_key": {
-					"type": "string"
 				}
 			}
 		},
@@ -20794,7 +19741,6 @@
 					"$ref": "#/definitions/codersdk.AIConfig"
 				},
 				"allow_workspace_renames": {
-					"description": "Deprecated: Use the per-template allow_workspace_renames setting instead.",
 					"type": "boolean"
 				},
 				"autobuild_poll_interval": {
@@ -20836,7 +19782,7 @@
 				"disable_path_apps": {
 					"type": "boolean"
 				},
-				"disable_workspace_agent_context_sync": {
+				"disable_user_secret_file_path": {
 					"type": "boolean"
 				},
 				"disable_workspace_sharing": {
@@ -20890,12 +19836,6 @@
 				},
 				"logging": {
 					"$ref": "#/definitions/codersdk.LoggingConfig"
-				},
-				"mcp_allowed_private_cidrs": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
 				},
 				"metrics_cache_refresh_interval": {
 					"type": "integer"
@@ -21753,21 +20693,13 @@
 		"codersdk.GroupMemberAISpend": {
 			"type": "object",
 			"properties": {
-				"effective_budget": {
-					"description": "EffectiveBudget is the spend limit that currently applies to the user.\nNull when no budget applies or the effective group belongs to a different\norganization than the queried group.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/codersdk.AIBudgetLimit"
-						}
-					]
-				},
 				"effective_group_id": {
 					"description": "EffectiveGroupID is the user's effective budget group within the queried\ngroup's organization, falling back to the Everyone group when no budget\napplies. Null when the effective group belongs to a different organization\nthan the queried group.",
 					"type": "string",
 					"format": "uuid"
 				},
 				"group_budget": {
-					"description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. When populated, it matches EffectiveBudget. Null\nwhen the user's budget resolves to another group or no budget applies.\nDeprecated: Use EffectiveBudget instead.",
+					"description": "GroupBudget is the budget when the queried group is this user's\neffective budget source. Null when the user's budget resolves to another\ngroup or no budget applies to the user.",
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.AIBudgetLimit"
@@ -24211,14 +23143,6 @@
 				}
 			}
 		},
-		"codersdk.ProposeChatTitleResponse": {
-			"type": "object",
-			"properties": {
-				"title": {
-					"type": "string"
-				}
-			}
-		},
 		"codersdk.ProvisionerConfig": {
 			"type": "object",
 			"properties": {
@@ -25390,17 +24314,6 @@
 				}
 			}
 		},
-		"codersdk.SubmitToolResultsRequest": {
-			"type": "object",
-			"properties": {
-				"results": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.ToolResult"
-					}
-				}
-			}
-		},
 		"codersdk.SupportConfig": {
 			"type": "object",
 			"properties": {
@@ -25506,10 +24419,6 @@
 					"type": "boolean"
 				},
 				"allow_user_cancel_workspace_jobs": {
-					"type": "boolean"
-				},
-				"allow_workspace_renames": {
-					"description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
 					"type": "boolean"
 				},
 				"autostart_requirement": {
@@ -26572,23 +25481,6 @@
 				}
 			}
 		},
-		"codersdk.ToolResult": {
-			"type": "object",
-			"properties": {
-				"is_error": {
-					"type": "boolean"
-				},
-				"output": {
-					"type": "array",
-					"items": {
-						"type": "integer"
-					}
-				},
-				"tool_call_id": {
-					"type": "string"
-				}
-			}
-		},
 		"codersdk.TraceConfig": {
 			"type": "object",
 			"properties": {
@@ -26697,30 +25589,6 @@
 				}
 			}
 		},
-		"codersdk.UpdateChatAutoArchiveDaysRequest": {
-			"type": "object",
-			"properties": {
-				"auto_archive_days": {
-					"type": "integer"
-				}
-			}
-		},
-		"codersdk.UpdateChatDebugLoggingAllowUsersRequest": {
-			"type": "object",
-			"properties": {
-				"allow_users": {
-					"type": "boolean"
-				}
-			}
-		},
-		"codersdk.UpdateChatDebugRetentionDaysRequest": {
-			"type": "object",
-			"properties": {
-				"debug_retention_days": {
-					"type": "integer"
-				}
-			}
-		},
 		"codersdk.UpdateChatModelACLRequest": {
 			"type": "object",
 			"properties": {
@@ -26779,22 +25647,6 @@
 				}
 			}
 		},
-		"codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest": {
-			"type": "object",
-			"properties": {
-				"allow_users": {
-					"type": "boolean"
-				}
-			}
-		},
-		"codersdk.UpdateChatPlanModeInstructionsRequest": {
-			"type": "object",
-			"properties": {
-				"plan_mode_instructions": {
-					"type": "string"
-				}
-			}
-		},
 		"codersdk.UpdateChatRequest": {
 			"type": "object",
 			"properties": {
@@ -26832,26 +25684,6 @@
 			"type": "object",
 			"properties": {
 				"retention_days": {
-					"type": "integer"
-				}
-			}
-		},
-		"codersdk.UpdateChatSystemPromptRequest": {
-			"type": "object",
-			"properties": {
-				"include_default_system_prompt": {
-					"type": "boolean"
-				},
-				"system_prompt": {
-					"type": "string"
-				}
-			}
-		},
-		"codersdk.UpdateChatWorkspaceTTLRequest": {
-			"type": "object",
-			"properties": {
-				"workspace_ttl_ms": {
-					"description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled; the template's own autostop setting applies.",
 					"type": "integer"
 				}
 			}
@@ -27060,10 +25892,6 @@
 				"allow_user_cancel_workspace_jobs": {
 					"type": "boolean"
 				},
-				"allow_workspace_renames": {
-					"description": "AllowWorkspaceRenames permits users to rename workspaces built from this\ntemplate. Renaming can be destructive for templates whose Terraform\nreferences the workspace name.",
-					"type": "boolean"
-				},
 				"autostart_requirement": {
 					"$ref": "#/definitions/codersdk.TemplateAutostartRequirement"
 				},
@@ -27181,24 +26009,6 @@
 				},
 				"theme_preference": {
 					"type": "string"
-				}
-			}
-		},
-		"codersdk.UpdateUserChatCompactionThresholdRequest": {
-			"type": "object",
-			"properties": {
-				"threshold_percent": {
-					"type": "integer",
-					"maximum": 100,
-					"minimum": 0
-				}
-			}
-		},
-		"codersdk.UpdateUserChatDebugLoggingRequest": {
-			"type": "object",
-			"properties": {
-				"debug_logging_enabled": {
-					"type": "boolean"
 				}
 			}
 		},
@@ -27616,23 +26426,6 @@
 				}
 			}
 		},
-		"codersdk.UserAIProviderKeyConfig": {
-			"type": "object",
-			"properties": {
-				"byok_enabled": {
-					"type": "boolean"
-				},
-				"has_provider_api_key": {
-					"type": "boolean"
-				},
-				"has_user_api_key": {
-					"type": "boolean"
-				},
-				"provider": {
-					"$ref": "#/definitions/codersdk.AIProviderSummary"
-				}
-			}
-		},
 		"codersdk.UserAISpendStatus": {
 			"type": "object",
 			"properties": {
@@ -27750,51 +26543,6 @@
 				"theme_preference": {
 					"description": "ThemePreference is the legacy single-field appearance setting. In\n\"single\" mode it mirrors the active theme. In \"sync\" mode modern\nclients normally mirror the active OS slot, but older clients can\nupdate only this field, so it may diverge from ThemeLight or\nThemeDark until a modern client saves the full appearance state\nagain.",
 					"type": "string"
-				}
-			}
-		},
-		"codersdk.UserChatCompactionThreshold": {
-			"type": "object",
-			"properties": {
-				"model_config_id": {
-					"type": "string",
-					"format": "uuid"
-				},
-				"threshold_percent": {
-					"type": "integer"
-				}
-			}
-		},
-		"codersdk.UserChatCompactionThresholds": {
-			"type": "object",
-			"properties": {
-				"thresholds": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.UserChatCompactionThreshold"
-					}
-				}
-			}
-		},
-		"codersdk.UserChatCustomPrompt": {
-			"type": "object",
-			"properties": {
-				"custom_prompt": {
-					"type": "string"
-				}
-			}
-		},
-		"codersdk.UserChatDebugLoggingSettings": {
-			"type": "object",
-			"properties": {
-				"debug_logging_enabled": {
-					"type": "boolean"
-				},
-				"forced_by_deployment": {
-					"type": "boolean"
-				},
-				"user_toggle_allowed": {
-					"type": "boolean"
 				}
 			}
 		},
@@ -27968,7 +26716,7 @@
 					"type": "string"
 				},
 				"enabled": {
-					"description": "Enabled controls whether the secret is injected into workspaces.\nDisabled secrets remain visible and editable, but are not added\nto the agent manifest, so they are not exposed as environment\nvariables or written to secret files.",
+					"description": "Enabled is stored intent. Deployment policy may block a stored target.",
 					"type": "boolean"
 				},
 				"env_name": {
@@ -28130,7 +26878,6 @@
 			"type": "object",
 			"properties": {
 				"allow_renames": {
-					"description": "AllowRenames is the effective rename permission for this workspace,\nderived from the template's allow_workspace_renames setting and the\ndeprecated deployment-wide flag.",
 					"type": "boolean"
 				},
 				"automatic_updates": {
@@ -28223,7 +26970,11 @@
 				},
 				"task_id": {
 					"description": "TaskID, if set, indicates that the workspace is relevant to the given codersdk.Task.",
-					"type": "string"
+					"allOf": [
+						{
+							"$ref": "#/definitions/uuid.NullUUID"
+						}
+					]
 				},
 				"template_active_version_id": {
 					"type": "string",
@@ -28380,8 +27131,12 @@
 					"type": "string"
 				},
 				"parent_id": {
-					"type": "string",
-					"format": "uuid"
+					"format": "uuid",
+					"allOf": [
+						{
+							"$ref": "#/definitions/uuid.NullUUID"
+						}
+					]
 				},
 				"ready_at": {
 					"type": "string",
@@ -28536,8 +27291,12 @@
 					]
 				},
 				"subagent_id": {
-					"type": "string",
-					"format": "uuid"
+					"format": "uuid",
+					"allOf": [
+						{
+							"$ref": "#/definitions/uuid.NullUUID"
+						}
+					]
 				},
 				"workspace_folder": {
 					"type": "string"
@@ -30258,6 +29017,10 @@
 					"description": "[ip]:port of global IPv6",
 					"type": "string"
 				},
+				"hairPinning": {
+					"description": "HairPinning is whether the router supports communicating\nbetween two local devices through the NATted public IP address\n(on IPv4).",
+					"type": "string"
+				},
 				"icmpv4": {
 					"description": "an ICMPv4 round trip completed",
 					"type": "boolean"
@@ -30677,6 +29440,18 @@
 		},
 		"url.Userinfo": {
 			"type": "object"
+		},
+		"uuid.NullUUID": {
+			"type": "object",
+			"properties": {
+				"uuid": {
+					"type": "string"
+				},
+				"valid": {
+					"description": "Valid is true if UUID is not NULL",
+					"type": "boolean"
+				}
+			}
 		},
 		"workspaceapps.AccessMethod": {
 			"type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3428,6 +3428,27 @@
 				]
 			}
 		},
+		"/api/v2/deployment/user-secrets/capabilities": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["General"],
+				"summary": "Get user secrets capabilities",
+				"operationId": "get-user-secrets-capabilities",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserSecretsCapabilities"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/v2/derp-map": {
 			"get": {
 				"tags": ["Agents"],
@@ -28014,6 +28035,15 @@
 				"updated_at": {
 					"type": "string",
 					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.UserSecretsCapabilities": {
+			"type": "object",
+			"properties": {
+				"file_path_delivery_enabled": {
+					"description": "FilePathDeliveryEnabled reports whether Coder writes stored file paths\ninto workspaces. Stored paths are preserved either way.",
+					"type": "boolean"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1442,6 +1442,7 @@ func New(options *Options) *API {
 			r.Get("/config", api.deploymentValues)
 			r.Get("/stats", api.deploymentStats)
 			r.Get("/ssh", api.sshConfig)
+			r.Get("/user-secrets/capabilities", api.userSecretsCapabilities)
 			r.Post("/premium-funnel-events", api.postPremiumFunnelEvent)
 		})
 		r.Route("/experiments", func(r chi.Router) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5388,6 +5388,15 @@ func (q *querier) GetUserSecretByUserIDAndName(ctx context.Context, arg database
 	return q.db.GetUserSecretByUserIDAndName(ctx, arg)
 }
 
+func (q *querier) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	obj := rbac.ResourceUserSecret.WithOwner(arg.UserID.String())
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, obj); err != nil {
+		return database.UserSecret{}, err
+	}
+
+	return q.db.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+}
+
 func (q *querier) GetUserSecretsTelemetrySummary(ctx context.Context) (database.GetUserSecretsTelemetrySummaryRow, error) {
 	// Telemetry queries are called from system contexts only. The
 	// query reads aggregate counts across all users' secrets, so

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6642,6 +6642,15 @@ func (s *MethodTestSuite) TestUserSecrets() {
 			Asserts(rbac.ResourceUserSecret.WithOwner(user.ID.String()), policy.ActionRead).
 			Returns(secret)
 	}))
+	s.Run("GetUserSecretByUserIDAndNameForUpdate", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		user := testutil.Fake(s.T(), faker, database.User{})
+		secret := testutil.Fake(s.T(), faker, database.UserSecret{UserID: user.ID})
+		arg := database.GetUserSecretByUserIDAndNameForUpdateParams{UserID: user.ID, Name: secret.Name}
+		dbm.EXPECT().GetUserSecretByUserIDAndNameForUpdate(gomock.Any(), arg).Return(secret, nil).AnyTimes()
+		check.Args(arg).
+			Asserts(rbac.ResourceUserSecret.WithOwner(user.ID.String()), policy.ActionUpdate).
+			Returns(secret)
+	}))
 	s.Run("ListUserSecrets", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		user := testutil.Fake(s.T(), faker, database.User{})
 		row := testutil.Fake(s.T(), faker, database.ListUserSecretsRow{UserID: user.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3448,6 +3448,14 @@ func (m queryMetricsStore) GetUserSecretByUserIDAndName(ctx context.Context, arg
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetUserSecretByUserIDAndNameForUpdate").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetUserSecretByUserIDAndNameForUpdate").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetUserSecretsTelemetrySummary(ctx context.Context) (database.GetUserSecretsTelemetrySummaryRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetUserSecretsTelemetrySummary(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6494,6 +6494,21 @@ func (mr *MockStoreMockRecorder) GetUserSecretByUserIDAndName(ctx, arg any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretByUserIDAndName", reflect.TypeOf((*MockStore)(nil).GetUserSecretByUserIDAndName), ctx, arg)
 }
 
+// GetUserSecretByUserIDAndNameForUpdate mocks base method.
+func (m *MockStore) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserSecretByUserIDAndNameForUpdate", ctx, arg)
+	ret0, _ := ret[0].(database.UserSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserSecretByUserIDAndNameForUpdate indicates an expected call of GetUserSecretByUserIDAndNameForUpdate.
+func (mr *MockStoreMockRecorder) GetUserSecretByUserIDAndNameForUpdate(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSecretByUserIDAndNameForUpdate", reflect.TypeOf((*MockStore)(nil).GetUserSecretByUserIDAndNameForUpdate), ctx, arg)
+}
+
 // GetUserSecretsTelemetrySummary mocks base method.
 func (m *MockStore) GetUserSecretsTelemetrySummary(ctx context.Context) (database.GetUserSecretsTelemetrySummaryRow, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -966,6 +966,7 @@ type sqlcQuerier interface {
 	GetUserNotificationPreferences(ctx context.Context, userID uuid.UUID) ([]NotificationPreference, error)
 	GetUserSecretByID(ctx context.Context, id uuid.UUID) (UserSecret, error)
 	GetUserSecretByUserIDAndName(ctx context.Context, arg GetUserSecretByUserIDAndNameParams) (UserSecret, error)
+	GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg GetUserSecretByUserIDAndNameForUpdateParams) (UserSecret, error)
 	// Returns deployment-wide aggregates for the telemetry snapshot.
 	//
 	// The denominator for both user-level counts and the per-user

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -30623,6 +30623,37 @@ func (q *sqlQuerier) GetUserSecretByUserIDAndName(ctx context.Context, arg GetUs
 	return i, err
 }
 
+const getUserSecretByUserIDAndNameForUpdate = `-- name: GetUserSecretByUserIDAndNameForUpdate :one
+SELECT id, user_id, name, description, value, env_name, file_path, created_at, updated_at, value_key_id, enabled
+FROM user_secrets
+WHERE user_id = $1 AND name = $2
+FOR UPDATE
+`
+
+type GetUserSecretByUserIDAndNameForUpdateParams struct {
+	UserID uuid.UUID `db:"user_id" json:"user_id"`
+	Name   string    `db:"name" json:"name"`
+}
+
+func (q *sqlQuerier) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg GetUserSecretByUserIDAndNameForUpdateParams) (UserSecret, error) {
+	row := q.db.QueryRowContext(ctx, getUserSecretByUserIDAndNameForUpdate, arg.UserID, arg.Name)
+	var i UserSecret
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.Description,
+		&i.Value,
+		&i.EnvName,
+		&i.FilePath,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ValueKeyID,
+		&i.Enabled,
+	)
+	return i, err
+}
+
 const getUserSecretsTelemetrySummary = `-- name: GetUserSecretsTelemetrySummary :one
 WITH active_users AS (
     SELECT id AS user_id

--- a/coderd/database/queries/user_secrets.sql
+++ b/coderd/database/queries/user_secrets.sql
@@ -8,6 +8,12 @@ SELECT *
 FROM user_secrets
 WHERE id = @id;
 
+-- name: GetUserSecretByUserIDAndNameForUpdate :one
+SELECT *
+FROM user_secrets
+WHERE user_id = @user_id AND name = @name
+FOR UPDATE;
+
 -- name: ListUserSecrets :many
 -- Returns metadata only (no value or value_key_id) for the
 -- REST API list and get endpoints.

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -2649,7 +2649,9 @@ type ChatDiffStatusSummary struct {
 // UsersWithSecrets is the count of active non-system users that have
 // at least one secret. TotalSecrets is the count of secrets owned by
 // those users. EnvNameOnly, FilePathOnly, Both, and Neither break
-// TotalSecrets down by which injection fields are populated.
+// TotalSecrets down by which target fields are stored. They do not
+// describe effective delivery because deployment policy can block a
+// stored target.
 //
 // The SecretsPerUser* fields describe the distribution of secrets per
 // user across the entire active non-system user base, including users

--- a/coderd/usersecrets.go
+++ b/coderd/usersecrets.go
@@ -44,41 +44,29 @@ const (
 	//nolint:gosec // User-facing validation text.
 	userSecretFilePathDisabledDetail = "File path delivery for user secrets is disabled by the deployment administrator. Clear file_path or use env_name instead."
 	//nolint:gosec // User-facing validation text.
-	userSecretEnvTargetRequiredDetail = "File path delivery for user secrets is disabled by the deployment administrator, so an enabled secret must have an env_name. Add env_name, or disable the secret."
+	userSecretEnvTargetRequiredDetail = "File path delivery for user secrets is disabled by the deployment administrator, so an enabled secret must have an env_name. Add env_name, or set enabled to false."
 )
 
-type userSecretFilePathPolicy int
-
-const (
-	userSecretFilePathAllowed userSecretFilePathPolicy = iota
-	userSecretFilePathBlocked
-)
-
-func (api *API) userSecretFilePathPolicy() userSecretFilePathPolicy {
-	if api.DeploymentValues != nil && api.DeploymentValues.DisableUserSecretFilePath.Value() {
-		return userSecretFilePathBlocked
-	}
-	return userSecretFilePathAllowed
+// userSecretFilePathBlocked reports whether the deployment forbids file path
+// delivery for user secrets.
+func (api *API) userSecretFilePathBlocked() bool {
+	return api.DeploymentValues != nil && api.DeploymentValues.DisableUserSecretFilePath.Value()
 }
 
-func userSecretCreatePolicyValidationErrors(req codersdk.CreateUserSecretRequest, policy userSecretFilePathPolicy) []codersdk.ValidationError {
-	if policy != userSecretFilePathBlocked || req.FilePath == "" {
-		return nil
-	}
-	return []codersdk.ValidationError{{
-		Field:  codersdk.UserSecretFilePathField,
-		Detail: userSecretFilePathDisabledDetail,
-	}}
-}
-
-func userSecretCreateValidationErrors(req codersdk.CreateUserSecretRequest, policy userSecretFilePathPolicy) []codersdk.ValidationError {
+//nolint:revive // blocked is deployment configuration, not caller control coupling.
+func userSecretCreateValidationErrors(req codersdk.CreateUserSecretRequest, blocked bool) []codersdk.ValidationError {
 	validations := codersdk.ValidateCreateUserSecretRequest(req)
-	if policy != userSecretFilePathBlocked {
+	if !blocked {
 		return validations
 	}
 
-	validations = append(validations, userSecretCreatePolicyValidationErrors(req, policy)...)
-	if req.Enabled != nil && !*req.Enabled || req.EnvName != "" {
+	if req.FilePath != "" {
+		validations = append(validations, codersdk.ValidationError{
+			Field:  codersdk.UserSecretFilePathField,
+			Detail: userSecretFilePathDisabledDetail,
+		})
+	}
+	if (req.Enabled != nil && !*req.Enabled) || req.EnvName != "" {
 		return validations
 	}
 
@@ -161,7 +149,7 @@ func (api *API) postUserSecret(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if validations := userSecretCreateValidationErrors(req, api.userSecretFilePathPolicy()); len(validations) > 0 {
+	if validations := userSecretCreateValidationErrors(req, api.userSecretFilePathBlocked()); len(validations) > 0 {
 		writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, validations)
 		return
 	}
@@ -248,10 +236,10 @@ func (api *API) postUserSecretsBatch(rw http.ResponseWriter, r *http.Request) {
 	// Validate every entry and accumulate all errors so the caller can
 	// fix the whole file in one round-trip. Each field is prefixed with
 	// the entry index, e.g. "secrets[2].env_name".
-	filePathPolicy := api.userSecretFilePathPolicy()
+	filePathBlocked := api.userSecretFilePathBlocked()
 	var validations []codersdk.ValidationError
 	for i, sreq := range reqs {
-		entryValidations := userSecretCreateValidationErrors(sreq, filePathPolicy)
+		entryValidations := userSecretCreateValidationErrors(sreq, filePathBlocked)
 		validations = append(validations, prefixUserSecretValidationErrors(i, entryValidations)...)
 	}
 	if len(validations) > 0 {
@@ -481,7 +469,7 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 
 	// Lock before computing post-state so concurrent PATCHes serialize.
 	var secret database.UserSecret
-	filePathPolicy := api.userSecretFilePathPolicy()
+	filePathBlocked := api.userSecretFilePathBlocked()
 	err := api.Database.InTx(func(tx database.Store) error {
 		old, err := tx.GetUserSecretByUserIDAndNameForUpdate(ctx, database.GetUserSecretByUserIDAndNameForUpdateParams{
 			UserID: user.ID,
@@ -508,7 +496,7 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 		if req.Enabled != nil {
 			postEnabled = *req.Enabled
 		}
-		if filePathPolicy == userSecretFilePathBlocked {
+		if filePathBlocked {
 			if err := userSecretFilePathPolicyError(old, req); err != nil {
 				return err
 			}
@@ -531,24 +519,19 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 			httpapi.ResourceNotFound(rw)
 			return
 		}
-		if errors.Is(err, errUserSecretInjectionTargetRequired) {
-			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, []codersdk.ValidationError{{
-				Field:  codersdk.UserSecretEnvNameField,
-				Detail: codersdk.UserSecretInjectionTargetRequiredDetail,
-			}})
-			return
+		var field, detail string
+		switch {
+		case errors.Is(err, errUserSecretInjectionTargetRequired):
+			field, detail = codersdk.UserSecretEnvNameField, codersdk.UserSecretInjectionTargetRequiredDetail
+		case errors.Is(err, errUserSecretFilePathDisabled):
+			field, detail = codersdk.UserSecretFilePathField, userSecretFilePathDisabledDetail
+		case errors.Is(err, errUserSecretEnvTargetRequired):
+			field, detail = codersdk.UserSecretEnvNameField, userSecretEnvTargetRequiredDetail
 		}
-		if errors.Is(err, errUserSecretFilePathDisabled) {
+		if field != "" {
 			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, []codersdk.ValidationError{{
-				Field:  codersdk.UserSecretFilePathField,
-				Detail: userSecretFilePathDisabledDetail,
-			}})
-			return
-		}
-		if errors.Is(err, errUserSecretEnvTargetRequired) {
-			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, []codersdk.ValidationError{{
-				Field:  codersdk.UserSecretEnvNameField,
-				Detail: userSecretEnvTargetRequiredDetail,
+				Field:  field,
+				Detail: detail,
 			}})
 			return
 		}

--- a/coderd/usersecrets.go
+++ b/coderd/usersecrets.go
@@ -35,6 +35,101 @@ const (
 // codersdk.ValidateCreateUserSecretRequest.
 var errUserSecretInjectionTargetRequired = xerrors.New("enabled user secret must have at least one of env_name or file_path set")
 
+var (
+	errUserSecretFilePathDisabled  = xerrors.New("file-based user secrets are disabled")
+	errUserSecretEnvTargetRequired = xerrors.New("enabled user secret requires env_name")
+)
+
+const (
+	//nolint:gosec // User-facing validation text.
+	userSecretFilePathDisabledDetail = "File path delivery for user secrets is disabled by the deployment administrator. Clear file_path or use env_name instead."
+	//nolint:gosec // User-facing validation text.
+	userSecretEnvTargetRequiredDetail = "File path delivery for user secrets is disabled by the deployment administrator, so an enabled secret must have an env_name. Add env_name, or disable the secret."
+)
+
+type userSecretFilePathPolicy int
+
+const (
+	userSecretFilePathAllowed userSecretFilePathPolicy = iota
+	userSecretFilePathBlocked
+)
+
+func (api *API) userSecretFilePathPolicy() userSecretFilePathPolicy {
+	if api.DeploymentValues != nil && api.DeploymentValues.DisableUserSecretFilePath.Value() {
+		return userSecretFilePathBlocked
+	}
+	return userSecretFilePathAllowed
+}
+
+func userSecretCreatePolicyValidationErrors(req codersdk.CreateUserSecretRequest, policy userSecretFilePathPolicy) []codersdk.ValidationError {
+	if policy != userSecretFilePathBlocked || req.FilePath == "" {
+		return nil
+	}
+	return []codersdk.ValidationError{{
+		Field:  codersdk.UserSecretFilePathField,
+		Detail: userSecretFilePathDisabledDetail,
+	}}
+}
+
+func userSecretCreateValidationErrors(req codersdk.CreateUserSecretRequest, policy userSecretFilePathPolicy) []codersdk.ValidationError {
+	validations := codersdk.ValidateCreateUserSecretRequest(req)
+	if policy != userSecretFilePathBlocked {
+		return validations
+	}
+
+	validations = append(validations, userSecretCreatePolicyValidationErrors(req, policy)...)
+	if req.Enabled != nil && !*req.Enabled || req.EnvName != "" {
+		return validations
+	}
+
+	for i := range validations {
+		if validations[i].Field == codersdk.UserSecretEnvNameField && validations[i].Detail == codersdk.UserSecretInjectionTargetRequiredDetail {
+			validations[i].Detail = userSecretEnvTargetRequiredDetail
+		}
+	}
+	return validations
+}
+
+func prefixUserSecretValidationErrors(index int, validations []codersdk.ValidationError) []codersdk.ValidationError {
+	if index < 0 {
+		return validations
+	}
+	prefixed := make([]codersdk.ValidationError, 0, len(validations))
+	for _, v := range validations {
+		prefixed = append(prefixed, codersdk.ValidationError{
+			Field:  fmt.Sprintf("secrets[%d].%s", index, v.Field),
+			Detail: v.Detail,
+		})
+	}
+	return prefixed
+}
+
+// Existing enabled file-only rows may be edited or disabled, but a PATCH
+// cannot add or change a path or enter a new enabled state without env_name.
+func userSecretFilePathPolicyError(old database.UserSecret, req codersdk.UpdateUserSecretRequest) error {
+	if req.FilePath != nil && *req.FilePath != "" && *req.FilePath != old.FilePath {
+		return errUserSecretFilePathDisabled
+	}
+
+	postEnvName := old.EnvName
+	if req.EnvName != nil {
+		postEnvName = *req.EnvName
+	}
+	postEnabled := old.Enabled
+	if req.Enabled != nil {
+		postEnabled = *req.Enabled
+	}
+	if postEnabled && postEnvName == "" && req.FilePath != nil && *req.FilePath == "" {
+		return errUserSecretEnvTargetRequired
+	}
+
+	predatesPolicy := old.Enabled && old.EnvName == ""
+	if postEnabled && postEnvName == "" && !predatesPolicy {
+		return errUserSecretEnvTargetRequired
+	}
+	return nil
+}
+
 // @Summary Create a new user secret
 // @ID create-a-new-user-secret
 // @Security CoderSessionToken
@@ -44,6 +139,8 @@ var errUserSecretInjectionTargetRequired = xerrors.New("enabled user secret must
 // @Param user path string true "User ID, username, or me"
 // @Param request body codersdk.CreateUserSecretRequest true "Create secret request"
 // @Success 201 {object} codersdk.UserSecret
+// @Failure 400 {object} codersdk.Response
+// @Failure 409 {object} codersdk.Response
 // @Router /api/v2/users/{user}/secrets [post]
 func (api *API) postUserSecret(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -64,7 +161,7 @@ func (api *API) postUserSecret(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if validations := codersdk.ValidateCreateUserSecretRequest(req); len(validations) > 0 {
+	if validations := userSecretCreateValidationErrors(req, api.userSecretFilePathPolicy()); len(validations) > 0 {
 		writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, validations)
 		return
 	}
@@ -151,14 +248,11 @@ func (api *API) postUserSecretsBatch(rw http.ResponseWriter, r *http.Request) {
 	// Validate every entry and accumulate all errors so the caller can
 	// fix the whole file in one round-trip. Each field is prefixed with
 	// the entry index, e.g. "secrets[2].env_name".
+	filePathPolicy := api.userSecretFilePathPolicy()
 	var validations []codersdk.ValidationError
 	for i, sreq := range reqs {
-		for _, v := range codersdk.ValidateCreateUserSecretRequest(sreq) {
-			validations = append(validations, codersdk.ValidationError{
-				Field:  fmt.Sprintf("secrets[%d].%s", i, v.Field),
-				Detail: v.Detail,
-			})
-		}
+		entryValidations := userSecretCreateValidationErrors(sreq, filePathPolicy)
+		validations = append(validations, prefixUserSecretValidationErrors(i, entryValidations)...)
 	}
 	if len(validations) > 0 {
 		writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, validations)
@@ -200,21 +294,11 @@ func (api *API) postUserSecretsBatch(rw http.ResponseWriter, r *http.Request) {
 		index := failedIndex
 
 		if conflicts := userSecretConflictValidationErrors(err); len(conflicts) > 0 {
-			if index >= 0 {
-				for i := range conflicts {
-					conflicts[i].Field = fmt.Sprintf("secrets[%d].%s", index, conflicts[i].Field)
-				}
-			}
-			writeUserSecretValidationErrors(ctx, rw, http.StatusConflict, conflicts)
+			writeUserSecretValidationErrors(ctx, rw, http.StatusConflict, prefixUserSecretValidationErrors(index, conflicts))
 			return
 		}
 		if validations := userSecretInjectionTargetValidationErrors(err); len(validations) > 0 {
-			if index >= 0 {
-				for i := range validations {
-					validations[i].Field = fmt.Sprintf("secrets[%d].%s", index, validations[i].Field)
-				}
-			}
-			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, validations)
+			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, prefixUserSecretValidationErrors(index, validations))
 			return
 		}
 		if resp, ok := userSecretLimitResponse(err); ok {
@@ -330,6 +414,8 @@ func (api *API) getUserSecret(rw http.ResponseWriter, r *http.Request) { //nolin
 // @Param name path string true "Secret name"
 // @Param request body codersdk.UpdateUserSecretRequest true "Update secret request"
 // @Success 200 {object} codersdk.UserSecret
+// @Failure 400 {object} codersdk.Response
+// @Failure 409 {object} codersdk.Response
 // @Router /api/v2/users/{user}/secrets/{name} [patch]
 func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -393,17 +479,11 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 		params.Enabled = *req.Enabled
 	}
 
-	// Pre-read the secret inside a transaction so the audit diff has both an
-	// "old" and "new" snapshot.
-	//
-	// Under read committed isolation, a concurrent writer between our SELECT
-	// and our UPDATE can cause the audit diff to attribute changes to us that
-	// we did not make. We accept this race to match other audit log diffs
-	// (templates, workspaces, chats, etc). In practice this should be unlikely
-	// to hit since a user can only modify their own secrets.
+	// Lock before computing post-state so concurrent PATCHes serialize.
 	var secret database.UserSecret
+	filePathPolicy := api.userSecretFilePathPolicy()
 	err := api.Database.InTx(func(tx database.Store) error {
-		old, err := tx.GetUserSecretByUserIDAndName(ctx, database.GetUserSecretByUserIDAndNameParams{
+		old, err := tx.GetUserSecretByUserIDAndNameForUpdate(ctx, database.GetUserSecretByUserIDAndNameForUpdateParams{
 			UserID: user.ID,
 			Name:   name,
 		})
@@ -428,6 +508,12 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 		if req.Enabled != nil {
 			postEnabled = *req.Enabled
 		}
+		if filePathPolicy == userSecretFilePathBlocked {
+			if err := userSecretFilePathPolicyError(old, req); err != nil {
+				return err
+			}
+		}
+
 		if postEnabled && postEnvName == "" && postFilePath == "" {
 			return errUserSecretInjectionTargetRequired
 		}
@@ -452,6 +538,20 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 			}})
 			return
 		}
+		if errors.Is(err, errUserSecretFilePathDisabled) {
+			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, []codersdk.ValidationError{{
+				Field:  codersdk.UserSecretFilePathField,
+				Detail: userSecretFilePathDisabledDetail,
+			}})
+			return
+		}
+		if errors.Is(err, errUserSecretEnvTargetRequired) {
+			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, []codersdk.ValidationError{{
+				Field:  codersdk.UserSecretEnvNameField,
+				Detail: userSecretEnvTargetRequiredDetail,
+			}})
+			return
+		}
 		if validations := userSecretInjectionTargetValidationErrors(err); len(validations) > 0 {
 			writeUserSecretValidationErrors(ctx, rw, http.StatusBadRequest, validations)
 			return
@@ -462,6 +562,10 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 		}
 		if resp, ok := userSecretLimitResponse(err); ok {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, resp)
+			return
+		}
+		if httpapi.IsUnauthorizedError(err) {
+			httpapi.Forbidden(rw)
 			return
 		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -578,7 +682,7 @@ func userSecretLimitResponse(err error) (codersdk.Response, bool) {
 			Detail: fmt.Sprintf(
 				"Stored bytes of env-injected secret values exceed the "+
 					"per-user budget (%d bytes after encryption, if applicable). "+
-					"Clear env_name on large secrets or use file_path instead.",
+					"Reduce the size or number of env-injected secrets. If your deployment permits file path delivery, clear env_name and use file_path instead.",
 				codersdk.MaxUserSecretValueBytes,
 			),
 		}, true

--- a/coderd/usersecrets.go
+++ b/coderd/usersecrets.go
@@ -118,6 +118,21 @@ func userSecretFilePathPolicyError(old database.UserSecret, req codersdk.UpdateU
 	return nil
 }
 
+// @Summary Get user secrets capabilities
+// @ID get-user-secrets-capabilities
+// @Security CoderSessionToken
+// @Produce json
+// @Tags General
+// @Success 200 {object} codersdk.UserSecretsCapabilities
+// @Router /api/v2/deployment/user-secrets/capabilities [get]
+func (api *API) userSecretsCapabilities(rw http.ResponseWriter, r *http.Request) {
+	// Any authenticated user may read this. It exposes only the delivery
+	// policy that shapes their own secrets, not the deployment config.
+	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.UserSecretsCapabilities{
+		FilePathDeliveryEnabled: !api.userSecretFilePathBlocked(),
+	})
+}
+
 // @Summary Create a new user secret
 // @ID create-a-new-user-secret
 // @Security CoderSessionToken

--- a/coderd/usersecrets_concurrency_test.go
+++ b/coderd/usersecrets_concurrency_test.go
@@ -1,0 +1,63 @@
+package coderd_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestGetUserSecretByUserIDAndNameForUpdateLocks(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	user := dbgen.User(t, db, database.User{})
+	secret := dbgen.UserSecret(t, db, database.UserSecret{
+		UserID: user.ID, Name: "lock-me", EnvName: "LOCK_ME",
+	})
+	arg := database.GetUserSecretByUserIDAndNameForUpdateParams{
+		UserID: user.ID, Name: secret.Name,
+	}
+	lock := func() (<-chan error, func()) {
+		locked, release, done := make(chan struct{}), make(chan struct{}), make(chan error, 1)
+		go func() {
+			done <- db.InTx(func(tx database.Store) error {
+				if _, err := tx.GetUserSecretByUserIDAndNameForUpdate(ctx, arg); err != nil {
+					return err
+				}
+				close(locked)
+				<-release
+				return nil
+			}, nil)
+		}()
+		testutil.TryReceive(ctx, t, locked)
+		return done, func() { close(release) }
+	}
+
+	firstDone, releaseFirst := lock()
+
+	second := make(chan error, 1)
+	go func() {
+		second <- db.InTx(func(tx database.Store) error {
+			_, err := tx.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+			return err
+		}, nil)
+	}()
+
+	select {
+	case err := <-second:
+		t.Fatalf("second transaction acquired the row lock while it was held: %v", err)
+	case <-time.After(testutil.IntervalMedium):
+	}
+
+	releaseFirst()
+	require.NoError(t, testutil.TryReceive(ctx, t, firstDone))
+	require.NoError(t, testutil.TryReceive(ctx, t, second))
+}

--- a/coderd/usersecrets_concurrency_test.go
+++ b/coderd/usersecrets_concurrency_test.go
@@ -2,7 +2,6 @@ package coderd_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -25,23 +24,21 @@ func TestGetUserSecretByUserIDAndNameForUpdateLocks(t *testing.T) {
 	arg := database.GetUserSecretByUserIDAndNameForUpdateParams{
 		UserID: user.ID, Name: secret.Name,
 	}
-	lock := func() (<-chan error, func()) {
-		locked, release, done := make(chan struct{}), make(chan struct{}), make(chan error, 1)
-		go func() {
-			done <- db.InTx(func(tx database.Store) error {
-				if _, err := tx.GetUserSecretByUserIDAndNameForUpdate(ctx, arg); err != nil {
-					return err
-				}
-				close(locked)
-				<-release
-				return nil
-			}, nil)
-		}()
-		testutil.TryReceive(ctx, t, locked)
-		return done, func() { close(release) }
-	}
 
-	firstDone, releaseFirst := lock()
+	// The first transaction holds the row lock until released.
+	locked, release := make(chan struct{}), make(chan struct{})
+	first := make(chan error, 1)
+	go func() {
+		first <- db.InTx(func(tx database.Store) error {
+			if _, err := tx.GetUserSecretByUserIDAndNameForUpdate(ctx, arg); err != nil {
+				return err
+			}
+			close(locked)
+			<-release
+			return nil
+		}, nil)
+	}()
+	testutil.TryReceive(ctx, t, locked)
 
 	second := make(chan error, 1)
 	go func() {
@@ -51,13 +48,42 @@ func TestGetUserSecretByUserIDAndNameForUpdateLocks(t *testing.T) {
 		}, nil)
 	}()
 
+	// Wait until the second transaction is observably blocked on the row lock,
+	// rather than inferring it from a fixed delay. A waiter for SELECT ... FOR
+	// UPDATE takes a granted "tuple" lock on the relation and then waits on the
+	// holder's transaction ID, so it appears in pg_locks as a backend holding
+	// both rows. Asserting the wait directly stops this from passing vacuously
+	// when the second goroutine is merely slow to reach the query.
+	require.Eventually(t, func() bool {
+		locks, err := db.PGLocks(ctx)
+		if err != nil {
+			return false
+		}
+		waitingOnRow := make(map[int]bool)
+		for _, l := range locks {
+			if l.LockType != nil && *l.LockType == "tuple" &&
+				l.RelationName != nil && *l.RelationName == "user_secrets" {
+				waitingOnRow[l.PID] = true
+			}
+		}
+		for _, l := range locks {
+			if !l.Granted && waitingOnRow[l.PID] &&
+				l.LockType != nil && *l.LockType == "transactionid" {
+				return true
+			}
+		}
+		return false
+	}, testutil.WaitShort, testutil.IntervalFast, "second transaction must block on the user_secrets row lock")
+
+	// With the second transaction proven blocked, it must not have completed
+	// while the row lock is still held.
 	select {
 	case err := <-second:
 		t.Fatalf("second transaction acquired the row lock while it was held: %v", err)
-	case <-time.After(testutil.IntervalMedium):
+	default:
 	}
 
-	releaseFirst()
-	require.NoError(t, testutil.TryReceive(ctx, t, firstDone))
+	close(release)
+	require.NoError(t, testutil.TryReceive(ctx, t, first))
 	require.NoError(t, testutil.TryReceive(ctx, t, second))
 }

--- a/coderd/usersecrets_filepath_policy_test.go
+++ b/coderd/usersecrets_filepath_policy_test.go
@@ -1,0 +1,79 @@
+package coderd_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/audit"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestUserSecretFilePathDisabledHandlers(t *testing.T) {
+	t.Parallel()
+
+	auditor := audit.NewMock()
+	dv := coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+		dv.DisableUserSecretFilePath = true
+	})
+	db, ps := dbtestutil.NewDB(t)
+	client := coderdtest.New(t, &coderdtest.Options{
+		Database: db, Pubsub: ps, DeploymentValues: dv, Auditor: auditor,
+	})
+	owner := coderdtest.CreateFirstUser(t, client)
+	ctx := testutil.Context(t, testutil.WaitMedium)
+
+	_, err := client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name: "file-secret", Value: "value", EnvName: "FILE_SECRET", FilePath: "/tmp/file-secret",
+	})
+	requireSecretValidationContainsError(t, err, http.StatusBadRequest, "file_path", "disabled")
+
+	imported, err := client.ImportUserSecrets(ctx, codersdk.Me, codersdk.ImportUserSecretsRequest{
+		Format: codersdk.SecretsFileFormatEnv, Content: "IMPORTED=value\nPATH=disabled\n",
+	})
+	require.NoError(t, err)
+	require.Len(t, imported, 2)
+
+	legacy := dbgen.UserSecret(t, db, database.UserSecret{UserID: owner.UserID, Name: "legacy"},
+		func(p *database.CreateUserSecretParams) {
+			p.EnvName, p.FilePath, p.Enabled = "", "/tmp/legacy", true
+		})
+
+	description := "updated"
+	updated, err := client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{
+		Description: &description,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/legacy", updated.FilePath)
+	assert.True(t, updated.Enabled)
+
+	empty := ""
+	_, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{FilePath: &empty})
+	requireSecretValidationContainsError(t, err, http.StatusBadRequest, "env_name", "Add env_name")
+
+	disabled := false
+	updated, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{Enabled: &disabled})
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/legacy", updated.FilePath)
+
+	auditor.ResetLogs()
+	newPath := "/tmp/other"
+	_, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{
+		FilePath: &newPath,
+	})
+	requireSecretValidationContainsError(t, err, http.StatusBadRequest, "file_path", "disabled")
+
+	logs := auditor.AuditLogs()
+	require.Len(t, logs, 1)
+	assert.Equal(t, database.AuditActionWrite, logs[0].Action)
+	assert.EqualValues(t, http.StatusBadRequest, logs[0].StatusCode)
+	assert.Equal(t, legacy.ID, logs[0].ResourceID)
+	assert.JSONEq(t, "{}", string(logs[0].Diff))
+}

--- a/coderd/usersecrets_filepath_policy_test.go
+++ b/coderd/usersecrets_filepath_policy_test.go
@@ -35,12 +35,6 @@ func TestUserSecretFilePathDisabledHandlers(t *testing.T) {
 	})
 	requireSecretValidationContainsError(t, err, http.StatusBadRequest, "file_path", "disabled")
 
-	imported, err := client.ImportUserSecrets(ctx, codersdk.Me, codersdk.ImportUserSecretsRequest{
-		Format: codersdk.SecretsFileFormatEnv, Content: "IMPORTED=value\nPATH=disabled\n",
-	})
-	require.NoError(t, err)
-	require.Len(t, imported, 2)
-
 	legacy := dbgen.UserSecret(t, db, database.UserSecret{UserID: owner.UserID, Name: "legacy"},
 		func(p *database.CreateUserSecretParams) {
 			p.EnvName, p.FilePath, p.Enabled = "", "/tmp/legacy", true
@@ -58,11 +52,7 @@ func TestUserSecretFilePathDisabledHandlers(t *testing.T) {
 	_, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{FilePath: &empty})
 	requireSecretValidationContainsError(t, err, http.StatusBadRequest, "env_name", "Add env_name")
 
-	disabled := false
-	updated, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{Enabled: &disabled})
-	require.NoError(t, err)
-	assert.Equal(t, "/tmp/legacy", updated.FilePath)
-
+	// Changing the path of the still-enabled legacy row is rejected.
 	auditor.ResetLogs()
 	newPath := "/tmp/other"
 	_, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{
@@ -76,4 +66,9 @@ func TestUserSecretFilePathDisabledHandlers(t *testing.T) {
 	assert.EqualValues(t, http.StatusBadRequest, logs[0].StatusCode)
 	assert.Equal(t, legacy.ID, logs[0].ResourceID)
 	assert.JSONEq(t, "{}", string(logs[0].Diff))
+
+	disabled := false
+	updated, err = client.UpdateUserSecret(ctx, codersdk.Me, legacy.Name, codersdk.UpdateUserSecretRequest{Enabled: &disabled})
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/legacy", updated.FilePath)
 }

--- a/coderd/usersecrets_filepath_policy_test.go
+++ b/coderd/usersecrets_filepath_policy_test.go
@@ -14,7 +14,45 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/serpent"
 )
+
+func TestUserSecretsCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		disableFilePath         bool
+		filePathDeliveryEnabled bool
+	}{
+		{name: "FilePathDeliveryEnabled", disableFilePath: false, filePathDeliveryEnabled: true},
+		{name: "FilePathDeliveryDisabled", disableFilePath: true, filePathDeliveryEnabled: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dv := coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+				dv.DisableUserSecretFilePath = serpent.Bool(tt.disableFilePath)
+			})
+			ownerClient := coderdtest.New(t, &coderdtest.Options{DeploymentValues: dv})
+			owner := coderdtest.CreateFirstUser(t, ownerClient)
+			memberClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+			ctx := testutil.Context(t, testutil.WaitMedium)
+
+			capabilities, err := memberClient.UserSecretsCapabilities(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.filePathDeliveryEnabled, capabilities.FilePathDeliveryEnabled)
+
+			// The same member may not read the deployment configuration that
+			// holds the underlying option.
+			_, err = memberClient.DeploymentConfig(ctx)
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			assert.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+		})
+	}
+}
 
 func TestUserSecretFilePathDisabledHandlers(t *testing.T) {
 	t.Parallel()

--- a/coderd/usersecrets_internal_test.go
+++ b/coderd/usersecrets_internal_test.go
@@ -1,0 +1,115 @@
+package coderd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }
+
+func TestUserSecretCreateValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	req := func(envName, filePath string, enabled *bool) codersdk.CreateUserSecretRequest {
+		return codersdk.CreateUserSecretRequest{
+			Name: "n", Value: "v", EnvName: envName, FilePath: filePath, Enabled: enabled,
+		}
+	}
+	const (
+		envField  = codersdk.UserSecretEnvNameField
+		pathField = codersdk.UserSecretFilePathField
+	)
+
+	tests := []struct {
+		name       string
+		policy     userSecretFilePathPolicy
+		req        codersdk.CreateUserSecretRequest
+		wantField  string
+		wantDetail string
+	}{
+		{name: "PolicyOffAllowsFilePath", policy: userSecretFilePathAllowed, req: req("X", "/tmp/x", nil)},
+		{name: "PolicyOnAllowsEnvOnly", policy: userSecretFilePathBlocked, req: req("X", "", nil)},
+		{name: "PolicyOnAllowsDisabledTargetless", policy: userSecretFilePathBlocked, req: req("", "", boolPtr(false))},
+		{name: "PolicyOnRejectsFilePath", policy: userSecretFilePathBlocked, req: req("X", "/tmp/x", nil), wantField: pathField, wantDetail: userSecretFilePathDisabledDetail},
+		{name: "PolicyOnRejectsFilePathOnDisabled", policy: userSecretFilePathBlocked, req: req("", "/tmp/x", boolPtr(false)), wantField: pathField, wantDetail: userSecretFilePathDisabledDetail},
+		{name: "PolicyOnRequiresEnvTarget", policy: userSecretFilePathBlocked, req: req("", "", nil), wantField: envField, wantDetail: userSecretEnvTargetRequiredDetail},
+		{name: "PolicyOffKeepsSharedMessage", policy: userSecretFilePathAllowed, req: req("", "", nil), wantField: envField, wantDetail: codersdk.UserSecretInjectionTargetRequiredDetail},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := userSecretCreateValidationErrors(tt.req, tt.policy)
+			if tt.wantField == "" {
+				require.Empty(t, got)
+				return
+			}
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.wantField, got[0].Field)
+			assert.Equal(t, tt.wantDetail, got[0].Detail)
+		})
+	}
+}
+
+func TestPrefixUserSecretValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	got := prefixUserSecretValidationErrors(2, []codersdk.ValidationError{
+		{Field: codersdk.UserSecretFilePathField, Detail: "nope"},
+		{Field: codersdk.UserSecretEnvNameField, Detail: "also nope"},
+	})
+	require.Len(t, got, 2)
+	assert.Equal(t, "secrets[2].file_path", got[0].Field)
+	assert.Equal(t, "nope", got[0].Detail)
+	assert.Equal(t, "secrets[2].env_name", got[1].Field)
+}
+
+func TestUserSecretFilePathPolicyError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		legacyFileOnly   = database.UserSecret{FilePath: "/tmp/legacy", Enabled: true}
+		bothTargets      = database.UserSecret{EnvName: "ENV", FilePath: "/tmp/legacy", Enabled: true}
+		disabledFileOnly = database.UserSecret{FilePath: "/tmp/legacy"}
+		envOnly          = database.UserSecret{EnvName: "ENV", Enabled: true}
+	)
+
+	tests := []struct {
+		name    string
+		old     database.UserSecret
+		req     codersdk.UpdateUserSecretRequest
+		wantErr error
+	}{
+		{name: "UnrelatedEdit", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{Description: strPtr("new")}},
+		{name: "ResubmitSamePath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("/tmp/legacy")}},
+		{name: "Disable", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{Enabled: boolPtr(false)}},
+		{name: "ClearOnlyPath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("")}, wantErr: errUserSecretEnvTargetRequired},
+		{name: "ClearPathAndDisable", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr(""), Enabled: boolPtr(false)}},
+		{name: "MigrateToEnv", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{EnvName: strPtr("ENV"), FilePath: strPtr("")}},
+		{name: "CleanupPathWithEnvTarget", old: bothTargets, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("")}},
+		{name: "AddPath", old: envOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("/tmp/new")}, wantErr: errUserSecretFilePathDisabled},
+		{name: "ChangePath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("/tmp/other")}, wantErr: errUserSecretFilePathDisabled},
+		{name: "ClearEnvLeavesOnlyPath", old: bothTargets, req: codersdk.UpdateUserSecretRequest{EnvName: strPtr("")}, wantErr: errUserSecretEnvTargetRequired},
+		{name: "ReEnableFileOnly", old: disabledFileOnly, req: codersdk.UpdateUserSecretRequest{Enabled: boolPtr(true)}, wantErr: errUserSecretEnvTargetRequired},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := userSecretFilePathPolicyError(tt.old, tt.req)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/coderd/usersecrets_internal_test.go
+++ b/coderd/usersecrets_internal_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 )
-
-func boolPtr(b bool) *bool    { return &b }
-func strPtr(s string) *string { return &s }
 
 func TestUserSecretCreateValidationErrors(t *testing.T) {
 	t.Parallel()
@@ -28,25 +26,25 @@ func TestUserSecretCreateValidationErrors(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		policy     userSecretFilePathPolicy
+		blocked    bool
 		req        codersdk.CreateUserSecretRequest
 		wantField  string
 		wantDetail string
 	}{
-		{name: "PolicyOffAllowsFilePath", policy: userSecretFilePathAllowed, req: req("X", "/tmp/x", nil)},
-		{name: "PolicyOnAllowsEnvOnly", policy: userSecretFilePathBlocked, req: req("X", "", nil)},
-		{name: "PolicyOnAllowsDisabledTargetless", policy: userSecretFilePathBlocked, req: req("", "", boolPtr(false))},
-		{name: "PolicyOnRejectsFilePath", policy: userSecretFilePathBlocked, req: req("X", "/tmp/x", nil), wantField: pathField, wantDetail: userSecretFilePathDisabledDetail},
-		{name: "PolicyOnRejectsFilePathOnDisabled", policy: userSecretFilePathBlocked, req: req("", "/tmp/x", boolPtr(false)), wantField: pathField, wantDetail: userSecretFilePathDisabledDetail},
-		{name: "PolicyOnRequiresEnvTarget", policy: userSecretFilePathBlocked, req: req("", "", nil), wantField: envField, wantDetail: userSecretEnvTargetRequiredDetail},
-		{name: "PolicyOffKeepsSharedMessage", policy: userSecretFilePathAllowed, req: req("", "", nil), wantField: envField, wantDetail: codersdk.UserSecretInjectionTargetRequiredDetail},
+		{name: "PolicyOffAllowsFilePath", blocked: false, req: req("X", "/tmp/x", nil)},
+		{name: "PolicyOnAllowsEnvOnly", blocked: true, req: req("X", "", nil)},
+		{name: "PolicyOnAllowsDisabledTargetless", blocked: true, req: req("", "", ptr.Ref(false))},
+		{name: "PolicyOnRejectsFilePath", blocked: true, req: req("X", "/tmp/x", nil), wantField: pathField, wantDetail: userSecretFilePathDisabledDetail},
+		{name: "PolicyOnRejectsFilePathOnDisabled", blocked: true, req: req("", "/tmp/x", ptr.Ref(false)), wantField: pathField, wantDetail: userSecretFilePathDisabledDetail},
+		{name: "PolicyOnRequiresEnvTarget", blocked: true, req: req("", "", nil), wantField: envField, wantDetail: userSecretEnvTargetRequiredDetail},
+		{name: "PolicyOffKeepsSharedMessage", blocked: false, req: req("", "", nil), wantField: envField, wantDetail: codersdk.UserSecretInjectionTargetRequiredDetail},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := userSecretCreateValidationErrors(tt.req, tt.policy)
+			got := userSecretCreateValidationErrors(tt.req, tt.blocked)
 			if tt.wantField == "" {
 				require.Empty(t, got)
 				return
@@ -71,6 +69,17 @@ func TestPrefixUserSecretValidationErrors(t *testing.T) {
 	assert.Equal(t, "secrets[2].env_name", got[1].Field)
 }
 
+func TestPrefixUserSecretValidationErrorsNegativeIndex(t *testing.T) {
+	t.Parallel()
+
+	// The batch handler passes failedIndex=-1 when no entry can be blamed.
+	in := []codersdk.ValidationError{{Field: codersdk.UserSecretEnvNameField, Detail: "nope"}}
+	got := prefixUserSecretValidationErrors(-1, in)
+	require.Len(t, got, 1)
+	assert.Equal(t, codersdk.UserSecretEnvNameField, got[0].Field)
+	assert.Equal(t, "nope", got[0].Detail)
+}
+
 func TestUserSecretFilePathPolicyError(t *testing.T) {
 	t.Parallel()
 
@@ -87,17 +96,17 @@ func TestUserSecretFilePathPolicyError(t *testing.T) {
 		req     codersdk.UpdateUserSecretRequest
 		wantErr error
 	}{
-		{name: "UnrelatedEdit", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{Description: strPtr("new")}},
-		{name: "ResubmitSamePath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("/tmp/legacy")}},
-		{name: "Disable", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{Enabled: boolPtr(false)}},
-		{name: "ClearOnlyPath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("")}, wantErr: errUserSecretEnvTargetRequired},
-		{name: "ClearPathAndDisable", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr(""), Enabled: boolPtr(false)}},
-		{name: "MigrateToEnv", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{EnvName: strPtr("ENV"), FilePath: strPtr("")}},
-		{name: "CleanupPathWithEnvTarget", old: bothTargets, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("")}},
-		{name: "AddPath", old: envOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("/tmp/new")}, wantErr: errUserSecretFilePathDisabled},
-		{name: "ChangePath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: strPtr("/tmp/other")}, wantErr: errUserSecretFilePathDisabled},
-		{name: "ClearEnvLeavesOnlyPath", old: bothTargets, req: codersdk.UpdateUserSecretRequest{EnvName: strPtr("")}, wantErr: errUserSecretEnvTargetRequired},
-		{name: "ReEnableFileOnly", old: disabledFileOnly, req: codersdk.UpdateUserSecretRequest{Enabled: boolPtr(true)}, wantErr: errUserSecretEnvTargetRequired},
+		{name: "UnrelatedEdit", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{Description: ptr.Ref("new")}},
+		{name: "ResubmitSamePath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: ptr.Ref("/tmp/legacy")}},
+		{name: "Disable", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{Enabled: ptr.Ref(false)}},
+		{name: "ClearOnlyPath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: ptr.Ref("")}, wantErr: errUserSecretEnvTargetRequired},
+		{name: "ClearPathAndDisable", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: ptr.Ref(""), Enabled: ptr.Ref(false)}},
+		{name: "MigrateToEnv", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{EnvName: ptr.Ref("ENV"), FilePath: ptr.Ref("")}},
+		{name: "CleanupPathWithEnvTarget", old: bothTargets, req: codersdk.UpdateUserSecretRequest{FilePath: ptr.Ref("")}},
+		{name: "AddPath", old: envOnly, req: codersdk.UpdateUserSecretRequest{FilePath: ptr.Ref("/tmp/new")}, wantErr: errUserSecretFilePathDisabled},
+		{name: "ChangePath", old: legacyFileOnly, req: codersdk.UpdateUserSecretRequest{FilePath: ptr.Ref("/tmp/other")}, wantErr: errUserSecretFilePathDisabled},
+		{name: "ClearEnvLeavesOnlyPath", old: bothTargets, req: codersdk.UpdateUserSecretRequest{EnvName: ptr.Ref("")}, wantErr: errUserSecretEnvTargetRequired},
+		{name: "ReEnableFileOnly", old: disabledFileOnly, req: codersdk.UpdateUserSecretRequest{Enabled: ptr.Ref(true)}, wantErr: errUserSecretEnvTargetRequired},
 	}
 
 	for _, tt := range tests {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -738,6 +738,7 @@ type DeploymentValues struct {
 	DisableWorkspaceSharing                 serpent.Bool                         `json:"disable_workspace_sharing,omitempty" typescript:",notnull"`
 	DisableChatSharing                      serpent.Bool                         `json:"disable_chat_sharing,omitempty" typescript:",notnull"`
 	DisableWorkspaceAgentContextSync        serpent.Bool                         `json:"disable_workspace_agent_context_sync,omitempty" typescript:",notnull"`
+	DisableUserSecretFilePath               serpent.Bool                         `json:"disable_user_secret_file_path,omitempty" typescript:",notnull"`
 	ProxyHealthStatusInterval               serpent.Duration                     `json:"proxy_health_status_interval,omitempty" typescript:",notnull"`
 	EnableTerraformDebugMode                serpent.Bool                         `json:"enable_terraform_debug_mode,omitempty" typescript:",notnull"`
 	UserQuietHoursSchedule                  UserQuietHoursScheduleConfig         `json:"user_quiet_hours_schedule,omitempty" typescript:",notnull"`
@@ -3808,6 +3809,15 @@ communicating directly.`,
 
 			Value: &c.DisableWorkspaceAgentContextSync,
 			YAML:  "disableWorkspaceAgentContextSync",
+		},
+		{
+			Name:        "Disable User Secret File Path",
+			Description: "Disable Coder-managed file path delivery for user secrets. Stored paths remain until users clear them and resume if this setting is turned off.",
+			Flag:        "user-secrets-disable-file-path",
+			Env:         "CODER_USER_SECRETS_DISABLE_FILE_PATH",
+
+			Value: &c.DisableUserSecretFilePath,
+			YAML:  "userSecretsDisableFilePath",
 		},
 		{
 			Name:        "Session Duration",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3813,11 +3813,11 @@ communicating directly.`,
 		{
 			Name:        "Disable User Secret File Path",
 			Description: "Disable Coder-managed file path delivery for user secrets. Stored paths remain until users clear them and resume if this setting is turned off.",
-			Flag:        "user-secrets-disable-file-path",
-			Env:         "CODER_USER_SECRETS_DISABLE_FILE_PATH",
+			Flag:        "disable-user-secret-file-path",
+			Env:         "CODER_DISABLE_USER_SECRET_FILE_PATH",
 
 			Value: &c.DisableUserSecretFilePath,
-			YAML:  "userSecretsDisableFilePath",
+			YAML:  "disableUserSecretFilePath",
 		},
 		{
 			Name:        "Session Duration",

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -1428,6 +1428,46 @@ func TestRetentionConfigParsing(t *testing.T) {
 	}
 }
 
+func TestUserSecretsDisableFilePath(t *testing.T) {
+	t.Parallel()
+
+	dv := codersdk.DeploymentValues{}
+	opts := dv.Options()
+	require.NoError(t, opts.SetDefaults())
+	require.False(t, dv.DisableUserSecretFilePath.Value(), "must default to false")
+
+	var opt serpent.Option
+	for _, o := range opts {
+		if o.Value == &dv.DisableUserSecretFilePath {
+			opt = o
+			break
+		}
+	}
+	require.NotEmpty(t, opt.Flag, "option must be registered")
+	assert.Equal(t, "user-secrets-disable-file-path", opt.Flag)
+	assert.Equal(t, "CODER_USER_SECRETS_DISABLE_FILE_PATH", opt.Env)
+	assert.Equal(t, "userSecretsDisableFilePath", opt.YAML)
+
+	require.NoError(t, opts.ParseEnv([]serpent.EnvVar{
+		{Name: "CODER_USER_SECRETS_DISABLE_FILE_PATH", Value: "true"},
+	}))
+	require.True(t, dv.DisableUserSecretFilePath.Value(), "env must set the value")
+
+	yamlDV := codersdk.DeploymentValues{}
+	yamlOpts := yamlDV.Options()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("userSecretsDisableFilePath: true\n"), &node))
+	require.NoError(t, node.Decode(&yamlOpts))
+	require.True(t, yamlDV.DisableUserSecretFilePath.Value(), "yaml must set the value")
+
+	// The option is not a secret, so telemetry and the config endpoint
+	// must keep reporting it after sanitization.
+	full := codersdk.DeploymentValues{DisableUserSecretFilePath: true}
+	sanitized, err := full.WithoutSecrets()
+	require.NoError(t, err)
+	require.True(t, sanitized.DisableUserSecretFilePath.Value())
+}
+
 func TestChatAIGatewayRoutingEnabledDefault(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -1428,7 +1428,7 @@ func TestRetentionConfigParsing(t *testing.T) {
 	}
 }
 
-func TestUserSecretsDisableFilePath(t *testing.T) {
+func TestDisableUserSecretFilePath(t *testing.T) {
 	t.Parallel()
 
 	dv := codersdk.DeploymentValues{}
@@ -1444,19 +1444,19 @@ func TestUserSecretsDisableFilePath(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, opt.Flag, "option must be registered")
-	assert.Equal(t, "user-secrets-disable-file-path", opt.Flag)
-	assert.Equal(t, "CODER_USER_SECRETS_DISABLE_FILE_PATH", opt.Env)
-	assert.Equal(t, "userSecretsDisableFilePath", opt.YAML)
+	assert.Equal(t, "disable-user-secret-file-path", opt.Flag)
+	assert.Equal(t, "CODER_DISABLE_USER_SECRET_FILE_PATH", opt.Env)
+	assert.Equal(t, "disableUserSecretFilePath", opt.YAML)
 
 	require.NoError(t, opts.ParseEnv([]serpent.EnvVar{
-		{Name: "CODER_USER_SECRETS_DISABLE_FILE_PATH", Value: "true"},
+		{Name: "CODER_DISABLE_USER_SECRET_FILE_PATH", Value: "true"},
 	}))
 	require.True(t, dv.DisableUserSecretFilePath.Value(), "env must set the value")
 
 	yamlDV := codersdk.DeploymentValues{}
 	yamlOpts := yamlDV.Options()
 	var node yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte("userSecretsDisableFilePath: true\n"), &node))
+	require.NoError(t, yaml.Unmarshal([]byte("disableUserSecretFilePath: true\n"), &node))
 	require.NoError(t, node.Decode(&yamlOpts))
 	require.True(t, yamlDV.DisableUserSecretFilePath.Value(), "yaml must set the value")
 

--- a/codersdk/usersecrets.go
+++ b/codersdk/usersecrets.go
@@ -17,21 +17,16 @@ type UserSecret struct {
 	Description string    `json:"description"`
 	EnvName     string    `json:"env_name"`
 	FilePath    string    `json:"file_path"`
-	// Enabled controls whether the secret is injected into workspaces.
-	// Disabled secrets remain visible and editable, but are not added
-	// to the agent manifest, so they are not exposed as environment
-	// variables or written to secret files.
+	// Enabled is stored intent. Deployment policy may block a stored target.
 	Enabled   bool      `json:"enabled"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	UpdatedAt time.Time `json:"updated_at" format:"date-time"`
 }
 
 // CreateUserSecretRequest is the payload for creating a new user
-// secret. Name and Value are required. An enabled secret must have at
-// least one of EnvName or FilePath non-empty so it has an injection
-// target; to keep a secret without injecting it, set Enabled to false.
-// All other fields are optional and default to empty string. Enabled
-// defaults to true when omitted.
+// secret. Name and Value are required. An enabled secret requires an
+// effective target; deployment policy may reject FilePath and require EnvName.
+// Enabled defaults to true.
 type CreateUserSecretRequest struct {
 	Name        string `json:"name"`
 	Value       string `json:"value"`
@@ -43,10 +38,8 @@ type CreateUserSecretRequest struct {
 
 // UpdateUserSecretRequest is the payload for partially updating a
 // user secret. At least one field must be non-nil. Pointer fields
-// distinguish "not sent" (nil) from "set to empty string" (pointer
-// to empty string). If the post-update row is enabled it must still
-// have at least one of EnvName or FilePath non-empty; clearing both
-// targets is only allowed when the secret is (or becomes) disabled.
+// distinguish "not sent" from "set empty". An enabled post-update row
+// requires an effective target; deployment policy may require EnvName.
 type UpdateUserSecretRequest struct {
 	Value       *string `json:"value,omitempty"`
 	Description *string `json:"description,omitempty"`

--- a/codersdk/usersecrets.go
+++ b/codersdk/usersecrets.go
@@ -17,16 +17,22 @@ type UserSecret struct {
 	Description string    `json:"description"`
 	EnvName     string    `json:"env_name"`
 	FilePath    string    `json:"file_path"`
-	// Enabled is stored intent. Deployment policy may block a stored target.
+	// Enabled controls whether the secret is injected into workspaces.
+	// Disabled secrets remain visible and editable, but are not added
+	// to the agent manifest, so they are not exposed as environment
+	// variables or written to secret files.
 	Enabled   bool      `json:"enabled"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	UpdatedAt time.Time `json:"updated_at" format:"date-time"`
 }
 
 // CreateUserSecretRequest is the payload for creating a new user
-// secret. Name and Value are required. An enabled secret requires an
-// effective target; deployment policy may reject FilePath and require EnvName.
-// Enabled defaults to true.
+// secret. Name and Value are required. An enabled secret must have at
+// least one of EnvName or FilePath non-empty so it has an injection
+// target; to keep a secret without injecting it, set Enabled to false.
+// A deployment may disable file path delivery, which rejects a
+// non-empty FilePath. All other fields are optional and default to
+// empty string. Enabled defaults to true when omitted.
 type CreateUserSecretRequest struct {
 	Name        string `json:"name"`
 	Value       string `json:"value"`
@@ -38,8 +44,12 @@ type CreateUserSecretRequest struct {
 
 // UpdateUserSecretRequest is the payload for partially updating a
 // user secret. At least one field must be non-nil. Pointer fields
-// distinguish "not sent" from "set empty". An enabled post-update row
-// requires an effective target; deployment policy may require EnvName.
+// distinguish "not sent" (nil) from "set to empty string" (pointer
+// to empty string). If the post-update row is enabled it must still
+// have at least one of EnvName or FilePath non-empty; clearing both
+// targets is only allowed when the secret is (or becomes) disabled.
+// When a deployment disables file path delivery, an enabled row also
+// requires EnvName.
 type UpdateUserSecretRequest struct {
 	Value       *string `json:"value,omitempty"`
 	Description *string `json:"description,omitempty"`

--- a/codersdk/usersecrets.go
+++ b/codersdk/usersecrets.go
@@ -58,6 +58,31 @@ type UpdateUserSecretRequest struct {
 	Enabled     *bool   `json:"enabled,omitempty"`
 }
 
+// UserSecretsCapabilities reports which user secret delivery targets the
+// deployment allows. Any authenticated user can read it, unlike the full
+// deployment configuration.
+type UserSecretsCapabilities struct {
+	// FilePathDeliveryEnabled reports whether Coder writes stored file paths
+	// into workspaces. Stored paths are preserved either way.
+	FilePathDeliveryEnabled bool `json:"file_path_delivery_enabled"`
+}
+
+// UserSecretsCapabilities reads the deployment's user secret delivery policy.
+// Deployments that predate this endpoint return a 404 error, which callers can
+// treat as "policy unknown" rather than a failure.
+func (c *Client) UserSecretsCapabilities(ctx context.Context) (UserSecretsCapabilities, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/deployment/user-secrets/capabilities", nil)
+	if err != nil {
+		return UserSecretsCapabilities{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return UserSecretsCapabilities{}, ReadBodyAsError(res)
+	}
+	var capabilities UserSecretsCapabilities
+	return capabilities, ReadBodyAsJSON(res, &capabilities)
+}
+
 func (c *Client) CreateUserSecret(ctx context.Context, user string, req CreateUserSecretRequest) (UserSecret, error) {
 	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/users/%s/secrets", user), req)
 	if err != nil {

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -22,6 +22,15 @@ Deprecated options are listed at the end of each section.
 
 ## General
 
+### Allow workspace renames
+
+Allow users to rename their workspaces. WARNING: Renaming a workspace can cause Terraform resources that depend on the workspace name to be destroyed and recreated, potentially causing data loss. Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.
+
+- Environment variable: `CODER_ALLOW_WORKSPACE_RENAMES`
+- CLI flag: [`--allow-workspace-renames`](../../reference/cli/server.md#--allow-workspace-renames)
+- YAML key: `allowWorkspaceRenames`
+- Default value: `false`
+
 ### Cache directory
 
 The directory to cache temporary files. If unspecified and $CACHE_DIRECTORY is set, it will be used for compatibility with systemd. This directory is NOT safe to be configured as a shared directory across coderd/provisionerd replicas.
@@ -73,13 +82,13 @@ Disable workspace apps that are not served from subdomains. Path-based apps can 
 - CLI flag: [`--disable-path-apps`](../../reference/cli/server.md#--disable-path-apps)
 - YAML key: `disablePathApps`
 
-### Disable workspace agent context sync
+### Disable user secret file path
 
-Stop persisting workspace agent context snapshots (instructions, skills, and MCP state used for pinned chat context). When set, coderd rejects agent context pushes as unimplemented and agents stop sending them; chats cannot pin workspace context. Use this to shed the database write load of context sync on large deployments.
+Disable Coder-managed file path delivery for user secrets. Stored paths remain until users clear them and resume if this setting is turned off.
 
-- Environment variable: `CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC`
-- CLI flag: [`--disable-workspace-agent-context-sync`](../../reference/cli/server.md#--disable-workspace-agent-context-sync)
-- YAML key: `disableWorkspaceAgentContextSync`
+- Environment variable: `CODER_USER_SECRETS_DISABLE_FILE_PATH`
+- CLI flag: [`--user-secrets-disable-file-path`](../../reference/cli/server.md#--user-secrets-disable-file-path)
+- YAML key: `userSecretsDisableFilePath`
 
 ### Disable workspace sharing
 
@@ -839,16 +848,6 @@ Serve pprof metrics on the address defined by pprof address.
 - Environment variable: `CODER_PPROF_ENABLE`
 - CLI flag: [`--pprof-enable`](../../reference/cli/server.md#--pprof-enable)
 - YAML key: `introspection.pprof.enable`
-
-## MCP
-
-### Allowed private CIDRs
-
-MCP server destinations in private or reserved IP ranges are blocked by default for SSRF protection. This applies to OAuth2 discovery, OAuth2 token and revocation exchanges, and runtime MCP connections from coderd. This option exempts specific CIDRs.
-
-- Environment variable: `CODER_MCP_ALLOWED_PRIVATE_CIDRS`
-- CLI flag: [`--mcp-allowed-private-cidrs`](../../reference/cli/server.md#--mcp-allowed-private-cidrs)
-- YAML key: `mcp.allowed_private_cidrs`
 
 ## Networking
 
@@ -1807,7 +1806,7 @@ Disable the template builder feature for guided template creation. When disabled
 
 ### Registry URL
 
-The module registry host the template builder uses for module source paths (for example, "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme and trailing slash are stripped; a path, query, fragment, or credentials is rejected.
+The base URL of the module registry used by the template builder for module source paths.
 
 - Environment variable: `CODER_TEMPLATE_BUILDER_REGISTRY_URL`
 - CLI flag: [`--template-builder-registry-url`](../../reference/cli/server.md#--template-builder-registry-url)

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -22,15 +22,6 @@ Deprecated options are listed at the end of each section.
 
 ## General
 
-### Allow workspace renames
-
-Allow users to rename their workspaces. WARNING: Renaming a workspace can cause Terraform resources that depend on the workspace name to be destroyed and recreated, potentially causing data loss. Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.
-
-- Environment variable: `CODER_ALLOW_WORKSPACE_RENAMES`
-- CLI flag: [`--allow-workspace-renames`](../../reference/cli/server.md#--allow-workspace-renames)
-- YAML key: `allowWorkspaceRenames`
-- Default value: `false`
-
 ### Cache directory
 
 The directory to cache temporary files. If unspecified and $CACHE_DIRECTORY is set, it will be used for compatibility with systemd. This directory is NOT safe to be configured as a shared directory across coderd/provisionerd replicas.
@@ -89,6 +80,14 @@ Disable Coder-managed file path delivery for user secrets. Stored paths remain u
 - Environment variable: `CODER_USER_SECRETS_DISABLE_FILE_PATH`
 - CLI flag: [`--user-secrets-disable-file-path`](../../reference/cli/server.md#--user-secrets-disable-file-path)
 - YAML key: `userSecretsDisableFilePath`
+
+### Disable workspace agent context sync
+
+Stop persisting workspace agent context snapshots (instructions, skills, and MCP state used for pinned chat context). When set, coderd rejects agent context pushes as unimplemented and agents stop sending them; chats cannot pin workspace context. Use this to shed the database write load of context sync on large deployments.
+
+- Environment variable: `CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC`
+- CLI flag: [`--disable-workspace-agent-context-sync`](../../reference/cli/server.md#--disable-workspace-agent-context-sync)
+- YAML key: `disableWorkspaceAgentContextSync`
 
 ### Disable workspace sharing
 
@@ -848,6 +847,16 @@ Serve pprof metrics on the address defined by pprof address.
 - Environment variable: `CODER_PPROF_ENABLE`
 - CLI flag: [`--pprof-enable`](../../reference/cli/server.md#--pprof-enable)
 - YAML key: `introspection.pprof.enable`
+
+## MCP
+
+### Allowed private CIDRs
+
+MCP server destinations in private or reserved IP ranges are blocked by default for SSRF protection. This applies to OAuth2 discovery, OAuth2 token and revocation exchanges, and runtime MCP connections from coderd. This option exempts specific CIDRs.
+
+- Environment variable: `CODER_MCP_ALLOWED_PRIVATE_CIDRS`
+- CLI flag: [`--mcp-allowed-private-cidrs`](../../reference/cli/server.md#--mcp-allowed-private-cidrs)
+- YAML key: `mcp.allowed_private_cidrs`
 
 ## Networking
 
@@ -1806,7 +1815,7 @@ Disable the template builder feature for guided template creation. When disabled
 
 ### Registry URL
 
-The base URL of the module registry used by the template builder for module source paths.
+The module registry host the template builder uses for module source paths (for example, "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme and trailing slash are stripped; a path, query, fragment, or credentials is rejected.
 
 - Environment variable: `CODER_TEMPLATE_BUILDER_REGISTRY_URL`
 - CLI flag: [`--template-builder-registry-url`](../../reference/cli/server.md#--template-builder-registry-url)

--- a/docs/admin/setup/configuration-reference.md
+++ b/docs/admin/setup/configuration-reference.md
@@ -77,9 +77,9 @@ Disable workspace apps that are not served from subdomains. Path-based apps can 
 
 Disable Coder-managed file path delivery for user secrets. Stored paths remain until users clear them and resume if this setting is turned off.
 
-- Environment variable: `CODER_USER_SECRETS_DISABLE_FILE_PATH`
-- CLI flag: [`--user-secrets-disable-file-path`](../../reference/cli/server.md#--user-secrets-disable-file-path)
-- YAML key: `userSecretsDisableFilePath`
+- Environment variable: `CODER_DISABLE_USER_SECRET_FILE_PATH`
+- CLI flag: [`--disable-user-secret-file-path`](../../reference/cli/server.md#--disable-user-secret-file-path)
+- YAML key: `disableUserSecretFilePath`
 
 ### Disable workspace agent context sync
 

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -312,6 +312,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_password_auth": true,
     "disable_path_apps": true,
     "disable_user_secret_file_path": true,
+    "disable_workspace_agent_context_sync": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -388,6 +389,9 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       ],
       "stackdriver": "string"
     },
+    "mcp_allowed_private_cidrs": [
+      "string"
+    ],
     "metrics_cache_refresh_interval": 0,
     "notifications": {
       "dispatch_timeout": 0,

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -311,7 +311,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
-    "disable_workspace_agent_context_sync": true,
+    "disable_user_secret_file_path": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -388,9 +388,6 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       ],
       "stackdriver": "string"
     },
-    "mcp_allowed_private_cidrs": [
-      "string"
-    ],
     "metrics_cache_refresh_interval": 0,
     "notifications": {
       "dispatch_timeout": 0,

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -817,6 +817,37 @@ curl -X GET http://coder-server:8080/api/v2/deployment/stats \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get user secrets capabilities
+
+### Code samples
+
+```sh
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/deployment/user-secrets/capabilities \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/v2/deployment/user-secrets/capabilities`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "file_path_delivery_enabled": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                         |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserSecretsCapabilities](schemas.md#codersdkusersecretscapabilities) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get enabled experiments
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -227,21 +227,6 @@ title: Schemas
 |--------------------|
 | `prebuild_claimed` |
 
-## coderd.chatsByWorkspaceResponse
-
-```json
-{
-  "property1": "string",
-  "property2": "string"
-}
-```
-
-### Properties
-
-| Name             | Type   | Required | Restrictions | Description |
-|------------------|--------|----------|--------------|-------------|
-| `[any property]` | string | false    |              |             |
-
 ## coderd.cspViolation
 
 ```json
@@ -1350,32 +1335,6 @@ None
 | Name       | Type            | Required | Restrictions | Description |
 |------------|-----------------|----------|--------------|-------------|
 | `warnings` | array of string | false    |              |             |
-
-## codersdk.AIProviderSummary
-
-```json
-{
-  "deleted": true,
-  "display_name": "string",
-  "enabled": true,
-  "icon": "string",
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "name": "string",
-  "type": "openai"
-}
-```
-
-### Properties
-
-| Name           | Type                                               | Required | Restrictions | Description |
-|----------------|----------------------------------------------------|----------|--------------|-------------|
-| `deleted`      | boolean                                            | false    |              |             |
-| `display_name` | string                                             | false    |              |             |
-| `enabled`      | boolean                                            | false    |              |             |
-| `icon`         | string                                             | false    |              |             |
-| `id`           | string                                             | false    |              |             |
-| `name`         | string                                             | false    |              |             |
-| `type`         | [codersdk.AIProviderType](#codersdkaiprovidertype) | false    |              |             |
 
 ## codersdk.AIProviderType
 
@@ -2563,20 +2522,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `groups` | array of [codersdk.ChatGroup](#codersdkchatgroup) | false    |              |             |
 | `users`  | array of [codersdk.ChatUser](#codersdkchatuser)   | false    |              |             |
 
-## codersdk.ChatAutoArchiveDaysResponse
-
-```json
-{
-  "auto_archive_days": 0
-}
-```
-
-### Properties
-
-| Name                | Type    | Required | Restrictions | Description |
-|---------------------|---------|----------|--------------|-------------|
-| `auto_archive_days` | integer | false    |              |             |
-
 ## codersdk.ChatBusyBehavior
 
 ```json
@@ -2775,36 +2720,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `request_count`          | integer | false    |              |             |
 | `total_cost_micros`      | integer | false    |              |             |
 | `unpriced_request_count` | integer | false    |              |             |
-
-## codersdk.ChatDebugLoggingAdminSettings
-
-```json
-{
-  "allow_users": true,
-  "forced_by_deployment": true
-}
-```
-
-### Properties
-
-| Name                   | Type    | Required | Restrictions | Description |
-|------------------------|---------|----------|--------------|-------------|
-| `allow_users`          | boolean | false    |              |             |
-| `forced_by_deployment` | boolean | false    |              |             |
-
-## codersdk.ChatDebugRetentionDaysResponse
-
-```json
-{
-  "debug_retention_days": 0
-}
-```
-
-### Properties
-
-| Name                   | Type    | Required | Restrictions | Description |
-|------------------------|---------|----------|--------------|-------------|
-| `debug_retention_days` | integer | false    |              |             |
 
 ## codersdk.ChatDiffContents
 
@@ -3078,7 +2993,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "args_delta": "string",
       "completed_at": "2019-08-24T14:15:22Z",
       "content": "string",
-      "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+      "context_file_agent_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "context_file_content": "string",
       "context_file_directory": "string",
       "context_file_os": "string",
@@ -3090,12 +3008,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         0
       ],
       "end_line": 0,
-      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "file_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "file_name": "string",
       "hook_rewritten": true,
       "is_error": true,
       "is_media": true,
-      "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+      "mcp_server_config_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "media_type": "string",
       "name": "string",
       "parsed_commands": [
@@ -3165,7 +3089,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "args_delta": "string",
   "completed_at": "2019-08-24T14:15:22Z",
   "content": "string",
-  "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+  "context_file_agent_id": {
+    "uuid": "string",
+    "valid": true
+  },
   "context_file_content": "string",
   "context_file_directory": "string",
   "context_file_os": "string",
@@ -3177,12 +3104,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     0
   ],
   "end_line": 0,
-  "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+  "file_id": {
+    "uuid": "string",
+    "valid": true
+  },
   "file_name": "string",
   "hook_rewritten": true,
   "is_error": true,
   "is_media": true,
-  "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+  "mcp_server_config_id": {
+    "uuid": "string",
+    "valid": true
+  },
   "media_type": "string",
   "name": "string",
   "parsed_commands": [
@@ -3221,7 +3154,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `args_delta`                   | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `completed_at`                 | string                                                       | false    |              | Completed at is the time a reasoning part finished streaming, so reasoning duration can be computed as completed_at minus created_at. For interrupted reasoning, this is the interruption time. Absent when reasoning timestamp data was not recorded (e.g. messages persisted before this feature was added).                                                                                             |
 | `content`                      | string                                                       | false    |              | The code content from the diff that was commented on.                                                                                                                                                                                                                                                                                                                                                      |
-| `context_file_agent_id`        | string                                                       | false    |              | Context file agent ID is the workspace agent that provided this context file. Used to detect when the agent changes (e.g. workspace rebuilt) so instruction files can be re-persisted with fresh content.                                                                                                                                                                                                  |
+| `context_file_agent_id`        | [uuid.NullUUID](#uuidnulluuid)                               | false    |              | Context file agent ID is the workspace agent that provided this context file. Used to detect when the agent changes (e.g. workspace rebuilt) so instruction files can be re-persisted with fresh content.                                                                                                                                                                                                  |
 | `context_file_content`         | string                                                       | false    |              | Context file content holds the file content sent to the LLM. Internal only: stripped before API responses to keep payloads small. The backend reads it when building the prompt via partsToMessageParts.                                                                                                                                                                                                   |
 | `context_file_directory`       | string                                                       | false    |              | Context file directory is the working directory of the workspace agent. Internal only: same purpose as ContextFileOS.                                                                                                                                                                                                                                                                                      |
 | `context_file_os`              | string                                                       | false    |              | Context file os is the operating system of the workspace agent. Internal only: used during prompt expansion so the LLM knows the OS even on turns where InsertSystem is not called.                                                                                                                                                                                                                        |
@@ -3231,12 +3164,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `created_at`                   | string                                                       | false    |              | Created at is the timestamp this part carries. The semantics depend on the part type: for tool-call and tool-result parts it is the time the call was emitted or the result was produced (tool duration is the result's created_at minus the call's created_at); for reasoning parts it is the time reasoning started streaming.                                                                           |
 | `data`                         | array of integer                                             | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `end_line`                     | integer                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `file_id`                      | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `file_id`                      | [uuid.NullUUID](#uuidnulluuid)                               | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `file_name`                    | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `hook_rewritten`               | boolean                                                      | false    |              | Hook rewritten indicates that a lifecycle hook replaced model-proposed tool input.                                                                                                                                                                                                                                                                                                                         |
 | `is_error`                     | boolean                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `is_media`                     | boolean                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `mcp_server_config_id`         | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `mcp_server_config_id`         | [uuid.NullUUID](#uuidnulluuid)                               | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `media_type`                   | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `name`                         | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `parsed_commands`              | array of array                                               | false    |              | Parsed commands holds parsed programs from an execute tool call's shell command, one entry per simple command in source order. Each entry is [program] or [program, arg] where arg is the first non-flag positional argument. Program names are normalized to their base name (e.g. /usr/bin/go becomes go). Only populated when ToolName is "execute" and the command parses successfully; nil otherwise. |
@@ -3327,7 +3260,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+          "context_file_agent_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -3339,12 +3275,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+          "file_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+          "mcp_server_config_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -3401,7 +3343,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+          "context_file_agent_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -3413,12 +3358,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+          "file_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+          "mcp_server_config_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -3660,55 +3611,25 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "groups": [
-    {
-      "avatar_url": "http://example.com",
-      "display_name": "string",
-      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-      "members": [
-        {
-          "avatar_url": "http://example.com",
-          "created_at": "2019-08-24T14:15:22Z",
-          "email": "user@example.com",
-          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-          "is_service_account": true,
-          "last_seen_at": "2019-08-24T14:15:22Z",
-          "login_type": "",
-          "name": "string",
-          "status": "active",
-          "theme_preference": "string",
-          "updated_at": "2019-08-24T14:15:22Z",
-          "username": "string"
-        }
-      ],
-      "name": "string",
-      "organization_display_name": "string",
-      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
-      "organization_name": "string",
-      "quota_allowance": 0,
-      "role": "read",
-      "source": "user",
-      "total_member_count": 0
-    }
-  ],
-  "users": [
-    {
-      "avatar_url": "http://example.com",
-      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-      "name": "string",
-      "role": "read",
-      "username": "string"
-    }
-  ]
+  "group_roles": {
+    "property1": "read",
+    "property2": "read"
+  },
+  "user_roles": {
+    "property1": "read",
+    "property2": "read"
+  }
 }
 ```
 
 ### Properties
 
-| Name     | Type                                              | Required | Restrictions | Description |
-|----------|---------------------------------------------------|----------|--------------|-------------|
-| `groups` | array of [codersdk.ChatGroup](#codersdkchatgroup) | false    |              |             |
-| `users`  | array of [codersdk.ChatUser](#codersdkchatuser)   | false    |              |             |
+| Name               | Type                                   | Required | Restrictions | Description |
+|--------------------|----------------------------------------|----------|--------------|-------------|
+| `group_roles`      | object                                 | false    |              |             |
+| » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
+| `user_roles`       | object                                 | false    |              |             |
+| » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
 
 ## codersdk.ChatModelAnthropicProviderOptions
 
@@ -4617,20 +4538,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |-----------------------------------------------|
 | `chat_default`, `deployment_default`, `model` |
 
-## codersdk.ChatPersonalModelOverridesAdminSettings
-
-```json
-{
-  "allow_users": true
-}
-```
-
-### Properties
-
-| Name          | Type    | Required | Restrictions | Description |
-|---------------|---------|----------|--------------|-------------|
-| `allow_users` | boolean | false    |              |             |
-
 ## codersdk.ChatPlanMode
 
 ```json
@@ -4644,20 +4551,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s) |
 |----------|
 | `plan`   |
-
-## codersdk.ChatPlanModeInstructionsResponse
-
-```json
-{
-  "plan_mode_instructions": "string"
-}
-```
-
-### Properties
-
-| Name                     | Type   | Required | Restrictions | Description |
-|--------------------------|--------|----------|--------------|-------------|
-| `plan_mode_instructions` | string | false    |              |             |
 
 ## codersdk.ChatPrompt
 
@@ -4707,7 +4600,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "args_delta": "string",
       "completed_at": "2019-08-24T14:15:22Z",
       "content": "string",
-      "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+      "context_file_agent_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "context_file_content": "string",
       "context_file_directory": "string",
       "context_file_os": "string",
@@ -4719,12 +4615,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         0
       ],
       "end_line": 0,
-      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "file_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "file_name": "string",
       "hook_rewritten": true,
       "is_error": true,
       "is_media": true,
-      "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+      "mcp_server_config_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "media_type": "string",
       "name": "string",
       "parsed_commands": [
@@ -4864,7 +4766,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+        "context_file_agent_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -4876,12 +4781,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           0
         ],
         "end_line": 0,
-        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+        "file_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+        "mcp_server_config_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -4936,7 +4847,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "args_delta": "string",
       "completed_at": "2019-08-24T14:15:22Z",
       "content": "string",
-      "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+      "context_file_agent_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "context_file_content": "string",
       "context_file_directory": "string",
       "context_file_os": "string",
@@ -4948,12 +4862,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         0
       ],
       "end_line": 0,
-      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "file_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "file_name": "string",
       "hook_rewritten": true,
       "is_error": true,
       "is_media": true,
-      "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+      "mcp_server_config_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "media_type": "string",
       "name": "string",
       "parsed_commands": [
@@ -4996,7 +4916,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+          "context_file_agent_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -5008,12 +4931,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+          "file_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+          "mcp_server_config_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -5105,7 +5034,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "args_delta": "string",
     "completed_at": "2019-08-24T14:15:22Z",
     "content": "string",
-    "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+    "context_file_agent_id": {
+      "uuid": "string",
+      "valid": true
+    },
     "context_file_content": "string",
     "context_file_directory": "string",
     "context_file_os": "string",
@@ -5117,12 +5049,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       0
     ],
     "end_line": 0,
-    "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+    "file_id": {
+      "uuid": "string",
+      "valid": true
+    },
     "file_name": "string",
     "hook_rewritten": true,
     "is_error": true,
     "is_media": true,
-    "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+    "mcp_server_config_id": {
+      "uuid": "string",
+      "valid": true
+    },
     "media_type": "string",
     "name": "string",
     "parsed_commands": [
@@ -5223,24 +5161,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `args`         | string | false    |              |             |
 | `tool_call_id` | string | false    |              |             |
 | `tool_name`    | string | false    |              |             |
-
-## codersdk.ChatSystemPromptResponse
-
-```json
-{
-  "default_system_prompt": "string",
-  "include_default_system_prompt": true,
-  "system_prompt": "string"
-}
-```
-
-### Properties
-
-| Name                            | Type    | Required | Restrictions | Description |
-|---------------------------------|---------|----------|--------------|-------------|
-| `default_system_prompt`         | string  | false    |              |             |
-| `include_default_system_prompt` | boolean | false    |              |             |
-| `system_prompt`                 | string  | false    |              |             |
 
 ## codersdk.ChatUnsupportedProvider
 
@@ -5424,20 +5344,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                                                                                                                                 |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `action_required`, `chat_summary_change`, `context_dirty`, `created`, `deleted`, `diff_status_change`, `status_change`, `summary_change`, `title_change` |
-
-## codersdk.ChatWorkspaceTTLResponse
-
-```json
-{
-  "workspace_ttl_ms": 0
-}
-```
-
-### Properties
-
-| Name               | Type    | Required | Restrictions | Description                                                                                                              |
-|--------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
-| `workspace_ttl_ms` | integer | false    |              | Workspace ttl ms is the workspace TTL in milliseconds. Zero means disabled; the template's own autostop setting applies. |
 
 ## codersdk.ClusterConfig
 
@@ -5832,7 +5738,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+        "context_file_agent_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -5844,12 +5753,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           0
         ],
         "end_line": 0,
-        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+        "file_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+        "mcp_server_config_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -5905,7 +5820,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+          "context_file_agent_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -5917,12 +5835,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+          "file_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+          "mcp_server_config_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -5979,7 +5903,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+        "context_file_agent_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -5991,12 +5918,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           0
         ],
         "end_line": 0,
-        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+        "file_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+        "mcp_server_config_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -6516,7 +6449,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "allow_user_autostart": true,
   "allow_user_autostop": true,
   "allow_user_cancel_workspace_jobs": true,
-  "allow_workspace_renames": true,
   "autostart_requirement": {
     "days_of_week": [
       "monday"
@@ -6555,7 +6487,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `allow_user_autostart`                | boolean                                                                        | false    |              | Allow user autostart allows users to set a schedule for autostarting their workspace. By default this is true. This can only be disabled when using an enterprise license.                                                                                                                                          |
 | `allow_user_autostop`                 | boolean                                                                        | false    |              | Allow user autostop allows users to set a custom workspace TTL to use in place of the template's DefaultTTL field. By default this is true. If false, the DefaultTTL will always be used. This can only be disabled when using an enterprise license.                                                               |
 | `allow_user_cancel_workspace_jobs`    | boolean                                                                        | false    |              | Allow users to cancel in-progress workspace jobs. *bool as the default value is "true".                                                                                                                                                                                                                             |
-| `allow_workspace_renames`             | boolean                                                                        | false    |              | Allow workspace renames permits users to rename workspaces built from this template. Renaming can be destructive for templates whose Terraform references the workspace name, so this defaults to false.                                                                                                            |
 | `autostart_requirement`               | [codersdk.TemplateAutostartRequirement](#codersdktemplateautostartrequirement) | false    |              | Autostart requirement allows optionally specifying the autostart allowed days for workspaces created from this template. This is an enterprise feature.                                                                                                                                                             |
 | `autostop_requirement`                | [codersdk.TemplateAutostopRequirement](#codersdktemplateautostoprequirement)   | false    |              | Autostop requirement allows optionally specifying the autostop requirement for workspaces created from this template. This is an enterprise feature.                                                                                                                                                                |
 | `cors_behavior`                       | [codersdk.CORSBehavior](#codersdkcorsbehavior)                                 | false    |              | Cors behavior allows optionally specifying the CORS behavior for all shared ports.                                                                                                                                                                                                                                  |
@@ -6747,20 +6678,6 @@ This is required on creation to enable a user-flow of validating a template work
 | `last_name`      | string                                                       | true     |              |                                                                                                                                            |
 | `phone_number`   | string                                                       | true     |              |                                                                                                                                            |
 | `source`         | [codersdk.PremiumFunnelSource](#codersdkpremiumfunnelsource) | false    |              | Source is the premium paywall the request came from, for telemetry. It is not forwarded to the licensor. Omit it to report "direct".       |
-
-## codersdk.CreateUserAIProviderKeyRequest
-
-```json
-{
-  "api_key": "string"
-}
-```
-
-### Properties
-
-| Name      | Type   | Required | Restrictions | Description |
-|-----------|--------|----------|--------------|-------------|
-| `api_key` | string | false    |              |             |
 
 ## codersdk.CreateUserRequestWithOrgs
 
@@ -7501,7 +7418,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
-    "disable_workspace_agent_context_sync": true,
+    "disable_user_secret_file_path": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -7578,9 +7495,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       ],
       "stackdriver": "string"
     },
-    "mcp_allowed_private_cidrs": [
-      "string"
-    ],
     "metrics_cache_refresh_interval": 0,
     "notifications": {
       "dispatch_timeout": 0,
@@ -8133,7 +8047,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "disable_owner_workspace_exec": true,
   "disable_password_auth": true,
   "disable_path_apps": true,
-  "disable_workspace_agent_context_sync": true,
+  "disable_user_secret_file_path": true,
   "disable_workspace_sharing": true,
   "docs_url": {
     "forceQuery": true,
@@ -8210,9 +8124,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     ],
     "stackdriver": "string"
   },
-  "mcp_allowed_private_cidrs": [
-    "string"
-  ],
   "metrics_cache_refresh_interval": 0,
   "notifications": {
     "dispatch_timeout": 0,
@@ -8510,85 +8421,84 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ### Properties
 
-| Name                                           | Type                                                                                                 | Required | Restrictions | Description                                                               |
-|------------------------------------------------|------------------------------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------|
-| `access_url`                                   | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                           |
-| `additional_csp_policy`                        | array of string                                                                                      | false    |              |                                                                           |
-| `address`                                      | [serpent.HostPort](#serpenthostport)                                                                 | false    |              | Deprecated: Use HTTPAddress or TLS.Address instead.                       |
-| `agent_fallback_troubleshooting_url`           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                           |
-| `agent_stat_refresh_interval`                  | integer                                                                                              | false    |              |                                                                           |
-| `ai`                                           | [codersdk.AIConfig](#codersdkaiconfig)                                                               | false    |              |                                                                           |
-| `allow_workspace_renames`                      | boolean                                                                                              | false    |              | Deprecated: Use the per-template allow_workspace_renames setting instead. |
-| `autobuild_poll_interval`                      | integer                                                                                              | false    |              |                                                                           |
-| `browser_only`                                 | boolean                                                                                              | false    |              |                                                                           |
-| `cache_directory`                              | string                                                                                               | false    |              |                                                                           |
-| `cli_upgrade_message`                          | string                                                                                               | false    |              |                                                                           |
-| `cluster`                                      | [codersdk.ClusterConfig](#codersdkclusterconfig)                                                     | false    |              |                                                                           |
-| `config`                                       | string                                                                                               | false    |              |                                                                           |
-| `config_ssh`                                   | [codersdk.SSHConfig](#codersdksshconfig)                                                             | false    |              |                                                                           |
-| `dangerous`                                    | [codersdk.DangerousConfig](#codersdkdangerousconfig)                                                 | false    |              |                                                                           |
-| `derp`                                         | [codersdk.DERP](#codersdkderp)                                                                       | false    |              |                                                                           |
-| `disable_chat_sharing`                         | boolean                                                                                              | false    |              |                                                                           |
-| `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                           |
-| `disable_password_auth`                        | boolean                                                                                              | false    |              |                                                                           |
-| `disable_path_apps`                            | boolean                                                                                              | false    |              |                                                                           |
-| `disable_workspace_agent_context_sync`         | boolean                                                                                              | false    |              |                                                                           |
-| `disable_workspace_sharing`                    | boolean                                                                                              | false    |              |                                                                           |
-| `docs_url`                                     | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                           |
-| `enable_ai_tasks`                              | boolean                                                                                              | false    |              |                                                                           |
-| `enable_authz_recording`                       | boolean                                                                                              | false    |              |                                                                           |
-| `enable_terraform_debug_mode`                  | boolean                                                                                              | false    |              |                                                                           |
-| `ephemeral_deployment`                         | boolean                                                                                              | false    |              |                                                                           |
-| `experiments`                                  | array of string                                                                                      | false    |              |                                                                           |
-| `external_auth`                                | [serpent.Struct-array_codersdk_ExternalAuthConfig](#serpentstruct-array_codersdk_externalauthconfig) | false    |              |                                                                           |
-| `external_auth_github_default_provider_enable` | boolean                                                                                              | false    |              |                                                                           |
-| `external_token_encryption_keys`               | array of string                                                                                      | false    |              |                                                                           |
-| `healthcheck`                                  | [codersdk.HealthcheckConfig](#codersdkhealthcheckconfig)                                             | false    |              |                                                                           |
-| `http_address`                                 | string                                                                                               | false    |              | Http address is a string because it may be set to zero to disable.        |
-| `http_cookies`                                 | [codersdk.HTTPCookieConfig](#codersdkhttpcookieconfig)                                               | false    |              |                                                                           |
-| `job_hang_detector_interval`                   | integer                                                                                              | false    |              |                                                                           |
-| `logging`                                      | [codersdk.LoggingConfig](#codersdkloggingconfig)                                                     | false    |              |                                                                           |
-| `mcp_allowed_private_cidrs`                    | array of string                                                                                      | false    |              |                                                                           |
-| `metrics_cache_refresh_interval`               | integer                                                                                              | false    |              |                                                                           |
-| `notifications`                                | [codersdk.NotificationsConfig](#codersdknotificationsconfig)                                         | false    |              |                                                                           |
-| `oauth2`                                       | [codersdk.OAuth2Config](#codersdkoauth2config)                                                       | false    |              |                                                                           |
-| `oidc`                                         | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                           | false    |              |                                                                           |
-| `pg_auth`                                      | string                                                                                               | false    |              |                                                                           |
-| `pg_conn_max_idle`                             | string                                                                                               | false    |              |                                                                           |
-| `pg_conn_max_open`                             | integer                                                                                              | false    |              |                                                                           |
-| `pg_connection_url`                            | string                                                                                               | false    |              |                                                                           |
-| `pprof`                                        | [codersdk.PprofConfig](#codersdkpprofconfig)                                                         | false    |              |                                                                           |
-| `prometheus`                                   | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                               | false    |              |                                                                           |
-| `provisioner`                                  | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                             | false    |              |                                                                           |
-| `proxy_health_status_interval`                 | integer                                                                                              | false    |              |                                                                           |
-| `proxy_trusted_headers`                        | array of string                                                                                      | false    |              |                                                                           |
-| `proxy_trusted_origins`                        | array of string                                                                                      | false    |              |                                                                           |
-| `rate_limit`                                   | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                 | false    |              |                                                                           |
-| `redirect_to_access_url`                       | boolean                                                                                              | false    |              |                                                                           |
-| `retention`                                    | [codersdk.RetentionConfig](#codersdkretentionconfig)                                                 | false    |              |                                                                           |
-| `scim_api_key`                                 | string                                                                                               | false    |              |                                                                           |
-| `scim_use_legacy`                              | boolean                                                                                              | false    |              |                                                                           |
-| `session_lifetime`                             | [codersdk.SessionLifetime](#codersdksessionlifetime)                                                 | false    |              |                                                                           |
-| `ssh_keygen_algorithm`                         | string                                                                                               | false    |              |                                                                           |
-| `stats_collection`                             | [codersdk.StatsCollectionConfig](#codersdkstatscollectionconfig)                                     | false    |              |                                                                           |
-| `strict_transport_security`                    | integer                                                                                              | false    |              |                                                                           |
-| `strict_transport_security_options`            | array of string                                                                                      | false    |              |                                                                           |
-| `support`                                      | [codersdk.SupportConfig](#codersdksupportconfig)                                                     | false    |              |                                                                           |
-| `swagger`                                      | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                     | false    |              |                                                                           |
-| `telemetry`                                    | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                 | false    |              |                                                                           |
-| `template_builder`                             | [codersdk.TemplateBuilderConfig](#codersdktemplatebuilderconfig)                                     | false    |              |                                                                           |
-| `terms_of_service_url`                         | string                                                                                               | false    |              |                                                                           |
-| `tls`                                          | [codersdk.TLSConfig](#codersdktlsconfig)                                                             | false    |              |                                                                           |
-| `trace`                                        | [codersdk.TraceConfig](#codersdktraceconfig)                                                         | false    |              |                                                                           |
-| `update_check`                                 | boolean                                                                                              | false    |              |                                                                           |
-| `user_quiet_hours_schedule`                    | [codersdk.UserQuietHoursScheduleConfig](#codersdkuserquiethoursscheduleconfig)                       | false    |              |                                                                           |
-| `verbose`                                      | boolean                                                                                              | false    |              |                                                                           |
-| `web_terminal_renderer`                        | string                                                                                               | false    |              |                                                                           |
-| `wgtunnel_host`                                | string                                                                                               | false    |              |                                                                           |
-| `wildcard_access_url`                          | string                                                                                               | false    |              |                                                                           |
-| `workspace_hostname_suffix`                    | string                                                                                               | false    |              |                                                                           |
-| `workspace_prebuilds`                          | [codersdk.PrebuildsConfig](#codersdkprebuildsconfig)                                                 | false    |              |                                                                           |
-| `write_config`                                 | boolean                                                                                              | false    |              |                                                                           |
+| Name                                           | Type                                                                                                 | Required | Restrictions | Description                                                        |
+|------------------------------------------------|------------------------------------------------------------------------------------------------------|----------|--------------|--------------------------------------------------------------------|
+| `access_url`                                   | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
+| `additional_csp_policy`                        | array of string                                                                                      | false    |              |                                                                    |
+| `address`                                      | [serpent.HostPort](#serpenthostport)                                                                 | false    |              | Deprecated: Use HTTPAddress or TLS.Address instead.                |
+| `agent_fallback_troubleshooting_url`           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
+| `agent_stat_refresh_interval`                  | integer                                                                                              | false    |              |                                                                    |
+| `ai`                                           | [codersdk.AIConfig](#codersdkaiconfig)                                                               | false    |              |                                                                    |
+| `allow_workspace_renames`                      | boolean                                                                                              | false    |              |                                                                    |
+| `autobuild_poll_interval`                      | integer                                                                                              | false    |              |                                                                    |
+| `browser_only`                                 | boolean                                                                                              | false    |              |                                                                    |
+| `cache_directory`                              | string                                                                                               | false    |              |                                                                    |
+| `cli_upgrade_message`                          | string                                                                                               | false    |              |                                                                    |
+| `cluster`                                      | [codersdk.ClusterConfig](#codersdkclusterconfig)                                                     | false    |              |                                                                    |
+| `config`                                       | string                                                                                               | false    |              |                                                                    |
+| `config_ssh`                                   | [codersdk.SSHConfig](#codersdksshconfig)                                                             | false    |              |                                                                    |
+| `dangerous`                                    | [codersdk.DangerousConfig](#codersdkdangerousconfig)                                                 | false    |              |                                                                    |
+| `derp`                                         | [codersdk.DERP](#codersdkderp)                                                                       | false    |              |                                                                    |
+| `disable_chat_sharing`                         | boolean                                                                                              | false    |              |                                                                    |
+| `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                    |
+| `disable_password_auth`                        | boolean                                                                                              | false    |              |                                                                    |
+| `disable_path_apps`                            | boolean                                                                                              | false    |              |                                                                    |
+| `disable_user_secret_file_path`                | boolean                                                                                              | false    |              |                                                                    |
+| `disable_workspace_sharing`                    | boolean                                                                                              | false    |              |                                                                    |
+| `docs_url`                                     | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
+| `enable_ai_tasks`                              | boolean                                                                                              | false    |              |                                                                    |
+| `enable_authz_recording`                       | boolean                                                                                              | false    |              |                                                                    |
+| `enable_terraform_debug_mode`                  | boolean                                                                                              | false    |              |                                                                    |
+| `ephemeral_deployment`                         | boolean                                                                                              | false    |              |                                                                    |
+| `experiments`                                  | array of string                                                                                      | false    |              |                                                                    |
+| `external_auth`                                | [serpent.Struct-array_codersdk_ExternalAuthConfig](#serpentstruct-array_codersdk_externalauthconfig) | false    |              |                                                                    |
+| `external_auth_github_default_provider_enable` | boolean                                                                                              | false    |              |                                                                    |
+| `external_token_encryption_keys`               | array of string                                                                                      | false    |              |                                                                    |
+| `healthcheck`                                  | [codersdk.HealthcheckConfig](#codersdkhealthcheckconfig)                                             | false    |              |                                                                    |
+| `http_address`                                 | string                                                                                               | false    |              | Http address is a string because it may be set to zero to disable. |
+| `http_cookies`                                 | [codersdk.HTTPCookieConfig](#codersdkhttpcookieconfig)                                               | false    |              |                                                                    |
+| `job_hang_detector_interval`                   | integer                                                                                              | false    |              |                                                                    |
+| `logging`                                      | [codersdk.LoggingConfig](#codersdkloggingconfig)                                                     | false    |              |                                                                    |
+| `metrics_cache_refresh_interval`               | integer                                                                                              | false    |              |                                                                    |
+| `notifications`                                | [codersdk.NotificationsConfig](#codersdknotificationsconfig)                                         | false    |              |                                                                    |
+| `oauth2`                                       | [codersdk.OAuth2Config](#codersdkoauth2config)                                                       | false    |              |                                                                    |
+| `oidc`                                         | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                           | false    |              |                                                                    |
+| `pg_auth`                                      | string                                                                                               | false    |              |                                                                    |
+| `pg_conn_max_idle`                             | string                                                                                               | false    |              |                                                                    |
+| `pg_conn_max_open`                             | integer                                                                                              | false    |              |                                                                    |
+| `pg_connection_url`                            | string                                                                                               | false    |              |                                                                    |
+| `pprof`                                        | [codersdk.PprofConfig](#codersdkpprofconfig)                                                         | false    |              |                                                                    |
+| `prometheus`                                   | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                               | false    |              |                                                                    |
+| `provisioner`                                  | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                             | false    |              |                                                                    |
+| `proxy_health_status_interval`                 | integer                                                                                              | false    |              |                                                                    |
+| `proxy_trusted_headers`                        | array of string                                                                                      | false    |              |                                                                    |
+| `proxy_trusted_origins`                        | array of string                                                                                      | false    |              |                                                                    |
+| `rate_limit`                                   | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                 | false    |              |                                                                    |
+| `redirect_to_access_url`                       | boolean                                                                                              | false    |              |                                                                    |
+| `retention`                                    | [codersdk.RetentionConfig](#codersdkretentionconfig)                                                 | false    |              |                                                                    |
+| `scim_api_key`                                 | string                                                                                               | false    |              |                                                                    |
+| `scim_use_legacy`                              | boolean                                                                                              | false    |              |                                                                    |
+| `session_lifetime`                             | [codersdk.SessionLifetime](#codersdksessionlifetime)                                                 | false    |              |                                                                    |
+| `ssh_keygen_algorithm`                         | string                                                                                               | false    |              |                                                                    |
+| `stats_collection`                             | [codersdk.StatsCollectionConfig](#codersdkstatscollectionconfig)                                     | false    |              |                                                                    |
+| `strict_transport_security`                    | integer                                                                                              | false    |              |                                                                    |
+| `strict_transport_security_options`            | array of string                                                                                      | false    |              |                                                                    |
+| `support`                                      | [codersdk.SupportConfig](#codersdksupportconfig)                                                     | false    |              |                                                                    |
+| `swagger`                                      | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                     | false    |              |                                                                    |
+| `telemetry`                                    | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                 | false    |              |                                                                    |
+| `template_builder`                             | [codersdk.TemplateBuilderConfig](#codersdktemplatebuilderconfig)                                     | false    |              |                                                                    |
+| `terms_of_service_url`                         | string                                                                                               | false    |              |                                                                    |
+| `tls`                                          | [codersdk.TLSConfig](#codersdktlsconfig)                                                             | false    |              |                                                                    |
+| `trace`                                        | [codersdk.TraceConfig](#codersdktraceconfig)                                                         | false    |              |                                                                    |
+| `update_check`                                 | boolean                                                                                              | false    |              |                                                                    |
+| `user_quiet_hours_schedule`                    | [codersdk.UserQuietHoursScheduleConfig](#codersdkuserquiethoursscheduleconfig)                       | false    |              |                                                                    |
+| `verbose`                                      | boolean                                                                                              | false    |              |                                                                    |
+| `web_terminal_renderer`                        | string                                                                                               | false    |              |                                                                    |
+| `wgtunnel_host`                                | string                                                                                               | false    |              |                                                                    |
+| `wildcard_access_url`                          | string                                                                                               | false    |              |                                                                    |
+| `workspace_hostname_suffix`                    | string                                                                                               | false    |              |                                                                    |
+| `workspace_prebuilds`                          | [codersdk.PrebuildsConfig](#codersdkprebuildsconfig)                                                 | false    |              |                                                                    |
+| `write_config`                                 | boolean                                                                                              | false    |              |                                                                    |
 
 ## codersdk.DiagnosticExtra
 
@@ -8807,7 +8717,10 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+        "context_file_agent_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -8819,12 +8732,18 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
           0
         ],
         "end_line": 0,
-        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+        "file_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+        "mcp_server_config_id": {
+          "uuid": "string",
+          "valid": true
+        },
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -8880,7 +8799,10 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
+          "context_file_agent_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -8892,12 +8814,18 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
             0
           ],
           "end_line": 0,
-          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+          "file_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
+          "mcp_server_config_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -9584,10 +9512,6 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 
 ```json
 {
-  "effective_budget": {
-    "limit_source": "user_override",
-    "spend_limit_micros": 0
-  },
   "effective_group_id": "85e2b926-ddfb-4c66-b68e-b66e5acec6c0",
   "group_budget": {
     "limit_source": "user_override",
@@ -9600,13 +9524,12 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 
 ### Properties
 
-| Name                 | Type                                             | Required | Restrictions | Description                                                                                                                                                                                                                                                |
-|----------------------|--------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `effective_budget`   | [codersdk.AIBudgetLimit](#codersdkaibudgetlimit) | false    |              | Effective budget is the spend limit that currently applies to the user. Null when no budget applies or the effective group belongs to a different organization than the queried group.                                                                     |
-| `effective_group_id` | string                                           | false    |              | Effective group ID is the user's effective budget group within the queried group's organization, falling back to the Everyone group when no budget applies. Null when the effective group belongs to a different organization than the queried group.      |
-| `group_budget`       | [codersdk.AIBudgetLimit](#codersdkaibudgetlimit) | false    |              | Group budget is the budget when the queried group is this user's effective budget source. When populated, it matches EffectiveBudget. Null when the user's budget resolves to another group or no budget applies. Deprecated: Use EffectiveBudget instead. |
-| `group_spend_micros` | integer                                          | false    |              | Group spend micros is the user's spend attributed to the queried group over the current budget period.                                                                                                                                                     |
-| `user_id`            | string                                           | false    |              |                                                                                                                                                                                                                                                            |
+| Name                 | Type                                             | Required | Restrictions | Description                                                                                                                                                                                                                                           |
+|----------------------|--------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `effective_group_id` | string                                           | false    |              | Effective group ID is the user's effective budget group within the queried group's organization, falling back to the Everyone group when no budget applies. Null when the effective group belongs to a different organization than the queried group. |
+| `group_budget`       | [codersdk.AIBudgetLimit](#codersdkaibudgetlimit) | false    |              | Group budget is the budget when the queried group is this user's effective budget source. Null when the user's budget resolves to another group or no budget applies to the user.                                                                     |
+| `group_spend_micros` | integer                                          | false    |              | Group spend micros is the user's spend attributed to the queried group over the current budget period.                                                                                                                                                |
+| `user_id`            | string                                           | false    |              |                                                                                                                                                                                                                                                       |
 
 ## codersdk.GroupMembersAISpend
 
@@ -9614,10 +9537,6 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 {
   "members": [
     {
-      "effective_budget": {
-        "limit_source": "user_override",
-        "spend_limit_micros": 0
-      },
       "effective_group_id": "85e2b926-ddfb-4c66-b68e-b66e5acec6c0",
       "group_budget": {
         "limit_source": "user_override",
@@ -12437,20 +12356,6 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `collect_db_metrics`       | boolean                              | false    |              |             |
 | `enable`                   | boolean                              | false    |              |             |
 
-## codersdk.ProposeChatTitleResponse
-
-```json
-{
-  "title": "string"
-}
-```
-
-### Properties
-
-| Name    | Type   | Required | Restrictions | Description |
-|---------|--------|----------|--------------|-------------|
-| `title` | string | false    |              |             |
-
 ## codersdk.ProvisionerConfig
 
 ```json
@@ -13571,28 +13476,6 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 |---------------|--------------------------------------------------------|----------|--------------|-------------|
 | `usage_stats` | [codersdk.UsageStatsConfig](#codersdkusagestatsconfig) | false    |              |             |
 
-## codersdk.SubmitToolResultsRequest
-
-```json
-{
-  "results": [
-    {
-      "is_error": true,
-      "output": [
-        0
-      ],
-      "tool_call_id": "string"
-    }
-  ]
-}
-```
-
-### Properties
-
-| Name      | Type                                                | Required | Restrictions | Description |
-|-----------|-----------------------------------------------------|----------|--------------|-------------|
-| `results` | array of [codersdk.ToolResult](#codersdktoolresult) | false    |              |             |
-
 ## codersdk.SupportConfig
 
 ```json
@@ -13716,7 +13599,6 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
   "allow_user_autostart": true,
   "allow_user_autostop": true,
   "allow_user_cancel_workspace_jobs": true,
-  "allow_workspace_renames": true,
   "autostart_requirement": {
     "days_of_week": [
       "monday"
@@ -13779,7 +13661,6 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `allow_user_autostart`             | boolean                                                                        | false    |              | Allow user autostart and AllowUserAutostop are enterprise-only. Their values are only used if your license is entitled to use the advanced template scheduling feature.                         |
 | `allow_user_autostop`              | boolean                                                                        | false    |              |                                                                                                                                                                                                 |
 | `allow_user_cancel_workspace_jobs` | boolean                                                                        | false    |              |                                                                                                                                                                                                 |
-| `allow_workspace_renames`          | boolean                                                                        | false    |              | Allow workspace renames permits users to rename workspaces built from this template. Renaming can be destructive for templates whose Terraform references the workspace name.                   |
 | `autostart_requirement`            | [codersdk.TemplateAutostartRequirement](#codersdktemplateautostartrequirement) | false    |              |                                                                                                                                                                                                 |
 | `autostop_requirement`             | [codersdk.TemplateAutostopRequirement](#codersdktemplateautostoprequirement)   | false    |              | Autostop requirement and AutostartRequirement are enterprise features. Its value is only used if your license is entitled to use the advanced template scheduling feature.                      |
 | `build_time_stats`                 | [codersdk.TemplateBuildTimeStats](#codersdktemplatebuildtimestats)             | false    |              |                                                                                                                                                                                                 |
@@ -14184,7 +14065,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
     "allow_user_autostart": true,
     "allow_user_autostop": true,
     "allow_user_cancel_workspace_jobs": true,
-    "allow_workspace_renames": true,
     "autostart_requirement": {
       "days_of_week": [
         "monday"
@@ -15100,26 +14980,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |----------------------|---------|----------|--------------|-------------|
 | `max_token_lifetime` | integer | false    |              |             |
 
-## codersdk.ToolResult
-
-```json
-{
-  "is_error": true,
-  "output": [
-    0
-  ],
-  "tool_call_id": "string"
-}
-```
-
-### Properties
-
-| Name           | Type             | Required | Restrictions | Description |
-|----------------|------------------|----------|--------------|-------------|
-| `is_error`     | boolean          | false    |              |             |
-| `output`       | array of integer | false    |              |             |
-| `tool_call_id` | string           | false    |              |             |
-
 ## codersdk.TraceConfig
 
 ```json
@@ -15252,48 +15112,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
 | `user_roles`       | object                                 | false    |              |             |
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
-
-## codersdk.UpdateChatAutoArchiveDaysRequest
-
-```json
-{
-  "auto_archive_days": 0
-}
-```
-
-### Properties
-
-| Name                | Type    | Required | Restrictions | Description |
-|---------------------|---------|----------|--------------|-------------|
-| `auto_archive_days` | integer | false    |              |             |
-
-## codersdk.UpdateChatDebugLoggingAllowUsersRequest
-
-```json
-{
-  "allow_users": true
-}
-```
-
-### Properties
-
-| Name          | Type    | Required | Restrictions | Description |
-|---------------|---------|----------|--------------|-------------|
-| `allow_users` | boolean | false    |              |             |
-
-## codersdk.UpdateChatDebugRetentionDaysRequest
-
-```json
-{
-  "debug_retention_days": 0
-}
-```
-
-### Properties
-
-| Name                   | Type    | Required | Restrictions | Description |
-|------------------------|---------|----------|--------------|-------------|
-| `debug_retention_days` | integer | false    |              |             |
 
 ## codersdk.UpdateChatModelACLRequest
 
@@ -15515,34 +15333,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `model`                 | string                                                       | false    |              |             |
 | `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
 
-## codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest
-
-```json
-{
-  "allow_users": true
-}
-```
-
-### Properties
-
-| Name          | Type    | Required | Restrictions | Description |
-|---------------|---------|----------|--------------|-------------|
-| `allow_users` | boolean | false    |              |             |
-
-## codersdk.UpdateChatPlanModeInstructionsRequest
-
-```json
-{
-  "plan_mode_instructions": "string"
-}
-```
-
-### Properties
-
-| Name                     | Type   | Required | Restrictions | Description |
-|--------------------------|--------|----------|--------------|-------------|
-| `plan_mode_instructions` | string | false    |              |             |
-
 ## codersdk.UpdateChatRequest
 
 ```json
@@ -15584,36 +15374,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Name             | Type    | Required | Restrictions | Description |
 |------------------|---------|----------|--------------|-------------|
 | `retention_days` | integer | false    |              |             |
-
-## codersdk.UpdateChatSystemPromptRequest
-
-```json
-{
-  "include_default_system_prompt": true,
-  "system_prompt": "string"
-}
-```
-
-### Properties
-
-| Name                            | Type    | Required | Restrictions | Description |
-|---------------------------------|---------|----------|--------------|-------------|
-| `include_default_system_prompt` | boolean | false    |              |             |
-| `system_prompt`                 | string  | false    |              |             |
-
-## codersdk.UpdateChatWorkspaceTTLRequest
-
-```json
-{
-  "workspace_ttl_ms": 0
-}
-```
-
-### Properties
-
-| Name               | Type    | Required | Restrictions | Description                                                                                                              |
-|--------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
-| `workspace_ttl_ms` | integer | false    |              | Workspace ttl ms is the workspace TTL in milliseconds. Zero means disabled; the template's own autostop setting applies. |
 
 ## codersdk.UpdateCheckResponse
 
@@ -15804,7 +15564,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "allow_user_autostart": true,
   "allow_user_autostop": true,
   "allow_user_cancel_workspace_jobs": true,
-  "allow_workspace_renames": true,
   "autostart_requirement": {
     "days_of_week": [
       "monday"
@@ -15846,7 +15605,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `allow_user_autostart`             | boolean                                                                        | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
 | `allow_user_autostop`              | boolean                                                                        | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
 | `allow_user_cancel_workspace_jobs` | boolean                                                                        | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
-| `allow_workspace_renames`          | boolean                                                                        | false    |              | Allow workspace renames permits users to rename workspaces built from this template. Renaming can be destructive for templates whose Terraform references the workspace name.                                                                                                                                                                                                      |
 | `autostart_requirement`            | [codersdk.TemplateAutostartRequirement](#codersdktemplateautostartrequirement) | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
 | `autostop_requirement`             | [codersdk.TemplateAutostopRequirement](#codersdktemplateautostoprequirement)   | false    |              | Autostop requirement and AutostartRequirement can only be set if your license includes the advanced template scheduling feature. If you attempt to set this value while unlicensed, it will be ignored.                                                                                                                                                                            |
 | `cors_behavior`                    | [codersdk.CORSBehavior](#codersdkcorsbehavior)                                 | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -15897,34 +15655,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `theme_dark`  | `dark`, `dark-protan-deuter`, `dark-tritan`, `light`, `light-protan-deuter`, `light-tritan` |
 | `theme_light` | `dark`, `dark-protan-deuter`, `dark-tritan`, `light`, `light-protan-deuter`, `light-tritan` |
 | `theme_mode`  | `single`, `sync`                                                                            |
-
-## codersdk.UpdateUserChatCompactionThresholdRequest
-
-```json
-{
-  "threshold_percent": 100
-}
-```
-
-### Properties
-
-| Name                | Type    | Required | Restrictions | Description |
-|---------------------|---------|----------|--------------|-------------|
-| `threshold_percent` | integer | false    |              |             |
-
-## codersdk.UpdateUserChatDebugLoggingRequest
-
-```json
-{
-  "debug_logging_enabled": true
-}
-```
-
-### Properties
-
-| Name                    | Type    | Required | Restrictions | Description |
-|-------------------------|---------|----------|--------------|-------------|
-| `debug_logging_enabled` | boolean | false    |              |             |
 
 ## codersdk.UpdateUserChatPersonalModelOverrideRequest
 
@@ -16434,34 +16164,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `updated_at`         | string  | false    |              |             |
 | `user_id`            | string  | false    |              |             |
 
-## codersdk.UserAIProviderKeyConfig
-
-```json
-{
-  "byok_enabled": true,
-  "has_provider_api_key": true,
-  "has_user_api_key": true,
-  "provider": {
-    "deleted": true,
-    "display_name": "string",
-    "enabled": true,
-    "icon": "string",
-    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-    "name": "string",
-    "type": "openai"
-  }
-}
-```
-
-### Properties
-
-| Name                   | Type                                                     | Required | Restrictions | Description |
-|------------------------|----------------------------------------------------------|----------|--------------|-------------|
-| `byok_enabled`         | boolean                                                  | false    |              |             |
-| `has_provider_api_key` | boolean                                                  | false    |              |             |
-| `has_user_api_key`     | boolean                                                  | false    |              |             |
-| `provider`             | [codersdk.AIProviderSummary](#codersdkaiprovidersummary) | false    |              |             |
-
 ## codersdk.UserAISpendStatus
 
 ```json
@@ -16597,73 +16299,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `theme_light`      | string                                                 | false    |              | Ignored when ThemeMode is "single"                                                                                                                                                                                                                                                                                                        |
 | `theme_mode`       | [codersdk.ThemeMode](#codersdkthememode)               | false    |              |                                                                                                                                                                                                                                                                                                                                           |
 | `theme_preference` | string                                                 | false    |              | Theme preference is the legacy single-field appearance setting. In "single" mode it mirrors the active theme. In "sync" mode modern clients normally mirror the active OS slot, but older clients can update only this field, so it may diverge from ThemeLight or ThemeDark until a modern client saves the full appearance state again. |
-
-## codersdk.UserChatCompactionThreshold
-
-```json
-{
-  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205",
-  "threshold_percent": 0
-}
-```
-
-### Properties
-
-| Name                | Type    | Required | Restrictions | Description |
-|---------------------|---------|----------|--------------|-------------|
-| `model_config_id`   | string  | false    |              |             |
-| `threshold_percent` | integer | false    |              |             |
-
-## codersdk.UserChatCompactionThresholds
-
-```json
-{
-  "thresholds": [
-    {
-      "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205",
-      "threshold_percent": 0
-    }
-  ]
-}
-```
-
-### Properties
-
-| Name         | Type                                                                                  | Required | Restrictions | Description |
-|--------------|---------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `thresholds` | array of [codersdk.UserChatCompactionThreshold](#codersdkuserchatcompactionthreshold) | false    |              |             |
-
-## codersdk.UserChatCustomPrompt
-
-```json
-{
-  "custom_prompt": "string"
-}
-```
-
-### Properties
-
-| Name            | Type   | Required | Restrictions | Description |
-|-----------------|--------|----------|--------------|-------------|
-| `custom_prompt` | string | false    |              |             |
-
-## codersdk.UserChatDebugLoggingSettings
-
-```json
-{
-  "debug_logging_enabled": true,
-  "forced_by_deployment": true,
-  "user_toggle_allowed": true
-}
-```
-
-### Properties
-
-| Name                    | Type    | Required | Restrictions | Description |
-|-------------------------|---------|----------|--------------|-------------|
-| `debug_logging_enabled` | boolean | false    |              |             |
-| `forced_by_deployment`  | boolean | false    |              |             |
-| `user_toggle_allowed`   | boolean | false    |              |             |
 
 ## codersdk.UserChatPersonalModelOverridesResponse
 
@@ -16921,16 +16556,16 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name          | Type    | Required | Restrictions | Description                                                                                                                                                                                                                          |
-|---------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `created_at`  | string  | false    |              |                                                                                                                                                                                                                                      |
-| `description` | string  | false    |              |                                                                                                                                                                                                                                      |
-| `enabled`     | boolean | false    |              | Enabled controls whether the secret is injected into workspaces. Disabled secrets remain visible and editable, but are not added to the agent manifest, so they are not exposed as environment variables or written to secret files. |
-| `env_name`    | string  | false    |              |                                                                                                                                                                                                                                      |
-| `file_path`   | string  | false    |              |                                                                                                                                                                                                                                      |
-| `id`          | string  | false    |              |                                                                                                                                                                                                                                      |
-| `name`        | string  | false    |              |                                                                                                                                                                                                                                      |
-| `updated_at`  | string  | false    |              |                                                                                                                                                                                                                                      |
+| Name          | Type    | Required | Restrictions | Description                                                            |
+|---------------|---------|----------|--------------|------------------------------------------------------------------------|
+| `created_at`  | string  | false    |              |                                                                        |
+| `description` | string  | false    |              |                                                                        |
+| `enabled`     | boolean | false    |              | Enabled is stored intent. Deployment policy may block a stored target. |
+| `env_name`    | string  | false    |              |                                                                        |
+| `file_path`   | string  | false    |              |                                                                        |
+| `id`          | string  | false    |              |                                                                        |
+| `name`        | string  | false    |              |                                                                        |
+| `updated_at`  | string  | false    |              |                                                                        |
 
 ## codersdk.UserSkill
 
@@ -17297,7 +16932,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
             ],
             "name": "string",
             "operating_system": "string",
-            "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
+            "parent_id": {
+              "uuid": "string",
+              "valid": true
+            },
             "ready_at": "2019-08-24T14:15:22Z",
             "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
             "scripts": [
@@ -17376,7 +17014,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       ]
     }
   ],
-  "task_id": "string",
+  "task_id": {
+    "uuid": "string",
+    "valid": true
+  },
   "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
   "template_allow_user_cancel_workspace_jobs": true,
   "template_display_name": "string",
@@ -17394,7 +17035,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 | Name                                        | Type                                                                    | Required | Restrictions | Description                                                                                                                                                                                                                                                                                                                                 |
 |---------------------------------------------|-------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `allow_renames`                             | boolean                                                                 | false    |              | Allow renames is the effective rename permission for this workspace, derived from the template's allow_workspace_renames setting and the deprecated deployment-wide flag.                                                                                                                                                                   |
+| `allow_renames`                             | boolean                                                                 | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `automatic_updates`                         | [codersdk.AutomaticUpdates](#codersdkautomaticupdates)                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `autostart_schedule`                        | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `created_at`                                | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
@@ -17416,7 +17057,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `owner_id`                                  | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `owner_name`                                | string                                                                  | false    |              | Owner name is the username of the owner of the workspace.                                                                                                                                                                                                                                                                                   |
 | `shared_with`                               | array of [codersdk.SharedWorkspaceActor](#codersdksharedworkspaceactor) | false    |              |                                                                                                                                                                                                                                                                                                                                             |
-| `task_id`                                   | string                                                                  | false    |              | Task ID if set, indicates that the workspace is relevant to the given codersdk.Task.                                                                                                                                                                                                                                                        |
+| `task_id`                                   | [uuid.NullUUID](#uuidnulluuid)                                          | false    |              | Task ID if set, indicates that the workspace is relevant to the given codersdk.Task.                                                                                                                                                                                                                                                        |
 | `template_active_version_id`                | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `template_allow_user_cancel_workspace_jobs` | boolean                                                                 | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `template_display_name`                     | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
@@ -17593,7 +17234,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   ],
   "name": "string",
   "operating_system": "string",
-  "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
+  "parent_id": {
+    "uuid": "string",
+    "valid": true
+  },
   "ready_at": "2019-08-24T14:15:22Z",
   "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
   "scripts": [
@@ -17653,7 +17297,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `metadata`                   | array of [codersdk.WorkspaceAgentMetadata](#codersdkworkspaceagentmetadata)                  | false    |              | Metadata is only populated on the workspaces list endpoint when the request opts in with the include_agent_metadata search key, and it only carries the requested keys. The description's script is always empty here: it can be long, and list consumers want values. |
 | `name`                       | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `operating_system`           | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
-| `parent_id`                  | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
+| `parent_id`                  | [uuid.NullUUID](#uuidnulluuid)                                                               | false    |              |                                                                                                                                                                                                                                                                        |
 | `ready_at`                   | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `resource_id`                | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `scripts`                    | array of [codersdk.WorkspaceAgentScript](#codersdkworkspaceagentscript)                      | false    |              |                                                                                                                                                                                                                                                                        |
@@ -17769,7 +17413,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
   "name": "string",
   "status": "running",
-  "subagent_id": "7b85d465-b649-4b8b-9da8-5f731c1d294d",
+  "subagent_id": {
+    "uuid": "string",
+    "valid": true
+  },
   "workspace_folder": "string"
 }
 ```
@@ -17786,7 +17433,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `id`               | string                                                                                 | false    |              |                            |
 | `name`             | string                                                                                 | false    |              |                            |
 | `status`           | [codersdk.WorkspaceAgentDevcontainerStatus](#codersdkworkspaceagentdevcontainerstatus) | false    |              | Additional runtime fields. |
-| `subagent_id`      | string                                                                                 | false    |              |                            |
+| `subagent_id`      | [uuid.NullUUID](#uuidnulluuid)                                                         | false    |              |                            |
 | `workspace_folder` | string                                                                                 | false    |              |                            |
 
 ## codersdk.WorkspaceAgentDevcontainerAgent
@@ -17960,7 +17607,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "name": "string",
       "status": "running",
-      "subagent_id": "7b85d465-b649-4b8b-9da8-5f731c1d294d",
+      "subagent_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "workspace_folder": "string"
     }
   ],
@@ -18631,7 +18281,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           ],
           "name": "string",
           "operating_system": "string",
-          "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
+          "parent_id": {
+            "uuid": "string",
+            "valid": true
+          },
           "ready_at": "2019-08-24T14:15:22Z",
           "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
           "scripts": [
@@ -19115,7 +18768,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       ],
       "name": "string",
       "operating_system": "string",
-      "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
+      "parent_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "ready_at": "2019-08-24T14:15:22Z",
       "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
       "scripts": [
@@ -19468,7 +19124,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
                 ],
                 "name": "string",
                 "operating_system": "string",
-                "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
+                "parent_id": {
+                  "uuid": "string",
+                  "valid": true
+                },
                 "ready_at": "2019-08-24T14:15:22Z",
                 "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
                 "scripts": [
@@ -19547,7 +19206,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           ]
         }
       ],
-      "task_id": "string",
+      "task_id": {
+        "uuid": "string",
+        "valid": true
+      },
       "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
       "template_allow_user_cancel_workspace_jobs": true,
       "template_display_name": "string",
@@ -19702,6 +19364,7 @@ Zero means unspecified. There might be a limit, but the client need not try to r
     "captivePortal": "string",
     "globalV4": "string",
     "globalV6": "string",
+    "hairPinning": "string",
     "icmpv4": true,
     "ipv4": true,
     "ipv4CanSend": true,
@@ -20238,6 +19901,7 @@ Zero means unspecified. There might be a limit, but the client need not try to r
       "captivePortal": "string",
       "globalV4": "string",
       "globalV6": "string",
+      "hairPinning": "string",
       "icmpv4": true,
       "ipv4": true,
       "ipv4CanSend": true,
@@ -20919,6 +20583,7 @@ None
   "captivePortal": "string",
   "globalV4": "string",
   "globalV6": "string",
+  "hairPinning": "string",
   "icmpv4": true,
   "ipv4": true,
   "ipv4CanSend": true,
@@ -20948,29 +20613,30 @@ None
 
 ### Properties
 
-| Name                    | Type    | Required | Restrictions | Description                                                                                         |
-|-------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------|
-| `captivePortal`         | string  | false    |              | Captiveportal is set when we think there's a captive portal that is intercepting HTTP traffic.      |
-| `globalV4`              | string  | false    |              | ip:port of global IPv4                                                                              |
-| `globalV6`              | string  | false    |              | [ip]:port of global IPv6                                                                            |
-| `icmpv4`                | boolean | false    |              | an ICMPv4 round trip completed                                                                      |
-| `ipv4`                  | boolean | false    |              | an IPv4 STUN round trip completed                                                                   |
-| `ipv4CanSend`           | boolean | false    |              | an IPv4 packet was able to be sent                                                                  |
-| `ipv6`                  | boolean | false    |              | an IPv6 STUN round trip completed                                                                   |
-| `ipv6CanSend`           | boolean | false    |              | an IPv6 packet was able to be sent                                                                  |
-| `mappingVariesByDestIP` | string  | false    |              | Mappingvariesbydestip is whether STUN results depend which STUN server you're talking to (on IPv4). |
-| `oshasIPv6`             | boolean | false    |              | could bind a socket to ::1                                                                          |
-| `pcp`                   | string  | false    |              | Pcp is whether PCP appears present on the LAN. Empty means not checked.                             |
-| `pmp`                   | string  | false    |              | Pmp is whether NAT-PMP appears present on the LAN. Empty means not checked.                         |
-| `preferredDERP`         | integer | false    |              | or 0 for unknown                                                                                    |
-| `regionLatency`         | object  | false    |              | keyed by DERP Region ID                                                                             |
-| » `[any property]`      | integer | false    |              |                                                                                                     |
-| `regionV4Latency`       | object  | false    |              | keyed by DERP Region ID                                                                             |
-| » `[any property]`      | integer | false    |              |                                                                                                     |
-| `regionV6Latency`       | object  | false    |              | keyed by DERP Region ID                                                                             |
-| » `[any property]`      | integer | false    |              |                                                                                                     |
-| `udp`                   | boolean | false    |              | a UDP STUN round trip completed                                                                     |
-| `upnP`                  | string  | false    |              | Upnp is whether UPnP appears present on the LAN. Empty means not checked.                           |
+| Name                    | Type    | Required | Restrictions | Description                                                                                                                        |
+|-------------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `captivePortal`         | string  | false    |              | Captiveportal is set when we think there's a captive portal that is intercepting HTTP traffic.                                     |
+| `globalV4`              | string  | false    |              | ip:port of global IPv4                                                                                                             |
+| `globalV6`              | string  | false    |              | [ip]:port of global IPv6                                                                                                           |
+| `hairPinning`           | string  | false    |              | Hairpinning is whether the router supports communicating between two local devices through the NATted public IP address (on IPv4). |
+| `icmpv4`                | boolean | false    |              | an ICMPv4 round trip completed                                                                                                     |
+| `ipv4`                  | boolean | false    |              | an IPv4 STUN round trip completed                                                                                                  |
+| `ipv4CanSend`           | boolean | false    |              | an IPv4 packet was able to be sent                                                                                                 |
+| `ipv6`                  | boolean | false    |              | an IPv6 STUN round trip completed                                                                                                  |
+| `ipv6CanSend`           | boolean | false    |              | an IPv6 packet was able to be sent                                                                                                 |
+| `mappingVariesByDestIP` | string  | false    |              | Mappingvariesbydestip is whether STUN results depend which STUN server you're talking to (on IPv4).                                |
+| `oshasIPv6`             | boolean | false    |              | could bind a socket to ::1                                                                                                         |
+| `pcp`                   | string  | false    |              | Pcp is whether PCP appears present on the LAN. Empty means not checked.                                                            |
+| `pmp`                   | string  | false    |              | Pmp is whether NAT-PMP appears present on the LAN. Empty means not checked.                                                        |
+| `preferredDERP`         | integer | false    |              | or 0 for unknown                                                                                                                   |
+| `regionLatency`         | object  | false    |              | keyed by DERP Region ID                                                                                                            |
+| » `[any property]`      | integer | false    |              |                                                                                                                                    |
+| `regionV4Latency`       | object  | false    |              | keyed by DERP Region ID                                                                                                            |
+| » `[any property]`      | integer | false    |              |                                                                                                                                    |
+| `regionV6Latency`       | object  | false    |              | keyed by DERP Region ID                                                                                                            |
+| » `[any property]`      | integer | false    |              |                                                                                                                                    |
+| `udp`                   | boolean | false    |              | a UDP STUN round trip completed                                                                                                    |
+| `upnP`                  | string  | false    |              | Upnp is whether UPnP appears present on the LAN. Empty means not checked.                                                          |
 
 ## oauth2.Token
 
@@ -21459,6 +21125,22 @@ RegionIDs in range 900-999 are reserved for end users to run their own DERP node
 ### Properties
 
 None
+
+## uuid.NullUUID
+
+```json
+{
+  "uuid": "string",
+  "valid": true
+}
+```
+
+### Properties
+
+| Name    | Type    | Required | Restrictions | Description                       |
+|---------|---------|----------|--------------|-----------------------------------|
+| `uuid`  | string  | false    |              |                                   |
+| `valid` | boolean | false    |              | Valid is true if UUID is not NULL |
 
 ## workspaceapps.AccessMethod
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -227,6 +227,21 @@ title: Schemas
 |--------------------|
 | `prebuild_claimed` |
 
+## coderd.chatsByWorkspaceResponse
+
+```json
+{
+  "property1": "string",
+  "property2": "string"
+}
+```
+
+### Properties
+
+| Name             | Type   | Required | Restrictions | Description |
+|------------------|--------|----------|--------------|-------------|
+| `[any property]` | string | false    |              |             |
+
 ## coderd.cspViolation
 
 ```json
@@ -1335,6 +1350,32 @@ None
 | Name       | Type            | Required | Restrictions | Description |
 |------------|-----------------|----------|--------------|-------------|
 | `warnings` | array of string | false    |              |             |
+
+## codersdk.AIProviderSummary
+
+```json
+{
+  "deleted": true,
+  "display_name": "string",
+  "enabled": true,
+  "icon": "string",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "name": "string",
+  "type": "openai"
+}
+```
+
+### Properties
+
+| Name           | Type                                               | Required | Restrictions | Description |
+|----------------|----------------------------------------------------|----------|--------------|-------------|
+| `deleted`      | boolean                                            | false    |              |             |
+| `display_name` | string                                             | false    |              |             |
+| `enabled`      | boolean                                            | false    |              |             |
+| `icon`         | string                                             | false    |              |             |
+| `id`           | string                                             | false    |              |             |
+| `name`         | string                                             | false    |              |             |
+| `type`         | [codersdk.AIProviderType](#codersdkaiprovidertype) | false    |              |             |
 
 ## codersdk.AIProviderType
 
@@ -2522,6 +2563,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `groups` | array of [codersdk.ChatGroup](#codersdkchatgroup) | false    |              |             |
 | `users`  | array of [codersdk.ChatUser](#codersdkchatuser)   | false    |              |             |
 
+## codersdk.ChatAutoArchiveDaysResponse
+
+```json
+{
+  "auto_archive_days": 0
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description |
+|---------------------|---------|----------|--------------|-------------|
+| `auto_archive_days` | integer | false    |              |             |
+
 ## codersdk.ChatBusyBehavior
 
 ```json
@@ -2720,6 +2775,36 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `request_count`          | integer | false    |              |             |
 | `total_cost_micros`      | integer | false    |              |             |
 | `unpriced_request_count` | integer | false    |              |             |
+
+## codersdk.ChatDebugLoggingAdminSettings
+
+```json
+{
+  "allow_users": true,
+  "forced_by_deployment": true
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `allow_users`          | boolean | false    |              |             |
+| `forced_by_deployment` | boolean | false    |              |             |
+
+## codersdk.ChatDebugRetentionDaysResponse
+
+```json
+{
+  "debug_retention_days": 0
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `debug_retention_days` | integer | false    |              |             |
 
 ## codersdk.ChatDiffContents
 
@@ -2993,10 +3078,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "args_delta": "string",
       "completed_at": "2019-08-24T14:15:22Z",
       "content": "string",
-      "context_file_agent_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
       "context_file_content": "string",
       "context_file_directory": "string",
       "context_file_os": "string",
@@ -3008,18 +3090,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         0
       ],
       "end_line": 0,
-      "file_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "file_name": "string",
       "hook_rewritten": true,
       "is_error": true,
       "is_media": true,
-      "mcp_server_config_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
       "media_type": "string",
       "name": "string",
       "parsed_commands": [
@@ -3089,10 +3165,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "args_delta": "string",
   "completed_at": "2019-08-24T14:15:22Z",
   "content": "string",
-  "context_file_agent_id": {
-    "uuid": "string",
-    "valid": true
-  },
+  "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
   "context_file_content": "string",
   "context_file_directory": "string",
   "context_file_os": "string",
@@ -3104,18 +3177,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     0
   ],
   "end_line": 0,
-  "file_id": {
-    "uuid": "string",
-    "valid": true
-  },
+  "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
   "file_name": "string",
   "hook_rewritten": true,
   "is_error": true,
   "is_media": true,
-  "mcp_server_config_id": {
-    "uuid": "string",
-    "valid": true
-  },
+  "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
   "media_type": "string",
   "name": "string",
   "parsed_commands": [
@@ -3154,7 +3221,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `args_delta`                   | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `completed_at`                 | string                                                       | false    |              | Completed at is the time a reasoning part finished streaming, so reasoning duration can be computed as completed_at minus created_at. For interrupted reasoning, this is the interruption time. Absent when reasoning timestamp data was not recorded (e.g. messages persisted before this feature was added).                                                                                             |
 | `content`                      | string                                                       | false    |              | The code content from the diff that was commented on.                                                                                                                                                                                                                                                                                                                                                      |
-| `context_file_agent_id`        | [uuid.NullUUID](#uuidnulluuid)                               | false    |              | Context file agent ID is the workspace agent that provided this context file. Used to detect when the agent changes (e.g. workspace rebuilt) so instruction files can be re-persisted with fresh content.                                                                                                                                                                                                  |
+| `context_file_agent_id`        | string                                                       | false    |              | Context file agent ID is the workspace agent that provided this context file. Used to detect when the agent changes (e.g. workspace rebuilt) so instruction files can be re-persisted with fresh content.                                                                                                                                                                                                  |
 | `context_file_content`         | string                                                       | false    |              | Context file content holds the file content sent to the LLM. Internal only: stripped before API responses to keep payloads small. The backend reads it when building the prompt via partsToMessageParts.                                                                                                                                                                                                   |
 | `context_file_directory`       | string                                                       | false    |              | Context file directory is the working directory of the workspace agent. Internal only: same purpose as ContextFileOS.                                                                                                                                                                                                                                                                                      |
 | `context_file_os`              | string                                                       | false    |              | Context file os is the operating system of the workspace agent. Internal only: used during prompt expansion so the LLM knows the OS even on turns where InsertSystem is not called.                                                                                                                                                                                                                        |
@@ -3164,12 +3231,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `created_at`                   | string                                                       | false    |              | Created at is the timestamp this part carries. The semantics depend on the part type: for tool-call and tool-result parts it is the time the call was emitted or the result was produced (tool duration is the result's created_at minus the call's created_at); for reasoning parts it is the time reasoning started streaming.                                                                           |
 | `data`                         | array of integer                                             | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `end_line`                     | integer                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `file_id`                      | [uuid.NullUUID](#uuidnulluuid)                               | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `file_id`                      | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `file_name`                    | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `hook_rewritten`               | boolean                                                      | false    |              | Hook rewritten indicates that a lifecycle hook replaced model-proposed tool input.                                                                                                                                                                                                                                                                                                                         |
 | `is_error`                     | boolean                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `is_media`                     | boolean                                                      | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `mcp_server_config_id`         | [uuid.NullUUID](#uuidnulluuid)                               | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `mcp_server_config_id`         | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `media_type`                   | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `name`                         | string                                                       | false    |              |                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `parsed_commands`              | array of array                                               | false    |              | Parsed commands holds parsed programs from an execute tool call's shell command, one entry per simple command in source order. Each entry is [program] or [program, arg] where arg is the first non-flag positional argument. Program names are normalized to their base name (e.g. /usr/bin/go becomes go). Only populated when ToolName is "execute" and the command parses successfully; nil otherwise. |
@@ -3260,10 +3327,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -3275,18 +3339,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -3343,10 +3401,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -3358,18 +3413,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -3611,25 +3660,55 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "group_roles": {
-    "property1": "read",
-    "property2": "read"
-  },
-  "user_roles": {
-    "property1": "read",
-    "property2": "read"
-  }
+  "groups": [
+    {
+      "avatar_url": "http://example.com",
+      "display_name": "string",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "members": [
+        {
+          "avatar_url": "http://example.com",
+          "created_at": "2019-08-24T14:15:22Z",
+          "email": "user@example.com",
+          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "is_service_account": true,
+          "last_seen_at": "2019-08-24T14:15:22Z",
+          "login_type": "",
+          "name": "string",
+          "status": "active",
+          "theme_preference": "string",
+          "updated_at": "2019-08-24T14:15:22Z",
+          "username": "string"
+        }
+      ],
+      "name": "string",
+      "organization_display_name": "string",
+      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+      "organization_name": "string",
+      "quota_allowance": 0,
+      "role": "read",
+      "source": "user",
+      "total_member_count": 0
+    }
+  ],
+  "users": [
+    {
+      "avatar_url": "http://example.com",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "name": "string",
+      "role": "read",
+      "username": "string"
+    }
+  ]
 }
 ```
 
 ### Properties
 
-| Name               | Type                                   | Required | Restrictions | Description |
-|--------------------|----------------------------------------|----------|--------------|-------------|
-| `group_roles`      | object                                 | false    |              |             |
-| » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
-| `user_roles`       | object                                 | false    |              |             |
-| » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
+| Name     | Type                                              | Required | Restrictions | Description |
+|----------|---------------------------------------------------|----------|--------------|-------------|
+| `groups` | array of [codersdk.ChatGroup](#codersdkchatgroup) | false    |              |             |
+| `users`  | array of [codersdk.ChatUser](#codersdkchatuser)   | false    |              |             |
 
 ## codersdk.ChatModelAnthropicProviderOptions
 
@@ -4538,6 +4617,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |-----------------------------------------------|
 | `chat_default`, `deployment_default`, `model` |
 
+## codersdk.ChatPersonalModelOverridesAdminSettings
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Properties
+
+| Name          | Type    | Required | Restrictions | Description |
+|---------------|---------|----------|--------------|-------------|
+| `allow_users` | boolean | false    |              |             |
+
 ## codersdk.ChatPlanMode
 
 ```json
@@ -4551,6 +4644,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s) |
 |----------|
 | `plan`   |
+
+## codersdk.ChatPlanModeInstructionsResponse
+
+```json
+{
+  "plan_mode_instructions": "string"
+}
+```
+
+### Properties
+
+| Name                     | Type   | Required | Restrictions | Description |
+|--------------------------|--------|----------|--------------|-------------|
+| `plan_mode_instructions` | string | false    |              |             |
 
 ## codersdk.ChatPrompt
 
@@ -4600,10 +4707,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "args_delta": "string",
       "completed_at": "2019-08-24T14:15:22Z",
       "content": "string",
-      "context_file_agent_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
       "context_file_content": "string",
       "context_file_directory": "string",
       "context_file_os": "string",
@@ -4615,18 +4719,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         0
       ],
       "end_line": 0,
-      "file_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "file_name": "string",
       "hook_rewritten": true,
       "is_error": true,
       "is_media": true,
-      "mcp_server_config_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
       "media_type": "string",
       "name": "string",
       "parsed_commands": [
@@ -4766,10 +4864,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -4781,18 +4876,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           0
         ],
         "end_line": 0,
-        "file_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -4847,10 +4936,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "args_delta": "string",
       "completed_at": "2019-08-24T14:15:22Z",
       "content": "string",
-      "context_file_agent_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
       "context_file_content": "string",
       "context_file_directory": "string",
       "context_file_os": "string",
@@ -4862,18 +4948,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         0
       ],
       "end_line": 0,
-      "file_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "file_name": "string",
       "hook_rewritten": true,
       "is_error": true,
       "is_media": true,
-      "mcp_server_config_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
       "media_type": "string",
       "name": "string",
       "parsed_commands": [
@@ -4916,10 +4996,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -4931,18 +5008,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -5034,10 +5105,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "args_delta": "string",
     "completed_at": "2019-08-24T14:15:22Z",
     "content": "string",
-    "context_file_agent_id": {
-      "uuid": "string",
-      "valid": true
-    },
+    "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
     "context_file_content": "string",
     "context_file_directory": "string",
     "context_file_os": "string",
@@ -5049,18 +5117,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       0
     ],
     "end_line": 0,
-    "file_id": {
-      "uuid": "string",
-      "valid": true
-    },
+    "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "file_name": "string",
     "hook_rewritten": true,
     "is_error": true,
     "is_media": true,
-    "mcp_server_config_id": {
-      "uuid": "string",
-      "valid": true
-    },
+    "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
     "media_type": "string",
     "name": "string",
     "parsed_commands": [
@@ -5161,6 +5223,24 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `args`         | string | false    |              |             |
 | `tool_call_id` | string | false    |              |             |
 | `tool_name`    | string | false    |              |             |
+
+## codersdk.ChatSystemPromptResponse
+
+```json
+{
+  "default_system_prompt": "string",
+  "include_default_system_prompt": true,
+  "system_prompt": "string"
+}
+```
+
+### Properties
+
+| Name                            | Type    | Required | Restrictions | Description |
+|---------------------------------|---------|----------|--------------|-------------|
+| `default_system_prompt`         | string  | false    |              |             |
+| `include_default_system_prompt` | boolean | false    |              |             |
+| `system_prompt`                 | string  | false    |              |             |
 
 ## codersdk.ChatUnsupportedProvider
 
@@ -5344,6 +5424,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                                                                                                                                 |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `action_required`, `chat_summary_change`, `context_dirty`, `created`, `deleted`, `diff_status_change`, `status_change`, `summary_change`, `title_change` |
+
+## codersdk.ChatWorkspaceTTLResponse
+
+```json
+{
+  "workspace_ttl_ms": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description                                                                                                              |
+|--------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
+| `workspace_ttl_ms` | integer | false    |              | Workspace ttl ms is the workspace TTL in milliseconds. Zero means disabled; the template's own autostop setting applies. |
 
 ## codersdk.ClusterConfig
 
@@ -5738,10 +5832,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -5753,18 +5844,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           0
         ],
         "end_line": 0,
-        "file_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -5820,10 +5905,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -5835,18 +5917,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
             0
           ],
           "end_line": 0,
-          "file_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -5903,10 +5979,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -5918,18 +5991,12 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
           0
         ],
         "end_line": 0,
-        "file_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -6449,6 +6516,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "allow_user_autostart": true,
   "allow_user_autostop": true,
   "allow_user_cancel_workspace_jobs": true,
+  "allow_workspace_renames": true,
   "autostart_requirement": {
     "days_of_week": [
       "monday"
@@ -6487,6 +6555,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `allow_user_autostart`                | boolean                                                                        | false    |              | Allow user autostart allows users to set a schedule for autostarting their workspace. By default this is true. This can only be disabled when using an enterprise license.                                                                                                                                          |
 | `allow_user_autostop`                 | boolean                                                                        | false    |              | Allow user autostop allows users to set a custom workspace TTL to use in place of the template's DefaultTTL field. By default this is true. If false, the DefaultTTL will always be used. This can only be disabled when using an enterprise license.                                                               |
 | `allow_user_cancel_workspace_jobs`    | boolean                                                                        | false    |              | Allow users to cancel in-progress workspace jobs. *bool as the default value is "true".                                                                                                                                                                                                                             |
+| `allow_workspace_renames`             | boolean                                                                        | false    |              | Allow workspace renames permits users to rename workspaces built from this template. Renaming can be destructive for templates whose Terraform references the workspace name, so this defaults to false.                                                                                                            |
 | `autostart_requirement`               | [codersdk.TemplateAutostartRequirement](#codersdktemplateautostartrequirement) | false    |              | Autostart requirement allows optionally specifying the autostart allowed days for workspaces created from this template. This is an enterprise feature.                                                                                                                                                             |
 | `autostop_requirement`                | [codersdk.TemplateAutostopRequirement](#codersdktemplateautostoprequirement)   | false    |              | Autostop requirement allows optionally specifying the autostop requirement for workspaces created from this template. This is an enterprise feature.                                                                                                                                                                |
 | `cors_behavior`                       | [codersdk.CORSBehavior](#codersdkcorsbehavior)                                 | false    |              | Cors behavior allows optionally specifying the CORS behavior for all shared ports.                                                                                                                                                                                                                                  |
@@ -6678,6 +6747,20 @@ This is required on creation to enable a user-flow of validating a template work
 | `last_name`      | string                                                       | true     |              |                                                                                                                                            |
 | `phone_number`   | string                                                       | true     |              |                                                                                                                                            |
 | `source`         | [codersdk.PremiumFunnelSource](#codersdkpremiumfunnelsource) | false    |              | Source is the premium paywall the request came from, for telemetry. It is not forwarded to the licensor. Omit it to report "direct".       |
+
+## codersdk.CreateUserAIProviderKeyRequest
+
+```json
+{
+  "api_key": "string"
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description |
+|-----------|--------|----------|--------------|-------------|
+| `api_key` | string | false    |              |             |
 
 ## codersdk.CreateUserRequestWithOrgs
 
@@ -7419,6 +7502,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_password_auth": true,
     "disable_path_apps": true,
     "disable_user_secret_file_path": true,
+    "disable_workspace_agent_context_sync": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -7495,6 +7579,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       ],
       "stackdriver": "string"
     },
+    "mcp_allowed_private_cidrs": [
+      "string"
+    ],
     "metrics_cache_refresh_interval": 0,
     "notifications": {
       "dispatch_timeout": 0,
@@ -8048,6 +8135,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "disable_password_auth": true,
   "disable_path_apps": true,
   "disable_user_secret_file_path": true,
+  "disable_workspace_agent_context_sync": true,
   "disable_workspace_sharing": true,
   "docs_url": {
     "forceQuery": true,
@@ -8124,6 +8212,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     ],
     "stackdriver": "string"
   },
+  "mcp_allowed_private_cidrs": [
+    "string"
+  ],
   "metrics_cache_refresh_interval": 0,
   "notifications": {
     "dispatch_timeout": 0,
@@ -8421,84 +8512,86 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ### Properties
 
-| Name                                           | Type                                                                                                 | Required | Restrictions | Description                                                        |
-|------------------------------------------------|------------------------------------------------------------------------------------------------------|----------|--------------|--------------------------------------------------------------------|
-| `access_url`                                   | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
-| `additional_csp_policy`                        | array of string                                                                                      | false    |              |                                                                    |
-| `address`                                      | [serpent.HostPort](#serpenthostport)                                                                 | false    |              | Deprecated: Use HTTPAddress or TLS.Address instead.                |
-| `agent_fallback_troubleshooting_url`           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
-| `agent_stat_refresh_interval`                  | integer                                                                                              | false    |              |                                                                    |
-| `ai`                                           | [codersdk.AIConfig](#codersdkaiconfig)                                                               | false    |              |                                                                    |
-| `allow_workspace_renames`                      | boolean                                                                                              | false    |              |                                                                    |
-| `autobuild_poll_interval`                      | integer                                                                                              | false    |              |                                                                    |
-| `browser_only`                                 | boolean                                                                                              | false    |              |                                                                    |
-| `cache_directory`                              | string                                                                                               | false    |              |                                                                    |
-| `cli_upgrade_message`                          | string                                                                                               | false    |              |                                                                    |
-| `cluster`                                      | [codersdk.ClusterConfig](#codersdkclusterconfig)                                                     | false    |              |                                                                    |
-| `config`                                       | string                                                                                               | false    |              |                                                                    |
-| `config_ssh`                                   | [codersdk.SSHConfig](#codersdksshconfig)                                                             | false    |              |                                                                    |
-| `dangerous`                                    | [codersdk.DangerousConfig](#codersdkdangerousconfig)                                                 | false    |              |                                                                    |
-| `derp`                                         | [codersdk.DERP](#codersdkderp)                                                                       | false    |              |                                                                    |
-| `disable_chat_sharing`                         | boolean                                                                                              | false    |              |                                                                    |
-| `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                    |
-| `disable_password_auth`                        | boolean                                                                                              | false    |              |                                                                    |
-| `disable_path_apps`                            | boolean                                                                                              | false    |              |                                                                    |
-| `disable_user_secret_file_path`                | boolean                                                                                              | false    |              |                                                                    |
-| `disable_workspace_sharing`                    | boolean                                                                                              | false    |              |                                                                    |
-| `docs_url`                                     | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
-| `enable_ai_tasks`                              | boolean                                                                                              | false    |              |                                                                    |
-| `enable_authz_recording`                       | boolean                                                                                              | false    |              |                                                                    |
-| `enable_terraform_debug_mode`                  | boolean                                                                                              | false    |              |                                                                    |
-| `ephemeral_deployment`                         | boolean                                                                                              | false    |              |                                                                    |
-| `experiments`                                  | array of string                                                                                      | false    |              |                                                                    |
-| `external_auth`                                | [serpent.Struct-array_codersdk_ExternalAuthConfig](#serpentstruct-array_codersdk_externalauthconfig) | false    |              |                                                                    |
-| `external_auth_github_default_provider_enable` | boolean                                                                                              | false    |              |                                                                    |
-| `external_token_encryption_keys`               | array of string                                                                                      | false    |              |                                                                    |
-| `healthcheck`                                  | [codersdk.HealthcheckConfig](#codersdkhealthcheckconfig)                                             | false    |              |                                                                    |
-| `http_address`                                 | string                                                                                               | false    |              | Http address is a string because it may be set to zero to disable. |
-| `http_cookies`                                 | [codersdk.HTTPCookieConfig](#codersdkhttpcookieconfig)                                               | false    |              |                                                                    |
-| `job_hang_detector_interval`                   | integer                                                                                              | false    |              |                                                                    |
-| `logging`                                      | [codersdk.LoggingConfig](#codersdkloggingconfig)                                                     | false    |              |                                                                    |
-| `metrics_cache_refresh_interval`               | integer                                                                                              | false    |              |                                                                    |
-| `notifications`                                | [codersdk.NotificationsConfig](#codersdknotificationsconfig)                                         | false    |              |                                                                    |
-| `oauth2`                                       | [codersdk.OAuth2Config](#codersdkoauth2config)                                                       | false    |              |                                                                    |
-| `oidc`                                         | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                           | false    |              |                                                                    |
-| `pg_auth`                                      | string                                                                                               | false    |              |                                                                    |
-| `pg_conn_max_idle`                             | string                                                                                               | false    |              |                                                                    |
-| `pg_conn_max_open`                             | integer                                                                                              | false    |              |                                                                    |
-| `pg_connection_url`                            | string                                                                                               | false    |              |                                                                    |
-| `pprof`                                        | [codersdk.PprofConfig](#codersdkpprofconfig)                                                         | false    |              |                                                                    |
-| `prometheus`                                   | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                               | false    |              |                                                                    |
-| `provisioner`                                  | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                             | false    |              |                                                                    |
-| `proxy_health_status_interval`                 | integer                                                                                              | false    |              |                                                                    |
-| `proxy_trusted_headers`                        | array of string                                                                                      | false    |              |                                                                    |
-| `proxy_trusted_origins`                        | array of string                                                                                      | false    |              |                                                                    |
-| `rate_limit`                                   | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                 | false    |              |                                                                    |
-| `redirect_to_access_url`                       | boolean                                                                                              | false    |              |                                                                    |
-| `retention`                                    | [codersdk.RetentionConfig](#codersdkretentionconfig)                                                 | false    |              |                                                                    |
-| `scim_api_key`                                 | string                                                                                               | false    |              |                                                                    |
-| `scim_use_legacy`                              | boolean                                                                                              | false    |              |                                                                    |
-| `session_lifetime`                             | [codersdk.SessionLifetime](#codersdksessionlifetime)                                                 | false    |              |                                                                    |
-| `ssh_keygen_algorithm`                         | string                                                                                               | false    |              |                                                                    |
-| `stats_collection`                             | [codersdk.StatsCollectionConfig](#codersdkstatscollectionconfig)                                     | false    |              |                                                                    |
-| `strict_transport_security`                    | integer                                                                                              | false    |              |                                                                    |
-| `strict_transport_security_options`            | array of string                                                                                      | false    |              |                                                                    |
-| `support`                                      | [codersdk.SupportConfig](#codersdksupportconfig)                                                     | false    |              |                                                                    |
-| `swagger`                                      | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                     | false    |              |                                                                    |
-| `telemetry`                                    | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                 | false    |              |                                                                    |
-| `template_builder`                             | [codersdk.TemplateBuilderConfig](#codersdktemplatebuilderconfig)                                     | false    |              |                                                                    |
-| `terms_of_service_url`                         | string                                                                                               | false    |              |                                                                    |
-| `tls`                                          | [codersdk.TLSConfig](#codersdktlsconfig)                                                             | false    |              |                                                                    |
-| `trace`                                        | [codersdk.TraceConfig](#codersdktraceconfig)                                                         | false    |              |                                                                    |
-| `update_check`                                 | boolean                                                                                              | false    |              |                                                                    |
-| `user_quiet_hours_schedule`                    | [codersdk.UserQuietHoursScheduleConfig](#codersdkuserquiethoursscheduleconfig)                       | false    |              |                                                                    |
-| `verbose`                                      | boolean                                                                                              | false    |              |                                                                    |
-| `web_terminal_renderer`                        | string                                                                                               | false    |              |                                                                    |
-| `wgtunnel_host`                                | string                                                                                               | false    |              |                                                                    |
-| `wildcard_access_url`                          | string                                                                                               | false    |              |                                                                    |
-| `workspace_hostname_suffix`                    | string                                                                                               | false    |              |                                                                    |
-| `workspace_prebuilds`                          | [codersdk.PrebuildsConfig](#codersdkprebuildsconfig)                                                 | false    |              |                                                                    |
-| `write_config`                                 | boolean                                                                                              | false    |              |                                                                    |
+| Name                                           | Type                                                                                                 | Required | Restrictions | Description                                                               |
+|------------------------------------------------|------------------------------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------|
+| `access_url`                                   | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                           |
+| `additional_csp_policy`                        | array of string                                                                                      | false    |              |                                                                           |
+| `address`                                      | [serpent.HostPort](#serpenthostport)                                                                 | false    |              | Deprecated: Use HTTPAddress or TLS.Address instead.                       |
+| `agent_fallback_troubleshooting_url`           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                           |
+| `agent_stat_refresh_interval`                  | integer                                                                                              | false    |              |                                                                           |
+| `ai`                                           | [codersdk.AIConfig](#codersdkaiconfig)                                                               | false    |              |                                                                           |
+| `allow_workspace_renames`                      | boolean                                                                                              | false    |              | Deprecated: Use the per-template allow_workspace_renames setting instead. |
+| `autobuild_poll_interval`                      | integer                                                                                              | false    |              |                                                                           |
+| `browser_only`                                 | boolean                                                                                              | false    |              |                                                                           |
+| `cache_directory`                              | string                                                                                               | false    |              |                                                                           |
+| `cli_upgrade_message`                          | string                                                                                               | false    |              |                                                                           |
+| `cluster`                                      | [codersdk.ClusterConfig](#codersdkclusterconfig)                                                     | false    |              |                                                                           |
+| `config`                                       | string                                                                                               | false    |              |                                                                           |
+| `config_ssh`                                   | [codersdk.SSHConfig](#codersdksshconfig)                                                             | false    |              |                                                                           |
+| `dangerous`                                    | [codersdk.DangerousConfig](#codersdkdangerousconfig)                                                 | false    |              |                                                                           |
+| `derp`                                         | [codersdk.DERP](#codersdkderp)                                                                       | false    |              |                                                                           |
+| `disable_chat_sharing`                         | boolean                                                                                              | false    |              |                                                                           |
+| `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                           |
+| `disable_password_auth`                        | boolean                                                                                              | false    |              |                                                                           |
+| `disable_path_apps`                            | boolean                                                                                              | false    |              |                                                                           |
+| `disable_user_secret_file_path`                | boolean                                                                                              | false    |              |                                                                           |
+| `disable_workspace_agent_context_sync`         | boolean                                                                                              | false    |              |                                                                           |
+| `disable_workspace_sharing`                    | boolean                                                                                              | false    |              |                                                                           |
+| `docs_url`                                     | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                           |
+| `enable_ai_tasks`                              | boolean                                                                                              | false    |              |                                                                           |
+| `enable_authz_recording`                       | boolean                                                                                              | false    |              |                                                                           |
+| `enable_terraform_debug_mode`                  | boolean                                                                                              | false    |              |                                                                           |
+| `ephemeral_deployment`                         | boolean                                                                                              | false    |              |                                                                           |
+| `experiments`                                  | array of string                                                                                      | false    |              |                                                                           |
+| `external_auth`                                | [serpent.Struct-array_codersdk_ExternalAuthConfig](#serpentstruct-array_codersdk_externalauthconfig) | false    |              |                                                                           |
+| `external_auth_github_default_provider_enable` | boolean                                                                                              | false    |              |                                                                           |
+| `external_token_encryption_keys`               | array of string                                                                                      | false    |              |                                                                           |
+| `healthcheck`                                  | [codersdk.HealthcheckConfig](#codersdkhealthcheckconfig)                                             | false    |              |                                                                           |
+| `http_address`                                 | string                                                                                               | false    |              | Http address is a string because it may be set to zero to disable.        |
+| `http_cookies`                                 | [codersdk.HTTPCookieConfig](#codersdkhttpcookieconfig)                                               | false    |              |                                                                           |
+| `job_hang_detector_interval`                   | integer                                                                                              | false    |              |                                                                           |
+| `logging`                                      | [codersdk.LoggingConfig](#codersdkloggingconfig)                                                     | false    |              |                                                                           |
+| `mcp_allowed_private_cidrs`                    | array of string                                                                                      | false    |              |                                                                           |
+| `metrics_cache_refresh_interval`               | integer                                                                                              | false    |              |                                                                           |
+| `notifications`                                | [codersdk.NotificationsConfig](#codersdknotificationsconfig)                                         | false    |              |                                                                           |
+| `oauth2`                                       | [codersdk.OAuth2Config](#codersdkoauth2config)                                                       | false    |              |                                                                           |
+| `oidc`                                         | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                           | false    |              |                                                                           |
+| `pg_auth`                                      | string                                                                                               | false    |              |                                                                           |
+| `pg_conn_max_idle`                             | string                                                                                               | false    |              |                                                                           |
+| `pg_conn_max_open`                             | integer                                                                                              | false    |              |                                                                           |
+| `pg_connection_url`                            | string                                                                                               | false    |              |                                                                           |
+| `pprof`                                        | [codersdk.PprofConfig](#codersdkpprofconfig)                                                         | false    |              |                                                                           |
+| `prometheus`                                   | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                               | false    |              |                                                                           |
+| `provisioner`                                  | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                             | false    |              |                                                                           |
+| `proxy_health_status_interval`                 | integer                                                                                              | false    |              |                                                                           |
+| `proxy_trusted_headers`                        | array of string                                                                                      | false    |              |                                                                           |
+| `proxy_trusted_origins`                        | array of string                                                                                      | false    |              |                                                                           |
+| `rate_limit`                                   | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                 | false    |              |                                                                           |
+| `redirect_to_access_url`                       | boolean                                                                                              | false    |              |                                                                           |
+| `retention`                                    | [codersdk.RetentionConfig](#codersdkretentionconfig)                                                 | false    |              |                                                                           |
+| `scim_api_key`                                 | string                                                                                               | false    |              |                                                                           |
+| `scim_use_legacy`                              | boolean                                                                                              | false    |              |                                                                           |
+| `session_lifetime`                             | [codersdk.SessionLifetime](#codersdksessionlifetime)                                                 | false    |              |                                                                           |
+| `ssh_keygen_algorithm`                         | string                                                                                               | false    |              |                                                                           |
+| `stats_collection`                             | [codersdk.StatsCollectionConfig](#codersdkstatscollectionconfig)                                     | false    |              |                                                                           |
+| `strict_transport_security`                    | integer                                                                                              | false    |              |                                                                           |
+| `strict_transport_security_options`            | array of string                                                                                      | false    |              |                                                                           |
+| `support`                                      | [codersdk.SupportConfig](#codersdksupportconfig)                                                     | false    |              |                                                                           |
+| `swagger`                                      | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                     | false    |              |                                                                           |
+| `telemetry`                                    | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                 | false    |              |                                                                           |
+| `template_builder`                             | [codersdk.TemplateBuilderConfig](#codersdktemplatebuilderconfig)                                     | false    |              |                                                                           |
+| `terms_of_service_url`                         | string                                                                                               | false    |              |                                                                           |
+| `tls`                                          | [codersdk.TLSConfig](#codersdktlsconfig)                                                             | false    |              |                                                                           |
+| `trace`                                        | [codersdk.TraceConfig](#codersdktraceconfig)                                                         | false    |              |                                                                           |
+| `update_check`                                 | boolean                                                                                              | false    |              |                                                                           |
+| `user_quiet_hours_schedule`                    | [codersdk.UserQuietHoursScheduleConfig](#codersdkuserquiethoursscheduleconfig)                       | false    |              |                                                                           |
+| `verbose`                                      | boolean                                                                                              | false    |              |                                                                           |
+| `web_terminal_renderer`                        | string                                                                                               | false    |              |                                                                           |
+| `wgtunnel_host`                                | string                                                                                               | false    |              |                                                                           |
+| `wildcard_access_url`                          | string                                                                                               | false    |              |                                                                           |
+| `workspace_hostname_suffix`                    | string                                                                                               | false    |              |                                                                           |
+| `workspace_prebuilds`                          | [codersdk.PrebuildsConfig](#codersdkprebuildsconfig)                                                 | false    |              |                                                                           |
+| `write_config`                                 | boolean                                                                                              | false    |              |                                                                           |
 
 ## codersdk.DiagnosticExtra
 
@@ -8717,10 +8810,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         "args_delta": "string",
         "completed_at": "2019-08-24T14:15:22Z",
         "content": "string",
-        "context_file_agent_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
         "context_file_content": "string",
         "context_file_directory": "string",
         "context_file_os": "string",
@@ -8732,18 +8822,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
           0
         ],
         "end_line": 0,
-        "file_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
         "file_name": "string",
         "hook_rewritten": true,
         "is_error": true,
         "is_media": true,
-        "mcp_server_config_id": {
-          "uuid": "string",
-          "valid": true
-        },
+        "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
         "media_type": "string",
         "name": "string",
         "parsed_commands": [
@@ -8799,10 +8883,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
           "args_delta": "string",
           "completed_at": "2019-08-24T14:15:22Z",
           "content": "string",
-          "context_file_agent_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "context_file_agent_id": "2e577c68-2ec9-4c84-a77a-5b3e1d7eae09",
           "context_file_content": "string",
           "context_file_directory": "string",
           "context_file_os": "string",
@@ -8814,18 +8895,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
             0
           ],
           "end_line": 0,
-          "file_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "file_name": "string",
           "hook_rewritten": true,
           "is_error": true,
           "is_media": true,
-          "mcp_server_config_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "mcp_server_config_id": "a9f436ed-69e7-459c-8308-a67ff5387e3e",
           "media_type": "string",
           "name": "string",
           "parsed_commands": [
@@ -9512,6 +9587,10 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 
 ```json
 {
+  "effective_budget": {
+    "limit_source": "user_override",
+    "spend_limit_micros": 0
+  },
   "effective_group_id": "85e2b926-ddfb-4c66-b68e-b66e5acec6c0",
   "group_budget": {
     "limit_source": "user_override",
@@ -9524,12 +9603,13 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 
 ### Properties
 
-| Name                 | Type                                             | Required | Restrictions | Description                                                                                                                                                                                                                                           |
-|----------------------|--------------------------------------------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `effective_group_id` | string                                           | false    |              | Effective group ID is the user's effective budget group within the queried group's organization, falling back to the Everyone group when no budget applies. Null when the effective group belongs to a different organization than the queried group. |
-| `group_budget`       | [codersdk.AIBudgetLimit](#codersdkaibudgetlimit) | false    |              | Group budget is the budget when the queried group is this user's effective budget source. Null when the user's budget resolves to another group or no budget applies to the user.                                                                     |
-| `group_spend_micros` | integer                                          | false    |              | Group spend micros is the user's spend attributed to the queried group over the current budget period.                                                                                                                                                |
-| `user_id`            | string                                           | false    |              |                                                                                                                                                                                                                                                       |
+| Name                 | Type                                             | Required | Restrictions | Description                                                                                                                                                                                                                                                |
+|----------------------|--------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `effective_budget`   | [codersdk.AIBudgetLimit](#codersdkaibudgetlimit) | false    |              | Effective budget is the spend limit that currently applies to the user. Null when no budget applies or the effective group belongs to a different organization than the queried group.                                                                     |
+| `effective_group_id` | string                                           | false    |              | Effective group ID is the user's effective budget group within the queried group's organization, falling back to the Everyone group when no budget applies. Null when the effective group belongs to a different organization than the queried group.      |
+| `group_budget`       | [codersdk.AIBudgetLimit](#codersdkaibudgetlimit) | false    |              | Group budget is the budget when the queried group is this user's effective budget source. When populated, it matches EffectiveBudget. Null when the user's budget resolves to another group or no budget applies. Deprecated: Use EffectiveBudget instead. |
+| `group_spend_micros` | integer                                          | false    |              | Group spend micros is the user's spend attributed to the queried group over the current budget period.                                                                                                                                                     |
+| `user_id`            | string                                           | false    |              |                                                                                                                                                                                                                                                            |
 
 ## codersdk.GroupMembersAISpend
 
@@ -9537,6 +9617,10 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 {
   "members": [
     {
+      "effective_budget": {
+        "limit_source": "user_override",
+        "spend_limit_micros": 0
+      },
       "effective_group_id": "85e2b926-ddfb-4c66-b68e-b66e5acec6c0",
       "group_budget": {
         "limit_source": "user_override",
@@ -12356,6 +12440,20 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `collect_db_metrics`       | boolean                              | false    |              |             |
 | `enable`                   | boolean                              | false    |              |             |
 
+## codersdk.ProposeChatTitleResponse
+
+```json
+{
+  "title": "string"
+}
+```
+
+### Properties
+
+| Name    | Type   | Required | Restrictions | Description |
+|---------|--------|----------|--------------|-------------|
+| `title` | string | false    |              |             |
+
 ## codersdk.ProvisionerConfig
 
 ```json
@@ -13476,6 +13574,28 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 |---------------|--------------------------------------------------------|----------|--------------|-------------|
 | `usage_stats` | [codersdk.UsageStatsConfig](#codersdkusagestatsconfig) | false    |              |             |
 
+## codersdk.SubmitToolResultsRequest
+
+```json
+{
+  "results": [
+    {
+      "is_error": true,
+      "output": [
+        0
+      ],
+      "tool_call_id": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name      | Type                                                | Required | Restrictions | Description |
+|-----------|-----------------------------------------------------|----------|--------------|-------------|
+| `results` | array of [codersdk.ToolResult](#codersdktoolresult) | false    |              |             |
+
 ## codersdk.SupportConfig
 
 ```json
@@ -13599,6 +13719,7 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
   "allow_user_autostart": true,
   "allow_user_autostop": true,
   "allow_user_cancel_workspace_jobs": true,
+  "allow_workspace_renames": true,
   "autostart_requirement": {
     "days_of_week": [
       "monday"
@@ -13661,6 +13782,7 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `allow_user_autostart`             | boolean                                                                        | false    |              | Allow user autostart and AllowUserAutostop are enterprise-only. Their values are only used if your license is entitled to use the advanced template scheduling feature.                         |
 | `allow_user_autostop`              | boolean                                                                        | false    |              |                                                                                                                                                                                                 |
 | `allow_user_cancel_workspace_jobs` | boolean                                                                        | false    |              |                                                                                                                                                                                                 |
+| `allow_workspace_renames`          | boolean                                                                        | false    |              | Allow workspace renames permits users to rename workspaces built from this template. Renaming can be destructive for templates whose Terraform references the workspace name.                   |
 | `autostart_requirement`            | [codersdk.TemplateAutostartRequirement](#codersdktemplateautostartrequirement) | false    |              |                                                                                                                                                                                                 |
 | `autostop_requirement`             | [codersdk.TemplateAutostopRequirement](#codersdktemplateautostoprequirement)   | false    |              | Autostop requirement and AutostartRequirement are enterprise features. Its value is only used if your license is entitled to use the advanced template scheduling feature.                      |
 | `build_time_stats`                 | [codersdk.TemplateBuildTimeStats](#codersdktemplatebuildtimestats)             | false    |              |                                                                                                                                                                                                 |
@@ -14065,6 +14187,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
     "allow_user_autostart": true,
     "allow_user_autostop": true,
     "allow_user_cancel_workspace_jobs": true,
+    "allow_workspace_renames": true,
     "autostart_requirement": {
       "days_of_week": [
         "monday"
@@ -14980,6 +15103,26 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |----------------------|---------|----------|--------------|-------------|
 | `max_token_lifetime` | integer | false    |              |             |
 
+## codersdk.ToolResult
+
+```json
+{
+  "is_error": true,
+  "output": [
+    0
+  ],
+  "tool_call_id": "string"
+}
+```
+
+### Properties
+
+| Name           | Type             | Required | Restrictions | Description |
+|----------------|------------------|----------|--------------|-------------|
+| `is_error`     | boolean          | false    |              |             |
+| `output`       | array of integer | false    |              |             |
+| `tool_call_id` | string           | false    |              |             |
+
 ## codersdk.TraceConfig
 
 ```json
@@ -15112,6 +15255,48 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
 | `user_roles`       | object                                 | false    |              |             |
 | » `[any property]` | [codersdk.ChatRole](#codersdkchatrole) | false    |              |             |
+
+## codersdk.UpdateChatAutoArchiveDaysRequest
+
+```json
+{
+  "auto_archive_days": 0
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description |
+|---------------------|---------|----------|--------------|-------------|
+| `auto_archive_days` | integer | false    |              |             |
+
+## codersdk.UpdateChatDebugLoggingAllowUsersRequest
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Properties
+
+| Name          | Type    | Required | Restrictions | Description |
+|---------------|---------|----------|--------------|-------------|
+| `allow_users` | boolean | false    |              |             |
+
+## codersdk.UpdateChatDebugRetentionDaysRequest
+
+```json
+{
+  "debug_retention_days": 0
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `debug_retention_days` | integer | false    |              |             |
 
 ## codersdk.UpdateChatModelACLRequest
 
@@ -15333,6 +15518,34 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `model`                 | string                                                       | false    |              |             |
 | `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
 
+## codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Properties
+
+| Name          | Type    | Required | Restrictions | Description |
+|---------------|---------|----------|--------------|-------------|
+| `allow_users` | boolean | false    |              |             |
+
+## codersdk.UpdateChatPlanModeInstructionsRequest
+
+```json
+{
+  "plan_mode_instructions": "string"
+}
+```
+
+### Properties
+
+| Name                     | Type   | Required | Restrictions | Description |
+|--------------------------|--------|----------|--------------|-------------|
+| `plan_mode_instructions` | string | false    |              |             |
+
 ## codersdk.UpdateChatRequest
 
 ```json
@@ -15374,6 +15587,36 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Name             | Type    | Required | Restrictions | Description |
 |------------------|---------|----------|--------------|-------------|
 | `retention_days` | integer | false    |              |             |
+
+## codersdk.UpdateChatSystemPromptRequest
+
+```json
+{
+  "include_default_system_prompt": true,
+  "system_prompt": "string"
+}
+```
+
+### Properties
+
+| Name                            | Type    | Required | Restrictions | Description |
+|---------------------------------|---------|----------|--------------|-------------|
+| `include_default_system_prompt` | boolean | false    |              |             |
+| `system_prompt`                 | string  | false    |              |             |
+
+## codersdk.UpdateChatWorkspaceTTLRequest
+
+```json
+{
+  "workspace_ttl_ms": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description                                                                                                              |
+|--------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------|
+| `workspace_ttl_ms` | integer | false    |              | Workspace ttl ms is the workspace TTL in milliseconds. Zero means disabled; the template's own autostop setting applies. |
 
 ## codersdk.UpdateCheckResponse
 
@@ -15564,6 +15807,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "allow_user_autostart": true,
   "allow_user_autostop": true,
   "allow_user_cancel_workspace_jobs": true,
+  "allow_workspace_renames": true,
   "autostart_requirement": {
     "days_of_week": [
       "monday"
@@ -15605,6 +15849,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `allow_user_autostart`             | boolean                                                                        | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
 | `allow_user_autostop`              | boolean                                                                        | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
 | `allow_user_cancel_workspace_jobs` | boolean                                                                        | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
+| `allow_workspace_renames`          | boolean                                                                        | false    |              | Allow workspace renames permits users to rename workspaces built from this template. Renaming can be destructive for templates whose Terraform references the workspace name.                                                                                                                                                                                                      |
 | `autostart_requirement`            | [codersdk.TemplateAutostartRequirement](#codersdktemplateautostartrequirement) | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
 | `autostop_requirement`             | [codersdk.TemplateAutostopRequirement](#codersdktemplateautostoprequirement)   | false    |              | Autostop requirement and AutostartRequirement can only be set if your license includes the advanced template scheduling feature. If you attempt to set this value while unlicensed, it will be ignored.                                                                                                                                                                            |
 | `cors_behavior`                    | [codersdk.CORSBehavior](#codersdkcorsbehavior)                                 | false    |              |                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -15655,6 +15900,34 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `theme_dark`  | `dark`, `dark-protan-deuter`, `dark-tritan`, `light`, `light-protan-deuter`, `light-tritan` |
 | `theme_light` | `dark`, `dark-protan-deuter`, `dark-tritan`, `light`, `light-protan-deuter`, `light-tritan` |
 | `theme_mode`  | `single`, `sync`                                                                            |
+
+## codersdk.UpdateUserChatCompactionThresholdRequest
+
+```json
+{
+  "threshold_percent": 100
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description |
+|---------------------|---------|----------|--------------|-------------|
+| `threshold_percent` | integer | false    |              |             |
+
+## codersdk.UpdateUserChatDebugLoggingRequest
+
+```json
+{
+  "debug_logging_enabled": true
+}
+```
+
+### Properties
+
+| Name                    | Type    | Required | Restrictions | Description |
+|-------------------------|---------|----------|--------------|-------------|
+| `debug_logging_enabled` | boolean | false    |              |             |
 
 ## codersdk.UpdateUserChatPersonalModelOverrideRequest
 
@@ -16164,6 +16437,34 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `updated_at`         | string  | false    |              |             |
 | `user_id`            | string  | false    |              |             |
 
+## codersdk.UserAIProviderKeyConfig
+
+```json
+{
+  "byok_enabled": true,
+  "has_provider_api_key": true,
+  "has_user_api_key": true,
+  "provider": {
+    "deleted": true,
+    "display_name": "string",
+    "enabled": true,
+    "icon": "string",
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "name": "string",
+    "type": "openai"
+  }
+}
+```
+
+### Properties
+
+| Name                   | Type                                                     | Required | Restrictions | Description |
+|------------------------|----------------------------------------------------------|----------|--------------|-------------|
+| `byok_enabled`         | boolean                                                  | false    |              |             |
+| `has_provider_api_key` | boolean                                                  | false    |              |             |
+| `has_user_api_key`     | boolean                                                  | false    |              |             |
+| `provider`             | [codersdk.AIProviderSummary](#codersdkaiprovidersummary) | false    |              |             |
+
 ## codersdk.UserAISpendStatus
 
 ```json
@@ -16299,6 +16600,73 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `theme_light`      | string                                                 | false    |              | Ignored when ThemeMode is "single"                                                                                                                                                                                                                                                                                                        |
 | `theme_mode`       | [codersdk.ThemeMode](#codersdkthememode)               | false    |              |                                                                                                                                                                                                                                                                                                                                           |
 | `theme_preference` | string                                                 | false    |              | Theme preference is the legacy single-field appearance setting. In "single" mode it mirrors the active theme. In "sync" mode modern clients normally mirror the active OS slot, but older clients can update only this field, so it may diverge from ThemeLight or ThemeDark until a modern client saves the full appearance state again. |
+
+## codersdk.UserChatCompactionThreshold
+
+```json
+{
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205",
+  "threshold_percent": 0
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description |
+|---------------------|---------|----------|--------------|-------------|
+| `model_config_id`   | string  | false    |              |             |
+| `threshold_percent` | integer | false    |              |             |
+
+## codersdk.UserChatCompactionThresholds
+
+```json
+{
+  "thresholds": [
+    {
+      "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205",
+      "threshold_percent": 0
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name         | Type                                                                                  | Required | Restrictions | Description |
+|--------------|---------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `thresholds` | array of [codersdk.UserChatCompactionThreshold](#codersdkuserchatcompactionthreshold) | false    |              |             |
+
+## codersdk.UserChatCustomPrompt
+
+```json
+{
+  "custom_prompt": "string"
+}
+```
+
+### Properties
+
+| Name            | Type   | Required | Restrictions | Description |
+|-----------------|--------|----------|--------------|-------------|
+| `custom_prompt` | string | false    |              |             |
+
+## codersdk.UserChatDebugLoggingSettings
+
+```json
+{
+  "debug_logging_enabled": true,
+  "forced_by_deployment": true,
+  "user_toggle_allowed": true
+}
+```
+
+### Properties
+
+| Name                    | Type    | Required | Restrictions | Description |
+|-------------------------|---------|----------|--------------|-------------|
+| `debug_logging_enabled` | boolean | false    |              |             |
+| `forced_by_deployment`  | boolean | false    |              |             |
+| `user_toggle_allowed`   | boolean | false    |              |             |
 
 ## codersdk.UserChatPersonalModelOverridesResponse
 
@@ -16556,16 +16924,16 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name          | Type    | Required | Restrictions | Description                                                            |
-|---------------|---------|----------|--------------|------------------------------------------------------------------------|
-| `created_at`  | string  | false    |              |                                                                        |
-| `description` | string  | false    |              |                                                                        |
-| `enabled`     | boolean | false    |              | Enabled is stored intent. Deployment policy may block a stored target. |
-| `env_name`    | string  | false    |              |                                                                        |
-| `file_path`   | string  | false    |              |                                                                        |
-| `id`          | string  | false    |              |                                                                        |
-| `name`        | string  | false    |              |                                                                        |
-| `updated_at`  | string  | false    |              |                                                                        |
+| Name          | Type    | Required | Restrictions | Description                                                                                                                                                                                                                          |
+|---------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `created_at`  | string  | false    |              |                                                                                                                                                                                                                                      |
+| `description` | string  | false    |              |                                                                                                                                                                                                                                      |
+| `enabled`     | boolean | false    |              | Enabled controls whether the secret is injected into workspaces. Disabled secrets remain visible and editable, but are not added to the agent manifest, so they are not exposed as environment variables or written to secret files. |
+| `env_name`    | string  | false    |              |                                                                                                                                                                                                                                      |
+| `file_path`   | string  | false    |              |                                                                                                                                                                                                                                      |
+| `id`          | string  | false    |              |                                                                                                                                                                                                                                      |
+| `name`        | string  | false    |              |                                                                                                                                                                                                                                      |
+| `updated_at`  | string  | false    |              |                                                                                                                                                                                                                                      |
 
 ## codersdk.UserSkill
 
@@ -16932,10 +17300,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
             ],
             "name": "string",
             "operating_system": "string",
-            "parent_id": {
-              "uuid": "string",
-              "valid": true
-            },
+            "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
             "ready_at": "2019-08-24T14:15:22Z",
             "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
             "scripts": [
@@ -17014,10 +17379,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       ]
     }
   ],
-  "task_id": {
-    "uuid": "string",
-    "valid": true
-  },
+  "task_id": "string",
   "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
   "template_allow_user_cancel_workspace_jobs": true,
   "template_display_name": "string",
@@ -17035,7 +17397,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 | Name                                        | Type                                                                    | Required | Restrictions | Description                                                                                                                                                                                                                                                                                                                                 |
 |---------------------------------------------|-------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `allow_renames`                             | boolean                                                                 | false    |              |                                                                                                                                                                                                                                                                                                                                             |
+| `allow_renames`                             | boolean                                                                 | false    |              | Allow renames is the effective rename permission for this workspace, derived from the template's allow_workspace_renames setting and the deprecated deployment-wide flag.                                                                                                                                                                   |
 | `automatic_updates`                         | [codersdk.AutomaticUpdates](#codersdkautomaticupdates)                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `autostart_schedule`                        | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `created_at`                                | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
@@ -17057,7 +17419,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `owner_id`                                  | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `owner_name`                                | string                                                                  | false    |              | Owner name is the username of the owner of the workspace.                                                                                                                                                                                                                                                                                   |
 | `shared_with`                               | array of [codersdk.SharedWorkspaceActor](#codersdksharedworkspaceactor) | false    |              |                                                                                                                                                                                                                                                                                                                                             |
-| `task_id`                                   | [uuid.NullUUID](#uuidnulluuid)                                          | false    |              | Task ID if set, indicates that the workspace is relevant to the given codersdk.Task.                                                                                                                                                                                                                                                        |
+| `task_id`                                   | string                                                                  | false    |              | Task ID if set, indicates that the workspace is relevant to the given codersdk.Task.                                                                                                                                                                                                                                                        |
 | `template_active_version_id`                | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `template_allow_user_cancel_workspace_jobs` | boolean                                                                 | false    |              |                                                                                                                                                                                                                                                                                                                                             |
 | `template_display_name`                     | string                                                                  | false    |              |                                                                                                                                                                                                                                                                                                                                             |
@@ -17234,10 +17596,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   ],
   "name": "string",
   "operating_system": "string",
-  "parent_id": {
-    "uuid": "string",
-    "valid": true
-  },
+  "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
   "ready_at": "2019-08-24T14:15:22Z",
   "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
   "scripts": [
@@ -17297,7 +17656,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `metadata`                   | array of [codersdk.WorkspaceAgentMetadata](#codersdkworkspaceagentmetadata)                  | false    |              | Metadata is only populated on the workspaces list endpoint when the request opts in with the include_agent_metadata search key, and it only carries the requested keys. The description's script is always empty here: it can be long, and list consumers want values. |
 | `name`                       | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `operating_system`           | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
-| `parent_id`                  | [uuid.NullUUID](#uuidnulluuid)                                                               | false    |              |                                                                                                                                                                                                                                                                        |
+| `parent_id`                  | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `ready_at`                   | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `resource_id`                | string                                                                                       | false    |              |                                                                                                                                                                                                                                                                        |
 | `scripts`                    | array of [codersdk.WorkspaceAgentScript](#codersdkworkspaceagentscript)                      | false    |              |                                                                                                                                                                                                                                                                        |
@@ -17413,10 +17772,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
   "name": "string",
   "status": "running",
-  "subagent_id": {
-    "uuid": "string",
-    "valid": true
-  },
+  "subagent_id": "7b85d465-b649-4b8b-9da8-5f731c1d294d",
   "workspace_folder": "string"
 }
 ```
@@ -17433,7 +17789,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `id`               | string                                                                                 | false    |              |                            |
 | `name`             | string                                                                                 | false    |              |                            |
 | `status`           | [codersdk.WorkspaceAgentDevcontainerStatus](#codersdkworkspaceagentdevcontainerstatus) | false    |              | Additional runtime fields. |
-| `subagent_id`      | [uuid.NullUUID](#uuidnulluuid)                                                         | false    |              |                            |
+| `subagent_id`      | string                                                                                 | false    |              |                            |
 | `workspace_folder` | string                                                                                 | false    |              |                            |
 
 ## codersdk.WorkspaceAgentDevcontainerAgent
@@ -17607,10 +17963,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "name": "string",
       "status": "running",
-      "subagent_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "subagent_id": "7b85d465-b649-4b8b-9da8-5f731c1d294d",
       "workspace_folder": "string"
     }
   ],
@@ -18281,10 +18634,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           ],
           "name": "string",
           "operating_system": "string",
-          "parent_id": {
-            "uuid": "string",
-            "valid": true
-          },
+          "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
           "ready_at": "2019-08-24T14:15:22Z",
           "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
           "scripts": [
@@ -18768,10 +19118,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       ],
       "name": "string",
       "operating_system": "string",
-      "parent_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
       "ready_at": "2019-08-24T14:15:22Z",
       "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
       "scripts": [
@@ -19124,10 +19471,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
                 ],
                 "name": "string",
                 "operating_system": "string",
-                "parent_id": {
-                  "uuid": "string",
-                  "valid": true
-                },
+                "parent_id": "1c6ca187-e61f-4301-8dcb-0e9749e89eef",
                 "ready_at": "2019-08-24T14:15:22Z",
                 "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
                 "scripts": [
@@ -19206,10 +19550,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           ]
         }
       ],
-      "task_id": {
-        "uuid": "string",
-        "valid": true
-      },
+      "task_id": "string",
       "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
       "template_allow_user_cancel_workspace_jobs": true,
       "template_display_name": "string",
@@ -19364,7 +19705,6 @@ Zero means unspecified. There might be a limit, but the client need not try to r
     "captivePortal": "string",
     "globalV4": "string",
     "globalV6": "string",
-    "hairPinning": "string",
     "icmpv4": true,
     "ipv4": true,
     "ipv4CanSend": true,
@@ -19901,7 +20241,6 @@ Zero means unspecified. There might be a limit, but the client need not try to r
       "captivePortal": "string",
       "globalV4": "string",
       "globalV6": "string",
-      "hairPinning": "string",
       "icmpv4": true,
       "ipv4": true,
       "ipv4CanSend": true,
@@ -20583,7 +20922,6 @@ None
   "captivePortal": "string",
   "globalV4": "string",
   "globalV6": "string",
-  "hairPinning": "string",
   "icmpv4": true,
   "ipv4": true,
   "ipv4CanSend": true,
@@ -20613,30 +20951,29 @@ None
 
 ### Properties
 
-| Name                    | Type    | Required | Restrictions | Description                                                                                                                        |
-|-------------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------|
-| `captivePortal`         | string  | false    |              | Captiveportal is set when we think there's a captive portal that is intercepting HTTP traffic.                                     |
-| `globalV4`              | string  | false    |              | ip:port of global IPv4                                                                                                             |
-| `globalV6`              | string  | false    |              | [ip]:port of global IPv6                                                                                                           |
-| `hairPinning`           | string  | false    |              | Hairpinning is whether the router supports communicating between two local devices through the NATted public IP address (on IPv4). |
-| `icmpv4`                | boolean | false    |              | an ICMPv4 round trip completed                                                                                                     |
-| `ipv4`                  | boolean | false    |              | an IPv4 STUN round trip completed                                                                                                  |
-| `ipv4CanSend`           | boolean | false    |              | an IPv4 packet was able to be sent                                                                                                 |
-| `ipv6`                  | boolean | false    |              | an IPv6 STUN round trip completed                                                                                                  |
-| `ipv6CanSend`           | boolean | false    |              | an IPv6 packet was able to be sent                                                                                                 |
-| `mappingVariesByDestIP` | string  | false    |              | Mappingvariesbydestip is whether STUN results depend which STUN server you're talking to (on IPv4).                                |
-| `oshasIPv6`             | boolean | false    |              | could bind a socket to ::1                                                                                                         |
-| `pcp`                   | string  | false    |              | Pcp is whether PCP appears present on the LAN. Empty means not checked.                                                            |
-| `pmp`                   | string  | false    |              | Pmp is whether NAT-PMP appears present on the LAN. Empty means not checked.                                                        |
-| `preferredDERP`         | integer | false    |              | or 0 for unknown                                                                                                                   |
-| `regionLatency`         | object  | false    |              | keyed by DERP Region ID                                                                                                            |
-| » `[any property]`      | integer | false    |              |                                                                                                                                    |
-| `regionV4Latency`       | object  | false    |              | keyed by DERP Region ID                                                                                                            |
-| » `[any property]`      | integer | false    |              |                                                                                                                                    |
-| `regionV6Latency`       | object  | false    |              | keyed by DERP Region ID                                                                                                            |
-| » `[any property]`      | integer | false    |              |                                                                                                                                    |
-| `udp`                   | boolean | false    |              | a UDP STUN round trip completed                                                                                                    |
-| `upnP`                  | string  | false    |              | Upnp is whether UPnP appears present on the LAN. Empty means not checked.                                                          |
+| Name                    | Type    | Required | Restrictions | Description                                                                                         |
+|-------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------|
+| `captivePortal`         | string  | false    |              | Captiveportal is set when we think there's a captive portal that is intercepting HTTP traffic.      |
+| `globalV4`              | string  | false    |              | ip:port of global IPv4                                                                              |
+| `globalV6`              | string  | false    |              | [ip]:port of global IPv6                                                                            |
+| `icmpv4`                | boolean | false    |              | an ICMPv4 round trip completed                                                                      |
+| `ipv4`                  | boolean | false    |              | an IPv4 STUN round trip completed                                                                   |
+| `ipv4CanSend`           | boolean | false    |              | an IPv4 packet was able to be sent                                                                  |
+| `ipv6`                  | boolean | false    |              | an IPv6 STUN round trip completed                                                                   |
+| `ipv6CanSend`           | boolean | false    |              | an IPv6 packet was able to be sent                                                                  |
+| `mappingVariesByDestIP` | string  | false    |              | Mappingvariesbydestip is whether STUN results depend which STUN server you're talking to (on IPv4). |
+| `oshasIPv6`             | boolean | false    |              | could bind a socket to ::1                                                                          |
+| `pcp`                   | string  | false    |              | Pcp is whether PCP appears present on the LAN. Empty means not checked.                             |
+| `pmp`                   | string  | false    |              | Pmp is whether NAT-PMP appears present on the LAN. Empty means not checked.                         |
+| `preferredDERP`         | integer | false    |              | or 0 for unknown                                                                                    |
+| `regionLatency`         | object  | false    |              | keyed by DERP Region ID                                                                             |
+| » `[any property]`      | integer | false    |              |                                                                                                     |
+| `regionV4Latency`       | object  | false    |              | keyed by DERP Region ID                                                                             |
+| » `[any property]`      | integer | false    |              |                                                                                                     |
+| `regionV6Latency`       | object  | false    |              | keyed by DERP Region ID                                                                             |
+| » `[any property]`      | integer | false    |              |                                                                                                     |
+| `udp`                   | boolean | false    |              | a UDP STUN round trip completed                                                                     |
+| `upnP`                  | string  | false    |              | Upnp is whether UPnP appears present on the LAN. Empty means not checked.                           |
 
 ## oauth2.Token
 
@@ -21125,22 +21462,6 @@ RegionIDs in range 900-999 are reserved for end users to run their own DERP node
 ### Properties
 
 None
-
-## uuid.NullUUID
-
-```json
-{
-  "uuid": "string",
-  "valid": true
-}
-```
-
-### Properties
-
-| Name    | Type    | Required | Restrictions | Description                       |
-|---------|---------|----------|--------------|-----------------------------------|
-| `uuid`  | string  | false    |              |                                   |
-| `valid` | boolean | false    |              | Valid is true if UUID is not NULL |
 
 ## workspaceapps.AccessMethod
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -16935,6 +16935,20 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `name`        | string  | false    |              |                                                                                                                                                                                                                                      |
 | `updated_at`  | string  | false    |              |                                                                                                                                                                                                                                      |
 
+## codersdk.UserSecretsCapabilities
+
+```json
+{
+  "file_path_delivery_enabled": true
+}
+```
+
+### Properties
+
+| Name                         | Type    | Required | Restrictions | Description                                                                                                                       |
+|------------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `file_path_delivery_enabled` | boolean | false    |              | File path delivery enabled reports whether Coder writes stored file paths into workspaces. Stored paths are preserved either way. |
+
 ## codersdk.UserSkill
 
 ```json

--- a/docs/reference/api/secrets.md
+++ b/docs/reference/api/secrets.md
@@ -53,17 +53,17 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/secrets \
 
 Status Code **200**
 
-| Name            | Type              | Required | Restrictions | Description                                                                                                                                                                                                                          |
-|-----------------|-------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `[array item]`  | array             | false    |              |                                                                                                                                                                                                                                      |
-| `» created_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
-| `» description` | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» enabled`     | boolean           | false    |              | Enabled controls whether the secret is injected into workspaces. Disabled secrets remain visible and editable, but are not added to the agent manifest, so they are not exposed as environment variables or written to secret files. |
-| `» env_name`    | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» file_path`   | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» id`          | string(uuid)      | false    |              |                                                                                                                                                                                                                                      |
-| `» name`        | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» updated_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
+| Name            | Type              | Required | Restrictions | Description                                                            |
+|-----------------|-------------------|----------|--------------|------------------------------------------------------------------------|
+| `[array item]`  | array             | false    |              |                                                                        |
+| `» created_at`  | string(date-time) | false    |              |                                                                        |
+| `» description` | string            | false    |              |                                                                        |
+| `» enabled`     | boolean           | false    |              | Enabled is stored intent. Deployment policy may block a stored target. |
+| `» env_name`    | string            | false    |              |                                                                        |
+| `» file_path`   | string            | false    |              |                                                                        |
+| `» id`          | string(uuid)      | false    |              |                                                                        |
+| `» name`        | string            | false    |              |                                                                        |
+| `» updated_at`  | string(date-time) | false    |              |                                                                        |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -120,9 +120,11 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/secrets \
 
 ### Responses
 
-| Status | Meaning                                                      | Description | Schema                                               |
-|--------|--------------------------------------------------------------|-------------|------------------------------------------------------|
-| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.UserSecret](schemas.md#codersdkusersecret) |
+| Status | Meaning                                                          | Description | Schema                                               |
+|--------|------------------------------------------------------------------|-------------|------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)     | Created     | [codersdk.UserSecret](schemas.md#codersdkusersecret) |
+| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1) | Bad Request | [codersdk.Response](schemas.md#codersdkresponse)     |
+| 409    | [Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)    | Conflict    | [codersdk.Response](schemas.md#codersdkresponse)     |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -188,17 +190,17 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/secrets/batch \
 
 Status Code **201**
 
-| Name            | Type              | Required | Restrictions | Description                                                                                                                                                                                                                          |
-|-----------------|-------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `[array item]`  | array             | false    |              |                                                                                                                                                                                                                                      |
-| `» created_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
-| `» description` | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» enabled`     | boolean           | false    |              | Enabled controls whether the secret is injected into workspaces. Disabled secrets remain visible and editable, but are not added to the agent manifest, so they are not exposed as environment variables or written to secret files. |
-| `» env_name`    | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» file_path`   | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» id`          | string(uuid)      | false    |              |                                                                                                                                                                                                                                      |
-| `» name`        | string            | false    |              |                                                                                                                                                                                                                                      |
-| `» updated_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
+| Name            | Type              | Required | Restrictions | Description                                                            |
+|-----------------|-------------------|----------|--------------|------------------------------------------------------------------------|
+| `[array item]`  | array             | false    |              |                                                                        |
+| `» created_at`  | string(date-time) | false    |              |                                                                        |
+| `» description` | string            | false    |              |                                                                        |
+| `» enabled`     | boolean           | false    |              | Enabled is stored intent. Deployment policy may block a stored target. |
+| `» env_name`    | string            | false    |              |                                                                        |
+| `» file_path`   | string            | false    |              |                                                                        |
+| `» id`          | string(uuid)      | false    |              |                                                                        |
+| `» name`        | string            | false    |              |                                                                        |
+| `» updated_at`  | string(date-time) | false    |              |                                                                        |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -327,8 +329,10 @@ curl -X PATCH http://coder-server:8080/api/v2/users/{user}/secrets/{name} \
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                               |
-|--------|---------------------------------------------------------|-------------|------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserSecret](schemas.md#codersdkusersecret) |
+| Status | Meaning                                                          | Description | Schema                                               |
+|--------|------------------------------------------------------------------|-------------|------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)          | OK          | [codersdk.UserSecret](schemas.md#codersdkusersecret) |
+| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1) | Bad Request | [codersdk.Response](schemas.md#codersdkresponse)     |
+| 409    | [Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)    | Conflict    | [codersdk.Response](schemas.md#codersdkresponse)     |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/secrets.md
+++ b/docs/reference/api/secrets.md
@@ -53,17 +53,17 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/secrets \
 
 Status Code **200**
 
-| Name            | Type              | Required | Restrictions | Description                                                            |
-|-----------------|-------------------|----------|--------------|------------------------------------------------------------------------|
-| `[array item]`  | array             | false    |              |                                                                        |
-| `» created_at`  | string(date-time) | false    |              |                                                                        |
-| `» description` | string            | false    |              |                                                                        |
-| `» enabled`     | boolean           | false    |              | Enabled is stored intent. Deployment policy may block a stored target. |
-| `» env_name`    | string            | false    |              |                                                                        |
-| `» file_path`   | string            | false    |              |                                                                        |
-| `» id`          | string(uuid)      | false    |              |                                                                        |
-| `» name`        | string            | false    |              |                                                                        |
-| `» updated_at`  | string(date-time) | false    |              |                                                                        |
+| Name            | Type              | Required | Restrictions | Description                                                                                                                                                                                                                          |
+|-----------------|-------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `[array item]`  | array             | false    |              |                                                                                                                                                                                                                                      |
+| `» created_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
+| `» description` | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» enabled`     | boolean           | false    |              | Enabled controls whether the secret is injected into workspaces. Disabled secrets remain visible and editable, but are not added to the agent manifest, so they are not exposed as environment variables or written to secret files. |
+| `» env_name`    | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» file_path`   | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» id`          | string(uuid)      | false    |              |                                                                                                                                                                                                                                      |
+| `» name`        | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» updated_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -190,17 +190,17 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/secrets/batch \
 
 Status Code **201**
 
-| Name            | Type              | Required | Restrictions | Description                                                            |
-|-----------------|-------------------|----------|--------------|------------------------------------------------------------------------|
-| `[array item]`  | array             | false    |              |                                                                        |
-| `» created_at`  | string(date-time) | false    |              |                                                                        |
-| `» description` | string            | false    |              |                                                                        |
-| `» enabled`     | boolean           | false    |              | Enabled is stored intent. Deployment policy may block a stored target. |
-| `» env_name`    | string            | false    |              |                                                                        |
-| `» file_path`   | string            | false    |              |                                                                        |
-| `» id`          | string(uuid)      | false    |              |                                                                        |
-| `» name`        | string            | false    |              |                                                                        |
-| `» updated_at`  | string(date-time) | false    |              |                                                                        |
+| Name            | Type              | Required | Restrictions | Description                                                                                                                                                                                                                          |
+|-----------------|-------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `[array item]`  | array             | false    |              |                                                                                                                                                                                                                                      |
+| `» created_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
+| `» description` | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» enabled`     | boolean           | false    |              | Enabled controls whether the secret is injected into workspaces. Disabled secrets remain visible and editable, but are not added to the agent manifest, so they are not exposed as environment variables or written to secret files. |
+| `» env_name`    | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» file_path`   | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» id`          | string(uuid)      | false    |              |                                                                                                                                                                                                                                      |
+| `» name`        | string            | false    |              |                                                                                                                                                                                                                                      |
+| `» updated_at`  | string(date-time) | false    |              |                                                                                                                                                                                                                                      |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -26,6 +26,16 @@ coder server [flags]
 
 ## Options
 
+### --mcp-allowed-private-cidrs
+
+|             |                                               |
+|-------------|-----------------------------------------------|
+| Type        | <code>string-array</code>                     |
+| Environment | <code>$CODER_MCP_ALLOWED_PRIVATE_CIDRS</code> |
+| YAML        | <code>mcp.allowed_private_cidrs</code>        |
+
+MCP server destinations in private or reserved IP ranges are blocked by default for SSRF protection. This applies to OAuth2 discovery, OAuth2 token and revocation exchanges, and runtime MCP connections from coderd. This option exempts specific CIDRs.
+
 ### --access-url
 
 |             |                                   |
@@ -1216,6 +1226,16 @@ Disable workspace sharing. Workspace ACL checking is disabled and only owners ca
 
 Disable chat sharing. Chat ACL checking is disabled and only owners can access their chats.
 
+### --disable-workspace-agent-context-sync
+
+|             |                                                          |
+|-------------|----------------------------------------------------------|
+| Type        | <code>bool</code>                                        |
+| Environment | <code>$CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC</code> |
+| YAML        | <code>disableWorkspaceAgentContextSync</code>            |
+
+Stop persisting workspace agent context snapshots (instructions, skills, and MCP state used for pinned chat context). When set, coderd rejects agent context pushes as unimplemented and agents stop sending them; chats cannot pin workspace context. Use this to shed the database write load of context sync on large deployments.
+
 ### --user-secrets-disable-file-path
 
 |             |                                                    |
@@ -1369,17 +1389,6 @@ Allow users to set their own quiet hours schedule for workspaces to stop in (dep
 | Default     | <code>canvas</code>                       |
 
 The renderer to use when opening a web terminal. Valid values are 'canvas', 'webgl', or 'dom'.
-
-### --allow-workspace-renames
-
-|             |                                             |
-|-------------|---------------------------------------------|
-| Type        | <code>bool</code>                           |
-| Environment | <code>$CODER_ALLOW_WORKSPACE_RENAMES</code> |
-| YAML        | <code>allowWorkspaceRenames</code>          |
-| Default     | <code>false</code>                          |
-
-Allow users to rename their workspaces. WARNING: Renaming a workspace can cause Terraform resources that depend on the workspace name to be destroyed and recreated, potentially causing data loss. Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.
 
 ### --health-check-refresh
 
@@ -2165,4 +2174,4 @@ Disable the template builder feature for guided template creation. When disabled
 | YAML        | <code>templateBuilder.registryURL</code>          |
 | Default     | <code>registry.coder.com</code>                   |
 
-The base URL of the module registry used by the template builder for module source paths.
+The module registry host the template builder uses for module source paths (for example, "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme and trailing slash are stripped; a path, query, fragment, or credentials is rejected.

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -26,16 +26,6 @@ coder server [flags]
 
 ## Options
 
-### --mcp-allowed-private-cidrs
-
-|             |                                               |
-|-------------|-----------------------------------------------|
-| Type        | <code>string-array</code>                     |
-| Environment | <code>$CODER_MCP_ALLOWED_PRIVATE_CIDRS</code> |
-| YAML        | <code>mcp.allowed_private_cidrs</code>        |
-
-MCP server destinations in private or reserved IP ranges are blocked by default for SSRF protection. This applies to OAuth2 discovery, OAuth2 token and revocation exchanges, and runtime MCP connections from coderd. This option exempts specific CIDRs.
-
 ### --access-url
 
 |             |                                   |
@@ -1226,15 +1216,15 @@ Disable workspace sharing. Workspace ACL checking is disabled and only owners ca
 
 Disable chat sharing. Chat ACL checking is disabled and only owners can access their chats.
 
-### --disable-workspace-agent-context-sync
+### --user-secrets-disable-file-path
 
-|             |                                                          |
-|-------------|----------------------------------------------------------|
-| Type        | <code>bool</code>                                        |
-| Environment | <code>$CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC</code> |
-| YAML        | <code>disableWorkspaceAgentContextSync</code>            |
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>bool</code>                                  |
+| Environment | <code>$CODER_USER_SECRETS_DISABLE_FILE_PATH</code> |
+| YAML        | <code>userSecretsDisableFilePath</code>            |
 
-Stop persisting workspace agent context snapshots (instructions, skills, and MCP state used for pinned chat context). When set, coderd rejects agent context pushes as unimplemented and agents stop sending them; chats cannot pin workspace context. Use this to shed the database write load of context sync on large deployments.
+Disable Coder-managed file path delivery for user secrets. Stored paths remain until users clear them and resume if this setting is turned off.
 
 ### --session-duration
 
@@ -1379,6 +1369,17 @@ Allow users to set their own quiet hours schedule for workspaces to stop in (dep
 | Default     | <code>canvas</code>                       |
 
 The renderer to use when opening a web terminal. Valid values are 'canvas', 'webgl', or 'dom'.
+
+### --allow-workspace-renames
+
+|             |                                             |
+|-------------|---------------------------------------------|
+| Type        | <code>bool</code>                           |
+| Environment | <code>$CODER_ALLOW_WORKSPACE_RENAMES</code> |
+| YAML        | <code>allowWorkspaceRenames</code>          |
+| Default     | <code>false</code>                          |
+
+Allow users to rename their workspaces. WARNING: Renaming a workspace can cause Terraform resources that depend on the workspace name to be destroyed and recreated, potentially causing data loss. Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.
 
 ### --health-check-refresh
 
@@ -2164,4 +2165,4 @@ Disable the template builder feature for guided template creation. When disabled
 | YAML        | <code>templateBuilder.registryURL</code>          |
 | Default     | <code>registry.coder.com</code>                   |
 
-The module registry host the template builder uses for module source paths (for example, "registry.coder.com" or "mirror.internal:8443"). An http(s):// scheme and trailing slash are stripped; a path, query, fragment, or credentials is rejected.
+The base URL of the module registry used by the template builder for module source paths.

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1236,13 +1236,13 @@ Disable chat sharing. Chat ACL checking is disabled and only owners can access t
 
 Stop persisting workspace agent context snapshots (instructions, skills, and MCP state used for pinned chat context). When set, coderd rejects agent context pushes as unimplemented and agents stop sending them; chats cannot pin workspace context. Use this to shed the database write load of context sync on large deployments.
 
-### --user-secrets-disable-file-path
+### --disable-user-secret-file-path
 
-|             |                                                    |
-|-------------|----------------------------------------------------|
-| Type        | <code>bool</code>                                  |
-| Environment | <code>$CODER_USER_SECRETS_DISABLE_FILE_PATH</code> |
-| YAML        | <code>userSecretsDisableFilePath</code>            |
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Type        | <code>bool</code>                                 |
+| Environment | <code>$CODER_DISABLE_USER_SECRET_FILE_PATH</code> |
+| YAML        | <code>disableUserSecretFilePath</code>            |
 
 Disable Coder-managed file path delivery for user secrets. Stored paths remain until users clear them and resume if this setting is turned off.
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -18,6 +18,13 @@ SUBCOMMANDS:
                                 PostgreSQL deployment.
 
 OPTIONS:
+      --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
+          Allow users to rename their workspaces. WARNING: Renaming a workspace
+          can cause Terraform resources that depend on the workspace name to be
+          destroyed and recreated, potentially causing data loss. Only enable
+          this if your templates do not use workspace names in resource
+          identifiers, or if you understand the risks.
+
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and
           $CACHE_DIRECTORY is set, it will be used for compatibility with
@@ -49,12 +56,10 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
-      --disable-workspace-agent-context-sync bool, $CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC
-          Stop persisting workspace agent context snapshots (instructions,
-          skills, and MCP state used for pinned chat context). When set, coderd
-          rejects agent context pushes as unimplemented and agents stop sending
-          them; chats cannot pin workspace context. Use this to shed the
-          database write load of context sync on large deployments.
+      --user-secrets-disable-file-path bool, $CODER_USER_SECRETS_DISABLE_FILE_PATH
+          Disable Coder-managed file path delivery for user secrets. Stored
+          paths remain until users clear them and resume if this setting is
+          turned off.
 
       --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
           Disable workspace sharing. Workspace ACL checking is disabled and only
@@ -447,13 +452,6 @@ INTROSPECTION / PPROF OPTIONS:
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
-
-MCP OPTIONS: 
-      --mcp-allowed-private-cidrs string-array, $CODER_MCP_ALLOWED_PRIVATE_CIDRS
-          MCP server destinations in private or reserved IP ranges are blocked
-          by default for SSRF protection. This applies to OAuth2 discovery,
-          OAuth2 token and revocation exchanges, and runtime MCP connections
-          from coderd. This option exempts specific CIDRs.
 
 NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
@@ -928,10 +926,8 @@ TEMPLATE BUILDER OPTIONS:
           When disabled, all /api/v2/templatebuilder/* endpoints return 404.
 
       --template-builder-registry-url string, $CODER_TEMPLATE_BUILDER_REGISTRY_URL (default: registry.coder.com)
-          The module registry host the template builder uses for module source
-          paths (for example, "registry.coder.com" or "mirror.internal:8443").
-          An http(s):// scheme and trailing slash are stripped; a path, query,
-          fragment, or credentials is rejected.
+          The base URL of the module registry used by the template builder for
+          module source paths.
 
 USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -18,13 +18,6 @@ SUBCOMMANDS:
                                 PostgreSQL deployment.
 
 OPTIONS:
-      --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
-          Allow users to rename their workspaces. WARNING: Renaming a workspace
-          can cause Terraform resources that depend on the workspace name to be
-          destroyed and recreated, potentially causing data loss. Only enable
-          this if your templates do not use workspace names in resource
-          identifiers, or if you understand the risks.
-
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and
           $CACHE_DIRECTORY is set, it will be used for compatibility with
@@ -60,6 +53,13 @@ OPTIONS:
           Disable Coder-managed file path delivery for user secrets. Stored
           paths remain until users clear them and resume if this setting is
           turned off.
+
+      --disable-workspace-agent-context-sync bool, $CODER_DISABLE_WORKSPACE_AGENT_CONTEXT_SYNC
+          Stop persisting workspace agent context snapshots (instructions,
+          skills, and MCP state used for pinned chat context). When set, coderd
+          rejects agent context pushes as unimplemented and agents stop sending
+          them; chats cannot pin workspace context. Use this to shed the
+          database write load of context sync on large deployments.
 
       --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
           Disable workspace sharing. Workspace ACL checking is disabled and only
@@ -452,6 +452,13 @@ INTROSPECTION / PPROF OPTIONS:
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
+
+MCP OPTIONS: 
+      --mcp-allowed-private-cidrs string-array, $CODER_MCP_ALLOWED_PRIVATE_CIDRS
+          MCP server destinations in private or reserved IP ranges are blocked
+          by default for SSRF protection. This applies to OAuth2 discovery,
+          OAuth2 token and revocation exchanges, and runtime MCP connections
+          from coderd. This option exempts specific CIDRs.
 
 NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
@@ -926,8 +933,10 @@ TEMPLATE BUILDER OPTIONS:
           When disabled, all /api/v2/templatebuilder/* endpoints return 404.
 
       --template-builder-registry-url string, $CODER_TEMPLATE_BUILDER_REGISTRY_URL (default: registry.coder.com)
-          The base URL of the module registry used by the template builder for
-          module source paths.
+          The module registry host the template builder uses for module source
+          paths (for example, "registry.coder.com" or "mirror.internal:8443").
+          An http(s):// scheme and trailing slash are stripped; a path, query,
+          fragment, or credentials is rejected.
 
 USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -49,7 +49,7 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
-      --user-secrets-disable-file-path bool, $CODER_USER_SECRETS_DISABLE_FILE_PATH
+      --disable-user-secret-file-path bool, $CODER_DISABLE_USER_SECRET_FILE_PATH
           Disable Coder-managed file path delivery for user secrets. Stored
           paths remain until users clear them and resume if this setting is
           turned off.

--- a/enterprise/dbcrypt/dbcrypt.go
+++ b/enterprise/dbcrypt/dbcrypt.go
@@ -939,6 +939,17 @@ func (db *dbCrypt) GetUserSecretByUserIDAndName(ctx context.Context, arg databas
 	return secret, nil
 }
 
+func (db *dbCrypt) GetUserSecretByUserIDAndNameForUpdate(ctx context.Context, arg database.GetUserSecretByUserIDAndNameForUpdateParams) (database.UserSecret, error) {
+	secret, err := db.Store.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+	if err != nil {
+		return database.UserSecret{}, err
+	}
+	if err := db.decryptField(&secret.Value, secret.ValueKeyID); err != nil {
+		return database.UserSecret{}, err
+	}
+	return secret, nil
+}
+
 func (db *dbCrypt) ListUserSecretsWithValues(ctx context.Context, userID uuid.UUID) ([]database.UserSecret, error) {
 	secrets, err := db.Store.ListUserSecretsWithValues(ctx, userID)
 	if err != nil {

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -1923,6 +1923,26 @@ func TestUserSecrets(t *testing.T) {
 		require.ErrorAs(t, err, &derr)
 	})
 
+	t.Run("GetUserSecretForUpdateDecryptErr", func(t *testing.T) {
+		t.Parallel()
+		db, crypt, ciphers := setup(t)
+		user := dbgen.User(t, db, database.User{})
+		dbgen.UserSecret(t, db, database.UserSecret{
+			UserID:     user.ID,
+			Name:       "corrupt-secret-for-update",
+			Value:      fakeBase64RandomData(t, 32),
+			ValueKeyID: sql.NullString{String: ciphers[0].HexDigest(), Valid: true},
+		})
+
+		_, err := crypt.GetUserSecretByUserIDAndNameForUpdate(ctx, database.GetUserSecretByUserIDAndNameForUpdateParams{
+			UserID: user.ID,
+			Name:   "corrupt-secret-for-update",
+		})
+		require.Error(t, err)
+		var derr *DecryptFailedError
+		require.ErrorAs(t, err, &derr)
+	})
+
 	t.Run("ListUserSecretsWithValuesDecryptErr", func(t *testing.T) {
 		t.Parallel()
 		db, crypt, ciphers := setup(t)

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -1886,6 +1886,23 @@ func TestUserSecrets(t *testing.T) {
 		require.Equal(t, rawBefore.ValueKeyID, rawAfter.ValueKeyID)
 	})
 
+	t.Run("GetUserSecretForUpdateDecryptsValue", func(t *testing.T) {
+		t.Parallel()
+		db, crypt, ciphers := setup(t)
+		secret := insertUserSecret(t, crypt, ciphers)
+		arg := database.GetUserSecretByUserIDAndNameForUpdateParams{
+			UserID: secret.UserID, Name: secret.Name,
+		}
+
+		got, err := crypt.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+		require.NoError(t, err)
+		require.Equal(t, initialValue, got.Value)
+
+		raw, err := db.GetUserSecretByUserIDAndNameForUpdate(ctx, arg)
+		require.NoError(t, err)
+		requireEncryptedEquals(t, ciphers[0], raw.Value, initialValue)
+	})
+
 	t.Run("GetUserSecretDecryptErr", func(t *testing.T) {
 		t.Parallel()
 		db, crypt, ciphers := setup(t)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2,7 +2,7 @@
 
 // From codersdk/templates.go
 /**
- * ACLAvailable is a list of users and groups that can be added to a template
+ * ACLAvailable is a list of users and groups that can be added to a resource
  * ACL.
  */
 export interface ACLAvailable {
@@ -2575,7 +2575,7 @@ export interface ChatGitChange {
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2591,7 +2591,7 @@ export const ChatGitWatchAgentStatePrefix = "Agent state is ";
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2604,7 +2604,7 @@ export const ChatGitWatchNoEligibleAgentMessage =
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2616,7 +2616,7 @@ export const ChatGitWatchNoWorkspaceMessage = "Chat has no workspace to watch.";
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/experimental/chats/{id}/stream/git when the chat cannot be
+ * /api/v2/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2855,11 +2855,12 @@ export interface ChatModel {
 // From codersdk/chats.go
 /**
  * ChatModelACL is the access control list for an organization-scoped chat
- * model. Each principal is mapped to its effective model role.
+ * model. Each principal includes the identity details needed to display and
+ * manage the ACL without separate directory lookups.
  */
 export interface ChatModelACL {
-	readonly user_roles: Record<string, ChatRole>;
-	readonly group_roles: Record<string, ChatRole>;
+	readonly users: readonly ChatUser[];
+	readonly groups: readonly ChatGroup[];
 }
 
 // From codersdk/chats.go
@@ -3050,8 +3051,8 @@ export interface ChatModelOverridesResponse {
  * ChatModelProviderDescriptor is the redacted view of an AI provider carried
  * on the org model collection response. It carries only the capability
  * metadata the Models UI needs; key material, base URLs, and headers are
- * never exposed. The fields mirror what /api/experimental/chats/models
- * already discloses to any authenticated caller.
+ * never exposed. The fields mirror the provider descriptors returned by the
+ * organization-scoped chat models collection.
  */
 export interface ChatModelProviderDescriptor {
 	readonly id: string;
@@ -3247,7 +3248,7 @@ export const ChatPlanModes: ChatPlanMode[] = ["plan"];
 // From codersdk/chats.go
 /**
  * ChatPrompt is a single user-authored prompt in a chat, returned by
- * GET /api/experimental/chats/{chat}/prompts. The text field contains
+ * GET /api/v2/chats/{chat}/prompts. The text field contains
  * the concatenated text payload of the underlying chat message; non-text
  * parts (tool calls, files, attachments) are omitted by the server.
  */
@@ -3272,7 +3273,7 @@ export interface ChatPromptsOptions {
 // From codersdk/chats.go
 /**
  * ChatPromptsResponse is the payload of
- * GET /api/experimental/chats/{chat}/prompts. Prompts are returned
+ * GET /api/v2/chats/{chat}/prompts. Prompts are returned
  * newest first so the client can index directly into the slice for
  * up/down arrow history cycling.
  */
@@ -3657,7 +3658,7 @@ export const ChatWatchEventKinds: ChatWatchEventKind[] = [
 export interface ChatWorkspaceTTLResponse {
 	/**
 	 * WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	 * Zero means disabled — the template's own autostop setting applies.
+	 * Zero means disabled; the template's own autostop setting applies.
 	 */
 	readonly workspace_ttl_ms: number;
 }
@@ -4198,6 +4199,12 @@ export interface CreateTemplateRequest {
 	 * this template. Defaults to true.
 	 */
 	readonly agents_allowed?: boolean;
+	/**
+	 * AllowWorkspaceRenames permits users to rename workspaces built from this
+	 * template. Renaming can be destructive for templates whose Terraform
+	 * references the workspace name, so this defaults to false.
+	 */
+	readonly allow_workspace_renames?: boolean;
 }
 
 // From codersdk/templateversions.go
@@ -4325,9 +4332,12 @@ export interface CreateUserRequestWithOrgs {
 // From codersdk/usersecrets.go
 /**
  * CreateUserSecretRequest is the payload for creating a new user
- * secret. Name and Value are required. An enabled secret requires an
- * effective target; deployment policy may reject FilePath and require EnvName.
- * Enabled defaults to true.
+ * secret. Name and Value are required. An enabled secret must have at
+ * least one of EnvName or FilePath non-empty so it has an injection
+ * target; to keep a secret without injecting it, set Enabled to false.
+ * A deployment may disable file path delivery, which rejects a
+ * non-empty FilePath. All other fields are optional and default to
+ * empty string. Enabled defaults to true when omitted.
  */
 export interface CreateUserSecretRequest {
 	readonly name: string;
@@ -4712,7 +4722,7 @@ export const DefaultChatDebugRetentionDays = 30;
 // From codersdk/chats.go
 /**
  * DefaultChatWorkspaceTTL is the default TTL for chat workspaces.
- * Zero means disabled — the template's own autostop setting applies.
+ * Zero means disabled; the template's own autostop setting applies.
  */
 export const DefaultChatWorkspaceTTL = 0;
 
@@ -4828,11 +4838,15 @@ export interface DeploymentValues {
 	readonly disable_owner_workspace_exec?: boolean;
 	readonly disable_workspace_sharing?: boolean;
 	readonly disable_chat_sharing?: boolean;
+	readonly disable_workspace_agent_context_sync?: boolean;
 	readonly disable_user_secret_file_path?: boolean;
 	readonly proxy_health_status_interval?: number;
 	readonly enable_terraform_debug_mode?: boolean;
 	readonly user_quiet_hours_schedule?: UserQuietHoursScheduleConfig;
 	readonly web_terminal_renderer?: string;
+	/**
+	 * @deprecated Use the per-template allow_workspace_renames setting instead.
+	 */
 	readonly allow_workspace_renames?: boolean;
 	readonly healthcheck?: HealthcheckConfig;
 	readonly retention?: RetentionConfig;
@@ -4843,6 +4857,7 @@ export interface DeploymentValues {
 	readonly workspace_hostname_suffix?: string;
 	readonly workspace_prebuilds?: PrebuildsConfig;
 	readonly enable_ai_tasks?: boolean;
+	readonly mcp_allowed_private_cidrs?: string;
 	readonly ai?: AIConfig;
 	readonly stats_collection?: StatsCollectionConfig;
 	readonly template_builder?: TemplateBuilderConfig;
@@ -5533,9 +5548,16 @@ export interface GroupMemberAISpend {
 	 */
 	readonly effective_group_id: string | null;
 	/**
+	 * EffectiveBudget is the spend limit that currently applies to the user.
+	 * Null when no budget applies or the effective group belongs to a different
+	 * organization than the queried group.
+	 */
+	readonly effective_budget: AIBudgetLimit | null;
+	/**
 	 * GroupBudget is the budget when the queried group is this user's
-	 * effective budget source. Null when the user's budget resolves to another
-	 * group or no budget applies to the user.
+	 * effective budget source. When populated, it matches EffectiveBudget. Null
+	 * when the user's budget resolves to another group or no budget applies.
+	 * @deprecated Use EffectiveBudget instead.
 	 */
 	readonly group_budget: AIBudgetLimit | null;
 	/**
@@ -6306,12 +6328,6 @@ export interface NetcheckReport {
 	 * STUN server you're talking to (on IPv4).
 	 */
 	readonly MappingVariesByDestIP: boolean | null;
-	/**
-	 * HairPinning is whether the router supports communicating
-	 * between two local devices through the NATted public IP address
-	 * (on IPv4).
-	 */
-	readonly HairPinning: boolean | null;
 	/**
 	 * UPnP is whether UPnP appears present on the LAN.
 	 * Empty means not checked.
@@ -8312,6 +8328,9 @@ export interface Role {
 // From codersdk/rbacroles.go
 /**
  * Ideally these roles would be generated from the rbac/roles.go package.
+ * @deprecated the agents-access role was removed. Coder Agents chat
+ * access is part of the organization-member permission floor, and
+ * servers without this built-in role reject assigning it.
  */
 export const RoleAgentsAccess = "agents-access";
 
@@ -9144,6 +9163,12 @@ export interface Template {
 	 * provisioning.
 	 */
 	readonly disable_module_cache: boolean;
+	/**
+	 * AllowWorkspaceRenames permits users to rename workspaces built from this
+	 * template. Renaming can be destructive for templates whose Terraform
+	 * references the workspace name.
+	 */
+	readonly allow_workspace_renames: boolean;
 }
 
 // From codersdk/templates.go
@@ -9905,7 +9930,7 @@ export interface UpdateChatSystemPromptRequest {
 export interface UpdateChatWorkspaceTTLRequest {
 	/**
 	 * WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	 * Zero means disabled — the template's own autostop setting applies.
+	 * Zero means disabled; the template's own autostop setting applies.
 	 */
 	readonly workspace_ttl_ms: number;
 }
@@ -10133,6 +10158,12 @@ export interface UpdateTemplateMeta {
 	 * this template. If omitted, the current value is preserved.
 	 */
 	readonly agents_allowed?: boolean;
+	/**
+	 * AllowWorkspaceRenames permits users to rename workspaces built from this
+	 * template. Renaming can be destructive for templates whose Terraform
+	 * references the workspace name.
+	 */
+	readonly allow_workspace_renames?: boolean;
 }
 
 // From codersdk/users.go
@@ -10246,8 +10277,12 @@ export interface UpdateUserQuietHoursScheduleRequest {
 /**
  * UpdateUserSecretRequest is the payload for partially updating a
  * user secret. At least one field must be non-nil. Pointer fields
- * distinguish "not sent" from "set empty". An enabled post-update row
- * requires an effective target; deployment policy may require EnvName.
+ * distinguish "not sent" (nil) from "set to empty string" (pointer
+ * to empty string). If the post-update row is enabled it must still
+ * have at least one of EnvName or FilePath non-empty; clearing both
+ * targets is only allowed when the secret is (or becomes) disabled.
+ * When a deployment disables file path delivery, an enabled row also
+ * requires EnvName.
  */
 export interface UpdateUserSecretRequest {
 	readonly value?: string;
@@ -10752,7 +10787,10 @@ export interface UserSecret {
 	readonly env_name: string;
 	readonly file_path: string;
 	/**
-	 * Enabled is stored intent. Deployment policy may block a stored target.
+	 * Enabled controls whether the secret is injected into workspaces.
+	 * Disabled secrets remain visible and editable, but are not added
+	 * to the agent manifest, so they are not exposed as environment
+	 * variables or written to secret files.
 	 */
 	readonly enabled: boolean;
 	readonly created_at: string;
@@ -10958,6 +10996,11 @@ export interface Workspace {
 	 */
 	readonly health: WorkspaceHealth;
 	readonly automatic_updates: AutomaticUpdates;
+	/**
+	 * AllowRenames is the effective rename permission for this workspace,
+	 * derived from the template's allow_workspace_renames setting and the
+	 * deprecated deployment-wide flag.
+	 */
 	readonly allow_renames: boolean;
 	readonly favorite: boolean;
 	readonly next_start_at: string | null;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2,7 +2,7 @@
 
 // From codersdk/templates.go
 /**
- * ACLAvailable is a list of users and groups that can be added to a resource
+ * ACLAvailable is a list of users and groups that can be added to a template
  * ACL.
  */
 export interface ACLAvailable {
@@ -2575,7 +2575,7 @@ export interface ChatGitChange {
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/v2/chats/{id}/stream/git when the chat cannot be
+ * /api/experimental/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2591,7 +2591,7 @@ export const ChatGitWatchAgentStatePrefix = "Agent state is ";
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/v2/chats/{id}/stream/git when the chat cannot be
+ * /api/experimental/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2604,7 +2604,7 @@ export const ChatGitWatchNoEligibleAgentMessage =
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/v2/chats/{id}/stream/git when the chat cannot be
+ * /api/experimental/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2616,7 +2616,7 @@ export const ChatGitWatchNoWorkspaceMessage = "Chat has no workspace to watch.";
 /**
  * Chat git watch error messages. These are the user-visible messages
  * the server returns in 400 responses from
- * /api/v2/chats/{id}/stream/git when the chat cannot be
+ * /api/experimental/chats/{id}/stream/git when the chat cannot be
  * observed through a workspace agent. They are exported so the CLI
  * (and any future consumer) can match them structurally via
  * IsChatGitWatchFallbackMessage instead of coupling to exact wording.
@@ -2855,12 +2855,11 @@ export interface ChatModel {
 // From codersdk/chats.go
 /**
  * ChatModelACL is the access control list for an organization-scoped chat
- * model. Each principal includes the identity details needed to display and
- * manage the ACL without separate directory lookups.
+ * model. Each principal is mapped to its effective model role.
  */
 export interface ChatModelACL {
-	readonly users: readonly ChatUser[];
-	readonly groups: readonly ChatGroup[];
+	readonly user_roles: Record<string, ChatRole>;
+	readonly group_roles: Record<string, ChatRole>;
 }
 
 // From codersdk/chats.go
@@ -3051,8 +3050,8 @@ export interface ChatModelOverridesResponse {
  * ChatModelProviderDescriptor is the redacted view of an AI provider carried
  * on the org model collection response. It carries only the capability
  * metadata the Models UI needs; key material, base URLs, and headers are
- * never exposed. The fields mirror the provider descriptors returned by the
- * organization-scoped chat models collection.
+ * never exposed. The fields mirror what /api/experimental/chats/models
+ * already discloses to any authenticated caller.
  */
 export interface ChatModelProviderDescriptor {
 	readonly id: string;
@@ -3248,7 +3247,7 @@ export const ChatPlanModes: ChatPlanMode[] = ["plan"];
 // From codersdk/chats.go
 /**
  * ChatPrompt is a single user-authored prompt in a chat, returned by
- * GET /api/v2/chats/{chat}/prompts. The text field contains
+ * GET /api/experimental/chats/{chat}/prompts. The text field contains
  * the concatenated text payload of the underlying chat message; non-text
  * parts (tool calls, files, attachments) are omitted by the server.
  */
@@ -3273,7 +3272,7 @@ export interface ChatPromptsOptions {
 // From codersdk/chats.go
 /**
  * ChatPromptsResponse is the payload of
- * GET /api/v2/chats/{chat}/prompts. Prompts are returned
+ * GET /api/experimental/chats/{chat}/prompts. Prompts are returned
  * newest first so the client can index directly into the slice for
  * up/down arrow history cycling.
  */
@@ -3658,7 +3657,7 @@ export const ChatWatchEventKinds: ChatWatchEventKind[] = [
 export interface ChatWorkspaceTTLResponse {
 	/**
 	 * WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	 * Zero means disabled; the template's own autostop setting applies.
+	 * Zero means disabled — the template's own autostop setting applies.
 	 */
 	readonly workspace_ttl_ms: number;
 }
@@ -4199,12 +4198,6 @@ export interface CreateTemplateRequest {
 	 * this template. Defaults to true.
 	 */
 	readonly agents_allowed?: boolean;
-	/**
-	 * AllowWorkspaceRenames permits users to rename workspaces built from this
-	 * template. Renaming can be destructive for templates whose Terraform
-	 * references the workspace name, so this defaults to false.
-	 */
-	readonly allow_workspace_renames?: boolean;
 }
 
 // From codersdk/templateversions.go
@@ -4332,11 +4325,9 @@ export interface CreateUserRequestWithOrgs {
 // From codersdk/usersecrets.go
 /**
  * CreateUserSecretRequest is the payload for creating a new user
- * secret. Name and Value are required. An enabled secret must have at
- * least one of EnvName or FilePath non-empty so it has an injection
- * target; to keep a secret without injecting it, set Enabled to false.
- * All other fields are optional and default to empty string. Enabled
- * defaults to true when omitted.
+ * secret. Name and Value are required. An enabled secret requires an
+ * effective target; deployment policy may reject FilePath and require EnvName.
+ * Enabled defaults to true.
  */
 export interface CreateUserSecretRequest {
 	readonly name: string;
@@ -4721,7 +4712,7 @@ export const DefaultChatDebugRetentionDays = 30;
 // From codersdk/chats.go
 /**
  * DefaultChatWorkspaceTTL is the default TTL for chat workspaces.
- * Zero means disabled; the template's own autostop setting applies.
+ * Zero means disabled — the template's own autostop setting applies.
  */
 export const DefaultChatWorkspaceTTL = 0;
 
@@ -4837,14 +4828,11 @@ export interface DeploymentValues {
 	readonly disable_owner_workspace_exec?: boolean;
 	readonly disable_workspace_sharing?: boolean;
 	readonly disable_chat_sharing?: boolean;
-	readonly disable_workspace_agent_context_sync?: boolean;
+	readonly disable_user_secret_file_path?: boolean;
 	readonly proxy_health_status_interval?: number;
 	readonly enable_terraform_debug_mode?: boolean;
 	readonly user_quiet_hours_schedule?: UserQuietHoursScheduleConfig;
 	readonly web_terminal_renderer?: string;
-	/**
-	 * @deprecated Use the per-template allow_workspace_renames setting instead.
-	 */
 	readonly allow_workspace_renames?: boolean;
 	readonly healthcheck?: HealthcheckConfig;
 	readonly retention?: RetentionConfig;
@@ -4855,7 +4843,6 @@ export interface DeploymentValues {
 	readonly workspace_hostname_suffix?: string;
 	readonly workspace_prebuilds?: PrebuildsConfig;
 	readonly enable_ai_tasks?: boolean;
-	readonly mcp_allowed_private_cidrs?: string;
 	readonly ai?: AIConfig;
 	readonly stats_collection?: StatsCollectionConfig;
 	readonly template_builder?: TemplateBuilderConfig;
@@ -5546,16 +5533,9 @@ export interface GroupMemberAISpend {
 	 */
 	readonly effective_group_id: string | null;
 	/**
-	 * EffectiveBudget is the spend limit that currently applies to the user.
-	 * Null when no budget applies or the effective group belongs to a different
-	 * organization than the queried group.
-	 */
-	readonly effective_budget: AIBudgetLimit | null;
-	/**
 	 * GroupBudget is the budget when the queried group is this user's
-	 * effective budget source. When populated, it matches EffectiveBudget. Null
-	 * when the user's budget resolves to another group or no budget applies.
-	 * @deprecated Use EffectiveBudget instead.
+	 * effective budget source. Null when the user's budget resolves to another
+	 * group or no budget applies to the user.
 	 */
 	readonly group_budget: AIBudgetLimit | null;
 	/**
@@ -6326,6 +6306,12 @@ export interface NetcheckReport {
 	 * STUN server you're talking to (on IPv4).
 	 */
 	readonly MappingVariesByDestIP: boolean | null;
+	/**
+	 * HairPinning is whether the router supports communicating
+	 * between two local devices through the NATted public IP address
+	 * (on IPv4).
+	 */
+	readonly HairPinning: boolean | null;
 	/**
 	 * UPnP is whether UPnP appears present on the LAN.
 	 * Empty means not checked.
@@ -8326,9 +8312,6 @@ export interface Role {
 // From codersdk/rbacroles.go
 /**
  * Ideally these roles would be generated from the rbac/roles.go package.
- * @deprecated the agents-access role was removed. Coder Agents chat
- * access is part of the organization-member permission floor, and
- * servers without this built-in role reject assigning it.
  */
 export const RoleAgentsAccess = "agents-access";
 
@@ -9161,12 +9144,6 @@ export interface Template {
 	 * provisioning.
 	 */
 	readonly disable_module_cache: boolean;
-	/**
-	 * AllowWorkspaceRenames permits users to rename workspaces built from this
-	 * template. Renaming can be destructive for templates whose Terraform
-	 * references the workspace name.
-	 */
-	readonly allow_workspace_renames: boolean;
 }
 
 // From codersdk/templates.go
@@ -9928,7 +9905,7 @@ export interface UpdateChatSystemPromptRequest {
 export interface UpdateChatWorkspaceTTLRequest {
 	/**
 	 * WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	 * Zero means disabled; the template's own autostop setting applies.
+	 * Zero means disabled — the template's own autostop setting applies.
 	 */
 	readonly workspace_ttl_ms: number;
 }
@@ -10156,12 +10133,6 @@ export interface UpdateTemplateMeta {
 	 * this template. If omitted, the current value is preserved.
 	 */
 	readonly agents_allowed?: boolean;
-	/**
-	 * AllowWorkspaceRenames permits users to rename workspaces built from this
-	 * template. Renaming can be destructive for templates whose Terraform
-	 * references the workspace name.
-	 */
-	readonly allow_workspace_renames?: boolean;
 }
 
 // From codersdk/users.go
@@ -10275,10 +10246,8 @@ export interface UpdateUserQuietHoursScheduleRequest {
 /**
  * UpdateUserSecretRequest is the payload for partially updating a
  * user secret. At least one field must be non-nil. Pointer fields
- * distinguish "not sent" (nil) from "set to empty string" (pointer
- * to empty string). If the post-update row is enabled it must still
- * have at least one of EnvName or FilePath non-empty; clearing both
- * targets is only allowed when the secret is (or becomes) disabled.
+ * distinguish "not sent" from "set empty". An enabled post-update row
+ * requires an effective target; deployment policy may require EnvName.
  */
 export interface UpdateUserSecretRequest {
 	readonly value?: string;
@@ -10783,10 +10752,7 @@ export interface UserSecret {
 	readonly env_name: string;
 	readonly file_path: string;
 	/**
-	 * Enabled controls whether the secret is injected into workspaces.
-	 * Disabled secrets remain visible and editable, but are not added
-	 * to the agent manifest, so they are not exposed as environment
-	 * variables or written to secret files.
+	 * Enabled is stored intent. Deployment policy may block a stored target.
 	 */
 	readonly enabled: boolean;
 	readonly created_at: string;
@@ -10992,11 +10958,6 @@ export interface Workspace {
 	 */
 	readonly health: WorkspaceHealth;
 	readonly automatic_updates: AutomaticUpdates;
-	/**
-	 * AllowRenames is the effective rename permission for this workspace,
-	 * derived from the template's allow_workspace_renames setting and the
-	 * deprecated deployment-wide flag.
-	 */
 	readonly allow_renames: boolean;
 	readonly favorite: boolean;
 	readonly next_start_at: string | null;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -10839,6 +10839,20 @@ export const UserSecretNameField = "name";
  */
 export const UserSecretValueField = "value";
 
+// From codersdk/usersecrets.go
+/**
+ * UserSecretsCapabilities reports which user secret delivery targets the
+ * deployment allows. Any authenticated user can read it, unlike the full
+ * deployment configuration.
+ */
+export interface UserSecretsCapabilities {
+	/**
+	 * FilePathDeliveryEnabled reports whether Coder writes stored file paths
+	 * into workspaces. Stored paths are preserved either way.
+	 */
+	readonly file_path_delivery_enabled: boolean;
+}
+
 // From codersdk/userskills.go
 /**
  * UserSkill represents a user skill with its raw Markdown content.


### PR DESCRIPTION
Adds the deployment option `--user-secrets-disable-file-path` / `CODER_USER_SECRETS_DISABLE_FILE_PATH` / `userSecretsDisableFilePath` (default `false`). When it is set, the create and batch-create user-secret endpoints reject requests with a non-empty file path, and PATCH validates the post-update state under a `SELECT ... FOR UPDATE` row lock, rejecting a new or changed file path as well as enabled states that would have no effective delivery target. Legacy stored paths are preserved, so users can still edit, disable, clear the path, or migrate the secret to env delivery.

This is PR 1 of a 4-PR stack; follow-ups cover manifest filtering, the dashboard, and CLI/docs.

Refs #27488

Reviewed and updated by Coder Agents on behalf of @dylanhuff-at-coder.
