### PR TITLE
docs(docs/.style/style-guide): add input-device-agnostic language guidance

### DIFF
--- a/docs/.style/style-guide/accessibility-and-inclusion.md
+++ b/docs/.style/style-guide/accessibility-and-inclusion.md
@@ -198,6 +198,33 @@ Idiomatic stack metaphors like "built on top of Terraform" and phrasal verbs lik
 *Documentation-only.
 No Vale rule.*
 
+## Input-device-agnostic language
+
+Coder docs reach readers on a mouse, a trackpad, a touchscreen, a keyboard, and assistive technology such as screen readers and switch devices.
+Don't assume the reader's input device when describing a UI interaction.
+
+"Select" is the default verb for choosing or activating a UI control, instead of "click," "tap," or "press" (see [Select, not click](./word-choice.md#select-not-click)).
+When a more specific verb names the interaction more precisely, use it instead, as long as it doesn't name a device: "open," "expand," "run," and "choose" are all device-agnostic.
+"Click," "tap," "swipe," and "press [key]" name a device and belong only where the content is specifically about that device.
+
+**Do**:
+
+> Select the workspace to open its details page.
+>
+> Open the **Templates** tab, then expand **Advanced** to see the resource limits.
+
+**Don't**:
+
+> Tap the workspace to open its details page.
+>
+> Click the **Templates** tab, then click **Advanced** to expand it.
+
+Exception: content that documents an input method by name describes that method directly, because the method itself is what the reader needs to know.
+This covers references to a specific mouse button (a right-click context menu), a keyboard shortcut list, a touch-gesture reference, or third-party software that specifically records mouse clicks and keystrokes as part of what it does.
+
+*Documentation-only.
+No Vale rule for the general principle; `Coder.SelectClick` (see [Select, not click](./word-choice.md#select-not-click)) enforces the "click" case specifically, since it's the word this policy is violated with most often.*
+
 ## Plain English for international readers
 
 Keep prose accessible to readers whose first language isn't English.

--- a/docs/.style/style-guide/accessibility-and-inclusion.md
+++ b/docs/.style/style-guide/accessibility-and-inclusion.md
@@ -200,7 +200,7 @@ No Vale rule.*
 
 ## Input-device-agnostic language
 
-Coder docs reach readers on a mouse, a trackpad, a touchscreen, a keyboard, and assistive technology such as screen readers and switch devices.
+Coder docs reach readers who use mice, trackpads, touchscreens, keyboards, and assistive technologies such as screen readers and switch devices.
 Don't assume the reader's input device when describing a UI interaction.
 
 "Select" is the default verb for choosing or activating a UI control, instead of "click," "tap," or "press" (refer to [Select, not click](./word-choice.md#select-not-click)).

--- a/docs/.style/style-guide/accessibility-and-inclusion.md
+++ b/docs/.style/style-guide/accessibility-and-inclusion.md
@@ -203,7 +203,7 @@ No Vale rule.*
 Coder docs reach readers on a mouse, a trackpad, a touchscreen, a keyboard, and assistive technology such as screen readers and switch devices.
 Don't assume the reader's input device when describing a UI interaction.
 
-"Select" is the default verb for choosing or activating a UI control, instead of "click," "tap," or "press" (see [Select, not click](./word-choice.md#select-not-click)).
+"Select" is the default verb for choosing or activating a UI control, instead of "click," "tap," or "press" (refer to [Select, not click](./word-choice.md#select-not-click)).
 When a more specific verb names the interaction more precisely, use it instead, as long as it doesn't name a device: "open," "expand," "run," and "choose" are all device-agnostic.
 "Click," "tap," "swipe," and "press [key]" name a device and belong only where the content is specifically about that device.
 
@@ -223,7 +223,7 @@ Exception: content that documents an input method by name describes that method 
 This covers references to a specific mouse button (a right-click context menu), a keyboard shortcut list, a touch-gesture reference, or third-party software that specifically records mouse clicks and keystrokes as part of what it does.
 
 *Documentation-only.
-No Vale rule for the general principle; `Coder.SelectClick` (see [Select, not click](./word-choice.md#select-not-click)) enforces the "click" case specifically, since it's the word this policy is violated with most often.*
+No Vale rule for the general principle; `Coder.SelectClick` (refer to [Select, not click](./word-choice.md#select-not-click)) enforces the "click" case specifically, since it's the word this policy is violated with most often.*
 
 ## Plain English for international readers
 


### PR DESCRIPTION
Adds a section to the accessibility page generalizing the existing "select, not click" rule: don't assume the reader's input device (mouse, trackpad, touchscreen, keyboard, or assistive technology) when describing a UI interaction, unless the content is specifically about that device.

Prompted by `docs/admin/integrations/island.md`, which lists "mouse clicks" and "keystrokes" among the input a third-party DLP agent can record — accurate there, since that's literally what the tool captures, but it raised the question of when naming an input device is fine at all. The new section states the general principle and the exception (keyboard shortcut lists, a right-click context menu, third-party software that records mouse/keyboard input by name), cross-linked with the click-specific rule in word-choice.md.

Documentation-only, no Vale rule for the general principle — it's judgment-bound the same way the existing "directional language" section is.

---
🤖 Built with AI assistance.