### PR TITLE
fix: unify workspace health filtering

### DIFF
--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -336,6 +336,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 		arg.Name,
 		pq.Array(arg.HasAgentStatuses),
 		arg.AgentInactiveDisconnectTimeoutSeconds,
+		arg.Healthy,
 		arg.Dormant,
 		arg.LastUsedBefore,
 		arg.LastUsedAfter,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -39695,32 +39695,82 @@ WHERE
 			) > 0
 		ELSE true
 	END
+	-- Filter by workspace health.
+	--
+	-- This mirrors the workspace-level health reported by the API
+	-- (codersdk.Workspace.Health): a workspace is healthy when every
+	-- non-deleted, top-level agent of its latest build is healthy.
+	-- Workspaces without such agents (for example stopped workspaces) are
+	-- healthy, which keeps healthy:true the exact complement of
+	-- healthy:false.
+	--
+	-- An agent is healthy when it is connected and its lifecycle state is
+	-- neither a start error nor shutting down, matching the agent health
+	-- calculation in coderd/database/db2sdk.WorkspaceAgent.
+	AND CASE
+		WHEN $16 :: boolean IS NOT NULL THEN
+			$16 :: boolean = NOT EXISTS (
+				SELECT
+					1
+				FROM
+					workspace_resources
+				JOIN
+					workspace_agents
+				ON
+					workspace_agents.resource_id = workspace_resources.id
+				WHERE
+					workspace_resources.job_id = latest_build.provisioner_job_id AND
+					workspace_agents.deleted = FALSE AND
+					-- Sub-agents (e.g. devcontainer agents) do not affect
+					-- workspace health.
+					workspace_agents.parent_id IS NULL AND
+					NOT (
+						-- Agent is connected.
+						workspace_agents.first_connected_at IS NOT NULL AND
+						workspace_agents.last_connected_at IS NOT NULL AND
+						(
+							workspace_agents.disconnected_at IS NULL OR
+							workspace_agents.disconnected_at < workspace_agents.last_connected_at
+						) AND
+						NOW() - workspace_agents.last_connected_at <= INTERVAL '1 second' * $15 :: bigint AND
+						-- Agent lifecycle is not failed or shutting down.
+						workspace_agents.lifecycle_state NOT IN (
+							'start_error'::workspace_agent_lifecycle_state,
+							'shutting_down'::workspace_agent_lifecycle_state,
+							'shutdown_timeout'::workspace_agent_lifecycle_state,
+							'shutdown_error'::workspace_agent_lifecycle_state,
+							'off'::workspace_agent_lifecycle_state
+						)
+					)
+			)
+		ELSE true
+	END
 	-- Filter by dormant workspaces.
 	AND CASE
-		WHEN $16 :: boolean != 'false' THEN
+		WHEN $17 :: boolean != 'false' THEN
 			dormant_at IS NOT NULL
 		ELSE true
 	END
 	-- Filter by last_used
 	AND CASE
-		  WHEN $17 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
-				  workspaces.last_used_at <= $17
+		  WHEN $18 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
+				  workspaces.last_used_at <= $18
 		  ELSE true
 	END
 	AND CASE
-		  WHEN $18 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
-				  workspaces.last_used_at >= $18
+		  WHEN $19 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
+				  workspaces.last_used_at >= $19
 		  ELSE true
 	END
   	AND CASE
-		  WHEN $19 :: boolean IS NOT NULL THEN
-			  (latest_build.template_version_id = template.active_version_id) = $19 :: boolean
+		  WHEN $20 :: boolean IS NOT NULL THEN
+			  (latest_build.template_version_id = template.active_version_id) = $20 :: boolean
 		  ELSE true
 	END
 	-- Filter by has_ai_task, checks if this is a task workspace.
 	AND CASE
