### PR TITLE
docs: correct plan mode MCP tool availability

### DIFF
--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -275,9 +275,7 @@ skills in its `.agents/skills/` directory.
 `propose_plan` and `ask_user_question` are only available while plan mode is active.
 In plan mode, the agent can still inspect the workspace and template metadata, execute shell commands for exploration, and read process output.
 `write_file` and `edit_files` remain available only for the chat-specific plan file under `.coder/plans/`.
-Root plan-mode chats can also use external MCP tools that an administrator approved for plan mode.
 Workspace MCP tools are unavailable in plan mode, and plan-mode sub-agents receive no MCP tools.
-Dynamic, provider-native, and computer-use tools are blocked.
 
 ## Plan mode
 
@@ -297,6 +295,7 @@ While plan mode is active:
 - `execute` and `process_output` remain available for exploration, such as cloning repositories, searching code, and running inspection commands.
 - External MCP tools are available to root chats only for the server configurations an administrator approved for plan mode; workspace MCP tools and MCP tools for plan-mode sub-agents are not available.
 - Dynamic tools, provider-native tools, and computer-use tools are not available.
+- Root plan-mode chats can also use external MCP tools that an administrator approved for plan mode.
 
 This keeps planning turns focused on analysis and plan authoring rather than
 implementation. Once you click **Implement plan**, the next turn runs in normal

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -272,11 +272,9 @@ enabled by an administrator.
 `read_skill` and `read_skill_file` are available when the workspace contains
 skills in its `.agents/skills/` directory.
 
-`propose_plan` and `ask_user_question` are only available while plan mode is
-active. In plan mode, the agent can still inspect the workspace and template
-metadata, execute shell commands for exploration, and read process output.
-`write_file` and `edit_files` remain available only for the chat-specific plan
-file under `.coder/plans/`.
+`propose_plan` and `ask_user_question` are only available while plan mode is active.
+In plan mode, the agent can still inspect the workspace and template metadata, execute shell commands for exploration, and read process output.
+`write_file` and `edit_files` remain available only for the chat-specific plan file under `.coder/plans/`.
 Root plan-mode chats can also use external MCP tools that an administrator approved for plan mode.
 Workspace MCP tools are unavailable in plan mode, and plan-mode sub-agents receive no MCP tools.
 Dynamic, provider-native, and computer-use tools are blocked.
@@ -292,15 +290,6 @@ current setting.
 
 While plan mode is active:
 
-- the agent can inspect repository files, workspace state, and available
-  templates
-- `write_file` and `edit_files` can only modify the chat-specific plan file
-  under `.coder/plans/`
-- `ask_user_question` can gather structured clarification from the user before
-  a plan is proposed
-- `propose_plan` snapshots the current plan file into the transcript so you can
-  review it before implementation starts
-- `execute` and `process_output` remain available for exploration, such as
 - The agent can inspect repository files, workspace state, and available templates.
 - `write_file` and `edit_files` can only modify the chat-specific plan file under `.coder/plans/`.
 - `ask_user_question` can gather structured clarification from the user before a plan is proposed.

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -276,9 +276,9 @@ skills in its `.agents/skills/` directory.
 active. In plan mode, the agent can still inspect the workspace and template
 metadata, execute shell commands for exploration, and read process output.
 `write_file` and `edit_files` remain available only for the chat-specific plan
-file under `.coder/plans/`. Root plan-mode chats can also use external MCP tools
-that an administrator approved for plan mode. Workspace MCP tools are
-unavailable in plan mode, and plan-mode sub-agents receive no MCP tools.
+file under `.coder/plans/`.
+Root plan-mode chats can also use external MCP tools that an administrator approved for plan mode.
+Workspace MCP tools are unavailable in plan mode, and plan-mode sub-agents receive no MCP tools.
 Dynamic, provider-native, and computer-use tools are blocked.
 
 ## Plan mode
@@ -301,11 +301,13 @@ While plan mode is active:
 - `propose_plan` snapshots the current plan file into the transcript so you can
   review it before implementation starts
 - `execute` and `process_output` remain available for exploration, such as
