### PR TITLE
feat: report template builder build failure reasons in telemetry

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -26900,6 +26900,11 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "session_id": {
+                    "description": "SessionID is the wizard session this request belongs to, as reported to\nPOST /api/v2/templatebuilder/sessions. It is optional and used only to\nattribute a build failure to the session that produced it.",
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -24751,6 +24751,11 @@
 					"additionalProperties": {
 						"type": "string"
 					}
+				},
+				"session_id": {
+					"description": "SessionID is the wizard session this request belongs to, as reported to\nPOST /api/v2/templatebuilder/sessions. It is optional and used only to\nattribute a build failure to the session that produced it.",
+					"type": "string",
+					"format": "uuid"
 				}
 			}
 		},

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -2671,9 +2671,8 @@ type UserSecretsSummary struct {
 }
 
 // TemplateBuilderSession tracks a single event in the template builder
-// wizard. Two events are emitted per session: one on wizard entry and
-// one on compose completion. User-supplied variable values are never
-// included.
+// wizard: entry, compose completion, and build failure. User-supplied
+// variable values are never included.
 type TemplateBuilderSession struct {
 	ID              uuid.UUID `json:"id"`
 	EventType       string    `json:"event_type"`
@@ -2682,8 +2681,32 @@ type TemplateBuilderSession struct {
 	ModuleIDs       []string  `json:"module_ids,omitempty"`
 	DurationSeconds float64   `json:"duration_seconds,omitempty"`
 	Success         bool      `json:"success,omitempty"`
+	FailureReason   string    `json:"failure_reason,omitempty"`
 	CreatedAt       time.Time `json:"created_at"`
 }
+
+// TemplateBuilderSessionEventBuildFailure is stamped by coderd when a
+// template builder create request fails. The wizard reports entry and
+// compose completion itself, but only the server knows why a build failed,
+// and the event must survive the browser navigating away. It is therefore
+// absent from the codersdk event type enum, which clients may send.
+const TemplateBuilderSessionEventBuildFailure = "build_failure"
+
+// Reasons a template builder build failed, reported on
+// TemplateBuilderSessionEventBuildFailure events. The provisioner reasons
+// mirror templatebuilder.ProvisionerErrorCategory, which is derived from the
+// provisioner job error and its logs.
+const (
+	TemplateBuilderFailureInvalidRequest     = "invalid_request"
+	TemplateBuilderFailureComposeInvalid     = "compose_invalid"
+	TemplateBuilderFailureNameConflict       = "name_conflict"
+	TemplateBuilderFailureImportCanceled     = "import_canceled"
+	TemplateBuilderFailureImportTimeout      = "import_timeout"
+	TemplateBuilderFailureProvisionerNetwork = "provisioner_network"
+	TemplateBuilderFailureProvisionerAuth    = "provisioner_auth"
+	TemplateBuilderFailureProvisionerUnknown = "provisioner_unknown"
+	TemplateBuilderFailureInternal           = "internal"
+)
 
 // Steps of the premium trial funnel. These are set by coderd rather than the
 // client so that a conversion cannot be forged.

--- a/coderd/templatebuilder/errors.go
+++ b/coderd/templatebuilder/errors.go
@@ -36,38 +36,71 @@ var authErrorPatterns = []string{
 // the error detail to avoid returning excessive output.
 const maxLogContextLines = 20
 
-// ClassifyProvisionerError inspects a provisioner job error and its log
-// lines, returning a user-friendly message for known failure modes.
-// For unrecognized errors, the raw jobError is returned with relevant
-// log context appended so the user can diagnose the failure.
-func ClassifyProvisionerError(jobError string, logs []string) string {
+// ProvisionerErrorCategory names the failure mode of a provisioner import
+// job. It carries no error text, so it can be reported as telemetry to
+// explain why a build failed without leaking deployment detail.
+type ProvisionerErrorCategory string
+
+const (
+	// ProvisionerErrorNetwork means the Terraform registry or a provider
+	// endpoint was unreachable from the provisioner.
+	ProvisionerErrorNetwork ProvisionerErrorCategory = "network"
+	// ProvisionerErrorAuth means the provisioner's cloud credentials were
+	// missing, expired, or insufficient.
+	ProvisionerErrorAuth ProvisionerErrorCategory = "auth"
+	// ProvisionerErrorUnknown means the failure matched no known pattern.
+	ProvisionerErrorUnknown ProvisionerErrorCategory = "unknown"
+)
+
+// ClassifyProvisionerErrorCategory inspects a provisioner job error and its
+// log lines and reports which known failure mode they match. Network
+// patterns are checked first: a credential lookup that fails because the
+// metadata endpoint is unreachable is a network problem.
+func ClassifyProvisionerErrorCategory(jobError string, logs []string) ProvisionerErrorCategory {
 	combined := strings.ToLower(jobError + "\n" + strings.Join(logs, "\n"))
 
 	for _, pattern := range networkErrorPatterns {
 		if strings.Contains(combined, pattern) {
-			return "The Terraform registry is unreachable from your provisioner. " +
-				"Check network configuration and ensure registry.terraform.io " +
-				"is accessible."
+			return ProvisionerErrorNetwork
 		}
 	}
 
 	for _, pattern := range authErrorPatterns {
 		if strings.Contains(combined, pattern) {
-			msg := "Cloud provider authentication failed. " +
-				"Check that valid credentials are configured for the provisioner."
-			if diag := extractDiagnostics(logs); diag != "" {
-				msg += "\n\n" + diag
-			}
-			return msg
+			return ProvisionerErrorAuth
 		}
 	}
 
-	// For unrecognized errors, include relevant Terraform output so the
-	// user can diagnose the failure.
-	if diag := extractDiagnostics(logs); diag != "" {
-		return jobError + "\n\n" + diag
+	return ProvisionerErrorUnknown
+}
+
+// ClassifyProvisionerError inspects a provisioner job error and its log
+// lines, returning a user-friendly message for known failure modes.
+// For unrecognized errors, the raw jobError is returned with relevant
+// log context appended so the user can diagnose the failure. The message
+// is derived from ClassifyProvisionerErrorCategory so that what a user
+// reads and what telemetry records cannot disagree.
+func ClassifyProvisionerError(jobError string, logs []string) string {
+	switch ClassifyProvisionerErrorCategory(jobError, logs) {
+	case ProvisionerErrorNetwork:
+		return "The Terraform registry is unreachable from your provisioner. " +
+			"Check network configuration and ensure registry.terraform.io " +
+			"is accessible."
+	case ProvisionerErrorAuth:
+		msg := "Cloud provider authentication failed. " +
+			"Check that valid credentials are configured for the provisioner."
+		if diag := extractDiagnostics(logs); diag != "" {
+			msg += "\n\n" + diag
+		}
+		return msg
+	default:
+		// For unrecognized errors, include relevant Terraform output so the
+		// user can diagnose the failure.
+		if diag := extractDiagnostics(logs); diag != "" {
+			return jobError + "\n\n" + diag
+		}
+		return jobError
 	}
-	return jobError
 }
 
 // diagnosticPrefixes identify Terraform diagnostic output lines worth

--- a/coderd/templatebuilder/errors_test.go
+++ b/coderd/templatebuilder/errors_test.go
@@ -203,3 +203,109 @@ func TestClassifyProvisionerError(t *testing.T) {
 		require.Equal(t, "terraform plan: exit status 1", result)
 	})
 }
+
+func TestClassifyProvisionerErrorCategory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		jobError string
+		logs     []string
+		expected templatebuilder.ProvisionerErrorCategory
+	}{
+		{
+			name:     "DNSFailure",
+			jobError: "init failed",
+			logs:     []string{"dial tcp: lookup registry.terraform.io: no such host"},
+			expected: templatebuilder.ProvisionerErrorNetwork,
+		},
+		{
+			name:     "TLSTimeout",
+			jobError: "init error",
+			logs:     []string{"net/http: TLS handshake timeout"},
+			expected: templatebuilder.ProvisionerErrorNetwork,
+		},
+		{
+			name:     "AWSNoCredentials",
+			jobError: "terraform plan: exit status 1",
+			logs:     []string{"Error: No valid credential sources found"},
+			expected: templatebuilder.ProvisionerErrorAuth,
+		},
+		{
+			name:     "CaseInsensitiveAuth",
+			jobError: "terraform plan: exit status 1",
+			logs:     []string{"Error: ACCESSDENIED on resource"},
+			expected: templatebuilder.ProvisionerErrorAuth,
+		},
+		{
+			name:     "NetworkTakesPrecedenceOverAuth",
+			jobError: "connection refused",
+			logs:     []string{"AccessDenied: check credentials"},
+			expected: templatebuilder.ProvisionerErrorNetwork,
+		},
+		{
+			name:     "TerraformSyntaxError",
+			jobError: "terraform plan: exit status 1",
+			logs:     []string{"Error: Unsupported block type"},
+			expected: templatebuilder.ProvisionerErrorUnknown,
+		},
+		{
+			name:     "Empty",
+			jobError: "",
+			logs:     nil,
+			expected: templatebuilder.ProvisionerErrorUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected,
+				templatebuilder.ClassifyProvisionerErrorCategory(tc.jobError, tc.logs))
+		})
+	}
+}
+
+// The message shown to the user and the category reported as telemetry are
+// derived from the same classification, so they must agree.
+func TestClassifyProvisionerErrorMessageMatchesCategory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		jobError        string
+		logs            []string
+		category        templatebuilder.ProvisionerErrorCategory
+		messageContains string
+	}{
+		{
+			name:            "Network",
+			jobError:        "terraform init: connection refused",
+			category:        templatebuilder.ProvisionerErrorNetwork,
+			messageContains: "unreachable from your provisioner",
+		},
+		{
+			name:            "Auth",
+			jobError:        "AccessDenied: you are not allowed",
+			category:        templatebuilder.ProvisionerErrorAuth,
+			messageContains: "Cloud provider authentication failed",
+		},
+		{
+			name:            "Unknown",
+			jobError:        "terraform plan: exit status 1",
+			category:        templatebuilder.ProvisionerErrorUnknown,
+			messageContains: "terraform plan: exit status 1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.category,
+				templatebuilder.ClassifyProvisionerErrorCategory(tc.jobError, tc.logs))
+			require.Contains(t,
+				templatebuilder.ClassifyProvisionerError(tc.jobError, tc.logs),
+				tc.messageContains)
+		})
+	}
+}

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -233,6 +233,50 @@ func (api *API) templateBuilderCompose(rw http.ResponseWriter, r *http.Request) 
 // for the provisioner import job to complete.
 const templateBuilderCreateTemplateTimeout = 2 * time.Minute
 
