### PR TITLE
fix: revert "chore(.github/workflows): remove Pixel CI check (#28001)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1060,6 +1060,37 @@ jobs:
           path: ./site/test-results/**/debug-pprof-*.txt
           retention-days: 7
 
+  storybook:
+    name: Storybook
+
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-24.04-16' || 'ubuntu-latest' }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        name: Checkout
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        name: Install dependencies
+        with:
+          run_install: true
+          cache: true
+
+      - run: pnpm storybook:build
+        working-directory: site/
+        name: Build Storybook
+
+      - run: pnpm playwright:install
+        working-directory: site/
+        name: Install Chromium
+
+      - run: pnpm pixel-storybook
+        working-directory: site/
+        name: Snapshot
+        env:
+          PIXEL_KEY: ${{ secrets.PIXEL_KEY }}
+
   offlinedocs:
     name: offlinedocs
     needs: changes


### PR DESCRIPTION
This reverts commit 1e68cef90746cde7579a5d61feff1e498d4d09fb.

We suspect that the change [interferes](https://docs.github.com/en/rest/releases/releases?utm_source=chatgpt.com&apiVersion=2026-03-10#create-a-release) with Github guardrails for creating a release.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
