### PR TITLE
fix(site/src/pages/AgentsPage/components/DiffViewer): keep last file's horizontal scrollbar reachable

### DIFF
--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -70,6 +70,15 @@ const diffViewerStyle = {
 	"--diffs-header-font-family": '"Geist Variable", system-ui, sans-serif',
 	"--diffs-font-size": "11px",
 	"--diffs-line-height": `${DIFF_VIEWER_LINE_HEIGHT}px`,
+	// Each file's code area is its own horizontal scroller. The library sizes
+	// that scroller's bottom strip from this gutter: it styles
+	// ::-webkit-scrollbar to it and subtracts it from the code area's bottom
+	// padding, so the strip stays at the 8px the virtualizer assumes per file.
+	// Left unset the library measures the platform scrollbar (15px in Chrome
+	// with classic scrollbars), every file renders 7px taller than estimated,
+	// and the accumulated drift cuts the scroll range short of the last file's
+	// scrollbar. Pinning the gutter keeps rendered and estimated heights equal.
+	"--diffs-scrollbar-gutter-override": "6px",
 } satisfies CSSProperties;
 
 const diffViewerMetrics: Partial<VirtualFileMetrics> = {
@@ -187,6 +196,25 @@ const fileTreeUnsafeCSS = [
 	"  scrollbar-width: thin;",
 	"}",
 ].join(" ");
+
+// Coder's global stylesheet sets `scrollbar-color`, which Chrome inherits into
+// the diff's shadow trees. A non-auto `scrollbar-color` makes Chrome ignore the
+// library's `::-webkit-scrollbar { height: var(--diffs-scrollbar-gutter) }`
+// rule, so each file's horizontal scroller falls back to the 15px platform
+// scrollbar instead of the 6px gutter the layout is built around. Resetting the
+// property on the code area restores the library's slim scrollbar so the
+// rendered file height matches the height the virtualizer estimates. The
+// feature query keeps the reset on engines that style scrollbars through
+// ::-webkit-scrollbar, leaving Firefox on the library's own scrollbar-color.
+const codeScrollbarUnsafeCSS = [
+	"@supports selector(::-webkit-scrollbar) {",
+	"  [data-code] {",
+	"    scrollbar-color: auto;",
+	"  }",
+	"}",
+].join(" ");
+
+const diffViewerUnsafeCSS = `${SEPARATOR_CSS} ${codeScrollbarUnsafeCSS}`;
 
 function gitStatusForFile(
 	fileDiff: FileDiffMetadata,
@@ -453,7 +481,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 		layout: { paddingTop: 0, paddingBottom: 0, gap: 0 },
 		hunkSeparators: "line-info",
 		itemMetrics: diffViewerMetrics,
-		unsafeCSS: SEPARATOR_CSS,
+		unsafeCSS: diffViewerUnsafeCSS,
 		themeType: isDark ? "dark" : "light",
 		theme: isDark ? "github-dark-high-contrast" : "github-light",
 		enableLineSelection: true,

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -60,6 +60,11 @@ const DIFF_VIEWER_LINE_HEIGHT = 16.5;
 const DIFF_HEADER_HEIGHT = 32;
 const HUNK_SEPARATOR_HEIGHT = 28;
 
+// Height (px) of each file's horizontal scrollbar track. Large enough to be a
+// comfortable grab target; the virtualizer's per-file bottom padding is kept
+// equal to it below so rendered and estimated file heights stay identical.
+const DIFF_SCROLLBAR_GUTTER = 10;
+
 // Minimum width (px) of the diff container at which the file tree sidebar is
 // shown alongside the diff. Below this the diff takes the full width unless the
 // viewer is explicitly expanded.
@@ -72,19 +77,24 @@ const diffViewerStyle = {
 	"--diffs-line-height": `${DIFF_VIEWER_LINE_HEIGHT}px`,
 	// Each file's code area is its own horizontal scroller. The library sizes
 	// that scroller's bottom strip from this gutter: it styles
-	// ::-webkit-scrollbar to it and subtracts it from the code area's bottom
-	// padding, so the strip stays at the 8px the virtualizer assumes per file.
-	// Left unset the library measures the platform scrollbar (15px in Chrome
-	// with classic scrollbars), every file renders 7px taller than estimated,
-	// and the accumulated drift cuts the scroll range short of the last file's
-	// scrollbar. Pinning the gutter keeps rendered and estimated heights equal.
-	"--diffs-scrollbar-gutter-override": "6px",
+	// ::-webkit-scrollbar to it and subtracts it from the code area's 8px
+	// block gap. Left unset the library measures the platform scrollbar (15px
+	// in Chrome with classic scrollbars) while the virtualizer budgets 8px,
+	// so every file renders 7px taller than estimated and the accumulated
+	// drift cuts the scroll range short of the last file's scrollbar. Pinning
+	// the gutter and mirroring it in the metrics below keeps rendered and
+	// estimated heights equal.
+	"--diffs-scrollbar-gutter-override": `${DIFF_SCROLLBAR_GUTTER}px`,
 } satisfies CSSProperties;
 
 const diffViewerMetrics: Partial<VirtualFileMetrics> = {
 	diffHeaderHeight: DIFF_HEADER_HEIGHT,
 	hunkSeparatorHeight: HUNK_SEPARATOR_HEIGHT,
 	lineHeight: DIFF_VIEWER_LINE_HEIGHT,
+	// The gutter exceeds the library's 8px block gap, so the rendered bottom
+	// strip is exactly the scrollbar (the gap-minus-gutter padding clamps to
+	// 0). The estimate must budget the same amount.
+	paddingBottom: DIFF_SCROLLBAR_GUTTER,
 };
 
 const fileTreeStyle = {
@@ -211,6 +221,18 @@ const codeScrollbarUnsafeCSS = [
 	"  [data-code] {",
 	"    scrollbar-color: auto;",
 	"  }",
+	"}",
+	// The library keeps the thumb transparent until the file is hovered and
+	// then paints it in a near-background color, which reads as broken next
+	// to the app's scrollbars. Match the app-wide thumb color instead, with
+	// a brighter hover state, and clear the 1px inset border so the full
+	// track height stays grabbable.
+	"[data-code]::-webkit-scrollbar-thumb {",
+	"  background-color: hsl(var(--surface-quaternary)) !important;",
+	"  border: 0 !important;",
+	"}",
+	"[data-code]::-webkit-scrollbar-thumb:hover {",
+	"  background-color: hsl(var(--content-secondary)) !important;",
 	"}",
 ].join(" ");
 


### PR DESCRIPTION
## Problem

In the Agents page git panel, with a long list of file diffs, the scroll range ends a few dozen pixels short of the bottom: the last file's horizontal scrollbar (and its bottom edge) is unreachable. The scrollbar that was reachable was also a poor grab target with a thumb that only appeared on hover, in a near-background color.

## Root cause

Our global scrollbar baseline in `site/src/index.css` (`:root { scrollbar-color: ... }`) is inherited, so it cascades into `@pierre/diffs`' shadow trees. When `scrollbar-color` is non-`auto`, Chrome ignores `::-webkit-scrollbar` rules for that scroller, so each file's horizontal code scroller (`[data-code]`) gets the 15px platform scrollbar instead of the library's styled one. The library's gutter probe measures the same 15px, driving `[data-code]`'s compensating bottom padding to 0.

The `CodeView` virtualizer sizes the scroll area from estimated per-file heights that budget 8px for the bottom strip, but each file actually renders a 15px strip: +7px drift per file, accumulating down the list until the bottom of the last file falls outside the scrollable range.

Measured with a Playwright harness (18 files, 520px panel): `assumed 334.5 / actual 341.5 / drift +7.0` per file; at max scroll the last file's bottom sat 21px below the viewport, hiding the entire scrollbar.

## Fix

In `DiffViewer.tsx` only:

- Reset `scrollbar-color: auto` on `[data-code]` via `unsafeCSS`, gated by `@supports selector(::-webkit-scrollbar)` so Chrome/Safari honor the library's `::-webkit-scrollbar` styling again while Firefox (where that query is false per css-conditional-4) keeps the library's own `scrollbar-color`.
- Pin `--diffs-scrollbar-gutter-override` to a 10px track (comfortable grab target) and mirror it in `itemMetrics.paddingBottom` so the virtualizer budgets exactly the rendered bottom strip. The pin also matters because the library caches its measured gutter once per page, so another diff surface without the reset could poison the shared measurement.
- Style the thumb in the app-wide scrollbar color (`--surface-quaternary`), always visible, with a `--content-secondary` hover state that differs from the base color in both themes.

Verified with the harness after the change, unified and split, normal and expanded panel: per-file drift 0.00, cumulative 0, last file's `[data-code]` bottom exactly flush with the scroller viewport at max scroll, thumb painted without hover in both themes. Header (32px), separator (28px), and 16.5px line heights were verified exact; the scrollbar strip was the only drift source.

FE1 note: no story change; the fix is shadow-DOM scrollbar geometry, which existing DiffViewer/GitPanel stories render and FE10 forbids asserting on directly.

Known limitation (pre-existing, untouched): Firefox uses the library's `scrollbar-width: thin` branch, which does not subtract the scrollbar from the padding, so a smaller drift can still occur there; that is upstream `@pierre/diffs` behavior.

---

🤖 This PR was generated by Coder Agents on behalf of @tracyjohnsonux.