+// reportTemplateBuilderBuildFailure reports why a template builder create
+// request failed. The wizard session ID doubles as the event ID, so a failure
+// joins to the wizard_entry and compose_completion events of the same visit;
+// callers without a session, such as the CLI, get a fresh ID. Only catalog
+// identifiers are reported, never variable values or error text.
+func (api *API) reportTemplateBuilderBuildFailure(req codersdk.TemplateBuilderCreateTemplateRequest, userID uuid.UUID, reason string) {
+	id := req.SessionID
+	if id == uuid.Nil {
+		id = uuid.New()
+	}
+
+	moduleIDs := make([]string, 0, len(req.Modules))
+	for _, m := range req.Modules {
+		moduleIDs = append(moduleIDs, m.ID)
+	}
+
+	api.Telemetry.Report(&telemetry.Snapshot{
+		TemplateBuilderSessions: []telemetry.TemplateBuilderSession{
+			{
+				ID:             id,
+				EventType:      telemetry.TemplateBuilderSessionEventBuildFailure,
+				UserID:         userID,
+				BaseTemplateID: req.BaseTemplateID,
+				ModuleIDs:      moduleIDs,
+				FailureReason:  reason,
+				CreatedAt:      dbtime.Now(),
+			},
+		},
+	})
+}
+
+// templateBuilderProvisionerFailureReason maps a classified provisioner import
+// failure to the telemetry failure reason reported for it.
+func templateBuilderProvisionerFailureReason(category templatebuilder.ProvisionerErrorCategory) string {
+	switch category {
+	case templatebuilder.ProvisionerErrorNetwork:
+		return telemetry.TemplateBuilderFailureProvisionerNetwork
+	case templatebuilder.ProvisionerErrorAuth:
+		return telemetry.TemplateBuilderFailureProvisionerAuth
+	default:
+		return telemetry.TemplateBuilderFailureProvisionerUnknown
+	}
+}
+
 // @Summary Compose and create a template
 // @ID compose-and-create-a-template
 // @Security CoderSessionToken
