### PR TITLE
fix: accept string-encoded files arg in edit_files tool

### DIFF
--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -982,6 +982,7 @@ The `compaction_requested_at` marker is one-shot: transitions that keep an activ
 
 When the `agent-lifecycle-hooks` experiment is enabled and a hook URL is configured, chatd sends events to an external consumer at key points in a conversation: session start, prompt submission, tool use, compaction, and turn completion.
 
+<!-- TODO(#28578): Document that admission canonicalizes builtin tool input encodings (edit_files string-encoded files) before pre_tool_use consumers observe them. -->
 The consumer can observe activity, add model-only or user-visible context, replace supported prompt or tool input, and deny prompts or tool calls. Prompt submission is evaluated once when the submission is accepted, including queued messages and subagent prompts. Returned context becomes part of the conversation for its intended audience, except that context returned before a compaction guides the compaction summary instead.
 
 Lifecycle hooks fail closed. If the consumer cannot be reached or returns an invalid response, Coder stops the triggering operation rather than continuing without the consumer's decision. Affected chats can enter an error state until the consumer recovers or hooks are disabled.

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"charm.land/fantasy"
+	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/x/chatd/toolschema"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
@@ -23,6 +26,43 @@ type EditFilesOptions struct {
 type EditFilesArgs struct {
 	Files []editFileEdits `json:"files" description:"Files to edit. Every entry must include path and at least one edit."`
 }
+
+// UnmarshalJSON also accepts a "files" value sent as a JSON-encoded
+// string of the declared array, which some models intermittently do.
+// Dispatch-time ambiguity validation cannot inspect keys inside a
+// string value, so the encoded content is checked against the same
+// schema before it is decoded.
+func (a *EditFilesArgs) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Files json.RawMessage `json:"files"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	a.Files = nil
+	filesJSON := raw.Files
+	if len(filesJSON) == 0 || string(filesJSON) == "null" {
+		return nil
+	}
+	var encoded string
+	if json.Unmarshal(filesJSON, &encoded) == nil {
+		if err := toolschema.ValidateUnambiguous(editFilesParameters(), []byte(`{"files":`+encoded+`}`)); err != nil {
+			return err
+		}
+		filesJSON = json.RawMessage(encoded)
+	}
+	if err := json.Unmarshal(filesJSON, &a.Files); err != nil {
+		return xerrors.Errorf("files must be a JSON array of {path, edits} entries: %w", err)
+	}
+	return nil
+}
+
+// editFilesParameters caches the advertised edit_files schema so the
+// decoder validates string-encoded content by the same rules a policy
+// reader applies to plain input.
+var editFilesParameters = sync.OnceValue(func() map[string]any {
+	return EditFiles(EditFilesOptions{}).Info().Parameters
+})
 
 type editFileEdits struct {
 	Path  string         `json:"path" description:"The absolute path of the file to edit, for example /home/coder/project/main.go."`

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -15,6 +15,9 @@ import (
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
 
+// EditFilesToolName is the canonical name of the edit_files tool.
+const EditFilesToolName = "edit_files"
+
 type EditFilesOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
 	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
@@ -29,9 +32,12 @@ type EditFilesArgs struct {
 
 // UnmarshalJSON also accepts a "files" value sent as a JSON-encoded
 // string of the declared array, which some models intermittently do.
-// Dispatch-time ambiguity validation cannot inspect keys inside a
-// string value, so the encoded content is checked against the same
-// schema before it is decoded.
+// Chatd admission canonicalizes that form before pre_tool_use
+// consumers see it (NormalizeEditFilesInput); this decoder keeps the
+// same leniency for inputs that bypass admission normalization, such
+// as hook input overrides. Dispatch-time ambiguity validation cannot
+// inspect keys inside a string value, so the encoded content is
+// checked against the same schema before it is decoded.
 func (a *EditFilesArgs) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Files json.RawMessage `json:"files"`
@@ -63,6 +69,36 @@ func (a *EditFilesArgs) UnmarshalJSON(data []byte) error {
 var editFilesParameters = sync.OnceValue(func() map[string]any {
 	return EditFiles(EditFilesOptions{}).Info().Parameters
 })
+
+// NormalizeEditFilesInput rewrites input whose "files" value is a
+// JSON-encoded string of the declared array into the plain array form
+// the schema advertises, so admission forwards the same structure to
+// pre_tool_use consumers that execution decodes. Input is returned
+// unchanged when files is absent, already an array, or a string that
+// does not itself decode as a JSON array; the decoder reports those.
+// Callers must validate input ambiguity before normalizing, because
+// the object rebuild collapses duplicate keys, and should re-validate
+// the normalized bytes to check the keys the string was hiding.
+func NormalizeEditFilesInput(input []byte) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return input, false
+	}
+	var encoded string
+	if err := json.Unmarshal(raw["files"], &encoded); err != nil {
+		return input, false
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal([]byte(encoded), &entries); err != nil {
+		return input, false
+	}
+	raw["files"] = json.RawMessage(encoded)
+	normalized, err := json.Marshal(raw)
+	if err != nil {
+		return input, false
+	}
+	return normalized, true
+}
 
 type editFileEdits struct {
 	Path  string         `json:"path" description:"The absolute path of the file to edit, for example /home/coder/project/main.go."`
@@ -139,7 +175,7 @@ func (a EditFilesArgs) toSDKFiles() []workspacesdk.FileEdits {
 
 func EditFiles(options EditFilesOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
-		"edit_files",
+		EditFilesToolName,
 		"Perform edits on one or more files by replacing old_text with"+
 			" new_text. Each entry in files must include the absolute path"+
 			" of the file to edit and at least one edit. Matching is fuzzy"+

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -822,6 +822,56 @@ func TestEditFiles_StringEncodedFilesRejectsBadContent(t *testing.T) {
 	}
 }
 
+func TestNormalizeEditFilesInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		wantChanged bool
+		want        string
+	}{
+		{
+			name:        "StringEncodedArrayNormalized",
+			input:       `{"files":"[{\"path\":\"/a.txt\",\"edits\":[{\"old_text\":\"x\",\"new_text\":\"y\"}]}]"}`,
+			wantChanged: true,
+			want:        `{"files":[{"path":"/a.txt","edits":[{"old_text":"x","new_text":"y"}]}]}`,
+		},
+		{
+			name:  "PlainArrayUnchanged",
+			input: `{"files":[{"path":"/a.txt","edits":[{"old_text":"x","new_text":"y"}]}]}`,
+		},
+		{
+			name:  "FilesMissingUnchanged",
+			input: `{"other":true}`,
+		},
+		{
+			name:  "StringNotJSONUnchanged",
+			input: `{"files":"lib/metrics.ts"}`,
+		},
+		{
+			name:  "StringEncodedObjectUnchanged",
+			input: `{"files":"{\"path\":\"/a.txt\"}"}`,
+		},
+		{
+			name:  "NonObjectInputUnchanged",
+			input: `"files"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			normalized, changed := chattool.NormalizeEditFilesInput([]byte(tc.input))
+			require.Equal(t, tc.wantChanged, changed)
+			if tc.wantChanged {
+				require.JSONEq(t, tc.want, string(normalized))
+			} else {
+				require.Equal(t, tc.input, string(normalized))
+			}
+		})
+	}
+}
+
 func TestEditFiles_ToolResponseCarriesFileResults(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -729,6 +729,99 @@ func TestEditFiles_NewFieldNamesTakePrecedenceOverOld(t *testing.T) {
 	assert.False(t, resp.IsError)
 }
 
+func TestEditFiles_StringEncodedFilesAccepted(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	targetPath := "/home/coder/main.go"
+
+	mockConn.EXPECT().
+		EditFiles(gomock.Any(), workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path: targetPath,
+				Edits: []workspacesdk.FileEdit{{
+					Search:  "old content",
+					Replace: "new content",
+				}},
+			}},
+			IncludeDiff: true,
+		}).
+		Return(workspacesdk.FileEditResponse{}, nil)
+
+	tool := chattool.EditFiles(chattool.EditFilesOptions{
+		GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+			return mockConn, nil
+		},
+	})
+
+	// Some models send files as a JSON-encoded string instead of the
+	// declared array.
+	filesJSON := `[{"path":"` + targetPath + `","edits":[{"old_text":"old content","new_text":"new content"}]}]`
+	input, err := json.Marshal(map[string]string{"files": filesJSON})
+	require.NoError(t, err)
+
+	resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  "edit_files",
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.IsError)
+}
+
+func TestEditFiles_StringEncodedFilesRejectsBadContent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		files   string
+		wantErr string
+	}{
+		{
+			name:    "NotJSON",
+			files:   "lib/metrics.ts",
+			wantErr: "files must be a JSON array",
+		},
+		{
+			// Keys hidden inside the encoded string get the same
+			// ambiguity checks as plain input.
+			name:    "DuplicateKey",
+			files:   `[{"path":"/home/coder/a.txt","path":"/home/coder/b.txt","edits":[{"old_text":"x","new_text":"y"}]}]`,
+			wantErr: `repeats the key "files[].path"`,
+		},
+		{
+			name:    "CaseVariantKey",
+			files:   `[{"Path":"/home/coder/a.txt","edits":[{"old_text":"x","new_text":"y"}]}]`,
+			wantErr: `differs from schema property "path" only by case`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			mockConn := agentconnmock.NewMockAgentConn(ctrl)
+			tool := chattool.EditFiles(chattool.EditFilesOptions{
+				GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+					return mockConn, nil
+				},
+			})
+
+			input, err := json.Marshal(map[string]string{"files": tc.files})
+			require.NoError(t, err)
+
+			resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+				ID:    "call-1",
+				Name:  "edit_files",
+				Input: string(input),
+			})
+			require.NoError(t, err)
+			assert.True(t, resp.IsError)
+			assert.Contains(t, resp.Content, tc.wantErr)
+		})
+	}
+}
+
 func TestEditFiles_ToolResponseCarriesFileResults(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/toolinput.go
+++ b/coderd/x/chatd/toolinput.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/x/chatd/chathooks"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/coderd/x/chatd/toolschema"
 )
 
