### PR TITLE
docs: fix Coder Agents tool tables, search filters, attachments, template ranking

### DIFF
--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -218,9 +218,7 @@ These tools are conditionally available based on the workspace contents.
 
 ### MCP tool search
 
-This tool runs in the control plane and replaces the full MCP tool schemas with
-a searchable catalog, so a large MCP surface does not consume the context
-window.
+This tool runs in the control plane and replaces the full MCP tool schemas with a searchable catalog, so a large MCP surface does not consume the context window.
 
 | Tool         | What it does                                                                                                                                                                                           |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -163,14 +163,15 @@ workspace connection. Platform and orchestration tools are only available to
 root chats — sub-agents spawned by `spawn_agent` do not have access to them
 and cannot create workspaces or spawn further sub-agents.
 
-| Tool                | What it does                                                                            |
-|---------------------|-----------------------------------------------------------------------------------------|
-| `list_templates`    | Browses available workspace templates, sorted by popularity.                            |
-| `read_template`     | Gets template details and configurable parameters.                                      |
-| `create_workspace`  | Creates a workspace from a template and waits for it to be ready.                       |
-| `start_workspace`   | Starts the chat's workspace if it is currently stopped. Idempotent if already running.  |
-| `propose_plan`      | Presents a Markdown plan file from the workspace for user review before implementation. |
-| `ask_user_question` | Asks the user structured clarification questions during plan mode.                      |
+| Tool                | What it does                                                                                      |
+|---------------------|---------------------------------------------------------------------------------------------------|
+| `list_templates`    | Browses available workspace templates, sorted by popularity.                                      |
+| `read_template`     | Gets template details and configurable parameters.                                                |
+| `create_workspace`  | Creates a workspace from a template and waits for it to be ready.                                 |
+| `start_workspace`   | Starts the chat's workspace if it is currently stopped. Idempotent if already running.            |
+| `stop_workspace`    | Stops the chat's workspace and waits for the stop build to finish. Idempotent if already stopped. |
+| `propose_plan`      | Presents a Markdown plan file from the workspace for user review before implementation.           |
+| `ask_user_question` | Asks the user structured clarification questions during plan mode.                                |
 
 `propose_plan` and `ask_user_question` are only exposed while plan mode is
 active. In that mode, `write_file` and `edit_files` are restricted to the
@@ -214,6 +215,16 @@ These tools are conditionally available based on the workspace contents.
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | `read_skill`      | Reads the instructions for a workspace skill by name. Available when the workspace has skills discovered in `.agents/skills/`. |
 | `read_skill_file` | Reads a supporting file from a skill's directory.                                                                              |
+
+### MCP tool search
+
+This tool runs in the control plane and replaces the full MCP tool schemas with
+a searchable catalog, so a large MCP surface does not consume the context
+window.
+
+| Tool         | What it does                                                                                                                                                                                           |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `find_tools` | Searches the deferred MCP tool catalog by keyword or exact name and activates the matching tools. Available only when the `mcp-tool-search` experiment is enabled and the turn has MCP tools to defer. |
 
 ## What runs where
 

--- a/docs/ai-coder/agents/chat-search-syntax.md
+++ b/docs/ai-coder/agents/chat-search-syntax.md
@@ -7,17 +7,18 @@ full-text search.
 
 ## Filters
 