-		WHEN $20::boolean IS NOT NULL
-		THEN $20::boolean = EXISTS (
+		WHEN $21::boolean IS NOT NULL
+		THEN $21::boolean = EXISTS (
 			SELECT
 				1
 			FROM
@@ -39734,26 +39784,26 @@ WHERE
 	END
 	-- Filter by has_external_agent in latest build
 	AND CASE
-		WHEN $21 :: boolean IS NOT NULL THEN
-			latest_build.has_external_agent = $21 :: boolean
+		WHEN $22 :: boolean IS NOT NULL THEN
+			latest_build.has_external_agent = $22 :: boolean
 		ELSE true
 	END
 	-- Filter by shared status
 	AND CASE
-		WHEN $22 :: boolean IS NOT NULL THEN
-			(workspaces.user_acl != '{}'::jsonb OR workspaces.group_acl != '{}'::jsonb) = $22 :: boolean
+		WHEN $23 :: boolean IS NOT NULL THEN
+			(workspaces.user_acl != '{}'::jsonb OR workspaces.group_acl != '{}'::jsonb) = $23 :: boolean
 		ELSE true
 	END
 	-- Filter by shared_with_user_id
 	AND CASE
-		WHEN $23 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			workspaces.user_acl ? ($23 :: uuid) :: text
+		WHEN $24 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.user_acl ? ($24 :: uuid) :: text
 		ELSE true
 	END
 	-- Filter by shared_with_group_id
 	AND CASE
-		WHEN $24 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			workspaces.group_acl ? ($24 :: uuid) :: text
+		WHEN $25 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.group_acl ? ($25 :: uuid) :: text
 		ELSE true
 	END
 
@@ -39766,7 +39816,7 @@ WHERE
 		filtered_workspaces fw
 	ORDER BY
 		-- To ensure that 'favorite' workspaces show up first in the list only for their owner.
-		CASE WHEN favorite AND owner_username = (SELECT users.username FROM users WHERE users.id = $25) THEN 0 ELSE 1 END ASC,
+		CASE WHEN favorite AND owner_username = (SELECT users.username FROM users WHERE users.id = $26) THEN 0 ELSE 1 END ASC,
 		(latest_build_completed_at IS NOT NULL AND
 			latest_build_canceled_at IS NULL AND
 			latest_build_error IS NULL AND
@@ -39775,11 +39825,11 @@ WHERE
 		LOWER(name) ASC
 	LIMIT
 		CASE
-			WHEN $27 :: integer > 0 THEN
-				$27
+			WHEN $28 :: integer > 0 THEN
+				$28
 		END
 	OFFSET
-		$26
+		$27
 ), filtered_workspaces_order_with_summary AS (
 	SELECT
 		fwo.id, fwo.created_at, fwo.updated_at, fwo.owner_id, fwo.organization_id, fwo.template_id, fwo.deleted, fwo.name, fwo.autostart_schedule, fwo.ttl, fwo.last_used_at, fwo.dormant_at, fwo.deleting_at, fwo.automatic_updates, fwo.favorite, fwo.next_start_at, fwo.group_acl, fwo.user_acl, fwo.owner_avatar_url, fwo.owner_username, fwo.owner_name, fwo.organization_name, fwo.organization_display_name, fwo.organization_icon, fwo.organization_description, fwo.template_name, fwo.template_display_name, fwo.template_icon, fwo.template_description, fwo.task_id, fwo.group_acl_display_info, fwo.user_acl_display_info, fwo.template_version_id, fwo.template_version_name, fwo.latest_build_completed_at, fwo.latest_build_canceled_at, fwo.latest_build_error, fwo.latest_build_transition, fwo.latest_build_status, fwo.latest_build_has_external_agent, fwo.latest_build_provisioner_job_id
@@ -39832,7 +39882,7 @@ WHERE
 		false, -- latest_build_has_external_agent
 		'00000000-0000-0000-0000-000000000000'::uuid -- latest_build_provisioner_job_id
 	WHERE
-		$28 :: boolean = true
+		$29 :: boolean = true
 ), total_count AS (
 	SELECT
 		count(*) AS count
@@ -39917,6 +39967,7 @@ type GetWorkspacesParams struct {
 	Name                                  string       `db:"name" json:"name"`
 	HasAgentStatuses                      []string     `db:"has_agent_statuses" json:"has_agent_statuses"`
 	AgentInactiveDisconnectTimeoutSeconds int64        `db:"agent_inactive_disconnect_timeout_seconds" json:"agent_inactive_disconnect_timeout_seconds"`
+	Healthy                               sql.NullBool `db:"healthy" json:"healthy"`
 	Dormant                               bool         `db:"dormant" json:"dormant"`
 	LastUsedBefore                        time.Time    `db:"last_used_before" json:"last_used_before"`
 	LastUsedAfter                         time.Time    `db:"last_used_after" json:"last_used_after"`
@@ -39998,6 +40049,7 @@ func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams)
 		arg.Name,
 		pq.Array(arg.HasAgentStatuses),
 		arg.AgentInactiveDisconnectTimeoutSeconds,
+		arg.Healthy,
 		arg.Dormant,
 		arg.LastUsedBefore,
 		arg.LastUsedAfter,

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -329,6 +329,56 @@ WHERE
 			) > 0
 		ELSE true
 	END
+	-- Filter by workspace health.
+	--
+	-- This mirrors the workspace-level health reported by the API
+	-- (codersdk.Workspace.Health): a workspace is healthy when every
+	-- non-deleted, top-level agent of its latest build is healthy.
+	-- Workspaces without such agents (for example stopped workspaces) are
+	-- healthy, which keeps healthy:true the exact complement of
+	-- healthy:false.
+	--
+	-- An agent is healthy when it is connected and its lifecycle state is
+	-- neither a start error nor shutting down, matching the agent health
+	-- calculation in coderd/database/db2sdk.WorkspaceAgent.
+	AND CASE
+		WHEN sqlc.narg('healthy') :: boolean IS NOT NULL THEN
+			sqlc.narg('healthy') :: boolean = NOT EXISTS (
+				SELECT
+					1
+				FROM
+					workspace_resources
+				JOIN
+					workspace_agents
+				ON
+					workspace_agents.resource_id = workspace_resources.id
+				WHERE
+					workspace_resources.job_id = latest_build.provisioner_job_id AND
+					workspace_agents.deleted = FALSE AND
+					-- Sub-agents (e.g. devcontainer agents) do not affect
+					-- workspace health.
+					workspace_agents.parent_id IS NULL AND
+					NOT (
+						-- Agent is connected.
+						workspace_agents.first_connected_at IS NOT NULL AND
+						workspace_agents.last_connected_at IS NOT NULL AND
+						(
+							workspace_agents.disconnected_at IS NULL OR
+							workspace_agents.disconnected_at < workspace_agents.last_connected_at
+						) AND
+						NOW() - workspace_agents.last_connected_at <= INTERVAL '1 second' * @agent_inactive_disconnect_timeout_seconds :: bigint AND
+						-- Agent lifecycle is not failed or shutting down.
+						workspace_agents.lifecycle_state NOT IN (
+							'start_error'::workspace_agent_lifecycle_state,
+							'shutting_down'::workspace_agent_lifecycle_state,
+							'shutdown_timeout'::workspace_agent_lifecycle_state,
+							'shutdown_error'::workspace_agent_lifecycle_state,
+							'off'::workspace_agent_lifecycle_state
+						)
+					)
+			)
+		ELSE true
+	END
 	-- Filter by dormant workspaces.
 	AND CASE
 		WHEN @dormant :: boolean != 'false' THEN

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -305,15 +305,10 @@ func Workspaces(ctx context.Context, db database.Store, query string, page coder
 	filter.Shared = parser.NullableBoolean(values, sql.NullBool{}, "shared")
 	filter.SharedWithUserID = parseUser(ctx, db, parser, values, "shared_with_user", actorID)
 	filter.SharedWithGroupID = parseGroup(ctx, db, parser, values, "shared_with_group")
-	// Translate healthy filter to has-agent statuses
-	// healthy:true = connected, healthy:false = disconnected or timeout
-	if healthy := parser.NullableBoolean(values, sql.NullBool{}, "healthy"); healthy.Valid {
-		if healthy.Bool {
-			filter.HasAgentStatuses = append(filter.HasAgentStatuses, "connected")
-		} else {
-			filter.HasAgentStatuses = append(filter.HasAgentStatuses, "disconnected", "timeout")
-		}
-	}
+	// healthy filters on workspace-level health, which aggregates the health
+	// of top-level agents. has-agent remains the raw connection status
+	// filter, and the two compose.
+	filter.Healthy = parser.NullableBoolean(values, sql.NullBool{}, "healthy")
 
 	type paramMatch struct {
 		name  string

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -317,28 +317,30 @@ func TestSearchWorkspace(t *testing.T) {
 			Name:  "HealthyTrue",
 			Query: "healthy:true",
 			Expected: database.GetWorkspacesParams{
-				HasAgentStatuses: []string{"connected"},
+				Healthy: sql.NullBool{Bool: true, Valid: true},
 			},
 		},
 		{
 			Name:  "HealthyFalse",
 			Query: "healthy:false",
 			Expected: database.GetWorkspacesParams{
-				HasAgentStatuses: []string{"disconnected", "timeout"},
+				Healthy: sql.NullBool{Bool: false, Valid: true},
 			},
 		},
 		{
 			Name:  "HealthyMissing",
 			Query: "",
 			Expected: database.GetWorkspacesParams{
-				HasAgentStatuses: []string{},
+				Healthy: sql.NullBool{},
 			},
 		},
 		{
+			// healthy and has-agent are independent, composable filters.
 			Name:  "HealthyAndHasAgent",
 			Query: "has-agent:connecting healthy:true",
 			Expected: database.GetWorkspacesParams{
-				HasAgentStatuses: []string{"connecting", "connected"},
+				HasAgentStatuses: []string{"connecting"},
+				Healthy:          sql.NullBool{Bool: true, Valid: true},
 			},
 		},
 		{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -3318,6 +3318,169 @@ func TestWorkspaceFilterManual(t *testing.T) {
 	})
 }
 
+// TestWorkspaceFilterHealthy asserts that the `healthy:` search filter matches
+// the workspace-level health reported by the API, and that it composes with
+// `has-agent:`, which filters raw agent connection statuses.
+func TestWorkspaceFilterHealthy(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{Database: db, Pubsub: ps})
+	api.AgentInactiveDisconnectTimeout = testutil.WaitSuperLong
+	owner := coderdtest.CreateFirstUser(t, client)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	newWorkspace := func(name string, agents int, transition database.WorkspaceTransition) dbfake.WorkspaceResponse {
+		t.Helper()
+		b := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+			Name:           name,
+			OwnerID:        owner.UserID,
+			OrganizationID: owner.OrganizationID,
+		}).Seed(database.WorkspaceBuild{Transition: transition})
+		if agents > 0 {
+			b = b.WithAgent(func(existing []*proto.Agent) []*proto.Agent {
+				for i := 1; i < agents; i++ {
+					existing = append(existing, &proto.Agent{
+						Id:   uuid.NewString(),
+						Name: fmt.Sprintf("dev%d", i),
+						Auth: &proto.Agent_Token{Token: uuid.NewString()},
+						Env:  map[string]string{},
+					})
+				}
+				return existing
+			})
+		}
+		return b.Do()
+	}
+	connectAgent := func(agentID uuid.UUID) {
+		t.Helper()
+		now := dbtime.Now()
+		require.NoError(t, db.UpdateWorkspaceAgentConnectionByID(ctx, database.UpdateWorkspaceAgentConnectionByIDParams{
+			ID:               agentID,
+			FirstConnectedAt: sql.NullTime{Time: now, Valid: true},
+			LastConnectedAt:  sql.NullTime{Time: now, Valid: true},
+			UpdatedAt:        now,
+		}))
+	}
+	disconnectAgent := func(agentID uuid.UUID) {
+		t.Helper()
+		now := dbtime.Now()
+		require.NoError(t, db.UpdateWorkspaceAgentConnectionByID(ctx, database.UpdateWorkspaceAgentConnectionByIDParams{
+			ID:               agentID,
+			FirstConnectedAt: sql.NullTime{Time: now.Add(-2 * time.Hour), Valid: true},
+			LastConnectedAt:  sql.NullTime{Time: now.Add(-2 * time.Hour), Valid: true},
+			DisconnectedAt:   sql.NullTime{Time: now.Add(-time.Hour), Valid: true},
+			UpdatedAt:        now,
+		}))
+	}
+	setLifecycle := func(agentID uuid.UUID, state database.WorkspaceAgentLifecycleState) {
+		t.Helper()
+		require.NoError(t, db.UpdateWorkspaceAgentLifecycleStateByID(ctx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{
+			ID:             agentID,
+			LifecycleState: state,
+		}))
+	}
+
+	// Healthy: a single connected agent.
+	connected := newWorkspace("connected", 1, database.WorkspaceTransitionStart)
+	connectAgent(connected.Agents[0].ID)
+
+	// Unhealthy: the agent connected and then dropped its connection.
+	disconnected := newWorkspace("disconnected", 1, database.WorkspaceTransitionStart)
+	disconnectAgent(disconnected.Agents[0].ID)
+
+	// Unhealthy: workspace health uses all-agent semantics, so a single
+	// disconnected agent makes the workspace unhealthy.
+	mixed := newWorkspace("mixed", 2, database.WorkspaceTransitionStart)
+	connectAgent(mixed.Agents[0].ID)
+	disconnectAgent(mixed.Agents[1].ID)
+
+	// Unhealthy: connected, but the startup script failed. This is invisible to
+	// raw connection-status filtering.
+	startError := newWorkspace("start-error", 1, database.WorkspaceTransitionStart)
+	connectAgent(startError.Agents[0].ID)
+	setLifecycle(startError.Agents[0].ID, database.WorkspaceAgentLifecycleStateStartError)
+
+	// Unhealthy: connected, but the agent is shutting down.
+	shuttingDown := newWorkspace("shutting-down", 1, database.WorkspaceTransitionStart)
+	connectAgent(shuttingDown.Agents[0].ID)
+	setLifecycle(shuttingDown.Agents[0].ID, database.WorkspaceAgentLifecycleStateShuttingDown)
+
+	// Healthy: start timeout is a soft issue and does not affect agent health.
+	startTimeout := newWorkspace("start-timeout", 1, database.WorkspaceTransitionStart)
+	connectAgent(startTimeout.Agents[0].ID)
+	setLifecycle(startTimeout.Agents[0].ID, database.WorkspaceAgentLifecycleStateStartTimeout)
+
+	// Healthy: sub-agents do not contribute to workspace health.
+	subAgent := newWorkspace("sub-agent", 1, database.WorkspaceTransitionStart)
+	connectAgent(subAgent.Agents[0].ID)
+	disconnectAgent(dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{
+		ResourceID: subAgent.Agents[0].ResourceID,
+		ParentID:   uuid.NullUUID{UUID: subAgent.Agents[0].ID, Valid: true},
+		Name:       "devcontainer",
+	}).ID)
+
+	// Unhealthy: the agent has never connected.
+	connecting := newWorkspace("connecting", 1, database.WorkspaceTransitionStart)
+
+	// Healthy: a stopped workspace has no agents to report on.
+	stopped := newWorkspace("stopped", 0, database.WorkspaceTransitionStop)
+
+	healthyWorkspaces := []uuid.UUID{
+		connected.Workspace.ID,
+		startTimeout.Workspace.ID,
+		subAgent.Workspace.ID,
+		stopped.Workspace.ID,
+	}
+	unhealthyWorkspaces := []uuid.UUID{
+		disconnected.Workspace.ID,
+		mixed.Workspace.ID,
+		startError.Workspace.ID,
+		shuttingDown.Workspace.ID,
+		connecting.Workspace.ID,
+	}
+
+	workspaceIDs := func(res codersdk.WorkspacesResponse) []uuid.UUID {
+		ids := make([]uuid.UUID, 0, len(res.Workspaces))
+		for _, ws := range res.Workspaces {
+			ids = append(ids, ws.ID)
+		}
+		return ids
+	}
+
+	// The same fixtures must produce the same answer through the reported
+	// workspace health and through the filter.
+	all, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	require.Len(t, all.Workspaces, len(healthyWorkspaces)+len(unhealthyWorkspaces))
+	for _, ws := range all.Workspaces {
+		if slices.Contains(healthyWorkspaces, ws.ID) {
+			require.True(t, ws.Health.Healthy, "workspace %q should report healthy", ws.Name)
+			continue
+		}
+		require.True(t, slices.Contains(unhealthyWorkspaces, ws.ID))
+		require.False(t, ws.Health.Healthy, "workspace %q should report unhealthy", ws.Name)
+	}
+
+	healthy, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{FilterQuery: "healthy:true"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, healthyWorkspaces, workspaceIDs(healthy))
+
+	unhealthy, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{FilterQuery: "healthy:false"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, unhealthyWorkspaces, workspaceIDs(unhealthy))
+
+	// healthy and has-agent are independent dimensions that compose. Only the
+	// workspaces that have a connected agent and are still unhealthy match.
+	composed, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{FilterQuery: "healthy:false has-agent:connected"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uuid.UUID{
+		mixed.Workspace.ID,
+		startError.Workspace.ID,
+		shuttingDown.Workspace.ID,
+	}, workspaceIDs(composed))
+}
+
 func TestOffsetLimit(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)

