### PR TITLE
fix: isolate external auth test ports

### DIFF
--- a/scripts/remote_playwright.sh
+++ b/scripts/remote_playwright.sh
@@ -87,7 +87,7 @@ main() {
 	)
 
 	# Also forward prometheus, pprof, and gitauth ports.
-	for p in 2114 6061 50515 50516; do
+	for p in 2114 6061 29515 29516; do
 		port_args+=(-L "${p}:127.0.0.1:${p}")
 	done
 

--- a/scripts/remote_playwright.sh
+++ b/scripts/remote_playwright.sh
@@ -103,7 +103,13 @@ main() {
 	echo
 	echo "Starting SSH tunnel, run test via \"pnpm run playwright:test\"..."
 	# shellcheck disable=SC2029 # This is intended to expand client-side.
-	ssh -t "${port_args[@]}" coder."${workspace}" "export CODER_E2E_PORT='${port}'; export CODER_E2E_WS_ENDPOINT='${ws_endpoint}'; export CODER_E2E_GITAUTH_DEVICE_PORT='${gitauth_device_port}'; export CODER_E2E_GITAUTH_WEB_PORT='${gitauth_web_port}'; [[ -d '${coder_repo}/site' ]] && cd '${coder_repo}/site'; exec \"\$(grep \"\${USER}\": /etc/passwd | cut -d: -f7)\" -i -l"
+	ssh -t "${port_args[@]}" coder."${workspace}" \
+		"export CODER_E2E_PORT='${port}';" \
+		"export CODER_E2E_WS_ENDPOINT='${ws_endpoint}';" \
+		"export CODER_E2E_GITAUTH_DEVICE_PORT='${gitauth_device_port}';" \
+		"export CODER_E2E_GITAUTH_WEB_PORT='${gitauth_web_port}';" \
+		"[[ -d '${coder_repo}/site' ]] && cd '${coder_repo}/site';" \
+		"exec \"\$(grep \"\${USER}\": /etc/passwd | cut -d: -f7)\" -i -l"
 }
 
 main

--- a/scripts/remote_playwright.sh
+++ b/scripts/remote_playwright.sh
@@ -4,11 +4,20 @@ set -euo pipefail
 workspace=${1:-}
 coder_repo=${2:-.}
 port=${3:-3111}
+gitauth_device_port=${CODER_E2E_GITAUTH_DEVICE_PORT:-29515}
+gitauth_web_port=${CODER_E2E_GITAUTH_WEB_PORT:-29516}
 
 if [[ -z "${workspace}" ]]; then
 	echo "Usage: $0 <workspace> [workspace coder/coder dir] [e2e port]"
 	exit 1
 fi
+
+for p in "${gitauth_device_port}" "${gitauth_web_port}"; do
+	if [[ ! ${p} =~ ^[0-9]+$ ]] || ((p < 1 || p > 65535)); then
+		echo "Git auth ports must be integers between 1 and 65535: ${p}"
+		exit 1
+	fi
+done
 
 main() {
 	# Check the Playwright version from the workspace so we have a 1-to-1 match
@@ -87,14 +96,14 @@ main() {
 	)
 
 	# Also forward prometheus, pprof, and gitauth ports.
-	for p in 2114 6061 29515 29516; do
+	for p in 2114 6061 "${gitauth_device_port}" "${gitauth_web_port}"; do
 		port_args+=(-L "${p}:127.0.0.1:${p}")
 	done
 
 	echo
 	echo "Starting SSH tunnel, run test via \"pnpm run playwright:test\"..."
 	# shellcheck disable=SC2029 # This is intended to expand client-side.
-	ssh -t "${port_args[@]}" coder."${workspace}" "export CODER_E2E_PORT='${port}'; export CODER_E2E_WS_ENDPOINT='${ws_endpoint}'; [[ -d '${coder_repo}/site' ]] && cd '${coder_repo}/site'; exec \"\$(grep \"\${USER}\": /etc/passwd | cut -d: -f7)\" -i -l"
+	ssh -t "${port_args[@]}" coder."${workspace}" "export CODER_E2E_PORT='${port}'; export CODER_E2E_WS_ENDPOINT='${ws_endpoint}'; export CODER_E2E_GITAUTH_DEVICE_PORT='${gitauth_device_port}'; export CODER_E2E_GITAUTH_WEB_PORT='${gitauth_web_port}'; [[ -d '${coder_repo}/site' ]] && cd '${coder_repo}/site'; exec \"\$(grep \"\${USER}\": /etc/passwd | cut -d: -f7)\" -i -l"
 }
 
 main

