### PR TITLE
feat(site/src/pages/DeploymentSettingsPage/LicensesSettingsPage): show agent usage in minutes and restructure license product grid

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceAddOnCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceAddOnCard.tsx
@@ -25,7 +25,7 @@ export const AIGovernanceAddOnCard: FC<AIGovernanceAddOnCardProps> = ({
 
 	return (
 		<div
-			className={`min-w-[320px] flex-1 rounded-sm border border-solid py-3 ${
+			className={`rounded-sm border border-solid py-3 ${
 				isExceeded ? "border-border-destructive" : "border-border"
 			}`}
 		>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceAddOnCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AIGovernanceAddOnCard.tsx
@@ -32,7 +32,10 @@ export const AIGovernanceAddOnCard: FC<AIGovernanceAddOnCardProps> = ({
 			<div className="flex items-center gap-1 px-6 py-1.5">
 				<div className="flex flex-1 items-center gap-1">
 					<div className="flex items-center gap-1">
-						<span className="overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-content-primary">
+						<span
+							data-testid="license-product-card-title"
+							className="overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-content-primary"
+						>
 							{title}
 						</span>
 						<Tooltip>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.stories.tsx
@@ -8,7 +8,8 @@ const meta: Meta<typeof CoderAgentsProductCard> = {
 	component: CoderAgentsProductCard,
 	args: {
 		allocation: 20000,
-		actual: 16264.3,
+		actualMinutes: 975_858,
+		isTrial: false,
 		isSoftLimitReached: false,
 		isExceeded: false,
 		isHardLimitExceeded: false,
@@ -25,9 +26,9 @@ export const Default: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Coder Agents")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"16,264.3 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("975,858 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -43,21 +44,26 @@ export const Default: Story = {
 export const TooltipInteractions: Story = {
 	play: async ({ canvasElement, step }) => {
 		const canvas = within(canvasElement);
-		await step("open the Total Agent hours tooltip from keyboard", async () => {
-			await userEvent.tab();
-			await expect(
-				canvas.getByRole("button", { name: "Total Agent hours information" }),
-			).toHaveFocus();
-			await waitFor(async () => {
-				await expect(screen.getByRole("tooltip")).toHaveTextContent(
-					"Total agent runtime hours used out of the hours included in this license.",
-				);
-			});
-			await userEvent.keyboard("{Escape}");
-			await waitFor(async () => {
-				await expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-			});
-		});
+		await step(
+			"open the Total Agent minutes tooltip from keyboard",
+			async () => {
+				await userEvent.tab();
+				await expect(
+					canvas.getByRole("button", {
+						name: "Total Agent minutes information",
+					}),
+				).toHaveFocus();
+				await waitFor(async () => {
+					await expect(screen.getByRole("tooltip")).toHaveTextContent(
+						"Total agent runtime minutes used out of the minutes included in this license.",
+					);
+				});
+				await userEvent.keyboard("{Escape}");
+				await waitFor(async () => {
+					await expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+				});
+			},
+		);
 		await step("open the Concurrent agents tooltip on hover", async () => {
 			await userEvent.hover(
 				canvas.getByRole("button", { name: "Concurrent agents information" }),
@@ -77,9 +83,9 @@ export const UnlimitedAllocation: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"Unlimited",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("Unlimited");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -88,28 +94,28 @@ export const UnlimitedAllocation: Story = {
 
 export const NotProvidingUsage: Story = {
 	args: {
-		actual: undefined,
+		actualMinutes: undefined,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"\u2014 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("\u2014 / 1,200,000");
 	},
 };
 
 export const SoftLimitReached: Story = {
 	args: {
-		actual: 16264.3,
+		actualMinutes: 975_858,
 		isSoftLimitReached: true,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"16,264.3 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("975,858 / 1,200,000");
 		await expect(canvas.getByRole("status")).toHaveTextContent(
-			"Approaching hours limit",
+			"Approaching minutes limit",
 		);
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
@@ -119,14 +125,14 @@ export const SoftLimitReached: Story = {
 
 export const Exceeded: Story = {
 	args: {
-		actual: 21000,
+		actualMinutes: 1_260_000,
 		isExceeded: true,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"21,000.0 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("1,260,000 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -136,14 +142,14 @@ export const Exceeded: Story = {
 
 export const HardLimitExceeded: Story = {
 	args: {
-		actual: 25000,
+		actualMinutes: 1_500_000,
 		isHardLimitExceeded: true,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"25,000.0 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("1,500,000 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"5",
 		);
@@ -159,36 +165,83 @@ export const HardLimitExceeded: Story = {
 	},
 };
 
-export const NoAllocation: Story = {
+export const Community: Story = {
 	args: {
 		allocation: undefined,
-		actual: undefined,
+		actualMinutes: undefined,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Coder Agents")).toBeInTheDocument();
 		await expect(
 			getMetricValue(canvas, "Max concurrent agents"),
 		).toHaveTextContent("5");
 		await expect(
-			canvas.queryByText(/Agent hours used/),
+			getMetricValue(canvas, "Agent minutes used"),
+		).toHaveTextContent("\u2014");
+		await expect(
+			canvas.getByRole("link", { name: "Try unlimited for 30 days" }),
+		).toHaveAttribute("href", "/deployment/premium");
+		await expect(
+			canvas.getByRole("link", { name: "View docs" }),
+		).toHaveAttribute(
+			"href",
+			expect.stringContaining("/ai-coder/agents/licensing-usage"),
+		);
+		await expect(
+			canvas.queryByRole("link", { name: "Upgrade" }),
 		).not.toBeInTheDocument();
-		const upgrade = canvas.getByRole("link", { name: "Upgrade" });
-		await expect(upgrade).toHaveAttribute("href", "mailto:sales@coder.com");
 	},
 };
 
-export const NoAllocationWithUsage: Story = {
+export const CommunityWithUsage: Story = {
 	args: {
 		allocation: undefined,
-		actual: 1234.5,
+		actualMinutes: 74_070,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Agent hours used")).toHaveTextContent(
-			"1,234.5",
+		await expect(
+			getMetricValue(canvas, "Agent minutes used"),
+		).toHaveTextContent("74,070");
+	},
+};
+
+export const Trial: Story = {
+	args: {
+		allocation: undefined,
+		actualMinutes: 74_070,
+		isTrial: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Coder Agents Trial")).toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Agent minutes used"),
+		).toHaveTextContent("74,070");
+		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
+			"Unlimited",
+		);
+		await expect(canvas.getByRole("link", { name: "Upgrade" })).toHaveAttribute(
+			"href",
+			"mailto:sales@coder.com",
 		);
 		await expect(
-			canvas.getByRole("link", { name: "Upgrade" }),
-		).toBeInTheDocument();
+			canvas.queryByRole("link", { name: "Try unlimited for 30 days" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const TrialWithoutUsage: Story = {
+	args: {
+		allocation: undefined,
+		actualMinutes: undefined,
+		isTrial: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			getMetricValue(canvas, "Agent minutes used"),
+		).toHaveTextContent("\u2014");
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
@@ -122,7 +122,7 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 		return (
 			<CardContainer
 				title={isTrial ? "Coder Agents Trial" : "Coder Agents"}
-				className="border-dashed border-highlight-purple"
+				className="border-dashed border-border"
 			>
 				<div className="mt-3 flex flex-wrap gap-x-12 gap-y-3 text-xs">
 					<MinutesUsedMetric actualMinutes={actualMinutes} />

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
@@ -77,7 +77,12 @@ const CardContainer: FC<{
 }> = ({ title, className, headerEnd, children }) => (
 	<div className={cn("rounded-sm border px-6 py-4", className)}>
 		<div className="flex items-center justify-between gap-3">
-			<div className="text-sm font-medium text-content-primary">{title}</div>
+			<div
+				data-testid="license-product-card-title"
+				className="text-sm font-medium text-content-primary"
+			>
+				{title}
+			</div>
 			{headerEnd}
 		</div>
 		{children}

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
@@ -1,5 +1,6 @@
 import { InfoIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
+import { Link as RouterLink } from "react-router";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
@@ -15,6 +16,8 @@ import { docs } from "#/utils/docs";
 // (AgentRuntimeHoursUnlimitedAllocation in enterprise/coderd/license).
 const unlimitedAllocation = -1;
 
+const minutesPerHour = 60;
+
 // Concurrent chat cap once the hard limit is reached. Mirrors
 // defaultMaxConcurrentRootAgents in coderd/x/chatd; keep in sync.
 const maxConcurrentChatsOverHardLimit = 5;
@@ -26,10 +29,12 @@ type CoderAgentsProductCardProps = {
 	 */
 	allocation?: number;
 	/**
-	 * Hours used in the current usage period, floored to tenths.
+	 * Whole minutes used in the current usage period.
 	 * Undefined when usage does not apply to this license.
 	 */
-	actual?: number;
+	actualMinutes?: number;
+	/** The license is a trial. */
+	isTrial: boolean;
 	/**
 	 * Usage is at or above this license's advisory soft limit, but still
 	 * within the purchased allocation.
@@ -65,20 +70,14 @@ const MetricLabel: FC<{ label: string; tooltip: string }> = ({
 );
 
 const CardContainer: FC<{
+	title: string;
 	className?: string;
 	headerEnd?: ReactNode;
 	children: ReactNode;
-}> = ({ className, headerEnd, children }) => (
-	<div
-		className={cn(
-			"min-w-[320px] flex-1 rounded-sm border px-6 py-4",
-			className,
-		)}
-	>
+}> = ({ title, className, headerEnd, children }) => (
+	<div className={cn("rounded-sm border px-6 py-4", className)}>
 		<div className="flex items-center justify-between gap-3">
-			<div className="text-sm font-medium text-content-primary">
-				Coder Agents
-			</div>
+			<div className="text-sm font-medium text-content-primary">{title}</div>
 			{headerEnd}
 		</div>
 		{children}
@@ -86,22 +85,31 @@ const CardContainer: FC<{
 );
 
 // TODO: placeholder tooltip copy pending product review.
-const totalAgentHoursTooltip =
-	"Total agent runtime hours used out of the hours included in this license.";
+const totalAgentMinutesTooltip =
+	"Total agent runtime minutes used out of the minutes included in this license.";
 const concurrentChatsTooltip =
 	"Number of agents that can run at the same time.";
 const concurrentChatsHardLimitTooltip = `${concurrentChatsTooltip} You've reached your limit: concurrent chats are now capped at ${maxConcurrentChatsOverHardLimit} (down from unlimited).`;
 
-// The value is already floored to tenths, so no rounding happens here.
-const formatHoursUsed = (hours: number) =>
-	hours.toLocaleString("en-US", {
-		minimumFractionDigits: 1,
-		maximumFractionDigits: 1,
-	});
+const formatMinutes = (minutes: number) => minutes.toLocaleString("en-US");
+
+const MinutesUsedMetric: FC<{ actualMinutes?: number }> = ({
+	actualMinutes,
+}) => (
+	<div>
+		<div className="flex items-center gap-1 font-medium text-content-secondary">
+			<span>Agent minutes used</span>
+		</div>
+		<div className="mt-0.5 text-sm font-medium text-content-primary">
+			{actualMinutes === undefined ? "\u2014" : formatMinutes(actualMinutes)}
+		</div>
+	</div>
+);
 
 export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 	allocation,
-	actual,
+	actualMinutes,
+	isTrial,
 	isSoftLimitReached,
 	isExceeded,
 	isHardLimitExceeded,
@@ -112,38 +120,47 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 
 	if (!grantsAgentHours) {
 		return (
-			<CardContainer className="border-dashed border-highlight-purple">
+			<CardContainer
+				title={isTrial ? "Coder Agents Trial" : "Coder Agents"}
+				className="border-dashed border-highlight-purple"
+			>
 				<div className="mt-3 flex flex-wrap gap-x-12 gap-y-3 text-xs">
+					<MinutesUsedMetric actualMinutes={actualMinutes} />
 					<div>
 						<MetricLabel
-							label="Max concurrent agents"
+							label={isTrial ? "Concurrent agents" : "Max concurrent agents"}
 							tooltip={concurrentChatsTooltip}
 						/>
 						<div className="mt-0.5 text-sm font-medium text-content-primary">
-							{maxConcurrentChatsOverHardLimit}
+							{isTrial ? "Unlimited" : maxConcurrentChatsOverHardLimit}
 						</div>
 					</div>
-					{actual !== undefined && (
-						<div>
-							<div className="flex items-center gap-1 font-medium text-content-secondary">
-								<span>Agent hours used</span>
-							</div>
-							<div className="mt-0.5 text-sm font-medium text-content-primary">
-								{formatHoursUsed(actual)}
-							</div>
-						</div>
-					)}
 				</div>
-				<Button asChild className="mt-4 w-full">
-					<a href="mailto:sales@coder.com">Upgrade</a>
-				</Button>
+				{isTrial ? (
+					<Button asChild className="mt-4 w-full">
+						<a href="mailto:sales@coder.com">Upgrade</a>
+					</Button>
+				) : (
+					<div className="mt-4 flex items-center gap-3 text-sm">
+						<Link asChild showExternalIcon={false} size="lg">
+							<RouterLink to="/deployment/premium">
+								Try unlimited for 30 days
+							</RouterLink>
+						</Link>
+						<div aria-hidden="true" className="h-4 w-px shrink-0 bg-border" />
+						<Link href={docs("/ai-coder/agents/licensing-usage")} size="lg">
+							View docs
+						</Link>
+					</div>
+				)}
 			</CardContainer>
 		);
 	}
 
 	const isOverage = isExceeded || isHardLimitExceeded;
-	const actualLabel = actual === undefined ? "\u2014" : formatHoursUsed(actual);
-	const hoursValueClassName = isOverage
+	const actualLabel =
+		actualMinutes === undefined ? "\u2014" : formatMinutes(actualMinutes);
+	const minutesValueClassName = isOverage
 		? "text-content-destructive"
 		: isSoftLimitReached
 			? "text-border-warning"
@@ -151,6 +168,7 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 
 	return (
 		<CardContainer
+			title="Coder Agents"
 			className={cn(
 				"border-solid",
 				isOverage
@@ -169,7 +187,7 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 					// The soft limit is otherwise only conveyed by the warning
 					// colors, so announce it for assistive technology too.
 					<span role="status" className="sr-only">
-						Approaching hours limit
+						Approaching minutes limit
 					</span>
 				) : undefined
 			}
@@ -177,16 +195,16 @@ export const CoderAgentsProductCard: FC<CoderAgentsProductCardProps> = ({
 			<div className="mt-3 flex flex-wrap gap-x-12 gap-y-3 text-xs">
 				<div>
 					<MetricLabel
-						label="Total Agent hours"
-						tooltip={totalAgentHoursTooltip}
+						label="Total Agent minutes"
+						tooltip={totalAgentMinutesTooltip}
 					/>
 					<div className="mt-0.5 text-sm font-medium text-content-primary">
 						{isUnlimited ? (
 							"Unlimited"
 						) : (
 							<>
-								<span className={hoursValueClassName}>{actualLabel}</span> /{" "}
-								{allocation.toLocaleString("en-US")}
+								<span className={minutesValueClassName}>{actualLabel}</span> /{" "}
+								{formatMinutes(allocation * minutesPerHour)}
 							</>
 						)}
 					</div>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderWorkspacesProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderWorkspacesProductCard.tsx
@@ -24,7 +24,10 @@ export const CoderWorkspacesProductCard: FC<
 
 	return (
 		<div className="rounded-sm border border-solid border-border px-6 py-4">
-			<div className="text-sm font-medium text-content-primary">
+			<div
+				data-testid="license-product-card-title"
+				className="text-sm font-medium text-content-primary"
+			>
 				Coder Workspaces
 			</div>
 			<div className="mt-3 text-xs">

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderWorkspacesProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderWorkspacesProductCard.tsx
@@ -23,7 +23,7 @@ export const CoderWorkspacesProductCard: FC<
 		: "Unlimited";
 
 	return (
-		<div className="min-w-[320px] flex-1 rounded-sm border border-solid border-border px-6 py-4">
+		<div className="rounded-sm border border-solid border-border px-6 py-4">
 			<div className="text-sm font-medium text-content-primary">
 				Coder Workspaces
 			</div>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.stories.tsx
@@ -37,6 +37,13 @@ const getIncludedProducts = (
 		name: (accessibleName: string) => accessibleName === label,
 	});
 
+const productCardTitles = (canvasElement: HTMLElement) =>
+	Array.from(
+		canvasElement.querySelectorAll(
+			".license-card [data-testid='license-product-card-title']",
+		),
+	).map((element) => element.textContent);
+
 export const Default: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -630,6 +637,11 @@ export const PremiumWithAIGovernance: Story = {
 		await expect(
 			getIncludedProducts(canvas, "Workspaces + AI Governance"),
 		).toBeInTheDocument();
+		await expect(productCardTitles(canvasElement)).toEqual([
+			"Coder Workspaces",
+			"AI Governance",
+			"Coder Agents",
+		]);
 		const seatsLabel = canvas.getByText("Seats");
 		const seatsValue = seatsLabel.nextElementSibling;
 		await expect(seatsValue).toHaveTextContent("750 / 1,000");

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.stories.tsx
@@ -26,6 +26,9 @@ type Story = StoryObj<typeof LicenseCard>;
 const getMetricValue = (canvas: ReturnType<typeof within>, label: string) =>
 	canvas.getByText(label).parentElement?.nextElementSibling;
 
+const getHeaderValue = (canvas: ReturnType<typeof within>, label: string) =>
+	canvas.getByText(label).nextElementSibling;
+
 const getIncludedProducts = (
 	canvas: ReturnType<typeof within>,
 	label: string,
@@ -43,7 +46,12 @@ export const Default: Story = {
 		await expect(canvas.getByText("Standard")).toBeInTheDocument();
 		await expect(canvas.getByText("Products")).toBeInTheDocument();
 		await expect(canvas.getByText("Coder Workspaces")).toBeInTheDocument();
-		await expect(canvas.queryByText("Coder Agents")).not.toBeInTheDocument();
+		// Licenses without an allocation still show the Coder Agents
+		// upsell card.
+		await expect(canvas.getByText("Coder Agents")).toBeInTheDocument();
+		await expect(
+			canvas.getByRole("link", { name: "Try unlimited for 30 days" }),
+		).toBeInTheDocument();
 		await expect(
 			getIncludedProducts(canvas, "Workspaces"),
 		).not.toBeInTheDocument();
@@ -84,6 +92,11 @@ export const Trial: Story = {
 		await expect(
 			getIncludedProducts(canvas, "Workspaces + Agents"),
 		).toBeInTheDocument();
+		await expect(canvas.getByText("Coder Agents Trial")).toBeInTheDocument();
+		await expect(canvas.getByRole("link", { name: "Upgrade" })).toHaveAttribute(
+			"href",
+			"mailto:sales@coder.com",
+		);
 	},
 };
 
@@ -145,7 +158,7 @@ export const Premium: Story = {
 			entitlement: "entitled",
 			limit: 0,
 			actual: 137,
-			// 137 hours and 18 minutes: renders as 137.3.
+			// 137 hours and 18 minutes: renders as 8,238 minutes.
 			actual_ms: 137 * 3_600_000 + 18 * 60_000,
 		},
 	},
@@ -159,12 +172,12 @@ export const Premium: Story = {
 		await expect(
 			getMetricValue(canvas, "Max concurrent agents"),
 		).toHaveTextContent("5");
-		await expect(getMetricValue(canvas, "Agent hours used")).toHaveTextContent(
-			"137.3",
-		);
-		const upgrade = canvas.getByRole("link", { name: "Upgrade" });
-		await expect(upgrade).toHaveAttribute("href", "mailto:sales@coder.com");
-		await expect(canvas.queryByText("Add-ons")).not.toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Agent minutes used"),
+		).toHaveTextContent("8,238");
+		await expect(
+			canvas.getByRole("link", { name: "Try unlimited for 30 days" }),
+		).toHaveAttribute("href", "/deployment/premium");
 		await expect(canvas.queryByText("AI Governance")).not.toBeInTheDocument();
 	},
 };
@@ -211,8 +224,8 @@ export const PremiumWithAgentHours: Story = {
 			soft_limit: 16000,
 			hard_limit: 25000,
 			actual: 12264,
-			// 12,264 hours and 18 minutes: renders as 12,264.3, below
-			// the 16,000-hour advisory soft limit.
+			// 12,264 hours and 18 minutes: renders as 735,858 minutes,
+			// below the 960,000-minute advisory soft limit.
 			actual_ms: 12_264 * 3_600_000 + 18 * 60_000,
 			usage_period: winningUsagePeriod,
 		},
@@ -220,12 +233,20 @@ export const PremiumWithAgentHours: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Active")).toBeInTheDocument();
+		// An allocation without a seat claim is an agents-only license.
 		await expect(
-			getIncludedProducts(canvas, "Workspaces + Agents"),
+			getIncludedProducts(canvas, "Coder Agents"),
 		).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"12,264.3 / 20,000",
+		await expect(getHeaderValue(canvas, "Minutes")).toHaveTextContent(
+			"735,858 / 1,200,000",
 		);
+		await expect(canvas.queryByText("Users")).not.toBeInTheDocument();
+		await expect(
+			canvas.queryByText("Coder Workspaces"),
+		).not.toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("735,858 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -234,6 +255,40 @@ export const PremiumWithAgentHours: Story = {
 		).not.toBeInTheDocument();
 		await expect(
 			canvas.getByRole("link", { name: "View docs" }),
+		).toBeInTheDocument();
+	},
+};
+
+export const AgentHoursWithSeatsKeepsUsersColumn: Story = {
+	args: {
+		license: (() => {
+			const license = premiumLicenseWithAgentHours(20000);
+			return {
+				...license,
+				claims: {
+					...license.claims,
+					features: { ...license.claims.features, user_limit: 10 },
+				},
+			};
+		})(),
+		agentRuntimeHoursFeature: {
+			enabled: true,
+			entitlement: "entitled",
+			limit: 20000,
+			soft_limit: 16000,
+			hard_limit: 25000,
+			actual: 12264,
+			actual_ms: 12_264 * 3_600_000 + 18 * 60_000,
+			usage_period: winningUsagePeriod,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Users")).toBeInTheDocument();
+		await expect(canvas.queryByText("Minutes")).not.toBeInTheDocument();
+		await expect(canvas.getByText("Coder Workspaces")).toBeInTheDocument();
+		await expect(
+			getIncludedProducts(canvas, "Workspaces + Agents"),
 		).toBeInTheDocument();
 	},
 };
@@ -248,8 +303,8 @@ export const PremiumWithAgentHoursSoftLimitReached: Story = {
 			soft_limit: 16000,
 			hard_limit: 25000,
 			actual: 16264,
-			// 16,264 hours and 18 minutes: renders as 16,264.3, at or
-			// above the 16,000-hour advisory soft limit.
+			// 16,264 hours and 18 minutes: renders as 975,858 minutes, at
+			// or above the 960,000-minute advisory soft limit.
 			actual_ms: 16_264 * 3_600_000 + 18 * 60_000,
 			usage_period: winningUsagePeriod,
 		},
@@ -257,11 +312,11 @@ export const PremiumWithAgentHoursSoftLimitReached: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Active")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"16,264.3 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("975,858 / 1,200,000");
 		await expect(canvas.getByRole("status")).toHaveTextContent(
-			"Approaching hours limit",
+			"Approaching minutes limit",
 		);
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
@@ -285,10 +340,12 @@ export const PremiumWithAgentHoursExceeded: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("Agent hours exceeded")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"21,000.0 / 20,000",
-		);
+		await expect(
+			canvas.getByText("Agent minutes exceeded"),
+		).toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("1,260,000 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -312,9 +369,9 @@ export const PremiumWithAgentHoursHardLimitExceeded: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Limit exceeded")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"25,000.0 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("1,500,000 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"5",
 		);
@@ -340,10 +397,12 @@ export const PremiumWithAgentHoursAtAllocation: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("Agent hours exceeded")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"20,000.0 / 20,000",
-		);
+		await expect(
+			canvas.getByText("Agent minutes exceeded"),
+		).toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("1,200,000 / 1,200,000");
 	},
 };
 
@@ -356,8 +415,8 @@ export const PremiumWithAgentHoursExceededByFraction: Story = {
 			limit: 20000,
 			soft_limit: 16000,
 			hard_limit: 25000,
-			// The extra 6 minutes render as a tenth past the allocation,
-			// so the display shows fractional overage.
+			// The extra 6 minutes push usage past the allocation, so the
+			// display shows the overage.
 			actual: 20000,
 			actual_ms: 20_000 * 3_600_000 + 6 * 60_000,
 			usage_period: winningUsagePeriod,
@@ -365,10 +424,12 @@ export const PremiumWithAgentHoursExceededByFraction: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("Agent hours exceeded")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"20,000.1 / 20,000",
-		);
+		await expect(
+			canvas.getByText("Agent minutes exceeded"),
+		).toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("1,200,006 / 1,200,000");
 	},
 };
 
