### PR TITLE
fix(coderd/x/chatd/chatprompt): keep NUL out of jsonb chat content

### DIFF
--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -1175,18 +1175,21 @@ func sanitizeToolCallID(id string) string {
 }
 
 // MarshalParts encodes SDK chat message parts for persistence.
-// NUL characters in string fields are encoded as PUA sentinel
-// pairs (U+E000 U+E001) before marshaling so the resulting JSON
-// never contains \u0000 (rejected by PostgreSQL jsonb). The
-// encoding operates on Go string values, not JSON bytes, so it
-// survives jsonb text normalization.
+// NUL characters in free-form and opaque fields are encoded as PUA
+// sentinel pairs (U+E000 U+E001) so PostgreSQL jsonb can store them.
+// Structured fields such as identifiers, paths, and media types reject
+// NUL because their downstream representations cannot consume it.
 func MarshalParts(parts []codersdk.ChatMessagePart) (pqtype.NullRawMessage, error) {
 	if len(parts) == 0 {
 		return pqtype.NullRawMessage{}, nil
 	}
-	data, err := json.Marshal(encodeNulInParts(parts))
+	encoded, err := encodeNulInParts(parts)
 	if err != nil {
-		return pqtype.NullRawMessage{}, xerrors.Errorf("encode chat message parts: %w", err)
+		return pqtype.NullRawMessage{}, xerrors.Errorf("validate chat message parts: %w", err)
+	}
+	data, err := json.Marshal(encoded)
+	if err != nil {
+		return pqtype.NullRawMessage{}, xerrors.Errorf("marshal chat message parts: %w", err)
 	}
 	return pqtype.NullRawMessage{RawMessage: data, Valid: true}, nil
 }
@@ -1797,16 +1800,12 @@ func decodeNulInValue(v any) any {
 }
 
 // encodeNulInJSON walks all string values (and keys) inside a
