### PR TITLE
docs: fix chat status names and auto-archive behavior claims

### DIFF
--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -70,8 +70,8 @@ Coder Agents does not change your workspace network requirements.
 When a user submits a prompt, the control plane processes it as a background
 job:
 
-1. The prompt is saved to the database and the chat is marked `pending`.
-1. The control plane picks up the chat and marks it `running`.
+1. The prompt is saved to the database and the chat is marked `running`.
+1. A chat worker in the control plane claims the chat and starts a turn.
 1. The control plane streams the conversation to the configured LLM provider.
 1. The model responds with text, reasoning, or tool calls.
 1. If the response includes tool calls, the control plane executes them

--- a/docs/ai-coder/agents/platform-controls/chat-auto-archive.md
+++ b/docs/ai-coder/agents/platform-controls/chat-auto-archive.md
@@ -7,20 +7,12 @@ out of the separate retention window, at which point they are purged.
 
 ## How it works
 
-A background process periodically scans the chat database for root
-conversations whose most recent non-deleted message predates the
-configured auto-archive window and flips them from "active" to
-"archived". Eligibility is evaluated at UTC day boundaries: all
-conversations whose last activity falls on the same UTC date are
-archived together on the first tick after midnight UTC following the
-expiration of their archive window. Cascaded children (chats
-linked into a larger conversation via `root_chat_id`) are archived
-alongside their parent so the conversation stays coherent.
+The Coder Agents chat worker scans the chat database once an hour for root conversations whose most recent non-deleted message predates the configured auto-archive window, and flips them from "active" to "archived".
+Eligibility is evaluated at UTC day boundaries: all conversations whose last activity falls on the same UTC date are archived together on the first tick after midnight UTC following the expiration of their archive window.
+Cascaded children (chats linked into a larger conversation via `root_chat_id`) are archived alongside their parent so the conversation stays coherent.
 
-Activity is defined as the most recent non-deleted message in the
-conversation family, counting messages from every role. Root chats
-whose status indicates ongoing work (`running`, `pending`, `paused`,
-or `requires_action`) are never selected for auto-archiving.
+Activity is defined as the most recent non-deleted message in the conversation family, counting messages from every role.
+Root chats whose status indicates ongoing work (`running`, `interrupting`, or `requires_action`) are never selected for auto-archiving.
 Children inherit their root's archival decision.
 
 Pinned root conversations (those with a non-zero pin order) are never
@@ -39,6 +31,9 @@ once per day (on the first tick after midnight UTC that finds newly
 eligible chats). A large backlog (initial enablement or bulk
 inactivity) may span multiple ticks, producing multiple notifications
 until the backlog drains.
+
+Each digest lists at most 25 conversation titles.
+When a tick archives more than that, the notification names the first 25 and reports the remainder as a count.
 
 If you find the digest noisy, you can disable the "Chats
 Auto-Archived" notification entirely from your notification preferences.
@@ -76,6 +71,8 @@ The auto-archive window is stored as the
 The default is `0` (disabled); set to a positive number of days to
 enable auto-archiving.
 
+Admins can set the window in the dashboard under **AI Settings** > **Coder Agents** > **Lifecycle**.
+
 Use the admin API to read or update the value:
 
     GET  /api/v2/chats/config/auto-archive-days
@@ -83,14 +80,11 @@ Use the admin API to read or update the value:
 
 ## Rollout advice
 
-Auto-archive is disabled by default, so upgrading to a release that
-includes this feature will not archive any existing chats until an
-admin opts in. The first tick after enabling auto-archive on a
-deployment with a long history will process up to 1,000 root chats
-(and their children). If your deployment has a large backlog, the
-initial rollout will span many ticks. This is intentional and avoids
-stalling the rest of `dbpurge` during the first run. To disable,
-set `auto_archive_days` back to `0`.
+Auto-archive is disabled by default, so upgrading to a release that includes this feature will not archive any existing chats until an admin opts in.
+The first tick after enabling auto-archive on a deployment with a long history will process up to 1,000 root chats (and their children).
+If your deployment has a large backlog, the initial rollout will span many ticks.
+This is intentional and keeps each tick bounded so auto-archive doesn't crowd out the chat worker's other background work.
+To disable, set `auto_archive_days` back to `0`.
 
 ## Audit trail
 