--- a/docs/user-guides/workspace-management.md
+++ b/docs/user-guides/workspace-management.md
@@ -68,11 +68,16 @@ The following filters are supported:
 - `outdated` - Filters workspaces using an outdated template version, e.g,
   `outdated:true`
 - `dormant` - Filters workspaces based on the dormant state, e.g `dormant:true`
-- `has-agent` - Only applicable for workspaces in "start" transition. Stopped
-  and deleted workspaces don't have agents. List of supported values
+- `has-agent` - Filters workspaces by raw agent connection status. Only applicable
+  for workspaces in the "start" transition. Stopped and deleted workspaces don't
+  have agents. List of supported values
   `connecting|connected|timeout|disconnected`, e.g, `has-agent:connecting`
 - `id` - Workspace UUID
-- `healthy` - Only applicable for workspaces in "start" transition. `healthy:false` is an alias for `has-agent:timeout,disconnected`, `healthy:true` is an alias for `has-agent:connected`.
+- `healthy` - Filters by workspace-level health. Workspace health aggregates the
+  health of top-level agents and includes connection and lifecycle failures.
+  Workspaces without agents, such as stopped workspaces, are healthy. For
+  example, `status:running healthy:false` returns running workspaces that need
+  attention.
 - `include_agent_metadata` - Not a filter: expands each agent in the API
   response with the named agent metadata keys, e.g,
   `include_agent_metadata:cpu_usage`. Repeat the key to request multiple

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.stories.tsx
@@ -769,6 +769,108 @@ export const OutdatedStoppedAlwaysUpdateHidesStartButton: Story = {
 	},
 };
 
