### PR TITLE
test(coderd/x/chatd): avoid advancing unrelated retry timers

### DIFF
--- a/coderd/x/chatd/chatd_retry_test.go
+++ b/coderd/x/chatd/chatd_retry_test.go
@@ -29,6 +29,8 @@ func TestActiveServer_RetryStatePersistedDuringBackoff(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 	db, ps := dbtestutil.NewDB(t)
 	clock := quartz.NewMock(t).WithLogger(quartz.NoOpLogger)
+	retryTrap := clock.Trap().NewTimer("chatworker", "generation-retry")
+	defer retryTrap.Close()
 	sink := testutil.NewFakeSink(t)
 	var calls atomic.Int32
 	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
@@ -65,8 +67,10 @@ func TestActiveServer_RetryStatePersistedDuringBackoff(t *testing.T) {
 	require.Equal(t, 429, retryPayload.StatusCode)
 	require.False(t, retryPayload.RetryingAt.IsZero())
 
-	advanceToNextTimer(ctx, clock)
-	advanceUntilProviderCall(ctx, clock, &calls, 2)
+	retryTimer := retryTrap.MustWait(ctx)
+	retryTimer.MustRelease(ctx)
+	advanceMockClockBy(ctx, t, clock, retryTimer.Duration)
+	waitUntilProviderCall(ctx, t, &calls, 2)
 	waitForChatStatus(ctx, t, db, chat.ID, database.ChatStatusWaiting)
 	require.Equal(t, int32(2), calls.Load())
 	latest, err := db.GetChatByID(ctx, chat.ID)
@@ -276,17 +280,6 @@ func advanceMockClockBy(ctx context.Context, t *testing.T, clock *quartz.Mock, d
 		waiter.MustWait(ctx)
 		remaining -= next
 	}
-}
-
-func advanceUntilProviderCall(ctx context.Context, clock *quartz.Mock, calls *atomic.Int32, want int32) {
-	for calls.Load() < want {
-		advanceToNextTimer(ctx, clock)
-	}
-}
-
-func advanceToNextTimer(ctx context.Context, clock *quartz.Mock) {
-	_, waiter := clock.AdvanceNext()
-	waiter.MustWait(ctx)
 }
 
 func openAITextChunksWithStop(deltas ...string) []chattest.OpenAIChunk {


### PR DESCRIPTION
`TestActiveServer_RetryStatePersistedDuringBackoff` advanced whichever mock-clock timer was next while waiting for the retried provider call. If the provider goroutine had not incremented its call count yet, the test could advance the unrelated 15-minute task timeout and trigger an extra whole-task retry.

Trap and release only the named generation-retry timer, then wait for the provider call without advancing the clock again.

Refs https://linear.app/codercom/issue/CODAGT-967/flake-testactiveserver-retrystatepersistedduringbackoff

<sub>Generated by Coder Agents.</sub>
