### PR TITLE
fix(site): preserve organization in model setup links

### DIFF
--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { cn } from "cn";
 import type { FC, ReactNode } from "react";
-import { NavLink } from "react-router";
+import { NavLink, type To } from "react-router";
 
 interface SidebarProps {
 	children?: ReactNode;
@@ -15,7 +15,7 @@ export const Sidebar: FC<SidebarProps> = ({ className, children }) => {
 
 interface SettingsSidebarNavItemProps {
 	children?: ReactNode;
-	href: string;
+	href: To;
 	end?: boolean;
 }
 

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -69,6 +69,37 @@ export const ModelsActive: Story = {
 	},
 };
 
+export const OrganizationParamPreserved: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/models",
+				searchParams: { org: "my organization" },
+			},
+			routing: [{ path: "/ai/settings/models", useStoryElement: true }],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("link", { name: "Models" })).toHaveAttribute(
+			"href",
+			"/ai/settings/models?org=my+organization",
+		);
+		await expect(
+			canvas.getByRole("link", { name: "Coder Agents" }),
+		).toHaveAttribute("href", "/ai/settings/coder-agents?org=my+organization");
+		await expect(
+			canvas.getByRole("link", { name: "MCP servers" }),
+		).toHaveAttribute("href", "/ai/settings/mcp-servers?org=my+organization");
+		await expect(
+			canvas.getByRole("link", { name: "Providers" }),
+		).toHaveAttribute("href", "/ai/settings/providers");
+		await expect(
+			canvas.getByRole("link", { name: "Templates" }),
+		).toHaveAttribute("href", "/ai/settings/templates");
+	},
+};
+
 export const ModelsActiveOnOrganizationRoute: Story = {
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -296,6 +327,35 @@ export const MCPServersForCreateOnlyAdmin: Story = {
 		await expect(
 			canvas.getByRole("link", { name: "MCP servers" }),
 		).toHaveAttribute("href", "/ai/settings/mcp-servers/add");
+	},
+};
+
+export const MCPServersForCreateOnlyAdminPreservesOrganization: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			createAnyMCPServerConfig: true,
+		},
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/ai/settings/mcp-servers/add",
+				searchParams: { org: MockDefaultOrganization.name },
+			},
+			routing: [
+				{ path: "/ai/settings/mcp-servers/add", useStoryElement: true },
+			],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: "MCP servers" }),
+		).toHaveAttribute(
+			"href",
+			`/ai/settings/mcp-servers/add?org=${MockDefaultOrganization.name}`,
+		);
 	},
 };
 

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLocation } from "react-router";
 import { expect, userEvent, waitFor, within } from "storybook/test";
