### PR TITLE
fix(site): show Manage agents link to organization model admins

### DIFF
--- a/site/src/modules/permissions/index.ts
+++ b/site/src/modules/permissions/index.ts
@@ -28,6 +28,22 @@ export const canAccessAnyChatModelConfig = (
 	);
 };
 
+/**
+ * Whether the user can open the Coder Agents settings page at
+ * /ai/settings/coder-agents. Deployment admins manage deployment-wide
+ * agent settings, and organization model admins manage their
+ * organizations' model configurations on the same page.
+ */
+export const canAccessCoderAgentsSettings = (
+	permissions: Permissions | undefined,
+): boolean => {
+	return (
+		permissions !== undefined &&
+		(permissions.editDeploymentConfig ||
+			canAccessAnyChatModelConfig(permissions))
+	);
+};
+
 export const canViewDeploymentSettings = (
 	permissions: Permissions | undefined,
 ): permissions is Permissions => {

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -1206,6 +1206,26 @@ export const OpensSettingsForNonAdmins: Story = {
 	},
 };
 
+export const OpensSettingsForOrgModelAdmins: Story = {
+	parameters: {
+		permissions: {
+			...MockNoPermissions,
+			editAnyChatModelConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		await openSettingsView(canvasElement);
+
+		const manageAgentsLink = await screen.findByRole("link", {
+			name: "Manage agents",
+		});
+		expect(manageAgentsLink).toHaveAttribute(
+			"href",
+			"/ai/settings/coder-agents",
+		);
+	},
+};
+
 export const OpensAISettingsFromManageAgentsOnMobile: Story = {
 	parameters: {
 		viewport: { defaultViewport: "mobile1" },

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -59,6 +59,7 @@ import {
 	getDefaultOrganizationName,
 	useDashboard,
 } from "#/modules/dashboard/useDashboard";
+import { canAccessCoderAgentsSettings } from "#/modules/permissions";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
@@ -170,6 +171,7 @@ const AgentsPageLayout: FC = () => {
 	const personalOverridesOrganizationId =
 		defaultOrganizationId || (organizations[0]?.id ?? "");
 	const isAgentsAdmin = permissions.editDeploymentConfig;
+	const canManageAgentSettings = canAccessCoderAgentsSettings(permissions);
 
 	const [sidebarFilters, setSidebarFilters] = getAgentSidebarFilters(
 		searchParams,
@@ -791,6 +793,7 @@ const AgentsPageLayout: FC = () => {
 							personalModelOverridesQuery.data?.enabled
 						}
 						isAdmin={isAgentsAdmin}
+						canManageAgentSettings={canManageAgentSettings}
 					/>
 				</ResizableChatsSidebarFrame>
 				<div

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -2690,6 +2690,7 @@ export const SettingsUserAgentsAdmin: Story = {
 	args: {
 		chats: [],
 		isAdmin: true,
+		canManageAgentSettings: true,
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -2708,6 +2709,40 @@ export const SettingsUserAgentsAdmin: Story = {
 			"href",
 			"/ai/settings/coder-agents",
 		);
+	},
+};
+
+export const SettingsManageAgentsOrgModelAdmin: Story = {
+	args: {
+		chats: [],
+		isAdmin: false,
+		canManageAgentSettings: true,
+	},
+	parameters: {
+		queries: [
+			{
+				key: userChatProviderConfigsKey,
+				data: [],
+			},
+		],
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents/settings/general" },
+			routing: settingsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const manageAgentsLink = await canvas.findByRole("link", {
+			name: "Manage agents",
+		});
+		expect(manageAgentsLink).toHaveAttribute(
+			"href",
+			"/ai/settings/coder-agents",
+		);
+		// API-key visibility stays tied to isAdmin and configured providers.
+		expect(
+			canvas.queryByRole("link", { name: "Secrets (API keys)" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
@@ -49,6 +49,12 @@ interface ChatsSidebarProps {
 	onCollapse?: () => void;
 	isPersonalModelOverridesEnabled?: boolean;
 	isAdmin?: boolean;
+	/**
+	 * Whether the user can open the Coder Agents settings page. Broader
+	 * than isAdmin: organization model admins qualify without deployment
+	 * config access.
+	 */
+	canManageAgentSettings?: boolean;
 	currentUserId: string;
 }
 
@@ -85,6 +91,7 @@ export const ChatsSidebar: FC<ChatsSidebarProps> = (props) => {
 		onCollapse,
 		isPersonalModelOverridesEnabled = false,
 		isAdmin = false,
+		canManageAgentSettings = false,
 		currentUserId,
 	} = props;
 	const { agentId, chatId } = useParams<{
@@ -156,7 +163,7 @@ export const ChatsSidebar: FC<ChatsSidebarProps> = (props) => {
 				settingsSection={settingsSection}
 				showApiKeysItem={showApiKeysItem}
 				isPersonalModelOverridesEnabled={isPersonalModelOverridesEnabled}
-				isAdmin={isAdmin}
+				canManageAgentSettings={canManageAgentSettings}
 				location={location}
 				onCollapse={onCollapse}
 			/>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsPanel.tsx
@@ -20,7 +20,7 @@ interface SettingsPanelProps {
 	readonly settingsSection: string | undefined;
 	readonly showApiKeysItem: boolean;
 	readonly isPersonalModelOverridesEnabled: boolean;
-	readonly isAdmin: boolean;
+	readonly canManageAgentSettings: boolean;
 	readonly location: Location;
 	readonly onCollapse?: () => void;
 }
@@ -30,7 +30,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
 	settingsSection,
 	showApiKeysItem,
 	isPersonalModelOverridesEnabled,
-	isAdmin,
+	canManageAgentSettings,
 	location,
 	onCollapse,
 }) => {
@@ -113,7 +113,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
 						state={location.state}
 					/>
 				)}
-				{isAdmin && (
+				{canManageAgentSettings && (
 					<SettingsNavItem
 						icon={Settings2Icon}
 						label="Manage agents"


### PR DESCRIPTION
The Agents settings panel only showed the **Manage agents** link to users with `editDeploymentConfig`, even though the Coder Agents page it links to (`/ai/settings/coder-agents`) already admits organization model admins, as does the AI settings sidebar. Organization model admins had no way to discover the page from the Agents settings panel.

Gate the link on a new `canAccessCoderAgentsSettings` helper (deployment edit access or any chat model config access), threaded as a separate `canManageAgentSettings` prop through `AgentsPageLayout`, `ChatsSidebar`, and `SettingsPanel`. `isAdmin` is left untouched because it also controls API-key item visibility and the provider configs query.

Refs CODAGT-74.

<details>
<summary>Implementation plan (Coder Agents)</summary>

### Bug: hidden Manage agents link

Current behavior:

- `AgentsPageLayout.tsx` defines agents administration as `permissions.editDeploymentConfig` and threads it as `isAdmin` through `ChatsSidebar`.
- `SettingsPanel.tsx` shows **Manage agents** only when `isAdmin`.
- `CoderAgentsPage.tsx` already allows organization model administrators, and #28473 explicitly intended the page and sidebar entry to support deployment access or organization model access.

Design:

- Add `canAccessCoderAgentsSettings(permissions)` in `site/src/modules/permissions/index.ts`, defined as deployment edit access or `canAccessAnyChatModelConfig(permissions)`.
- Add a separate `canManageAgentSettings` prop through `AgentsPageLayout`, `ChatsSidebar`, and `SettingsPanel`.
- Do not widen `isAdmin`, because it also controls API-key visibility and provider queries.

Tests:

- `ChatsSidebar` story where `isAdmin` is false and organization model access is true: the link appears and the API-key item stays hidden.
- `AgentsPageLayout` story with `MockNoPermissions` plus `editAnyChatModelConfig`: the link appears through the full permission-driven flow.
- The plain-member denial stories stay green.

</details>

---

Generated by Coder Agents on behalf of @ethanndickson.