@@ -387,11 +448,14 @@ export const PremiumWithUnlimitedAgentHours: Story = {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Active")).toBeInTheDocument();
 		await expect(
-			getIncludedProducts(canvas, "Workspaces + Agents"),
+			getIncludedProducts(canvas, "Coder Agents"),
 		).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"Unlimited",
+		await expect(getHeaderValue(canvas, "Minutes")).toHaveTextContent(
+			"975,858 / Unlimited",
 		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("Unlimited");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -415,11 +479,11 @@ export const LowerAgentHoursCardUsesMergedEntitlement: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"\u2014 / 10,000",
-		);
 		await expect(
-			canvas.queryByText("Agent hours exceeded"),
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("\u2014 / 600,000");
+		await expect(
+			canvas.queryByText("Agent minutes exceeded"),
 		).not.toBeInTheDocument();
 	},
 };
@@ -446,9 +510,9 @@ export const ReplacedDuplicateAllocationShowsNoUsage: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Active")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"\u2014 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("\u2014 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -485,9 +549,9 @@ export const SameIssuedAtDifferentTermEndShowsNoUsage: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Active")).toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"\u2014 / 20,000",
-		);
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("\u2014 / 1,200,000");
 		await expect(getMetricValue(canvas, "Concurrent agents")).toHaveTextContent(
 			"Unlimited",
 		);