@@ -256,6 +300,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 	}
 
 	if req.BaseTemplateID == "" {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInvalidRequest)
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Missing base_template_id.",
 		})
@@ -265,12 +310,14 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 	// Resolve and authorize against the organization.
 	organization, err := api.Database.GetOrganizationByID(ctx, req.OrganizationID)
 	if httpapi.Is404Error(err) {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInvalidRequest)
 		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
 			Message: "Organization not found.",
 		})
 		return
 	}
 	if err != nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching organization.",
 			Detail:  err.Error(),
@@ -290,12 +337,14 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		Deleted:        false,
 	})
 	if err == nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureNameConflict)
 		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
 			Message: "A template with this name already exists in the organization.",
 		})
 		return
 	}
 	if !xerrors.Is(err, sql.ErrNoRows) {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error checking template name.",
 			Detail:  err.Error(),
@@ -318,6 +367,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 
 	result, err := templatebuilder.Compose(composeReq)
 	if err != nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureComposeInvalid)
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to compose template.",
 			Detail:  err.Error(),
@@ -327,6 +377,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 
 	tarData, err := templatebuilder.BundleTar(result)
 	if err != nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error bundling template.",
 			Detail:  err.Error(),
@@ -343,6 +394,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		CreatedBy: apiKey.UserID,
 	})
 	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error checking file.",
 			Detail:  err.Error(),