--- a/docs/ai-coder/agents/platform-controls/chat-auto-archive.md
+++ b/docs/ai-coder/agents/platform-controls/chat-auto-archive.md
@@ -7,12 +7,12 @@ out of the separate retention window, at which point they are purged.
 
 ## How it works
 
-The Coder Agents chat worker scans the chat database once an hour for root conversations whose most recent non-deleted message predates the configured auto-archive window, and flips them from "active" to "archived".
-Eligibility is evaluated at UTC day boundaries: all conversations whose last activity falls on the same UTC date are archived together on the first tick after midnight UTC following the expiration of their archive window.
-Cascaded children (chats linked into a larger conversation via `root_chat_id`) are archived alongside their parent so the conversation stays coherent.
+The Coder Agents chat worker scans the chat database once an hour for root conversations where the most recent non-deleted message predates the configured auto-archive window, and flips them from "active" to "archived".
+Eligibility is evaluated at UTC day boundaries: all conversations with last activity falling on the same UTC date are archived together on the first tick after midnight UTC following the expiration of their archive window.
+Cascaded child chats are archived alongside their parent so the conversation stays coherent.
 
 Activity is defined as the most recent non-deleted message in the conversation family, counting messages from every role.
-Root chats whose status indicates ongoing work (`running`, `interrupting`, or `requires_action`) are never selected for auto-archiving.
+Root chats that have ongoing work are never selected for auto-archiving.
 Children inherit their root's archival decision.
 
 Pinned root conversations (those with a non-zero pin order) are never


### PR DESCRIPTION
Two Coder Agents pages describe chat statuses that no longer exist and attribute auto-archive to the wrong subsystem. The valid status set is `waiting`, `running`, `error`, `requires_action`, `interrupting`.

- `architecture.md`: a submitted prompt marks the chat `running`, not `pending`; there is no queued state.
- `chat-auto-archive.md`: the excluded status set is `running`, `interrupting`, `requires_action`.
- `chat-auto-archive.md`: the job runs in the chatd chat worker on an hourly tick, not in `dbpurge`.
- `chat-auto-archive.md`: documents the dashboard control at **AI Settings** > **Coder Agents** > **Lifecycle**, and the 25-title cap on the digest notification.

API paths on the auto-archive page are intentionally untouched; a separate PR fixes the `/api/v2` to `/api/experimental` drift.

Linear: DOCS-722 https://linear.app/codercom/issue/DOCS-722

<details><summary>Analysis evidence</summary>

- `codersdk/chats.go`: `ChatStatus` constants are `waiting`, `running`, `error`, `requires_action`, `interrupting`. No `pending`, `paused`, or `completed`.
- `coderd/x/chatd/chatstate/transitions.go`: `sendMessageQueueAndSetStatus` and the send paths apply `database.ChatStatusRunning`, so a submitted prompt is `running` immediately. `docs/ai-coder/agents/tasks-to-chats-migration.md` already states that chats have no separate queued state.
- `coderd/database/queries/chats.sql`, `GetAutoArchiveInactiveChatCandidates`: `status NOT IN ('running', 'interrupting', 'requires_action')`, plus `archived = false`, `pin_order = 0`, `parent_chat_id IS NULL`.
- `coderd/x/chatd/auto_archive.go`: `archiveLoop` runs from `coderd/x/chatd/worker.go` on `opts.ArchiveInterval`; `coderd/x/chatd/options.go` sets `defaultArchiveInterval = time.Hour`. Nothing in `dbpurge` performs chat auto-archive.
- `coderd/x/chatd/auto_archive.go`: `chatAutoArchiveDigestMaxChats = 25`; `buildAutoArchiveDigestData` truncates to 25 titles and reports the remainder as `additional_archived_count`.
- `coderd/x/chatd/options.go`: `defaultArchiveBatchSize = int32(1000)`, so the existing "up to 1,000 root chats" claim stands.
- `site/src/pages/AISettingsPage/LifecyclePage/LifecyclePageView.tsx` mounts `AutoArchiveSettings`; `site/src/modules/management/AISettingsSidebarView.tsx` places the Lifecycle sub-nav item under Coder Agents.

Validation: `pnpm run format-docs` (no changes) and `pnpm run lint-docs` (0 errors).

</details>

Generated by Coder Agents on behalf of @nickvigilante.