@@ -524,16 +588,15 @@ export const EnterpriseWithAgentHours: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Enterprise")).toBeInTheDocument();
-		await expect(canvas.getByText("Coder Agents")).toBeInTheDocument();
 		await expect(
 			getIncludedProducts(canvas, "Workspaces"),
 		).not.toBeInTheDocument();
 		await expect(
-			getIncludedProducts(canvas, "Workspaces + Agents"),
-		).not.toBeInTheDocument();
-		await expect(getMetricValue(canvas, "Total Agent hours")).toHaveTextContent(
-			"12,264.3 / 20,000",
-		);
+			getIncludedProducts(canvas, "Coder Agents"),
+		).toBeInTheDocument();
+		await expect(
+			getMetricValue(canvas, "Total Agent minutes"),
+		).toHaveTextContent("735,858 / 1,200,000");
 	},
 };
 
@@ -559,7 +622,9 @@ export const PremiumWithAIGovernance: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText(/add-ons/i)).toBeInTheDocument();
+		// The add-on card lives in the Products grid, so no separate
+		// Add-ons section exists.
+		await expect(canvas.queryByText("Add-ons")).not.toBeInTheDocument();
 		// Matches both the included-products line and the add-on card title.
 		await expect(canvas.getAllByText(/ai governance/i)).toHaveLength(2);
 		await expect(
@@ -807,6 +872,7 @@ export const EnterpriseDoesNotShowAIGovernanceAddOn: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.queryByText("Add-ons")).not.toBeInTheDocument();
+		await expect(canvas.queryByText("AI Governance")).not.toBeInTheDocument();
+		await expect(canvas.queryByText("Seats")).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.tsx
@@ -391,14 +391,6 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 									userLimitLimit={currentUserLimit}
 								/>
 							)}