-| Key          | Values                              | Description                                                                                               |
-|--------------|-------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `title`      | substring                           | Case-insensitive substring match. Quote multi-word values.                                                |
-| `archived`   | `true`, `false`                     | Filter by archived state. Default: `false`.                                                               |
-| `has_unread` | `true`, `false`                     | Conversations with unread assistant messages.                                                             |
-| `pr_status`  | `draft`, `open`, `merged`, `closed` | Linked pull request state. Comma-separated for OR.                                                        |
-| `diff_url`   | URL                                 | Match by associated diff URL. Quote values containing colons.                                             |
-| `pr`         | positive integer                    | Exact PR number match.                                                                                    |
-| `repo`       | substring                           | Case-insensitive substring match against git remote origin or URL. Quote values containing colons.        |
-| `pr_title`   | substring                           | Case-insensitive PR title substring match. Quote multi-word values.                                       |
-| `search`     | text                                | Full-text search across chat titles, PR titles, PR numbers, and message content. Quote multi-word values. |
+| Key          | Values                              | Description                                                                                                           |
+|--------------|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| `title`      | substring                           | Case-insensitive substring match. Quote multi-word values.                                                            |
+| `archived`   | `true`, `false`                     | Filter by archived state. Default: `false`.                                                                           |
+| `has_unread` | `true`, `false`                     | Conversations with unread assistant messages.                                                                         |
+| `pr_status`  | `draft`, `open`, `merged`, `closed` | Linked pull request state. Comma-separated for OR.                                                                    |
+| `diff_url`   | URL                                 | Match by associated diff URL. Quote values containing colons.                                                         |
+| `pr`         | positive integer                    | Exact PR number match.                                                                                                |
+| `repo`       | substring                           | Case-insensitive substring match against git remote origin or URL. Quote values containing colons.                    |
+| `pr_title`   | substring                           | Case-insensitive PR title substring match. Quote multi-word values.                                                   |
+| `source`     | `created_by_me`, `shared_with_me`   | Ownership scope. Default: `created_by_me`. Pass both values comma-separated to return owned and shared conversations. |
+| `search`     | text                                | Full-text search across chat titles, PR titles, PR numbers, and message content. Quote multi-word values.             |
 
 Multiple filters in one query combine with AND logic. `search:` cannot
 be combined with `title:`, `pr_title:`, or `pr:`.
@@ -72,6 +73,9 @@ be combined with `title:`, `pr_title:`, or `pr:`.
 
 # Conversations with a specific PR title
 ?q=pr_title:"fix auth bug"
+
+# Conversations shared with you, plus your own
+?q=source:created_by_me,shared_with_me
 
 # Full-text search across titles, PR titles, and messages
 ?q=search:"kubernetes restart"

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -129,10 +129,10 @@ direction.
 
 Users can attach files to chat messages by pasting from the clipboard, dragging files into the input area, or using the attachment button.
 Supported types are PNG, JPEG, GIF, and WebP images, plus plain text, Markdown, CSV, JSON, and PDF files.
-Each upload can be up to 10&nbsp;MiB, and a single conversation can reference at most 50 attachments. Attachments are sent to the model as multimodal content alongside the text prompt.
+Each upload can be up to 10&nbsp;MiB, and a single conversation can reference at most 50 attachments.
+Attachments are sent to the model as multimodal content alongside the text prompt.
 
-This is useful for sharing screenshots of errors, UI mockups, terminal output,
-logs, or other context that helps the agent understand the task.
+This is useful for sharing screenshots of errors, UI mockups, terminal output, logs, or other context that helps the agent understand the task.
 Messages can contain attachments alone or combined with text.
 Image attachments require a model that supports vision input, and Anthropic models (including Bedrock-hosted Claude) cap each inline image at 5&nbsp;MiB.
 Providers differ in which types they accept as native file content; a part the provider rejects is downgraded to text instead of being dropped.

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -125,17 +125,22 @@ are queued and delivered when the agent completes its current step, so there is
 no need to wait for a response before providing additional context or changing
 direction.
 
-### Image attachments
+### File attachments
 
-Users can attach images to chat messages by pasting from the clipboard, dragging
-files into the input area, or using the attachment button. Supported formats are
-PNG, JPEG, GIF, and WebP up to 10 MB per file. Images are sent to the model as
+Users can attach files to chat messages by pasting from the clipboard, dragging
+files into the input area, or using the attachment button. Supported types are
+PNG, JPEG, GIF, and WebP images, plus plain text, Markdown, CSV, JSON, and PDF
+files. Each upload can be up to 10&nbsp;MiB, and a single conversation can
+reference at most 50 attachments. Attachments are sent to the model as
 multimodal content alongside the text prompt.
 
 This is useful for sharing screenshots of errors, UI mockups, terminal output,
