### PR TITLE
fix: include connecting agents in unhealthy filter

### DIFF
--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -305,13 +305,13 @@ func Workspaces(ctx context.Context, db database.Store, query string, page coder
 	filter.Shared = parser.NullableBoolean(values, sql.NullBool{}, "shared")
 	filter.SharedWithUserID = parseUser(ctx, db, parser, values, "shared_with_user", actorID)
 	filter.SharedWithGroupID = parseGroup(ctx, db, parser, values, "shared_with_group")
-	// Translate healthy filter to has-agent statuses
-	// healthy:true = connected, healthy:false = disconnected or timeout
+	// Translate healthy filter to has-agent statuses.
+	// healthy:true = connected, healthy:false = connecting, disconnected, or timeout.
 	if healthy := parser.NullableBoolean(values, sql.NullBool{}, "healthy"); healthy.Valid {
 		if healthy.Bool {
 			filter.HasAgentStatuses = append(filter.HasAgentStatuses, "connected")
 		} else {
-			filter.HasAgentStatuses = append(filter.HasAgentStatuses, "disconnected", "timeout")
+			filter.HasAgentStatuses = append(filter.HasAgentStatuses, "connecting", "disconnected", "timeout")
 		}
 	}
 

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -324,7 +324,7 @@ func TestSearchWorkspace(t *testing.T) {
 			Name:  "HealthyFalse",
 			Query: "healthy:false",
 			Expected: database.GetWorkspacesParams{
-				HasAgentStatuses: []string{"disconnected", "timeout"},
+				HasAgentStatuses: []string{"connecting", "disconnected", "timeout"},
 			},
 		},
 		{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -3073,8 +3073,8 @@ func TestWorkspaceFilterManual(t *testing.T) {
 		t.Run("Unhealthy", func(t *testing.T) {
 			t.Parallel()
 
-			// healthy:false should return workspaces with disconnected or timed out agents
-			// and exclude workspaces with connected agents
+			// healthy:false should return workspaces with connecting, disconnected,
+			// or timed out agents and exclude workspaces with connected agents
 			store, ps, sqlDB := dbtestutil.NewDBWithSQLDB(t)
 			client := coderdtest.New(t, &coderdtest.Options{
 				Database: store,
@@ -3102,6 +3102,13 @@ func TestWorkspaceFilterManual(t *testing.T) {
 				LastConnectedReplicaID: uuid.NullUUID{},
 			})
 			require.NoError(t, err)
+
+			// Create a workspace with an agent that has not connected.
+			connectingBuild := dbfake.WorkspaceBuild(t, store, database.WorkspaceTable{
+				OrganizationID: user.OrganizationID,
+				OwnerID:        user.UserID,
+				Name:           "connecting-workspace",
+			}).WithAgent().Do()
 
 			// Create a workspace with a disconnected agent
 			disconnectedBuild := dbfake.WorkspaceBuild(t, store, database.WorkspaceTable{
@@ -3139,13 +3146,14 @@ func TestWorkspaceFilterManual(t *testing.T) {
 			testCtx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()
 
-			// healthy:false should return both disconnected and timed out workspaces
+			// healthy:false should return connecting, disconnected, and timed out workspaces.
 			res, err := client.Workspaces(testCtx, codersdk.WorkspaceFilter{
 				FilterQuery: "healthy:false",
 			})
 			require.NoError(t, err)
-			require.Len(t, res.Workspaces, 2)
-			workspaceIDs := []uuid.UUID{res.Workspaces[0].ID, res.Workspaces[1].ID}
+			require.Len(t, res.Workspaces, 3)
+			workspaceIDs := []uuid.UUID{res.Workspaces[0].ID, res.Workspaces[1].ID, res.Workspaces[2].ID}
+			require.Contains(t, workspaceIDs, connectingBuild.Workspace.ID)
 			require.Contains(t, workspaceIDs, disconnectedBuild.Workspace.ID)
 			require.Contains(t, workspaceIDs, timedOutBuild.Workspace.ID)
 		})

--- a/docs/user-guides/workspace-management.md
+++ b/docs/user-guides/workspace-management.md
@@ -72,7 +72,7 @@ The following filters are supported:
   and deleted workspaces don't have agents. List of supported values
   `connecting|connected|timeout|disconnected`, e.g, `has-agent:connecting`
 - `id` - Workspace UUID
-- `healthy` - Only applicable for workspaces in "start" transition. `healthy:false` is an alias for `has-agent:timeout,disconnected`, `healthy:true` is an alias for `has-agent:connected`.
+- `healthy` - Only applicable for workspaces in the "start" transition. `healthy:false` is an alias for `has-agent:connecting,timeout,disconnected`, and `healthy:true` is an alias for `has-agent:connected`.
 - `include_agent_metadata` - Not a filter: expands each agent in the API
   response with the named agent metadata keys, e.g,
   `include_agent_metadata:cpu_usage`. Repeat the key to request multiple


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Workspaces with agents that are still connecting are reported as unhealthy, but `healthy:false` only matched disconnected and timed-out agents.

Include connecting agents in the unhealthy workspace filter and update its tests and documentation.

Refs coder/coder#16047