-							<CoderAgentsProductCard
-								allocation={agentHoursAllocation}
-								actualMinutes={agentMinutesDisplayActual}
-								isTrial={Boolean(license.claims.trial)}
-								isSoftLimitReached={isAgentHoursSoftLimitReached}
-								isExceeded={isAgentHoursExceeded}
-								isHardLimitExceeded={isAgentHoursHardLimitExceeded}
-							/>
 							{hasExplicitAiGovernanceAddOn && (
 								<AIGovernanceAddOnCard
 									title="AI Governance"
@@ -408,6 +400,14 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 									isExceeded={isAiGovernanceAddOnExceeded}
 								/>
 							)}
+							<CoderAgentsProductCard
+								allocation={agentHoursAllocation}
+								actualMinutes={agentMinutesDisplayActual}
+								isTrial={Boolean(license.claims.trial)}
+								isSoftLimitReached={isAgentHoursSoftLimitReached}
+								isExceeded={isAgentHoursExceeded}
+								isHardLimitExceeded={isAgentHoursHardLimitExceeded}
+							/>
 						</div>
 					</div>
 				</CollapsibleContent>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.tsx
@@ -23,6 +23,9 @@ import { CoderAgentsProductCard } from "./CoderAgentsProductCard";
 import { CoderWorkspacesProductCard } from "./CoderWorkspacesProductCard";
 import { isLicenseApplicableForFeatureUsage } from "./licenseApplicability";
 
+const minutesPerHour = 60;
+const unlimitedAgentHoursAllocation = -1;
+
 type LicenseCardProps = {
 	license: GetLicensesResponse;
 	aiGovernanceUserFeature?: Feature;
@@ -92,14 +95,14 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 	// negatives are ignored and zero grants the feature disabled.
 	const agentHoursAllocation =
 		license.claims.features.agent_runtime_hours_allocation;
-	// The backend decodes these claims for any feature set, so a
-	// non-Premium license with a usable claim also shows Coder Agents.
-	const hasAgentHoursClaim =
-		agentHoursAllocation !== undefined &&
-		(agentHoursAllocation >= 0 || agentHoursAllocation === -1);
 	const licenseGrantsAgentHours =
 		agentHoursAllocation !== undefined &&
-		(agentHoursAllocation > 0 || agentHoursAllocation === -1);
+		(agentHoursAllocation > 0 ||
+			agentHoursAllocation === unlimitedAgentHoursAllocation);
+	// An agents-only license sells runtime hours without seats, so it
+	// reports minutes where seat-based licenses report users.
+	const isAgentsOnlyLicense =
+		licenseGrantsAgentHours && !license.claims.features.user_limit;
 	// Mirror the backend's threshold validation; invalid claims are
 	// ignored rather than disqualifying the license.
 	const agentHoursSoftLimitClaim =
@@ -151,25 +154,25 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 				agentHoursAllocation === agentRuntimeHoursFeature?.limit);
 	const canUseAgentHoursUsageForThisLicense =
 		isAgentHoursLicenseApplicable && isWinningAgentHoursLicense;
-	// Usage floored to tenths of an hour via integer math so the display
+	// Usage is displayed and compared in whole minutes, so the display
 	// and the exceeded states below flip at the same instant.
 	const agentHoursActualMs = agentRuntimeHoursFeature?.actual_ms;