@@ -29,6 +30,18 @@ func partitionAmbiguousToolCalls(
 		if err := validateBuiltinToolInput(prepared, toolCall.ToolName, []byte(toolCall.Input)); err != nil {
 			rejected = append(rejected, ambiguousToolResult(toolCall, err))
 			continue
+		}
+		// Canonicalize alternate encodings the tool decoder accepts so a
+		// pre_tool_use consumer authorizes the same structure execution
+		// uses. Normalizing after validation keeps the duplicate-key
+		// check on the original bytes; re-validating checks the keys the
+		// alternate encoding was hiding.
+		if normalized, changed := normalizeBuiltinToolInput(prepared, toolCall.ToolName, []byte(toolCall.Input)); changed {
+			if err := validateBuiltinToolInput(prepared, toolCall.ToolName, normalized); err != nil {
+				rejected = append(rejected, ambiguousToolResult(toolCall, err))
+				continue
+			}
+			toolCall.Input = string(normalized)
 		}
 		allowed = append(allowed, toolCall)
 		allowedIndexes = append(allowedIndexes, i)
@@ -71,6 +84,20 @@ func validateBuiltinToolInput(prepared generationPrepared, toolName string, inpu
 		return toolschema.ValidateUnambiguous(info.Parameters, input)
 	}
 	return nil
+}
+
+// normalizeBuiltinToolInput canonicalizes alternate input encodings the
+// tool decoder accepts, so hooks and execution read one structure. Only
+// builtin tools are normalized; dynamic and MCP inputs are executed by
+// their own servers, which see the original bytes.
+func normalizeBuiltinToolInput(prepared generationPrepared, toolName string, input []byte) (json.RawMessage, bool) {
+	if canonical, aliased := subagentToolNameAliases[toolName]; aliased {
+		toolName = canonical
+	}
+	if !prepared.BuiltinToolNames[toolName] || toolName != chattool.EditFilesToolName {
+		return input, false
+	}
+	return chattool.NormalizeEditFilesInput(input)
 }
 
 // malformedToolResult reports input the tool decoder would reject anyway. It