-import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import {
+	type RouterRoute,
+	reactRouterParameters,
+} from "storybook-addon-remix-react-router";
 import { organizationsPermissions } from "#/api/queries/organizations";
 import {
 	MockDefaultOrganization,
@@ -16,27 +20,68 @@ import {
 import { AISettingsSidebar } from "./AISettingsSidebar";
 import AISettingsSidebarView from "./AISettingsSidebarView";
 
+const LocationProbe = () => {
+	const location = useLocation();
+	return (
+		<p role="status" aria-label="Current location" className="sr-only">
+			{location.pathname}
+			{location.search}
+		</p>
+	);
+};
+
+const aiSettingsRoutes: [RouterRoute, ...RouterRoute[]] = [
+	{ path: "/ai/settings/governance", useStoryElement: true },
+	{ path: "/ai/settings/gateway-keys", useStoryElement: true },
+	{ path: "/ai/settings/providers", useStoryElement: true },
+	{ path: "/ai/settings/coder-agents", useStoryElement: true },
+	{ path: "/ai/settings/models", useStoryElement: true },
+	{
+		path: "/ai/settings/organizations/:organization/models",
+		useStoryElement: true,
+	},
+	{ path: "/ai/settings/mcp-servers", useStoryElement: true },
+	{ path: "/ai/settings/mcp-servers/add", useStoryElement: true },
+	{ path: "/ai/settings/templates", useStoryElement: true },
+	{ path: "/ai/settings/instructions", useStoryElement: true },
+	{ path: "/ai/settings/lifecycle", useStoryElement: true },
+];
+
+const atLocation = (path: string, searchParams?: Record<string, string>) =>
+	reactRouterParameters({
+		location: { path, searchParams },
+		routing: aiSettingsRoutes,
+	});
+
+const followLink = async (
+	canvas: ReturnType<typeof within>,
+	name: string,
+	expectedLocation: string,
+) => {
+	await userEvent.click(canvas.getByRole("link", { name }));
+	await waitFor(() =>
+		expect(
+			canvas.getByRole("status", { name: "Current location" }).textContent,
+		).toBe(expectedLocation),
+	);
+};
+
 const meta: Meta<typeof AISettingsSidebarView> = {
 	title: "modules/management/AISettingsSidebarView",
 	component: AISettingsSidebarView,
+	decorators: [
+		(Story) => (
+			<>
+				<Story />
+				<LocationProbe />
+			</>
+		),
+	],
 	args: {
 		permissions: MockPermissions,
 	},
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/ai/settings/coder-agents" },
-			routing: [
-				{ path: "/ai/settings/governance", useStoryElement: true },
-				{ path: "/ai/settings/gateway-keys", useStoryElement: true },
-				{ path: "/ai/settings/providers", useStoryElement: true },
-				{ path: "/ai/settings/coder-agents", useStoryElement: true },
-				{ path: "/ai/settings/models", useStoryElement: true },
-				{ path: "/ai/settings/mcp-servers", useStoryElement: true },
-				{ path: "/ai/settings/templates", useStoryElement: true },
-				{ path: "/ai/settings/instructions", useStoryElement: true },
-				{ path: "/ai/settings/lifecycle", useStoryElement: true },
-			],
-		}),
+		reactRouter: atLocation("/ai/settings/coder-agents"),
 	},
 };
 
