### PR TITLE
fix: reject invalid AI provider base URLs

### DIFF
--- a/coderd/aibridged/provider.go
+++ b/coderd/aibridged/provider.go
@@ -37,13 +37,8 @@ type ProviderOutcome struct {
 	Err    error
 }
 
-// BaseURLHostname returns the normalized hostname from a provider
-// base URL. It is the canonical normalization used by the proxy
-// classifier and the API status check. The base URL must be absolute
-// with an http or https scheme and a hostname; every other input,
-// including a scheme-less value such as "example.com/v1", returns an
-// empty string so callers report the provider as misconfigured instead
-// of routing traffic to a guessed host.
+// BaseURLHostname returns the normalized hostname from an absolute HTTP(S)
+// provider base URL. Invalid and scheme-less URLs return an empty string.
 func BaseURLHostname(baseURL string) string {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {

--- a/coderd/aibridged/provider.go
+++ b/coderd/aibridged/provider.go
@@ -39,18 +39,22 @@ type ProviderOutcome struct {
 
 // BaseURLHostname returns the normalized hostname from a provider
 // base URL. It is the canonical normalization used by the proxy
-// classifier and the API status check. Scheme-less inputs (from
-// env-config seeding) get https:// prepended.
+// classifier and the API status check. The base URL must be absolute
+// with an http or https scheme and a hostname; every other input,
+// including a scheme-less value such as "example.com/v1", returns an
+// empty string so callers report the provider as misconfigured instead
+// of routing traffic to a guessed host.
 func BaseURLHostname(baseURL string) string {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return ""
 	}
 	parsed, err := url.Parse(baseURL)
-	if err == nil && parsed.Hostname() == "" && !strings.Contains(baseURL, "://") {
-		parsed, err = url.Parse("https://" + baseURL)
-	}
 	if err != nil {
+		return ""
+	}
+	// url.Parse lowercases the scheme, so a direct comparison is enough.
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return ""
 	}
 	return strings.ToLower(parsed.Hostname())

--- a/coderd/aibridged/provider.go
+++ b/coderd/aibridged/provider.go
@@ -48,7 +48,6 @@ func BaseURLHostname(baseURL string) string {
 	if err != nil {
 		return ""
 	}
-	// url.Parse lowercases the scheme, so a direct comparison is enough.
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return ""
 	}

--- a/coderd/aibridged/provider_test.go
+++ b/coderd/aibridged/provider_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/coder/coder/v2/coderd/aibridged"
 )
 
+// TestBaseURLHostname pins the strict contract: only an absolute http
+// or https URL with a hostname yields a hostname. Scheme-less and
+// otherwise malformed values return "" so callers surface the provider
+// as misconfigured rather than routing to a synthesized host.
 func TestBaseURLHostname(t *testing.T) {
 	t.Parallel()
 
@@ -16,13 +20,25 @@ func TestBaseURLHostname(t *testing.T) {
 		baseURL string
 		want    string
 	}{
-		{name: "URL", baseURL: "https://openrouter.ai/api/v1", want: "openrouter.ai"},
-		{name: "BareHost", baseURL: "openrouter.ai", want: "openrouter.ai"},
+		{name: "HTTPS", baseURL: "https://openrouter.ai/api/v1", want: "openrouter.ai"},
+		{name: "HTTP", baseURL: "http://llm-relay.internal/v1", want: "llm-relay.internal"},
 		{name: "HostWithPort", baseURL: "https://openrouter.ai:443/api/v1", want: "openrouter.ai"},
+		{name: "HTTPHostWithPort", baseURL: "http://localhost:8080/v1", want: "localhost"},
 		{name: "UppercaseHost", baseURL: "https://API.OpenRouter.AI/v1", want: "api.openrouter.ai"},
+		{name: "UppercaseScheme", baseURL: "HTTPS://OpenRouter.AI/api/v1", want: "openrouter.ai"},
+		{name: "SurroundingWhitespace", baseURL: "  https://openrouter.ai/api/v1\n", want: "openrouter.ai"},
 		{name: "IPv6", baseURL: "https://[::1]:8080/v1", want: "::1"},
+		{name: "BareHost", baseURL: "openrouter.ai", want: ""},
+		{name: "SchemeLessPath", baseURL: "openrouter.ai/api/v1", want: ""},
+		{name: "SchemeLessHostWithPort", baseURL: "localhost:8080", want: ""},
+		{name: "ProtocolRelative", baseURL: "//openrouter.ai/api/v1", want: ""},
+		{name: "UnsupportedScheme", baseURL: "ftp://openrouter.ai/api/v1", want: ""},
+		{name: "FileScheme", baseURL: "file:///etc/hosts", want: ""},
 		{name: "Empty", baseURL: "", want: ""},
-		{name: "Invalid", baseURL: "://", want: ""},
+		{name: "Whitespace", baseURL: "   ", want: ""},
+		{name: "MissingScheme", baseURL: "://", want: ""},
+		{name: "NoHost", baseURL: "https://", want: ""},
+		{name: "UnbracketedIPv6", baseURL: "https://[::1", want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/coderd/aibridged/provider_test.go
+++ b/coderd/aibridged/provider_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/coder/coder/v2/coderd/aibridged"
 )
 
-// TestBaseURLHostname pins the strict contract: only an absolute http
-// or https URL with a hostname yields a hostname. Scheme-less and
-// otherwise malformed values return "" so callers surface the provider
-// as misconfigured rather than routing to a synthesized host.
 func TestBaseURLHostname(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/exp_chats_internal_test.go
+++ b/coderd/exp_chats_internal_test.go
@@ -397,6 +397,19 @@ func TestValidateChatModelConfigProviderModel(t *testing.T) {
 			wantDetail: "Change the AI provider type to openrouter or openai-compat.",
 		},
 		{
+			// A scheme-less base URL is not a usable endpoint, so it is
+			// not classified as an OpenRouter host. Such a row is
+			// reported as misconfigured by the provider status checks
+			// instead of being inferred as https://openrouter.ai.
+			name:  "SchemeLessOpenRouterHostNotDetected",
+			model: "anthropic/claude-opus-4.6",
+			provider: database.AIProvider{
+				Name:    "private-relay",
+				Type:    database.AIProviderTypeOpenai,
+				BaseUrl: "openrouter.ai/api/v1",
+			},
+		},
+		{
 			name:  "OpenRouterTypeAllowsSlashModel",
 			model: "anthropic/claude-opus-4.6",
 			provider: database.AIProvider{

--- a/enterprise/cli/aibridgeproxyd_internal_test.go
+++ b/enterprise/cli/aibridgeproxyd_internal_test.go
@@ -153,4 +153,26 @@ func TestClassifyProviderRow(t *testing.T) {
 		assert.Equal(t, aibridged.ProviderStatusEnabled, got.Status)
 		assert.Equal(t, "api.example.com", got.Host)
 	})
+
+	// SchemeLessBaseURLDoesNotClaimHostname is the regression guard for
+	// a scheme-less base URL being normalized to an https hostname: the
+	// row was routed as if it were valid and it consumed the hostname
+	// slot, demoting the correctly configured provider on that hostname
+	// to proxy_excluded.
+	t.Run("SchemeLessBaseURLDoesNotClaimHostname", func(t *testing.T) {
+		t.Parallel()
+
+		seen := map[string]string{}
+		schemeLess := classifyProviderRow(enabledRow("scheme-less", "api.example.com/v1"), seen)
+		assert.Equal(t, aibridged.ProviderStatusError, schemeLess.Status)
+		assert.Empty(t, schemeLess.Host, "scheme-less provider must not expose a host")
+		assert.ErrorContains(t, schemeLess.Err, "no hostname")
+		assert.Empty(t, seen, "scheme-less provider must not claim a hostname")
+
+		valid := classifyProviderRow(enabledRow("valid", "https://api.example.com/v1"), seen)
+		assert.Equal(t, aibridged.ProviderStatusEnabled, valid.Status)
+		assert.Equal(t, "api.example.com", valid.Host)
+		assert.NoError(t, valid.Err)
+		assert.Equal(t, "valid", seen["api.example.com"])
+	})
 }


### PR DESCRIPTION
Scheme-less provider base URLs were interpreted as HTTPS when deriving hostnames, which could let an invalid provider claim a proxy hostname and exclude a valid provider using the same host.

Require absolute HTTP or HTTPS base URLs during hostname extraction, preserve valid OpenRouter detection, and classify malformed providers as errors without letting them claim a hostname.

Follow-up to #28208.

> [!NOTE]
> Generated by Coder Agents for @ssncferreira.