+async function selectFilterOption(
+	canvas: ReturnType<typeof within>,
+	user: ReturnType<typeof userEvent.setup>,
+	menuName: string,
+	optionName: string,
+) {
+	const body = within(document.body);
+	await user.click(await canvas.findByRole("button", { name: menuName }));
+	await user.click(await body.findByRole("option", { name: optionName }));
+}
+
+export const HealthMenuFiltersUnhealthyWorkspaces: Story = {
+	parameters: { pixel: { exclude: true } },
+	beforeEach: () => {
+		spyOn(API, "getWorkspaces").mockResolvedValue(MockWorkspacesResponse);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+
+		await selectFilterOption(
+			canvas,
+			user,
+			"Select a health state",
+			"Unhealthy",
+		);
+
+		await waitFor(() => {
+			expect(API.getWorkspaces).toHaveBeenCalledWith(
+				expect.objectContaining({ q: "owner:me healthy:false" }),
+			);
+		});
+	},
+};
+
+export const StatusAndHealthFiltersCompose: Story = {
+	parameters: { pixel: { exclude: true } },
+	beforeEach: () => {
+		spyOn(API, "getWorkspaces").mockResolvedValue(MockWorkspacesResponse);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+
+		await step("Select the Running status", async () => {
+			await selectFilterOption(canvas, user, "Select a status", "Running");
+			await waitFor(() => {
+				expect(API.getWorkspaces).toHaveBeenCalledWith(
+					expect.objectContaining({ q: "owner:me status:running" }),
+				);
+			});
+		});
+
+		await step("Add the Unhealthy health state", async () => {
+			await selectFilterOption(
+				canvas,
+				user,
+				"Select a health state",
+				"Unhealthy",
+			);
+			await waitFor(() => {
+				expect(API.getWorkspaces).toHaveBeenCalledWith(
+					expect.objectContaining({
+						q: "owner:me status:running healthy:false",
+					}),
+				);
+			});
+		});
+	},
+};
+
+export const StatusAndHealthMenusHydrateFromUrl: Story = {
+	parameters: {
+		pixel: { exclude: true },
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/workspaces",
+				searchParams: { filter: "status:running healthy:false" },
+			},
+			routing: [{ path: "/workspaces", useStoryElement: true }],
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API, "getWorkspaces").mockResolvedValue(MockWorkspacesResponse);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const statusMenu = await canvas.findByRole("button", {
+			name: "Select a status",
+		});
+		const healthMenu = await canvas.findByRole("button", {
+			name: "Select a health state",
+		});
+
+		await waitFor(() => {
+			expect(within(statusMenu).getByText("Running")).toBeInTheDocument();
+			expect(within(healthMenu).getByText("Unhealthy")).toBeInTheDocument();
+		});
+	},
+};
+
 async function selectWorkspaces(
 	canvas: ReturnType<typeof within>,
 	user: ReturnType<typeof userEvent.setup>,

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -26,7 +26,11 @@ import { BatchDeleteConfirmation } from "./BatchDeleteConfirmation";
 import { BatchStopConfirmation } from "./BatchStopConfirmation";
 import { BatchUpdateModalForm } from "./BatchUpdateModalForm";
 import { useBatchActions } from "./batchActions";
-import { useStatusFilterMenu, useTemplateFilterMenu } from "./filter/menus";
+import {
+	useHealthFilterMenu,
+	useStatusFilterMenu,
+	useTemplateFilterMenu,
+} from "./filter/menus";
 import { WorkspacesPageView } from "./WorkspacesPageView";
 
 // To reduce the number of fetches, we reduce the fetch interval if there are no
@@ -317,6 +321,12 @@ const useWorkspacesFilter = ({
 			filter.update({ ...filter.values, status: option?.value }),
 	});
 
+	const healthMenu = useHealthFilterMenu({
+		value: filter.values.healthy,
+		onChange: (option) =>
+			filter.update({ ...filter.values, healthy: option?.value }),
+	});
+
 	const { showOrganizations } = useDashboard();
 	const organizationsMenu = useOrganizationsFilterMenu({
 		value: filter.values.organization,
@@ -334,6 +344,7 @@ const useWorkspacesFilter = ({
 			user: canFilterByUser ? userMenu : undefined,
 			template: templateMenu,
 			status: statusMenu,
+			health: healthMenu,
 			organizations: showOrganizations ? organizationsMenu : undefined,
 		},
 	};

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -141,12 +141,14 @@ const defaultFilterProps = getDefaultFilterProps<WorkspaceFilterState>({
 		user: MockMenu,
 		template: MockMenu,
 		status: MockMenu,
+		health: MockMenu,
 		organizations: MockMenu,
 	},
 	values: {
 		owner: MockUserOwner.username,
 		template: undefined,
 		status: undefined,
+		healthy: undefined,
 	},
 });
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
@@ -29,6 +29,7 @@ const createFilterState = (used = false) =>
 			user: mockMenu,
 			template: mockMenu,
 			status: mockMenu,
+			health: mockMenu,
 			organizations: mockMenu,
 		},
 	}) as WorkspaceFilterState;

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -117,6 +117,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					filter={filterState.filter}
 					error={error}
 					statusMenu={filterState.menus.status}