-  cloning repositories, searching code, and running inspection commands
-- external MCP tools are available to root chats only for the server
-  configurations an administrator approved for plan mode; workspace MCP tools
-  and MCP tools for plan-mode sub-agents are not available
-- dynamic tools, provider-native tools, and computer-use tools are not available
+- The agent can inspect repository files, workspace state, and available templates.
+- `write_file` and `edit_files` can only modify the chat-specific plan file under `.coder/plans/`.
+- `ask_user_question` can gather structured clarification from the user before a plan is proposed.
+- `propose_plan` snapshots the current plan file into the transcript so you can review it before implementation starts.
+- `execute` and `process_output` remain available for exploration, such as cloning repositories, searching code, and running inspection commands.
+- External MCP tools are available to root chats only for the server configurations an administrator approved for plan mode; workspace MCP tools and MCP tools for plan-mode sub-agents are not available.
+- Dynamic tools, provider-native tools, and computer-use tools are not available.
 
 This keeps planning turns focused on analysis and plan authoring rather than
 implementation. Once you click **Implement plan**, the next turn runs in normal

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -276,8 +276,10 @@ skills in its `.agents/skills/` directory.
 active. In plan mode, the agent can still inspect the workspace and template
 metadata, execute shell commands for exploration, and read process output.
 `write_file` and `edit_files` remain available only for the chat-specific plan
-file under `.coder/plans/`. MCP, dynamic, provider-native, and computer-use
-tools are blocked.
+file under `.coder/plans/`. Root plan-mode chats can also use external MCP tools
+that an administrator approved for plan mode. Workspace MCP tools are
+unavailable in plan mode, and plan-mode sub-agents receive no MCP tools.
+Dynamic, provider-native, and computer-use tools are blocked.
 
 ## Plan mode
 
@@ -300,8 +302,10 @@ While plan mode is active:
   review it before implementation starts
 - `execute` and `process_output` remain available for exploration, such as
   cloning repositories, searching code, and running inspection commands
-- MCP tools, dynamic tools, provider-native tools, and computer-use tools are
-  not available
+- external MCP tools are available to root chats only for the server
+  configurations an administrator approved for plan mode; workspace MCP tools
+  and MCP tools for plan-mode sub-agents are not available
+- dynamic tools, provider-native tools, and computer-use tools are not available
 
 This keeps planning turns focused on analysis and plan authoring rather than
 implementation. Once you click **Implement plan**, the next turn runs in normal


### PR DESCRIPTION
`docs/ai-coder/agents/index.md` claimed that MCP tools are blocked in plan mode. Root plan-mode chats actually receive external MCP tools for each server configuration an administrator approved for plan mode; only workspace MCP tools and plan-mode sub-agents get none.

Corrects the plan-mode tool-availability wording in both places it appears in `index.md` so it matches `docs/ai-coder/agents/architecture.md` and the implementation. The tool table and attachment wording are out of scope here.

Linear: DOCS-724 https://linear.app/codercom/issue/DOCS-724

<details><summary>Analysis evidence</summary>

`coderd/x/chatd/chatd.go`, `filterExternalMCPConfigsForTurn`: in plan mode, a chat with a parent gets no external MCP configs ("Plan-mode subagents do not receive external MCP tools"); a root chat keeps every config whose `AllowInPlanMode` flag is set and returns those IDs as approved.

`coderd/x/chatd/generation_preparer.go`: the returned `approvedPlanMCPConfigIDs` flows into `filterToolsForTurn` and `activeToolNamesForTurn`, so approved external MCP tools remain exposed for the turn.

`coderd/x/chatd/chatd.go`, `toolAllowedForTurn`: in plan mode a tool passes only if it is on the built-in plan allowlist or is an MCP tool whose `MCPServerConfigID()` is in the approved set. Workspace MCP tools are not in the external config set, so they stay unavailable.

`docs/ai-coder/agents/architecture.md` already documents this behavior; `index.md` now uses the same framing.

</details>

Generated by Coder Agents on behalf of @nickvigilante.
