### PR TITLE
docs: rewrite extending-agents MCP and skills discovery for pushed context

### DIFF
--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -47,11 +47,14 @@ To pick up context in another directory, declare that directory as its own sourc
 
 A snapshot is capped so a large workspace cannot flood a chat's prompt:
 
-| Limit                              | Behavior when exceeded                                                                                   |
-|------------------------------------|----------------------------------------------------------------------------------------------------------|
-| 64&nbsp;KiB per resource           | The resource is reported with an oversize status and no content, so the chat lists it but cannot read it |
-| 2&nbsp;MiB total across a snapshot | Resources past the cap are reported as excluded with no content                                          |
-| 500 resources per snapshot         | Resources past the cap are reported as excluded with no content                                          |
+| Limit                                        | Behavior when exceeded                                                                                   |
+|----------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| 64&nbsp;KiB per file resource                | The resource is reported with an oversize status and no content, so the chat lists it but cannot read it |
+| 2&nbsp;MiB of file content across a snapshot | Resources past the cap are reported as excluded with no content                                          |
+| 500 resources per snapshot                   | Resources past the cap are reported as excluded with no content                                          |
+
+The byte caps measure file contents, such as instruction files and skill files.
+MCP server entries count toward the 500-resource cap, but their tool definitions are not measured by the byte caps.
 
 Excluded and oversize resources still appear in the chat's context list with their status and error, so a dropped skill or instruction file is visible rather than silently missing.
 
@@ -220,7 +223,8 @@ When the connected tool list changes, the agent re-scans and pushes a new snapsh
 
 Editing `.mcp.json` does not require a workspace restart.
 A file watcher fires 250&nbsp;ms after the file is created, written, removed, or renamed, and the agent reloads its servers from the file on disk.
-The reload changes the pushed snapshot, which marks existing chats out of date; the new tool set reaches a chat when the chat is refreshed.
+The reload changes the pushed snapshot, but an MCP-only change does not mark existing chats out of date.
+Chats that have not pinned a snapshot yet receive the new tool set immediately; a chat that already pinned one keeps its current tool set until you select **Refresh context** in that chat.
 
 The snapshot carries tool definitions only, not a way to run them.
 Every workspace MCP tool call is proxied back through the workspace agent, so a chat can list workspace MCP tools while the workspace is unreachable, but calling one requires a running workspace with the server connected.

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -17,10 +17,10 @@ The pinned copy is what the agent's system prompt and tool list are built from, 
 The lifecycle of an edit looks like this:
 
 1. You add a skill, edit `.mcp.json`, or change an instruction file in the workspace.
-2. A file watcher notices the change and the agent re-scans after a 250&nbsp;ms debounce, then pushes a new snapshot.
-3. Chats that have not pinned a snapshot yet pin the new one immediately.
-4. Chats that already pinned an older snapshot are marked out of date instead of being switched over.
-5. Selecting **Refresh context** in the chat re-pins that chat to the latest snapshot.
+1. A file watcher notices the change and the agent re-scans after a 250&nbsp;ms debounce, then pushes a new snapshot.
+1. Chats that have not pinned a snapshot yet pin the new one immediately.
+1. Chats that already pinned an older snapshot are marked out of date instead of being switched over.
+1. Selecting **Refresh context** in the chat re-pins that chat to the latest snapshot.
 
 This is why an in-flight chat can keep using an older snapshot: a push never rewrites a chat's pinned context.
 The pin only moves when the chat is first hydrated or when you refresh it.
@@ -31,12 +31,12 @@ Until startup scripts finish, the agent holds an empty snapshot, so a chat opene
 ### Where the agent looks
 
 Each scan location is a scan root.
-The agent scans:
+The agent scans the following:
 
-- the workspace working directory
+- The workspace working directory
 - `~/.coder` and `~/.coder/skills`
 - `~/.claude/plugins/cache`
