### PR TITLE
refactor: upgrade golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -141,6 +141,8 @@ linters:
         - name: redefines-builtin-id
         - name: string-of-int
         - name: struct-tag
+          arguments:
+            - "validate,username,organization_name,template_name,workspace_name,oauth2_app_name,organization_display_name,template_display_name,group_display_name,template_version_name,user_real_name,group_name,gte,http_url,excluded_with"
         - name: superfluous-else
         - name: time-naming
         - name: unconditional-recursion

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -716,6 +716,7 @@ func TestAWSBedrockIntegration(t *testing.T) {
 		// Sends a bridge request through a mock egress proxy that
 		// mutates X-Forwarded-For, then verifies the SigV4 signature
 		// still matches at the mock Bedrock endpoint.
+		//nolint:paralleltest // Must finish before the next subtest inspects the last request received by the shared mockBedrock.
 		t.Run("bridge SigV4 signature valid", func(t *testing.T) {
 			reqBody, err := sjson.SetBytes(fix.Request(), "stream", false)
 			require.NoError(t, err)
@@ -733,6 +734,7 @@ func TestAWSBedrockIntegration(t *testing.T) {
 		// the request as-is without SigV4 signing, so proxy headers
 		// are safe to include. ReverseProxy sets its own X-Forwarded-*
 		// headers via SetXForwarded. This verifies they arrive upstream.
+		//nolint:paralleltest // Asserts on the last request received by the shared mockBedrock, so it must run after the subtest above.
 		t.Run("passthrough proxy sets own forwarded headers", func(t *testing.T) {
 			resp, err := bridgeServer.makeRequest(t, http.MethodGet, "/anthropic/v1/models", nil, proxyHeaders)
 			require.NoError(t, err)

--- a/cli/clilog/clilog_test.go
+++ b/cli/clilog/clilog_test.go
@@ -97,6 +97,8 @@ func TestBuilder(t *testing.T) {
 		t.Parallel()
 
 		t.Run("Defaults", func(t *testing.T) {
+			t.Parallel()
+
 			stdoutPath := filepath.Join(t.TempDir(), "stdout")
 			stderrPath := filepath.Join(t.TempDir(), "stderr")
 
@@ -125,6 +127,8 @@ func TestBuilder(t *testing.T) {
 		})
 
 		t.Run("Override", func(t *testing.T) {
+			t.Parallel()
+
 			tempFile := filepath.Join(t.TempDir(), "test.log")
 			tempJSON := filepath.Join(t.TempDir(), "test.json")
 			dv := &codersdk.DeploymentValues{

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -2020,6 +2020,8 @@ func TestCreateValidateRichParameters(t *testing.T) {
 		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
 
 		t.Run("Prompt", func(t *testing.T) {
+			t.Parallel()
+
 			logger := testutil.Logger(t)
 			ctx := testutil.Context(t, testutil.WaitMedium)
 			inv, root := clitest.New(t, "create", "my-workspace-1", "--template", template.Name)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -531,6 +531,7 @@ func TestServer(t *testing.T) {
 				expectGithubDefaultProviderConfigured: true,
 			},
 		} {
+			//nolint:paralleltest // runGitHubProviderTest calls t.Parallel itself; calling it here too would panic.
 			t.Run(tc.name, func(t *testing.T) {
 				runGitHubProviderTest(t, tc)
 			})

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2295,6 +2295,7 @@ func TestSSH_CoderConnect(t *testing.T) {
 		defer cancel()
 
 		// Test successful exit code
+		//nolint:paralleltest // Uses the parent's ctx, which the parent's defer cancels, and the parent's shared workspace agent.
 		t.Run("Success", func(t *testing.T) {
 			inv, root := clitest.New(t, "ssh", workspace.Name, "exit 0")
 			clitest.SetupConfig(t, client, root)
@@ -2304,6 +2305,7 @@ func TestSSH_CoderConnect(t *testing.T) {
 		})
 
 		// Test error exit code
+		//nolint:paralleltest // Uses the parent's ctx, which the parent's defer cancels, and the parent's shared workspace agent.
 		t.Run("Error", func(t *testing.T) {
 			inv, root := clitest.New(t, "ssh", workspace.Name, "exit 1")
 			clitest.SetupConfig(t, client, root)

--- a/cli/user_delete_test.go
+++ b/cli/user_delete_test.go
@@ -140,6 +140,7 @@ func TestUserDelete(t *testing.T) {
 	t.Run("DeleteSelf", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Owner", func(t *testing.T) {
+			t.Parallel()
 			client := coderdtest.New(t, nil)
 			_ = coderdtest.CreateFirstUser(t, client)
 			inv, root := clitest.New(t, "users", "delete", "me")
@@ -149,6 +150,7 @@ func TestUserDelete(t *testing.T) {
 			require.ErrorContains(t, inv.Run(), "You cannot delete yourself!")
 		})
 		t.Run("UserAdmin", func(t *testing.T) {
+			t.Parallel()
 			client := coderdtest.New(t, nil)
 			owner := coderdtest.CreateFirstUser(t, client)
 			userAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleUserAdmin())

--- a/coderd/ai_providers_backfill_test.go
+++ b/coderd/ai_providers_backfill_test.go
@@ -29,6 +29,7 @@ func TestBackfillBedrockProviderType(t *testing.T) {
 	}
 
 	// All DB subtests share one database instance and run sequentially.
+	//nolint:paralleltest // Subtests share one database and each builds on the state left by the previous one.
 	t.Run("DB", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)

--- a/coderd/ai_providers_test.go
+++ b/coderd/ai_providers_test.go
@@ -48,7 +48,6 @@ func TestAIProvidersCRUD(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		_ = coderdtest.CreateFirstUser(t, client)
-		ctx := testutil.Context(t, testutil.WaitLong)
 
 		tests := []struct {
 			providerType codersdk.AIProviderType
@@ -62,6 +61,9 @@ func TestAIProvidersCRUD(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(string(tt.providerType), func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
 				created, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
 					Type:    tt.providerType,
 					Name:    "type-preserve-" + string(tt.providerType),

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -800,7 +800,7 @@ func TestTasks(t *testing.T) {
 
 			statusResponse = agentapisdk.StatusStable
 
-			//nolint:tparallel // Not intended to run in parallel.
+			//nolint:paralleltest,tparallel // Subtests share the parent's task, agent and mutable statusResponse, so they must run in order.
 			t.Run("SendOK", func(t *testing.T) {
 				err = client.TaskSend(ctx, "me", task.ID, codersdk.TaskSendRequest{
 					Input: "Hello, Agent!",
@@ -808,7 +808,7 @@ func TestTasks(t *testing.T) {
 				require.NoError(t, err, "wanted no error due to healthy sidebar app and stable status")
 			})
 
-			//nolint:tparallel // Not intended to run in parallel.
+			//nolint:paralleltest,tparallel // Subtests share the parent's task, agent and mutable statusResponse, so they must run in order.
 			t.Run("MissingContent", func(t *testing.T) {
 				err = client.TaskSend(ctx, "me", task.ID, codersdk.TaskSendRequest{
 					Input: "",
@@ -1026,7 +1026,7 @@ func TestTasks(t *testing.T) {
 		task, err = client.TaskByID(ctx, task.ID)
 		require.NoError(t, err)
 
-		//nolint:tparallel // Not intended to run in parallel.
+		//nolint:paralleltest,tparallel // Subtests share the parent's task and toggle the mutable shouldReturnError flag.
 		t.Run("OK", func(t *testing.T) {
 			// Fetch logs.
 			resp, err := client.TaskLogs(ctx, "me", task.ID)
@@ -1045,7 +1045,7 @@ func TestTasks(t *testing.T) {
 			assert.Equal(t, "What would you like to work on today?", resp.Logs[2].Content)
 		})
 
-		//nolint:tparallel // Not intended to run in parallel.
+		//nolint:paralleltest,tparallel // Subtests share the parent's task and toggle the mutable shouldReturnError flag.
 		t.Run("UpstreamError", func(t *testing.T) {
 			shouldReturnError = true
 			t.Cleanup(func() { shouldReturnError = false })
@@ -2801,7 +2801,6 @@ func TestPauseTask(t *testing.T) {
 	t.Run("Non-owner role access", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testutil.Context(t, testutil.WaitShort)
 		db, ps := dbtestutil.NewDB(t)
 		client := setupClient(t, db, ps, nil)
 		owner := coderdtest.CreateFirstUser(t, client)
@@ -2834,6 +2833,9 @@ func TestPauseTask(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
 				task, _ := setupWorkspaceTask(t, db, owner)
 				userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, tc.roles...)
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -2625,6 +2625,9 @@ func TestListChats(t *testing.T) {
 		}))
 
 		t.Run("MatchesRoot", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Query: `diff_url:"https://github.com/coder/coder/pull/1"`,
 			})
@@ -2634,6 +2637,9 @@ func TestListChats(t *testing.T) {
 		})
 
 		t.Run("MatchesViaSubAgent", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Query: `diff_url:"https://github.com/coder/coder/pull/2"`,
 			})
@@ -2643,6 +2649,9 @@ func TestListChats(t *testing.T) {
 		})
 
 		t.Run("CaseInsensitive", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Query: `diff_url:"HTTPS://GITHUB.COM/CODER/CODER/PULL/1"`,
 			})
@@ -2652,6 +2661,9 @@ func TestListChats(t *testing.T) {
 		})
 
 		t.Run("NoMatch", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Query: `diff_url:"https://github.com/coder/coder/pull/424242"`,
 			})
@@ -2660,6 +2672,9 @@ func TestListChats(t *testing.T) {
 		})
 
 		t.Run("InvalidURL", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			_, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Query: `diff_url:"ftp://example.com/x"`,
 			})
@@ -2669,6 +2684,9 @@ func TestListChats(t *testing.T) {
 		})
 
 		t.Run("ArchivedFilteredOut", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			// Default archived filter is false, so an archived chat with
 			// a matching diff URL must not surface.
 			chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
@@ -2679,6 +2697,9 @@ func TestListChats(t *testing.T) {
 		})
 
 		t.Run("ArchivedTrueComposes", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
 			chats, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Query: `archived:true diff_url:"https://github.com/coder/coder/pull/3"`,
 			})
@@ -4890,6 +4911,7 @@ func TestGetChatModel(t *testing.T) {
 			{name: "Patch", method: http.MethodPatch, body: codersdk.UpdateChatModelRequest{DisplayName: "wrong organization"}},
 			{name: "Delete", method: http.MethodDelete},
 		} {
+			//nolint:paralleltest // The parent asserts the stored model config after these subtests have attempted to modify it.
 			t.Run(tc.name, func(t *testing.T) {
 				res, err := client.Request(ctx, tc.method, fmt.Sprintf(
 					"/api/experimental/organizations/%s/chats/models/%s",
@@ -4976,6 +4998,9 @@ func TestCreateChatModelConfig(t *testing.T) {
 			{"configured", configuredProvider.ID},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
 				contextLimit := int64(4096)
 				_, err := memberClient.CreateChatModel(ctx, firstUser.OrganizationID, codersdk.CreateChatModelRequest{
 					AIProviderID: &tc.providerID,
@@ -6149,7 +6174,6 @@ func TestUpdateChatModel(t *testing.T) {
 	t.Run("RejectsACLKeys", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
 		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModel(t, client)
@@ -6165,6 +6189,9 @@ func TestUpdateChatModel(t *testing.T) {
 			{name: "user_acl/null", key: "user_acl", value: nil},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitLong)
+
 				res, err := client.Request(ctx, http.MethodPatch, fmt.Sprintf(
 					"/api/experimental/organizations/%s/chats/models/%s",
 					modelConfig.OrganizationID,

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1152,6 +1152,8 @@ func TestUpdateJob(t *testing.T) {
 		t.Parallel()
 
 		t.Run("Valid", func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()
 
@@ -1193,6 +1195,8 @@ func TestUpdateJob(t *testing.T) {
 		})
 
 		t.Run("Missing required value", func(t *testing.T) {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()
 

--- a/coderd/rbac/roles_internal_test.go
+++ b/coderd/rbac/roles_internal_test.go
@@ -232,6 +232,7 @@ func TestRoleByName(t *testing.T) {
 
 		for _, c := range testCases {
 			t.Run(c.Role.Identifier.String(), func(t *testing.T) {
+				t.Parallel()
 				role, err := RoleByName(c.Role.Identifier)
 				require.NoError(t, err, "role exists")
 				equalRoles(t, c.Role, role)

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -510,6 +510,8 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		t.Parallel()
 
 		t.Run("OK", func(t *testing.T) {
+			t.Parallel()
+
 			client := coderdtest.New(t, nil)
 			user := coderdtest.CreateFirstUser(t, client)
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -526,6 +528,8 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		})
 
 		t.Run("EnterpriseLevelError", func(t *testing.T) {
+			t.Parallel()
+
 			client := coderdtest.New(t, nil)
 			user := coderdtest.CreateFirstUser(t, client)
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -2450,6 +2450,7 @@ func TestUserThemeMode(t *testing.T) {
 				themeDark: "xss-payload",
 			},
 		} {
+			//nolint:paralleltest // Subtests share the parent's ctx, which the parent's defer cancels.
 			t.Run(tc.name, func(t *testing.T) {
 				_, err := client.UpdateUserAppearanceSettings(ctx, codersdk.Me, codersdk.UpdateUserAppearanceSettingsRequest{
 					ThemePreference: "dark",
@@ -2825,6 +2826,7 @@ func TestAgentDisplayModePreferences(t *testing.T) {
 				mode: codersdk.AgentDisplayMode(codersdk.ThinkingDisplayModePreview),
 			},
 		} {
+			//nolint:paralleltest // Subtests share the parent's ctx, which the parent's defer cancels.
 			t.Run(tt.name, func(t *testing.T) {
 				_, err := client.UpdateUserPreferenceSettings(ctx, codersdk.Me, codersdk.UpdateUserPreferenceSettingsRequest{
 					ShellToolDisplayMode: tt.mode,
@@ -2855,6 +2857,7 @@ func TestAgentDisplayModePreferences(t *testing.T) {
 				mode: codersdk.AgentDisplayMode(codersdk.ThinkingDisplayModePreview),
 			},
 		} {
+			//nolint:paralleltest // Subtests share the parent's ctx, which the parent's defer cancels.
 			t.Run(tt.name, func(t *testing.T) {
 				_, err := client.UpdateUserPreferenceSettings(ctx, codersdk.Me, codersdk.UpdateUserPreferenceSettingsRequest{
 					CodeDiffDisplayMode: tt.mode,

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -764,6 +764,8 @@ func TestWorkspaceAgentConnectRPC(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				client, db := coderdtest.NewWithDatabase(t, nil)
 				user := coderdtest.CreateFirstUser(t, client)
 				r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{

--- a/coderd/workspaceapps/db_test.go
+++ b/coderd/workspaceapps/db_test.go
@@ -532,6 +532,8 @@ func Test_ResolveRequest(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
+				t.Parallel()
+
 				req := (workspaceapps.Request{
 					AccessMethod:      workspaceapps.AccessMethodPath,
 					BasePath:          "/app",

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -452,6 +452,8 @@ func TestWorkspaceBuildsProvisionerState(t *testing.T) {
 		})
 
 		t.Run("OK", func(t *testing.T) {
+			t.Parallel()
+
 			// Include a provisioner so that we can test that provisionerdserver
 			// performs deletion.
 			auditor := audit.NewMock()

--- a/codersdk/toolsdk/bash_test.go
+++ b/codersdk/toolsdk/bash_test.go
@@ -52,6 +52,8 @@ func TestWorkspaceBash(t *testing.T) {
 
 		// Test input validation errors (these should fail before client access)
 		t.Run("EmptyWorkspace", func(t *testing.T) {
+			t.Parallel()
+
 			args := toolsdk.WorkspaceBashArgs{
 				Workspace: "", // Empty workspace should be caught by validation
 				Command:   "echo test",
@@ -62,6 +64,8 @@ func TestWorkspaceBash(t *testing.T) {
 		})
 
 		t.Run("EmptyCommand", func(t *testing.T) {
+			t.Parallel()
+
 			args := toolsdk.WorkspaceBashArgs{
 				Workspace: "test-workspace",
 				Command:   "", // Empty command should be caught by validation

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -173,7 +173,7 @@ type CreateUserRequest struct {
 	// from being able to use a password or any other authentication method to login.
 	// Deprecated: Set UserLoginType=LoginTypeDisabled instead.
 	DisableLogin   bool      `json:"disable_login"`
-	OrganizationID uuid.UUID `json:"organization_id" validate:"" format:"uuid"`
+	OrganizationID uuid.UUID `json:"organization_id" format:"uuid"`
 }
 
 type CreateUserRequestWithOrgs struct {
@@ -186,7 +186,7 @@ type CreateUserRequestWithOrgs struct {
 	// UserStatus defaults to UserStatusDormant.
 	UserStatus *UserStatus `json:"user_status"`
 	// OrganizationIDs is a list of organization IDs that the user should be a member of.
-	OrganizationIDs []uuid.UUID `json:"organization_ids" validate:"" format:"uuid"`
+	OrganizationIDs []uuid.UUID `json:"organization_ids" format:"uuid"`
 	// Service accounts are admin-managed accounts that cannot login.
 	ServiceAccount bool `json:"service_account,omitempty"`
 	// Roles is an optional list of site-level roles to assign at creation.
@@ -365,7 +365,7 @@ var ValidAgentDisplayModes = []AgentDisplayMode{
 }
 
 type UpdateUserPasswordRequest struct {
-	OldPassword string `json:"old_password" validate:""`
+	OldPassword string `json:"old_password"`
 	Password    string `json:"password" validate:"required"`
 }
 
@@ -402,7 +402,7 @@ type UpdateUserQuietHoursScheduleRequest struct {
 }
 
 type UpdateRoles struct {
-	Roles []string `json:"roles" validate:""`
+	Roles []string `json:"roles"`
 }
 
 type UserRoles struct {

--- a/enterprise/coderd/license/usercount_test.go
+++ b/enterprise/coderd/license/usercount_test.go
@@ -305,21 +305,24 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		now := time.Now()
 		enablements := map[codersdk.FeatureName]bool{}
 
-		dbLicense := func(opts coderdenttest.LicenseOptions) database.License {
+		dbLicense := func(t *testing.T, opts coderdenttest.LicenseOptions) database.License {
+			t.Helper()
 			return database.License{
 				UUID: uuid.New(),
 				JWT:  coderdenttest.GenerateLicense(t, opts),
 				Exp:  now.Add(time.Hour * 24 * 60),
 			}
 		}
-		addonLicense := func() database.License {
-			return dbLicense(*(&coderdenttest.LicenseOptions{
+		addonLicense := func(t *testing.T) database.License {
+			t.Helper()
+			return dbLicense(t, *(&coderdenttest.LicenseOptions{
 				Features: license.Features{codersdk.FeatureUserLimit: 100},
 			}).Valid(now).AIGovernanceAddon(10))
 		}
 
 		t.Run("NoAddonFnNotCalled", func(t *testing.T) {
-			licenses := []database.License{dbLicense(*(&coderdenttest.LicenseOptions{
+			t.Parallel()
+			licenses := []database.License{dbLicense(t, *(&coderdenttest.LicenseOptions{
 				Features: license.Features{codersdk.FeatureUserLimit: 100},
 			}).Valid(now))}
 			entitlements, err := license.LicensesEntitlements(ctx, now, licenses, enablements, coderdenttest.Keys, license.FeatureArguments{
@@ -335,6 +338,7 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("AddonMissingDependenciesIgnored", func(t *testing.T) {
+			t.Parallel()
 			// A license carrying the addon without its required features
 			// records a validation error and the addon is skipped, so
 			// workspace-capable counting must not activate.
@@ -342,7 +346,7 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 				Features: license.Features{codersdk.FeatureUserLimit: 100},
 			}).Valid(now)
 			opts.Addons = append(opts.Addons, codersdk.AddonAIGovernance)
-			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{dbLicense(*opts)}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{dbLicense(t, *opts)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount:  7,
 				UserCountingMode: license.UserCountingModeWorkspaceCapable,
 				WorkspaceCapableUserCountFn: func(context.Context) (int64, error) {
@@ -356,10 +360,11 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("ActiveModeIgnoresFn", func(t *testing.T) {
+			t.Parallel()
 			// UserCountingMode is authoritative: with the mode left at its
 			// active-users zero value, the counting function must not be
 			// called even though it is set and the addon is present.
-			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense()}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense(t)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount: 7,
 				WorkspaceCapableUserCountFn: func(context.Context) (int64, error) {
 					t.Fatal("count fn must not be called in active counting mode")
@@ -372,7 +377,8 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("AddonUsesFn", func(t *testing.T) {
-			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense()}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			t.Parallel()
+			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense(t)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount:   7,
 				ActiveAISeatCount: 5,
 				UserCountingMode:  license.UserCountingModeWorkspaceCapable,
@@ -401,14 +407,15 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("BestPairSelection", func(t *testing.T) {
+			t.Parallel()
 			// A deployment holding both an addon license and a non-addon
 			// license has two user_limit candidates, each evaluated with
 			// its own counting mode. Limits and modes never mix.
 			licenses := []database.License{
-				dbLicense(*(&coderdenttest.LicenseOptions{
+				dbLicense(t, *(&coderdenttest.LicenseOptions{
 					Features: license.Features{codersdk.FeatureUserLimit: 200},
 				}).Valid(now)),
-				addonLicense(), // user_limit 100, AI Governance addon.
+				addonLicense(t), // user_limit 100, AI Governance addon.
 			}
 			run := func(t *testing.T, activeUsers, capableUsers int64) codersdk.Entitlements {
 				entitlements, err := license.LicensesEntitlements(ctx, now, licenses, enablements, coderdenttest.Keys, license.FeatureArguments{
@@ -423,6 +430,7 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			}
 
 			t.Run("LegacyPairCompliant", func(t *testing.T) {
+				t.Parallel()
 				// 180 active <= 200 wins over 150 capable > 100: the
 				// non-addon license keeps the deployment compliant.
 				entitlements := run(t, 180, 150)
@@ -434,6 +442,7 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			})
 
 			t.Run("AddonPairCompliant", func(t *testing.T) {
+				t.Parallel()
 				// 90 capable <= 100 wins over 250 active > 200: the addon
 				// license keeps the deployment compliant.
 				entitlements := run(t, 250, 90)
@@ -445,6 +454,7 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			})
 
 			t.Run("NeitherPairCompliant", func(t *testing.T) {
+				t.Parallel()
 				// Both pairs over: the higher limit is reported, with the
 				// counting mode of its own license.
 				entitlements := run(t, 250, 150)
@@ -455,14 +465,15 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			})
 
 			t.Run("GraceAddonCompliantBeatsEntitledOver", func(t *testing.T) {
+				t.Parallel()
 				// A grace-period addon pair that fits its count wins over an
 				// entitled non-addon pair that does not, carrying its grace
 				// entitlement and the revert warning with it.
 				licenses := []database.License{
-					dbLicense(*(&coderdenttest.LicenseOptions{
+					dbLicense(t, *(&coderdenttest.LicenseOptions{
 						Features: license.Features{codersdk.FeatureUserLimit: 200},
 					}).Valid(now)),
-					dbLicense(*(&coderdenttest.LicenseOptions{
+					dbLicense(t, *(&coderdenttest.LicenseOptions{
 						Features: license.Features{codersdk.FeatureUserLimit: 100},
 					}).GracePeriod(now).AIGovernanceAddon(10)),
 				}
@@ -484,14 +495,15 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			})
 
 			t.Run("EqualLimitsPreferAddon", func(t *testing.T) {
+				t.Parallel()
 				// Identical limit and entitlement on an addon and a
 				// non-addon license: the addon pair wins the tie, so the
 				// workspace-capable count is displayed.
 				licenses := []database.License{
-					dbLicense(*(&coderdenttest.LicenseOptions{
+					dbLicense(t, *(&coderdenttest.LicenseOptions{
 						Features: license.Features{codersdk.FeatureUserLimit: 100},
 					}).Valid(now)),
-					addonLicense(),
+					addonLicense(t),
 				}
 				entitlements, err := license.LicensesEntitlements(ctx, now, licenses, enablements, coderdenttest.Keys, license.FeatureArguments{
 					ActiveUserCount:  80,
@@ -506,14 +518,15 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 			})
 
 			t.Run("TwoAddonCandidates", func(t *testing.T) {
+				t.Parallel()
 				// Two addon licenses: the entitled higher-limit pair fits
 				// the capable count and wins over the grace pair, and its
 				// presence suppresses the revert warning.
 				licenses := []database.License{
-					dbLicense(*(&coderdenttest.LicenseOptions{
+					dbLicense(t, *(&coderdenttest.LicenseOptions{
 						Features: license.Features{codersdk.FeatureUserLimit: 100},
 					}).GracePeriod(now).AIGovernanceAddon(10)),
-					dbLicense(*(&coderdenttest.LicenseOptions{
+					dbLicense(t, *(&coderdenttest.LicenseOptions{
 						Features: license.Features{codersdk.FeatureUserLimit: 300},
 					}).Valid(now).AIGovernanceAddon(10)),
 				}
@@ -536,7 +549,8 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("ModeWithoutFnIsDevError", func(t *testing.T) {
-			_, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense()}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			t.Parallel()
+			_, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense(t)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount:  7,
 				UserCountingMode: license.UserCountingModeWorkspaceCapable,
 			})
@@ -544,10 +558,11 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("OverLimitWarnsWithCapableCount", func(t *testing.T) {
+			t.Parallel()
 			// The over-limit warning must report the workspace-capable
 			// count it was compared against, and say so, rather than
 			// claiming that many "active users" exist.
-			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense()}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			entitlements, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense(t)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount:  7,
 				UserCountingMode: license.UserCountingModeWorkspaceCapable,
 				WorkspaceCapableUserCountFn: func(context.Context) (int64, error) {
@@ -561,9 +576,10 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("GracePeriodAddonUsesFn", func(t *testing.T) {
+			t.Parallel()
 			// A license in its grace period still includes the addon, so
 			// counting must not revert until the license hard-expires.
-			licenses := []database.License{dbLicense(*(&coderdenttest.LicenseOptions{
+			licenses := []database.License{dbLicense(t, *(&coderdenttest.LicenseOptions{
 				Features: license.Features{codersdk.FeatureUserLimit: 100},
 			}).GracePeriod(now).AIGovernanceAddon(10))}
 			entitlements, err := license.LicensesEntitlements(ctx, now, licenses, enablements, coderdenttest.Keys, license.FeatureArguments{
@@ -584,11 +600,12 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("FnErrorPropagates", func(t *testing.T) {
+			t.Parallel()
 			// A failed capable count aborts the computation, matching the
 			// legacy active-user-count error semantics; the caller keeps
 			// the previous entitlements rather than seeing a silently
 			// different count.
-			_, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense()}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			_, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense(t)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount:  7,
 				UserCountingMode: license.UserCountingModeWorkspaceCapable,
 				WorkspaceCapableUserCountFn: func(context.Context) (int64, error) {
@@ -600,7 +617,8 @@ func TestCountWorkspaceCapableUsers(t *testing.T) {
 		})
 
 		t.Run("ContextCanceledBails", func(t *testing.T) {
-			_, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense()}, enablements, coderdenttest.Keys, license.FeatureArguments{
+			t.Parallel()
+			_, err := license.LicensesEntitlements(ctx, now, []database.License{addonLicense(t)}, enablements, coderdenttest.Keys, license.FeatureArguments{
 				ActiveUserCount:  7,
 				UserCountingMode: license.UserCountingModeWorkspaceCapable,
 				WorkspaceCapableUserCountFn: func(context.Context) (int64, error) {

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -422,6 +422,7 @@ func TestCreateUserWorkspace(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assert all authz properties
+		//nolint:paralleltest // Inspects the authz calls recorded by the parent after workspace creation.
 		t.Run("OnlyOrganizationAuthzCalls", func(t *testing.T) {
 			// Creating workspaces is an organization action. So organization
 			// permissions should be sufficient to complete the action.

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -417,6 +417,7 @@ func TestExternalAuthLinks(t *testing.T) {
 		})
 
 		t.Run("DecryptErr", func(t *testing.T) {
+			t.Parallel()
 			db, crypt, ciphers := setup(t)
 			user := dbgen.User(t, db, database.User{})
 			link := dbgen.ExternalAuthLink(t, db, database.ExternalAuthLink{

--- a/mise.lock
+++ b/mise.lock
@@ -497,7 +497,7 @@ version = "v4.19.0"
 backend = "go:github.com/golang-migrate/migrate/v4/cmd/migrate"
 
 [[tools."go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint"]]
-version = "2.0.2"
+version = "2.1.6"
 backend = "go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 
 [[tools."go:github.com/goreleaser/nfpm/v2/cmd/nfpm"]]

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,7 @@ protoc-gen-go = "1.30.0"
 # (and older included versions of packages like go/ast) that can result in them
 # being unable to lint code for our Go version. Upgrading to a new enough
 # version should let us use the native mise backend and GitHub release binaries.
-"go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint" = "v2.0.2"
+"go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint" = "v2.1.6"
 "go:github.com/golang-migrate/migrate/v4/cmd/migrate" = "v4.19.0"
 "go:github.com/goreleaser/nfpm/v2/cmd/nfpm" = "v2.35.1"
 "go:github.com/slsyy/mtimehash/cmd/mtimehash" = "v1.0.0"


### PR DESCRIPTION
Upgrades golangci-lint to v2.1.6 and resolves the newly enabled lint findings.

This is the next incremental step toward a version that fully supports expression-based `new` calls.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents.
</details>