-	const agentHoursActual =
+	const agentMinutesActual =
 		agentHoursActualMs === undefined
 			? undefined
-			: Math.floor(agentHoursActualMs / 360_000) / 10;
+			: Math.floor(agentHoursActualMs / 60_000);
 	// Licenses without an allocation show deployment-wide usage in their
 	// upgrade card.
-	const agentHoursDisplayActual =
+	const agentMinutesDisplayActual =
 		isAgentHoursLicenseApplicable &&
 		(isWinningAgentHoursLicense || !licenseGrantsAgentHours)
-			? agentHoursActual
+			? agentMinutesActual
 			: undefined;
 	const isAgentHoursHardLimitExceeded =
 		canUseAgentHoursUsageForThisLicense &&
 		agentHoursHardLimit !== undefined &&
-		agentHoursDisplayActual !== undefined &&
-		agentHoursDisplayActual >= agentHoursHardLimit;
+		agentMinutesDisplayActual !== undefined &&
+		agentMinutesDisplayActual >= agentHoursHardLimit * minutesPerHour;
 	// Inclusive: usage equal to the allocation is already over, matching
 	// the backend's "allocation reached" warning boundary.
 	const isAgentHoursExceeded =
@@ -177,8 +180,8 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 		!isAgentHoursHardLimitExceeded &&
 		agentHoursAllocation !== undefined &&
 		agentHoursAllocation > 0 &&
-		agentHoursDisplayActual !== undefined &&
-		agentHoursDisplayActual >= agentHoursAllocation;
+		agentMinutesDisplayActual !== undefined &&
+		agentMinutesDisplayActual >= agentHoursAllocation * minutesPerHour;
 	// Advisory only: at or above the soft threshold, still inside the
 	// purchased allocation. Allocation and hard-limit overage supersede
 	// this so the product card never stacks warning on destructive.
@@ -189,9 +192,9 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 		agentHoursAllocation !== undefined &&
 		agentHoursAllocation > 0 &&
 		agentHoursSoftLimit !== undefined &&
-		agentHoursDisplayActual !== undefined &&
-		agentHoursDisplayActual >= agentHoursSoftLimit &&
-		agentHoursDisplayActual < agentHoursAllocation;
+		agentMinutesDisplayActual !== undefined &&
+		agentMinutesDisplayActual >= agentHoursSoftLimit * minutesPerHour &&
+		agentMinutesDisplayActual < agentHoursAllocation * minutesPerHour;
 
 	const statusClassName =
 		isAgentHoursHardLimitExceeded ||
@@ -205,7 +208,7 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 	const statusText = isAgentHoursHardLimitExceeded
 		? "Limit exceeded"
 		: isAgentHoursExceeded
-			? "Agent hours exceeded"
+			? "Agent minutes exceeded"
 			: isAiGovernanceAddOnExceeded
 				? "Add-on exceeded"
 				: isExpired
@@ -215,13 +218,15 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 						: "Active";
 	const includesAgents =
 		Boolean(license.claims.trial) || licenseGrantsAgentHours;