@@ -55,10 +100,7 @@ export const CoderAgentsActive: Story = {
 
 export const ModelsActive: Story = {
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/ai/settings/models" },
-			routing: [{ path: "/ai/settings/models", useStoryElement: true }],
-		}),
+		reactRouter: atLocation("/ai/settings/models"),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -71,48 +113,34 @@ export const ModelsActive: Story = {
 
 export const OrganizationParamPreserved: Story = {
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: {
-				path: "/ai/settings/models",
-				searchParams: { org: "my organization" },
-			},
-			routing: [{ path: "/ai/settings/models", useStoryElement: true }],
-		}),
+		reactRouter: atLocation("/ai/settings/models", { org: "my organization" }),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByRole("link", { name: "Models" })).toHaveAttribute(
-			"href",
+		await followLink(
+			canvas,
+			"Coder Agents",
+			"/ai/settings/coder-agents?org=my+organization",
+		);
+		await followLink(
+			canvas,
+			"MCP servers",
+			"/ai/settings/mcp-servers?org=my+organization",
+		);
+		await followLink(
+			canvas,
+			"Models",
 			"/ai/settings/models?org=my+organization",
 		);
-		await expect(
-			canvas.getByRole("link", { name: "Coder Agents" }),
-		).toHaveAttribute("href", "/ai/settings/coder-agents?org=my+organization");
-		await expect(
-			canvas.getByRole("link", { name: "MCP servers" }),
-		).toHaveAttribute("href", "/ai/settings/mcp-servers?org=my+organization");
-		await expect(
-			canvas.getByRole("link", { name: "Providers" }),
-		).toHaveAttribute("href", "/ai/settings/providers");
-		await expect(
-			canvas.getByRole("link", { name: "Templates" }),
-		).toHaveAttribute("href", "/ai/settings/templates");
+		await followLink(canvas, "Providers", "/ai/settings/providers");
 	},
 };
 
 export const ModelsActiveOnOrganizationRoute: Story = {
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: {
-				path: "/ai/settings/organizations/my-organization/models",
-			},
-			routing: [
-				{
-					path: "/ai/settings/organizations/:organization/models",
-					useStoryElement: true,
-				},
-			],
-		}),
+		reactRouter: atLocation(
+			"/ai/settings/organizations/my-organization/models",
+		),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -125,19 +153,13 @@ export const ModelsActiveOnOrganizationRoute: Story = {
 
 export const LifecycleActive: Story = {
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/ai/settings/lifecycle" },
-			routing: [{ path: "/ai/settings/lifecycle", useStoryElement: true }],
-		}),
+		reactRouter: atLocation("/ai/settings/lifecycle"),
 	},
 };
 
 export const ProvidersActive: Story = {
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/ai/settings/providers" },
-			routing: [{ path: "/ai/settings/providers", useStoryElement: true }],
-		}),
+		reactRouter: atLocation("/ai/settings/providers"),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -338,22 +360,15 @@ export const MCPServersForCreateOnlyAdminPreservesOrganization: Story = {
 		},
 	},
 	parameters: {
-		reactRouter: reactRouterParameters({
-			location: {
-				path: "/ai/settings/mcp-servers/add",
-				searchParams: { org: MockDefaultOrganization.name },
-			},
-			routing: [
-				{ path: "/ai/settings/mcp-servers/add", useStoryElement: true },
-			],
+		reactRouter: atLocation("/ai/settings/mcp-servers", {
+			org: MockDefaultOrganization.name,
 		}),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(
-			canvas.getByRole("link", { name: "MCP servers" }),
-		).toHaveAttribute(
-			"href",
+		await followLink(
+			canvas,
+			"MCP servers",
 			`/ai/settings/mcp-servers/add?org=${MockDefaultOrganization.name}`,
 		);
 	},

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,6 +1,6 @@
 import { cn } from "cn";
 import type { FC, ReactNode } from "react";
-import { Link, NavLink, useMatch } from "react-router";
+import { Link, NavLink, useMatch, useSearchParams } from "react-router";
 import {
 	Sidebar as BaseSidebar,
 	SettingsSidebarNavItem as SidebarNavItem,
@@ -9,6 +9,7 @@ import {
 	canAccessAnyChatModelConfig,
 	type Permissions,
 } from "#/modules/permissions";
+import { modelOrganizationSearchParam } from "#/pages/AISettingsPage/ModelsPage/organizationModels";
 
 interface AISettingsSidebarViewProps {
 	/** Site-wide permissions. */
@@ -36,7 +37,19 @@ const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
 	</NavLink>
 );
 
-const ModelsSidebarNavItem: FC = () => {
+const organizationScopedPath = (
+	pathname: string,
+	organizationName: string | null,
+): string => {
+	if (!organizationName) {
+		return pathname;
+	}
+	const next = new URLSearchParams();
+	next.set(modelOrganizationSearchParam, organizationName);
+	return `${pathname}?${next.toString()}`;
+};
+
+const ModelsSidebarNavItem: FC<{ href: string }> = ({ href }) => {
 	const legacyMatch = useMatch("/ai/settings/models/*");
 	const organizationMatch = useMatch(
 		"/ai/settings/organizations/:organization/models/*",
@@ -45,7 +58,7 @@ const ModelsSidebarNavItem: FC = () => {
 
 	return (
 		<Link
-			to="/ai/settings/models"
+			to={href}
 			aria-current={isActive ? "page" : undefined}
 			className={cn(
 				"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
@@ -62,6 +75,25 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 	canAccessOrganizationModels = false,
 	canShareOrganizationMCPServers = false,
 }) => {
+	const [searchParams] = useSearchParams();
+	const organizationName = searchParams.get(modelOrganizationSearchParam);
+	const modelsPath = organizationScopedPath(
+		"/ai/settings/models",
+		organizationName,
+	);
+	const coderAgentsPath = organizationScopedPath(
+		"/ai/settings/coder-agents",
+		organizationName,
+	);
+	const mcpServersPath = organizationScopedPath(
+		"/ai/settings/mcp-servers",
+		organizationName,
+	);
+	const addMCPServerPath = organizationScopedPath(
+		"/ai/settings/mcp-servers/add",
+		organizationName,
+	);
+
 	return (
 		<BaseSidebar>
 			<div className="flex flex-col gap-1">
@@ -81,15 +113,15 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 					</SidebarNavItem>
 				)}
 				{(canAccessAnyChatModelConfig(permissions) ||
-					canAccessOrganizationModels) && <ModelsSidebarNavItem />}
+					canAccessOrganizationModels) && (
+					<ModelsSidebarNavItem href={modelsPath} />
+				)}
 				{(permissions.editDeploymentConfig || canAccessOrganizationModels) && (
-					<SidebarNavItem href="/ai/settings/coder-agents">
-						Coder Agents
-					</SidebarNavItem>
+					<SidebarNavItem href={coderAgentsPath}>Coder Agents</SidebarNavItem>
 				)}
 				{permissions.editDeploymentConfig && (
 					<div className="flex flex-col gap-1 ml-3 border-0 border-solid border-l border-l-border">
-						<SubNavItem href="/ai/settings/mcp-servers">MCP servers</SubNavItem>
+						<SubNavItem href={mcpServersPath}>MCP servers</SubNavItem>
 						{permissions.updateAnyTemplate && (
 							<SubNavItem href="/ai/settings/templates">Templates</SubNavItem>
 						)}
@@ -112,8 +144,8 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 									permissions.updateAnyMCPServerConfig ||
 									permissions.deleteAnyMCPServerConfig ||
 									canShareOrganizationMCPServers
-										? "/ai/settings/mcp-servers"
-										: "/ai/settings/mcp-servers/add"
+										? mcpServersPath
+										: addMCPServerPath
 								}
 							>
 								MCP servers

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,6 +1,12 @@
 import { cn } from "cn";
 import type { FC, ReactNode } from "react";
-import { Link, NavLink, useMatch, useSearchParams } from "react-router";
+import {
+	Link,
+	NavLink,
+	type To,
+	useMatch,
+	useSearchParams,
+} from "react-router";
 import {
 	Sidebar as BaseSidebar,
 	SettingsSidebarNavItem as SidebarNavItem,
@@ -18,7 +24,7 @@ interface AISettingsSidebarViewProps {
 	canShareOrganizationMCPServers?: boolean;
 }
 
-const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
+const SubNavItem: FC<{ href: To; children?: ReactNode }> = ({
 	href,
 	children,
 }) => (
@@ -40,16 +46,16 @@ const SubNavItem: FC<{ href: string; children?: ReactNode }> = ({
 const organizationScopedPath = (
 	pathname: string,
 	organizationName: string | null,
-): string => {
-	if (!organizationName) {
-		return pathname;
-	}
-	const next = new URLSearchParams();
-	next.set(modelOrganizationSearchParam, organizationName);
-	return `${pathname}?${next.toString()}`;
-};
+): To => ({
+	pathname,
+	search: organizationName
+		? new URLSearchParams({
+				[modelOrganizationSearchParam]: organizationName,
+			}).toString()
+		: "",
+});
 
-const ModelsSidebarNavItem: FC<{ href: string }> = ({ href }) => {
+const ModelsSidebarNavItem: FC<{ href: To }> = ({ href }) => {
 	const legacyMatch = useMatch("/ai/settings/models/*");
 	const organizationMatch = useMatch(
 		"/ai/settings/organizations/:organization/models/*",

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.test.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "#/testHelpers/entities";
 import {
 	organizationAddModelPath,
+	organizationModelsPath,
 	selectModelOrganization,
 	useAccessibleModelOrganizations,
 } from "./organizationModels";
@@ -65,6 +66,12 @@ describe("selectModelOrganization", () => {
 			organization: MockDefaultOrganization,
 			requestedOrganizationDenied: true,
 		});
+	});
+
+	it("builds an organization-scoped models path", () => {
+		expect(organizationModelsPath(MockOrganization2)).toBe(
+			`/ai/settings/models?org=${MockOrganization2.name}`,
+		);
 	});
 
 	it("preserves auxiliary parameters in organization model paths", () => {

--- a/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/organizationModels.tsx
@@ -149,6 +149,11 @@ const organizationModelSettingsPath = (
 	return `/ai/settings/models${suffix}?${next.toString()}`;
 };
 
+export const organizationModelsPath = (
+	organization: Organization,
+	searchParams?: URLSearchParams,
+): string => organizationModelSettingsPath(organization, "", searchParams);
+
 export const organizationAddModelPath = (
 	organization: Organization,
 	searchParams?: URLSearchParams,
@@ -168,5 +173,5 @@ export const organizationModelPath = (
 export const useOrganizationModelsPath = (): string => {
 	const { organization } = useOrganizationModels();
 	const [searchParams] = useSearchParams();
-	return organizationModelSettingsPath(organization, "", searchParams);
+	return organizationModelsPath(organization, searchParams);
 };

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -724,6 +724,7 @@ export const MissingProviderAndModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			canConfigureAgentSetup
+			organizationId={MockDefaultOrganization.id}
 			providerCount={0}
 			modelCount={0}
 			hasModelOptions={false}
@@ -750,7 +751,7 @@ export const MissingProviderAndModelSetup: Story = {
 		);
 		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
-			"/ai/settings/models",
+			`/ai/settings/models?org=${MockDefaultOrganization.name}`,
 		);
 	},
 };
@@ -759,6 +760,7 @@ export const MissingModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			canConfigureAgentSetup
+			organizationId={MockDefaultOrganization.id}
 			providerCount={1}
 			modelCount={0}
 			hasModelOptions={false}
@@ -781,7 +783,7 @@ export const MissingModelSetup: Story = {
 		});
 		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
-			"/ai/settings/models",
+			`/ai/settings/models?org=${MockDefaultOrganization.name}`,
 		);
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -724,7 +724,7 @@ export const MissingProviderAndModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			canConfigureAgentSetup
-			organizationId={MockDefaultOrganization.id}
+			chat={{ organization_id: MockDefaultOrganization.id }}
 			providerCount={0}
 			modelCount={0}
 			hasModelOptions={false}
@@ -760,7 +760,7 @@ export const MissingModelSetup: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			canConfigureAgentSetup
-			organizationId={MockDefaultOrganization.id}
+			chat={{ organization_id: MockDefaultOrganization.id }}
 			providerCount={1}
 			modelCount={0}
 			hasModelOptions={false}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -15,7 +15,11 @@ import {
 	MockWorkspaceAgent,
 } from "#/testHelpers/entities";
 import { createMockFile } from "#/testHelpers/files";
-import { withProxyProvider, withToaster } from "#/testHelpers/storybook";
+import {
+	withDashboardProvider,
+	withProxyProvider,
+	withToaster,
+} from "#/testHelpers/storybook";
 import {
 	AgentChatInput,
 	type AgentContextUsage,
@@ -37,7 +41,7 @@ const defaultModelOptions = [
 const meta: Meta<typeof AgentChatInput> = {
 	title: "pages/AgentsPage/AgentChatInput",
 	component: AgentChatInput,
-	decorators: [withProxyProvider()],
+	decorators: [withDashboardProvider, withProxyProvider()],
 	parameters: {
 		queries: [
 			{

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -60,6 +60,7 @@ import {
 	ModelSelector,
 	type ModelSelectorOption,
 } from "#/modules/aiModels/ModelSelector";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { countInvisibleCharacters } from "#/utils/invisibleUnicode";
 import { isBelowMdViewport, isMobileViewport } from "#/utils/mobile";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
@@ -426,6 +427,10 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		preferencesQuery.isLoading,
 	);
 	const [chatFullWidth] = useChatFullWidth();
+	const { organizations } = useDashboard();
+	const chatOrganization = organizations.find(
+		(organization) => organization.id === chatOrganizationId,
+	);
 	const showAgentSetupNotice =
 		aiGatewayDisabled ||
 		(canConfigureAgentSetup
@@ -1098,6 +1103,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 							isAdmin
 							providerCount={providerCount ?? 0}
 							modelCount={modelCount ?? 0}
+							organization={chatOrganization}
 							unsupportedProviderNames={unsupportedProviderNames}
 							aiGatewayDisabled={aiGatewayDisabled}
 						/>
@@ -1106,6 +1112,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 							isAdmin={false}
 							providerCount={0}
 							modelCount={0}
+							organization={chatOrganization}
 							unsupportedProviderNames={unsupportedProviderNames}
 							aiGatewayDisabled={aiGatewayDisabled}
 						/>

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -2,6 +2,7 @@ import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { delay } from "msw";
 import { type ComponentProps, useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider, useQueryClient } from "react-query";
+import { useLocation } from "react-router";
 import {
 	expect,
 	fn,
@@ -11,6 +12,7 @@ import {
 	waitFor,
 	within,
 } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
 import { aiProvidersListKey } from "#/api/queries/aiProviders";
 import {
@@ -50,6 +52,16 @@ let pendingOrganizationAuthorization: Deferred<
 	Awaited<ReturnType<typeof API.checkAuthorization>>
 >;
 let capturedQueryClient: QueryClient | undefined;
+
+const LocationProbe = () => {
+	const location = useLocation();
+	return (
+		<output aria-label="Current location">
+			{location.pathname}
+			{location.search}
+		</output>
+	);
+};
 
 const permittedOrgsKey = permittedOrganizationsKey({
 	object: { resource_type: "chat", owner_id: "me" },
@@ -1178,6 +1190,13 @@ export const LocalOrganizationMissingProviderAndModelSetup: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockOrganization2],
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: [
+				{ path: "/agents", useStoryElement: true },
+				{ path: "/ai/settings/models", element: <LocationProbe /> },
+			],
+		}),
 		queries: [
 			{
 				key: permittedOrgsKey,
@@ -1211,10 +1230,10 @@ export const LocalOrganizationMissingProviderAndModelSetup: Story = {
 				})[0],
 			).toBeVisible();
 		});
-		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
-			"href",
-			`/ai/settings/models?org=${MockOrganization2.name}`,
-		);
+		await userEvent.click(canvas.getByRole("link", { name: "model" }));
+		await expect(
+			await canvas.findByRole("status", { name: "Current location" }),
+		).toHaveTextContent(`/ai/settings/models?org=${MockOrganization2.name}`);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1169,7 +1169,51 @@ export const MissingProviderAndModelSetup: Story = {
 		);
 		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
-			"/ai/settings/models",
+			`/ai/settings/models?org=${MockDefaultOrganization.name}`,
+		);
+	},
+};
+
+export const LocalOrganizationMissingProviderAndModelSetup: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockOrganization2],
+			},
+			{
+				key: organizationChatModelsKey(MockOrganization2.id),
+				data: emptyModelCatalog,
+			},
+			{
+				key: userChatProviderConfigsKey,
+				data: defaultUserProviderConfigs,
+			},
+			{ key: aiProvidersListKey, data: [] },
+		],
+	},
+	args: {
+		...defaultArgs,
+		canConfigureAgentSetup: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await waitFor(() => {
+			expect(
+				canvas.getAllByText((_content, element) => {
+					return (
+						element?.textContent ===
+						"To chat with Coder Agents, set up a provider then add a model."
+					);
+				})[0],
+			).toBeVisible();
+		});
+		expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
+			"href",
+			`/ai/settings/models?org=${MockOrganization2.name}`,
 		);
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
+import { MockDefaultOrganization } from "#/testHelpers/entities";
 import { AgentSetupNotice } from "./AgentSetupNotice";
 
 const meta: Meta<typeof AgentSetupNotice> = {
 	title: "pages/AgentsPage/AgentSetupNotice",
 	component: AgentSetupNotice,
+	args: {
+		organization: MockDefaultOrganization,
+	},
 };
 
 export default meta;
@@ -22,9 +26,10 @@ export const AdminNoProvider: Story = {
 		await expect(
 			canvas.getByRole("link", { name: "provider" }),
 		).toHaveAttribute("href", "/ai/settings/providers");
-		await expect(
-			canvas.getByRole("link", { name: "model" }),
-		).toBeInTheDocument();
+		await expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
+			"href",
+			`/ai/settings/models?org=${MockDefaultOrganization.name}`,
+		);
 	},
 };
 
@@ -39,7 +44,7 @@ export const AdminNoModel: Story = {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByRole("link", { name: "model" })).toHaveAttribute(
 			"href",
-			"/ai/settings/models",
+			`/ai/settings/models?org=${MockDefaultOrganization.name}`,
 		);
 		await expect(
 			canvas.queryByRole("link", { name: "provider" }),

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -1,11 +1,14 @@
 import type { FC, ReactNode } from "react";
 import { Link } from "react-router";
+import type { Organization } from "#/api/typesGenerated";
+import { organizationModelsPath } from "#/pages/AISettingsPage/ModelsPage/organizationModels";
 import { docs } from "#/utils/docs";
 
 interface AgentSetupNoticeProps {
 	isAdmin: boolean;
 	providerCount: number;
 	modelCount: number;
+	organization?: Organization;
 	// Names of configured providers the harness cannot use, populated by
 	// the page only when no supported provider is configured.
 	unsupportedProviderNames?: readonly string[];
@@ -26,12 +29,16 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 	isAdmin,
 	providerCount,
 	modelCount,
+	organization,
 	unsupportedProviderNames = [],
 	aiGatewayDisabled,
 }) => {
 	const hasProvider = providerCount > 0;
 	const hasModel = modelCount > 0;
 	const hasUnsupportedProviderNames = unsupportedProviderNames.length > 0;
+	const modelsPath = organization
+		? organizationModelsPath(organization)
+		: "/ai/settings/models";
 
 	// AI Gateway can be disabled even when providers/models exist in the DB
 	// catalog, so check it before the provider/model counts below. Unlike
@@ -115,7 +122,7 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 						{" "}
 						then add a{" "}
 						<Link
-							to="/ai/settings/models"
+							to={modelsPath}
 							className="text-content-link transition-colors hover:text-content-link/80"
 						>
 							model
@@ -132,7 +139,7 @@ export const AgentSetupNotice: FC<AgentSetupNoticeProps> = ({
 		<NoticeContainer>
 			To chat with Coder Agents, set up a{" "}
 			<Link
-				to="/ai/settings/models"
+				to={modelsPath}
 				className="text-content-link transition-colors hover:text-content-link/80"
 			>
 				model

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -16,7 +16,10 @@ import {
 	MockUserOwner,
 	MockUserPreferenceSettings,
 } from "#/testHelpers/entities";
-import { withAuthProvider } from "#/testHelpers/storybook";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+} from "#/testHelpers/storybook";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -42,7 +45,7 @@ const StoryChatPageTimeline: FC<{
 
 const meta = {
 	title: "pages/AgentsPage/ChatPageContent",
-	decorators: [withAuthProvider],
+	decorators: [withAuthProvider, withDashboardProvider],
 	parameters: {
 		user: MockUserOwner,
 		queries: [


### PR DESCRIPTION
The model setup call to action opened AI settings without the current chat's organisation, so the models page would select a different one. We'll now carry the chat organisation through in the setup link.

The AI settings sidebar had the same gap: the Models, Coder Agents and MCP servers links were hardcoded without `?org=`, so switching between them from a non-default organisation dropped you back to the default. Those three links now forward the current `org` search param; deployment-wide links (Providers, Templates, etc.) don't need it.