-or other visual context that helps the agent understand the task. Messages can
-contain images alone or combined with text. Image attachments require a model
-that supports vision input.
+logs, or other context that helps the agent understand the task. Messages can
+contain attachments alone or combined with text. Image attachments require a
+model that supports vision input, and Anthropic models (including
+Bedrock-hosted Claude) cap each inline image at 5&nbsp;MiB. Providers differ in
+which types they accept as native file content; a part the provider rejects is
+downgraded to text instead of being dropped.
 
 ## Security benefits of the control plane architecture
 
@@ -229,39 +234,41 @@ model. Developers select from enabled models when starting a chat.
 The agent has access to a set of workspace tools that it uses to accomplish
 tasks:
 
-| Tool                                        | Description                                                                                        |
-|---------------------------------------------|----------------------------------------------------------------------------------------------------|
-| `list_templates`                            | Browse available workspace templates                                                               |
-| `read_template`                             | Get template details and configurable parameters                                                   |
-| `create_workspace`                          | Create a workspace from a template                                                                 |
-| `start_workspace`                           | Start a stopped workspace for the current chat                                                     |
-| `propose_plan`                              | Present a Markdown plan file for user review                                                       |
-| `ask_user_question`                         | Ask the user structured clarification questions during plan mode                                   |
-| `read_file`                                 | Read file contents from the workspace                                                              |
-| `write_file`                                | Write a file to the workspace                                                                      |
-| `edit_files`                                | Perform search-and-replace edits across files                                                      |
-| `execute`                                   | Run shell commands in the workspace                                                                |
-| `process_output`                            | Retrieve output from a background process                                                          |
-| `process_list`                              | List all tracked processes in the workspace                                                        |
-| `process_signal`                            | Send a signal (terminate/kill) to a tracked process                                                |
-| `attach_file`                               | Attach a workspace file to the chat as a durable downloadable attachment                           |
-| `spawn_agent` (`type=general` or `explore`) | Delegate a task to a sub-agent running in parallel, optionally on a specific model                 |
-| `list_subagent_models`                      | List the models available for `spawn_agent`'s `model_config_id` argument                           |
-| `wait_agent`                                | Wait for a sub-agent to complete and collect its result                                            |
-| `message_agent`                             | Send a follow-up message to a running sub-agent                                                    |
-| `interrupt_agent`                           | Halt a sub-agent's current turn; it transitions to waiting or running if there are queued messages |
-| `spawn_agent` (`type=computer_use`)         | Spawn a sub-agent with desktop interaction (screenshot, mouse, keyboard)                           |
-| `list_agents`                               | List spawned child agents, most recently active first                                              |
-| `read_skill`                                | Read the instructions for a workspace skill by name                                                |
-| `read_skill_file`                           | Read a supporting file from a skill's directory                                                    |
-| `web_search`                                | Search the internet (provider-native, when enabled)                                                |
+| Tool                                        | Description                                                                                                                                                           |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `list_templates`                            | Browse available workspace templates                                                                                                                                  |
+| `read_template`                             | Get template details and configurable parameters                                                                                                                      |
+| `create_workspace`                          | Create a workspace from a template                                                                                                                                    |
+| `start_workspace`                           | Start a stopped workspace for the current chat                                                                                                                        |
+| `stop_workspace`                            | Stop the current chat's workspace and wait for the stop build to finish                                                                                               |
+| `propose_plan`                              | Present a Markdown plan file for user review                                                                                                                          |
+| `ask_user_question`                         | Ask the user structured clarification questions during plan mode                                                                                                      |
+| `read_file`                                 | Read file contents from the workspace                                                                                                                                 |
+| `write_file`                                | Write a file to the workspace                                                                                                                                         |
+| `edit_files`                                | Perform search-and-replace edits across files                                                                                                                         |
+| `execute`                                   | Run shell commands in the workspace                                                                                                                                   |
+| `process_output`                            | Retrieve output from a background process                                                                                                                             |
+| `process_list`                              | List all tracked processes in the workspace                                                                                                                           |
+| `process_signal`                            | Send a signal (terminate/kill) to a tracked process                                                                                                                   |
+| `attach_file`                               | Attach a workspace file to the chat as a durable downloadable attachment                                                                                              |
+| `spawn_agent` (`type=general` or `explore`) | Delegate a task to a sub-agent running in parallel, optionally on a specific model                                                                                    |
+| `list_subagent_models`                      | List the models available for `spawn_agent`'s `model_config_id` argument                                                                                              |
+| `wait_agent`                                | Wait for a sub-agent to complete and collect its result                                                                                                               |
+| `message_agent`                             | Send a follow-up message to a running sub-agent                                                                                                                       |
+| `interrupt_agent`                           | Halt a sub-agent's current turn; it transitions to waiting or running if there are queued messages                                                                    |
+| `spawn_agent` (`type=computer_use`)         | Spawn a sub-agent with desktop interaction (screenshot, mouse, keyboard)                                                                                              |
+| `list_agents`                               | List spawned child agents, most recently active first                                                                                                                 |
+| `read_skill`                                | Read the instructions for a workspace skill by name                                                                                                                   |
+| `read_skill_file`                           | Read a supporting file from a skill's directory                                                                                                                       |
+| `web_search`                                | Search the internet (provider-native, when enabled)                                                                                                                   |
+| `find_tools`                                | Search the deferred MCP tool catalog and activate matching tools. Only available when the `mcp-tool-search` experiment is enabled and the turn has MCP tools to defer |
 
 These tools connect to the workspace over the same secure connection used for
 web terminals and IDE access. No additional ports or services are required in
 the workspace.
 
 Platform tools (`list_templates`, `read_template`, `create_workspace`,
-`start_workspace`, `propose_plan`, `ask_user_question`) and orchestration tools (`spawn_agent`,
+`start_workspace`, `stop_workspace`, `propose_plan`, `ask_user_question`) and orchestration tools (`spawn_agent`,
 `list_subagent_models`, `wait_agent`, `message_agent`, `interrupt_agent`, `list_agents`)
 are only available to root chats. Sub-agents do not have access to these
 tools and cannot create workspaces or spawn further sub-agents.

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -127,20 +127,15 @@ direction.
 
 ### File attachments
 