-- any additional source you declare through the agent's context sources API
+- Any additional source you declare through the agent's context sources API
 
 Discovery is shallow.
 Instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`) and `.mcp.json` are read only at the top level of a scan root, and skills are read only from the fixed container directories described below.
@@ -131,10 +131,10 @@ Instructions for the skill go here...
   directory name exactly.
 - `SKILL.md` has a maximum size of 64&nbsp;KB.
   A larger file is reported with an oversize status and contributes no content to the chat.
-- Supporting files have a maximum size of 512&nbsp;KB. Files exceeding the limit
-  are silently truncated.
+- Supporting files have a maximum size of 512&nbsp;KB.
+  Files exceeding the limit are silently truncated.
 
-A skill whose frontmatter is missing, unparsable, not kebab-case, or does not match its directory name is reported as invalid and contributes no instructions.
+A skill with its frontmatter missing, unparsable, not kebab-case, or not matching its directory name is reported as invalid and contributes no instructions.
 
 ### Path safety
 
@@ -166,8 +166,7 @@ Instructions for the skill go here...
 
 Each personal skill is stored as a single `SKILL.md` file containing
 frontmatter and body content. Supporting files are not supported. Each
-`SKILL.md` file can be up to 64&nbsp;KB, and each user can create up to 100
-personal skills.
+`SKILL.md` file can be up to 64&nbsp;KB, and each user can create up to 100 personal skills.
 
 Personal skills are stored in Coder, not in the workspace, so they are not part of a workspace context snapshot and do not depend on a pin or a refresh.
 
@@ -179,9 +178,8 @@ workspace skills instead. Store them in the repo under
 
 Workspace templates can expose custom
 [MCP](https://modelcontextprotocol.io/introduction) tools by placing a
-`.mcp.json` file in the workspace working directory. The agent connects to
-these servers, reports their tools in the context snapshot it pushes, and
-chats register those tools alongside their built-in tools.
+`.mcp.json` file in the workspace working directory.
+The agent connects to these servers, reports their tools in the context snapshot it pushes, and chats register those tools alongside their built-in tools.
 
 ### Configuration
 

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -38,6 +38,9 @@ The agent scans the following:
 - `~/.claude/plugins/cache`
 - Any additional source you declare through the agent's context sources API
 
+Declared sources contribute instruction files and skills only.
+A `.mcp.json` file inside a declared source appears in the context inventory, but the agent does not connect to the servers it lists; MCP servers load only from the workspace working directory.
+
 Discovery is shallow.
 Instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`) and `.mcp.json` are read only at the top level of a scan root, and skills are read only from the fixed container directories described below.
 The agent never walks further down the tree and never climbs to a parent directory.
@@ -223,8 +226,9 @@ When the connected tool list changes, the agent re-scans and pushes a new snapsh
 
 Editing `.mcp.json` does not require a workspace restart.
 A file watcher fires 250&nbsp;ms after the file is created, written, removed, or renamed, and the agent reloads its servers from the file on disk.
-The reload changes the pushed snapshot, but an MCP-only change does not mark existing chats out of date.
-Chats that have not pinned a snapshot yet receive the new tool set immediately; a chat that already pinned one keeps its current tool set until you select **Refresh context** in that chat.
+The reload changes the pushed snapshot, but an MCP-only change does not mark existing chats out of date, and the dashboard offers **Refresh context** only on chats that are marked out of date.
+New chats and chats that have not pinned a snapshot yet receive the new tool set immediately.
+An existing chat keeps its current tool set until another context change, such as editing an instruction file or a skill, marks it out of date; refreshing then re-pins the whole snapshot, including the new MCP tools.
 
 The snapshot carries tool definitions only, not a way to run them.
 Every workspace MCP tool call is proxied back through the workspace agent, so a chat can list workspace MCP tools while the workspace is unreachable, but calling one requires a running workspace with the server connected.

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -17,7 +17,7 @@ The pinned copy is what the agent's system prompt and tool list are built from, 
 The lifecycle of an edit looks like this:
 
 1. You add a skill, edit `.mcp.json`, or change an instruction file in the workspace.
-1. A file watcher notices the change and the agent re-scans after a 250&nbsp;ms debounce, then pushes a new snapshot.
+1. A file watcher notices the change, and the agent re-scans after a short period and then pushes a new snapshot.
 1. Chats that have not pinned a snapshot yet pin the new one immediately.
 1. Chats that already pinned an older snapshot are marked out of date instead of being switched over.
 1. Selecting **Refresh context** in the chat re-pins that chat to the latest snapshot.