-	const includedProducts = isPremium
-		? [
-				"Workspaces",
-				...(hasExplicitAiGovernanceAddOn ? ["AI Governance"] : []),
-				...(includesAgents ? ["Agents"] : []),
-			]
-		: [];
+	const includedProducts = isAgentsOnlyLicense
+		? ["Coder Agents"]
+		: isPremium
+			? [
+					"Workspaces",
+					...(hasExplicitAiGovernanceAddOn ? ["AI Governance"] : []),
+					...(includesAgents ? ["Agents"] : []),
+				]
+			: [];
 	const includedProductsLabel = includedProducts.join(" + ");
 	const headerContent = (
 		<>
@@ -264,12 +269,31 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 						{license.claims.trial ? "Trial" : "Standard"}
 					</span>
 				</div>
-				<div className="flex flex-col items-center">
-					<span className="text-content-secondary">Users</span>
-					<span className="text-content-primary user-limit">
-						{userLimitActual} {` / ${currentUserLimit || "Unlimited"}`}
-					</span>
-				</div>
+				{isAgentsOnlyLicense ? (
+					<div className="flex flex-col items-center">
+						<span className="text-content-secondary">Minutes</span>
+						<span className="text-content-primary agent-minutes">
+							{agentMinutesDisplayActual === undefined
+								? "\u2014"
+								: agentMinutesDisplayActual.toLocaleString("en-US")}{" "}
+							{`/ ${
+								agentHoursAllocation === unlimitedAgentHoursAllocation ||
+								agentHoursAllocation === undefined
+									? "Unlimited"
+									: (agentHoursAllocation * minutesPerHour).toLocaleString(
+											"en-US",
+										)
+							}`}
+						</span>
+					</div>
+				) : (
+					<div className="flex flex-col items-center">
+						<span className="text-content-secondary">Users</span>
+						<span className="text-content-primary user-limit">
+							{userLimitActual} {` / ${currentUserLimit || "Unlimited"}`}
+						</span>
+					</div>
+				)}
 				{license.claims.nbf && (
 					<div className="flex flex-col items-center">
 						<span className="text-content-secondary">Valid From</span>
@@ -360,37 +384,31 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 						<div className="text-sm font-medium text-content-secondary">
 							Products
 						</div>
-						<div className="mt-3 flex flex-wrap gap-3">
-							<CoderWorkspacesProductCard
-								userLimitActual={userLimitActual}
-								userLimitLimit={currentUserLimit}
+						<div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-2">
+							{!isAgentsOnlyLicense && (
+								<CoderWorkspacesProductCard
+									userLimitActual={userLimitActual}
+									userLimitLimit={currentUserLimit}
+								/>
+							)}
+							<CoderAgentsProductCard
+								allocation={agentHoursAllocation}
+								actualMinutes={agentMinutesDisplayActual}
+								isTrial={Boolean(license.claims.trial)}
+								isSoftLimitReached={isAgentHoursSoftLimitReached}
+								isExceeded={isAgentHoursExceeded}
+								isHardLimitExceeded={isAgentHoursHardLimitExceeded}
 							/>
-							{(isPremium || hasAgentHoursClaim) && (
-								<CoderAgentsProductCard
-									allocation={agentHoursAllocation}
-									actual={agentHoursDisplayActual}
-									isSoftLimitReached={isAgentHoursSoftLimitReached}
-									isExceeded={isAgentHoursExceeded}
-									isHardLimitExceeded={isAgentHoursHardLimitExceeded}
+							{hasExplicitAiGovernanceAddOn && (
+								<AIGovernanceAddOnCard
+									title="AI Governance"
+									unit="Seats"
+									actual={aiGovernanceDisplayActual}
+									limit={aiGovernanceLimit}
+									isExceeded={isAiGovernanceAddOnExceeded}
 								/>
 							)}
 						</div>
-						{hasExplicitAiGovernanceAddOn && (
-							<>
-								<div className="mt-4 text-sm font-medium text-content-secondary">
-									Add-ons
-								</div>
-								<div className="mt-3 flex flex-wrap gap-3">
-									<AIGovernanceAddOnCard
-										title="AI Governance"
-										unit="Seats"
-										actual={aiGovernanceDisplayActual}
-										limit={aiGovernanceLimit}
-										isExceeded={isAiGovernanceAddOnExceeded}
-									/>
-								</div>
-							</>
-						)}
 					</div>
 				</CollapsibleContent>
 			</div>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.stories.tsx
@@ -162,7 +162,6 @@ export const ShowsAddonUiForFutureLicenseBeforeNbf: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText(/add-ons/i)).toBeInTheDocument();
 		const aiGovernanceTitles = canvas.getAllByText(/^ai governance$/i);
 		await expect(aiGovernanceTitles.length).toBeGreaterThan(0);
 		await expect(canvas.getByText(/not started/i)).toBeInTheDocument();

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
@@ -79,30 +79,34 @@ export const ActiveAIGovernanceAddOnUsage: Story = {
 	},
 };
 
-export const TotalAgentHoursUsage: Story = {
+export const TotalAgentMinutesUsage: Story = {
 	args: {
 		agentRuntimeHoursFeature: {
 			...MockAgentRuntimeHoursFeature,
 			limit: 2000,
 			soft_limit: 1700,
 			actual: 435,
-			// 435 hours and 48 minutes: renders as 435.8.
+			// 435 hours and 48 minutes: renders as 26,148 minutes.
 			actual_ms: 435 * 3_600_000 + 48 * 60_000,
 		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const agentHoursHeading = canvas.getByRole("heading", {
-			name: "Total agent hours",
+		const agentMinutesHeading = canvas.getByRole("heading", {
+			name: "Total agent minutes",
 		});
-		const agentHoursCard = within(agentHoursHeading.closest("section")!);
-		await expect(agentHoursCard.getByText("435.8")).toBeInTheDocument();
-		await expect(agentHoursCard.getByText("2,000")).toBeInTheDocument();
+		const agentMinutesSection = agentMinutesHeading.closest("section");
+		if (!agentMinutesSection) {
+			throw new Error("Total agent minutes card is missing its section");
+		}
+		const agentMinutesCard = within(agentMinutesSection);
+		await expect(agentMinutesCard.getByText("26,148")).toBeInTheDocument();
+		await expect(agentMinutesCard.getByText("120,000")).toBeInTheDocument();
 		const managedAgentsSection = canvas.getByText(
 			"Agent Workspace Builds Disabled",
 		);
 		await expect(
-			agentHoursHeading.compareDocumentPosition(managedAgentsSection) &
+			agentMinutesHeading.compareDocumentPosition(managedAgentsSection) &
 				Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
 	},

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -26,7 +26,7 @@ import { LicenseCard } from "./LicenseCard";
 import { LicenseSeatConsumptionChart } from "./LicenseSeatConsumptionChart";
 import { ManagedAgentsConsumption } from "./ManagedAgentsConsumption";
 import { SeatUsageBarCard } from "./SeatUsageBarCard";
-import { TotalAgentHoursCard } from "./TotalAgentHoursCard";
+import { TotalAgentMinutesCard } from "./TotalAgentMinutesCard";
 
 type Props = {
 	showConfetti: boolean;
@@ -193,7 +193,7 @@ const LicensesSettingsPageView: FC<Props> = ({
 							/>
 						</div>
 
-						<TotalAgentHoursCard feature={agentRuntimeHoursFeature} />
+						<TotalAgentMinutesCard feature={agentRuntimeHoursFeature} />
 
 						<ManagedAgentsConsumption
 							managedAgentFeature={managedAgentFeature}

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentMinutesCard.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentMinutesCard.stories.tsx
@@ -1,28 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
 import { MockAgentRuntimeHoursFeature } from "#/testHelpers/entities";
-import { TotalAgentHoursCard } from "./TotalAgentHoursCard";
+import { TotalAgentMinutesCard } from "./TotalAgentMinutesCard";
 
-const meta: Meta<typeof TotalAgentHoursCard> = {
+const meta: Meta<typeof TotalAgentMinutesCard> = {
 	title:
-		"pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentHoursCard",
-	component: TotalAgentHoursCard,
+		"pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentMinutesCard",
+	component: TotalAgentMinutesCard,
 	args: {
 		feature: {
 			...MockAgentRuntimeHoursFeature,
-			// 400 hours and 18 minutes: renders as 400.3.
+			// 400 hours and 18 minutes: renders as 24,018 minutes.
 			actual_ms: 400 * 3_600_000 + 18 * 60_000,
 		},
 	},
 };
 
 export default meta;
-type Story = StoryObj<typeof TotalAgentHoursCard>;
+type Story = StoryObj<typeof TotalAgentMinutesCard>;
 
 const hoverInfoIcon = async (canvasElement: HTMLElement) => {
 	const canvas = within(canvasElement);
 	await userEvent.hover(
-		canvas.getByRole("button", { name: "Total agent hours information" }),
+		canvas.getByRole("button", { name: "Total agent minutes information" }),
 	);
 	return within(canvasElement.ownerDocument.body);
 };
@@ -41,11 +41,11 @@ const expectTooltipText = async (
 export const Default: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("400.3")).toBeInTheDocument();
+		await expect(canvas.getByText("24,018")).toBeInTheDocument();
 		await expect(canvas.getByText(/Warning:/)).toBeInTheDocument();
-		await expect(canvas.getByText("850")).toBeInTheDocument();
+		await expect(canvas.getByText("51,000")).toBeInTheDocument();
 		await expect(canvas.getByText(/Allocation:/)).toBeInTheDocument();
-		await expect(canvas.getByText("1,000")).toBeInTheDocument();
+		await expect(canvas.getByText("60,000")).toBeInTheDocument();
 		await expect(canvas.queryByText(/Limit:/)).not.toBeInTheDocument();
 		await expect(
 			canvas.getByText("(June 1, 2026 - May 31, 2027)"),
@@ -86,11 +86,11 @@ export const ReachedSoftLimit: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("850.0")).toBeInTheDocument();
+		await expect(canvas.getAllByText("51,000")).toHaveLength(2);
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 85% or more of your Total Agent hours for this license\. Agent sessions are still working normally, but you'll want to plan for the 100% limit\./,
+			/You've used 85% or more of your Total Agent minutes for this license\. Agent sessions are still working normally, but you'll want to plan for the 100% limit\./,
 		);
 	},
 };
@@ -105,12 +105,11 @@ export const ReachedAllocation: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,000.0")).toBeInTheDocument();
-		await expect(canvas.getByText("1,000")).toBeInTheDocument();
+		await expect(canvas.getAllByText("60,000")).toHaveLength(2);
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 100% of your Total Agent hours for this license\. Contact sales to receive more Agent hours\./,
+			/You've used 100% of your Total Agent minutes for this license\. Contact sales to receive more Agent minutes\./,
 		);
 	},
 };
@@ -125,18 +124,18 @@ export const OverAllocation: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,200.0")).toBeInTheDocument();
-		await expect(canvas.getByText("1,000")).toBeInTheDocument();
+		await expect(canvas.getByText("72,000")).toBeInTheDocument();
+		await expect(canvas.getByText("60,000")).toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 120% of your Total Agent hours for this license\. Contact sales to receive more Agent hours\./,
+			/You've used 120% of your Total Agent minutes for this license\. Contact sales to receive more Agent minutes\./,
 		);
 	},
 };
 
-// The extra 6 minutes alone push the tenths value past the whole-hour
-// allocation and flip the reached state.
+// The extra 6 minutes alone push usage past the allocation and flip the
+// reached state.
 export const ReachedAllocationByFraction: Story = {
 	args: {
 		feature: {
@@ -147,11 +146,11 @@ export const ReachedAllocationByFraction: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,000.1")).toBeInTheDocument();
+		await expect(canvas.getByText("60,006")).toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 100% of your Total Agent hours for this license\. Contact sales to receive more Agent hours\./,
+			/You've used 100% of your Total Agent minutes for this license\. Contact sales to receive more Agent minutes\./,
 		);
 	},
 };
@@ -170,9 +169,9 @@ export const SoftLimitExactPercent: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("10.0")).toBeInTheDocument();
-		await expect(canvas.getByText("29")).toBeInTheDocument();
-		await expect(canvas.getByText("100")).toBeInTheDocument();
+		await expect(canvas.getByText("600")).toBeInTheDocument();
+		await expect(canvas.getByText("1,740")).toBeInTheDocument();
+		await expect(canvas.getByText("6,000")).toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
@@ -193,11 +192,11 @@ export const NearAllocation: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("999.0")).toBeInTheDocument();
+		await expect(canvas.getAllByText("59,940")).toHaveLength(2);
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 99\.9% or more of your Total Agent hours for this license\. Agent sessions are still working normally, but you'll want to plan for the 100% limit\./,
+			/You've used 99\.9% or more of your Total Agent minutes for this license\. Agent sessions are still working normally, but you'll want to plan for the 100% limit\./,
 		);
 	},
 };
