### PR TITLE
fix(cli): exit coder ssh --stdio when stdin closes before connection

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gen2brain/beeep"
@@ -247,9 +248,28 @@ func (r *RootCmd) ssh() *serpent.Command {
 			// In stdio mode, we can't allow any writes to stdin or stdout
 			// because they are used by the SSH protocol.
 			stdioReader, stdioWriter := inv.Stdin, inv.Stdout
+			// connected is set once the SSH session is consuming stdin, at
+			// which point its copy logic handles stdin termination.
+			var connected atomic.Bool
 			if stdio {
 				inv.Stdin = stdioErrLogReader{inv.Logger}
 				inv.Stdout = inv.Stderr
+
+				// ProxyCommand clients close stdin when they abandon a
+				// connection attempt. Relay stdin through a pipe so that its
+				// termination is observed even before the connection exists,
+				// canceling this process instead of leaking it while it waits
+				// for the agent or dials. See #27954.
+				piper, pipew := io.Pipe()
+				go func(src io.Reader) {
+					_, err := io.Copy(pipew, src)
+					_ = pipew.CloseWithError(err)
+					logger.Debug(ctx, "stdin relay finished", slog.Error(err))
+					if !connected.Load() {
+						cancel()
+					}
+				}(stdioReader)
+				stdioReader = piper
 			}
 
 			// This WaitGroup solves for a race condition where we were logging
@@ -460,6 +480,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 						})
 						defer closeUsage()
 					}
+					connected.Store(true)
 					return runCoderConnectStdio(ctx, fmt.Sprintf("%s:22", coderConnectHost), stdioReader, stdioWriter, stack, logger)
 				}
 			}
@@ -549,6 +570,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 						return nil
 					}, logger, client, workspace, errCh)
 				}()
+				connected.Store(true)
 				copier.copy(&wg)
 				return nil
 			}

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2170,8 +2170,17 @@ func TestSSH_CoderConnect(t *testing.T) {
 		ctx = context.WithValue(ctx, "fs", fs)
 
 		client, workspace, agentToken := setupWorkspaceForAgent(t)
+		// Provide a live stdin for the command; with no stdin attached, the
+		// command treats it as an abandoned connection and exits early.
+		clientOutput, clientInput := io.Pipe()
+		defer func() {
+			for _, c := range []io.Closer{clientOutput, clientInput} {
+				_ = c.Close()
+			}
+		}()
 		inv, root := clitest.New(t, "ssh", workspace.Name, "--network-info-dir", "/net", "--stdio")
 		clitest.SetupConfig(t, client, root)
+		inv.Stdin = clientOutput
 
 		ctx = cli.WithTestOnlyCoderConnectDialer(ctx, &fakeCoderConnectDialer{})
 		ctx = withCoderConnectRunning(ctx)
@@ -2455,6 +2464,48 @@ type fakeCoderConnectDialer struct{}
 
 func (*fakeCoderConnectDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	return nil, xerrors.Errorf("dial coder connect host %q over %s", addr, network)
+}
+
+// TestSSHStdio_ExitWhenStdinClosedBeforeAgentConnects ensures the command exits
+// promptly when the client closes stdin before a connection is established,
+// instead of leaking the process while waiting for the agent or dialing.
+// See https://github.com/coder/coder/issues/27954
+func TestSSHStdio_ExitWhenStdinClosedBeforeAgentConnects(t *testing.T) {
+	t.Parallel()
+
+	client, workspace, _ := setupWorkspaceForAgent(t)
+
+	clientOutput, clientInput := io.Pipe()
+	serverOutput, serverInput := io.Pipe()
+	defer func() {
+		for _, c := range []io.Closer{clientOutput, clientInput, serverOutput, serverInput} {
+			_ = c.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancel()
+
+	inv, root := clitest.New(t, "ssh", "--stdio", workspace.Name)
+	clitest.SetupConfig(t, client, root)
+	inv.Stdin = clientOutput
+	inv.Stdout = serverInput
+	inv.Stderr = io.Discard
+
+	cmdDone := tGo(t, func() {
+		err := inv.WithContext(ctx).Run()
+		assert.Error(t, err)
+	})
+
+	// The client abandons the connection attempt by closing stdin. No agent
+	// is started, so the command would wait for it forever unless it notices.
+	require.NoError(t, clientOutput.Close())
+
+	select {
+	case <-cmdDone:
+	case <-time.After(testutil.WaitShort):
+		require.Fail(t, "coder ssh --stdio did not exit after stdin was closed")
+	}
 }
 
 // tGoContext runs fn in a goroutine passing a context that will be


### PR DESCRIPTION
Fixes #27954

## Problem

On Windows, `coder ssh --stdio` proxy processes leak when the ProxyCommand client (e.g. Codex Desktop) abandons or retries a connection attempt. The CLI does not observe stdin closing until the SSH session is established, so abandoned processes keep waiting for the agent or sit in dial retries. One reporter accumulated 283 orphaned processes (~7 GB working set) that required `taskkill /F` to clear.

## Root cause

In stdio mode nothing reads stdin before `copier.copy` starts. Every pre-connection stage (workspace resolution, agent wait, dial retries, the Coder Connect probe) ignores stdin, so a pipe closed by a dead or giving-up parent is never noticed. Unlike Linux, Windows has no SIGHUP-style parent-death signal to fall back on, which is why the accumulation shows up there.

## Fix

Relay stdin through an `io.Pipe` starting at command setup. If the relay observes EOF or a read error before the SSH session begins consuming stdin, the command cancels itself and exits. After connection, the existing copy logic keeps owning stdin termination exactly as before; an atomic flag set in both connection paths gates the cancel so established-session semantics do not change.

## Testing

New regression test fails on current main and passes with the fix:

```text
$ go test ./cli/ -run 'TestSSHStdio_ExitWhenStdinClosedBeforeAgentConnects' -count=1

main (60b03138a):
    --- FAIL: TestSSHStdio_ExitWhenStdinClosedBeforeAgentConnects (17.09s)
        ssh_test.go:2498: coder ssh --stdio did not exit after stdin was closed

branch:
    --- PASS: TestSSHStdio_ExitWhenStdinClosedBeforeAgentConnects (2.57s)
```

Additional verification run locally on windows/amd64, Go 1.26.5:

```text
$ go test ./cli/ -run 'TestSSH' -count=1 -timeout 2400s
ok      github.com/coder/coder/v2/cli   51.426s

$ gofmt -l cli/ssh.go cli/ssh_test.go        # no output
$ go vet ./cli/                              # exit 0
```

Broader cli-package failures seen on this machine (TestRoot, TestGitSSH, TestDERPHeaders, TestCommandHelp, TestServer, TestWorkspaceAgent) were confirmed to reproduce identically on pristine main; for example TestRoot shells out to `cmd.exe /c printf`, which does not exist on Windows. They are unrelated to this change.

AI involvement: developed with AI assistance under human direction; the commands and results above were produced by running them locally, per the AI contribution guidelines.