@@ -218,14 +218,14 @@ to the HTTP endpoint from the workspace.
 
 ### How discovery works
 
-The agent connects to the servers declared in `.mcp.json` once startup scripts finish, and it allows each server 30&nbsp;seconds to start its transport and finish initialization.
+The agent connects to the servers declared in `.mcp.json` once startup scripts finish.
 Servers that fail to connect are skipped, and the rest still contribute their tools.
 
 A single set of connections is shared by tool discovery and tool execution, so each declared server is launched once.
 When the connected tool list changes, the agent re-scans and pushes a new snapshot.
 
 Editing `.mcp.json` does not require a workspace restart.
-A file watcher fires 250&nbsp;ms after the file is created, written, removed, or renamed, and the agent reloads its servers from the file on disk.
+The agent notices edits to the file and reloads its servers automatically.
 The reload changes the pushed snapshot, but an MCP-only change does not mark existing chats out of date, and the dashboard offers **Refresh context** only on chats that are marked out of date.
 New chats and chats that have not pinned a snapshot yet receive the new tool set immediately.
 An existing chat keeps its current tool set until another context change, such as editing an instruction file or a skill, marks it out of date; refreshing then re-pins the whole snapshot, including the new MCP tools.

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -5,6 +5,56 @@ These mechanisms let platform teams provide repository-specific instructions,
 domain expertise, and external tool integrations without modifying the agent
 itself.
 
+## How the workspace shares context with chats
+
+The workspace agent owns discovery.
+It scans a fixed set of locations for instruction files, skills, and MCP configuration, then pushes the result to Coder as a single context snapshot.
+Chats never scan the workspace themselves; they read the snapshot the agent pushed.
+
+A workspace-attached chat pins one snapshot.
+The pinned copy is what the agent's system prompt and tool list are built from, so a chat keeps working with a consistent view of your skills and MCP tools even while you edit files in the workspace.
+
+The lifecycle of an edit looks like this:
+
+1. You add a skill, edit `.mcp.json`, or change an instruction file in the workspace.
+2. A file watcher notices the change and the agent re-scans after a 250&nbsp;ms debounce, then pushes a new snapshot.
+3. Chats that have not pinned a snapshot yet pin the new one immediately.
+4. Chats that already pinned an older snapshot are marked out of date instead of being switched over.
+5. Selecting **Refresh context** in the chat re-pins that chat to the latest snapshot.
+
+This is why an in-flight chat can keep using an older snapshot: a push never rewrites a chat's pinned context.
+The pin only moves when the chat is first hydrated or when you refresh it.
+
+The agent publishes nothing until the workspace is ready.
+Until startup scripts finish, the agent holds an empty snapshot, so a chat opened during workspace startup can show no skills and no MCP tools until the first real push lands.
+
+### Where the agent looks
+
+Each scan location is a scan root.
+The agent scans:
+
+- the workspace working directory
+- `~/.coder` and `~/.coder/skills`
+- `~/.claude/plugins/cache`
+- any additional source you declare through the agent's context sources API
+
+Discovery is shallow.
+Instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`) and `.mcp.json` are read only at the top level of a scan root, and skills are read only from the fixed container directories described below.
+The agent never walks further down the tree and never climbs to a parent directory.
+To pick up context in another directory, declare that directory as its own source.
+
+### Snapshot limits
+
+A snapshot is capped so a large workspace cannot flood a chat's prompt:
+
+| Limit                              | Behavior when exceeded                                                                                   |
+|------------------------------------|----------------------------------------------------------------------------------------------------------|
+| 64&nbsp;KiB per resource           | The resource is reported with an oversize status and no content, so the chat lists it but cannot read it |
+| 2&nbsp;MiB total across a snapshot | Resources past the cap are reported as excluded with no content                                          |
+| 500 resources per snapshot         | Resources past the cap are reported as excluded with no content                                          |
+
+Excluded and oversize resources still appear in the chat's context list with their status and error, so a dropped skill or instruction file is visible rather than silently missing.
+
 ## Skills
 
 Skills are structured, reusable instruction sets that the agent loads on
@@ -13,15 +63,19 @@ automatically when a chat attaches to a workspace.
 
 ### How skills work
 
-Place skill directories under `.agents/skills/` relative to the workspace
-working directory. Each directory contains a required `SKILL.md` file and
-any supporting files the skill needs.
+A skill is a directory containing a required `SKILL.md` file and any supporting files the skill needs.
+The agent looks for skill directories in the immediate children of these containers, relative to each scan root:
 
-On the first turn of a workspace-attached chat, the agent scans
-`.agents/skills/` and builds an `<available-skills>` block in its system
-prompt listing each skill's name and description. Only frontmatter is read
-during discovery. The full skill content is loaded lazily when the agent
-calls a tool.
+- `skills/`
+- `.agents/skills/`
+- `.claude/skills/`
+- `.codex/skills/`
+
+Because `~/.coder/skills` is itself a scan root, skills placed directly under it are discovered too.
+
+Each discovered skill contributes its name and description to the `<available-skills>` block in the agent's system prompt.
+The full instructions are loaded only when the agent calls a tool, and they are served from the chat's pinned snapshot rather than read live from the workspace.
+A skill added after a chat pinned its snapshot appears in that chat after you refresh its context.
 
 Two tools are registered when skills are present:
 
@@ -36,6 +90,9 @@ tools operate on that same workspace filesystem, so you can join `dir` with a
 supporting file's relative path to read or run that file directly, for example
 to execute a bundled `scripts/` helper. `read_skill_file` remains available as
 a path-safe convenience for reading supporting files.
+
+Supporting files are read over the workspace connection, so `read_skill_file` and the supporting-file list need a reachable workspace.
+The skill body comes from the pin and keeps working when the workspace is unreachable.
 
 ### Directory structure
 
@@ -72,9 +129,12 @@ Instructions for the skill go here...
 
 - Names must be kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`) and match the
   directory name exactly.