+					healthMenu={filterState.menus.health}
 					templateMenu={filterState.menus.template}
 					userMenu={filterState.menus.user}
 					organizationsMenu={filterState.menus.organizations}

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.stories.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.stories.tsx
@@ -14,12 +14,14 @@ const defaultFilterProps = getDefaultFilterProps<WorkspaceFilterState>({
 		user: MockMenu,
 		template: MockMenu,
 		status: MockMenu,
+		health: MockMenu,
 		organizations: MockMenu,
 	},
 	values: {
 		owner: "me",
 		template: undefined,
 		status: undefined,
+		healthy: undefined,
 	},
 });
 
@@ -31,6 +33,7 @@ const meta: Meta<typeof WorkspacesFilter> = {
 		error: undefined,
 		templateMenu: MockMenu,
 		statusMenu: MockMenu,
+		healthMenu: MockMenu,
 	},
 	decorators: [withDashboardProvider],
 };

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -16,6 +16,8 @@ import {
 } from "#/modules/tableFiltering/options";
 import { docs } from "#/utils/docs";
 import {
+	type HealthFilterMenu,
+	HealthMenu,
 	type StatusFilterMenu,
 	StatusMenu,
 	type TemplateFilterMenu,
@@ -28,6 +30,7 @@ const workspaceFilterQuery = {
 	running: "status:running",
 	failed: "status:failed",
 	dormant: "dormant:true",
+	unhealthy: "healthy:false",
 	outdated: "outdated:true",
 	shared: "shared:true",
 };
@@ -57,6 +60,10 @@ const PRESET_FILTERS: FilterPreset[] = [
 		name: "Failed workspaces",
 	},
 	{
+		query: workspaceFilterQuery.unhealthy,
+		name: "Unhealthy workspaces",
+	},
+	{
 		query: workspaceFilterQuery.outdated,
 		name: "Outdated workspaces",
 	},
@@ -82,6 +89,7 @@ export type WorkspaceFilterState = {
 		user?: UserFilterMenu;
 		template: TemplateFilterMenu;
 		status: StatusFilterMenu;
+		health: HealthFilterMenu;
 		organizations?: OrganizationsFilterMenu;
 	};
 };