-Users can attach files to chat messages by pasting from the clipboard, dragging
-files into the input area, or using the attachment button. Supported types are
-PNG, JPEG, GIF, and WebP images, plus plain text, Markdown, CSV, JSON, and PDF
-files. Each upload can be up to 10&nbsp;MiB, and a single conversation can
-reference at most 50 attachments. Attachments are sent to the model as
-multimodal content alongside the text prompt.
+Users can attach files to chat messages by pasting from the clipboard, dragging files into the input area, or using the attachment button.
+Supported types are PNG, JPEG, GIF, and WebP images, plus plain text, Markdown, CSV, JSON, and PDF files.
+Each upload can be up to 10&nbsp;MiB, and a single conversation can reference at most 50 attachments. Attachments are sent to the model as multimodal content alongside the text prompt.
 
 This is useful for sharing screenshots of errors, UI mockups, terminal output,
-logs, or other context that helps the agent understand the task. Messages can
-contain attachments alone or combined with text. Image attachments require a
-model that supports vision input, and Anthropic models (including
-Bedrock-hosted Claude) cap each inline image at 5&nbsp;MiB. Providers differ in
-which types they accept as native file content; a part the provider rejects is
-downgraded to text instead of being dropped.
+logs, or other context that helps the agent understand the task.
+Messages can contain attachments alone or combined with text.
+Image attachments require a model that supports vision input, and Anthropic models (including Bedrock-hosted Claude) cap each inline image at 5&nbsp;MiB.
+Providers differ in which types they accept as native file content; a part the provider rejects is downgraded to text instead of being dropped.
 
 ## Security benefits of the control plane architecture
 

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -31,13 +31,10 @@ With this setting, platform teams can apply stricter policies to agent workloads
 
 ## Write discoverable template descriptions
 