-- `SKILL.md` has a maximum size of 64 KB.
-- Supporting files have a maximum size of 512 KB. Files exceeding the limit
+- `SKILL.md` has a maximum size of 64&nbsp;KB.
+  A larger file is reported with an oversize status and contributes no content to the chat.
+- Supporting files have a maximum size of 512&nbsp;KB. Files exceeding the limit
   are silently truncated.
+
+A skill whose frontmatter is missing, unparsable, not kebab-case, or does not match its directory name is reported as invalid and contributes no instructions.
 
 ### Path safety
 
@@ -106,8 +166,10 @@ Instructions for the skill go here...
 
 Each personal skill is stored as a single `SKILL.md` file containing
 frontmatter and body content. Supporting files are not supported. Each
-`SKILL.md` file can be up to 64 KB, and each user can create up to 100
+`SKILL.md` file can be up to 64&nbsp;KB, and each user can create up to 100
 personal skills.
+
+Personal skills are stored in Coder, not in the workspace, so they are not part of a workspace context snapshot and do not depend on a pin or a refresh.
 
 If you need richer skills with supporting files or multiple files, use
 workspace skills instead. Store them in the repo under
@@ -117,9 +179,9 @@ workspace skills instead. Store them in the repo under
 
 Workspace templates can expose custom
 [MCP](https://modelcontextprotocol.io/introduction) tools by placing a
-`.mcp.json` file in the workspace working directory. The agent discovers
-these tools automatically when it connects to a workspace and registers
-them alongside its built-in tools.
+`.mcp.json` file in the workspace working directory. The agent connects to
+these servers, reports their tools in the context snapshot it pushes, and
+chats register those tools alongside their built-in tools.
 
 ### Configuration
 
@@ -152,10 +214,18 @@ to the HTTP endpoint from the workspace.
 
 ### How discovery works
 
-The agent reads `.mcp.json` via the workspace agent connection on each chat
-turn. Discovery uses a 5-second timeout. Servers that fail to
-respond are skipped. Partial success is acceptable. Empty results are not
-cached because the MCP servers may still be starting.
+The agent connects to the servers declared in `.mcp.json` once startup scripts finish, and it allows each server 30&nbsp;seconds to start its transport and finish initialization.
+Servers that fail to connect are skipped, and the rest still contribute their tools.
+
+A single set of connections is shared by tool discovery and tool execution, so each declared server is launched once.
+When the connected tool list changes, the agent re-scans and pushes a new snapshot.
+
+Editing `.mcp.json` does not require a workspace restart.
+A file watcher fires 250&nbsp;ms after the file is created, written, removed, or renamed, and the agent reloads its servers from the file on disk.
+The reload changes the pushed snapshot, which marks existing chats out of date; the new tool set reaches a chat when the chat is refreshed.
+
+The snapshot carries tool definitions only, not a way to run them.
+Every workspace MCP tool call is proxied back through the workspace agent, so a chat can list workspace MCP tools while the workspace is unreachable, but calling one requires a running workspace with the server connected.
 
 ### Tool naming
 
@@ -164,5 +234,5 @@ avoid collisions between servers and with built-in tools.
 
 ### Timeouts
 
-- **Discovery**: 5-second timeout.
-- **Tool calls**: 60 seconds per invocation.
+- **Server connect**: 30&nbsp;seconds per server.
+- **Tool calls**: 60&nbsp;seconds per invocation.


### PR DESCRIPTION
This PR rewrites the MCP and skills discovery sections of `docs/ai-coder/agents/extending-agents.md` to match the current pushed-context architecture.

The page documented a removed mechanism: per-chat-turn `.mcp.json` reads with a 5-second discovery timeout, first-turn scans of `.agents/skills/` only, and no mention of pinning.

What changed:

- Adds a "How the workspace shares context with chats" section: the agent scans and pushes a context snapshot, chats pin one snapshot, a push marks already-pinned chats out of date, and **Refresh context** re-pins. Explains why an in-flight chat can keep an older snapshot.
- Documents the readiness gate: only an empty snapshot is published until startup scripts finish.
- Documents the scan roots (working directory, `~/.coder`, `~/.coder/skills`, `~/.claude/plugins/cache`, user-declared sources) and that discovery is shallow.
- Documents all four skill container directories (`skills`, `.agents/skills`, `.claude/skills`, `.codex/skills`) instead of only `.agents/skills`.
- Adds snapshot limits and failure modes: 64 KiB per resource emitted as oversize with no content, 2 MiB aggregate and 500 resource caps emitted as excluded, invalid skill frontmatter.
- Replaces the 5-second discovery claim with the 30-second per-server connect timeout and the fsnotify watcher with a 250 ms debounce; notes that tool calls are proxied through the agent, so a pinned chat can list tools it cannot execute while the workspace is unreachable.
- Keeps the values that are still correct: 60 s per tool call, `SKILL.md` <= 64 KB, supporting files <= 512 KB truncated, personal skills single file <= 64 KB and <= 100 per user, `read_skill_file` path restrictions.

Linear: DOCS-723 https://linear.app/codercom/issue/DOCS-723

<details><summary>Analysis evidence</summary>

Every claim was verified against code on this branch's merge base.

**Push and pin model**

- `agent/agentcontext/push.go`: `RunPush` ships the current snapshot and every subsequent snapshot on change; it skips version 0 (pre-ready).
- `coderd/agentapi/context.go`: `PushContextState` persists the snapshot and calls `ContextDirtyMarker.HydrateAndMarkChatsDirty` inside the transaction; the doc comment states it "hydrates chats for the agent that have no pinned hash yet ... and flips already-pinned chats whose hash differs".
- `coderd/x/chatd/context_hydration.go`: `HydrateAndMarkChatsDirty` stamps NULL-hash chats via `HydrateAgentChatsContext` and dirties differing chats via `MarkChatsContextDirtyByAgent`; "The pinned hash on dirtied chats is intentionally left unchanged; the refresh endpoint re-pins it." `RefreshChatContext` backs `PUT /chats/{chat}/context` (route registered in `coderd/coderd.go`), and `site/src/pages/AgentsPage/components/ChatPageContent.tsx` wires the **Refresh context** button to it. This confirms the pinning semantics claim: a chat mid-turn keeps its older snapshot until refreshed.
- `coderd/x/chatd/chatd.go` (`resolveWorkspaceMCPTools` / `pinnedWorkspaceMCPTools`) builds the turn's MCP tools from `chat_context_resources`, and `coderd/x/chatd/context_prompt.go` builds the instruction block and skill index from the same pinned rows. No per-turn live discovery remains.

**Readiness gate**

- `agent/agentcontext/manager.go`: `resolveAndBroadcast` returns early while `!m.ready`; `agent/agentcontext/doc.go` describes the version-0 empty snapshot. `agent/agent.go` calls `a.contextManager.SetReady()` after the startup-script lifecycle transition, then reloads MCP servers. (The gate lives on `agentcontext.Manager`, not `agentmcp.Manager`.)

**Scan roots and shallow discovery**

- `agent/agentcontext/manager.go` `scanRootsLocked`: user sources, then `defaultBuiltinRoots()`, then the working directory.
- `agent/agentcontext/defaults.go`: built-in roots are `~/.coder`, `~/.coder/skills`, `~/.claude/plugins/cache`.
- `agent/agentcontext/doc.go` and `resolve.go`: instruction files and `.mcp.json` are read only at a scan root's top level; the resolver never descends or climbs.

**Skills**

- `agent/agentcontext/resolve.go` `skillContainerRelPaths`: `skills`, `.agents/skills`, `.claude/skills`, `.codex/skills`; `skillContainersFor` also treats a root named `skills` as a container, which is what makes `~/.coder/skills` work.
- `readSkillMeta`: frontmatter name must match the directory basename and match `workspacesdk.SkillNamePattern` (`^[a-z0-9]+(-[a-z0-9]+)*$`), otherwise `StatusInvalid`; oversize files get `StatusOversize` with no payload.
- `coderd/x/chatd/chattool/skill.go`: `maxSkillMetaBytes = workspacesdk.MaxSkillMetaBytes` (64 KiB), `maxSkillFileBytes = 512 * 1024` with truncation, `validateSkillFilePath` rejects absolute paths, `..`, and hidden components. `loadPinnedWorkspaceSkillContent` serves the body from the pin; `bestEffortSkillFiles` needs a live connection.
- `coderd/x/skills/skills.go`: `MaxPersonalSkillSizeBytes` = 64 KiB, `MaxPersonalSkillsPerUser` = 100.

**Caps**

- `agent/agentcontext/resolve.go`: `DefaultMaxResourceBytes` 64 KiB (oversize, empty payload), `DefaultMaxSnapshotBytes` 2 MiB and `DefaultMaxResources` 500 (excluded, payload cleared). `coderd/x/chatd/context_prompt.go` `pinnedContextResources` surfaces non-OK rows with status and error.

**MCP timeouts and watcher**

- `agent/x/agentmcp/manager.go`: `connectTimeout = 30 * time.Second`, `toolCallTimeout = 60 * time.Second`. No 5-second discovery timeout exists anywhere in `coderd/x/chatd` or `agent/x/agentmcp`.
- `agent/x/agentmcp/configwatcher.go`: `defaultWatchDebounce = 250 * time.Millisecond`; the watcher fires on create, write, remove, and rename. `agent/agentcontext/watcher.go` uses the same 250 ms window.
- `agent/agent.go`: `a.mcpManager.SetOnReload(a.contextManager.Trigger)` re-resolves and re-pushes when the catalog changes; the shared engine owns one connection set for discovery and execution.
- `coderd/x/chatd/chattool/mcpworkspace.go`: tool calls proxy back through the agent connection, so execution requires a reachable workspace.

**Validation**

- `pnpm install --frozen-lockfile`, `pnpm run format-docs` (no changes), `pnpm run lint-docs` (0 errors), `vale` on the page (0 errors; 1 pre-existing `Coder.GerundHeading` warning on the untouched H1).

</details>

Generated by Coder Agents on behalf of @nickvigilante.


<details><summary>CI flake note</summary>

The CI run for commit a60db5adee concluded with `startup_failure` (workflow never started; runner infrastructure), marking Flake Check, Storybook, and gen as failed on a markdown-only change. Unrelated to the changed paths; both runs re-triggered.

</details>