--- a/coderd/x/chatd/toolinput_internal_test.go
+++ b/coderd/x/chatd/toolinput_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 )
 
 func TestPartitionAmbiguousToolCallsGatesOnBuiltins(t *testing.T) {
@@ -89,6 +90,88 @@ func TestPartitionAmbiguousToolCallsGatesOnBuiltins(t *testing.T) {
 		}
 		_, _, rejected := partitionAmbiguousToolCalls(prepared, []fantasy.ToolCallContent{aliased})
 		require.Len(t, rejected, 1)
+	})
+}
+
+// TestPartitionAmbiguousToolCallsNormalizesEditFiles guards the invariant
+// that a pre_tool_use consumer authorizes the same structure execution
+// decodes: a string-encoded files value is rewritten to the advertised
+// array form before admission, and content the string was hiding gets the
+// same ambiguity checks as plain input.
+func TestPartitionAmbiguousToolCallsNormalizesEditFiles(t *testing.T) {
+	t.Parallel()
+
+	editFiles := chattool.EditFiles(chattool.EditFilesOptions{})
+	prepared := generationPrepared{
+		Tools:            []fantasy.AgentTool{editFiles},
+		BuiltinToolNames: map[string]bool{chattool.EditFilesToolName: true},
+	}
+
+	t.Run("StringEncodedFilesNormalized", func(t *testing.T) {
+		t.Parallel()
+
+		call := fantasy.ToolCallContent{
+			ToolCallID: "call_encoded",
+			ToolName:   chattool.EditFilesToolName,
+			Input:      `{"files":"[{\"path\":\"/a.txt\",\"edits\":[{\"old_text\":\"x\",\"new_text\":\"y\"}]}]"}`,
+		}
+		allowed, allowedIndexes, rejected := partitionAmbiguousToolCalls(prepared, []fantasy.ToolCallContent{call})
+		require.Empty(t, rejected)
+		require.Len(t, allowed, 1)
+		require.Equal(t, []int{0}, allowedIndexes)
+		require.JSONEq(t,
+			`{"files":[{"path":"/a.txt","edits":[{"old_text":"x","new_text":"y"}]}]}`,
+			allowed[0].Input)
+		var decoded map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(allowed[0].Input), &decoded))
+		require.True(t, json.Valid(decoded["files"]))
+		require.Equal(t, byte('['), decoded["files"][0], "files must be forwarded as an array, not a string")
+	})
+
+	t.Run("HiddenAmbiguityRejected", func(t *testing.T) {
+		t.Parallel()
+
+		call := fantasy.ToolCallContent{
+			ToolCallID: "call_hidden",
+			ToolName:   chattool.EditFilesToolName,
+			Input:      `{"files":"[{\"Path\":\"/a.txt\",\"edits\":[{\"old_text\":\"x\",\"new_text\":\"y\"}]}]"}`,
+		}
+		allowed, _, rejected := partitionAmbiguousToolCalls(prepared, []fantasy.ToolCallContent{call})
+		require.Empty(t, allowed)
+		require.Len(t, rejected, 1)
+		require.Equal(t, "call_hidden", rejected[0].ToolCallID)
+	})
+
+	t.Run("PlainArrayUntouched", func(t *testing.T) {
+		t.Parallel()
+
+		input := `{"files":[{"path":"/a.txt","edits":[{"old_text":"x","new_text":"y"}]}]}`
+		call := fantasy.ToolCallContent{
+			ToolCallID: "call_plain",
+			ToolName:   chattool.EditFilesToolName,
+			Input:      input,
+		}
+		allowed, _, rejected := partitionAmbiguousToolCalls(prepared, []fantasy.ToolCallContent{call})
+		require.Empty(t, rejected)
+		require.Len(t, allowed, 1)
+		require.Equal(t, input, allowed[0].Input, "already-canonical input must pass through byte-identical")
+	})
+
+	t.Run("NonBuiltinUntouched", func(t *testing.T) {
+		t.Parallel()
+
+		input := `{"files":"[{\"path\":\"/a.txt\",\"edits\":[{\"old_text\":\"x\",\"new_text\":\"y\"}]}]"}`
+		call := fantasy.ToolCallContent{
+			ToolCallID: "call_dynamic",
+			ToolName:   chattool.EditFilesToolName,
+			Input:      input,
+		}
+		allowed, _, rejected := partitionAmbiguousToolCalls(generationPrepared{
+			Tools: []fantasy.AgentTool{editFiles},
+		}, []fantasy.ToolCallContent{call})
+		require.Empty(t, rejected)
+		require.Len(t, allowed, 1)
+		require.Equal(t, input, allowed[0].Input, "non-builtin input belongs to its own executor")
 	})
 }
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -608,6 +608,24 @@ describe("parseEditFilesArgs", () => {
 		expect(result[0].path).toBe("test.ts");
 	});
 