@@ -247,7 +246,7 @@ export const MissingUsagePeriod: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("400.0")).toBeInTheDocument();
+		await expect(canvas.getByText("24,000")).toBeInTheDocument();
 		await expect(
 			canvas.queryByText("(June 1, 2026 - May 31, 2027)"),
 		).not.toBeInTheDocument();
@@ -263,16 +262,16 @@ export const HardCap: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("400.0")).toBeInTheDocument();
+		await expect(canvas.getByText("24,000")).toBeInTheDocument();
 		await expect(canvas.getByText(/Warning:/)).toBeInTheDocument();
-		await expect(canvas.getByText("850")).toBeInTheDocument();
+		await expect(canvas.getByText("51,000")).toBeInTheDocument();
 		await expect(canvas.getByText(/Allocation:/)).toBeInTheDocument();
-		await expect(canvas.getByText("1,000")).toBeInTheDocument();
+		await expect(canvas.getByText("60,000")).toBeInTheDocument();
 		await expect(canvas.getByText(/Limit:/)).toBeInTheDocument();
-		await expect(canvas.getByText("1,500")).toBeInTheDocument();
+		await expect(canvas.getByText("90,000")).toBeInTheDocument();
 		await expect(
 			canvas.queryByText(
-				"Agent hours limit reached. Concurrent chats are now limited to 5.",
+				"Agent minutes limit reached. Concurrent chats are now limited to 5.",
 			),
 		).not.toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
@@ -294,16 +293,16 @@ export const HardCapBetweenSoftLimitAndLimit: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("900.0")).toBeInTheDocument();
+		await expect(canvas.getByText("54,000")).toBeInTheDocument();
 		await expect(
 			canvas.queryByText(
-				"Agent hours limit reached. Concurrent chats are now limited to 5.",
+				"Agent minutes limit reached. Concurrent chats are now limited to 5.",
 			),
 		).not.toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 85% or more of your Total Agent hours for this license\. Agent sessions are still working normally, but you'll want to plan for the 100% limit\./,
+			/You've used 85% or more of your Total Agent minutes for this license\. Agent sessions are still working normally, but you'll want to plan for the 100% limit\./,
 		);
 	},
 };
@@ -319,16 +318,16 @@ export const HardCapBetweenLimitAndHardCap: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,200.0")).toBeInTheDocument();
+		await expect(canvas.getByText("72,000")).toBeInTheDocument();
 		await expect(
 			canvas.queryByText(
-				"Agent hours limit reached. Concurrent chats are now limited to 5.",
+				"Agent minutes limit reached. Concurrent chats are now limited to 5.",
 			),
 		).not.toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 120% of your Total Agent hours for this license\. Contact sales to receive more Agent hours\./,
+			/You've used 120% of your Total Agent minutes for this license\. Contact sales to receive more Agent minutes\./,
 		);
 	},
 };
@@ -344,16 +343,16 @@ export const ReachedHardCap: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,600.0")).toBeInTheDocument();
+		await expect(canvas.getByText("96,000")).toBeInTheDocument();
 		await expect(
 			canvas.getByText(
-				"Agent hours limit reached. Concurrent chats are now limited to 5.",
+				"Agent minutes limit reached. Concurrent chats are now limited to 5.",
 			),
 		).toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 160% of your Total Agent hours for this license and reached the hard cap of 1,500 hours\. Contact sales to receive more Agent hours\./,
+			/You've used 160% of your Total Agent minutes for this license and reached the hard cap of 90,000 minutes\. Contact sales to receive more Agent minutes\./,
 		);
 	},
 };
@@ -370,16 +369,16 @@ export const ReachedCoincidentHardCap: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,000.0")).toBeInTheDocument();
+		await expect(canvas.getAllByText("60,000")).toHaveLength(3);
 		await expect(
 			canvas.getByText(
-				"Agent hours limit reached. Concurrent chats are now limited to 5.",
+				"Agent minutes limit reached. Concurrent chats are now limited to 5.",
 			),
 		).toBeInTheDocument();
 		const body = await hoverInfoIcon(canvasElement);
 		await expectTooltipText(
 			body,
-			/You've used 100% of your Total Agent hours for this license and reached the hard cap of 1,000 hours\. Contact sales to receive more Agent hours\./,
+			/You've used 100% of your Total Agent minutes for this license and reached the hard cap of 60,000 minutes\. Contact sales to receive more Agent minutes\./,
 		);
 	},
 };
@@ -395,7 +394,7 @@ export const Disabled: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(
-			canvas.queryByRole("heading", { name: "Total agent hours" }),
+			canvas.queryByRole("heading", { name: "Total agent minutes" }),
 		).not.toBeInTheDocument();
 	},
 };
@@ -407,13 +406,13 @@ export const Unlimited: Story = {
 			limit: undefined,
 			soft_limit: undefined,
 			actual: 1200,
-			// 1,200 hours and 30 minutes: renders as 1,200.5.
+			// 1,200 hours and 30 minutes: renders as 72,030 minutes.
 			actual_ms: 1200 * 3_600_000 + 30 * 60_000,
 		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByText("1,200.5")).toBeInTheDocument();
+		await expect(canvas.getByText("72,030")).toBeInTheDocument();
 		await expect(canvas.queryByText(/Warning:/)).not.toBeInTheDocument();
 		await expect(canvas.getByText(/Allocation:/)).toBeInTheDocument();
 		await expect(canvas.getByText("Unlimited")).toBeInTheDocument();

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentMinutesCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentMinutesCard.tsx
@@ -11,11 +11,13 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
 
-type TotalAgentHoursCardProps = {
+type TotalAgentMinutesCardProps = {
 	feature?: Feature;
 };
 
-export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
+const minutesPerHour = 60;
+
+export const TotalAgentMinutesCard: FC<TotalAgentMinutesCardProps> = ({
 	feature,
 }) => {
 	// A zero-hour allocation arrives with enabled=false, which hides the
@@ -45,32 +47,33 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 		);
 	}
 
-	const meteredLimit = limit ?? 0;
-	const usedTenths =
-		actualMs === undefined ? 0 : Math.floor(actualMs / 360_000);
-	const usedHours = usedTenths / 10;
+	const meteredLimit = (limit ?? 0) * minutesPerHour;
+	const usedMinutes =
+		actualMs === undefined ? 0 : Math.floor(actualMs / 60_000);
 	const hardCap =
 		!isUnlimited &&
 		hardLimit !== undefined &&
 		hardLimit > 0 &&
-		hardLimit >= meteredLimit
-			? hardLimit
+		hardLimit * minutesPerHour >= meteredLimit
+			? hardLimit * minutesPerHour
 			: undefined;
+	const softLimitMinutes =
+		softLimit === undefined ? undefined : softLimit * minutesPerHour;
 	const reachedAllocation =
-		!isUnlimited && actualMs !== undefined && usedHours >= meteredLimit;
+		!isUnlimited && actualMs !== undefined && usedMinutes >= meteredLimit;
 	const reachedHardCap =
-		hardCap !== undefined && actualMs !== undefined && usedHours >= hardCap;
+		hardCap !== undefined && actualMs !== undefined && usedMinutes >= hardCap;
 	const reachedSoftLimit =
 		!isUnlimited &&
 		!reachedAllocation &&
 		actualMs !== undefined &&
-		softLimit !== undefined &&
-		usedHours >= softLimit;
+		softLimitMinutes !== undefined &&
+		usedMinutes >= softLimitMinutes;
 	const barScale = hardCap ?? meteredLimit;
 	const usagePercentage = isUnlimited
 		? 100
 		: barScale > 0
-			? Math.min((usedHours / barScale) * 100, 100)
+			? Math.min((usedMinutes / barScale) * 100, 100)
 			: 0;
 	const allocationMarkerPercent =
 		hardCap === undefined
