### PR TITLE
ci: resolve org installation for release App token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -552,6 +552,10 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # The App is installed at the org level, so resolve the org
+          # installation (avoids a 404 on the per-repo installation lookup).
+          owner: ${{ github.repository_owner }}
+          repositories: coder
 
       - name: Publish release
         run: |


### PR DESCRIPTION
Follow-up to #28553 (already merged), which missed this fix.

## Problem

The `Generate release App token` step failed with:

```
GET https://api.github.com/repos/coder/coder/installation - 404 Not Found
```

`create-github-app-token` defaulted to a per-repo installation lookup, which 404s when the App is installed at the org level.

## Change

Resolve the org installation explicitly:

```yaml
owner: ${{ github.repository_owner }}
repositories: coder
```

Refs coder/security-automation#297.
