### PR TITLE
revert(site): remove built-in emoji avatar inset

### DIFF
--- a/site/src/components/Avatar/Avatar.stories.tsx
+++ b/site/src/components/Avatar/Avatar.stories.tsx
@@ -53,26 +53,6 @@ export const NonSquaredIcon: Story = {
 	},
 };
 
-export const BuiltInEmojiLgSize: Story = {
-	args: {
-		size: "lg",
-		src: "/emojis/1f64c.png",
-	},
-};
-
-export const BuiltInEmojiMdSize: Story = {
-	args: {
-		src: "/emojis/1f64c.png",
-	},
-};
-
-export const BuiltInEmojiSmSize: Story = {
-	args: {
-		size: "sm",
-		src: "/emojis/1f64c.png",
-	},
-};
-
 export const FallbackLgSize: Story = {
 	args: {
 		src: "",

--- a/site/src/components/Avatar/Avatar.tsx
+++ b/site/src/components/Avatar/Avatar.tsx
@@ -73,26 +73,13 @@ export const Avatar: React.FC<AvatarProps> = ({
 	fallback,
 	alt = "",
 	children,
-	style,
 	...props
 }) => {
 	const { externalImages } = useAppearance();
 
-	const isEmoji = src?.startsWith("/emojis/");
-
 	return (
 		<AvatarPrimitive.Root
-			className={cn(
-				avatarVariants({
-					size,
-					variant: isEmoji ? "default" : variant,
-					className,
-				}),
-			)}
-			style={{
-				...style,
-				padding: isEmoji ? "20%" : style?.padding,
-			}}
+			className={cn(avatarVariants({ size, variant, className }))}
 			{...props}
 		>
 			<AvatarPrimitive.Image


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Reverts `75400428ad2b84c707f60fc5e6b378f46f565ef9` (`fix(site/src): give built-in emoji avatars a consistent inset`).

The global built-in emoji detection and inline padding are causing regressions. Revert this behavior so a replacement can be developed separately.

## Changes

- Remove automatic `/emojis/` source detection from `Avatar`.
- Restore caller-controlled avatar variants and styles.
- Remove the built-in emoji inset stories.

## Verification

- Confirmed the resulting patch is the inverse of the target commit.