### PR TITLE
feat: backfill retained Agent Time history

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -751,7 +751,8 @@ var (
 					rbac.ResourceWorkspaceBuildOrchestration.Type: {policy.ActionDelete},
 					// Chat auto-archive sets archived=true on inactive chats and computes
 					// search_tsv tsvector for chat_messages.
-					rbac.ResourceChat.Type: {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceChat.Type:       {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceUsageEvent.Type: {policy.ActionRead},
 					// Purge old boundary logs past the retention period.
 					rbac.ResourceBoundaryLog.Type: {policy.ActionDelete},
 				}),
@@ -2756,6 +2757,13 @@ func (q *querier) EnqueueNotificationMessage(ctx context.Context, arg database.E
 	return q.db.EnqueueNotificationMessage(ctx, arg)
 }
 
+func (q *querier) EnsureAgentRuntimeBackfillCheckpoint(ctx context.Context) error {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceUsageEvent); err != nil {
+		return err
+	}
+	return q.db.EnsureAgentRuntimeBackfillCheckpoint(ctx)
+}
+
 func (q *querier) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error {
 	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceApiKey); err != nil {
 		return err
@@ -3055,6 +3063,13 @@ func (q *querier) GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, temp
 		return []database.WorkspaceBuild{}, err
 	}
 	return q.db.GetActiveWorkspaceBuildsByTemplateID(ctx, templateID)
+}
+
+func (q *querier) GetAgentRuntimeBackfillCheckpoint(ctx context.Context) (database.GetAgentRuntimeBackfillCheckpointRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceUsageEvent); err != nil {
+		return database.GetAgentRuntimeBackfillCheckpointRow{}, err
+	}
+	return q.db.GetAgentRuntimeBackfillCheckpoint(ctx)
 }
 
 func (q *querier) GetAllTailnetCoordinators(ctx context.Context) ([]database.TailnetCoordinator, error) {
@@ -3868,6 +3883,13 @@ func (q *querier) GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, cre
 
 func (q *querier) GetDeploymentWorkspaceStats(ctx context.Context) (database.GetDeploymentWorkspaceStatsRow, error) {
 	return q.db.GetDeploymentWorkspaceStats(ctx)
+}
+
+func (q *querier) GetEarliestChatMessageRuntimeBucket(ctx context.Context) (time.Time, error) {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceUsageEvent); err != nil {
+		return time.Time{}, err
+	}
+	return q.db.GetEarliestChatMessageRuntimeBucket(ctx)
 }
 
 func (q *querier) GetEligibleProvisionerDaemonsByProvisionerJobIDs(ctx context.Context, provisionerJobIDs []uuid.UUID) ([]database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow, error) {
@@ -6980,6 +7002,13 @@ func (q *querier) ListChatContextResourcesByChatID(ctx context.Context, chatID u
 	return q.db.ListChatContextResourcesByChatID(ctx, chatID)
 }
 
+func (q *querier) ListMissingChatMessageRuntimeBuckets(ctx context.Context, arg database.ListMissingChatMessageRuntimeBucketsParams) ([]database.ListMissingChatMessageRuntimeBucketsRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceUsageEvent); err != nil {
+		return nil, err
+	}
+	return q.db.ListMissingChatMessageRuntimeBuckets(ctx, arg)
+}
+
 func (q *querier) ListProvisionerKeysByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.ProvisionerKey, error) {
 	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.ListProvisionerKeysByOrganization)(ctx, organizationID)
 }
@@ -7436,6 +7465,13 @@ func (q *querier) UpdateAPIKeyByID(ctx context.Context, arg database.UpdateAPIKe
 		return q.db.GetAPIKeyByID(ctx, arg.ID)
 	}
 	return update(q.log, q.auth, fetch, q.db.UpdateAPIKeyByID)(ctx, arg)
+}
+
+func (q *querier) UpdateAgentRuntimeBackfillCheckpoint(ctx context.Context, value string) (int64, error) {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceUsageEvent); err != nil {
+		return 0, err
+	}
+	return q.db.UpdateAgentRuntimeBackfillCheckpoint(ctx, value)
 }
 
 func (q *querier) UpdateChatACLByID(ctx context.Context, arg database.UpdateChatACLByIDParams) error {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6815,6 +6815,34 @@ func (s *MethodTestSuite) TestUsageEvents() {
 		check.Args(params).Asserts(rbac.ResourceUsageEvent, policy.ActionRead)
 	}))
 
+	s.Run("EnsureAgentRuntimeBackfillCheckpoint", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		db.EXPECT().EnsureAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(nil)
+		check.Args().Asserts(rbac.ResourceUsageEvent, policy.ActionCreate)
+	}))
+
+	s.Run("GetAgentRuntimeBackfillCheckpoint", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		row := database.GetAgentRuntimeBackfillCheckpointRow{Value: `{}`, Present: true}
+		db.EXPECT().GetAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(row, nil)
+		check.Args().Asserts(rbac.ResourceUsageEvent, policy.ActionRead)
+	}))
+
+	s.Run("UpdateAgentRuntimeBackfillCheckpoint", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		db.EXPECT().UpdateAgentRuntimeBackfillCheckpoint(gomock.Any(), `{}`).Return(int64(1), nil)
+		check.Args(`{}`).Asserts(rbac.ResourceUsageEvent, policy.ActionUpdate)
+	}))
+
+	s.Run("GetEarliestChatMessageRuntimeBucket", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		now := dbtime.Now()
+		db.EXPECT().GetEarliestChatMessageRuntimeBucket(gomock.Any()).Return(now, nil)
+		check.Args().Asserts(rbac.ResourceUsageEvent, policy.ActionCreate)
+	}))
+
+	s.Run("ListMissingChatMessageRuntimeBuckets", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		params := database.ListMissingChatMessageRuntimeBucketsParams{StartTime: dbtime.Now(), EndTime: dbtime.Now().Add(time.Hour)}
+		db.EXPECT().ListMissingChatMessageRuntimeBuckets(gomock.Any(), params).Return([]database.ListMissingChatMessageRuntimeBucketsRow{}, nil)
+		check.Args(params).Asserts(rbac.ResourceUsageEvent, policy.ActionCreate)
+	}))
+
 	// GetTotalChatMessageRuntimeMsInRange exists solely to compute usage
 	// event payloads, so it asserts usage event creation rather than chat
 	// read permissions.
@@ -6877,6 +6905,45 @@ func TestGetTotalChatMessageRuntimeMsInRange_HumanRolesDenied(t *testing.T) {
 		_, err := dbz.GetTotalChatMessageRuntimeMsInRange(ctx, database.GetTotalChatMessageRuntimeMsInRangeParams{})
 		require.True(t, dbauthz.IsNotAuthorizedError(err), "role %s must be denied", role)
 	}
