### PR TITLE
fix(site/src): move deployment docs links inline as View docs text links

### DIFF
--- a/site/src/components/SettingsHeader/SettingsHeader.tsx
+++ b/site/src/components/SettingsHeader/SettingsHeader.tsx
@@ -1,7 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import { SquareArrowOutUpRightIcon } from "lucide-react";
 import type { FC, PropsWithChildren, ReactNode } from "react";
-import { Button } from "#/components/Button/Button";
+import { Link } from "#/components/Link/Link";
 import { cn } from "#/utils/cn";
 
 type SettingsHeaderProps = Readonly<
@@ -30,16 +29,13 @@ type SettingsHeaderDocsLinkProps = Readonly<
 >;
 export const SettingsHeaderDocsLink: FC<SettingsHeaderDocsLinkProps> = ({
 	href,
-	children = "Read the docs",
+	children = "View docs",
 }) => {
 	return (
-		<Button asChild variant="outline">
-			<a href={href} target="_blank" rel="noreferrer">
-				<SquareArrowOutUpRightIcon />
-				{children}
-				<span className="sr-only"> (link opens in new tab)</span>
-			</a>
-		</Button>
+		<Link href={href} target="_blank" rel="noreferrer">
+			{children}
+			<span className="sr-only"> (opens in new tab)</span>
+		</Link>
 	);
 };
 