@@ -91,6 +99,7 @@ type WorkspaceFilterProps = Readonly<{
 	error: unknown;
 	templateMenu: TemplateFilterMenu;
 	statusMenu: StatusFilterMenu;
+	healthMenu: HealthFilterMenu;
 
 	userMenu?: UserFilterMenu;
 	organizationsMenu?: OrganizationsFilterMenu;
@@ -101,6 +110,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 	error,
 	templateMenu,
 	statusMenu,
+	healthMenu,
 	userMenu,
 	organizationsMenu,
 }) => {
@@ -126,6 +136,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 					{userMenu && <UserMenu width={width} menu={userMenu} />}
 					<TemplateMenu width={width} menu={templateMenu} />
 					<StatusMenu width={width} menu={statusMenu} />
+					<HealthMenu width={width} menu={healthMenu} />
 					{organizationsActive && (
 						<OrganizationsMenu width={width} menu={organizationsMenu} />
 					)}
@@ -134,6 +145,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 			optionsSkeleton={
 				<>
 					{userMenu && <MenuSkeleton />}
+					<MenuSkeleton />
 					<MenuSkeleton />
 					<MenuSkeleton />
 					{organizationsActive && <MenuSkeleton />}

--- a/site/src/pages/WorkspacesPage/filter/menus.tsx
+++ b/site/src/pages/WorkspacesPage/filter/menus.tsx
@@ -147,6 +147,55 @@ export const StatusMenu: FC<StatusMenuProps> = ({ width, menu }) => {
 	);
 };
 
+/** Health Filter Menu */
+
+const healthOptions: SelectFilterOption[] = [
+	{
+		label: "Healthy",
+		value: "true",
+		startIcon: <StatusIndicatorDot variant="success" />,
+	},
+	{
+		label: "Unhealthy",
+		value: "false",
+		startIcon: <StatusIndicatorDot variant="warning" />,
+	},
+];
+
+export const useHealthFilterMenu = ({
+	value,
+	onChange,
+}: Pick<UseFilterMenuOptions, "value" | "onChange">) => {
+	return useFilterMenu({
+		onChange,
+		value,
+		id: "healthy",
+		getSelectedOption: async () =>
+			healthOptions.find((option) => option.value === value) ?? null,
+		getOptions: async () => healthOptions,
+	});
+};
+
+export type HealthFilterMenu = ReturnType<typeof useHealthFilterMenu>;
+
+type HealthMenuProps = Readonly<{
+	width?: number;
+	menu: HealthFilterMenu;
+}>;
+
+export const HealthMenu: FC<HealthMenuProps> = ({ width, menu }) => {
+	return (
+		<SelectFilter
+			width={width}
+			placeholder="All health"
+			label="Select a health state"
+			options={menu.searchOptions}
+			selectedOption={menu.selectedOption ?? undefined}
+			onSelect={menu.selectOption}
+		/>
+	);
+};
+
 const getStatusIndicatorVariant = (
 	status: WorkspaceStatus,
 ): StatusIndicatorDotProps["variant"] => {


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

## Summary

Make `healthy:` match the workspace-level health returned by the API instead of aliasing raw agent connection states. Health now aggregates non-deleted top-level agents from the latest build, including connection and lifecycle failures, while `has-agent:` remains an independent raw connectivity filter.

Add a separate Health facet and Unhealthy preset to the Workspaces page so status and health compose, including `status:running healthy:false` for running workspaces that need attention. Update the workspace management documentation with the unified model.

Refs #16047

<details>
<summary>Implementation plan</summary>

# Unify workspace status and health filtering

## Problem

Coder currently has three incompatible definitions:

1. `WorkspaceStatus` describes the latest build lifecycle, such as running, stopped, pending, and failed.
2. `workspace.health.healthy` aggregates the health of top-level workspace agents. It includes connection and lifecycle conditions such as connecting, timeout, disconnected, start error, and shutting down.
3. The `healthy:` search filter is an alias for raw agent connection states. It does not match workspace health aggregation, includes sub-agents, and uses any-agent rather than all-agent semantics.

This means the orange Running indicator cannot be filtered reliably. A frontend-only filter would also be incorrect because workspace results are paginated on the server.

## Product model

Use two orthogonal concepts:

- **Status**: the workspace build lifecycle. Keep `status:` and the existing status menu for this.
- **Health**: whether the workspace needs attention. Keep `healthy:` as a separate, composable filter dimension.

Do not add `unhealthy` to `WorkspaceStatus` or the status menu. The query for the state users described is:

```text
status:running healthy:false
```

Use the workspace-level health shown by the UI as the canonical definition. A workspace is unhealthy when at least one non-deleted, top-level agent in its latest build is unhealthy according to the same agent-health rules used to populate `workspace.health`.

`healthy:true` and `healthy:false` must be complements. Raw connectivity filtering remains available through `has-agent:`.

## Implementation

### 1. Make `healthy:` an independent backend filter

- Add a nullable health field to the workspace database query parameters instead of translating `healthy:` into `HasAgentStatuses`.
- Keep `has-agent:` unchanged as the raw connection-status filter.
- Update the workspace SQL query so health filtering:
  - ignores sub-agents, matching workspace health aggregation;
  - ignores deleted agents;
  - uses the latest build, matching workspace health aggregation;
  - includes connection and lifecycle conditions used by agent health;
  - uses workspace-level all-agent semantics;
  - makes `healthy:true` the complement of `healthy:false`.
- Avoid duplicating an unexplained predicate. Document the correspondence between the SQL predicate and the Go agent-health calculation.

### 2. Prevent the definitions from drifting again

Use a red-green-refactor sequence:

1. Add failing integration cases demonstrating current mismatches:
   - mixed connected and disconnected agents;
   - connected agent with `start_error`;
   - unhealthy sub-agent with a healthy parent;
   - connecting agent;
   - stopped/no-agent workspace;
   - simultaneous `healthy:` and `has-agent:` filters.
2. Implement the independent health predicate.
3. Refactor test setup so the same fixtures assert both returned `workspace.health.healthy` and `healthy:` filter membership.

The intended connecting behavior should follow the existing API health value initially: connecting agents are unhealthy. If product wants connecting to be informational rather than unhealthy, change the canonical agent-health calculation and frontend presentation together in a separate deliberate change, not only the filter.

### 3. Add a separate frontend health facet

- Add a Health filter menu beside Status with Healthy and Unhealthy options.
- Write the selection to `healthy:true` or `healthy:false` without removing `status:`.
- Add an `Unhealthy workspaces` preset using `healthy:false`.
- Keep the status menu limited to real `WorkspaceStatus` values.
- Reuse the existing status indicator primitives and filter infrastructure.

### 4. Add frontend interaction coverage

- Add or update a Workspaces page Storybook story that selects Unhealthy and verifies the emitted filter query.
- Verify Status and Health compose to produce `status:running healthy:false`.
- Verify a URL containing both filters hydrates both selected menu values.
- Run the frontend review skill because the change touches `site/src/`.

### 5. Update documentation

- Replace the statement that `healthy:` is an alias for `has-agent:`.
- Explain that health is workspace-level and that `has-agent:` filters raw agent connectivity.
- Include the composable orange Running example: `status:running healthy:false`.

## Verification

- Targeted search-query unit tests.
- Targeted workspace API integration tests.
- Targeted Workspaces page Storybook interaction test.
- Frontend typecheck, Biome, lint, and formatting checks.
- Repository pre-commit hooks.
- Create a new draft PR from a fresh `jakehwll/DEVEX-174-*` branch. Do not reuse or reopen closed PR #28617.

</details>