@@ -359,6 +411,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 			Data:      tarData,
 		})
 		if err != nil {
+			api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Internal error saving file.",
 				Detail:  err.Error(),
@@ -370,6 +423,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 	tags := provisionersdk.MutateTags(apiKey.UserID, nil, req.ProvisionerTags)
 	traceMetadataRaw, err := json.Marshal(tracing.MetadataFromContext(ctx))
 	if err != nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error marshaling trace metadata.",
 			Detail:  err.Error(),
@@ -441,6 +495,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		return nil
 	}, nil)
 	if err != nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error creating template version.",
 			Detail:  err.Error(),
@@ -463,12 +518,14 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 	completedJob, err := api.waitForProvisionerJob(jobCtx, provisionerJob.ID)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureImportTimeout)
 			httpapi.Write(ctx, rw, http.StatusGatewayTimeout, codersdk.Response{
 				Message: "Timed out waiting for template import to complete.",
 				Detail:  "The template version is still being imported. You can check its status manually.",
 			})
 			return
 		}
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error waiting for template import.",
 			Detail:  err.Error(),
@@ -478,6 +535,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 
 	// Check if the job was canceled.
 	if completedJob.CanceledAt.Valid {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureImportCanceled)
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Template import was canceled.",
 		})
@@ -499,6 +557,8 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		}
 
 		classified := templatebuilder.ClassifyProvisionerError(completedJob.Error.String, logLines)
+		category := templatebuilder.ClassifyProvisionerErrorCategory(completedJob.Error.String, logLines)
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, templateBuilderProvisionerFailureReason(category))
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Template import failed.",
 			Detail:  classified,
@@ -559,6 +619,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		})
 		if err != nil {
 			if database.IsUniqueViolation(err, database.UniqueTemplatesOrganizationIDNameIndex) {
+				api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureNameConflict)
 				httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
 					Message: "A template with this name already exists in the organization.",
 				})
