### PR TITLE
fix(site): standardize AI provider badge tooltips

### DIFF
--- a/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.tsx
@@ -98,7 +98,7 @@ const ProvidersPageView: React.FC<ProvidersPageViewProps> = ({
 					<ErrorAlert error={error} />
 				</div>
 			)}
-			<Table className="table-fixed" aria-label="AI providers">
+			<Table aria-label="AI providers">
 				<TableHeader>
 					<TableRow>
 						<TableHead className="w-1/3">Name</TableHead>

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
@@ -84,9 +84,17 @@ export const NotSupportedInAgents: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(
-			canvas.getByText("Not supported in Agents"),
-		).toBeInTheDocument();
+		const badge = canvas.getByRole("button", {
+			name: "Not supported in Agents",
+		});
+		await expect(badge).toBeInTheDocument();
+		await userEvent.hover(badge);
+		const tooltip = await within(canvasElement.ownerDocument.body).findByRole(
+			"tooltip",
+		);
+		await expect(tooltip).toHaveTextContent(
+			"This provider works with the AI Gateway proxy but Coder Agents can't use it.",
+		);
 	},
 };
 
@@ -117,7 +125,7 @@ export const WithHostnameCollisionWarning: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const badge = canvas.getByText(/warning/i);
+		const badge = canvas.getByLabelText(/^Warning: Hostname/);
 		await expect(badge).toBeInTheDocument();
 		await expect(badge).toHaveAttribute(
 			"aria-label",
@@ -127,9 +135,10 @@ export const WithHostnameCollisionWarning: Story = {
 
 		// Hover shows the tooltip with the warning text.
 		await userEvent.hover(badge);
-		await expect(
-			await canvas.findByText(/api\.openai\.com/, {}, { timeout: 2000 }),
-		).toBeInTheDocument();
+		const tooltip = await within(canvasElement.ownerDocument.body).findByRole(
+			"tooltip",
+		);
+		await expect(tooltip).toHaveTextContent("api.openai.com");
 
 		// Keyboard and mouse activation must not navigate the row.
 		badge.focus();

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
@@ -26,14 +26,9 @@ const meta: Meta<typeof ProviderRow> = {
 			<Table className="table-fixed" aria-label="AI providers">
 				<TableHeader>
 					<TableRow>
-						<TableHead className="w-[42%]">Name</TableHead>
-						<TableHead className="w-[38%]">Base URL</TableHead>
-						<TableHead className="w-20 text-center">
-							<span className="sr-only">Enabled</span>
-						</TableHead>
-						<TableHead className="w-12">
-							<span className="sr-only">Open provider</span>
-						</TableHead>
+						<TableHead className="w-1/3">Name</TableHead>
+						<TableHead className="w-1/3">Base URL</TableHead>
+						<TableHead className="w-22">Status</TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody>

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof ProviderRow> = {
 	},
 	decorators: [
 		(Story) => (
-			<Table className="table-fixed" aria-label="AI providers">
+			<Table aria-label="AI providers">
 				<TableHeader>
 					<TableRow>
 						<TableHead className="w-1/3">Name</TableHead>

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.stories.tsx
@@ -93,7 +93,7 @@ export const NotSupportedInAgents: Story = {
 			"tooltip",
 		);
 		await expect(tooltip).toHaveTextContent(
-			"This provider works with the AI Gateway proxy but Coder Agents can't use it.",
+			"This provider works with the AI Gateway Proxy but Coder Agents can't use it.",
 		);
 	},
 };

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
@@ -82,7 +82,7 @@ export const ProviderRow: React.FC<ProviderRowProps> = ({
 								</Badge>
 							</TooltipTrigger>
 							<TooltipContent className="max-w-xs">
-								This provider works with the AI Gateway proxy but Coder Agents
+								This provider works with the AI Gateway Proxy but Coder Agents
 								can't use it.
 							</TooltipContent>
 						</Tooltip>

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
@@ -68,18 +68,31 @@ export const ProviderRow: React.FC<ProviderRowProps> = ({
 				<div className="flex flex-wrap items-center gap-1">
 					{provider.enabled && <Badge variant="default">Enabled</Badge>}
 					{AgentsUnsupportedProviderTypes.some((t) => t === provider.type) && (
-						<Badge
-							variant="info"
-							title="This provider works with the AI Gateway proxy but Coder Agents can't use it."
-						>
-							Not supported in Agents
-						</Badge>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Badge
+									variant="info"
+									role="button"
+									tabIndex={0}
+									onClick={stopPropagation}
+									onKeyDown={stopPropagation}
+									onKeyUp={stopPropagation}
+								>
+									Not supported in Agents
+								</Badge>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-xs">
+								This provider works with the AI Gateway proxy but Coder Agents
+								can't use it.
+							</TooltipContent>
+						</Tooltip>
 					)}
 					{provider.status?.warnings && provider.status.warnings.length > 0 && (
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<Badge
 									variant="warning"
+									role="button"
 									tabIndex={0}
 									aria-label={`Warning: ${provider.status.warnings.join("; ")}`}
 									onClick={stopPropagation}
@@ -89,7 +102,7 @@ export const ProviderRow: React.FC<ProviderRowProps> = ({
 									Warning
 								</Badge>
 							</TooltipTrigger>
-							<TooltipContent>
+							<TooltipContent className="max-w-xs">
 								{provider.status.warnings.map((warning) => (
 									<p key={warning}>{warning}</p>
 								))}


### PR DESCRIPTION
The AI provider status badges used different tooltip implementations, and long warning messages could render as a single wide line.

Use the shared tooltip component for both badges, constrain tooltip width for readable wrapping, and cover the portaled tooltip content and accessible triggers in Storybook.

Related to #28549.

<details>
<summary>Screenshots</summary>

**Before**

<img width="1274" height="113" alt="before_proxy_warning" src="https://github.com/user-attachments/assets/3fb6f317-50d5-434c-8713-cbfab60f6550" />

<img width="1085" height="116" alt="before_agent_warning" src="https://github.com/user-attachments/assets/4d0f4a6a-81b6-49bc-8bc0-f4ea63eb9af0" />

**After**

<img width="998" height="190" alt="after_proxy_warning" src="https://github.com/user-attachments/assets/57076e70-eaaf-43b7-b15a-5861ffe5054c" />

<img width="974" height="121" alt="after_agent_warning" src="https://github.com/user-attachments/assets/d27d1940-8ade-4ee2-b8a4-4f368450e6d6" />

</details>

> [!NOTE]
> Generated by Coder Agents for @ssncferreira.