-The agent selects templates by reading their names and descriptions, the same
-metadata shown on the templates page in the Coder dashboard. The agent's
-`list_templates` tool ranks matches by query relevance first, then by an
-affinity score that weights the developer's own recent template usage far more
-heavily than organization popularity. It does not inspect the template's
-Terraform to understand what infrastructure is inside. For the ranking details,
-refer to [list_templates](../tools/index.md#how-templates-are-ranked).
+The agent selects templates by reading their names and descriptions, the same metadata shown on the templates page in the Coder dashboard.
+The agent's `list_templates` tool ranks matches by query relevance first, then by an affinity score that weights the developer's own recent template usage far more heavily than organization popularity.
+It does not inspect the template's Terraform to understand what infrastructure is inside.
+For the ranking details, refer to [list_templates](../tools/index.md#how-templates-are-ranked).
 
 This means the template description is the single most important factor in
 whether the agent picks the right template for a given task.
@@ -70,8 +67,8 @@ A good template description tells the agent:
 > [!TIP]
 > If many developers already use a template, the agent is more likely to
 > select it, because organization popularity contributes to the affinity score
-> that orders the shortlist. A well-written description on a popular template
-> is the strongest routing signal you can provide.
+> that orders the shortlist. 
+> A well-written description on a popular template is the strongest routing signal you can provide.
 
 ### Template display names
 

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -31,10 +31,13 @@ With this setting, platform teams can apply stricter policies to agent workloads
 
 ## Write discoverable template descriptions
 
-The agent selects templates by reading their names and descriptions — the same
-metadata shown on the templates page in the Coder dashboard, sorted by number
-of active developers. It does not inspect the template's Terraform to
-understand what infrastructure is inside.
+The agent selects templates by reading their names and descriptions, the same
+metadata shown on the templates page in the Coder dashboard. The agent's
+`list_templates` tool ranks matches by query relevance first, then by an
+affinity score that weights the developer's own recent template usage far more
+heavily than organization popularity. It does not inspect the template's
+Terraform to understand what infrastructure is inside. For the ranking details,
+refer to [list_templates](../tools/index.md#how-templates-are-ranked).
 
 This means the template description is the single most important factor in
 whether the agent picks the right template for a given task.
@@ -66,9 +69,9 @@ A good template description tells the agent:
 
 > [!TIP]
 > If many developers already use a template, the agent is more likely to
-> select it because templates are sorted by active developer count. A
-> well-written description on a popular template is the strongest routing
-> signal you can provide.
+> select it, because organization popularity contributes to the affinity score
+> that orders the shortlist. A well-written description on a popular template
+> is the strongest routing signal you can provide.
 
 ### Template display names
 

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -65,9 +65,7 @@ A good template description tells the agent:
 | Default            | Tells the agent nothing                                                 |
 
 > [!TIP]
-> If many developers already use a template, the agent is more likely to
-> select it, because organization popularity contributes to the affinity score
-> that orders the shortlist.
+> If many developers already use a template, the agent is more likely to select it, because organization popularity contributes to the affinity score that orders the shortlist.
 > A well-written description on a popular template is the strongest routing signal you can provide.
 
 ### Template display names

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -67,7 +67,7 @@ A good template description tells the agent:
 > [!TIP]
 > If many developers already use a template, the agent is more likely to
 > select it, because organization popularity contributes to the affinity score
-> that orders the shortlist. 
+> that orders the shortlist.
 > A well-written description on a popular template is the strongest routing signal you can provide.
 
 ### Template display names


### PR DESCRIPTION
Corrects four independent factual errors in the Coder Agents documentation, each verified against the current implementation.

- **Missing tools in the tool tables.** `stop_workspace` was absent from the built-in tool table in `docs/ai-coder/agents/index.md` and the platform tool table in `docs/ai-coder/agents/architecture.md`, and from the root-chat-only tool list. `find_tools` was undocumented entirely; both docs now list it with its `mcp-tool-search` experiment gating.
- **Missing `source:` search filter.** `docs/ai-coder/agents/chat-search-syntax.md` documented every chat filter except `source:`, while also stating that unrecognized keys return HTTP 400. Adds the filter row and an example.
- **Attachments described as images only.** The attachments section claimed PNG, JPEG, GIF, and WebP up to 10 MB. The upload allowlist also accepts plain text, Markdown, CSV, JSON, and PDF; the cap is 10 MiB per upload with at most 50 attachments per conversation, and Anthropic models cap inline images at 5 MiB. Also notes that providers differ in accepted file types and that rejected parts are downgraded to text.
- **Template ranking described as popularity sort.** `docs/ai-coder/agents/platform-controls/template-optimization.md` said templates are sorted by active developer count. `list_templates` ranks by query relevance tiers first, then by an affinity score that weights the user's own recent usage far above organization popularity. Wording now matches `docs/ai-coder/agents/tools/index.md`, which already documents the formula, and links to it.

Linear: DOCS-716 https://linear.app/codercom/issue/DOCS-716

<details><summary>Analysis evidence</summary>

| Claim | Source |
|-------|--------|
| `stop_workspace` is a root-chat platform tool registered alongside `create_workspace` and `start_workspace` | `coderd/x/chatd/chattool/stopworkspace.go`; registration in `coderd/x/chatd/chatd.go` (`chattool.StopWorkspace`), root-only gate in `builtinPlanToolAllowed`, disabled for explore sub-agents in `allowedExploreToolNames` |
| `find_tools` requires the `mcp-tool-search` experiment and deferrable MCP candidates | `coderd/x/chatd/chattool/findtools.go`; `decideMCPToolSearch` in `coderd/x/chatd/mcp_tool_search.go` returns false without `codersdk.ExperimentMCPToolSearch` or with no candidates; wired in `coderd/x/chatd/generation_preparer.go` |
| `source:` accepts `created_by_me` and `shared_with_me`; passing both returns owned plus shared; default is owned only | `coderd/searchquery/search.go` (`Chats`): filter defaults to `OwnedOnly: true`; the `source` parser rejects any other value, and both values together set `OwnedOnly` and `SharedOnly`. The literal value `all` appears in the doc comment but is not accepted by the parser, so it is not documented. |
| Attachment allowlist, size caps, and per-conversation limit | `codersdk/chats.go`: `AllChatAttachmentMediaTypes` covers `application/json`, `application/pdf`, `image/gif`, `image/jpeg`, `image/png`, `image/webp`, `text/csv`, `text/markdown`, `text/plain`; `MaxChatFileSizeBytes = 10 * 1024 * 1024`; `MaxChatFileIDs = 50`; `AnthropicInlineImageCapBytes = 5 * 1024 * 1024` |
| Anthropic and Bedrock share the inline image cap; rejected file parts are downgraded to text | `coderd/x/chatd/chatprovider/chatprovider.go`: `InlineImageCapBytes` and `Model.AcceptsFilePartMediaType` |
| Template ranking is relevance tiers then a composite affinity score | `coderd/x/chatd/chattool/listtemplates.go`: `rankTemplates` sorts by query score first; `computeAffinityScore` adds recency-decayed personal usage at `listTemplatesPersonalWeight = 10.0` to `ln(1 + active_developers)` at `listTemplatesOrgWeight = 1.0` |

Note: `MaxChatFileIDs` is enforced per chat, not per message (`coderd/exp_chats.go`: "A chat can reference at most %d attachments"), so the docs say per conversation.

Validation: `pnpm run format-docs` and `pnpm run lint-docs` both pass (0 errors). The formatter widened the touched tables, which accounts for the reformatted rows in the diff.

</details>

Generated by Coder Agents on behalf of @nickvigilante.