--- a/site/e2e/constants.ts
+++ b/site/e2e/constants.ts
@@ -66,11 +66,14 @@ export const users = {
 export const gitAuth = {
 	deviceProvider: "device",
 	webProvider: "web",
-	// These ports need to be hardcoded so that they can be
-	// used in `playwright.config.ts` to set the environment
-	// variables for the server.
-	devicePort: 50515,
-	webPort: 50516,
+	// Keep these below Linux's default ephemeral port range. Otherwise, an
+	// outbound connection can claim one and prevent the mock server from binding.
+	devicePort: process.env.CODER_E2E_GITAUTH_DEVICE_PORT
+		? Number(process.env.CODER_E2E_GITAUTH_DEVICE_PORT)
+		: 29515,
+	webPort: process.env.CODER_E2E_GITAUTH_WEB_PORT
+		? Number(process.env.CODER_E2E_GITAUTH_WEB_PORT)
+		: 29516,
 
 	authPath: "/auth",
 	tokenPath: "/token",

--- a/site/e2e/constants.ts
+++ b/site/e2e/constants.ts
@@ -2,6 +2,19 @@ import * as path from "node:path";
 
 export const coderBinary = path.join(__dirname, "./bin/coder");
 
+const portFromEnv = (name: string, defaultPort: number): number => {
+	const value = process.env[name];
+	if (value === undefined) {
+		return defaultPort;
+	}
+
+	const port = Number(value);
+	if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+		throw new Error(`${name} must be an integer between 1 and 65535: ${value}`);
+	}
+	return port;
+};
+
 // The oldest client and agent versions that Coder still supports. The
 // compatibility tests download these release binaries and run them against the
 // current server. Changing either value changes which release asset the e2e
@@ -68,12 +81,8 @@ export const gitAuth = {
 	webProvider: "web",
 	// Keep these below Linux's default ephemeral port range. Otherwise, an
 	// outbound connection can claim one and prevent the mock server from binding.
-	devicePort: process.env.CODER_E2E_GITAUTH_DEVICE_PORT
-		? Number(process.env.CODER_E2E_GITAUTH_DEVICE_PORT)
-		: 29515,
-	webPort: process.env.CODER_E2E_GITAUTH_WEB_PORT
-		? Number(process.env.CODER_E2E_GITAUTH_WEB_PORT)
-		: 29516,
+	devicePort: portFromEnv("CODER_E2E_GITAUTH_DEVICE_PORT", 29515),
+	webPort: portFromEnv("CODER_E2E_GITAUTH_WEB_PORT", 29516),
 
 	authPath: "/auth",
 	tokenPath: "/token",

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -907,8 +907,7 @@ export const createServer = async (port: number): Promise<MockServer> => {
 
 	const app = express();
 	// We need to specify the local IP address as the web server
-	// tends to fail with IPv6 related error:
-	// listen EADDRINUSE: address already in use :::50516
+	// tends to fail with IPv6 related EADDRINUSE errors.
 	const server = await new Promise<Server>((resolve) => {
 		const s = app.listen(port, "0.0.0.0", () => resolve(s));
 	});
@@ -927,7 +926,7 @@ export const createServer = async (port: number): Promise<MockServer> => {
 async function waitForPort(
 	port: number,
 	host = "0.0.0.0",
-	timeout = 60_000,
+	timeout = 20_000,
 ): Promise<void> {
 	const start = Date.now();
 	while (Date.now() - start < timeout) {


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

The external auth mock ports were inside [Linux's default ephemeral port range](https://en.wikipedia.org/wiki/Ephemeral_port), so outbound connections from coderd, agents, the browser, or Node could claim them and prevent the test server from binding until the connection and its `TIME_WAIT` state expired.

Move the default mock ports below the ephemeral range, retain environment overrides for shared development hosts, and shorten the availability wait so any genuine collision reports its error before Playwright's 30-second hook timeout.

Refs https://linear.app/codercom/issue/DEVEX-413

<details>
<summary>Decision log</summary>

The previous teardown fix correctly closed listeners owned by the test suite, but the August 25, 2026 recurrence began with port 50516 already occupied before the suite's `beforeAll` hook ran. On Linux, ports 50515 and 50516 fall within the default ephemeral range of 32768 through 60999, allowing unrelated outbound connections to reserve them.

Using fixed ports below that range keeps coderd's startup configuration and the Playwright workers consistent without a free-port probe race. Environment overrides remain available for remote or shared development environments.

</details>

