### PR TITLE
docs: align Coder Agents docs with GA framing and licensing terms

### DIFF
--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -219,13 +219,13 @@ token volume. Consider:
 
 - Starting with a single model to establish a cost baseline.
 - Capping spend with [AI Gateway budgets](./platform-controls/spend-management.md).
-- Monitoring provider dashboards for usage trends during the evaluation.
+- Monitoring provider dashboards for usage trends as adoption grows.
 
 ### Plan for concurrency limits
 
 Community licenses run up to 5 agents at once.
 Additional agents queue and start automatically when capacity frees.
-Premium licenses with Agent Hours do not impose a concurrency limit unless the Agent Hours hard limit is reached.
+A Premium license with the Agent Hours entitlement does not impose a concurrency limit unless the Agent Hours hard limit is reached.
 If the Agent Hours allocation is exhausted without a configured hard limit, Coder warns about usage but does not impose a concurrency limit.
 When the Agent Hours hard limit is reached, additional agents queue under the concurrency limit.
 Refer to [Concurrent agents](./platform-controls/index.md#concurrent-agents) for details.
@@ -242,8 +242,8 @@ Good starting points:
 - **Prototyping** — building proof-of-concept implementations, simple
   dashboards, internal tools.
 
-Set expectations that this is an evaluation period. Developers should still
-review all agent-produced code before merging. The agent is a force
+Set expectations for how the team reviews agent output. Developers should
+still review all agent-produced code before merging. The agent is a force
 multiplier, not a replacement for developer judgment.
 
 ### Use the API for programmatic automation
@@ -305,20 +305,18 @@ already-running workspace instead of provisioning from scratch.
 
 ## Providing feedback
 
-Coder Agents is a collaborative evaluation between your team and Coder.
-Share feedback — workflow observations, feature requests, bugs, performance
-issues, or operational challenges — through your **customer-specific Slack
-channel** with the Coder team.
+Report bugs and feature requests as
+[GitHub issues](https://github.com/coder/coder/issues/new/choose).
+For deployment-specific problems, such as provider configuration or
+performance in your environment, use your usual Coder support channel.
 
-Good feedback includes:
+Good reports include:
 
-- **What you tried** — the prompt, the template, and the model.
-- **What happened** — the agent's behavior, any errors, unexpected results.
-- **What you expected** — the outcome you were looking for.
-- **Context** — screenshots, `chat_id` values, or links to the Agents page help
+- **What you tried**: the prompt, the template, and the model.
+- **What happened**: the agent's behavior, any errors, and unexpected results.
+- **What you expected**: the outcome you were looking for.
+- **Context**: screenshots, `chat_id` values, or links to the Agents page help
   the team investigate quickly.
-
-Your input directly influences product direction.
 
 ## Next steps
 

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -225,7 +225,7 @@ token volume. Consider:
 
 Community licenses run up to 5 agents at once.
 Additional agents queue and start automatically when capacity frees.
-A Premium license with the Agent Hours entitlement does not impose a concurrency limit unless the Agent Hours hard limit is reached.
+A Premium license with Agent Hours does not impose a concurrency limit unless the Agent Hours hard limit is reached.
 If the Agent Hours allocation is exhausted without a configured hard limit, Coder warns about usage but does not impose a concurrency limit.
 When the Agent Hours hard limit is reached, additional agents queue under the concurrency limit.
 Refer to [Concurrent agents](./platform-controls/index.md#concurrent-agents) for details.

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -242,9 +242,9 @@ Good starting points:
 - **Prototyping** — building proof-of-concept implementations, simple
   dashboards, internal tools.
 
-Set expectations for how the team reviews agent output. Developers should
-still review all agent-produced code before merging. The agent is a force
-multiplier, not a replacement for developer judgment.
+Set expectations for how the team reviews agent output.
+Developers should still review all agent-produced code before merging.
+The agent is a force multiplier, not a replacement for developer judgment.
 
 ### Use the API for programmatic automation
 
@@ -305,10 +305,8 @@ already-running workspace instead of provisioning from scratch.
 
 ## Providing feedback
 
-Report bugs and feature requests as
-[GitHub issues](https://github.com/coder/coder/issues/new/choose).
-For deployment-specific problems, such as provider configuration or
-performance in your environment, use your usual Coder support channel.
+Report bugs and feature requests as [GitHub issues](https://github.com/coder/coder/issues/new/choose).
+For deployment-specific problems, such as provider configuration or performance in your environment, use your usual Coder support channel.
 
 Good reports include:
 

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -13,7 +13,7 @@ With this agent pool, individuals and small teams can experiment with Coder Agen
 
 ## Premium licenses and Agent Hours
 
-A Premium license with the Agent Hours entitlement includes a customizable amount of Agent Time, the measured usage that draws down the entitlement.
+A Premium license includes a preset amount of Agent Time.
 Agent Time is shared across the deployment, allowing unlimited agents to run concurrently while consuming from a shared pool of purchased working hours.
 This usage-based model supports enterprise workloads where large development teams, background automation, and API-triggered tasks can create variable bursts of agent activity.
 

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -11,9 +11,9 @@ Coder doesn't limit how long those agents can run or how many tasks they complet
 Agents queue when more than five agents are active at a time.
 With this agent pool, individuals and small teams can experiment with Coder Agents at no cost.
 
-## AI Premium licenses and Agent Time
+## Premium licenses and Agent Hours
 
-AI Premium licenses include a customizable amount of Agent Time.
+A Premium license with the Agent Hours entitlement includes a customizable amount of Agent Time, the measured usage that draws down the entitlement.
 Agent Time is shared across the deployment, allowing unlimited agents to run concurrently while consuming from a shared pool of purchased working hours.
 This usage-based model supports enterprise workloads where large development teams, background automation, and API-triggered tasks can create variable bursts of agent activity.
 
@@ -49,7 +49,7 @@ Coder handles concurrency and usage limits differently depending on the license 
 When a Community license deployment reaches its limit of five concurrently active agents, Coder places additional agents in a queue.
 When an active agent completes its task, the next queued agent begins its work.
 
-### AI Premium Agent Time exhaustion
+### Agent Hours exhaustion
 
 Coder sends deployment administrators an in-app soft warning as the deployment approaches its maximum allotted Agent Time, so they can purchase additional Agent Time before the concurrency fallback takes effect.
 

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -123,7 +123,7 @@ Queued agents show a banner in the chat and start automatically when capacity fr
 Subtasks delegated by an agent don't count toward this limit.
 Those subtasks run in a separate pool of up to 10 concurrent subtasks.
 
-Premium deployments can purchase Agent Hours with their Premium license.
+Deployments with a Premium license can purchase the Agent Hours entitlement.
 Agent Hours are shared across the deployment, and agents can run concurrently unless the Agent Hours hard limit is reached.
 If the Agent Hours allocation is exhausted without a configured hard limit, Coder warns about usage but does not impose a concurrency limit.
 When the Agent Hours hard limit is reached, additional agents queue under the concurrency limit.

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -123,7 +123,7 @@ Queued agents show a banner in the chat and start automatically when capacity fr
 Subtasks delegated by an agent don't count toward this limit.
 Those subtasks run in a separate pool of up to 10 concurrent subtasks.
 
-Deployments with a Premium license can purchase the Agent Hours entitlement.
+Deployments with a Premium license can purchase Agent Hours.
 Agent Hours are shared across the deployment, and agents can run concurrently unless the Agent Hours hard limit is reached.
 If the Agent Hours allocation is exhausted without a configured hard limit, Coder warns about usage but does not impose a concurrency limit.
 When the Agent Hours hard limit is reached, additional agents queue under the concurrency limit.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1089,8 +1089,7 @@
 								{
 									"title": "Chat debug logging",
 									"description": "Record detailed traces of each Coder Agents chat turn to troubleshoot agent behavior.",
-									"path": "./ai-coder/agents/platform-controls/chat-debug-logging.md",
-									"state": ["early access"]
+									"path": "./ai-coder/agents/platform-controls/chat-debug-logging.md"
 								}
 							]
 						},


### PR DESCRIPTION
Removes early-access-program framing from the Coder Agents docs, drops a stale `early access` manifest tag, and standardizes the licensing wording on "Premium license with the Agent Hours entitlement".

- `docs/ai-coder/agents/getting-started.md`: replaces the "collaborative evaluation between your team and Coder" and customer-specific Slack channel feedback path with GitHub issues plus normal Coder support channels, and rewrites the remaining evaluation-period wording to GA tone. Rollout guidance (pilot group, cost planning, concurrency) is kept.
- `docs/manifest.json`: removes `"state": ["early access"]` from `ai-coder/agents/platform-controls/chat-debug-logging.md`, which is not experiment-gated.
- Licensing terminology aligned across `getting-started.md`, `licensing-usage.md`, and `platform-controls/index.md`.

No changes to `docs/reference/api/**` and no API path changes.

<details><summary>Analysis evidence</summary>

**Manifest state tag decisions (all `ai-coder/agents` pages)**

| Page | Tag before | Tag after | Why |
|------|-----------|-----------|-----|
| `platform-controls/chat-debug-logging.md` | `["early access"]` | none | Routes at `coderd/coderd.go` (`GET`/`PUT /debug-logging`, `GET`/`PUT /user-debug-logging`) sit outside any `RequireExperimentWithDevBypass` group, there is no matching experiment in the `codersdk.Experiment` list, and the page body already states the feature is not experiment-gated. |
| `platform-controls/advisor.md` | `["early access"]` | unchanged | Gated by `codersdk.ExperimentChatAdvisor` (`chat-advisor`); routes wrapped in `RequireExperimentWithDevBypass`. |
| `platform-controls/virtual-desktop.md` | `["early access"]` | unchanged | Gated by `codersdk.ExperimentChatVirtualDesktop` (`chat-virtual-desktop`); routes wrapped in `RequireExperimentWithDevBypass`. |
| `platform-controls/spend-management.md` | `["premium"]` | unchanged | `premium` is a licensing tag, not a maturity tag, and the page states budget endpoints require a license that includes AI Gateway. Flagging for awareness rather than changing it. |
| All other `ai-coder/agents` pages | none | none | No maturity tags to review. |

**Licensing mechanics**

`enterprise/coderd/license/license.go` decodes `agent_runtime_hours_allocation`, `agent_runtime_hours_limit_soft`, and `agent_runtime_hours_limit_hard` into `codersdk.FeatureAgentRuntimeHours` on Premium licenses. `enterprise/coderd/x/chatd/agentadmission.go` lifts the concurrency cap only when that feature is enabled and usage is below the hard limit. So the entitlement, not the license tier alone, is what removes the cap. Wording is now "Premium license with the Agent Hours entitlement".

`licensing-usage.md` keeps "Agent Time" as the name of the measured usage metric (matching `runtime_ms` reporting) and now says explicitly that Agent Time draws down the Agent Hours entitlement. Renaming the metric itself was left out of scope; flagging in case the product team wants one name for both.

**Validation**

`pnpm install --frozen-lockfile`, `pnpm run format-docs` (no table changes), `pnpm run lint-docs` (499 files, 0 errors).

</details>

Linear: DOCS-718 https://linear.app/codercom/issue/DOCS-718

Generated by Coder Agents on behalf of @nickvigilante.
