### PR TITLE
docs: reference Coder Agents instead of Coder Tasks in style guide

### DIFF
--- a/docs/.style/style-guide/audience-and-scope.md
+++ b/docs/.style/style-guide/audience-and-scope.md
@@ -314,10 +314,10 @@ They value clear logs, traceable errors, and clean rollback paths over flashy fe
 #### Caitlin the Citizen Developer
 
 Caitlin is non-technical (customer success) but uses agentic AI tools to make small product changes without writing code.
-They need docs that explain Coder Tasks and the agent-driven flows in plain language, with no assumed dev-environment knowledge and no manual setup steps.
+They need docs that explain Coder Agents and the agent-driven flows in plain language, with no assumed dev-environment knowledge and no manual setup steps.
 They avoid anything that requires opening a terminal or editing a config file.
 
-*Coder surface:* Coder Tasks, AI Gateway, prompt-driven workflows, web-based interfaces.
+*Coder surface:* Coder Agents, AI Gateway, prompt-driven workflows, web-based interfaces.
 
 #### Felipe the FinOps
 


### PR DESCRIPTION
## Summary

Updates the Caitlin the Citizen Developer persona in the style guide to reference Coder Agents instead of the deprecated Coder Tasks product.

### Changes

* `docs/.style/style-guide/audience-and-scope.md`: replaced both "Coder Tasks" mentions with "Coder Agents" in the Caitlin persona description and Coder surface list.

<details><summary>Context</summary>

Coder Tasks is deprecated as of v2.34 and replaced by Coder Agents. This change keeps the internal style guide's persona reference aligned with current product naming.

</details>

---

This PR was drafted by a Coder Agent on behalf of Matt.