### PR TITLE
test(cli): wait for expected GitHub auth state

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -397,15 +397,15 @@ func TestServer(t *testing.T) {
 			createUserPostRestart                 bool
 		}
 
-		waitAuthMethods := func(t *testing.T, ctx context.Context, client *codersdk.Client) codersdk.AuthMethods {
+		waitAuthMethods := func(t *testing.T, ctx context.Context, client *codersdk.Client, expected codersdk.GithubAuthMethod) codersdk.AuthMethods {
 			t.Helper()
 
 			var authMethods codersdk.AuthMethods
 			testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 				var err error
 				authMethods, err = client.AuthMethods(ctx)
-				return err == nil
-			}, testutil.IntervalFast, "failed to get auth methods")
+				return err == nil && authMethods.Github == expected
+			}, testutil.IntervalFast, "github auth method did not reach expected state: %+v", expected)
 			return authMethods
 		}
 
@@ -463,9 +463,12 @@ func TestServer(t *testing.T) {
 			}
 
 			client := codersdk.New(accessURL)
-			authMethods := waitAuthMethods(t, ctx, client)
-			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
-			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
+			expectedGithubAuthMethod := codersdk.GithubAuthMethod{
+				Enabled:                   tc.expectGithubEnabled,
+				DefaultProviderConfigured: tc.expectGithubDefaultProviderConfigured,
+			}
+			authMethods := waitAuthMethods(t, ctx, client, expectedGithubAuthMethod)
+			require.Equal(t, expectedGithubAuthMethod, authMethods.Github)
 
 			cancelFunc()
 			select {
@@ -486,9 +489,8 @@ func TestServer(t *testing.T) {
 			client = codersdk.New(accessURL)
 
 			ctx = testutil.Context(t, testutil.WaitLong)
-			authMethods = waitAuthMethods(t, ctx, client)
-			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
-			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
+			authMethods = waitAuthMethods(t, ctx, client, expectedGithubAuthMethod)
+			require.Equal(t, expectedGithubAuthMethod, authMethods.Github)
 		}
 
 		for _, tc := range []testCase{


### PR DESCRIPTION
The GitHub OAuth server test treated any successful `AuthMethods` response after restart as ready. In the failing macOS run in CI (described in the linked Linear issue), the response decoded successfully but reported GitHub authentication as disabled, even though startup logged the default GitHub provider configuration.

Wait until the complete GitHub authentication method reaches the expected state before asserting it. This preserves retries for transport readiness while also covering successful but incorrect startup responses.

Closes https://linear.app/codercom/issue/ENG-3285/flake-testserveroauth2githubdefaultprovidernewdeployment

<sub>Generated by Coder Agents.</sub>