+}
+
+func TestAgentRuntimeBackfillState_HumanRolesDenied(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	var roles []rbac.RoleIdentifier
+	for _, role := range rbac.SiteBuiltInRoles() {
+		roles = append(roles, role.Identifier)
+	}
+	for _, role := range rbac.OrganizationRoles(orgID) {
+		roles = append(roles, role.Identifier)
+	}
+
+	for _, role := range roles {
+		subj := rbac.Subject{
+			ID:    uuid.NewString(),
+			Roles: rbac.RoleIdentifiers{role},
+			Scope: rbac.ScopeAll,
+		}
+		ctx := dbauthz.As(testutil.Context(t, testutil.WaitShort), subj)
+		mDB := dbmock.NewMockStore(gomock.NewController(t))
+		mDB.EXPECT().Wrappers().Times(1).Return([]string{})
+		dbz := dbauthz.New(mDB, rbac.NewStrictAuthorizer(prometheus.NewRegistry()), slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		_, err := dbz.GetAgentRuntimeBackfillCheckpoint(ctx)
+		require.True(t, dbauthz.IsNotAuthorizedError(err), "role %s must be denied", role)
+	}
+}
+
+func TestAgentRuntimeBackfillState_DBPurgeCanRead(t *testing.T) {
+	t.Parallel()
+
+	ctx := dbauthz.AsDBPurge(testutil.Context(t, testutil.WaitShort))
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	mDB.EXPECT().Wrappers().Times(1).Return([]string{})
+	mDB.EXPECT().GetAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(database.GetAgentRuntimeBackfillCheckpointRow{}, nil)
+	dbz := dbauthz.New(mDB, rbac.NewStrictAuthorizer(prometheus.NewRegistry()), slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+	_, err := dbz.GetAgentRuntimeBackfillCheckpoint(ctx)
+	require.NoError(t, err)
 }
 
 func (s *MethodTestSuite) TestAIBridge() {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1000,6 +1000,14 @@ func (m queryMetricsStore) EnqueueNotificationMessage(ctx context.Context, arg d
 	return r0
 }
 
+func (m queryMetricsStore) EnsureAgentRuntimeBackfillCheckpoint(ctx context.Context) error {
+	start := time.Now()
+	r0 := m.s.EnsureAgentRuntimeBackfillCheckpoint(ctx)
+	m.queryLatencies.WithLabelValues("EnsureAgentRuntimeBackfillCheckpoint").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "EnsureAgentRuntimeBackfillCheckpoint").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error {
 	start := time.Now()
 	r0 := m.s.ExpirePrebuildsAPIKeys(ctx, now)
@@ -1325,6 +1333,14 @@ func (m queryMetricsStore) GetActiveWorkspaceBuildsByTemplateID(ctx context.Cont
 	r0, r1 := m.s.GetActiveWorkspaceBuildsByTemplateID(ctx, templateID)
 	m.queryLatencies.WithLabelValues("GetActiveWorkspaceBuildsByTemplateID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetActiveWorkspaceBuildsByTemplateID").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetAgentRuntimeBackfillCheckpoint(ctx context.Context) (database.GetAgentRuntimeBackfillCheckpointRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAgentRuntimeBackfillCheckpoint(ctx)
+	m.queryLatencies.WithLabelValues("GetAgentRuntimeBackfillCheckpoint").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAgentRuntimeBackfillCheckpoint").Inc()
 	return r0, r1
 }
 
@@ -2021,6 +2037,14 @@ func (m queryMetricsStore) GetDeploymentWorkspaceStats(ctx context.Context) (dat
 	r0, r1 := m.s.GetDeploymentWorkspaceStats(ctx)
 	m.queryLatencies.WithLabelValues("GetDeploymentWorkspaceStats").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetDeploymentWorkspaceStats").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetEarliestChatMessageRuntimeBucket(ctx context.Context) (time.Time, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetEarliestChatMessageRuntimeBucket(ctx)
+	m.queryLatencies.WithLabelValues("GetEarliestChatMessageRuntimeBucket").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetEarliestChatMessageRuntimeBucket").Inc()
 	return r0, r1
 }
 
@@ -4840,6 +4864,14 @@ func (m queryMetricsStore) ListChatContextResourcesByChatID(ctx context.Context,
 	return r0, r1
 }
 
+func (m queryMetricsStore) ListMissingChatMessageRuntimeBuckets(ctx context.Context, arg database.ListMissingChatMessageRuntimeBucketsParams) ([]database.ListMissingChatMessageRuntimeBucketsRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.ListMissingChatMessageRuntimeBuckets(ctx, arg)
+	m.queryLatencies.WithLabelValues("ListMissingChatMessageRuntimeBuckets").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "ListMissingChatMessageRuntimeBuckets").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) ListProvisionerKeysByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.ProvisionerKey, error) {
 	start := time.Now()
 	r0, r1 := m.s.ListProvisionerKeysByOrganization(ctx, organizationID)
@@ -5238,6 +5270,14 @@ func (m queryMetricsStore) UpdateAPIKeyByID(ctx context.Context, arg database.Up
 	m.queryLatencies.WithLabelValues("UpdateAPIKeyByID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateAPIKeyByID").Inc()
 	return r0
+}
+
+func (m queryMetricsStore) UpdateAgentRuntimeBackfillCheckpoint(ctx context.Context, value string) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.UpdateAgentRuntimeBackfillCheckpoint(ctx, value)
+	m.queryLatencies.WithLabelValues("UpdateAgentRuntimeBackfillCheckpoint").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateAgentRuntimeBackfillCheckpoint").Inc()
+	return r0, r1
 }
 
 func (m queryMetricsStore) UpdateChatACLByID(ctx context.Context, arg database.UpdateChatACLByIDParams) error {

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1726,6 +1726,20 @@ func (mr *MockStoreMockRecorder) EnqueueNotificationMessage(ctx, arg any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueNotificationMessage", reflect.TypeOf((*MockStore)(nil).EnqueueNotificationMessage), ctx, arg)
 }
 
+// EnsureAgentRuntimeBackfillCheckpoint mocks base method.
+func (m *MockStore) EnsureAgentRuntimeBackfillCheckpoint(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureAgentRuntimeBackfillCheckpoint", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureAgentRuntimeBackfillCheckpoint indicates an expected call of EnsureAgentRuntimeBackfillCheckpoint.
+func (mr *MockStoreMockRecorder) EnsureAgentRuntimeBackfillCheckpoint(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAgentRuntimeBackfillCheckpoint", reflect.TypeOf((*MockStore)(nil).EnsureAgentRuntimeBackfillCheckpoint), ctx)
+}
+
 // ExpirePrebuildsAPIKeys mocks base method.
 func (m *MockStore) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error {
 	m.ctrl.T.Helper()
@@ -2337,6 +2351,21 @@ func (m *MockStore) GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, te
 func (mr *MockStoreMockRecorder) GetActiveWorkspaceBuildsByTemplateID(ctx, templateID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveWorkspaceBuildsByTemplateID", reflect.TypeOf((*MockStore)(nil).GetActiveWorkspaceBuildsByTemplateID), ctx, templateID)
+}
+
+// GetAgentRuntimeBackfillCheckpoint mocks base method.
+func (m *MockStore) GetAgentRuntimeBackfillCheckpoint(ctx context.Context) (database.GetAgentRuntimeBackfillCheckpointRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentRuntimeBackfillCheckpoint", ctx)
+	ret0, _ := ret[0].(database.GetAgentRuntimeBackfillCheckpointRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAgentRuntimeBackfillCheckpoint indicates an expected call of GetAgentRuntimeBackfillCheckpoint.
+func (mr *MockStoreMockRecorder) GetAgentRuntimeBackfillCheckpoint(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentRuntimeBackfillCheckpoint", reflect.TypeOf((*MockStore)(nil).GetAgentRuntimeBackfillCheckpoint), ctx)
 }
 
 // GetAllTailnetCoordinators mocks base method.
@@ -3792,6 +3821,21 @@ func (m *MockStore) GetDeploymentWorkspaceStats(ctx context.Context) (database.G
 func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceStats(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceStats), ctx)
+}
+
+// GetEarliestChatMessageRuntimeBucket mocks base method.
+func (m *MockStore) GetEarliestChatMessageRuntimeBucket(ctx context.Context) (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEarliestChatMessageRuntimeBucket", ctx)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEarliestChatMessageRuntimeBucket indicates an expected call of GetEarliestChatMessageRuntimeBucket.
+func (mr *MockStoreMockRecorder) GetEarliestChatMessageRuntimeBucket(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEarliestChatMessageRuntimeBucket", reflect.TypeOf((*MockStore)(nil).GetEarliestChatMessageRuntimeBucket), ctx)
 }
 
 // GetEligibleProvisionerDaemonsByProvisionerJobIDs mocks base method.
@@ -9177,6 +9221,21 @@ func (mr *MockStoreMockRecorder) ListChatContextResourcesByChatID(ctx, chatID an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChatContextResourcesByChatID", reflect.TypeOf((*MockStore)(nil).ListChatContextResourcesByChatID), ctx, chatID)
 }
 
+// ListMissingChatMessageRuntimeBuckets mocks base method.
+func (m *MockStore) ListMissingChatMessageRuntimeBuckets(ctx context.Context, arg database.ListMissingChatMessageRuntimeBucketsParams) ([]database.ListMissingChatMessageRuntimeBucketsRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMissingChatMessageRuntimeBuckets", ctx, arg)
+	ret0, _ := ret[0].([]database.ListMissingChatMessageRuntimeBucketsRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMissingChatMessageRuntimeBuckets indicates an expected call of ListMissingChatMessageRuntimeBuckets.
+func (mr *MockStoreMockRecorder) ListMissingChatMessageRuntimeBuckets(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMissingChatMessageRuntimeBuckets", reflect.TypeOf((*MockStore)(nil).ListMissingChatMessageRuntimeBuckets), ctx, arg)
+}
+
 // ListProvisionerKeysByOrganization mocks base method.
 func (m *MockStore) ListProvisionerKeysByOrganization(ctx context.Context, organizationID uuid.UUID) ([]database.ProvisionerKey, error) {
 	m.ctrl.T.Helper()
@@ -9937,6 +9996,21 @@ func (m *MockStore) UpdateAPIKeyByID(ctx context.Context, arg database.UpdateAPI
 func (mr *MockStoreMockRecorder) UpdateAPIKeyByID(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAPIKeyByID", reflect.TypeOf((*MockStore)(nil).UpdateAPIKeyByID), ctx, arg)
+}
+
+// UpdateAgentRuntimeBackfillCheckpoint mocks base method.
+func (m *MockStore) UpdateAgentRuntimeBackfillCheckpoint(ctx context.Context, value string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAgentRuntimeBackfillCheckpoint", ctx, value)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAgentRuntimeBackfillCheckpoint indicates an expected call of UpdateAgentRuntimeBackfillCheckpoint.
+func (mr *MockStoreMockRecorder) UpdateAgentRuntimeBackfillCheckpoint(ctx, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAgentRuntimeBackfillCheckpoint", reflect.TypeOf((*MockStore)(nil).UpdateAgentRuntimeBackfillCheckpoint), ctx, value)
 }
 
 // UpdateChatACLByID mocks base method.

--- a/coderd/database/dbpurge/agent_runtime_backfill_internal_test.go
+++ b/coderd/database/dbpurge/agent_runtime_backfill_internal_test.go
@@ -1,0 +1,103 @@
+package dbpurge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
+)
+
+func TestAgentRuntimeBackfillProtectsChats(t *testing.T) {
+	t.Parallel()
+
+	cutoff := time.Date(2025, 3, 10, 10, 30, 0, 0, time.UTC)
+	before := cutoff.Truncate(time.Hour)
+	atOrAfter := before.Add(time.Hour)
+	end := atOrAfter.Add(time.Hour)
+	completedAt := end.Add(time.Minute)
+
+	stateJSON := func(state agplusage.AgentRuntimeBackfillState) string {
+		t.Helper()
+		value, err := agplusage.MarshalAgentRuntimeBackfillState(state)
+		require.NoError(t, err)
+		return value
+	}
+
+	for _, tc := range []struct {
+		name       string
+		checkpoint database.GetAgentRuntimeBackfillCheckpointRow
+		want       bool
+		wantErr    bool
+	}{
+		{name: "missing"},
+		{
+			name: "pending",
+			checkpoint: database.GetAgentRuntimeBackfillCheckpointRow{
+				Present: true,
+				Value:   agplusage.AgentRuntimeBackfillPendingJSON,
+			},
+			want: true,
+		},
+		{
+			name: "malformed",
+			checkpoint: database.GetAgentRuntimeBackfillCheckpointRow{
+				Present: true,
+				Value:   "not-json",
+			},
+			want:    true,
+			wantErr: true,
+		},
+		{
+			name: "cursor before cutoff",
+			checkpoint: database.GetAgentRuntimeBackfillCheckpointRow{
+				Present: true,
+				Value: stateJSON(agplusage.AgentRuntimeBackfillState{
+					Version:      agplusage.AgentRuntimeBackfillVersion,
+					Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+					NextBucket:   &before,
+					EndExclusive: &end,
+				}),
+			},
+			want: true,
+		},
+		{
+			name: "cursor at or after cutoff",
+			checkpoint: database.GetAgentRuntimeBackfillCheckpointRow{
+				Present: true,
+				Value: stateJSON(agplusage.AgentRuntimeBackfillState{
+					Version:      agplusage.AgentRuntimeBackfillVersion,
+					Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+					NextBucket:   &atOrAfter,
+					EndExclusive: &end,
+				}),
+			},
+		},
+		{
+			name: "complete",
+			checkpoint: database.GetAgentRuntimeBackfillCheckpointRow{
+				Present: true,
+				Value: stateJSON(agplusage.AgentRuntimeBackfillState{
+					Version:      agplusage.AgentRuntimeBackfillVersion,
+					Status:       agplusage.AgentRuntimeBackfillStatusComplete,
+					NextBucket:   &end,
+					EndExclusive: &end,
+					CompletedAt:  &completedAt,
+				}),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, _, err := agentRuntimeBackfillProtectsChats(tc.checkpoint, cutoff)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/pproflabel"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/quartz"
 )
@@ -173,6 +174,8 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 		i.logger.Error(ctx, "failed to read chat retention config: skipping chat purge this tick", slog.Error(chatRetentionErr))
 	}
 
+	var agentRuntimeBackfillErr error
+
 	chatDebugRetentionDays, chatDebugRetentionErr := db.GetChatDebugRetentionDays(ctx, codersdk.DefaultChatDebugRetentionDays)
 	purgeChatDebugRuns := chatDebugRetentionErr == nil
 	if chatDebugRetentionErr != nil {
@@ -188,6 +191,9 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 	// Start a transaction to grab advisory lock, we don't want to run
 	// multiple purges at the same time (multiple replicas).
 	err := db.InTx(func(tx database.Store) error {
+		// InTx may retry, so do not preserve a checkpoint error from an
+		// aborted transaction attempt.
+		agentRuntimeBackfillErr = nil
 		// Acquire a lock to ensure that only one instance of the
 		// purge is running at a time.
 		ok, err := tx.TryAcquireLock(ctx, database.LockIDDBPurge)
@@ -320,9 +326,29 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 
 		var purgedChats, purgedChatFiles, purgedChatDebugRuns int64
 		if purgeChats {
-			purgedChats, purgedChatFiles, err = i.purgeChatsInTx(ctx, tx, start, chatRetentionDays)
-			if err != nil {
-				return xerrors.Errorf("failed to purge chats: %w", err)
+			checkpoint, checkpointErr := tx.GetAgentRuntimeBackfillCheckpoint(ctx)
+			if checkpointErr != nil {
+				agentRuntimeBackfillErr = xerrors.Errorf("read agent runtime catch-up checkpoint: %w", checkpointErr)
+				i.logger.Error(ctx, "failed to read agent runtime catch-up checkpoint: skipping chat purge this tick", slog.Error(checkpointErr))
+			} else {
+				deleteChatsBefore := start.Add(-time.Duration(chatRetentionDays) * 24 * time.Hour)
+				protects, state, stateErr := agentRuntimeBackfillProtectsChats(checkpoint, deleteChatsBefore)
+				switch {
+				case stateErr != nil:
+					agentRuntimeBackfillErr = stateErr
+					i.logger.Error(ctx, "invalid agent runtime catch-up checkpoint: skipping chat purge this tick", slog.Error(stateErr))
+				case protects:
+					i.logger.Info(ctx, "agent runtime catch-up is protecting retained chat history: skipping chat purge this tick",
+						slog.F("status", state.Status),
+						slog.F("next_bucket", state.NextBucket),
+						slog.F("delete_chats_before", deleteChatsBefore),
+					)
+				default:
+					purgedChats, purgedChatFiles, err = i.purgeChatsInTx(ctx, tx, start, chatRetentionDays)
+					if err != nil {
+						return xerrors.Errorf("failed to purge chats: %w", err)
+					}
+				}
 			}
 		}
 		if purgeChatDebugRuns && chatDebugRetentionDays > 0 {
@@ -413,9 +439,9 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 			i.chatSearchRowsBackfilled.Add(float64(backfilledChatSearchRows))
 		}
 
-		// chatConfigErr is returned after the tx, so do not record this
-		// iteration as successful when only the deferred config read failed.
-		if i.iterationDuration != nil && chatConfigErr == nil {
+		// Deferred configuration and checkpoint errors are returned after the
+		// transaction, so do not also record the iteration as successful.
+		if i.iterationDuration != nil && errors.Join(chatConfigErr, agentRuntimeBackfillErr) == nil {
 			duration := i.clk.Since(start)
 			i.iterationDuration.WithLabelValues("true").Observe(duration.Seconds())
 		}
@@ -429,13 +455,30 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 		i.chatSearchStaleDrained = true
 	}
 
-	// Surface the deferred chat-config error so doTick records
-	// the failed iteration metric.
-	if chatConfigErr != nil {
-		return xerrors.Errorf("chat config read failed this tick: %w", chatConfigErr)
+	// Surface deferred chat configuration and catch-up checkpoint errors so
+	// doTick records the failed iteration metric after unrelated purges commit.
+	if err := errors.Join(chatConfigErr, agentRuntimeBackfillErr); err != nil {
+		return xerrors.Errorf("chat purge configuration failed this tick: %w", err)
 	}
 
 	return nil
+}
+
+func agentRuntimeBackfillProtectsChats(checkpoint database.GetAgentRuntimeBackfillCheckpointRow, cutoff time.Time) (bool, agplusage.AgentRuntimeBackfillState, error) {
+	if !checkpoint.Present {
+		return false, agplusage.AgentRuntimeBackfillState{}, nil
+	}
+	state, err := agplusage.ParseAgentRuntimeBackfillState(checkpoint.Value)
+	if err != nil {
+		return true, agplusage.AgentRuntimeBackfillState{}, err
+	}
+	if state.Status == agplusage.AgentRuntimeBackfillStatusPending {
+		return true, state, nil
+	}
+	if state.Status == agplusage.AgentRuntimeBackfillStatusComplete {
+		return false, state, nil
+	}
+	return state.NextBucket.Before(cutoff), state, nil
 }
 
 type instance struct {

--- a/coderd/database/dbpurge/dbpurge_internal_test.go
+++ b/coderd/database/dbpurge/dbpurge_internal_test.go
@@ -8,12 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
+	"github.com/coder/serpent"
 )
 
 func TestDBPurgeAuthorization(t *testing.T) {
@@ -21,6 +25,9 @@ func TestDBPurgeAuthorization(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	rawDB, _ := dbtestutil.NewDB(t)
+
+	require.NoError(t, rawDB.UpsertChatRetentionDays(ctx, 30))
+	require.NoError(t, rawDB.EnsureAgentRuntimeBackfillCheckpoint(ctx))
 
 	authz := rbac.NewAuthorizer(prometheus.NewRegistry())
 	db := dbauthz.New(rawDB, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
@@ -42,4 +49,67 @@ func TestDBPurgeAuthorization(t *testing.T) {
 
 	err := inst.purgeTick(ctx, db, now)
 	require.NoError(t, err)
+}
+
+func TestAgentRuntimeBackfillDefersOnlyChatPurge(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, rawDB := dbtestutil.NewDBWithSQLDB(t)
+	now := time.Date(2025, 3, 10, 14, 0, 0, 0, time.UTC)
+
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+	_ = dbgen.ChatProvider(t, db, database.ChatProvider{Provider: "openai", DisplayName: "OpenAI"})
+	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{Model: "purge-catchup", ContextLimit: 8192})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: modelConfig.ID,
+	})
+	_, err := db.ArchiveChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	_, err = rawDB.ExecContext(ctx, "UPDATE chats SET updated_at = $1 WHERE id = $2", now.Add(-31*24*time.Hour), chat.ID)
+	require.NoError(t, err)
+
+	expiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+		UserID:    user.ID,
+		ExpiresAt: now.Add(-8 * 24 * time.Hour),
+		TokenName: "catchup-purge-test",
+	})
+	require.NoError(t, db.UpsertChatRetentionDays(ctx, 30))
+	require.NoError(t, db.EnsureAgentRuntimeBackfillCheckpoint(ctx))
+
+	inst := &instance{
+		logger: testutil.Logger(t),
+		vals: &codersdk.DeploymentValues{Retention: codersdk.RetentionConfig{
+			APIKeys: serpent.Duration(7 * 24 * time.Hour),
+		}},
+		clk: quartz.NewMock(t),
+	}
+	require.NoError(t, inst.purgeTick(ctx, db, now))
+
+	_, err = db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err, "pending catch-up must preserve the archived chat")
+	_, err = db.GetAPIKeyByID(ctx, expiredKey.ID)
+	require.Error(t, err, "unrelated API key purge must still run")
+
+	completedAt := now
+	endExclusive := now.Add(-7 * 24 * time.Hour).Truncate(time.Hour)
+	state, err := agplusage.MarshalAgentRuntimeBackfillState(agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusComplete,
+		NextBucket:   &endExclusive,
+		EndExclusive: &endExclusive,
+		CompletedAt:  &completedAt,
+	})
+	require.NoError(t, err)
+	updated, err := db.UpdateAgentRuntimeBackfillCheckpoint(ctx, state)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated)
+	require.NoError(t, inst.purgeTick(ctx, db, now))
+
+	_, err = db.GetChatByID(ctx, chat.ID)
+	require.Error(t, err, "completed catch-up must allow archived chat deletion")
 }

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -310,6 +310,7 @@ func TestMetrics(t *testing.T) {
 		mDB.EXPECT().DeleteOldAuditLogConnectionEvents(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		mDB.EXPECT().BackfillChatMessagesSearchTsv(gomock.Any(), gomock.Any()).Return(int64(0), nil).AnyTimes()
 		mDB.EXPECT().ReindexStaleChatMessagesSearchTsv(gomock.Any(), gomock.Any()).Return(int64(0), nil).AnyTimes()
+		mDB.EXPECT().GetAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(database.GetAgentRuntimeBackfillCheckpointRow{}, nil).AnyTimes()
 		mDB.EXPECT().DeleteOldChats(gomock.Any(), gomock.AssignableToTypeOf(database.DeleteOldChatsParams{})).Return(int64(0), nil).MinTimes(1)
 		mDB.EXPECT().DeleteOldChatFiles(gomock.Any(), gomock.AssignableToTypeOf(database.DeleteOldChatFilesParams{})).Return(int64(0), nil).MinTimes(1)
 		mDB.EXPECT().InTx(gomock.Any(), database.DefaultTXOptions().WithID("db_purge")).

--- a/coderd/database/lock.go
+++ b/coderd/database/lock.go
@@ -19,6 +19,7 @@ const (
 	// Deprecated: Reserved to prevent reuse. Do not use at runtime.
 	LockIDChatModelConfigWrites
 	LockIDChatCapacityAdmission
+	LockIDAgentRuntimeHistoricalBackfill
 )
 
 // Per-setting advisory lock IDs for the chat instruction settings. These

--- a/coderd/database/lock_internal_test.go
+++ b/coderd/database/lock_internal_test.go
@@ -21,17 +21,27 @@ func TestChatInstructionLockIDsDistinct(t *testing.T) {
 	}
 
 	sequential := map[string]int64{
-		"LockIDDeploymentSetup":              LockIDDeploymentSetup,
-		"LockIDEnterpriseDeploymentSetup":    LockIDEnterpriseDeploymentSetup,
-		"LockIDDBRollup":                     LockIDDBRollup,
-		"LockIDDBPurge":                      LockIDDBPurge,
-		"LockIDNotificationsReportGenerator": LockIDNotificationsReportGenerator,
-		"LockIDCryptoKeyRotation":            LockIDCryptoKeyRotation,
-		"LockIDReconcilePrebuilds":           LockIDReconcilePrebuilds,
-		"LockIDReconcileSystemRoles":         LockIDReconcileSystemRoles,
-		"LockIDBoundaryUsageStats":           LockIDBoundaryUsageStats,
-		"LockIDAIProvidersEnvSeed":           LockIDAIProvidersEnvSeed,
-		"LockIDChatModelConfigWrites":        LockIDChatModelConfigWrites,
+		"LockIDDeploymentSetup":                LockIDDeploymentSetup,
+		"LockIDEnterpriseDeploymentSetup":      LockIDEnterpriseDeploymentSetup,
+		"LockIDDBRollup":                       LockIDDBRollup,
+		"LockIDDBPurge":                        LockIDDBPurge,
+		"LockIDNotificationsReportGenerator":   LockIDNotificationsReportGenerator,
+		"LockIDCryptoKeyRotation":              LockIDCryptoKeyRotation,
+		"LockIDReconcilePrebuilds":             LockIDReconcilePrebuilds,
+		"LockIDReconcileSystemRoles":           LockIDReconcileSystemRoles,
+		"LockIDBoundaryUsageStats":             LockIDBoundaryUsageStats,
+		"LockIDAIProvidersEnvSeed":             LockIDAIProvidersEnvSeed,
+		"LockIDChatModelConfigWrites":          LockIDChatModelConfigWrites,
+		"LockIDChatCapacityAdmission":          LockIDChatCapacityAdmission,
+		"LockIDAgentRuntimeHistoricalBackfill": LockIDAgentRuntimeHistoricalBackfill,
+	}
+
+	seenSequential := make(map[int64]string, len(sequential))
+	for name, id := range sequential {
+		if previous, ok := seenSequential[id]; ok {
+			t.Fatalf("sequential lock ID %s (%d) collides with %s", name, id, previous)
+		}
+		seenSequential[id] = name
 	}
 
 	// The two generated IDs are pairwise distinct.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -252,6 +252,7 @@ type sqlcQuerier interface {
 	// of the test-only in-memory database. Do not use this in new code.
 	DisableForeignKeysAndTriggers(ctx context.Context) error
 	EnqueueNotificationMessage(ctx context.Context, arg EnqueueNotificationMessageParams) error
+	EnsureAgentRuntimeBackfillCheckpoint(ctx context.Context) error
 	// Firstly, collect api_keys owned by the prebuilds user that correlate
 	// to workspaces no longer owned by the prebuilds user.
 	// Next, collect api_keys that belong to the prebuilds user but have no token name.
@@ -377,6 +378,7 @@ type sqlcQuerier interface {
 	// TestGetActiveUsersAuthorizationRolesParity enforces this.
 	GetActiveUsersAuthorizationRoles(ctx context.Context) ([]GetActiveUsersAuthorizationRolesRow, error)
 	GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, templateID uuid.UUID) ([]WorkspaceBuild, error)
+	GetAgentRuntimeBackfillCheckpoint(ctx context.Context) (GetAgentRuntimeBackfillCheckpointRow, error)
 	// For PG Coordinator HTMLDebug
 	GetAllTailnetCoordinators(ctx context.Context) ([]TailnetCoordinator, error)
 	GetAllTailnetPeers(ctx context.Context) ([]TailnetPeer, error)
@@ -571,6 +573,9 @@ type sqlcQuerier interface {
 	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
 	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error)
 	GetDeploymentWorkspaceStats(ctx context.Context) (GetDeploymentWorkspaceStatsRow, error)
+	// Returns the first retained UTC hour with derivable Agent Time usage. No row
+	// is returned when no retained message has runtime data.
+	GetEarliestChatMessageRuntimeBucket(ctx context.Context) (time.Time, error)
 	GetEligibleProvisionerDaemonsByProvisionerJobIDs(ctx context.Context, provisionerJobIds []uuid.UUID) ([]GetEligibleProvisionerDaemonsByProvisionerJobIDsRow, error)
 	// Providers can be disabled independently of their model configs.
 	// Check both to ensure the selected config is actually usable.
@@ -1294,6 +1299,10 @@ type sqlcQuerier interface {
 	// Lists a chat's pinned context resources, ordered deterministically by
 	// source.
 	ListChatContextResourcesByChatID(ctx context.Context, chatID uuid.UUID) ([]ChatContextResource, error)
+	// Returns missing hb_agent_runtime_v1 buckets in the bounded, end-exclusive
+	// range. The generated series preserves zero-runtime hours, and existing
+	// runtime events remain sealed.
+	ListMissingChatMessageRuntimeBuckets(ctx context.Context, arg ListMissingChatMessageRuntimeBucketsParams) ([]ListMissingChatMessageRuntimeBucketsRow, error)
 	ListProvisionerKeysByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerKey, error)
 	ListProvisionerKeysByOrganizationExcludeReserved(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerKey, error)
 	ListTasks(ctx context.Context, arg ListTasksParams) ([]Task, error)
@@ -1444,6 +1453,7 @@ type sqlcQuerier interface {
 	UpdateAIGatewayKeyLastHeartbeatAt(ctx context.Context, id uuid.UUID) (int64, error)
 	UpdateAIProvider(ctx context.Context, arg UpdateAIProviderParams) (AIProvider, error)
 	UpdateAPIKeyByID(ctx context.Context, arg UpdateAPIKeyByIDParams) error
+	UpdateAgentRuntimeBackfillCheckpoint(ctx context.Context, value string) (int64, error)
 	UpdateChatACLByID(ctx context.Context, arg UpdateChatACLByIDParams) error
 	UpdateChatBuildAgentBinding(ctx context.Context, arg UpdateChatBuildAgentBindingParams) (Chat, error)
 	UpdateChatByID(ctx context.Context, arg UpdateChatByIDParams) (Chat, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
 	"github.com/coder/coder/v2/coderd/usage/usagetypes"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
@@ -11223,6 +11224,131 @@ func TestGetTotalChatMessageRuntimeMsInRange(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 79, total)
+}
+
+func TestAgentRuntimeHistoricalQueries(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+
+	_, err := db.GetEarliestChatMessageRuntimeBucket(ctx)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+	_ = dbgen.ChatProvider(t, db, database.ChatProvider{Provider: "openai", DisplayName: "OpenAI"})
+	modelConfig := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{Model: "historical-runtime", ContextLimit: 8192})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: modelConfig.ID,
+	})
+
+	insertMessage := func(runtime sql.NullInt64, createdAt time.Time, deleted bool) {
+		t.Helper()
+		msg := dbgen.ChatMessage(t, db, database.ChatMessage{
+			ChatID:        chat.ID,
+			CreatedBy:     uuid.NullUUID{UUID: user.ID, Valid: true},
+			ModelConfigID: uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+			Role:          database.ChatMessageRoleAssistant,
+			RuntimeMs:     runtime,
+		})
+		_, err := sqlDB.ExecContext(ctx, "UPDATE chat_messages SET created_at = $1, deleted = $2, runtime_ms = $3 WHERE id = $4", createdAt, deleted, runtime, msg.ID)
+		require.NoError(t, err)
+	}
+
+	start := time.Date(2025, 3, 10, 10, 0, 0, 0, time.UTC)
+	end := start.Add(4 * time.Hour)
+	locSydney, err := time.LoadLocation("Australia/Sydney")
+	require.NoError(t, err)
+
+	// Sydney is UTC+11 on this date, so 21:00 addresses the inclusive UTC
+	// start boundary. The soft-deleted row is included and the NULL row is not.
+	insertMessage(sql.NullInt64{Int64: 1, Valid: true}, time.Date(2025, 3, 10, 21, 0, 0, 0, locSydney), false)
+	insertMessage(sql.NullInt64{Int64: 2, Valid: true}, start.Add(20*time.Minute), true)
+	insertMessage(sql.NullInt64{}, start.Add(30*time.Minute), false)
+	insertMessage(sql.NullInt64{Int64: 4, Valid: true}, start.Add(time.Hour+10*time.Minute), false)
+	insertMessage(sql.NullInt64{Int64: 8, Valid: true}, start.Add(2*time.Hour), false)
+	insertMessage(sql.NullInt64{Int64: 16, Valid: true}, start.Add(3*time.Hour-time.Second), false)
+	insertMessage(sql.NullInt64{Int64: 32, Valid: true}, end, false)
+
+	earliest, err := db.GetEarliestChatMessageRuntimeBucket(ctx)
+	require.NoError(t, err)
+	require.Equal(t, start, earliest.UTC())
+
+	// Existing runtime events seal only their own buckets. An event of another
+	// type at the same time must not suppress the zero-runtime bucket.
+	err = db.InsertUsageEvent(ctx, database.InsertUsageEventParams{
+		ID:        "historical-runtime-existing",
+		EventType: string(usagetypes.UsageEventTypeHBAgentRuntimeV1),
+		EventData: []byte(`{"runtime_ms":99}`),
+		CreatedAt: start.Add(time.Hour),
+	})
+	require.NoError(t, err)
+	err = db.InsertUsageEvent(ctx, database.InsertUsageEventParams{
+		ID:        "historical-runtime-other-type",
+		EventType: "hb_ai_seats_v1",
+		EventData: []byte(`{"count":1}`),
+		CreatedAt: start.Add(3 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	buckets, err := db.ListMissingChatMessageRuntimeBuckets(ctx, database.ListMissingChatMessageRuntimeBucketsParams{
+		StartTime: start.In(locSydney),
+		EndTime:   end.In(locSydney),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []database.ListMissingChatMessageRuntimeBucketsRow{
+		{Bucket: start, RuntimeMs: 3},
+		{Bucket: start.Add(2 * time.Hour), RuntimeMs: 24},
+		{Bucket: start.Add(3 * time.Hour), RuntimeMs: 0},
+	}, normalizeHistoricalRuntimeBuckets(buckets))
+}
+
+func normalizeHistoricalRuntimeBuckets(buckets []database.ListMissingChatMessageRuntimeBucketsRow) []database.ListMissingChatMessageRuntimeBucketsRow {
+	for i := range buckets {
+		buckets[i].Bucket = buckets[i].Bucket.UTC()
+	}
+	return buckets
+}
+
+func TestAgentRuntimeBackfillCheckpointQueries(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
+
+	checkpoint, err := db.GetAgentRuntimeBackfillCheckpoint(ctx)
+	require.NoError(t, err)
+	require.False(t, checkpoint.Present)
+	require.Empty(t, checkpoint.Value)
+
+	require.NoError(t, db.EnsureAgentRuntimeBackfillCheckpoint(ctx))
+	checkpoint, err = db.GetAgentRuntimeBackfillCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, checkpoint.Present)
+	require.JSONEq(t, agplusage.AgentRuntimeBackfillPendingJSON, checkpoint.Value)
+
+	next := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := next.Add(24 * time.Hour)
+	value, err := agplusage.MarshalAgentRuntimeBackfillState(agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+		NextBucket:   &next,
+		EndExclusive: &end,
+	})
+	require.NoError(t, err)
+	updated, err := db.UpdateAgentRuntimeBackfillCheckpoint(ctx, value)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated)
+
+	// Ensure is idempotent and never resets progress.
+	require.NoError(t, db.EnsureAgentRuntimeBackfillCheckpoint(ctx))
+	checkpoint, err = db.GetAgentRuntimeBackfillCheckpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, value, checkpoint.Value)
 }
 
 func TestListUsageEventCreatedAtsByTypeSince(t *testing.T) {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10190,6 +10190,25 @@ func (q *sqlQuerier) GetDatabaseNow(ctx context.Context) (time.Time, error) {
 	return now, err
 }
 
+const getEarliestChatMessageRuntimeBucket = `-- name: GetEarliestChatMessageRuntimeBucket :one
+SELECT (
+    date_trunc('hour', cm.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+)::timestamptz AS earliest_bucket
+FROM chat_messages cm
+WHERE cm.runtime_ms IS NOT NULL
+ORDER BY cm.created_at ASC
+LIMIT 1
+`
+
+// Returns the first retained UTC hour with derivable Agent Time usage. No row
+// is returned when no retained message has runtime data.
+func (q *sqlQuerier) GetEarliestChatMessageRuntimeBucket(ctx context.Context) (time.Time, error) {
+	row := q.db.QueryRowContext(ctx, getEarliestChatMessageRuntimeBucket)
+	var earliest_bucket time.Time
+	err := row.Scan(&earliest_bucket)
+	return earliest_bucket, err
+}
+
 const getLastChatMessageByRole = `-- name: GetLastChatMessageByRole :one
 SELECT
     id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, search_tsv_config
@@ -11072,6 +11091,74 @@ func (q *sqlQuerier) ListChatContextResourcesByChatID(ctx context.Context, chatI
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMissingChatMessageRuntimeBuckets = `-- name: ListMissingChatMessageRuntimeBuckets :many
+WITH buckets AS (
+    SELECT generate_series(
+        $1::timestamptz,
+        ($2::timestamptz) - INTERVAL '1 hour',
+        INTERVAL '1 hour'
+    )::timestamptz AS bucket
+),
+runtime_by_bucket AS (
+    SELECT
+        (
+            date_trunc('hour', cm.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+        )::timestamptz AS bucket,
+        SUM(cm.runtime_ms)::bigint AS runtime_ms
+    FROM chat_messages cm
+    WHERE cm.created_at >= $1::timestamptz
+      AND cm.created_at < $2::timestamptz
+      AND cm.runtime_ms IS NOT NULL
+    GROUP BY 1
+)
+SELECT
+    buckets.bucket,
+    COALESCE(runtime_by_bucket.runtime_ms, 0)::bigint AS runtime_ms
+FROM buckets
+LEFT JOIN runtime_by_bucket USING (bucket)
+LEFT JOIN usage_events
+    ON usage_events.event_type = 'hb_agent_runtime_v1'
+    AND usage_events.created_at = buckets.bucket
+WHERE usage_events.id IS NULL
+ORDER BY buckets.bucket ASC
+`
+
+type ListMissingChatMessageRuntimeBucketsParams struct {
+	StartTime time.Time `db:"start_time" json:"start_time"`
+	EndTime   time.Time `db:"end_time" json:"end_time"`
+}
+
+type ListMissingChatMessageRuntimeBucketsRow struct {
+	Bucket    time.Time `db:"bucket" json:"bucket"`
+	RuntimeMs int64     `db:"runtime_ms" json:"runtime_ms"`
+}
+
+// Returns missing hb_agent_runtime_v1 buckets in the bounded, end-exclusive
+// range. The generated series preserves zero-runtime hours, and existing
+// runtime events remain sealed.
+func (q *sqlQuerier) ListMissingChatMessageRuntimeBuckets(ctx context.Context, arg ListMissingChatMessageRuntimeBucketsParams) ([]ListMissingChatMessageRuntimeBucketsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listMissingChatMessageRuntimeBuckets, arg.StartTime, arg.EndTime)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMissingChatMessageRuntimeBucketsRow
+	for rows.Next() {
+		var i ListMissingChatMessageRuntimeBucketsRow
+		if err := rows.Scan(&i.Bucket, &i.RuntimeMs); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -25600,6 +25687,35 @@ func (q *sqlQuerier) DeleteRuntimeConfig(ctx context.Context, key string) error 
 	return err
 }
 
+const ensureAgentRuntimeBackfillCheckpoint = `-- name: EnsureAgentRuntimeBackfillCheckpoint :exec
+INSERT INTO site_configs (key, value)
+VALUES ('agent_runtime_all_history_catchup_v1', '{"version":1,"status":"pending"}')
+ON CONFLICT (key) DO NOTHING
+`
+
+func (q *sqlQuerier) EnsureAgentRuntimeBackfillCheckpoint(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, ensureAgentRuntimeBackfillCheckpoint)
+	return err
+}
+
+const getAgentRuntimeBackfillCheckpoint = `-- name: GetAgentRuntimeBackfillCheckpoint :one
+SELECT
+    COALESCE((SELECT value FROM site_configs WHERE key = 'agent_runtime_all_history_catchup_v1'), '')::text AS value,
+    EXISTS(SELECT 1 FROM site_configs WHERE key = 'agent_runtime_all_history_catchup_v1')::boolean AS present
+`
+
+type GetAgentRuntimeBackfillCheckpointRow struct {
+	Value   string `db:"value" json:"value"`
+	Present bool   `db:"present" json:"present"`
+}
+
+func (q *sqlQuerier) GetAgentRuntimeBackfillCheckpoint(ctx context.Context) (GetAgentRuntimeBackfillCheckpointRow, error) {
+	row := q.db.QueryRowContext(ctx, getAgentRuntimeBackfillCheckpoint)
+	var i GetAgentRuntimeBackfillCheckpointRow
+	err := row.Scan(&i.Value, &i.Present)
+	return i, err
+}
+
 const getAnnouncementBanners = `-- name: GetAnnouncementBanners :one
 SELECT value FROM site_configs WHERE key = 'announcement_banners'
 `
@@ -26048,6 +26164,20 @@ INSERT INTO site_configs (key, value) VALUES ('deployment_id', $1)
 func (q *sqlQuerier) InsertDeploymentID(ctx context.Context, value string) error {
 	_, err := q.db.ExecContext(ctx, insertDeploymentID, value)
 	return err
+}
+
+const updateAgentRuntimeBackfillCheckpoint = `-- name: UpdateAgentRuntimeBackfillCheckpoint :one
+UPDATE site_configs
+SET value = $1::text
+WHERE key = 'agent_runtime_all_history_catchup_v1'
+RETURNING 1::bigint AS updated_rows
+`
+
+func (q *sqlQuerier) UpdateAgentRuntimeBackfillCheckpoint(ctx context.Context, value string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, updateAgentRuntimeBackfillCheckpoint, value)
+	var updated_rows int64
+	err := row.Scan(&updated_rows)
+	return updated_rows, err
 }
 
 const upsertAnnouncementBanners = `-- name: UpsertAnnouncementBanners :exec

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -2231,6 +2231,51 @@ WHERE cm.created_at >= @start_time::timestamptz
   AND cm.created_at < @end_time::timestamptz
   AND cm.runtime_ms IS NOT NULL;
 
+-- name: GetEarliestChatMessageRuntimeBucket :one
+-- Returns the first retained UTC hour with derivable Agent Time usage. No row
+-- is returned when no retained message has runtime data.
+SELECT (
+    date_trunc('hour', cm.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+)::timestamptz AS earliest_bucket
+FROM chat_messages cm
+WHERE cm.runtime_ms IS NOT NULL
+ORDER BY cm.created_at ASC
+LIMIT 1;
+
+-- name: ListMissingChatMessageRuntimeBuckets :many
+-- Returns missing hb_agent_runtime_v1 buckets in the bounded, end-exclusive
+-- range. The generated series preserves zero-runtime hours, and existing
+-- runtime events remain sealed.
+WITH buckets AS (
+    SELECT generate_series(
+        @start_time::timestamptz,
+        (@end_time::timestamptz) - INTERVAL '1 hour',
+        INTERVAL '1 hour'
+    )::timestamptz AS bucket
+),
+runtime_by_bucket AS (
+    SELECT
+        (
+            date_trunc('hour', cm.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+        )::timestamptz AS bucket,
+        SUM(cm.runtime_ms)::bigint AS runtime_ms
+    FROM chat_messages cm
+    WHERE cm.created_at >= @start_time::timestamptz
+      AND cm.created_at < @end_time::timestamptz
+      AND cm.runtime_ms IS NOT NULL
+    GROUP BY 1
+)
+SELECT
+    buckets.bucket,
+    COALESCE(runtime_by_bucket.runtime_ms, 0)::bigint AS runtime_ms
+FROM buckets
+LEFT JOIN runtime_by_bucket USING (bucket)
+LEFT JOIN usage_events
+    ON usage_events.event_type = 'hb_agent_runtime_v1'
+    AND usage_events.created_at = buckets.bucket
+WHERE usage_events.id IS NULL
+ORDER BY buckets.bucket ASC;
+
 -- name: GetChatsByWorkspaceIDs :many
 SELECT *
 FROM chats_expanded

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -23,6 +23,22 @@ INSERT INTO site_configs (key, value) VALUES ('deployment_id', $1);
 -- name: GetDeploymentID :one
 SELECT value FROM site_configs WHERE key = 'deployment_id';
 
+-- name: EnsureAgentRuntimeBackfillCheckpoint :exec
+INSERT INTO site_configs (key, value)
+VALUES ('agent_runtime_all_history_catchup_v1', '{"version":1,"status":"pending"}')
+ON CONFLICT (key) DO NOTHING;
+
+-- name: GetAgentRuntimeBackfillCheckpoint :one
+SELECT
+    COALESCE((SELECT value FROM site_configs WHERE key = 'agent_runtime_all_history_catchup_v1'), '')::text AS value,
+    EXISTS(SELECT 1 FROM site_configs WHERE key = 'agent_runtime_all_history_catchup_v1')::boolean AS present;
+
+-- name: UpdateAgentRuntimeBackfillCheckpoint :one
+UPDATE site_configs
+SET value = @value::text
+WHERE key = 'agent_runtime_all_history_catchup_v1'
+RETURNING 1::bigint AS updated_rows;
+
 -- name: InsertDERPMeshKey :exec
 INSERT INTO site_configs (key, value) VALUES ('derp_mesh_key', $1);
 

--- a/coderd/database/queries_internal_test.go
+++ b/coderd/database/queries_internal_test.go
@@ -26,3 +26,27 @@ func TestGetTotalUsageHBAgentRuntimeV1QueryEventType(t *testing.T) {
 			"event_data->>'"+field+"'")
 	}
 }
+
+func TestListMissingChatMessageRuntimeBucketsQueryLiterals(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, listMissingChatMessageRuntimeBuckets,
+		string(usagetypes.UsageEventTypeHBAgentRuntimeV1))
+	for field := range (usagetypes.HBAgentRuntime{}).Fields() {
+		require.Contains(t, listMissingChatMessageRuntimeBuckets,
+			"SUM(cm."+field+")")
+	}
+}
+
+func TestAgentRuntimeBackfillCheckpointQueryLiterals(t *testing.T) {
+	t.Parallel()
+
+	const (
+		checkpointKey     = "agent_runtime_all_history_catchup_v1"
+		pendingCheckpoint = `{"version":1,"status":"pending"}`
+	)
+	require.Contains(t, ensureAgentRuntimeBackfillCheckpoint, checkpointKey)
+	require.Contains(t, ensureAgentRuntimeBackfillCheckpoint, pendingCheckpoint)
+	require.Contains(t, getAgentRuntimeBackfillCheckpoint, checkpointKey)
+	require.Contains(t, updateAgentRuntimeBackfillCheckpoint, checkpointKey)
+}

--- a/coderd/usage/agent_runtime_backfill.go
+++ b/coderd/usage/agent_runtime_backfill.go
@@ -1,0 +1,119 @@
+package usage
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	// AgentRuntimeBackfillSiteConfigKey stores the durable checkpoint for the
+	// retained-history Agent Time catch-up.
+	AgentRuntimeBackfillSiteConfigKey = "agent_runtime_all_history_catchup_v1"
+	// AgentRuntimeBackfillVersion is the current checkpoint schema version.
+	AgentRuntimeBackfillVersion = 1
+	// AgentRuntimeBackfillPendingJSON is the initial durable checkpoint value.
+	AgentRuntimeBackfillPendingJSON = `{"version":1,"status":"pending"}`
+)
+
+// AgentRuntimeBackfillStatus is the lifecycle state of the retained-history
+// Agent Time catch-up.
+type AgentRuntimeBackfillStatus string
+
+const (
+	AgentRuntimeBackfillStatusPending  AgentRuntimeBackfillStatus = "pending"
+	AgentRuntimeBackfillStatusRunning  AgentRuntimeBackfillStatus = "running"
+	AgentRuntimeBackfillStatusComplete AgentRuntimeBackfillStatus = "complete"
+)
+
+// AgentRuntimeBackfillState is the durable checkpoint for the retained-history
+// Agent Time catch-up. Bucket bounds are UTC and end-exclusive.
+type AgentRuntimeBackfillState struct {
+	Version      int                        `json:"version"`
+	Status       AgentRuntimeBackfillStatus `json:"status"`
+	NextBucket   *time.Time                 `json:"next_bucket,omitempty"`
+	EndExclusive *time.Time                 `json:"end_exclusive,omitempty"`
+	CompletedAt  *time.Time                 `json:"completed_at,omitempty"`
+}
+
+// ParseAgentRuntimeBackfillState strictly parses and validates a checkpoint.
+func ParseAgentRuntimeBackfillState(value string) (AgentRuntimeBackfillState, error) {
+	var state AgentRuntimeBackfillState
+	dec := json.NewDecoder(bytes.NewBufferString(value))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&state); err != nil {
+		return AgentRuntimeBackfillState{}, xerrors.Errorf("decode agent runtime backfill state: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = xerrors.New("unexpected trailing JSON value")
+		}
+		return AgentRuntimeBackfillState{}, xerrors.Errorf("decode agent runtime backfill state: %w", err)
+	}
+	if err := state.validate(); err != nil {
+		return AgentRuntimeBackfillState{}, err
+	}
+	return state, nil
+}
+
+// MarshalAgentRuntimeBackfillState validates and serializes a checkpoint.
+func MarshalAgentRuntimeBackfillState(state AgentRuntimeBackfillState) (string, error) {
+	if err := state.validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", xerrors.Errorf("marshal agent runtime backfill state: %w", err)
+	}
+	return string(data), nil
+}
+
+func (s AgentRuntimeBackfillState) validate() error {
+	if s.Version != AgentRuntimeBackfillVersion {
+		return xerrors.Errorf("unsupported agent runtime backfill state version %d", s.Version)
+	}
+
+	switch s.Status {
+	case AgentRuntimeBackfillStatusPending:
+		if s.NextBucket != nil || s.EndExclusive != nil || s.CompletedAt != nil {
+			return xerrors.New("pending agent runtime backfill state must not contain progress")
+		}
+		return nil
+	case AgentRuntimeBackfillStatusRunning, AgentRuntimeBackfillStatusComplete:
+		if s.NextBucket == nil || s.EndExclusive == nil {
+			return xerrors.Errorf("%s agent runtime backfill state requires bucket bounds", s.Status)
+		}
+	default:
+		return xerrors.Errorf("invalid agent runtime backfill status %q", s.Status)
+	}
+
+	if !isUTCHour(*s.NextBucket) || !isUTCHour(*s.EndExclusive) {
+		return xerrors.New("agent runtime backfill bucket bounds must be UTC hours")
+	}
+	if s.NextBucket.After(*s.EndExclusive) {
+		return xerrors.New("agent runtime backfill next bucket is after end")
+	}
+
+	if s.Status == AgentRuntimeBackfillStatusRunning {
+		if s.CompletedAt != nil {
+			return xerrors.New("running agent runtime backfill state must not have completion time")
+		}
+		return nil
+	}
+	if s.CompletedAt == nil || s.CompletedAt.IsZero() {
+		return xerrors.New("complete agent runtime backfill state requires completion time")
+	}
+	if !s.NextBucket.Equal(*s.EndExclusive) {
+		return xerrors.New("complete agent runtime backfill state must be at its end")
+	}
+	return nil
+}
+
+func isUTCHour(t time.Time) bool {
+	_, offset := t.Zone()
+	return offset == 0 && t.Equal(t.UTC().Truncate(time.Hour))
+}

--- a/coderd/usage/agent_runtime_backfill_test.go
+++ b/coderd/usage/agent_runtime_backfill_test.go
@@ -1,0 +1,78 @@
+package usage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/usage"
+)
+
+func TestAgentRuntimeBackfillState(t *testing.T) {
+	t.Parallel()
+
+	next := time.Date(2025, 1, 2, 3, 0, 0, 0, time.UTC)
+	end := next.Add(time.Hour)
+	completedAt := end.Add(time.Minute)
+
+	for _, tc := range []struct {
+		name    string
+		value   string
+		want    usage.AgentRuntimeBackfillState
+		wantErr bool
+	}{
+		{
+			name:  "pending",
+			value: usage.AgentRuntimeBackfillPendingJSON,
+			want: usage.AgentRuntimeBackfillState{
+				Version: usage.AgentRuntimeBackfillVersion,
+				Status:  usage.AgentRuntimeBackfillStatusPending,
+			},
+		},
+		{
+			name:  "running",
+			value: `{"version":1,"status":"running","next_bucket":"2025-01-02T03:00:00Z","end_exclusive":"2025-01-02T04:00:00Z"}`,
+			want: usage.AgentRuntimeBackfillState{
+				Version:      usage.AgentRuntimeBackfillVersion,
+				Status:       usage.AgentRuntimeBackfillStatusRunning,
+				NextBucket:   &next,
+				EndExclusive: &end,
+			},
+		},
+		{
+			name:  "complete",
+			value: `{"version":1,"status":"complete","next_bucket":"2025-01-02T04:00:00Z","end_exclusive":"2025-01-02T04:00:00Z","completed_at":"2025-01-02T04:01:00Z"}`,
+			want: usage.AgentRuntimeBackfillState{
+				Version:      usage.AgentRuntimeBackfillVersion,
+				Status:       usage.AgentRuntimeBackfillStatusComplete,
+				NextBucket:   &end,
+				EndExclusive: &end,
+				CompletedAt:  &completedAt,
+			},
+		},
+		{name: "unknown field", value: `{"version":1,"status":"pending","extra":true}`, wantErr: true},
+		{name: "trailing value", value: usage.AgentRuntimeBackfillPendingJSON + `{}`, wantErr: true},
+		{name: "wrong version", value: `{"version":2,"status":"pending"}`, wantErr: true},
+		{name: "invalid status", value: `{"version":1,"status":"wat"}`, wantErr: true},
+		{name: "running missing bounds", value: `{"version":1,"status":"running"}`, wantErr: true},
+		{name: "non-hour bound", value: `{"version":1,"status":"running","next_bucket":"2025-01-02T03:01:00Z","end_exclusive":"2025-01-02T04:00:00Z"}`, wantErr: true},
+		{name: "next after end", value: `{"version":1,"status":"running","next_bucket":"2025-01-02T05:00:00Z","end_exclusive":"2025-01-02T04:00:00Z"}`, wantErr: true},
+		{name: "complete missing time", value: `{"version":1,"status":"complete","next_bucket":"2025-01-02T04:00:00Z","end_exclusive":"2025-01-02T04:00:00Z"}`, wantErr: true},
+		{name: "complete before end", value: `{"version":1,"status":"complete","next_bucket":"2025-01-02T03:00:00Z","end_exclusive":"2025-01-02T04:00:00Z","completed_at":"2025-01-02T04:01:00Z"}`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := usage.ParseAgentRuntimeBackfillState(tc.value)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			marshaled, err := usage.MarshalAgentRuntimeBackfillState(got)
+			require.NoError(t, err)
+			require.JSONEq(t, tc.value, marshaled)
+		})
+	}
+}

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -75,8 +75,16 @@ Coder sends the license JWT and deployment ID as request headers.
 The request body contains one `hb_agent_runtime_v1` event for each UTC hour.
 The `runtime_ms` value is the total Agent Time recorded during that hour.
 Idle hours have a value of `0`.
-If the deployment was offline, Coder backfills missed hours for up to seven days, batching up to 100 events per request.
-Hours missing beyond seven days aren't reported.
+
+Coder continuously backfills missing events from the previous 7 days when a deployment restarts after downtime.
+Coder also performs a one-time, resumable catch-up for older retained chat messages that contain recorded runtime data.
+The catch-up includes zero-runtime hours between the earliest retained runtime-bearing message and the start of the continuous 7-day window.
+It cannot reconstruct Agent Time from before runtime recording began or from chat history that the deployment already hard-deleted.
+
+An existing `hb_agent_runtime_v1` event seals its UTC hour.
+Coder doesn't recalculate or overwrite that event, even if the event was already published or permanently rejected.
+Coder sends only events newer than 30 days to Tallyman, so older catch-up events remain available locally but aren't published.
+Coder batches up to 100 eligible events per publishing request.
 
 The following example reports 1 hour of Agent Time:
 

--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -157,7 +157,10 @@ func (r *RootCmd) Server(_ func()) *serpent.Command {
 		// Usage generation is deliberately not license-gated; the
 		// publish_usage_data license flag only gates publishing to Tallyman.
 		usageGenerator := usage.NewGenerator(quartz.NewReal(), options.Logger.Named("usage-event-generator"), options.Database, *options.UsageInserter.Load())
-		usageGenerator.Start(ctx)
+		if err := usageGenerator.Start(ctx); err != nil {
+			_ = closers.Close()
+			return nil, nil, xerrors.Errorf("start usage event generator: %w", err)
+		}
 		closers.Add(usageGenerator)
 
 		// In-memory AI Bridge Proxy daemon. The bridge daemon itself is

--- a/enterprise/coderd/usage/generator.go
+++ b/enterprise/coderd/usage/generator.go
@@ -20,10 +20,10 @@ import (
 const (
 	// AgentRuntimeInterval is the bucket size of hb_agent_runtime_v1 events.
 	AgentRuntimeInterval = time.Hour
-	// AgentRuntimeWindow is the trailing window scanned for missing buckets.
-	// Buckets still missing beyond this window (e.g. because the deployment
-	// was down for longer) are forfeited, which can only ever undercount
-	// usage.
+	// AgentRuntimeWindow is the trailing window continually scanned for
+	// missing buckets. A separate one-time catch-up handles retained history
+	// before this window. After the catch-up completes, any newly discovered
+	// gap older than the window is forfeited, which can only undercount usage.
 	AgentRuntimeWindow = 7 * 24 * time.Hour
 	// AgentRuntimeEligibilityLag is how long after a bucket closes before it
 	// becomes eligible for generation, giving replicas time to commit
@@ -46,16 +46,19 @@ const (
 
 // Generator reconciles hb_agent_runtime_v1 heartbeat usage events. Unlike
 // Cron jobs, which sample live state when they fire, the Generator derives
-// events from data already persisted in the database, so it can
-// deterministically backfill hours missed while the deployment was down,
-// zero-filling idle hours. Deterministic event IDs make concurrent replicas
+// events from data already persisted in the database. It continually repairs
+// the trailing seven-day window and performs one resumable catch-up over older
+// retained runtime-bearing chat history, zero-filling idle hours. History from
+// before runtime recording began or already hard-deleted chats is unavailable.
+// Deterministic event IDs make concurrent replicas
 // safe without locking: the insert's ON CONFLICT (id) arbiter turns a
 // re-insert of a bucket into a no-op, even when the competing insert is
 // still in flight (once its arbiter index entry is visible, PostgreSQL
 // waits on that transaction and takes the DO NOTHING path if it commits).
 // Only the narrow speculative-insertion race, before the competing row's
 // arbiter entry exists, surfaces a bucket unique violation instead, which
-// generateBucket recognizes as the other replica winning.
+// generateBucket recognizes as the other replica winning. Any existing runtime
+// event seals its hour and is never recalculated or overwritten.
 //
 // Events are generated unconditionally in enterprise builds; the
 // publish_usage_data license flag only gates publishing to Tallyman.
@@ -65,9 +68,11 @@ type Generator struct {
 	db    database.Store
 	ins   agplusage.Inserter
 
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	startOnce sync.Once
+	cancel                   context.CancelFunc
+	wg                       sync.WaitGroup
+	startOnce                sync.Once
+	startErr                 error
+	initialRecentWindowStart time.Time
 }
 
 // NewGenerator creates an unstarted Generator.
@@ -80,16 +85,49 @@ func NewGenerator(clock quartz.Clock, log slog.Logger, db database.Store, ins ag
 	}
 }
 
-// Start launches the reconciliation goroutine. Subsequent calls are no-ops;
-// a closed Generator cannot be restarted.
-func (g *Generator) Start(ctx context.Context) {
+// Start ensures the durable historical checkpoint exists, then launches the
+// recent reconciliation and retained-history catch-up goroutines. Subsequent
+// calls return the first call's result; a closed Generator cannot be restarted.
+func (g *Generator) Start(ctx context.Context) error {
 	g.startOnce.Do(func() {
+		// The marker must exist before dbpurge's immediate startup tick so it can
+		// protect retained chat history until the catch-up reaches it.
+		//nolint:gocritic // Startup work requires the usage publisher subject.
+		publisherCtx := dbauthz.AsUsagePublisher(ctx)
+		if err := g.db.EnsureAgentRuntimeBackfillCheckpoint(publisherCtx); err != nil {
+			g.startErr = xerrors.Errorf("ensure agent runtime backfill checkpoint: %w", err)
+			return
+		}
+
+		// Historical catch-up stops at this fixed boundary. The recent loop's
+		// first pass starts at the same boundary even if startup crosses an hour,
+		// preventing an unowned bucket between the two loops.
+		g.initialRecentWindowStart = g.clock.Now().UTC().Truncate(AgentRuntimeInterval).Add(-AgentRuntimeWindow)
+		checkpoint, err := g.db.GetAgentRuntimeBackfillCheckpoint(publisherCtx)
+		if err != nil {
+			g.log.Warn(ctx, "read agent runtime backfill checkpoint at startup", slog.Error(err))
+		} else if checkpoint.Present {
+			state, err := agplusage.ParseAgentRuntimeBackfillState(checkpoint.Value)
+			if err != nil {
+				g.log.Warn(ctx, "parse agent runtime backfill checkpoint at startup", slog.Error(err))
+			} else if state.Status == agplusage.AgentRuntimeBackfillStatusRunning {
+				// A restart may happen after the original fixed boundary has aged
+				// beyond the trailing window. Preserve adjacency by letting the
+				// first recent pass resume at the historical boundary.
+				g.initialRecentWindowStart = *state.EndExclusive
+			}
+		}
+
 		ctx, g.cancel = context.WithCancel(ctx)
-		g.wg.Add(1)
+		g.wg.Add(2)
 		pproflabel.Go(ctx, pproflabel.Service(pproflabel.ServiceUsageEventGenerator), func(ctx context.Context) {
 			g.run(ctx)
 		})
+		pproflabel.Go(ctx, pproflabel.Service(pproflabel.ServiceUsageEventGenerator), func(ctx context.Context) {
+			g.runHistoricalCatchup(ctx)
+		})
 	})
+	return g.startErr
 }
 
 // Close stops the Generator and waits for its goroutine to exit.
@@ -111,6 +149,7 @@ func (g *Generator) run(ctx context.Context) {
 	// The random initial delay staggers replicas that start simultaneously.
 	//nolint:gosec // Jitter does not need cryptographic randomness.
 	delay := agentRuntimeStartupDelay + time.Duration(rand.Int63n(int64(agentRuntimeJitter)))
+	earliest := g.initialRecentWindowStart
 	for {
 		timer := g.clock.NewTimer(delay, generatorTimerName)
 
@@ -123,7 +162,10 @@ func (g *Generator) run(ctx context.Context) {
 		case <-timer.C:
 		}
 
-		err := g.generateAgentRuntimeEvents(ctx)
+		err := g.generateAgentRuntimeEvents(ctx, earliest)
+		if err == nil {
+			earliest = time.Time{}
+		}
 		if ctx.Err() != nil {
 			return
 		}
@@ -144,11 +186,13 @@ func (g *Generator) run(ctx context.Context) {
 // missing hourly bucket in the trailing window. Per-bucket errors skip only
 // that bucket; the next tick rescans the whole window, so transient failures
 // self-heal.
-func (g *Generator) generateAgentRuntimeEvents(ctx context.Context) error {
+func (g *Generator) generateAgentRuntimeEvents(ctx context.Context, earliest time.Time) error {
 	now := g.clock.Now().UTC()
 	// Bucket [H, H+1) becomes eligible at H + interval + lag.
 	latestEligible := now.Add(-AgentRuntimeInterval - AgentRuntimeEligibilityLag).Truncate(AgentRuntimeInterval)
-	earliest := now.Truncate(AgentRuntimeInterval).Add(-AgentRuntimeWindow)
+	if earliest.IsZero() {
+		earliest = now.Truncate(AgentRuntimeInterval).Add(-AgentRuntimeWindow)
+	}
 	if latestEligible.Before(earliest) {
 		return nil
 	}
@@ -239,16 +283,21 @@ func (g *Generator) generateBucket(ctx context.Context, bucket time.Time) error 
 	// The deterministic ID makes concurrent inserts of the same bucket
 	// idempotent, and created_at is the bucket start (not the insertion
 	// time) so daily rollups attribute backfilled hours to the correct day.
+	_, err = g.insertAgentRuntimeEvent(ctx, g.db, bucket, runtimeMs)
+	return err
+}
+
+func (g *Generator) insertAgentRuntimeEvent(ctx context.Context, db database.Store, bucket time.Time, runtimeMs int64) (bool, error) {
 	stableID := string(usagetypes.UsageEventTypeHBAgentRuntimeV1) + ":" + bucket.Format(usageEventIDTimeFormat)
-	err = g.ins.InsertHeartbeatUsageEvent(ctx, g.db, stableID, bucket, usagetypes.HBAgentRuntime{RuntimeMs: runtimeMs})
+	err := g.ins.InsertHeartbeatUsageEvent(ctx, db, stableID, bucket, usagetypes.HBAgentRuntime{RuntimeMs: runtimeMs})
 	if database.IsUniqueViolation(err, database.UniqueIndexUsageEventsAgentRuntime) {
 		// Another replica already created this bucket's row. The Generator
 		// doc comment explains why this race reaches the bucket unique
 		// index instead of the insert's ON CONFLICT (id) arbiter.
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return xerrors.Errorf("insert usage event: %w", err)
+		return false, xerrors.Errorf("insert usage event: %w", err)
 	}
-	return nil
+	return true, nil
 }

--- a/enterprise/coderd/usage/generator_internal_test.go
+++ b/enterprise/coderd/usage/generator_internal_test.go
@@ -1,16 +1,19 @@
 package usage
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -40,4 +43,125 @@ func TestGenerateBucketUniqueViolation(t *testing.T) {
 
 	bucket := time.Date(2025, 3, 10, 10, 0, 0, 0, time.UTC)
 	require.NoError(t, gen.generateBucket(ctx, bucket))
+}
+
+func TestGeneratorStartCheckpointFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	mDB.EXPECT().EnsureAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(xerrors.New("boom"))
+	gen := NewGenerator(quartz.NewMock(t), slogtest.Make(t, nil), mDB, NewDBInserter())
+
+	err := gen.Start(ctx)
+	require.ErrorContains(t, err, "ensure agent runtime backfill checkpoint")
+	require.Equal(t, err, gen.Start(ctx), "subsequent starts return the initialization error")
+	require.NoError(t, gen.Close())
+}
+
+func TestGenerateHistoricalCatchupBatchLockUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	mDB.EXPECT().InTx(gomock.Any(), database.DefaultTXOptions().WithID("agent_runtime_historical_backfill")).
+		DoAndReturn(func(f func(database.Store) error, _ *database.TxOptions) error { return f(mDB) })
+	mDB.EXPECT().TryAcquireLock(gomock.Any(), int64(database.LockIDAgentRuntimeHistoricalBackfill)).Return(false, nil)
+	gen := NewGenerator(quartz.NewMock(t), slogtest.Make(t, nil), mDB, NewDBInserter())
+
+	result, err := gen.generateHistoricalCatchupBatch(ctx)
+	require.NoError(t, err)
+	require.False(t, result.lockAcquired)
+}
+
+func TestGenerateHistoricalCatchupBatchFailureDoesNotAdvance(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	start := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	checkpoint, err := agplusage.MarshalAgentRuntimeBackfillState(agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+		NextBucket:   &start,
+		EndExclusive: &end,
+	})
+	require.NoError(t, err)
+
+	mDB.EXPECT().InTx(gomock.Any(), database.DefaultTXOptions().WithID("agent_runtime_historical_backfill")).
+		DoAndReturn(func(f func(database.Store) error, _ *database.TxOptions) error { return f(mDB) })
+	mDB.EXPECT().TryAcquireLock(gomock.Any(), int64(database.LockIDAgentRuntimeHistoricalBackfill)).Return(true, nil)
+	mDB.EXPECT().GetAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(database.GetAgentRuntimeBackfillCheckpointRow{
+		Value: checkpoint, Present: true,
+	}, nil)
+	mDB.EXPECT().ListMissingChatMessageRuntimeBuckets(gomock.Any(), database.ListMissingChatMessageRuntimeBucketsParams{
+		StartTime: start, EndTime: end,
+	}).Return([]database.ListMissingChatMessageRuntimeBucketsRow{{Bucket: start, RuntimeMs: 1000}}, nil)
+	mDB.EXPECT().InsertUsageEvent(gomock.Any(), gomock.Any()).Return(xerrors.New("insert failed"))
+	// No checkpoint update is expected, so gomock fails if the cursor advances.
+	gen := NewGenerator(quartz.NewMock(t), slogtest.Make(t, nil), mDB, NewDBInserter())
+
+	_, err = gen.generateHistoricalCatchupBatch(ctx)
+	require.ErrorContains(t, err, "insert historical bucket")
+}
+
+func TestUpdateHistoricalCatchupCheckpointRequiresExistingRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	start := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	mDB.EXPECT().UpdateAgentRuntimeBackfillCheckpoint(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+
+	err := updateHistoricalCatchupCheckpoint(ctx, mDB, agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+		NextBucket:   &start,
+		EndExclusive: &end,
+	})
+	require.ErrorContains(t, err, "expected 1 row, updated 0")
+}
+
+func TestGenerateHistoricalCatchupBatchSkipsNegativeBucket(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	clock := quartz.NewMock(t)
+	clock.Set(time.Date(2025, 3, 10, 14, 0, 0, 0, time.UTC))
+	start := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	checkpoint, err := agplusage.MarshalAgentRuntimeBackfillState(agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+		NextBucket:   &start,
+		EndExclusive: &end,
+	})
+	require.NoError(t, err)
+
+	mDB.EXPECT().InTx(gomock.Any(), database.DefaultTXOptions().WithID("agent_runtime_historical_backfill")).
+		DoAndReturn(func(f func(database.Store) error, _ *database.TxOptions) error { return f(mDB) })
+	mDB.EXPECT().TryAcquireLock(gomock.Any(), int64(database.LockIDAgentRuntimeHistoricalBackfill)).Return(true, nil)
+	mDB.EXPECT().GetAgentRuntimeBackfillCheckpoint(gomock.Any()).Return(database.GetAgentRuntimeBackfillCheckpointRow{
+		Value: checkpoint, Present: true,
+	}, nil)
+	mDB.EXPECT().ListMissingChatMessageRuntimeBuckets(gomock.Any(), database.ListMissingChatMessageRuntimeBucketsParams{
+		StartTime: start, EndTime: end,
+	}).Return([]database.ListMissingChatMessageRuntimeBucketsRow{{Bucket: start, RuntimeMs: -1}}, nil)
+	mDB.EXPECT().UpdateAgentRuntimeBackfillCheckpoint(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, value string) (int64, error) {
+			state, err := agplusage.ParseAgentRuntimeBackfillState(value)
+			require.NoError(t, err)
+			require.Equal(t, agplusage.AgentRuntimeBackfillStatusComplete, state.Status)
+			require.Equal(t, end, *state.NextBucket)
+			return 1, nil
+		})
+	gen := NewGenerator(clock, slogtest.Make(t, nil), mDB, NewDBInserter())
+
+	result, err := gen.generateHistoricalCatchupBatch(ctx)
+	require.NoError(t, err)
+	require.True(t, result.complete)
+	require.Equal(t, []time.Time{start}, result.invalidBuckets)
 }

--- a/enterprise/coderd/usage/generator_test.go
+++ b/enterprise/coderd/usage/generator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
 	"github.com/coder/coder/v2/coderd/usage/usagetypes"
 	"github.com/coder/coder/v2/enterprise/coderd/usage"
 	"github.com/coder/coder/v2/testutil"
@@ -83,6 +84,24 @@ func newGeneratorHarness(t *testing.T) *generatorHarness {
 		OwnerID:           user.ID,
 		LastModelConfigID: mc.ID,
 	})
+
+	// Most generator tests exercise the steady-state loop. Mark the one-time
+	// historical catch-up complete so it cannot add older buckets in parallel;
+	// focused catch-up tests reset this checkpoint to pending.
+	require.NoError(t, db.EnsureAgentRuntimeBackfillCheckpoint(t.Context()))
+	completedAt := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	checkpoint, err := agplusage.MarshalAgentRuntimeBackfillState(agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusComplete,
+		NextBucket:   &completedAt,
+		EndExclusive: &completedAt,
+		CompletedAt:  &completedAt,
+	})
+	require.NoError(t, err)
+	updated, err := db.UpdateAgentRuntimeBackfillCheckpoint(t.Context(), checkpoint)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated)
+
 	return &generatorHarness{
 		db:          db,
 		authzDB:     authzDB,
@@ -92,6 +111,25 @@ func newGeneratorHarness(t *testing.T) *generatorHarness {
 		chat:        chat,
 		chat2:       chat2,
 	}
+}
+
+func (h *generatorHarness) setBackfillState(t *testing.T, state agplusage.AgentRuntimeBackfillState) {
+	t.Helper()
+	value, err := agplusage.MarshalAgentRuntimeBackfillState(state)
+	require.NoError(t, err)
+	updated, err := h.db.UpdateAgentRuntimeBackfillCheckpoint(t.Context(), value)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated)
+}
+
+func (h *generatorHarness) backfillState(t *testing.T) agplusage.AgentRuntimeBackfillState {
+	t.Helper()
+	checkpoint, err := h.db.GetAgentRuntimeBackfillCheckpoint(t.Context())
+	require.NoError(t, err)
+	require.True(t, checkpoint.Present)
+	state, err := agplusage.ParseAgentRuntimeBackfillState(checkpoint.Value)
+	require.NoError(t, err)
+	return state
 }
 
 func (h *generatorHarness) insertRuntimeMessage(ctx context.Context, t *testing.T, chatID uuid.UUID, runtimeMs int64, createdAt time.Time, deleted bool) {
@@ -188,7 +226,7 @@ func TestGenerator(t *testing.T) {
 	defer trap.Close()
 
 	gen := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
-	gen.Start(ctx)
+	require.NoError(t, gen.Start(ctx))
 	defer gen.Close()
 
 	call := trap.MustWait(ctx)
@@ -251,7 +289,7 @@ func TestGenerator(t *testing.T) {
 	// A separate generator started later (e.g. another replica restarting)
 	// finds nothing to do: all buckets in its window already exist.
 	gen2 := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
-	gen2.Start(ctx)
+	require.NoError(t, gen2.Start(ctx))
 	defer gen2.Close()
 	call = trap.MustWait(ctx)
 	call.MustRelease(ctx)
@@ -261,6 +299,155 @@ func TestGenerator(t *testing.T) {
 
 	runtimes2, _ := h.fetchRuntimeEvents(ctx, t)
 	require.Equal(t, runtimes, runtimes2)
+}
+
+func TestGeneratorStartupHourBoundary(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	h := newGeneratorHarness(t)
+	clock := quartz.NewMock(t)
+	startTime := time.Date(2025, 3, 10, 14, 59, 0, 0, time.UTC)
+	clock.Set(startTime)
+	initialWindowStart := startTime.Truncate(time.Hour).Add(-usage.AgentRuntimeWindow)
+	h.insertRuntimeMessage(ctx, t, h.chat.ID, 1000, initialWindowStart.Add(10*time.Minute), false)
+
+	trap := clock.Trap().NewTimer(generatorTimerName)
+	defer trap.Close()
+	gen := usage.NewGenerator(clock, slogtest.Make(t, nil), h.authzDB, usage.NewDBInserter())
+	require.NoError(t, gen.Start(ctx))
+	defer gen.Close()
+
+	call := trap.MustWait(ctx)
+	call.MustRelease(ctx)
+	clock.Advance(call.Duration).MustWait(ctx)
+	require.False(t, clock.Now().Before(startTime.Add(time.Minute)), "first pass must cross the hour boundary")
+	call = trap.MustWait(ctx)
+	call.MustRelease(ctx)
+
+	runtimes, _ := h.fetchRuntimeEvents(ctx, t)
+	require.EqualValues(t, 1000, runtimes[initialWindowStart],
+		"the historical and recent loops must not leave an unowned startup bucket")
+}
+
+func TestGeneratorRestartWhileHistoricalCatchupRunning(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	h := newGeneratorHarness(t)
+	clock := quartz.NewMock(t)
+	startTime := time.Date(2025, 3, 20, 14, 0, 0, 0, time.UTC)
+	clock.Set(startTime)
+
+	// The historical boundary was fixed during an earlier startup and has
+	// since aged beyond the current trailing seven-day window.
+	historicalBoundary := time.Date(2025, 3, 10, 14, 0, 0, 0, time.UTC)
+	h.setBackfillState(t, agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+		NextBucket:   &historicalBoundary,
+		EndExclusive: &historicalBoundary,
+	})
+	h.insertRuntimeMessage(ctx, t, h.chat.ID, 1000, historicalBoundary.Add(10*time.Minute), false)
+
+	trap := clock.Trap().NewTimer(generatorTimerName)
+	defer trap.Close()
+	gen := usage.NewGenerator(clock, slogtest.Make(t, nil), h.authzDB, usage.NewDBInserter())
+	require.NoError(t, gen.Start(ctx))
+	defer gen.Close()
+
+	call := trap.MustWait(ctx)
+	call.MustRelease(ctx)
+	clock.Advance(call.Duration).MustWait(ctx)
+	call = trap.MustWait(ctx)
+	call.MustRelease(ctx)
+
+	runtimes, _ := h.fetchRuntimeEvents(ctx, t)
+	require.EqualValues(t, 1000, runtimes[historicalBoundary],
+		"restart must preserve adjacency with the fixed historical boundary")
+}
+
+func TestGeneratorHistoricalCatchup(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	log := slogtest.Make(t, nil)
+	h := newGeneratorHarness(t)
+	clock := quartz.NewMock(t)
+	startTime := time.Date(2025, 3, 10, 14, 0, 0, 0, time.UTC)
+	clock.Set(startTime)
+
+	earliest := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	poison := earliest.Add(time.Hour)
+	existingBucket := time.Date(2025, 3, 2, 10, 0, 0, 0, time.UTC)
+	endExclusive := startTime.Add(-usage.AgentRuntimeWindow)
+
+	h.insertRuntimeMessage(ctx, t, h.chat.ID, 1000, earliest.Add(10*time.Minute), false)
+	h.insertRuntimeMessage(ctx, t, h.chat.ID, -5, poison.Add(10*time.Minute), false)
+	h.insertRuntimeMessage(ctx, t, h.chat2.ID, 2000, earliest.Add(2*time.Hour+10*time.Minute), true)
+
+	inserter := usage.NewDBInserter()
+	require.NoError(t, inserter.InsertHeartbeatUsageEvent(ctx, h.db,
+		"hb_agent_runtime_v1:"+existingBucket.Format("2006-01-02_15:04:05"),
+		existingBucket, usagetypes.HBAgentRuntime{RuntimeMs: 999}))
+
+	h.setBackfillState(t, agplusage.AgentRuntimeBackfillState{
+		Version: agplusage.AgentRuntimeBackfillVersion,
+		Status:  agplusage.AgentRuntimeBackfillStatusPending,
+	})
+
+	gen := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
+	require.NoError(t, gen.Start(ctx))
+	defer gen.Close()
+
+	testutil.Eventually(ctx, t, func(context.Context) bool {
+		return h.backfillState(t).Status == agplusage.AgentRuntimeBackfillStatusComplete
+	}, testutil.IntervalFast)
+
+	state := h.backfillState(t)
+	require.Equal(t, endExclusive, *state.NextBucket)
+	require.Equal(t, endExclusive, *state.EndExclusive)
+
+	runtimes, _ := h.fetchRuntimeEvents(ctx, t)
+	expected := expectedBuckets(earliest, endExclusive.Add(-time.Hour), map[time.Time]int64{
+		earliest:                    1000,
+		earliest.Add(2 * time.Hour): 2000,
+		existingBucket:              999,
+	})
+	delete(expected, poison)
+	require.Equal(t, expected, runtimes)
+	require.NotContains(t, runtimes, endExclusive, "historical and recent ranges must not overlap")
+
+	// Completion is durable: a restarted generator does not recalculate or
+	// overwrite any existing event.
+	gen2 := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
+	require.NoError(t, gen2.Start(ctx))
+	require.NoError(t, gen2.Close())
+	runtimesAfterRestart, _ := h.fetchRuntimeEvents(ctx, t)
+	require.Equal(t, runtimes, runtimesAfterRestart)
+}
+
+func TestGeneratorHistoricalCatchupNoRetainedRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	h := newGeneratorHarness(t)
+	clock := quartz.NewMock(t)
+	clock.Set(time.Date(2025, 3, 10, 14, 0, 0, 0, time.UTC))
+	h.setBackfillState(t, agplusage.AgentRuntimeBackfillState{
+		Version: agplusage.AgentRuntimeBackfillVersion,
+		Status:  agplusage.AgentRuntimeBackfillStatusPending,
+	})
+
+	gen := usage.NewGenerator(clock, slogtest.Make(t, nil), h.authzDB, usage.NewDBInserter())
+	require.NoError(t, gen.Start(ctx))
+	defer gen.Close()
+
+	testutil.Eventually(ctx, t, func(context.Context) bool {
+		return h.backfillState(t).Status == agplusage.AgentRuntimeBackfillStatusComplete
+	}, testutil.IntervalFast)
+	runtimes, _ := h.fetchRuntimeEvents(ctx, t)
+	require.Empty(t, runtimes)
 }
 
 // TestGeneratorBackfillAfterDowntime simulates a deployment that was down
@@ -293,7 +480,7 @@ func TestGeneratorBackfillAfterDowntime(t *testing.T) {
 	defer trap.Close()
 
 	gen := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
-	gen.Start(ctx)
+	require.NoError(t, gen.Start(ctx))
 	defer gen.Close()
 
 	call := trap.MustWait(ctx)
@@ -339,7 +526,7 @@ func TestGeneratorInserterArguments(t *testing.T) {
 	defer trap.Close()
 
 	gen := usage.NewGenerator(clock, log, h.authzDB, ins)
-	gen.Start(ctx)
+	require.NoError(t, gen.Start(ctx))
 	defer gen.Close()
 
 	// Each pass requests its next timer only after finishing, so trapping
@@ -399,7 +586,7 @@ func TestGeneratorConcurrentReplicas(t *testing.T) {
 		traps = append(traps, trap)
 
 		gen := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
-		gen.Start(ctx)
+		require.NoError(t, gen.Start(ctx))
 		// Cleanups run LIFO, so each generator is closed before its trap.
 		t.Cleanup(func() { _ = gen.Close() })
 
@@ -458,7 +645,7 @@ func TestGeneratorPoisonBucket(t *testing.T) {
 	defer trap.Close()
 
 	gen := usage.NewGenerator(clock, log, h.authzDB, usage.NewDBInserter())
-	gen.Start(ctx)
+	require.NoError(t, gen.Start(ctx))
 	defer gen.Close()
 
 	call := trap.MustWait(ctx)

--- a/enterprise/coderd/usage/history_catchup.go
+++ b/enterprise/coderd/usage/history_catchup.go
@@ -1,0 +1,272 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	agplusage "github.com/coder/coder/v2/coderd/usage"
+)
+
+const (
+	historicalCatchupBatchSize  = 7 * 24 * time.Hour
+	historicalCatchupBatchDelay = 100 * time.Millisecond
+	historicalCatchupRetryDelay = time.Minute
+	historicalCatchupTimerName  = "agent-runtime-history-catchup"
+)
+
+type historicalCatchupBatchResult struct {
+	lockAcquired bool
+	initialized  bool
+	complete     bool
+
+	start          time.Time
+	end            time.Time
+	next           time.Time
+	endExclusive   time.Time
+	inserted       int
+	existing       int
+	invalidBuckets []time.Time
+	duration       time.Duration
+}
+
+func (g *Generator) runHistoricalCatchup(ctx context.Context) {
+	//nolint:gocritic // We are a publisher in this function.
+	ctx = dbauthz.AsUsagePublisher(ctx)
+	defer g.wg.Done()
+
+	for {
+		result, err := g.generateHistoricalCatchupBatch(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+
+		delay := historicalCatchupBatchDelay
+		switch {
+		case err != nil:
+			g.log.Warn(ctx, "generate historical agent runtime usage events",
+				slog.F("batch_start", result.start),
+				slog.F("batch_end", result.end),
+				slog.F("next_bucket", result.next),
+				slog.F("end_exclusive", result.endExclusive),
+				slog.F("duration", result.duration),
+				slog.Error(err),
+			)
+			delay = historicalCatchupRetryDelay
+		case !result.lockAcquired:
+			g.log.Debug(ctx, "historical agent runtime catch-up lock unavailable")
+			delay = historicalCatchupRetryDelay
+		case result.complete:
+			return
+		}
+
+		timer := g.clock.NewTimer(delay, historicalCatchupTimerName)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (g *Generator) generateHistoricalCatchupBatch(ctx context.Context) (historicalCatchupBatchResult, error) {
+	startedAt := g.clock.Now()
+	result := historicalCatchupBatchResult{}
+
+	err := g.db.InTx(func(tx database.Store) error {
+		// InTx can retry a transaction, so discard counters from an aborted
+		// attempt before recording the committed attempt.
+		result = historicalCatchupBatchResult{}
+		locked, err := tx.TryAcquireLock(ctx, database.LockIDAgentRuntimeHistoricalBackfill)
+		if err != nil {
+			return xerrors.Errorf("acquire historical catch-up lock: %w", err)
+		}
+		result.lockAcquired = locked
+		if !locked {
+			return nil
+		}
+
+		checkpoint, err := tx.GetAgentRuntimeBackfillCheckpoint(ctx)
+		if err != nil {
+			return xerrors.Errorf("read historical catch-up checkpoint: %w", err)
+		}
+		if !checkpoint.Present {
+			return xerrors.New("historical catch-up checkpoint is missing")
+		}
+		state, err := agplusage.ParseAgentRuntimeBackfillState(checkpoint.Value)
+		if err != nil {
+			return xerrors.Errorf("parse historical catch-up checkpoint: %w", err)
+		}
+		if state.Status == agplusage.AgentRuntimeBackfillStatusComplete {
+			result.complete = true
+			result.next = *state.NextBucket
+			result.endExclusive = *state.EndExclusive
+			return nil
+		}
+
+		if state.Status == agplusage.AgentRuntimeBackfillStatusPending {
+			state, err = g.initializeHistoricalCatchup(ctx, tx)
+			if err != nil {
+				return err
+			}
+			result.initialized = true
+			result.next = *state.NextBucket
+			result.endExclusive = *state.EndExclusive
+			if state.Status == agplusage.AgentRuntimeBackfillStatusComplete {
+				if err := updateHistoricalCatchupCheckpoint(ctx, tx, state); err != nil {
+					return err
+				}
+				result.complete = true
+				return nil
+			}
+		}
+
+		result.start = *state.NextBucket
+		result.endExclusive = *state.EndExclusive
+		result.end = minTime(result.start.Add(historicalCatchupBatchSize), result.endExclusive)
+		if !result.start.Before(result.end) {
+			completedAt := g.clock.Now().UTC()
+			state.Status = agplusage.AgentRuntimeBackfillStatusComplete
+			state.NextBucket = state.EndExclusive
+			state.CompletedAt = &completedAt
+			if err := updateHistoricalCatchupCheckpoint(ctx, tx, state); err != nil {
+				return err
+			}
+			result.complete = true
+			result.next = result.endExclusive
+			return nil
+		}
+
+		buckets, err := tx.ListMissingChatMessageRuntimeBuckets(ctx, database.ListMissingChatMessageRuntimeBucketsParams{
+			StartTime: result.start,
+			EndTime:   result.end,
+		})
+		if err != nil {
+			return xerrors.Errorf("list historical runtime buckets: %w", err)
+		}
+		result.existing = int(result.end.Sub(result.start)/AgentRuntimeInterval) - len(buckets)
+		for _, bucket := range buckets {
+			bucketTime := bucket.Bucket.UTC()
+			if bucket.RuntimeMs < 0 {
+				result.invalidBuckets = append(result.invalidBuckets, bucketTime)
+				continue
+			}
+			inserted, err := g.insertAgentRuntimeEvent(ctx, tx, bucketTime, bucket.RuntimeMs)
+			if err != nil {
+				return xerrors.Errorf("insert historical bucket %s: %w", bucketTime, err)
+			}
+			if inserted {
+				result.inserted++
+			} else {
+				result.existing++
+			}
+		}
+
+		state.NextBucket = &result.end
+		result.next = result.end
+		if result.end.Equal(result.endExclusive) {
+			completedAt := g.clock.Now().UTC()
+			state.Status = agplusage.AgentRuntimeBackfillStatusComplete
+			state.CompletedAt = &completedAt
+			result.complete = true
+		}
+		return updateHistoricalCatchupCheckpoint(ctx, tx, state)
+	}, database.DefaultTXOptions().WithID("agent_runtime_historical_backfill"))
+
+	result.duration = g.clock.Since(startedAt)
+	if err != nil {
+		return result, err
+	}
+	if !result.lockAcquired {
+		return result, nil
+	}
+
+	if result.initialized {
+		g.log.Info(ctx, "initialized historical agent runtime catch-up",
+			slog.F("next_bucket", result.next),
+			slog.F("end_exclusive", result.endExclusive),
+			slog.F("completed", result.complete),
+		)
+	}
+	for _, bucket := range result.invalidBuckets {
+		g.log.Warn(ctx, "skip negative historical agent runtime bucket",
+			slog.F("bucket", bucket),
+		)
+	}
+	if !result.start.IsZero() {
+		g.log.Info(ctx, "committed historical agent runtime catch-up batch",
+			slog.F("batch_start", result.start),
+			slog.F("batch_end", result.end),
+			slog.F("buckets_inserted", result.inserted),
+			slog.F("buckets_existing", result.existing),
+			slog.F("buckets_failed", len(result.invalidBuckets)),
+			slog.F("next_bucket", result.next),
+			slog.F("duration", result.duration),
+			slog.F("completed", result.complete),
+		)
+	}
+	if result.complete {
+		g.log.Info(ctx, "completed historical agent runtime catch-up",
+			slog.F("end_exclusive", result.endExclusive),
+			slog.F("completed_at", g.clock.Now().UTC()),
+		)
+	}
+	return result, nil
+}
+
+func (g *Generator) initializeHistoricalCatchup(ctx context.Context, tx database.Store) (agplusage.AgentRuntimeBackfillState, error) {
+	endExclusive := g.initialRecentWindowStart
+	if endExclusive.IsZero() {
+		endExclusive = g.clock.Now().UTC().Truncate(AgentRuntimeInterval).Add(-AgentRuntimeWindow)
+	}
+	earliest, err := tx.GetEarliestChatMessageRuntimeBucket(ctx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return agplusage.AgentRuntimeBackfillState{}, xerrors.Errorf("find earliest historical runtime bucket: %w", err)
+	}
+
+	earliest = earliest.UTC().Truncate(AgentRuntimeInterval)
+	state := agplusage.AgentRuntimeBackfillState{
+		Version:      agplusage.AgentRuntimeBackfillVersion,
+		Status:       agplusage.AgentRuntimeBackfillStatusRunning,
+		NextBucket:   &earliest,
+		EndExclusive: &endExclusive,
+	}
+	if errors.Is(err, sql.ErrNoRows) || !earliest.Before(endExclusive) {
+		completedAt := g.clock.Now().UTC()
+		state.Status = agplusage.AgentRuntimeBackfillStatusComplete
+		state.NextBucket = &endExclusive
+		state.CompletedAt = &completedAt
+	}
+	return state, nil
+}
+
+func updateHistoricalCatchupCheckpoint(ctx context.Context, tx database.Store, state agplusage.AgentRuntimeBackfillState) error {
+	value, err := agplusage.MarshalAgentRuntimeBackfillState(state)
+	if err != nil {
+		return xerrors.Errorf("marshal historical catch-up checkpoint: %w", err)
+	}
+	updated, err := tx.UpdateAgentRuntimeBackfillCheckpoint(ctx, value)
+	if err != nil {
+		return xerrors.Errorf("update historical catch-up checkpoint: %w", err)
+	}
+	if updated != 1 {
+		return xerrors.Errorf("update historical catch-up checkpoint: expected 1 row, updated %d", updated)
+	}
+	return nil
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

Add a resumable one-time catch-up that converts retained `chat_messages.runtime_ms` history into hourly `hb_agent_runtime_v1` usage events while preserving the existing trailing seven-day reconciliation.

## Problem

The steady-state generator repairs only the previous seven days. On upgrade, older retained runtime-bearing chat messages could be deleted by the immediate database purge tick before their Agent Time was recorded, and idle hours or interior historical gaps had no durable recovery path.

## Fix

Store a versioned catch-up checkpoint in `site_configs`, process history oldest-first in atomic seven-day batches under an advisory lock, and insert only missing UTC hourly events. Existing events remain sealed, negative buckets are skipped without blocking later history, and the recent and historical loops share a fixed boundary so startup or restart timing cannot leave an unowned hour.

Database purge now defers only archived chat and chat-file deletion while the checkpoint still covers rows before the retention cutoff. Other purge categories continue normally. The standard/full server creates the checkpoint synchronously before the purge service starts.

The bounded historical query uses the existing `idx_chat_messages_created_at` index. Seeded query-plan validation measured approximately 0.26 ms for sparse history and 5.4 ms for a dense seven-day range, so no new index is added.
