### PR TITLE
fix(site): support Vite native config loading

### DIFF
--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -44,15 +44,18 @@ export default defineConfig({
 	worker: {
 		format: "es",
 	},
-	publicDir: path.resolve(__dirname, "./static"),
+	publicDir: path.resolve(import.meta.dirname, "./static"),
 	build: {
-		outDir: path.resolve(__dirname, "./out"),
+		outDir: path.resolve(import.meta.dirname, "./out"),
 		emptyOutDir: false, // We need to keep the /bin folder and GITKEEP files
 		sourcemap: isProfilingBuild ? true : "hidden",
 		rolldownOptions: {
 			input: {
-				index: path.resolve(__dirname, "./index.html"),
-				serviceWorker: path.resolve(__dirname, "./src/serviceWorker.ts"),
+				index: path.resolve(import.meta.dirname, "./index.html"),
+				serviceWorker: path.resolve(
+					import.meta.dirname,
+					"./src/serviceWorker.ts",
+				),
 			},
 			output: {
 				entryFileNames: (chunkInfo) => {
@@ -203,7 +206,7 @@ export default defineConfig({
 				extends: true,
 				plugins: [
 					storybookTest({
-						configDir: path.join(__dirname, ".storybook"),
+						configDir: path.join(import.meta.dirname, ".storybook"),
 					}),
 					{
 						name: "storybook-test-setup",


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Vite warns that `__dirname` in the ESM config is incompatible with its native config loader and will fail when that loader becomes the default.

```
[info]  build: (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
[info]  build: - `__dirname` (vite.config.mts:47:26). Use `import.meta.dirname` instead
```

Use `import.meta.dirname` for paths resolved relative to `site/vite.config.mts`, allowing both the current bundled loader and the native loader to build successfully.