+	it("parses files sent as a JSON-encoded string", () => {
+		const args = {
+			files: JSON.stringify([
+				{ path: "test.ts", edits: [{ old_text: "old", new_text: "new" }] },
+			]),
+		};
+		const result = parseEditFilesArgs(args);
+		expect(result).toHaveLength(1);
+		expect(result[0].path).toBe("test.ts");
+		expect(result[0].edits[0]).toEqual({ search: "old", replace: "new" });
+	});
+
+	it("returns empty array when string files decodes to a non-array", () => {
+		expect(
+			parseEditFilesArgs({ files: JSON.stringify({ path: "x.ts" }) }),
+		).toEqual([]);
+	});
+
 	it("filters out edits with non-string search or replace", () => {
 		const args = {
 			files: [

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -518,7 +518,16 @@ export const COLLAPSED_REPORT_HEIGHT = 72;
 export const parseEditFilesArgs = (args: unknown): EditFilesFileEntry[] => {
 	const parsed = parseArgs(args);
 	if (!parsed) return [];
-	const files = parsed.files;
+	let files = parsed.files;
+	// Some models send files as a JSON-encoded string of the array; the
+	// backend decoder tolerates that, so rendering must parse it too.
+	if (typeof files === "string") {
+		try {
+			files = JSON.parse(files);
+		} catch {
+			return [];
+		}
+	}
 	if (!Array.isArray(files)) return [];
 	return files
 		.filter((f): f is FileEntry => isValid(fileEntrySchema, f))


### PR DESCRIPTION
Sonnet 5 intermittently sends the `edit_files` tool's `files` parameter as a JSON-encoded string of the declared array, so every such call failed with `invalid parameters: json: cannot unmarshal string into Go struct field EditFilesArgs.files of type []chattool.editFileEdits` until the model happened to resend a plain array.

Accept the string-encoded form instead: `EditFilesArgs.UnmarshalJSON` decodes the encoded content after re-validating it with `toolschema.ValidateUnambiguous`, so keys hidden inside the string get the same duplicate-key and case-variant ambiguity checks as plain input (the invariant that keeps hook/policy readers and the Go decoder in agreement). Content that still fails to decode returns an actionable tool error the model can correct. The frontend `parseEditFilesArgs` unwraps the same shape so the tool card keeps rendering file names and diffs for these calls.

> 🤖 Xum created this PR on behalf of Mike (@ibetitsmike).
