### PR TITLE
fix(site/src/pages/AIBridgePage/ListSessionsPage): remove last prompt timestamp column

### DIFF
--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -121,6 +121,8 @@ export const MenuSkeleton: FC = () => {
 	return <BaseSkeleton className="min-w-[200px] shrink-0" />;
 };
 
+const identityQuery = (query: string): string => query;
+
 type FilterProps = ComponentProps<"div"> & {
 	filter: ReturnType<typeof useFilter>;
 	optionsSkeleton: ReactNode;
@@ -131,6 +133,8 @@ type FilterProps = ComponentProps<"div"> & {
 	error?: unknown;
 	options?: ReactNode;
 	presets: PresetFilter[];
+	formatQuery?: (query: string) => string;
+	parseQuery?: (query: string) => string;
 };
 
 export const Filter: FC<FilterProps> = ({
@@ -143,6 +147,8 @@ export const Filter: FC<FilterProps> = ({
 	learnMoreLabel2,
 	learnMoreLink2,
 	presets,
+	formatQuery = identityQuery,
+	parseQuery = identityQuery,
 	className,
 	...props
 }) => {
@@ -150,7 +156,7 @@ export const Filter: FC<FilterProps> = ({
 	// aggressively without re-renders rippling out to the rest of the app every
 	// single time. Exists for performance reasons - not really a good way to
 	// remove this; render keys would cause the component to remount too often
-	const [queryCopy, setQueryCopy] = useState(filter.query);
+	const [queryCopy, setQueryCopy] = useState(formatQuery(filter.query));
 	const textboxInputRef = useRef<HTMLInputElement>(null);
 
 	// Conditionally re-syncs the parent and local filter queries
@@ -162,9 +168,9 @@ export const Filter: FC<FilterProps> = ({
 		// user removes focus just after this synchronizing effect fires. Also need
 		// to rely on onBlur behavior as an extra safety measure
 		if (!hasSelfOrInnerFocus) {
-			setQueryCopy(filter.query);
+			setQueryCopy(formatQuery(filter.query));
 		}
-	}, [filter.query]);
+	}, [filter.query, formatQuery]);
 
 	const shouldDisplayError = hasError(error) && isApiValidationError(error);
 
@@ -199,7 +205,7 @@ export const Filter: FC<FilterProps> = ({
 							aria-invalid={shouldDisplayError}
 							onChange={(query) => {
 								setQueryCopy(query);
-								filter.debounceUpdate(query);
+								filter.debounceUpdate(parseQuery(query));
 							}}
 							onClear={() => {
 								setQueryCopy("");
@@ -207,8 +213,9 @@ export const Filter: FC<FilterProps> = ({
 								filter.update("");
 							}}
 							onBlur={() => {
-								if (queryCopy === filter.query) return;
-								setQueryCopy(filter.query);
+								const formattedQuery = formatQuery(filter.query);
+								if (queryCopy === formattedQuery) return;
+								setQueryCopy(formattedQuery);
 							}}
 							placeholder="Search..."
 						/>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.stories.tsx
@@ -104,6 +104,34 @@ export const ExplicitTimeRange: Story = {
 	},
 };
 
+export const WithReadableTimeRangeQuery: Story = {
+	args: {
+		...getDefaultFilterProps<FilterAndMenus>({
+			query:
+				'initiator:me started_after:"2026-08-25T20:00:00Z" started_before:"2026-08-26T06:59:59Z"',
+			values: {
+				initiator: "me",
+				started_after: "2026-08-25T20:00:00Z",
+				started_before: "2026-08-26T06:59:59Z",
+			},
+			menus: {
+				user: MockMenu,
+				provider: MockMenu,
+				client: MockMenu,
+				model: MockMenu,
+			},
+			used: true,
+		}),
+		...timeRangeProps,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByLabelText("Filter")).toHaveValue(
+			"initiator:me 2026/08/25/20:00 to 2026/08/26/06:59",
+		);
+	},
+};
+
 export const Loading: Story = {
 	args: {
 		...defaultFilterProps,

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsFilter.tsx
@@ -13,6 +13,7 @@ import {
 	ProviderFilter,
 	type ProviderFilterMenu,
 } from "../filters/ProviderFilter";
+import { formatTimeRangeQuery, parseTimeRangeQuery } from "./timeRange";
 
 // Narrower than the SelectFilter default so the search input keeps most
 // of the row on wide viewports.
@@ -46,6 +47,8 @@ export const ListSessionsFilter: FC<ListSessionsFilterProps> = ({
 			// No preset queries; the search field and menus already cover them.
 			presets={[]}
 			error={error}
+			formatQuery={formatTimeRangeQuery}
+			parseQuery={parseTimeRangeQuery}
 			options={
 				<>
 					<DateTimeRangePicker

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
@@ -89,7 +89,7 @@ export const ListSessionsPageView: FC<ListSessionsPageViewProps> = ({
 							<TableHead className="text-nowrap">Client</TableHead>
 							<TableHead className="text-nowrap">In/Out Tokens</TableHead>
 							<TableHead className="text-nowrap">Network Requests</TableHead>
-							<TableHead className="flex items-center flex-nowrap gap-1">
+							<TableHead className="flex w-24 items-center flex-nowrap gap-1">
 								Threads
 								<ThreadTooltip>
 									<InfoIcon className="size-icon-xs" />

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.tsx
@@ -21,7 +21,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { PremiumPaywallAIGovernance } from "#/modules/paywall/PremiumPaywallAIGovernance";
-import { DATE_FORMAT, formatDateTime } from "#/utils/time";
 import { AIBridgeSetupAlert } from "../AIBridgeSetupAlert";
 import { ListSessionsFilter } from "./ListSessionsFilter";
 import { ListSessionsRow } from "./ListSessionsRow";
@@ -76,8 +75,6 @@ export const ListSessionsPageView: FC<ListSessionsPageViewProps> = ({
 		return <AIBridgeSetupAlert />;
 	}
 
-	const utcOffset = formatDateTime(new Date(), DATE_FORMAT.UTC_OFFSET);
-
 	return (
 		<>
 			<ListSessionsFilter {...filterProps} />
@@ -97,9 +94,6 @@ export const ListSessionsPageView: FC<ListSessionsPageViewProps> = ({
 								<ThreadTooltip>
 									<InfoIcon className="size-icon-xs" />
 								</ThreadTooltip>
-							</TableHead>
-							<TableHead className="text-nowrap">
-								Last Prompt At [UTC{utcOffset}]
 							</TableHead>
 						</TableRow>
 					</TableHeader>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
@@ -92,6 +92,32 @@ export const LongPrompt: Story = {
 	},
 };
 
+export const MobilePromptIcon: Story = {
+	args: {
+		session: {
+			...MockSession,
+			last_prompt:
+				"Can you refactor the entire authentication module to use JWT tokens instead of session cookies?",
+		},
+	},
+	parameters: {
+		viewport: {
+			defaultViewport: "mobile1",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByLabelText("View last prompt")).toBeVisible();
+		expect(canvas.getByText(/^Can you refactor/)).not.toBeVisible();
+		await userEvent.hover(canvas.getByLabelText("View last prompt"));
+		await waitFor(() =>
+			expect(screen.getByRole("tooltip")).toHaveTextContent(
+				"Can you refactor the entire authentication module",
+			),
+		);
+	},
+};
+
 export const NoPrompt: Story = {
 	args: {
 		session: { ...MockSession, last_prompt: undefined },

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
@@ -92,7 +92,7 @@ export const LongPrompt: Story = {
 	},
 };
 
-export const MobilePromptIcon: Story = {
+export const NarrowPromptIcon: Story = {
 	args: {
 		session: {
 			...MockSession,
@@ -102,7 +102,7 @@ export const MobilePromptIcon: Story = {
 	},
 	parameters: {
 		viewport: {
-			defaultViewport: "mobile1",
+			defaultViewport: "ipad",
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { Table, TableBody } from "#/components/Table/Table";
 import { MockSession } from "#/testHelpers/entities";
 import { ListSessionsRow } from "./ListSessionsRow";
@@ -45,6 +45,16 @@ export const MultipleProviders: Story = {
 			...MockSession,
 			providers: ["anthropic", "openai", "copilot"],
 		},
+	},
+	play: async ({ canvasElement }) => {
+		await userEvent.hover(within(canvasElement).getByText("3 providers"));
+		await waitFor(() => {
+			const tooltip = screen.getByRole("tooltip");
+			expect(tooltip).toHaveTextContent("Providers");
+			expect(tooltip).toHaveTextContent("Anthropic");
+			expect(tooltip).toHaveTextContent("OpenAI");
+			expect(tooltip).toHaveTextContent("GitHub Copilot");
+		});
 	},
 };
 

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.stories.tsx
@@ -102,7 +102,7 @@ export const NarrowPromptIcon: Story = {
 	},
 	parameters: {
 		viewport: {
-			defaultViewport: "ipad",
+			defaultViewport: "mobile2",
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -38,12 +38,12 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<span className="inline-flex min-w-0 max-w-full items-center">
-								<span className="hidden min-w-0 max-w-full truncate xl:block">
+								<span className="hidden min-w-0 max-w-full truncate lg:block">
 									{session.last_prompt}
 								</span>
 								<MessageSquareTextIcon
 									aria-label="View last prompt"
-									className="block size-icon-sm text-content-secondary xl:hidden"
+									className="block size-icon-sm text-content-secondary lg:hidden"
 								/>
 							</span>
 						</TooltipTrigger>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -33,12 +33,12 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 				onClick?.();
 			}}
 		>
-			<TableCell className="max-w-32 min-w-10 flex-1 overflow-auto font-normal">
+			<TableCell className="max-w-32 min-w-10 flex-1 overflow-hidden font-normal">
 				<TooltipProvider>
 					<Tooltip>
 						<TooltipTrigger asChild>
-							<span className="inline-flex min-w-0 items-center">
-								<span className="hidden truncate sm:block">
+							<span className="inline-flex min-w-0 max-w-full items-center">
+								<span className="hidden min-w-0 max-w-full truncate sm:block">
 									{session.last_prompt}
 								</span>
 								<MessageSquareTextIcon

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -1,4 +1,3 @@
-import { ChevronRightIcon } from "lucide-react";
 import type { FC } from "react";
 import type { AIBridgeSession } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
@@ -12,7 +11,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { AIBridgeClientIcon } from "#/pages/AIBridgePage/icons/AIBridgeClientIcon";
 import { AIBridgeProviderIcon } from "#/pages/AIBridgePage/icons/AIBridgeProviderIcon";
-import { DATE_FORMAT, formatDateTime } from "#/utils/time";
 import { NetworkCallBadges } from "../NetworkCallBadges";
 import { TokenBadges } from "../TokenBadges";
 import { getProviderDisplayName } from "../utils";
@@ -113,17 +111,6 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 				<Badge className="bg-surface-secondary align-end">
 					{session.threads}
 				</Badge>
-			</TableCell>
-			<TableCell className="w-48 whitespace-nowrap font-normal">
-				<div className="flex items-center justify-between">
-					<span>
-						{formatDateTime(
-							new Date(session.last_active_at),
-							DATE_FORMAT.FULL_DATETIME,
-						)}
-					</span>
-					<ChevronRightIcon className="ml-4 size-icon-sm" />
-				</div>
 			</TableCell>
 		</TableRow>
 	);

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -1,3 +1,4 @@
+import { MessageSquareTextIcon } from "lucide-react";
 import type { FC } from "react";
 import type { AIBridgeSession } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
@@ -32,11 +33,19 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 				onClick?.();
 			}}
 		>
-			<TableCell className="max-w-32 flex-1 overflow-auto font-normal">
+			<TableCell className="max-w-32 min-w-10 flex-1 overflow-auto font-normal">
 				<TooltipProvider>
 					<Tooltip>
 						<TooltipTrigger asChild>
-							<p className="truncate">{session.last_prompt}</p>
+							<span className="inline-flex min-w-0 items-center">
+								<span className="hidden truncate sm:block">
+									{session.last_prompt}
+								</span>
+								<MessageSquareTextIcon
+									aria-label="View last prompt"
+									className="block size-icon-sm text-content-secondary sm:hidden"
+								/>
+							</span>
 						</TooltipTrigger>
 						<TooltipContent className="max-w-[512px]" side="top" align="start">
 							<div className="font-bold">Last prompt</div>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -63,9 +63,33 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 			<TableCell className="w-40 max-w-40">
 				<div className="min-w-0 overflow-hidden">
 					{session.providers.length > 1 ? (
-						<Badge className="max-w-full">
-							{session.providers.length} providers
-						</Badge>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span>
+										<Badge className="max-w-full">
+											{session.providers.length} providers
+										</Badge>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent side="top" align="start">
+									<div className="flex flex-col gap-2">
+										<div className="text-content-primary text-sm font-medium">
+											Providers
+										</div>
+										{session.providers.map((provider) => (
+											<div key={provider} className="flex items-center gap-2">
+												<AIBridgeProviderIcon
+													provider={provider}
+													className="size-icon-xs"
+												/>
+												<span>{getProviderDisplayName(provider)}</span>
+											</div>
+										))}
+									</div>
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
 					) : session.providers.length === 1 ? (
 						<Badge className="gap-1.5 max-w-full">
 							<div className="flex-shrink-0 flex items-center">

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -38,12 +38,12 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<span className="inline-flex min-w-0 max-w-full items-center">
-								<span className="hidden min-w-0 max-w-full truncate sm:block">
+								<span className="hidden min-w-0 max-w-full truncate xl:block">
 									{session.last_prompt}
 								</span>
 								<MessageSquareTextIcon
 									aria-label="View last prompt"
-									className="block size-icon-sm text-content-secondary sm:hidden"
+									className="block size-icon-sm text-content-secondary xl:hidden"
 								/>
 							</span>
 						</TooltipTrigger>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -38,9 +38,9 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 						<TooltipTrigger asChild>
 							<p className="truncate">{session.last_prompt}</p>
 						</TooltipTrigger>
-						<TooltipContent className="max-w-64" side="top" align="start">
+						<TooltipContent className="max-w-[512px]" side="top" align="start">
 							<div className="font-bold">Last prompt</div>
-							<div>{session.last_prompt}</div>
+							<div className="line-clamp-5">{session.last_prompt}</div>
 						</TooltipContent>
 					</Tooltip>
 				</TooltipProvider>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -72,7 +72,7 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 										</Badge>
 									</span>
 								</TooltipTrigger>
-								<TooltipContent side="top" align="start">
+								<TooltipContent side="top" align="start" sideOffset={8}>
 									<div className="flex flex-col gap-2">
 										<div className="text-content-primary text-sm font-medium">
 											Providers

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -131,7 +131,7 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 			<TableCell className="w-40">
 				<NetworkCallBadges summary={session.network_calls} />
 			</TableCell>
-			<TableCell className="w-32">
+			<TableCell className="w-24 max-w-24">
 				<Badge className="bg-surface-secondary align-end">
 					{session.threads}
 				</Badge>

--- a/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.test.ts
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { TimeRange } from "./timeRange";
 import {
 	defaultTimeRange,
+	formatTimeRangeQuery,
 	parseTimeRange,
+	parseTimeRangeQuery,
 	queryWithTimeRange,
 	toRFC3339,
 	withDefaultTimeRange,
@@ -14,6 +16,30 @@ describe("toRFC3339", () => {
 	it("serializes in UTC with second precision", () => {
 		expect(toRFC3339(new Date(Date.UTC(2026, 7, 13, 10, 0, 0, 500)))).toBe(
 			"2026-08-13T10:00:00Z",
+		);
+	});
+});
+
+describe("time range search formatting", () => {
+	it("formats explicit timestamp filters as a compact display range", () => {
+		expect(
+			formatTimeRangeQuery(
+				'initiator:me started_after:"2026-08-25T20:00:00Z" started_before:"2026-08-26T06:59:59Z"',
+			),
+		).toBe("initiator:me 2026/08/25/20:00 to 2026/08/26/06:59");
+	});
+
+	it("parses compact display ranges back into timestamp filters", () => {
+		expect(
+			parseTimeRangeQuery("initiator:me 2026/08/25/20:00 to 2026/08/26/06:59"),
+		).toBe(
+			'initiator:me started_after:"2026-08-25T20:00:00Z" started_before:"2026-08-26T06:59:59Z"',
+		);
+	});
+
+	it("leaves malformed compact ranges untouched", () => {
+		expect(parseTimeRangeQuery("2026/99/25/20:00 to 2026/08/26/06:59")).toBe(
+			"2026/99/25/20:00 to 2026/08/26/06:59",
 		);
 	});
 });

--- a/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.ts
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/timeRange.ts
@@ -8,6 +8,65 @@ import {
 
 dayjs.extend(utc);
 
+const readableTimeRangePattern =
+	/(\d{4}\/\d{2}\/\d{2}\/\d{2}:\d{2})\s+to\s+(\d{4}\/\d{2}\/\d{2}\/\d{2}:\d{2})/g;
+const timeRangeQueryPattern =
+	/started_after:"([^"]+)"\s+started_before:"([^"]+)"/g;
+
+const formatReadableTime = (value: string): string | null => {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+	return dayjs(date).utc().format("YYYY/MM/DD/HH:mm");
+};
+
+const parseReadableTime = (value: string, seconds: number): string | null => {
+	const match = /^(\d{4})\/(\d{2})\/(\d{2})\/(\d{2}):(\d{2})$/.exec(value);
+	if (match === null) {
+		return null;
+	}
+	const [, year, month, day, hour, minute] = match.map(Number);
+	const date = new Date(Date.UTC(year, month - 1, day, hour, minute, seconds));
+	if (
+		date.getUTCFullYear() !== year ||
+		date.getUTCMonth() !== month - 1 ||
+		date.getUTCDate() !== day ||
+		date.getUTCHours() !== hour ||
+		date.getUTCMinutes() !== minute
+	) {
+		return null;
+	}
+	return dayjs(date).utc().format("YYYY-MM-DDTHH:mm:ss[Z]");
+};
+
+/** Formats verbose time bounds into a compact display-only search string. */
+export const formatTimeRangeQuery = (query: string): string => {
+	return query.replace(timeRangeQueryPattern, (match, startValue, endValue) => {
+		const start = formatReadableTime(startValue);
+		const end = formatReadableTime(endValue);
+		if (start === null || end === null) {
+			return match;
+		}
+		return `${start} to ${end}`;
+	});
+};
+
+/** Parses compact display-only time bounds back into backend filter syntax. */
+export const parseTimeRangeQuery = (query: string): string => {
+	return query.replace(
+		readableTimeRangePattern,
+		(match, startValue, endValue) => {
+			const start = parseReadableTime(startValue, 0);
+			const end = parseReadableTime(endValue, 59);
+			if (start === null || end === null) {
+				return match;
+			}
+			return `started_after:"${start}" started_before:"${end}"`;
+		},
+	);
+};
+
 /** The resolved time window a sessions query spans. */
 export type TimeRange = Pick<DateTimeRangeValue, "start" | "end">;
 

--- a/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
+++ b/site/src/pages/AIBridgePage/NetworkCallBadges.stories.tsx
@@ -55,18 +55,20 @@ export const TotalAndBlockedKeyboard: Story = {
 	},
 };
 
-// Tabbing to the disabled indicator's info button and pressing Enter reveals
-// the reason popover without a mouse.
-export const DisabledKeyboard: Story = {
+// Hovering the disabled indicator's info button reveals why tracking is off.
+export const DisabledHover: Story = {
 	args: {
 		summary: undefined,
 	},
 	play: async () => {
-		await userEvent.tab();
-		await userEvent.keyboard("{Enter}");
+		await userEvent.hover(
+			screen.getByRole("button", {
+				name: "Why network request tracking is disabled",
+			}),
+		);
 		await waitFor(() =>
-			expect(screen.getByRole("dialog")).toHaveTextContent(
-				"Network request monitoring was not active for this session.",
+			expect(screen.getByRole("tooltip")).toHaveTextContent(
+				"Agent Firewall is off. Enable it in the workspace template to track network requests.",
 			),
 		);
 	},

--- a/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
+++ b/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
@@ -1,5 +1,11 @@
+import { CircleHelpIcon } from "lucide-react";
 import type { FC } from "react";
-import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 
 // Shared by the sessions list badges and the session detail summary card, which
 // render the same two non-numeric states for a session's network requests but
@@ -8,7 +14,24 @@ import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 export const NetworkMonitoringDisabled: FC = () => (
 	<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
 		Disabled
-		<InfoTooltip message="Network request monitoring was not active for this session." />
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Why network request tracking is disabled"
+						className="flex items-center justify-center border-0 bg-transparent p-0 text-content-secondary"
+						onClick={(event) => event.stopPropagation()}
+					>
+						<CircleHelpIcon className="size-3" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="top" align="start" className="max-w-[320px]">
+					Agent Firewall is off. Enable it in the workspace template to track
+					network requests.
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
 	</span>
 );
 

--- a/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
+++ b/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
@@ -1,4 +1,4 @@
-import { CircleHelpIcon } from "lucide-react";
+import { InfoIcon } from "lucide-react";
 import type { FC } from "react";
 import {
 	Tooltip,
@@ -23,7 +23,7 @@ export const NetworkMonitoringDisabled: FC = () => (
 						className="flex items-center justify-center border-0 bg-transparent p-0 text-content-secondary"
 						onClick={(event) => event.stopPropagation()}
 					>
-						<CircleHelpIcon className="size-3" />
+						<InfoIcon className="size-3" />
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="top" align="start" className="max-w-[320px]">

--- a/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
+++ b/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
@@ -26,7 +26,7 @@ export const NetworkMonitoringDisabled: FC = () => (
 						<InfoIcon className="size-3" />
 					</button>
 				</TooltipTrigger>
-				<TooltipContent side="top" align="start" className="max-w-[320px]">
+				<TooltipContent side="top" align="start" className="max-w-[260px]">
 					Agent Firewall is off. Enable it in the workspace template to track
 					network requests.
 				</TooltipContent>


### PR DESCRIPTION
Removes the `Last Prompt At` timestamp column from the AI Gateway sessions table and drops the matching timestamp cell from each session row.

Also widens the last prompt tooltip and clamps the prompt preview to five lines so long prompts remain readable without taking over the page.

Finally, displays AI Gateway session time filters in a compact frontend-only format such as `2026/08/25/20:00 to 2026/08/26/06:59` while preserving the existing `started_after` and `started_before` query syntax sent to the backend.

Generated by Coder Agents.
