### PR TITLE
ci: use dedicated release App token to publish releases (backport 2.34) [ESR]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -553,6 +553,18 @@ jobs:
             gcloud storage cp "./build/${detached_signature}" "gs://releases.coder.com/coder-cli/${version}/${cli_name}.asc"
           done
 
+      # Mint a short-lived installation token from the dedicated release
+      # GitHub App. The default GITHUB_TOKEN (github-actions[bot]) cannot be
+      # added to the "Auto-imported tag create protections" ruleset bypass
+      # list, so `gh release create` fails to create the tag with a 403. The
+      # App is added to that ruleset's bypass list as an Integration actor.
+      - name: Generate release App token
+        id: release_app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Publish release
         run: |
           set -euo pipefail
@@ -591,7 +603,9 @@ jobs:
             --release-notes-file "$CODER_RELEASE_NOTES_FILE" \
             "${files[@]}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the dedicated release App token (github-actions[bot] is blocked
+          # from creating tags by the tag-create protection ruleset).
+          GITHUB_TOKEN: ${{ steps.release_app_token.outputs.token }}
           CODER_GPG_RELEASE_KEY_BASE64: ${{ secrets.GPG_RELEASE_KEY_BASE64 }}
           VERSION: ${{ steps.version.outputs.version }}
           CREATED_LATEST_TAG: ${{ steps.build_docker.outputs.created_latest_tag }}


### PR DESCRIPTION
Backport of #28553 to `release/2.34`.

Use a dedicated GitHub App token (`secrets.RELEASE_APP_ID` / `secrets.RELEASE_APP_PRIVATE_KEY`) for the `Publish release` step instead of the default `GITHUB_TOKEN`.

`gh release create` targets a release-branch commit that modifies files under `.github/workflows/` relative to the default branch. The create-release API requires the authenticating token to be authorized to modify workflows; the default `GITHUB_TOKEN` is not, so it fails with `HTTP 403: Resource not accessible by integration`. The `coder-release-publisher` App token has code + workflows write.

Requires `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` to be configured (already set on `coder/coder`).

Refs coder/security-automation#297.