--- a/site/src/components/SettingsHeader/SettingsHeader.tsx
+++ b/site/src/components/SettingsHeader/SettingsHeader.tsx
@@ -25,15 +25,20 @@ export const SettingsHeader: FC<SettingsHeaderProps> = ({
 };
 
 type SettingsHeaderDocsLinkProps = Readonly<
-	PropsWithChildren<{ href: string }>
+	PropsWithChildren<{
+		href: string;
+		context?: string;
+	}>
 >;
 export const SettingsHeaderDocsLink: FC<SettingsHeaderDocsLinkProps> = ({
 	href,
+	context,
 	children = "View docs",
 }) => {
 	return (
 		<Link href={href} target="_blank" rel="noreferrer">
 			{children}
+			{context && <span className="sr-only"> {context}</span>}
 			<span className="sr-only"> (opens in new tab)</span>
 		</Link>
 	);

--- a/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.stories.tsx
@@ -83,7 +83,7 @@ export const Paywall: Story = {
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute(
 			"href",
 			docs("/ai-coder/ai-gateway/standalone#create-a-gateway-key"),

--- a/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.tsx
+++ b/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.tsx
@@ -47,25 +47,21 @@ export const GatewayKeysPageView: FC<GatewayKeysPageViewProps> = ({
 		<div>
 			<SettingsHeader
 				actions={
-					<div className="flex flex-row gap-2 items-center">
-						<SettingsHeaderDocsLink
-							href={docs(
-								"/ai-coder/ai-gateway/standalone#create-a-gateway-key",
-							)}
-						/>
-						{!showPaywall && (
-							<Button variant="outline" onClick={onCreateKey}>
-								<PlusIcon />
-								Create key
-							</Button>
-						)}
-					</div>
+					!showPaywall && (
+						<Button variant="outline" onClick={onCreateKey}>
+							<PlusIcon />
+							Create key
+						</Button>
+					)
 				}
 			>
 				<SettingsHeaderTitle>AI Gateway Keys</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Keys authenticate standalone AI Gateway replicas to this deployment.
-					The key value is shown only once when created.
+					The key value is shown only once when created.{" "}
+					<SettingsHeaderDocsLink
+						href={docs("/ai-coder/ai-gateway/standalone#create-a-gateway-key")}
+					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/AuditPage/AuditPageView.stories.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.stories.tsx
@@ -103,7 +103,7 @@ export const NotVisible: Story = {
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute("href", docs("/admin/security/audit-logs"));
 	},
 };

--- a/site/src/pages/AuditPage/AuditPageView.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.tsx
@@ -51,18 +51,17 @@ export const AuditPageView: FC<AuditPageViewProps> = ({
 
 	return (
 		<Margins className="pb-12">
-			<PageHeader
-				actions={
-					<SettingsHeaderDocsLink href={docs("/admin/security/audit-logs")} />
-				}
-			>
+			<PageHeader>
 				<PageHeaderTitle>
 					<div className="flex flex-row gap-2 items-center">
 						<span>Audit</span>
 						<AuditHelpPopover />
 					</div>
 				</PageHeaderTitle>
-				<PageHeaderSubtitle>View events in your audit log.</PageHeaderSubtitle>
+				<PageHeaderSubtitle>
+					View events in your audit log.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/security/audit-logs")} />
+				</PageHeaderSubtitle>
 			</PageHeader>
 
 			{isAuditLogVisible ? (

--- a/site/src/pages/ConnectionLogPage/ConnectionLogPageView.stories.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogPageView.stories.tsx
@@ -102,7 +102,7 @@ export const NotVisible: Story = {
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute("href", docs("/admin/monitoring/connection-logs"));
 	},
 };

--- a/site/src/pages/ConnectionLogPage/ConnectionLogPageView.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogPageView.tsx
@@ -50,13 +50,7 @@ export const ConnectionLogPageView: FC<ConnectionLogPageViewProps> = ({
 
 	return (
 		<Margins className="pb-12">
-			<PageHeader
-				actions={
-					<SettingsHeaderDocsLink
-						href={docs("/admin/monitoring/connection-logs")}
-					/>
-				}
-			>
+			<PageHeader>
 				<PageHeaderTitle>
 					<div className="flex flex-row gap-2 items-center">
 						<span>Connection Log</span>
@@ -64,7 +58,10 @@ export const ConnectionLogPageView: FC<ConnectionLogPageViewProps> = ({
 					</div>
 				</PageHeaderTitle>
 				<PageHeaderSubtitle>
-					View workspace connection events.
+					View workspace connection events.{" "}
+					<SettingsHeaderDocsLink
+						href={docs("/admin/monitoring/connection-logs")}
+					/>
 				</PageHeaderSubtitle>
 			</PageHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/AIGovernanceSettingsPage/AIGovernanceSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AIGovernanceSettingsPage/AIGovernanceSettingsPageView.tsx
@@ -29,16 +29,13 @@ export const AIGovernanceSettingsPageView: FC<
 			</SettingsHeader>
 
 			<div>
-				<SettingsHeader
-					actions={
-						<SettingsHeaderDocsLink href={docs("/ai-coder/ai-governance")} />
-					}
-				>
+				<SettingsHeader>
 					<SettingsHeaderTitle hierarchy="secondary" level="h2">
 						AI Gateway
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Monitor and manage AI requests across your deployment.
+						Monitor and manage AI requests across your deployment.{" "}
+						<SettingsHeaderDocsLink href={docs("/ai-coder/ai-governance")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.stories.tsx
@@ -58,7 +58,7 @@ export const NotEntitled: Story = {
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute("href", docs("/admin/setup/appearance"));
 		await expect(
 			canvas.queryByRole("form", { name: "Appearance settings" }),

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -49,14 +49,11 @@ export const AppearanceSettingsPageView: FC<
 
 	return (
 		<div>
-			<SettingsHeader
-				actions={
-					<SettingsHeaderDocsLink href={docs("/admin/setup/appearance")} />
-				}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Appearance</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
-					Customize the look and feel of your Coder deployment.
+					Customize the look and feel of your Coder deployment.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/setup/appearance")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
+import { docs } from "#/utils/docs";
 import { ExternalAuthSettingsPageView } from "./ExternalAuthSettingsPageView";
 
 const meta: Meta<typeof ExternalAuthSettingsPageView> = {
@@ -49,6 +50,9 @@ export const Page: Story = {
 		await expect(
 			canvas.getByRole("link", { name: "Start trial for free" }),
 		).toHaveAttribute("href", "/deployment/premium");
+		await expect(
+			canvas.getByRole("link", { name: /View docs/ }),
+		).toHaveAttribute("href", docs("/admin/external-auth"));
 	},
 };
 

--- a/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.tsx
@@ -33,13 +33,12 @@ export const ExternalAuthSettingsPageView: FC<
 > = ({ config, isEntitled, canViewPremium }) => {
 	return (
 		<>
-			<SettingsHeader
-				actions={<SettingsHeaderDocsLink href={docs("/admin/external-auth")} />}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>External Authentication</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Coder integrates with GitHub, GitLab, BitBucket, Azure Repos, and
-					OpenID Connect to authenticate developers with external services.
+					OpenID Connect to authenticate developers with external services.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/external-auth")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPage.tsx
@@ -70,19 +70,15 @@ const IdpOrgSyncPage: FC = () => {
 
 			<div>
 				<SettingsHeader
-					actions={
-						<div className="flex flex-row gap-2 items-center">
-							<SettingsHeaderDocsLink
-								href={docs("/admin/users/idp-sync#organization-sync")}
-							/>
-							<ExportPolicyButton syncSettings={settingsQuery.data} />
-						</div>
-					}
+					actions={<ExportPolicyButton syncSettings={settingsQuery.data} />}
 				>
 					<SettingsHeaderTitle>Organization IdP Sync</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Automatically assign users to an organization based on their IdP
-						claims.
+						claims.{" "}
+						<SettingsHeaderDocsLink
+							href={docs("/admin/users/idp-sync#organization-sync")}
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 				{!isIdpSyncEnabled ? (

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import type { SerpentGroup } from "#/api/typesGenerated";
+import { docs } from "#/utils/docs";
 import { NetworkSettingsPageView } from "./NetworkSettingsPageView";
 
 const group: SerpentGroup = {
@@ -67,4 +69,18 @@ const meta: Meta<typeof NetworkSettingsPageView> = {
 export default meta;
 type Story = StoryObj<typeof NetworkSettingsPageView>;
 
-export const Page: Story = {};
+export const Page: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const docsLinks = canvas.getAllByRole("link", { name: /View docs/ });
+		await expect(docsLinks).toHaveLength(2);
+		await expect(docsLinks[0]).toHaveAttribute(
+			"href",
+			docs("/admin/networking"),
+		);
+		await expect(docsLinks[1]).toHaveAttribute(
+			"href",
+			docs("/admin/networking/port-forwarding"),
+		);
+	},
+};

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
@@ -27,12 +27,11 @@ export const NetworkSettingsPageView: FC<NetworkSettingsPageViewProps> = ({
 }) => (
 	<div className="flex flex-col gap-12">
 		<div>
-			<SettingsHeader
-				actions={<SettingsHeaderDocsLink href={docs("/admin/networking")} />}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Network</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
-					Configure your deployment connectivity.
+					Configure your deployment connectivity.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/networking")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 
@@ -44,19 +43,16 @@ export const NetworkSettingsPageView: FC<NetworkSettingsPageViewProps> = ({
 		</div>
 
 		<div>
-			<SettingsHeader
-				actions={
-					<SettingsHeaderDocsLink
-						href={docs("/admin/networking/port-forwarding")}
-					/>
-				}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle level="h2" hierarchy="secondary">
 					Port Forwarding
 				</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Port forwarding lets developers securely access processes on their
-					Coder workspace from a local machine.
+					Coder workspace from a local machine.{" "}
+					<SettingsHeaderDocsLink
+						href={docs("/admin/networking/port-forwarding")}
+					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
@@ -31,7 +31,10 @@ export const NetworkSettingsPageView: FC<NetworkSettingsPageViewProps> = ({
 				<SettingsHeaderTitle>Network</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Configure your deployment connectivity.{" "}
-					<SettingsHeaderDocsLink href={docs("/admin/networking")} />
+					<SettingsHeaderDocsLink
+						href={docs("/admin/networking")}
+						context="about deployment networking"
+					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 
@@ -52,6 +55,7 @@ export const NetworkSettingsPageView: FC<NetworkSettingsPageViewProps> = ({
 					Coder workspace from a local machine.{" "}
 					<SettingsHeaderDocsLink
 						href={docs("/admin/networking/port-forwarding")}
+						context="about port forwarding"
 					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { spyOn, userEvent, within } from "storybook/test";
+import { expect, spyOn, userEvent, within } from "storybook/test";
 import { API } from "#/api/api";
 import { selectTemplatesByGroup } from "#/api/queries/notifications";
 import type { DeploymentValues } from "#/api/typesGenerated";
 import { MockSystemNotificationTemplates } from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
 import { NotificationEvents } from "./NotificationEvents";
 import { baseMeta } from "./storybookUtils";
 
@@ -36,6 +37,15 @@ export const SMTPNotConfigured: Story = {
 			},
 		} as DeploymentValues,
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: /View docs/ }),
+		).toHaveAttribute(
+			"href",
+			docs("/admin/monitoring/notifications#smtp-email"),
+		);
+	},
 };
 
 export const WebhookNotConfigured: Story = {
@@ -52,6 +62,12 @@ export const WebhookNotConfigured: Story = {
 				},
 			},
 		} as DeploymentValues,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: /View docs/ }),
+		).toHaveAttribute("href", docs("/admin/monitoring/notifications#webhook"));
 	},
 };
 

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
@@ -8,7 +8,7 @@ import {
 } from "#/api/queries/notifications";
 import type { DeploymentValues } from "#/api/typesGenerated";
 import { Alert } from "#/components/Alert/Alert";
-import { Button } from "#/components/Button/Button";
+import { Link } from "#/components/Link/Link";
 import {
 	Select,
 	SelectContent,
@@ -66,15 +66,13 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 					severity="warning"
 					prominent
 					actions={
-						<Button size="sm" asChild>
-							<a
-								target="_blank"
-								rel="noreferrer"
-								href={docs("/admin/monitoring/notifications#webhook")}
-							>
-								Read the docs
-							</a>
-						</Button>
+						<Link
+							href={docs("/admin/monitoring/notifications#webhook")}
+							target="_blank"
+							rel="noreferrer"
+						>
+							View docs
+						</Link>
 					}
 				>
 					Webhook notifications are enabled, but not properly configured.
@@ -86,15 +84,13 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 					severity="warning"
 					prominent
 					actions={
-						<Button size="sm" asChild>
-							<a
-								target="_blank"
-								rel="noreferrer"
-								href={docs("/admin/monitoring/notifications#smtp-email")}
-							>
-								Read the docs
-							</a>
-						</Button>
+						<Link
+							href={docs("/admin/monitoring/notifications#smtp-email")}
+							target="_blank"
+							rel="noreferrer"
+						>
+							View docs
+						</Link>
 					}
 				>
 					SMTP notifications are enabled but not properly configured.

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
@@ -72,6 +72,7 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 							rel="noreferrer"
 						>
 							View docs
+							<span className="sr-only"> (opens in new tab)</span>
 						</Link>
 					}
 				>
@@ -90,6 +91,7 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 							rel="noreferrer"
 						>
 							View docs
+							<span className="sr-only"> (opens in new tab)</span>
 						</Link>
 					}
 				>

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import {
 	customNotificationTemplatesKey,
 	notificationDispatchMethodsKey,
@@ -10,6 +10,7 @@ import {
 	MockNotificationMethodsResponse,
 	MockSystemNotificationTemplates,
 } from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
 import NotificationsPage from "./NotificationsPage";
 import { baseMeta } from "./storybookUtils";
 
@@ -64,6 +65,20 @@ export const LoadingDispatchMethods: Story = {
 export const Events: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		const docsLinks = canvas.getAllByRole("link", { name: /View docs/ });
+		await expect(docsLinks).toHaveLength(3);
+		await expect(docsLinks[0]).toHaveAttribute(
+			"href",
+			docs("/admin/monitoring/notifications"),
+		);
+		await expect(docsLinks[1]).toHaveAttribute(
+			"href",
+			docs("/admin/monitoring/notifications#webhook"),
+		);
+		await expect(docsLinks[2]).toHaveAttribute(
+			"href",
+			docs("/admin/monitoring/notifications#smtp-email"),
+		);
 
 		// System notification templates
 		await canvas.findByText("Template Events");

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -78,16 +78,13 @@ const NotificationsPage: FC = () => {
 		<>
 			<title>{pageTitle("Notifications Settings")}</title>
 
-			<SettingsHeader
-				actions={
+			<SettingsHeader>
+				<SettingsHeaderTitle>Notifications</SettingsHeaderTitle>
+				<SettingsHeaderDescription>
+					Control delivery methods for notifications on this deployment.{" "}
 					<SettingsHeaderDocsLink
 						href={docs("/admin/monitoring/notifications")}
 					/>
-				}
-			>
-				<SettingsHeaderTitle>Notifications</SettingsHeaderTitle>
-				<SettingsHeaderDescription>
-					Control delivery methods for notifications on this deployment.
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -84,6 +84,7 @@ const NotificationsPage: FC = () => {
 					Control delivery methods for notifications on this deployment.{" "}
 					<SettingsHeaderDocsLink
 						href={docs("/admin/monitoring/notifications")}
+						context="about notifications"
 					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
@@ -167,7 +167,7 @@ export const AddApplicationIsScopedToApplicationsTab: Story = {
 
 		// The docs link is tab-agnostic and stays put, which is what makes the
 		// other one's disappearance a scoping decision rather than a quirk.
-		const docsLink = canvas.getByRole("link", { name: /read the docs/i });
+		const docsLink = canvas.getByRole("link", { name: /view docs/i });
 		await expect(docsLink).toBeVisible();
 
 		await userEvent.click(canvas.getByRole("tab", { name: "Settings" }));
@@ -175,7 +175,7 @@ export const AddApplicationIsScopedToApplicationsTab: Story = {
 			canvas.queryByRole("link", { name: "Add application" }),
 		).not.toBeInTheDocument();
 		await expect(
-			canvas.getByRole("link", { name: /read the docs/i }),
+			canvas.getByRole("link", { name: /view docs/i }),
 		).toBeVisible();
 
 		await userEvent.click(canvas.getByRole("tab", { name: "Applications" }));

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
@@ -141,23 +141,10 @@ const OAuth2AppsSettingsPageView: FC<OAuth2AppsSettingsProps> = ({
 
 	return (
 		<div>
-			{/*
-			 * The header sits outside the tabs, so a tab-specific action here would
-			 * promise to act on content it navigates away from. The docs link is
-			 * tab-agnostic, so it stays on both.
-			 */}
 			<SettingsHeader
 				actions={
-					<>
-						{canCreateApp && activeTab === "applications" && (
-							<AddApplicationButton />
-						)}
-						<SettingsHeaderDocsLink
-							href={docs(
-								"/admin/integrations/oauth2-provider#dynamic-client-registration",
-							)}
-						/>
-					</>
+					canCreateApp &&
+					activeTab === "applications" && <AddApplicationButton />
 				}
 			>
 				<SettingsHeaderTitle>OAuth2 applications</SettingsHeaderTitle>
@@ -168,7 +155,12 @@ const OAuth2AppsSettingsPageView: FC<OAuth2AppsSettingsProps> = ({
 				 */}
 				<SettingsHeaderDescription>
 					Register applications to use Coder as an OAuth2 provider
-					{settings && ", and configure how this deployment behaves as one"}.
+					{settings && ", and configure how this deployment behaves as one"}.{" "}
+					<SettingsHeaderDocsLink
+						href={docs(
+							"/admin/integrations/oauth2-provider#dynamic-client-registration",
+						)}
+					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
@@ -82,9 +82,20 @@ export const OSS: Story = {
 		await expect(
 			canvas.getByRole("link", { name: "Start trial for free" }),
 		).toHaveAttribute("href", "/deployment/premium");
-		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
-		).toHaveAttribute("href", docs("/admin/security/audit-logs"));
+		const docsLinks = canvas.getAllByRole("link", { name: /View docs/ });
+		await expect(docsLinks).toHaveLength(3);
+		await expect(docsLinks[0]).toHaveAttribute(
+			"href",
+			docs("/admin/monitoring"),
+		);
+		await expect(docsLinks[1]).toHaveAttribute(
+			"href",
+			docs("/admin/security/audit-logs"),
+		);
+		await expect(docsLinks[2]).toHaveAttribute(
+			"href",
+			docs("/admin/monitoring"),
+		);
 		await expect(
 			canvas.queryByText("Audit Logs Retention"),
 		).not.toBeInTheDocument();

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
@@ -83,16 +83,12 @@ export const OSS: Story = {
 			canvas.getByRole("link", { name: "Start trial for free" }),
 		).toHaveAttribute("href", "/deployment/premium");
 		const docsLinks = canvas.getAllByRole("link", { name: /View docs/ });
-		await expect(docsLinks).toHaveLength(3);
+		await expect(docsLinks).toHaveLength(2);
 		await expect(docsLinks[0]).toHaveAttribute(
-			"href",
-			docs("/admin/monitoring"),
-		);
-		await expect(docsLinks[1]).toHaveAttribute(
 			"href",
 			docs("/admin/security/audit-logs"),
 		);
-		await expect(docsLinks[2]).toHaveAttribute(
+		await expect(docsLinks[1]).toHaveAttribute(
 			"href",
 			docs("/admin/monitoring"),
 		);

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -25,10 +25,6 @@ export const ObservabilitySettingsPageView: FC<
 			<div>
 				<SettingsHeader>
 					<SettingsHeaderTitle>Observability</SettingsHeaderTitle>
-					<SettingsHeaderDescription>
-						Monitor logs, metrics, and audit events for your Coder deployment.{" "}
-						<SettingsHeaderDocsLink href={docs("/admin/monitoring")} />
-					</SettingsHeaderDescription>
 				</SettingsHeader>
 
 				<SettingsHeader>

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -33,7 +33,10 @@ export const ObservabilitySettingsPageView: FC<
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Allow auditors to monitor user operations in your deployment.{" "}
-						<SettingsHeaderDocsLink href={docs("/admin/security/audit-logs")} />
+						<SettingsHeaderDocsLink
+							href={docs("/admin/security/audit-logs")}
+							context="about audit logging"
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
@@ -64,7 +67,10 @@ export const ObservabilitySettingsPageView: FC<
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Monitoring your Coder application with logs and metrics.{" "}
-						<SettingsHeaderDocsLink href={docs("/admin/monitoring")} />
+						<SettingsHeaderDocsLink
+							href={docs("/admin/monitoring")}
+							context="about monitoring"
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -23,12 +23,12 @@ export const ObservabilitySettingsPageView: FC<
 	return (
 		<div className="flex flex-col gap-12">
 			<div>
-				<SettingsHeader
-					actions={
-						<SettingsHeaderDocsLink href={docs("/admin/security/audit-logs")} />
-					}
-				>
+				<SettingsHeader>
 					<SettingsHeaderTitle>Observability</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Monitor logs, metrics, and audit events for your Coder deployment.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/monitoring")} />
+					</SettingsHeaderDescription>
 				</SettingsHeader>
 
 				<SettingsHeader>
@@ -36,7 +36,8 @@ export const ObservabilitySettingsPageView: FC<
 						Audit Logging
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Allow auditors to monitor user operations in your deployment.
+						Allow auditors to monitor user operations in your deployment.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/security/audit-logs")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
@@ -66,7 +67,8 @@ export const ObservabilitySettingsPageView: FC<
 						Monitoring
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Monitoring your Coder application with logs and metrics.
+						Monitoring your Coder application with logs and metrics.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/monitoring")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { MockDeploymentDAUResponse } from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
 import { OverviewPageView } from "./OverviewPageView";
 
 const meta: Meta<typeof OverviewPageView> = {
@@ -44,7 +46,14 @@ const meta: Meta<typeof OverviewPageView> = {
 export default meta;
 type Story = StoryObj<typeof OverviewPageView>;
 
-export const Page: Story = {};
+export const Page: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: /View docs/ }),
+		).toHaveAttribute("href", docs("/admin/setup"));
+	},
+};
 
 export const allExperimentsEnabled: Story = {
 	args: {

--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.tsx
@@ -32,12 +32,11 @@ export const OverviewPageView: FC<OverviewPageViewProps> = ({
 }) => {
 	return (
 		<>
-			<SettingsHeader
-				actions={<SettingsHeaderDocsLink href={docs("/admin/setup")} />}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>General</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
-					Information about your Coder deployment.
+					Information about your Coder deployment.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/setup")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/PremiumPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/PremiumPage.tsx
@@ -49,17 +49,14 @@ const PremiumPage: FC = () => {
 		<>
 			<title>{pageTitle("Start a Coder trial")}</title>
 
-			<SettingsHeader
-				actions={
-					<SettingsHeaderDocsLink href={docs(DATABASE_DOCS_LINK)}>
-						Review Coder system requirements
-					</SettingsHeaderDocsLink>
-				}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Start a Coder trial</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					For enterprises ready to achieve world-class security, scalability,
-					and developer experience.
+					and developer experience.{" "}
+					<SettingsHeaderDocsLink href={docs(DATABASE_DOCS_LINK)}>
+						Review Coder system requirements
+					</SettingsHeaderDocsLink>
 				</SettingsHeaderDescription>
 				<Link
 					href="https://coder.com/pricing#compare"

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import type { SerpentGroup, SerpentOption } from "#/api/typesGenerated";
+import { docs } from "#/utils/docs";
 import { SecuritySettingsPageView } from "./SecuritySettingsPageView";
 
 const group: SerpentGroup = {
@@ -54,7 +56,18 @@ const meta: Meta<typeof SecuritySettingsPageView> = {
 export default meta;
 type Story = StoryObj<typeof SecuritySettingsPageView>;
 
-export const Page: Story = {};
+export const Page: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const docsLinks = canvas.getAllByRole("link", { name: /View docs/ });
+		await expect(docsLinks).toHaveLength(2);
+		await expect(docsLinks[0]).toHaveAttribute("href", docs("/admin/security"));
+		await expect(docsLinks[1]).toHaveAttribute(
+			"href",
+			docs("/admin/networking#browser-only-connections"),
+		);
+	},
+};
 
 export const NoTLS = {
 	args: {

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -55,7 +55,11 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 
 			<div>
 				<SettingsHeader>
-					<SettingsHeaderTitle level="h2" hierarchy="secondary">
+					<SettingsHeaderTitle
+						level="h2"
+						hierarchy="secondary"
+						className="items-center"
+					>
 						Browser-Only Connections{" "}
 						<Badges>
 							{featureBrowserOnlyEnabled ? <EnabledBadge /> : <DisabledBadge />}
@@ -70,9 +74,6 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<Badges>
-					{featureBrowserOnlyEnabled ? <EnabledBadge /> : <DisabledBadge />}
-				</Badges>
 				{!featureBrowserOnlyEnabled ? (
 					<PremiumPaywallSmall
 						source="browser_only"

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -38,7 +38,8 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 				<SettingsHeader>
 					<SettingsHeaderTitle>Security</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Ensure your Coder deployment is secure.
+						Ensure your Coder deployment is secure.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/security")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
@@ -53,13 +54,7 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 			</div>
 
 			<div>
-				<SettingsHeader
-					actions={
-						<SettingsHeaderDocsLink
-							href={docs("/admin/networking#browser-only-connections")}
-						/>
-					}
-				>
+				<SettingsHeader>
 					<SettingsHeaderTitle level="h2" hierarchy="secondary">
 						Browser-Only Connections{" "}
 						<Badges>
@@ -68,7 +63,10 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Block all workspace access via SSH, port forward, and other
-						non-browser connections.
+						non-browser connections.{" "}
+						<SettingsHeaderDocsLink
+							href={docs("/admin/networking#browser-only-connections")}
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -39,7 +39,10 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 					<SettingsHeaderTitle>Security</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Ensure your Coder deployment is secure.{" "}
-						<SettingsHeaderDocsLink href={docs("/admin/security")} />
+						<SettingsHeaderDocsLink
+							href={docs("/admin/security")}
+							context="about security"
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
@@ -70,6 +73,7 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 						non-browser connections.{" "}
 						<SettingsHeaderDocsLink
 							href={docs("/admin/networking#browser-only-connections")}
+							context="about browser-only connections"
 						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import type { SerpentGroup } from "#/api/typesGenerated";
+import { docs } from "#/utils/docs";
 import { UserAuthSettingsPageView } from "./UserAuthSettingsPageView";
 
 const oidcGroup: SerpentGroup = {
@@ -139,4 +141,18 @@ const meta: Meta<typeof UserAuthSettingsPageView> = {
 export default meta;
 type Story = StoryObj<typeof UserAuthSettingsPageView>;
 
-export const Page: Story = {};
+export const Page: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const docsLinks = canvas.getAllByRole("link", { name: /View docs/ });
+		await expect(docsLinks).toHaveLength(2);
+		await expect(docsLinks[0]).toHaveAttribute(
+			"href",
+			docs("/admin/users/oidc-auth"),
+		);
+		await expect(docsLinks[1]).toHaveAttribute(
+			"href",
+			docs("/admin/users/github-auth"),
+		);
+	},
+};

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
@@ -39,16 +39,13 @@ export const UserAuthSettingsPageView = ({
 					<SettingsHeaderTitle>User Authentication</SettingsHeaderTitle>
 				</SettingsHeader>
 
-				<SettingsHeader
-					actions={
-						<SettingsHeaderDocsLink href={docs("/admin/users/oidc-auth")} />
-					}
-				>
+				<SettingsHeader>
 					<SettingsHeaderTitle level="h2" hierarchy="secondary">
 						Login with OpenID Connect
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Set up authentication to login with OpenID Connect.
+						Set up authentication to login with OpenID Connect.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/users/oidc-auth")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
@@ -64,16 +61,13 @@ export const UserAuthSettingsPageView = ({
 			</div>
 
 			<div>
-				<SettingsHeader
-					actions={
-						<SettingsHeaderDocsLink href={docs("/admin/users/github-auth")} />
-					}
-				>
+				<SettingsHeader>
 					<SettingsHeaderTitle level="h2" hierarchy="secondary">
 						Login with GitHub
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Set up authentication to login with GitHub.
+						Set up authentication to login with GitHub.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/users/github-auth")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
@@ -45,7 +45,10 @@ export const UserAuthSettingsPageView = ({
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Set up authentication to login with OpenID Connect.{" "}
-						<SettingsHeaderDocsLink href={docs("/admin/users/oidc-auth")} />
+						<SettingsHeaderDocsLink
+							href={docs("/admin/users/oidc-auth")}
+							context="about OpenID Connect login"
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
@@ -67,7 +70,10 @@ export const UserAuthSettingsPageView = ({
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Set up authentication to login with GitHub.{" "}
-						<SettingsHeaderDocsLink href={docs("/admin/users/github-auth")} />
+						<SettingsHeaderDocsLink
+							href={docs("/admin/users/github-auth")}
+							context="about GitHub login"
+						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/GroupsPage/GroupsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.tsx
@@ -113,15 +113,12 @@ const GroupsPage: FC = () => {
 		<div className="w-full max-w-screen-2xl pb-10">
 			{title}
 
-			<SettingsHeader
-				actions={
-					<SettingsHeaderDocsLink href={docs("/admin/users/groups-roles")} />
-				}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Groups</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Manage groups for this{" "}
-					{showOrganizations ? "organization" : "deployment"}.
+					{showOrganizations ? "organization" : "deployment"}.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/users/groups-roles")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.stories.tsx
@@ -36,7 +36,7 @@ export const NotEntitled: Story = {
 		const canvas = within(canvasElement);
 
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute("href", docs("/admin/users/organizations"));
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");

--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
@@ -76,9 +76,6 @@ export const CreateOrganizationPageView: FC<
 					Go Back
 				</Link>
 			</div>
-			<div className="absolute right-12">
-				<SettingsHeaderDocsLink href={docs("/admin/users/organizations")} />
-			</div>
 			<div className="flex flex-col gap-4 w-full min-w-96 mx-auto">
 				<div className="flex flex-col items-center">
 					{Boolean(error) && !isApiValidationError(error) && (
@@ -97,7 +94,10 @@ export const CreateOrganizationPageView: FC<
 						<h1 className="text-3xl font-semibold m-0">New Organization</h1>
 						<p className="max-w-md text-sm text-content-secondary text-center">
 							Organize your deployment into multiple platform teams with unique
-							provisioners, templates, groups, and members.
+							provisioners, templates, groups, and members.{" "}
+							<SettingsHeaderDocsLink
+								href={docs("/admin/users/organizations")}
+							/>
 						</p>
 					</header>
 				</div>

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -82,14 +82,11 @@ const CustomRolesPage: FC = () => {
 			<RequirePermission
 				isFeatureVisible={organizationPermissions?.viewOrgRoles ?? false}
 			>
-				<SettingsHeader
-					actions={
-						<SettingsHeaderDocsLink href={docs("/admin/users/groups-roles")} />
-					}
-				>
+				<SettingsHeader>
 					<SettingsHeaderTitle>Roles</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Manage roles for this organization.
+						Manage roles for this organization.{" "}
+						<SettingsHeaderDocsLink href={docs("/admin/users/groups-roles")} />
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -123,15 +123,12 @@ const IdpSyncPage: FC = () => {
 		<div className="w-full max-w-screen-2xl pb-10">
 			{title}
 
-			<SettingsHeader
-				actions={
-					<SettingsHeaderDocsLink href={docs("/admin/users/idp-sync")} />
-				}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>IdP Sync</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Automatically assign groups or roles to a user based on their IdP
-					claims.
+					claims.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/users/idp-sync")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 			{!isIdpSyncEnabled ? (

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type { ProvisionerJob } from "#/api/typesGenerated";
 import { MockOrganization, MockProvisionerJob } from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
 import { daysAgo } from "#/utils/time";
 import OrganizationProvisionerJobsPageView from "./OrganizationProvisionerJobsPageView";
 
@@ -29,7 +30,17 @@ const meta: Meta<typeof OrganizationProvisionerJobsPageView> = {
 export default meta;
 type Story = StoryObj<typeof OrganizationProvisionerJobsPageView>;
 
-export const Default: Story = {};
+export const Default: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: /View docs/ }),
+		).toHaveAttribute(
+			"href",
+			docs("/admin/provisioners/manage-provisioner-jobs"),
+		);
+	},
+};
 
 export const OrganizationNotFound: Story = {
 	args: {

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -110,7 +110,9 @@ const OrganizationProvisionerJobsPageView: FC<
 					<SettingsHeaderDescription>
 						Provisioner Jobs are the individual tasks assigned to Provisioners
 						when the workspaces are being built.{" "}
-						<Link href={docs("/admin/provisioners")}>View docs</Link>
+						<Link href={docs("/admin/provisioners/manage-provisioner-jobs")}>
+							View docs
+						</Link>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPageView.stories.tsx
@@ -101,7 +101,7 @@ export const Paywalled: Story = {
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute("href", docs("/admin/provisioners"));
 	},
 };

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPageView.tsx
@@ -51,12 +51,11 @@ export const OrganizationProvisionerKeysPageView: FC<
 
 	return (
 		<section className="w-full max-w-screen-2xl pb-10">
-			<SettingsHeader
-				actions={<SettingsHeaderDocsLink href={docs("/admin/provisioners")} />}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Provisioner Keys</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
-					Manage provisioner keys used to authenticate provisioner instances.
+					Manage provisioner keys used to authenticate provisioner instances.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/provisioners")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.stories.tsx
@@ -77,7 +77,7 @@ export const Paywall: Story = {
 		const cta = canvas.getByRole("link", { name: "Start trial for free" });
 		await expect(cta).toHaveAttribute("href", "/deployment/premium");
 		await expect(
-			canvas.getByRole("link", { name: /Read the docs/ }),
+			canvas.getByRole("link", { name: /View docs/ }),
 		).toHaveAttribute("href", docs("/admin/provisioners"));
 	},
 };

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
@@ -61,13 +61,12 @@ export const OrganizationProvisionersPageView: FC<
 }) => {
 	return (
 		<section className="w-full max-w-screen-2xl pb-10">
-			<SettingsHeader
-				actions={<SettingsHeaderDocsLink href={docs("/admin/provisioners")} />}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Provisioners</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Coder server runs provisioner daemons which execute terraform during
-					workspace and template builds.
+					workspace and template builds.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/provisioners")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
@@ -41,16 +41,13 @@ const TemplatePermissionsPage: FC = () => {
 			<title>{pageTitle(template.name, "Permissions")}</title>
 
 			<div className="flex flex-col gap-12">
-				<SettingsHeader
-					actions={
+				<SettingsHeader>
+					<SettingsHeaderTitle>Permissions</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Manage which members and groups can use this template.{" "}
 						<SettingsHeaderDocsLink
 							href={docs("/admin/templates/template-permissions")}
 						/>
-					}
-				>
-					<SettingsHeaderTitle>Permissions</SettingsHeaderTitle>
-					<SettingsHeaderDescription>
-						Manage which members and groups can use this template.
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.stories.tsx
@@ -109,7 +109,7 @@ export const Loaded: Story = {
 		await expect(canvas.getByText("env var + file")).toBeInTheDocument();
 		await expect(canvas.getByText("not injected")).toBeInTheDocument();
 
-		const docsLink = canvas.getByRole("link", { name: "Read the docs" });
+		const docsLink = canvas.getByRole("link", { name: /View docs/ });
 		await expect(docsLink).toHaveAttribute(
 			"href",
 			expect.stringContaining("/user-guides/user-secrets"),

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.tsx
@@ -1,4 +1,4 @@
-import { PlusIcon, SquareArrowOutUpRightIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { type FC, useRef, useState } from "react";
 import type {
 	CreateUserSecretRequest,
@@ -11,6 +11,7 @@ import { Button } from "#/components/Button/Button";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
+	SettingsHeaderDocsLink,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
 import { docs } from "#/utils/docs";
@@ -86,29 +87,18 @@ export const SecretsPageView: FC<SecretsPageViewProps> = ({
 		<div className="flex flex-col gap-6">
 			<SettingsHeader
 				actions={
-					<div className="flex flex-wrap gap-2">
-						<Button variant="outline" asChild>
-							<a
-								href={docs("/user-guides/user-secrets")}
-								target="_blank"
-								rel="noreferrer"
-							>
-								<SquareArrowOutUpRightIcon />
-								Read the docs
-							</a>
-						</Button>
-						<Button onClick={(event) => openAddSecret(event.currentTarget)}>
-							<PlusIcon />
-							Add secret
-						</Button>
-					</div>
+					<Button onClick={(event) => openAddSecret(event.currentTarget)}>
+						<PlusIcon />
+						Add secret
+					</Button>
 				}
 			>
 				<SettingsHeaderTitle>Secrets</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Secrets with an environment variable or file path are injected into
 					workspaces you own when they start. Each environment variable and file
-					path must be unique.
+					path must be unique.{" "}
+					<SettingsHeaderDocsLink href={docs("/user-guides/user-secrets")} />
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.stories.tsx
@@ -8,6 +8,7 @@ import {
 	MockWorkspaceProxies,
 	mockApiError,
 } from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
 import { WorkspaceProxyView } from "./WorkspaceProxyView";
 
 const meta: Meta<typeof WorkspaceProxyView> = {
@@ -29,6 +30,12 @@ export const PrimarySelected: Story = {
 		proxies: MockWorkspaceProxies,
 		proxyLatencies: MockProxyLatencies,
 		preferredProxy: MockPrimaryWorkspaceProxy,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: /View docs/ }),
+		).toHaveAttribute("href", docs("/admin/networking/workspace-proxies"));
 	},
 };
 

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.tsx
@@ -46,17 +46,14 @@ export const WorkspaceProxyView: FC<WorkspaceProxyViewProps> = ({
 }) => {
 	return (
 		<div>
-			<SettingsHeader
-				actions={
-					<SettingsHeaderDocsLink
-						href={docs("/admin/networking/workspace-proxies")}
-					/>
-				}
-			>
+			<SettingsHeader>
 				<SettingsHeaderTitle>Workspace Proxies</SettingsHeaderTitle>
 				<SettingsHeaderDescription>
 					Workspace proxies improve terminal and web app connections to
-					workspaces.
+					workspaces.{" "}
+					<SettingsHeaderDocsLink
+						href={docs("/admin/networking/workspace-proxies")}
+					/>
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
@@ -59,16 +59,13 @@ export const WorkspaceSharingPageView: FC<WorkspaceSharingPageViewProps> = ({
 }) => {
 	return (
 		<div className="flex flex-col gap-12">
-			<SettingsHeader
-				actions={
+			<SettingsHeader>
+				<SettingsHeaderTitle>Sharing</SettingsHeaderTitle>
+				<SettingsHeaderDescription>
+					Share this workspace with other users and groups.{" "}
 					<SettingsHeaderDocsLink
 						href={docs("/user-guides/shared-workspaces")}
 					/>
-				}
-			>
-				<SettingsHeaderTitle>Sharing</SettingsHeaderTitle>
-				<SettingsHeaderDescription>
-					Share this workspace with other users and groups.
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 


### PR DESCRIPTION
Moves documentation CTAs that were previously rendered as header buttons into inline `View docs` external text links under the relevant header or section copy.

## Pages updated

Deployment settings:
- `/deployment/overview`
- `/deployment/appearance`
- `/deployment/external-auth`
- `/deployment/oauth2-provider/apps`
- `/deployment/network`
- `/deployment/workspace-proxies`
- `/deployment/idp-org-sync`
- `/deployment/notifications`
- `/deployment/userauth`
- `/deployment/security`
- `/deployment/observability`
- `/deployment/premium`
- `/deployment/ai-governance`

Organization and user settings:
- `/organizations/:organization/groups`
- `/organizations/:organization/roles`
- `/organizations/:organization/idp-sync`
- `/organizations/new`
- `/organizations/:organization/provisioners`
- `/organizations/:organization/provisioner-keys`
- workspace sharing settings

Other admin/tool pages:
- `/ai/settings/gateway-keys`
- `/audit`
- `/connectionlog`
- template permissions settings

## Changes

- `SettingsHeaderDocsLink` now renders the shared inline `Link` component with the default label `View docs`, external icon, and screen-reader text for new-tab behavior.
- Right-side header actions now remain reserved for real actions such as `Add application`, `Create key`, or export buttons.
- `/deployment/security`: removed the duplicate Browser-Only Connections badge and vertically aligned the remaining badge with the section heading.
- `/deployment/observability`: kept docs links scoped to Audit Logging and Monitoring, and removed the top-level observability docs link.
- Notification misconfiguration alerts now use the same `View docs` text-link treatment.
- Storybook stories updated to assert the new link labels and hrefs where covered.

## Validation

- `pnpm check`
- `pnpm lint:types`
- Targeted Storybook interaction tests for the updated pages.

_This PR was generated by Coder Agents on behalf of @tracyjohnsonux._