@@ -78,8 +81,8 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 			: Math.min((meteredLimit / hardCap) * 100, 100);
 
 	const softMarkerPercent =
-		!isUnlimited && softLimit !== undefined && barScale > 0
-			? Math.min((softLimit / barScale) * 100, 100)
+		!isUnlimited && softLimitMinutes !== undefined && barScale > 0
+			? Math.min((softLimitMinutes / barScale) * 100, 100)
 			: undefined;
 	const fillClassName = reachedAllocation
 		? "bg-highlight-red"
@@ -87,17 +90,11 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 			? "bg-border-warning"
 			: "bg-highlight-green";
 
-	// Already floored to tenths, so rendering one decimal never rounds.
 	const usedLabel =
-		actualMs === undefined
-			? "N/A"
-			: usedHours.toLocaleString("en-US", {
-					minimumFractionDigits: 1,
-					maximumFractionDigits: 1,
-				});
+		actualMs === undefined ? "N/A" : usedMinutes.toLocaleString("en-US");
 	const warningLabel =
-		!isUnlimited && softLimit !== undefined
-			? softLimit.toLocaleString("en-US")
+		!isUnlimited && softLimitMinutes !== undefined
+			? softLimitMinutes.toLocaleString("en-US")
 			: undefined;
 	const allocationLabel = isUnlimited
 		? "Unlimited"
@@ -115,8 +112,8 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 		(Math.floor((numerator * 1000) / denominator) / 10).toLocaleString("en-US");
 
 	const softLimitPercent =
-		!isUnlimited && softLimit !== undefined && meteredLimit > 0
-			? formatPercent(softLimit, meteredLimit)
+		!isUnlimited && softLimitMinutes !== undefined && meteredLimit > 0
+			? formatPercent(softLimitMinutes, meteredLimit)
 			: undefined;
 
 	// A fading green fill reads as an unmetered allocation rather than
@@ -130,12 +127,12 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 	let tooltip: string;
 	if (reachedAllocation) {
 		const usedPercent =
-			meteredLimit > 0 ? formatPercent(usedTenths, meteredLimit * 10) : "100";
+			meteredLimit > 0 ? formatPercent(usedMinutes, meteredLimit) : "100";
 		tooltip = reachedHardCap
-			? `You've used ${usedPercent}% of your Total Agent hours for this license and reached the hard cap of ${limitLabel} hours. Contact sales to receive more Agent hours.`
-			: `You've used ${usedPercent}% of your Total Agent hours for this license. Contact sales to receive more Agent hours.`;
+			? `You've used ${usedPercent}% of your Total Agent minutes for this license and reached the hard cap of ${limitLabel} minutes. Contact sales to receive more Agent minutes.`
+			: `You've used ${usedPercent}% of your Total Agent minutes for this license. Contact sales to receive more Agent minutes.`;
 	} else if (reachedSoftLimit) {
-		tooltip = `You've used ${softLimitPercent}% or more of your Total Agent hours for this license. Agent sessions are still working normally, but you'll want to plan for the 100% limit.`;
+		tooltip = `You've used ${softLimitPercent}% or more of your Total Agent minutes for this license. Agent sessions are still working normally, but you'll want to plan for the 100% limit.`;
 	} else if (softLimitPercent !== undefined) {
 		tooltip = `Total time agents have been working across all workspaces this license. A soft-limit warning appears at ${softLimitPercent}%`;
 	} else {
@@ -149,12 +146,12 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 				<div className="flex flex-col gap-2">
 					<div className="flex flex-col gap-0.5">
 						<div className="flex items-center gap-1">
-							<h3 className="text-md m-0 font-medium">Total agent hours</h3>
+							<h3 className="text-md m-0 font-medium">Total agent minutes</h3>
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<button
 										type="button"
-										aria-label="Total agent hours information"
+										aria-label="Total agent minutes information"
 										className="m-0 inline-flex appearance-none border-0 bg-transparent p-0 text-content-secondary"
 									>
 										<InfoIcon className="size-3" />
@@ -186,7 +183,7 @@ export const TotalAgentHoursCard: FC<TotalAgentHoursCardProps> = ({
 								className="h-auto rounded-full text-wrap"
 							>
 								<BanIcon />
-								Agent hours limit reached. Concurrent chats are now limited to
+								Agent minutes limit reached. Concurrent chats are now limited to
 								5.
 							</Badge>
 						</div>


### PR DESCRIPTION
Visual updates to the licenses page (`/deployment/licenses`), frontend only. Agent usage is now displayed in minutes instead of hours, the per-license Products area uses a responsive 2-up grid, agents-only licenses report Minutes in the license row, every license shows a Coder Agents trial or community card when it has no agents grant, and legacy AI Governance seats render inside Products instead of a separate Add-ons section.

## Changes

- **Products grid**: replaced `flex-wrap` + `min-w-[320px] flex-1` cards (which stretched a wrapped card to full width) with `grid grid-cols-1 lg:grid-cols-2`, so cards stay 2-up and only stack at narrow widths.
- **Hours to minutes**: display-only conversion from existing data. Used minutes = `floor(actual_ms / 60_000)`; allocation and thresholds = claim hours × 60. Copy updated ("Total Agent minutes", "Agent minutes used", "Agent minutes exceeded"). `TotalAgentHoursCard` renamed to `TotalAgentMinutesCard` with bar math and warnings converted.
- **Agents-only licenses**: a license that grants agent runtime hours but has no `user_limit` claim shows a **Minutes** column (`used / allocation`, `Unlimited` for `-1`) in place of **Users**, hides the Coder Workspaces card, and labels itself "Coder Agents".
- **Trial / community cards**: the Coder Agents card renders for all licenses. Without an agents grant, trial licenses show "Coder Agents Trial" (minutes used, unlimited concurrency, Upgrade), and non-trial licenses show the community card (minutes used, max 5 concurrent agents, "Try unlimited for 30 days" → `/deployment/premium`, "View docs").
- **AI Governance seats**: moved from the "Add-ons" section into the Products grid; the Add-ons heading is removed.

No API or backend changes; all values derive from existing entitlement fields (`actual_ms`) and license JWT claims.

## Testing

- `pnpm check` (biome), `tsc -p .`, and knip pass.
- `LicenseCard.test.tsx` (3 tests) and the Storybook vitest project for the directory (12 files, 101 tests) pass, including new stories for the licensed-minutes, agents-only, trial, and community states.

<details>
<summary>Implementation notes and decisions</summary>

- **Overlap review**: checked open PRs from @jaaydenh. #28488 (split public capabilities from entitlement details) rewrites `LicensesSettingsPage.tsx` query wiring, which this PR does not touch. #28489 (community Agent Time usage) is the backend change that populates `actual_ms` without a `usage_period` on unlicensed deployments; the community/trial cards consume that as-is. No file conflicts.
- **Agents-only detection heuristic**: a license is treated as agents-only when it grants agent runtime hours (`agent_runtime_hours_allocation > 0` or `-1`) and carries no `user_limit` claim. A license bundling seats and agent hours keeps the Users column (covered by the `AgentHoursWithSeatsKeepsUsersColumn` story).
- **Minutes comparisons**: exceeded/soft-limit checks moved from tenths-of-hours flooring to whole minutes so the displayed value and the warning states flip at the same instant.
- **Breakpoint choice**: Tailwind 3.4 without container queries, so the grid collapses at the `lg` viewport breakpoint; below that the settings content area is too narrow for two 320px cards.
- **Upsell card layouts**: both trial and community variants show "Agent minutes used" first (em dash when usage is unavailable) so the two layouts stay consistent; previously the metric was hidden when undefined.
- **Rename**: `TotalAgentHoursCard` → `TotalAgentMinutesCard` (component, file, stories) so the name matches what it renders.

</details>

---

🤖 This PR was generated by Coder Agents on behalf of @tracyjohnsonux.