@@ -605,6 +666,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 		return nil
 	}, nil)
 	if err != nil {
+		api.reportTemplateBuilderBuildFailure(req, apiKey.UserID, telemetry.TemplateBuilderFailureInternal)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error creating template.",
 			Detail:  err.Error(),

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -235,13 +235,13 @@ const templateBuilderCreateTemplateTimeout = 2 * time.Minute
 
 // reportTemplateBuilderBuildFailure reports why a template builder create
 // request failed. The wizard session ID doubles as the event ID, so a failure
-// joins to the wizard_entry and compose_completion events of the same visit;
-// callers without a session, such as the CLI, get a fresh ID. Only catalog
-// identifiers are reported, never variable values or error text.
+// joins to the wizard_entry and compose_completion events of the same visit.
+// A request without a session ID did not come from the wizard, so there is
+// nothing to join to and nothing is reported. Only catalog identifiers are
+// reported, never variable values or error text.
 func (api *API) reportTemplateBuilderBuildFailure(req codersdk.TemplateBuilderCreateTemplateRequest, userID uuid.UUID, reason string) {
-	id := req.SessionID
-	if id == uuid.Nil {
-		id = uuid.New()
+	if req.SessionID == uuid.Nil {
+		return
 	}
 
 	moduleIDs := make([]string, 0, len(req.Modules))
@@ -252,7 +252,7 @@ func (api *API) reportTemplateBuilderBuildFailure(req codersdk.TemplateBuilderCr
 	api.Telemetry.Report(&telemetry.Snapshot{
 		TemplateBuilderSessions: []telemetry.TemplateBuilderSession{
 			{
-				ID:             id,
+				ID:             req.SessionID,
 				EventType:      telemetry.TemplateBuilderSessionEventBuildFailure,
 				UserID:         userID,
 				BaseTemplateID: req.BaseTemplateID,

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/templatebuilder"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -355,4 +359,116 @@ func TestTemplateBuilderSession(t *testing.T) {
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
 	})
+}
+
+func TestTemplateBuilderCreateTemplateFailureTelemetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ComposeInvalid", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		reporter := newFakeTelemetryReporter(ctx, t, 100)
+		client := coderdtest.New(t, &coderdtest.Options{
+			TelemetryReporter: reporter,
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+
+		sessionID := uuid.New()
+		_, err := client.TemplateBuilderCreateTemplate(ctx, codersdk.TemplateBuilderCreateTemplateRequest{
+			SessionID:      sessionID,
+			BaseTemplateID: "nonexistent",
+			Modules: []codersdk.TemplateBuilderComposeModule{
+				{ID: "code-server"},
+			},
+			OrganizationID: user.OrganizationID,
+			Name:           "compose-invalid",
+		})
+		require.Error(t, err)
+
+		event := receiveTemplateBuilderSession(ctx, t, reporter)
+		require.Equal(t, telemetry.TemplateBuilderSessionEventBuildFailure, event.EventType)
+		require.Equal(t, telemetry.TemplateBuilderFailureComposeInvalid, event.FailureReason)
+		// The session ID doubles as the event ID so the failure joins to the
+		// wizard_entry event of the same visit.
+		require.Equal(t, sessionID, event.ID)
+		require.Equal(t, user.UserID, event.UserID)
+		require.Equal(t, "nonexistent", event.BaseTemplateID)
+		require.Equal(t, []string{"code-server"}, event.ModuleIDs)
+		require.False(t, event.Success)
+	})
+
+	t.Run("MissingBaseTemplateID", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		reporter := newFakeTelemetryReporter(ctx, t, 100)
+		client := coderdtest.New(t, &coderdtest.Options{
+			TelemetryReporter: reporter,
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.TemplateBuilderCreateTemplate(ctx, codersdk.TemplateBuilderCreateTemplateRequest{
+			OrganizationID: user.OrganizationID,
+			Name:           "missing-base",
+		})
+		require.Error(t, err)
+
+		event := receiveTemplateBuilderSession(ctx, t, reporter)
+		require.Equal(t, telemetry.TemplateBuilderSessionEventBuildFailure, event.EventType)
+		require.Equal(t, telemetry.TemplateBuilderFailureInvalidRequest, event.FailureReason)
+		// Callers without a wizard session still produce a usable row.
+		require.NotEqual(t, uuid.Nil, event.ID)
+	})
+
+	t.Run("NameConflict", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		reporter := newFakeTelemetryReporter(ctx, t, 100)
+		db, ps := dbtestutil.NewDB(t)
+		client := coderdtest.New(t, &coderdtest.Options{
+			Database:          db,
+			Pubsub:            ps,
+			TelemetryReporter: reporter,
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+
+		existing := dbgen.Template(t, db, database.Template{
+			OrganizationID: user.OrganizationID,
+			CreatedBy:      user.UserID,
+			Name:           "taken-name",
+		})
+
+		_, err := client.TemplateBuilderCreateTemplate(ctx, codersdk.TemplateBuilderCreateTemplateRequest{
+			BaseTemplateID: "docker",
+			OrganizationID: user.OrganizationID,
+			Name:           existing.Name,
+		})
+		require.Error(t, err)
+
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusConflict, sdkErr.StatusCode())
+
+		event := receiveTemplateBuilderSession(ctx, t, reporter)
+		require.Equal(t, telemetry.TemplateBuilderSessionEventBuildFailure, event.EventType)
+		require.Equal(t, telemetry.TemplateBuilderFailureNameConflict, event.FailureReason)
+		require.Equal(t, "docker", event.BaseTemplateID)
+	})
+}
+
+// receiveTemplateBuilderSession drains snapshots until one carries a template
+// builder session event. Unrelated snapshots, such as those reported while
+// creating the first user, arrive on the same channel.
+func receiveTemplateBuilderSession(ctx context.Context, t *testing.T, reporter *fakeTelemetryReporter) telemetry.TemplateBuilderSession {
+	t.Helper()
+	for {
+		snapshot := testutil.TryReceive(ctx, t, reporter.snapshots)
+		if len(snapshot.TemplateBuilderSessions) == 0 {
+			continue
+		}
+		require.Len(t, snapshot.TemplateBuilderSessions, 1)
+		return snapshot.TemplateBuilderSessions[0]
+	}
 }

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -408,7 +408,9 @@ func TestTemplateBuilderCreateTemplateFailureTelemetry(t *testing.T) {
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
+		sessionID := uuid.New()
 		_, err := client.TemplateBuilderCreateTemplate(ctx, codersdk.TemplateBuilderCreateTemplateRequest{
+			SessionID:      sessionID,
 			OrganizationID: user.OrganizationID,
 			Name:           "missing-base",
 		})
@@ -417,8 +419,7 @@ func TestTemplateBuilderCreateTemplateFailureTelemetry(t *testing.T) {
 		event := receiveTemplateBuilderSession(ctx, t, reporter)
 		require.Equal(t, telemetry.TemplateBuilderSessionEventBuildFailure, event.EventType)
 		require.Equal(t, telemetry.TemplateBuilderFailureInvalidRequest, event.FailureReason)
-		// Callers without a wizard session still produce a usable row.
-		require.NotEqual(t, uuid.Nil, event.ID)
+		require.Equal(t, sessionID, event.ID)
 	})
 
 	t.Run("NameConflict", func(t *testing.T) {
@@ -441,6 +442,7 @@ func TestTemplateBuilderCreateTemplateFailureTelemetry(t *testing.T) {
 		})
 
 		_, err := client.TemplateBuilderCreateTemplate(ctx, codersdk.TemplateBuilderCreateTemplateRequest{
+			SessionID:      uuid.New(),
 			BaseTemplateID: "docker",
 			OrganizationID: user.OrganizationID,
 			Name:           existing.Name,

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -142,6 +142,10 @@ type TemplateBuilderCreateTemplateRequest struct {
 	Description        string                         `json:"description,omitempty" validate:"lt=128"`
 	Icon               string                         `json:"icon,omitempty"`
 	ProvisionerTags    map[string]string              `json:"provisioner_tags,omitempty"`
+	// SessionID is the wizard session this request belongs to, as reported to
+	// POST /api/v2/templatebuilder/sessions. It is optional and used only to
+	// attribute a build failure to the session that produced it.
+	SessionID uuid.UUID `json:"session_id,omitempty" format:"uuid"`
 }
 
 // TemplateBuilderCreateTemplateResponse is the response body for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -14047,25 +14047,27 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "provisioner_tags": {
     "property1": "string",
     "property2": "string"
-  }
+  },
+  "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82"
 }
 ```
 
 ### Properties
 
-| Name                   | Type                                                                                    | Required | Restrictions | Description |
-|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `base_template_id`     | string                                                                                  | false    |              |             |
-| `base_variable_values` | object                                                                                  | false    |              |             |
-| » `[any property]`     | string                                                                                  | false    |              |             |
-| `description`          | string                                                                                  | false    |              |             |
-| `display_name`         | string                                                                                  | false    |              |             |
-| `icon`                 | string                                                                                  | false    |              |             |
-| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
-| `name`                 | string                                                                                  | true     |              |             |
-| `organization_id`      | string                                                                                  | true     |              |             |
-| `provisioner_tags`     | object                                                                                  | false    |              |             |
-| » `[any property]`     | string                                                                                  | false    |              |             |
+| Name                   | Type                                                                                    | Required | Restrictions | Description                                                                                                                                                                                                |
+|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `base_template_id`     | string                                                                                  | false    |              |                                                                                                                                                                                                            |
+| `base_variable_values` | object                                                                                  | false    |              |                                                                                                                                                                                                            |
+| » `[any property]`     | string                                                                                  | false    |              |                                                                                                                                                                                                            |
+| `description`          | string                                                                                  | false    |              |                                                                                                                                                                                                            |
+| `display_name`         | string                                                                                  | false    |              |                                                                                                                                                                                                            |
+| `icon`                 | string                                                                                  | false    |              |                                                                                                                                                                                                            |
+| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |                                                                                                                                                                                                            |
+| `name`                 | string                                                                                  | true     |              |                                                                                                                                                                                                            |
+| `organization_id`      | string                                                                                  | true     |              |                                                                                                                                                                                                            |
+| `provisioner_tags`     | object                                                                                  | false    |              |                                                                                                                                                                                                            |
+| » `[any property]`     | string                                                                                  | false    |              |                                                                                                                                                                                                            |
+| `session_id`           | string                                                                                  | false    |              | Session ID is the wizard session this request belongs to, as reported to POST /api/v2/templatebuilder/sessions. It is optional and used only to attribute a build failure to the session that produced it. |
 
 ## codersdk.TemplateBuilderCreateTemplateResponse
 

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -145,7 +145,8 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose/template \
   "provisioner_tags": {
     "property1": "string",
     "property2": "string"
-  }
+  },
+  "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82"
 }
 ```
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -9275,6 +9275,12 @@ export interface TemplateBuilderCreateTemplateRequest {
 	readonly description?: string;
 	readonly icon?: string;
 	readonly provisioner_tags?: Record<string, string>;
+	/**
+	 * SessionID is the wizard session this request belongs to, as reported to
+	 * POST /api/v2/templatebuilder/sessions. It is optional and used only to
+	 * attribute a build failure to the session that produced it.
+	 */
+	readonly session_id?: string;
 }
 
 // From codersdk/templatebuilder.go

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -517,6 +517,7 @@ describe("toCreateTemplateRequest", () => {
 			description: "A test template",
 			icon: "/icon/docker.svg",
 			modules: [{ id: "code-server" }],
+			sessionId: "session-123",
 		};
 		const request = toCreateTemplateRequest(state, {
 			organization_id: "org-123",
@@ -532,6 +533,8 @@ describe("toCreateTemplateRequest", () => {
 		expect(request.description).toBe("A test template");
 		expect(request.icon).toBe("/icon/docker.svg");
 		expect(request.modules).toEqual([{ id: "code-server" }]);
+		// Correlates a server-reported build failure with this wizard visit.
+		expect(request.session_id).toBe("session-123");
 	});
 
 	it("omits empty optional fields", () => {
@@ -550,6 +553,7 @@ describe("toCreateTemplateRequest", () => {
 		expect(request.display_name).toBeUndefined();
 		expect(request.description).toBeUndefined();
 		expect(request.icon).toBeUndefined();
+		expect(request.session_id).toBeUndefined();
 	});
 });
 

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -275,5 +275,7 @@ export const toCreateTemplateRequest = (
 		display_name: customizations.display_name || undefined,
 		description: customizations.description || undefined,
 		icon: customizations.icon || undefined,
+		// Lets the server attribute a build failure to this wizard visit.
+		session_id: state.sessionId || undefined,
 	};
 };


### PR DESCRIPTION
Template builder telemetry reports a single `success` bit on `compose_completion`, so a failed build is visible but unexplained. The reason exists only in the HTTP response body that the browser discards, and the three failure modes the provisioner error classifier already distinguishes are never recorded.

`coderd` now stamps a `build_failure` event on the existing `template_builder_sessions` snapshot with a `failure_reason`. The reason is server-only knowledge and must survive the browser navigating away, so the server reports it, which is also why `build_failure` stays out of the client-facing `codersdk` event type enum. The wizard's session ID rides along on the create request and doubles as the event ID, so failures self join to the `wizard_entry` and `compose_completion` rows of the same visit. Only catalog identifiers are reported: no variable values, no error text.

`ClassifyProvisionerError` keeps its signature and now derives its message from a new `ClassifyProvisionerErrorCategory`, so the message a user reads and the reason recorded cannot diverge.

| `failure_reason` | Branch |
|---|---|
| `invalid_request` | missing `base_template_id`, unknown organization |
| `compose_invalid` | `templatebuilder.Compose` rejected the base, module, or variable set |
| `name_conflict` | name taken, both the early check and the unique violation |
| `import_timeout` | timed out waiting for the import job |
| `import_canceled` | import job canceled |
| `provisioner_network` | classifier: registry or provider unreachable |
| `provisioner_auth` | classifier: cloud credentials |
| `provisioner_unknown` | classifier: unrecognized provisioner failure |
| `internal` | tar, file, and transaction failures |

Ingest side: coder/coder-telemetry-server#50, stacked on coder/coder-telemetry-server#49. Merge this first, then add `failure_reason STRING` to the live `coder-telemetry.coder.template_builder_sessions` table, then merge the ingest PR.

## Evidence

Captured from `./scripts/develop.sh` with `CODER_TELEMETRY_URL` pointed at a local sink.

A real provisioner failure, driven through the wizard UI (AWS EC2 (Linux) base, no AWS credentials on the dev host). All three events share the session ID, so the failure reason joins to the visit that produced it:

```json
[
  {
    "id": "4ef4dcd3-c1bd-43e7-815b-37781b951bb6",
    "event_type": "wizard_entry",
    "user_id": "0bd6d5a4-7daa-48ec-9df6-89daf5fd8304",
    "created_at": "2026-08-25T17:01:00.137880Z"
  },
  {
    "id": "4ef4dcd3-c1bd-43e7-815b-37781b951bb6",
    "event_type": "build_failure",
    "user_id": "0bd6d5a4-7daa-48ec-9df6-89daf5fd8304",
    "base_template_id": "aws-linux",
    "module_ids": ["code-server"],
    "failure_reason": "provisioner_auth",
    "created_at": "2026-08-25T17:04:00.333686Z"
  },
  {
    "id": "4ef4dcd3-c1bd-43e7-815b-37781b951bb6",
    "event_type": "compose_completion",
    "user_id": "0bd6d5a4-7daa-48ec-9df6-89daf5fd8304",
    "base_template_id": "aws-linux",
    "module_ids": ["code-server"],
    "duration_seconds": 171.404,
    "created_at": "2026-08-25T17:04:00.340803Z"
  }
]
```

The UI is unchanged. The wizard showed its usual failure state, matching the reported reason:

> Template import failed.
> Cloud provider authentication failed. Check that valid credentials are configured for the provisioner. Error: No valid credential sources found on main.tf line 142, in provider "aws" ...

Two more reasons, driven directly against the same deployment:

```console
$ curl ... -d '{"session_id":"8601d685-...","base_template_id":"not-a-real-base","modules":[{"id":"code-server"}],...}' \
    /api/v2/templatebuilder/compose/template
HTTP 400 {"message":"Failed to compose template.","detail":"render base template: unknown base template \"not-a-real-base\""}
```

```json
{
  "id": "8601d685-ab84-454b-9f3b-7eb82e4250e8",
  "event_type": "build_failure",
  "base_template_id": "not-a-real-base",
  "module_ids": ["code-server"],
  "failure_reason": "compose_invalid"
}
```

```console
$ curl ... -d '{"session_id":"4a7f597b-...","base_template_id":"docker","name":"docker",...}' \
    /api/v2/templatebuilder/compose/template
HTTP 409 {"message":"A template with this name already exists in the organization."}
```

```json
{
  "id": "4a7f597b-6945-43ac-b24b-b74e370391ab",
  "event_type": "build_failure",
  "base_template_id": "docker",
  "failure_reason": "name_conflict"
}
```

The query this is for:

```sql
SELECT failure_reason, base_template_id, COUNT(*) AS failures
FROM `coder-telemetry.coder.template_builder_sessions`
WHERE event_type = 'build_failure'
GROUP BY failure_reason, base_template_id
ORDER BY failures DESC;
```

Unrelated observation from the capture: `wizard_entry` fired twice for one visit on the dev server, which is React StrictMode double-invoking the mount effect. It predates this change.

<details>
<summary>Implementation plan</summary>

# Template builder build-failure telemetry

## Goal

Answer "why did a template builder build fail?" from telemetry. Today
`compose_completion` carries a single `success` bit and the reason lives only in
the HTTP response the browser throws away.

## Data model

One new **server-stamped** event on the existing `template_builder_sessions`
table (one table + `event_type` keeps funnel queries to a self join):

- `event_type = "build_failure"`, plus a new `failure_reason` column.
- `id` = the wizard `session_id` when the caller supplies one, so failures join
  to the `wizard_entry` / `compose_completion` rows of the same visit. Callers
  without a session (CLI, direct API) get a fresh UUID.
- `base_template_id` and `module_ids` are copied from the request, so failures
  can be attributed to a base or module.

The browser cannot know the reason (it only receives prose), and a failed
attempt must be recorded even if the tab closes, so `coderd` reports it. That
also keeps the value unforgeable, which is why `build_failure` stays out of the
public `codersdk` event-type enum.

### `failure_reason` values

| Reason | Branch |
|---|---|
| `invalid_request` | missing `base_template_id`, unknown organization |
| `compose_invalid` | `templatebuilder.Compose` rejected the base/module/variable set |
| `name_conflict` | name taken (early check and unique violation) |
| `import_timeout` | 504 waiting for the import job |
| `import_canceled` | import job canceled |
| `provisioner_network` | classifier: registry/provider unreachable |
| `provisioner_auth` | classifier: cloud credentials |
| `provisioner_unknown` | classifier: unrecognized provisioner failure |
| `internal` | tar, file, transaction, and other 500 paths |

The three `provisioner_*` values come from the existing error classifier, which
currently only produces a user-facing string.

## coder/coder changes

1. `coderd/templatebuilder/errors.go`: extract `ProvisionerErrorCategory`
   (`network`, `auth`, `unknown`) and `ClassifyProvisionerErrorCategory()`.
   `ClassifyProvisionerError()` keeps its signature and derives its message from
   the category, so the message a user sees and the reason we report can never
   diverge.
2. `coderd/telemetry/telemetry.go`: add `FailureReason` to
   `TemplateBuilderSession`, the `build_failure` event type, and the reason
   constants.
3. `codersdk/templatebuilder.go`: optional `session_id` on
   `TemplateBuilderCreateTemplateRequest` (attribution token only).
4. `coderd/templatebuilder_handler.go`: `reportTemplateBuilderBuildFailure`
   helper called from every failure branch of `templateBuilderCreateTemplate`.
5. `site/.../wizardState.ts`: send `session_id` with the create request.
6. `make gen`.

## Tests

- `coderd/templatebuilder/errors_test.go`: category per pattern set, network
  precedence over auth, unknown fallback, and message/category agreement.
- `coderd/templatebuilder_handler_test.go`: drive the endpoint with a fake
  telemetry reporter and assert the reported event for `invalid_request`,
  `compose_invalid`, and `name_conflict`; assert the session ID is echoed as the
  event ID and that a missing session ID still produces an event.
- `site/.../wizardState.test.ts`: `session_id` is included, omitted when empty.

## coder/coder-telemetry-server (stacked)

`failure_reason` column on `bqTemplateBuilderSession`, conversion test, pin
bump. Required before the field reaches BigQuery: the ingest server decodes
snapshots into its pinned `coder/coder` structs, so an unknown field is dropped.

## Out of scope

Step-level wizard events, builder attribution on created templates, and
instrumenting the read-only `/bases`, `/modules`, and `/compose` endpoints.

</details>

> 🤖 Generated by Coder Agents
