### PR TITLE
docs: add branch-naming rule to prevent issue-tracker auto-link collisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ For changes under `site/src/`, also read [FRONTEND_PATTERNS.md](.claude/docs/FRO
 - Prefer targeted tests and checks while iterating. Run the broader checks required by the affected area before handoff.
 - Do not force-push unless explicitly requested.
 - Commit and PR titles use `type(scope): message`. A scope must be a real path containing every changed file. Use a broader scope or no scope for cross-cutting changes.
+- Name branches so they do not collide with issue-tracker IDs. When a branch references a GitHub issue number, write it as `issue-<number>` (for example, `issue-1234-fix-flake`), not as a bare `<word>-<number>` such as `docs-1234` or a leading number. Connected trackers like Linear auto-link any branch containing a `<key>-<number>` token to the same-numbered issue on the team that owns `<key>`, silently attaching the PR to an unrelated ticket and moving it through that ticket's workflow.
 
 ## Essential commands
 


### PR DESCRIPTION
## What

Add a branch-naming rule to `AGENTS.md`: when a branch references a GitHub issue
number, write it as `issue-<number>` instead of a bare `<word>-<number>` (e.g.
`docs-1234`) or a leading number.

## Why

Connected issue trackers (e.g. Linear) auto-link any branch whose name contains
a `<key>-<number>` token to the same-numbered issue on the team that owns
`<key>`, silently attaching the PR to an unrelated ticket and moving it through
that ticket's workflow. The `issue-` prefix keeps the number readable while
avoiding the match.

Docs / agent-instructions only: one added bullet under `## Workflow`.
markdownlint and markdown-table-formatter are clean on the changed file.

Linear: DOCS-725

> This PR was created with AI assistance (Coder Agents).