-// json.RawMessage and applies encodeNulInString. Returns the
-// original unchanged when the raw message does not contain NUL
-// escapes or U+E000 bytes, or when parsing fails.
+// json.RawMessage and applies encodeNulInString. It also normalizes
+// unpaired UTF-16 surrogate escapes, which PostgreSQL jsonb rejects.
+// Returns the original unchanged when no transformation is needed or
+// when parsing fails.
 func encodeNulInJSON(raw json.RawMessage) json.RawMessage {
-	if len(raw) == 0 {
-		return raw
-	}
-	// Quick exit: no \u0000 escape and no U+E000 UTF-8 bytes.
-	if !bytes.Contains(raw, []byte(`\u0000`)) &&
-		!bytes.Contains(raw, []byte{0xEE, 0x80, 0x80}) {
+	if len(raw) == 0 || !needsNulEncodingInJSON(raw) || !json.Valid(raw) {
 		return raw
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
@@ -1820,6 +1819,80 @@ func encodeNulInJSON(raw json.RawMessage) json.RawMessage {
 		return raw
 	}
 	return result
+}
+
+// needsNulEncodingInJSON reports whether valid JSON contains a string
+// value or object key that encodeNulInJSON must transform. It only
+// detects candidates; encoding/json owns parsing and normalization.
+func needsNulEncodingInJSON(raw json.RawMessage) bool {
+	// encoding/json emits U+E000 literally, while json.RawMessage may
+	// contain either the literal UTF-8 bytes or a Unicode escape.
+	if bytes.Contains(raw, []byte{0xEE, 0x80, 0x80}) {
+		return true
+	}
+
+	inString := false
+	for i := 0; i < len(raw); {
+		switch raw[i] {
+		case '"':
+			inString = !inString
+			i++
+		case '\\':
+			if !inString || i+1 >= len(raw) {
+				i++
+				continue
+			}
+			if raw[i+1] != 'u' {
+				i += 2
+				continue
+			}
+			value, ok := parseJSONHexEscape(raw[i+2:])
+			if !ok {
+				return true
+			}
+			switch {
+			case value == 0 || value == 0xE000:
+				return true
+			case 0xD800 <= value && value <= 0xDBFF:
+				if i+12 <= len(raw) && raw[i+6] == '\\' && raw[i+7] == 'u' {
+					low, lowOK := parseJSONHexEscape(raw[i+8:])
+					if lowOK && 0xDC00 <= low && low <= 0xDFFF {
+						i += 12
+						continue
+					}
+				}
+				return true
+			case 0xDC00 <= value && value <= 0xDFFF:
+				return true
+			default:
+				i += 6
+			}
+		default:
+			i++
+		}
+	}
+	return false
+}
+
+func parseJSONHexEscape(raw []byte) (uint16, bool) {
+	if len(raw) < 4 {
+		return 0, false
+	}
+	var value uint16
+	for _, c := range raw[:4] {
+		value <<= 4
+		switch {
+		case '0' <= c && c <= '9':
+			value |= uint16(c - '0')
+		case 'a' <= c && c <= 'f':
+			value |= uint16(c-'a') + 10
+		case 'A' <= c && c <= 'F':
+			value |= uint16(c-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return value, true
 }
 
 // decodeNulInJSON walks all string values (and keys) inside a
@@ -1845,33 +1918,154 @@ func decodeNulInJSON(raw json.RawMessage) json.RawMessage {
 	return result
 }
 
-// encodeNulInParts returns a shallow copy of parts with all
-// string and json.RawMessage fields NUL-encoded. The caller's
-// slice is not modified.
-func encodeNulInParts(parts []codersdk.ChatMessagePart) []codersdk.ChatMessagePart {
+// nulPolicy classifies how MarshalParts treats NUL in one persisted
+// ChatMessagePart field.
+type nulPolicy int
+
+const (
+	// nulEncode reversibly encodes NUL as PUA sentinel pairs. Used for
+	// free-form text and opaque provider data that must survive
+	// persistence byte-for-byte, e.g. Gemini binary thought signatures
+	// in ProviderMetadata.
+	nulEncode nulPolicy = iota
+	// nulReject fails MarshalParts with an actionable error. Used for
+	// structured values (enums, identifiers, paths, filenames, URLs,
+	// media types, OS labels, and parsed commands) whose downstream
+	// consumers cannot handle NUL, so persisting an encoded form would
+	// only hide invalid input.
+	nulReject
+)
+
+// partNulField binds one string-bearing ChatMessagePart field to its
+// NUL policy. Pointer accessors let encoding, decoding, and validation
+// share the table. Exactly one accessor is set per entry; grid is only
+// supported with nulReject and raw only with nulEncode. Unsupported
+// combinations and missing entries for new string-bearing fields are
+// caught by TestChatMessagePartNULCoverage.
+type partNulField struct {
+	name   string
+	policy nulPolicy
+	str    func(*codersdk.ChatMessagePart) *string
+	raw    func(*codersdk.ChatMessagePart) *json.RawMessage
+	grid   func(*codersdk.ChatMessagePart) [][]string
+}
+
+// partNulFields classifies every persisted string-bearing field of
+// codersdk.ChatMessagePart. Adding a string-bearing field to the struct
+// requires an entry here.
+var partNulFields = []partNulField{
+	{name: "Text", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.Text }},
+	{name: "Args", policy: nulEncode, raw: func(p *codersdk.ChatMessagePart) *json.RawMessage { return &p.Args }},
+	{name: "ArgsDelta", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.ArgsDelta }},
+	{name: "Result", policy: nulEncode, raw: func(p *codersdk.ChatMessagePart) *json.RawMessage { return &p.Result }},
+	{name: "ResultDelta", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.ResultDelta }},
+	{name: "Title", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.Title }},
+	{name: "Content", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.Content }},
+	{name: "ProviderMetadata", policy: nulEncode, raw: func(p *codersdk.ChatMessagePart) *json.RawMessage { return &p.ProviderMetadata }},
+	{name: "ContextFileContent", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.ContextFileContent }},
+	{name: "SkillDescription", policy: nulEncode, str: func(p *codersdk.ChatMessagePart) *string { return &p.SkillDescription }},
+	{name: "Type", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return (*string)(&p.Type) }},
+	{name: "ToolCallID", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.ToolCallID }},
+	{name: "ToolName", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.ToolName }},
+	{name: "ParsedCommands", policy: nulReject, grid: func(p *codersdk.ChatMessagePart) [][]string { return p.ParsedCommands }},
+	{name: "SourceID", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.SourceID }},
+	{name: "URL", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.URL }},
+	{name: "MediaType", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.MediaType }},
+	{name: "Name", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.Name }},
+	{name: "FileName", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.FileName }},
+	{name: "ContextFilePath", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.ContextFilePath }},
+	{name: "ContextFileOS", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.ContextFileOS }},
+	{name: "ContextFileDirectory", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.ContextFileDirectory }},
+	{name: "ContextFileSkillMetaFile", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.ContextFileSkillMetaFile }},
+	{name: "SkillName", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.SkillName }},
+	{name: "SkillDir", policy: nulReject, str: func(p *codersdk.ChatMessagePart) *string { return &p.SkillDir }},
+}
+
+// encode applies the reversible NUL encoding to a nulEncode field.
+func (f partNulField) encode(p *codersdk.ChatMessagePart) {
+	switch {
+	case f.str != nil:
+		*f.str(p) = encodeNulInString(*f.str(p))
+	case f.raw != nil:
+		*f.raw(p) = encodeNulInJSON(*f.raw(p))
+	}
+}
+
+// decode reverses encode.
+func (f partNulField) decode(p *codersdk.ChatMessagePart) {
+	switch {
+	case f.str != nil:
+		*f.str(p) = decodeNulInString(*f.str(p))
+	case f.raw != nil:
+		*f.raw(p) = decodeNulInJSON(*f.raw(p))
+	}
+}
+
+// validateNulFree returns an actionable error when a nulReject field
+// contains NUL.
+func (f partNulField) validateNulFree(partIndex int, p *codersdk.ChatMessagePart) error {
+	switch {
+	case f.str != nil:
+		if nul := strings.IndexByte(*f.str(p), 0); nul >= 0 {
+			return xerrors.Errorf(
+				"chat message part %d field %s contains NUL at byte %d",
+				partIndex,
+				f.name,
+				nul,
+			)
+		}
+	case f.grid != nil:
+		for i, values := range f.grid(p) {
+			for j, value := range values {
+				if nul := strings.IndexByte(value, 0); nul >= 0 {
+					return xerrors.Errorf(
+						"chat message part %d field %s[%d][%d] contains NUL at byte %d",
+						partIndex,
+						f.name,
+						i,
+						j,
+						nul,
+					)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// encodeNulInParts returns a copy of parts with every nulEncode field
+// encoded and every nulReject field validated per partNulFields. The
+// caller's values are not modified.
+//
+// Content version 1 cannot distinguish sentinel pairs written by this
+// codec from matching natural text stored before a field was covered, so
+// matching historical values in encoded fields decode as NUL.
+func encodeNulInParts(parts []codersdk.ChatMessagePart) ([]codersdk.ChatMessagePart, error) {
 	encoded := make([]codersdk.ChatMessagePart, len(parts))
 	copy(encoded, parts)
 	for i := range encoded {
 		p := &encoded[i]
-		p.Text = encodeNulInString(p.Text)
-		p.Content = encodeNulInString(p.Content)
-		p.Args = encodeNulInJSON(p.Args)
-		p.ArgsDelta = encodeNulInString(p.ArgsDelta)
-		p.Result = encodeNulInJSON(p.Result)
-		p.ResultDelta = encodeNulInString(p.ResultDelta)
+		for _, f := range partNulFields {
+			switch f.policy {
+			case nulEncode:
+				f.encode(p)
+			case nulReject:
+				if err := f.validateNulFree(i, p); err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
-	return encoded
+	return encoded, nil
 }
 
 // decodeNulInParts reverses encodeNulInParts in place.
 func decodeNulInParts(parts []codersdk.ChatMessagePart) {
 	for i := range parts {
-		p := &parts[i]
-		p.Text = decodeNulInString(p.Text)
-		p.Content = decodeNulInString(p.Content)
-		p.Args = decodeNulInJSON(p.Args)
-		p.ArgsDelta = decodeNulInString(p.ArgsDelta)
-		p.Result = decodeNulInJSON(p.Result)
-		p.ResultDelta = decodeNulInString(p.ResultDelta)
+		for _, f := range partNulFields {
+			if f.policy == nulEncode {
+				f.decode(&parts[i])
+			}
+		}
 	}
 }

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -2008,7 +2008,7 @@ func extractToolResultIDs(t *testing.T, msgs ...fantasy.Message) []string {
 func TestNulEscapeRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	db, _ := dbtestutil.NewDB(t)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
 
 	// Seed minimal dependencies for the DB round-trip path:
 	// user, provider, model config, chat.
@@ -2189,6 +2189,15 @@ func TestNulEscapeRoundTrip(t *testing.T) {
 		})
 		readBack, err := db.GetChatMessageByID(ctx, dbMsg.ID)
 		require.NoError(t, err)
+
+		// Physical evidence of the encoding: the stored jsonb row contains
+		// one sentinel pair per NUL byte and no \u0000 escape.
+		var stored string
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT content::text FROM chat_messages WHERE id = $1", dbMsg.ID,
+		).Scan(&stored))
+		require.NotContains(t, stored, `\u0000`)
+		require.Equal(t, 2, strings.Count(stored, "\uE000\uE001"))
 
 		prompt, err := chatprompt.ConvertMessagesWithFiles(
 			ctx,

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasygoogle "charm.land/fantasy/providers/google"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/assert"
@@ -2155,6 +2156,88 @@ func TestNulEscapeRoundTrip(t *testing.T) {
 		// JSON re-serialization may reformat, so compare
 		// semantically.
 		assert.JSONEq(t, string(resultJSON), string(decoded[0].Result))
+	})
+
+	// Gemini thought signatures are binary data converted directly to a
+	// string by the Google provider. NUL bytes in the signature must survive
+	// the full persistence and provider-metadata round-trip.
+	t.Run("GeminiReasoningMetadataWithNul", func(t *testing.T) {
+		t.Parallel()
+
+		const signature = "binary\x00thought\x00signature"
+		part := chatprompt.PartFromContent(fantasy.ReasoningContent{
+			Text: "reasoning",
+			ProviderMetadata: fantasy.ProviderMetadata{
+				fantasygoogle.Name: &fantasygoogle.ReasoningMetadata{
+					Signature: signature,
+					ToolID:    "tool-1",
+				},
+			},
+		})
+		encoded, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{part})
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded.RawMessage), `\u0000`)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		dbMsg := dbgen.ChatMessage(t, db, database.ChatMessage{
+			ChatID:         chat.ID,
+			CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+			ModelConfigID:  uuid.NullUUID{UUID: model.ID, Valid: true},
+			Role:           database.ChatMessageRoleAssistant,
+			Content:        encoded,
+			ContentVersion: chatprompt.CurrentContentVersion,
+		})
+		readBack, err := db.GetChatMessageByID(ctx, dbMsg.ID)
+		require.NoError(t, err)
+
+		prompt, err := chatprompt.ConvertMessagesWithFiles(
+			ctx,
+			[]database.ChatMessage{readBack},
+			nil,
+			slogtest.Make(t, nil),
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, prompt, 1)
+		require.Len(t, prompt[0].Content, 1)
+		reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](prompt[0].Content[0])
+		require.True(t, ok)
+		metadata := fantasygoogle.GetReasoningMetadata(reasoning.ProviderOptions)
+		require.NotNil(t, metadata)
+		require.Equal(t, signature, metadata.Signature)
+	})
+
+	// PostgreSQL rejects lone UTF-16 surrogate escapes. The RawMessage
+	// encoder normalizes them through encoding/json before persistence.
+	t.Run("ToolArgsWithLoneSurrogate", func(t *testing.T) {
+		t.Parallel()
+
+		parts := []codersdk.ChatMessagePart{{
+			Type: codersdk.ChatMessagePartTypeToolCall,
+			Args: json.RawMessage(`{"value":"before\uD800after","pair":"\uD83D\uDE00","literal":"\\uD800"}`),
+		}}
+		encoded, err := chatprompt.MarshalParts(parts)
+		require.NoError(t, err)
+		require.NotContains(t, string(encoded.RawMessage), `\uD800after`)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		dbMsg := dbgen.ChatMessage(t, db, database.ChatMessage{
+			ChatID:         chat.ID,
+			CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+			ModelConfigID:  uuid.NullUUID{UUID: model.ID, Valid: true},
+			Role:           database.ChatMessageRoleAssistant,
+			Content:        encoded,
+			ContentVersion: chatprompt.CurrentContentVersion,
+		})
+		readBack, err := db.GetChatMessageByID(ctx, dbMsg.ID)
+		require.NoError(t, err)
+		decoded, err := chatprompt.ParseContent(readBack)
+		require.NoError(t, err)
+		require.Len(t, decoded, 1)
+		assert.JSONEq(t,
+			`{"value":"before�after","pair":"😀","literal":"\\uD800"}`,
+			string(decoded[0].Args),
+		)
 	})
 
 	// Multiple parts in one message: one with NUL, one without.

--- a/coderd/x/chatd/chatprompt/export_test.go
+++ b/coderd/x/chatd/chatprompt/export_test.go
@@ -15,6 +15,12 @@ const SyntheticPasteTitleBudgetForTest = syntheticPasteTitleBudget
 // for external tests.
 var ToolResultPartToMessagePartForTest = toolResultPartToMessagePart
 
+// EncodeNulInJSONForTest exposes encodeNulInJSON for external tests.
+var EncodeNulInJSONForTest = encodeNulInJSON
+
+// NeedsNulEncodingInJSONForTest exposes needsNulEncodingInJSON for external tests.
+var NeedsNulEncodingInJSONForTest = needsNulEncodingInJSON
+
 // ToolResultContentToPartForTest exposes toolResultContentToPart
 // for external tests.
 var ToolResultContentToPartForTest = func(logger slog.Logger, content fantasy.ToolResultContent) codersdk.ChatMessagePart {

--- a/coderd/x/chatd/chatprompt/nul_coverage_test.go
+++ b/coderd/x/chatd/chatprompt/nul_coverage_test.go
@@ -1,0 +1,302 @@
+package chatprompt_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// Probe values injected into string-bearing fields. The NUL probe's
+// prefix "before" puts the NUL at byte 6, which rejection tests assert.
+const (
+	nulProbe             = "before\x00middle\uE000\uE001after"
+	naturalSentinelProbe = "before\uE000\uE001after"
+)
+
+func TestNeedsNulEncodingInJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{name: "clean", raw: json.RawMessage(`{"value":"clean"}`)},
+		{name: "nul", raw: json.RawMessage(`{"value":"\u0000"}`), want: true},
+		{name: "escaped nul text", raw: json.RawMessage(`{"value":"\\u0000"}`)},
+		{name: "escaped backslash then nul", raw: json.RawMessage(`{"value":"\\\u0000"}`), want: true},
+		{name: "ordinary unicode escape", raw: json.RawMessage(`{"value":"\u1234"}`)},
+		{name: "truncated unicode escape", raw: json.RawMessage(`{"value":"\u12"}`), want: true},
+		{name: "unicode escape without digits", raw: json.RawMessage(`{"value":"\u`), want: true},
+		{name: "invalid unicode escape", raw: json.RawMessage(`{"value":"\uZZZZ"}`), want: true},
+		{name: "backslash outside string", raw: json.RawMessage(`\`)},
+		{name: "trailing backslash in string", raw: json.RawMessage(`{"value":"\`)},
+
+		{name: "two escaped backslashes then nul text", raw: json.RawMessage(`{"value":"\\\\u0000"}`)},
+		{name: "escaped sentinel", raw: json.RawMessage(`{"value":"\uE000"}`), want: true},
+		{name: "literal sentinel", raw: json.RawMessage(`{"value":""}`), want: true},
+		{name: "valid surrogate pair", raw: json.RawMessage(`{"value":"\uD83D\uDE00"}`)},
+		{name: "mixed case surrogate pair", raw: json.RawMessage(`{"value":"\ud83D\uDe00"}`)},
+		{name: "lone high surrogate", raw: json.RawMessage(`{"value":"\uD800"}`), want: true},
+		{name: "lone low surrogate", raw: json.RawMessage(`{"value":"\udc00"}`), want: true},
+		{name: "reversed surrogate pair", raw: json.RawMessage(`{"value":"\uDC00\uD800"}`), want: true},
+		{name: "surrogate literal text", raw: json.RawMessage(`{"value":"\\uD800"}`)},
+		{name: "object key", raw: json.RawMessage(`{"key\u0000":"value"}`), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chatprompt.NeedsNulEncodingInJSONForTest(tt.raw)
+			require.Equalf(t, tt.want, got, "needsNulEncodingInJSON(%s)", tt.raw)
+		})
+	}
+}
+
+func TestEncodeNulInJSONPreservesCleanInput(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"number":1.2300,"pair":"\uD83D\uDE00","literal":"\\u0000"}`)
+	encoded := chatprompt.EncodeNulInJSONForTest(raw)
+	require.Equal(t, raw, encoded, "clean JSON changed")
+	require.Same(t, &raw[0], &encoded[0], "clean JSON did not preserve its backing array")
+}
+
+func TestEncodeNulInJSONNormalizesSurrogates(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"high":"\uD800","low":"\uDC00","pair":"\uD83D\uDE00","literal":"\\uD800"}`)
+	encoded := chatprompt.EncodeNulInJSONForTest(raw)
+	require.Truef(t, json.Valid(encoded), "encoded invalid JSON: %s", encoded)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(encoded, &got))
+	want := map[string]string{
+		"high":    "�",
+		"low":     "�",
+		"pair":    "😀",
+		"literal": `\uD800`,
+	}
+	require.Equal(t, want, got, "normalized JSON mismatch")
+}
+
+func TestEncodeNulInJSONPreservesInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"value":"\uD800"} trailing`)
+	encoded := chatprompt.EncodeNulInJSONForTest(raw)
+	require.Equal(t, raw, encoded, "invalid JSON changed")
+}
+
+func TestChatMessagePartNaturalSentinelCoverage(t *testing.T) {
+	t.Parallel()
+
+	partType := reflect.TypeFor[codersdk.ChatMessagePart]()
+	for i := range partType.NumField() {
+		field := partType.Field(i)
+		if _, transforms := chatMessagePartNULProbe(t, field); !transforms {
+			continue
+		}
+
+		t.Run(field.Name, func(t *testing.T) {
+			t.Parallel()
+
+			part := reflect.New(partType).Elem()
+			part.Field(i).Set(chatMessagePartNaturalSentinelProbeValue(t, field.Type))
+			parts := []codersdk.ChatMessagePart{part.Interface().(codersdk.ChatMessagePart)}
+
+			encoded, err := chatprompt.MarshalParts(parts)
+			require.NoErrorf(t, err, "MarshalParts rejected natural sentinels in ChatMessagePart.%s (%s)", field.Name, field.Type)
+			decoded, err := chatprompt.ParseContent(database.ChatMessage{
+				Role:           database.ChatMessageRoleAssistant,
+				Content:        encoded,
+				ContentVersion: chatprompt.CurrentContentVersion,
+			})
+			require.NoErrorf(t, err, "ParseContent with natural sentinels in ChatMessagePart.%s (%s)", field.Name, field.Type)
+			require.Equalf(t, parts, decoded, "natural sentinels in ChatMessagePart.%s did not round-trip", field.Name)
+		})
+	}
+}
+
+func TestChatMessagePartNULCoverage(t *testing.T) {
+	t.Parallel()
+
+	partType := reflect.TypeFor[codersdk.ChatMessagePart]()
+	for i := range partType.NumField() {
+		field := partType.Field(i)
+		probe, transforms := chatMessagePartNULProbe(t, field)
+
+		t.Run(field.Name, func(t *testing.T) {
+			t.Parallel()
+
+			part := reflect.New(partType).Elem()
+			part.Field(i).Set(probe)
+			parts := []codersdk.ChatMessagePart{part.Interface().(codersdk.ChatMessagePart)}
+
+			want := reflect.New(partType).Elem()
+			want.Field(i).Set(chatMessagePartNULProbeValue(t, field.Type))
+			wantParts := []codersdk.ChatMessagePart{want.Interface().(codersdk.ChatMessagePart)}
+
+			encoded, err := chatprompt.MarshalParts(parts)
+			require.Equalf(t, wantParts, parts, "MarshalParts mutated caller-owned ChatMessagePart.%s data", field.Name)
+			if err != nil {
+				require.Truef(t, transforms, "MarshalParts rejected NUL-free ChatMessagePart.%s (%s): %v", field.Name, field.Type, err)
+				require.ErrorContainsf(t, err, "chat message part 0", "MarshalParts rejection for ChatMessagePart.%s does not name the part", field.Name)
+				require.ErrorContainsf(t, err, "field "+field.Name, "MarshalParts rejection for ChatMessagePart.%s does not name the field", field.Name)
+				require.ErrorContainsf(t, err, "contains NUL at byte 6", "MarshalParts rejection for ChatMessagePart.%s does not locate the NUL", field.Name)
+				return
+			}
+			if transforms {
+				require.NotContainsf(t, string(encoded.RawMessage), `\u0000`, "ChatMessagePart.%s is neither rejected nor handled by encodeNulInParts", field.Name)
+			}
+
+			decoded, err := chatprompt.ParseContent(database.ChatMessage{
+				Role:           database.ChatMessageRoleAssistant,
+				Content:        encoded,
+				ContentVersion: chatprompt.CurrentContentVersion,
+			})
+			require.NoErrorf(t, err, "ParseContent with ChatMessagePart.%s (%s)", field.Name, field.Type)
+			require.Equalf(t, wantParts, decoded, "ChatMessagePart.%s is not handled by decodeNulInParts", field.Name)
+			require.Equalf(t, wantParts, parts, "ParseContent mutated caller-owned ChatMessagePart.%s data through an encoded alias", field.Name)
+		})
+	}
+}
+
+func chatMessagePartNaturalSentinelProbeValue(t *testing.T, typ reflect.Type) reflect.Value {
+	t.Helper()
+
+	if typ == reflect.TypeFor[json.RawMessage]() {
+		return reflect.ValueOf(json.RawMessage(`{"key":"value"}`))
+	}
+	if typ.Kind() == reflect.String {
+		value := reflect.New(typ).Elem()
+		value.SetString(naturalSentinelProbe)
+		return value
+	}
+	if chatMessagePartNULTransforms(typ) {
+		return chatMessagePartStringContainerValue(t, typ, naturalSentinelProbe)
+	}
+
+	t.Fatalf("no natural sentinel probe for ChatMessagePart field type %s", typ)
+	return reflect.Value{}
+}
+
+func chatMessagePartNULProbe(t *testing.T, field reflect.StructField) (reflect.Value, bool) {
+	t.Helper()
+
+	transforms := chatMessagePartNULTransforms(field.Type)
+	if transforms || chatMessagePartNULSafeType(field.Type) {
+		return chatMessagePartNULProbeValue(t, field.Type), transforms
+	}
+
+	t.Fatalf(
+		"ChatMessagePart.%s has unknown NUL coverage shape %s; classify the type and add a partNulFields entry if it can contain strings",
+		field.Name,
+		field.Type,
+	)
+	return reflect.Value{}, false
+}
+
+func chatMessagePartNULTransforms(typ reflect.Type) bool {
+	if typ == reflect.TypeFor[json.RawMessage]() {
+		return true
+	}
+	if typ.Kind() == reflect.String {
+		return true
+	}
+	if typ.Kind() != reflect.Slice && typ.Kind() != reflect.Array {
+		return false
+	}
+	return chatMessagePartNULStringContainer(typ.Elem())
+}
+
+func chatMessagePartNULStringContainer(typ reflect.Type) bool {
+	if typ.Kind() == reflect.String {
+		return true
+	}
+	if typ.Kind() != reflect.Slice && typ.Kind() != reflect.Array {
+		return false
+	}
+	return chatMessagePartNULStringContainer(typ.Elem())
+}
+
+func chatMessagePartNULSafeType(typ reflect.Type) bool {
+	switch typ {
+	case reflect.TypeFor[bool](),
+		reflect.TypeFor[int](),
+		reflect.TypeFor[[]byte](),
+		reflect.TypeFor[uuid.NullUUID](),
+		reflect.TypeFor[*time.Time]():
+		return true
+	default:
+		return false
+	}
+}
+
+func chatMessagePartNULProbeValue(t *testing.T, typ reflect.Type) reflect.Value {
+	t.Helper()
+
+	if typ == reflect.TypeFor[json.RawMessage]() {
+		return reflect.ValueOf(json.RawMessage(`{"key\u0000":"value\u0000"}`))
+	}
+	if typ == reflect.TypeFor[[][]string]() {
+		return reflect.ValueOf([][]string{{nulProbe}, nil})
+	}
+	if typ.Kind() == reflect.String {
+		value := reflect.New(typ).Elem()
+		value.SetString(nulProbe)
+		return value
+	}
+	if chatMessagePartNULTransforms(typ) {
+		return chatMessagePartStringContainerValue(t, typ, nulProbe)
+	}
+
+	switch typ {
+	case reflect.TypeFor[bool]():
+		return reflect.ValueOf(true)
+	case reflect.TypeFor[int]():
+		return reflect.ValueOf(42)
+	case reflect.TypeFor[[]byte]():
+		return reflect.ValueOf([]byte{0, 1, 2})
+	case reflect.TypeFor[uuid.NullUUID]():
+		return reflect.ValueOf(uuid.NullUUID{UUID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Valid: true})
+	case reflect.TypeFor[*time.Time]():
+		return reflect.ValueOf(new(time.Date(2026, time.August, 25, 1, 2, 3, 0, time.UTC)))
+	default:
+		t.Fatalf("no probe value for recognized ChatMessagePart field type %s", typ)
+		return reflect.Value{}
+	}
+}
+
+func chatMessagePartStringContainerValue(t *testing.T, typ reflect.Type, probe string) reflect.Value {
+	t.Helper()
+
+	if typ.Kind() == reflect.String {
+		value := reflect.New(typ).Elem()
+		value.SetString(probe)
+		return value
+	}
+
+	switch typ.Kind() {
+	case reflect.Slice:
+		value := reflect.MakeSlice(typ, 1, 1)
+		value.Index(0).Set(chatMessagePartStringContainerValue(t, typ.Elem(), probe))
+		return value
+	case reflect.Array:
+		if typ.Len() == 0 {
+			t.Fatalf("cannot inject a string probe into zero-length string container %s", typ)
+		}
+		value := reflect.New(typ).Elem()
+		value.Index(0).Set(chatMessagePartStringContainerValue(t, typ.Elem(), probe))
+		return value
+	default:
+		t.Fatalf("unsupported recursive string container %s", typ)
+		return reflect.Value{}
+	}
+}


### PR DESCRIPTION
Fixes #25555
Refs CODAGT-463

## Why

PostgreSQL jsonb rejects `\u0000` and lone UTF-16 surrogate escapes. Gemini binary thought signatures reach `ChatMessagePart.ProviderMetadata` as strings containing NUL (fantasy converts `ThoughtSignature []byte` with `string(...)`), and the existing sentinel codec covered only six fields, so persisting Gemini tool-use steps failed with `pq: unsupported Unicode escape sequence`.

## Approach

One production table, `partNulFields`, classifies every string-bearing `ChatMessagePart` field:

- **Encode** (free-form or opaque data that must survive byte-for-byte: text, args, results, titles, provider metadata): NUL is reversibly encoded as PUA sentinel pairs, the same scheme the codec already used.
- **Reject** (structured values: enums, identifiers, paths, URLs, media types, parsed commands): `MarshalParts` errors, naming the part, field, and byte offset, because downstream consumers (syscalls, `url.Parse`) cannot handle NUL and persisting an encoded form would only hide invalid input.

Raw JSON is additionally normalized for lone surrogate escapes (to U+FFFD; PostgreSQL cannot store them), gated by a read-only lexical detector plus `json.Valid` so clean or malformed input passes through byte-identical instead of being reformatted or truncated by a lenient decode.

A reflection-driven coverage test injects NUL and natural-sentinel probes into every field through the public `MarshalParts`/`ParseContent` API. A future string-bearing field that is missing from the table fails the test with instructions; verified by mutation (removing a table entry or no-op'ing the encoder fails the corresponding subtests). Two regressions run the real flows end to end against PostgreSQL: a Gemini `ReasoningMetadata` signature with binary NUL, and tool args with lone/paired/escaped surrogates.

## A/B proof at the production insert statement

The same Gemini payload (`ReasoningMetadata` signature containing binary NUL, built via `PartFromContent` and `MarshalParts`) was inserted through the production `InsertChatMessages` query against real PostgreSQL on both sides:

- Base `64d2d8a108` (unfixed): fails with `pq: unsupported Unicode escape sequence`, the exact leaf error in the customer's log.
- This branch: insert succeeds, the stored jsonb row physically contains one U+E000 U+E001 sentinel pair per NUL byte and no `\u0000`, and `ConvertMessagesWithFiles` restores the byte-exact signature.

The committed Gemini regression now asserts the stored-row sentinel evidence directly (raw `SELECT content::text`).

The payload is representative of real traffic, not just synthetic: fantasy's recorded Gemini API cassettes (`providertests/testdata/TestGoogleCommon`) contain 34 real Google-issued thought signatures; 22 contain NUL bytes and all 34 are invalid UTF-8 when cast to a Go string. Repeating the A/B with one of those real signatures gives the same result: the customer's exact error on base, successful sentinel-encoded persistence with the NUL escape restored on decode on this branch.

## E2E verification (dev server on this branch, real Gemini key)

The reported repro was run live through the gateway path: a `gemini-3.5-flash` chat executed `which workspaces are available` (tool call, tool result, answer) and a follow-up turn replayed the persisted history. Both turns completed; zero `unsupported Unicode escape sequence` errors in the server log. Note the live run could not exercise the signature vector itself: on this branch chat generation always routes through the AI gateway's OpenAI-compat wire, where signatures travel as base64 text in `tool_calls[].extra_content.google.thought_signature` (with Google's documented dummy-signature fallback injected by `googleopenai.AddThoughtSignaturesToLatestTurn`). Base64 text cannot contain binary NUL, so the customer's exact payload cannot arrive via chat anymore; the binary vector remains reachable only through native `fantasygoogle` paths. The NUL/surrogate class is exercised against real PostgreSQL by the regression tests instead.

## Known limitations

- NUL is the only byte class preserved in signatures. Other invalid UTF-8 is corrupted to U+FFFD by `json.Marshal` upstream of this codec; root fix belongs in fantasy (`Signature` should be `[]byte`). Tracked in CODAGT-986 and scoped to paths using the native `fantasygoogle` client: current chat generation routes exclusively through the AI gateway on the OpenAI-compat wire, which carries no thought signatures at all.
- NUL now survives decode into memory, so chat debug step inserts fail non-fatally (warn + dropped debug data) when prompt text contains NUL. Tracked in CODAGT-987.
- Content version 1 cannot distinguish codec sentinels from identical natural U+E000 U+E001 text stored before a field was covered; such historical values decode as NUL. Documented at `encodeNulInParts`; probability negligible.
- Alternative considered and rejected: switching the column to the permissive `json` type removes the codec but breaks `jsonb_array_elements`, `jsonb_typeof`, `@>`, and content search in `chats.sql` (verified against Postgres 13).

<details>
<summary>Implementation plan</summary>

# CODAGT-463: Complete the existing V1 field codec

## Direction for approval

### Outcome

Gemini tool-use steps and other chat messages persist successfully when any `codersdk.ChatMessagePart` string contains NUL or any raw JSON field contains PostgreSQL-invalid Unicode escapes.

### Recommended direction

Make the smallest extension of the existing V1 design:

1. Keep `encodeNulInParts` and `decodeNulInParts` as direct, handwritten traversal.
2. Add every current string-bearing field omitted from that traversal.
3. Keep the existing semantic `json.RawMessage` decode, walk, and re-marshal implementation, but activate it for NUL, escaped or literal U+E000, and unpaired surrogate escapes.
4. Add one reflection-driven behavioral test that automatically exercises every current and future string-bearing `ChatMessagePart` field through `MarshalParts` and `ParseContent`.

There is no production registry, reflection, code generation, whole-document transform, content-version change, or migration.

### Reason

The production fix is ordinary field assignment and one loop for `ParsedCommands`. The test supplies the durability: a new direct string, raw JSON field, or nested string container is automatically populated with a probe value and fails by field name if the production traversal does not encode and decode it.

This retains the existing, understood V1 boundary and limits lexical JSON logic to detection. Actual raw JSON transformation continues to use `encoding/json` rather than a handwritten mutating parser.

### Observable end state

- All current direct string fields round-trip NUL and natural sentinel values.
- `Args`, `Result`, and `ProviderMetadata` encode NUL in keys and values.
- `ParsedCommands [][]string` is encoded without mutating caller-owned slices.
- Lone surrogate escapes in raw JSON become U+FFFD before PostgreSQL.
- Valid surrogate pairs retain their semantic value.
- Adding a future string-bearing field causes a test failure naming the field and the required production functions to update.
- Adding an unsupported field shape causes an actionable test failure instead of being skipped.

### Decisions and constraints

- `ContentVersionV1` remains current.
- Historical V1 sentinel ambiguity is accepted because a new content version is explicitly out of scope.
- Existing REST and SSE serialization must not change.
- The encoder must not mutate the caller's parts or nested slices.
- Raw JSON may be reformatted only when it contains data requiring transformation. Clean raw JSON returns unchanged.
- The unavailable customer payload prevents proving its exact offending field. The regression covers the demonstrated Gemini metadata path and the separate raw-surrogate path.

### Ruled-out directions

- **Content V2:** explicitly rejected.
- **Whole-document lexical transform:** rejected because it widens V1 decoding and adds a larger custom JSON parser surface.
- **Production handler registry:** rejected as more machinery than direct assignments.
- **Generics-based registry:** rejected as harder to read without removing explicit field maintenance.
- **Code generation:** rejected as unnecessary once behavior is mechanically tested.
- **Runtime reflection or persistence tags:** rejected as production complexity for a small traversal.

## Implementation detail

### 1. Complete the handwritten traversal

Update `encodeNulInParts` and `decodeNulInParts` in `coderd/x/chatd/chatprompt/chatprompt.go`.

Apply the string codec to every direct or named string field on `codersdk.ChatMessagePart`, including the discriminant and all tool, source, file, context-file, and skill strings.

Apply the raw JSON codec to:

- `Args`
- `Result`
- `ProviderMetadata`

Handle `ParsedCommands [][]string` with typed nested loops. Encoding must clone the outer and inner slices before changing strings. Decoding may operate in place after `json.Unmarshal`.

Leave scalar booleans, integers, UUID values, timestamps, and `[]byte` unchanged.

### 2. Extend raw JSON candidate detection

Keep `encodeNulInJSON` based on `json.Unmarshal`, recursive semantic transformation, and `json.Marshal`.

Replace its current incomplete fast-path check with a read-only detector that recognizes actual JSON string content requiring the slow path:

- `\u0000`
- escaped or literal U+E000
- lone high or low surrogate escapes

The detector must account for JSON string boundaries and escaped backslashes. It must not mutate JSON. Valid adjacent surrogate pairs alone do not require transformation.

When the detector reports a candidate:

- `json.Unmarshal` supplies the semantic value and normalizes lone surrogates to U+FFFD;
- the existing recursive value walker encodes NUL and U+E000 in keys and values;
- `json.Marshal` produces PostgreSQL-safe JSON.

Keep `decodeNulInJSON` unchanged except for applying it to `ProviderMetadata` through the completed part traversal.

### 3. Add automatic field coverage

Add `TestChatMessagePartNULCoverage` in the internal `chatprompt` test package.

For each reflected `ChatMessagePart` field, run a subtest named after that field:

- Direct or named strings receive a value containing NUL, U+E000, and U+E001.
- `json.RawMessage` receives valid nested JSON with NUL and natural sentinel values in keys and values.
- Slices and arrays recursively containing strings receive populated nested values, covering `ParsedCommands`.
- Known non-string representations such as booleans, numbers, UUIDs, timestamps, and `[]byte` are recognized as safe and skipped.
- Any unknown shape fails with the full field name and type.

Each transforming subtest must:

1. Call `MarshalParts` on a value with only that field populated.
2. Assert the persisted JSON contains no `\u0000`.
3. Call `ParseContent` and compare the named field with its original value.
4. Assert the input value and nested containers were not mutated.

A missing traversal assignment must fail in the subtest for that field. An unsupported future shape must fail with guidance equivalent to:

```text
ChatMessagePart.<Field> has unsupported persistence coverage type <Type>.
If it can marshal arbitrary strings, extend the test probe and
encodeNulInParts/decodeNulInParts. Otherwise classify its concrete type as safe.
```

This test has no production field-name list and no parallel test registry to maintain.

### 4. Add focused regressions

Extend `chatprompt` tests with:

- actual `fantasygoogle.ReasoningMetadata` whose signature contains binary NUL, serialized through `ProviderMetadata`;
- NUL in raw JSON object keys and values;
- lone high and low surrogate escapes becoming U+FFFD;
- valid surrogate pairs preserving their semantic character;
- escaped literal text such as `\\u0000` and `\\uD800` remaining literal text;
- clean raw JSON returning unchanged;
- PostgreSQL `jsonb` insertion and read-back for Gemini metadata and raw tool arguments.

### 5. Verification

Run:

```sh
go test ./coderd/x/chatd/chatprompt -count=1
go test ./coderd/x/chatd/chatstate ./coderd/database -count=1
make fmt
make lint
make pre-commit
```

Verify the original failure path: a Gemini-shaped tool-use step containing a binary thought signature marshals, inserts through `InsertChatMessages`, and parses successfully.

## Invariants

- V1 remains the only current write format.
- Production traversal stays explicit and local.
- Every present and future string-bearing field is behaviorally covered by reflection-driven tests.
- Unknown future field shapes fail rather than being silently skipped.
- NUL and unpaired surrogate escapes cannot reach PostgreSQL JSONB through `ChatMessagePart`.
- Valid data round-trips once through the existing V1 codec.
- Caller-owned data is not mutated.
- No unrelated code, schema, API, or generated artifact changes.

## Post-review revision (2026-08-26)

Applied after a fresh critique and a second independent review:

- The field policy now lives in one production table, `partNulFields`, mapping every string-bearing `ChatMessagePart` field to `nulEncode` or `nulReject` with pointer accessors shared by encode, decode, and validate. Removing an entry fails `TestChatMessagePartNULCoverage` (proven by mutation).
- `MarshalParts` wraps rejection as "validate chat message parts" and marshal failure as "marshal chat message parts".
- The coverage test uses testify and one shared probe walker; probe strings are named constants.
- A reviewer claim that the RawMessage natural-sentinel subtests were vacuous was rejected with evidence: the probes contain literal, invisible U+E000 U+E001 bytes (od-verified), and a no-op-encoder mutation fails those subtests.

## Residual limitations for the PR body

- The fix stops the pq error, but Gemini thought signatures with invalid UTF-8 (nearly all binary blobs) are corrupted to U+FFFD by json.Marshal upstream of this codec. NUL is the only byte class preserved. Filed as CODAGT-986; root fix is fantasy's `Signature string` becoming `[]byte`.
- NUL now survives decode into memory; chat debug step inserts fail non-fatally when prompt text contains NUL, silently dropping debug data. Filed as CODAGT-987.
- Lone surrogate escapes in raw JSON normalize to U+FFFD (PostgreSQL cannot store them); this is lossy by design and covered by tests.
- Historical rows containing natural U+E000 U+E001 pairs in newly covered fields decode as NUL (documented at `encodeNulInParts`; probability negligible).
- Alternative rejected with evidence: switching the column to the permissive `json` type would delete the codec but break `jsonb_array_elements`, `jsonb_typeof`, `@>`, and content search in chats.sql (verified against Postgres 13).

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
