### PR TITLE
test(coderd/notifications/reports): cover generator ticker

### DIFF
--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -32,6 +33,39 @@ var (
 	jobError     = sql.NullString{String: "badness", Valid: true}
 	jobErrorCode = sql.NullString{String: "ERR-42", Valid: true}
 )
+
+func TestReportGenerator_Ticks(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	_, logger, db, _, notifEnq, clk := setup(t)
+	seedOwner(t, db)
+
+	resetTrap := clk.Trap().TickerReset()
+	defer resetTrap.Close()
+
+	generator := NewReportGenerator(ctx, logger, db, notifEnq, clk)
+	t.Cleanup(func() {
+		require.NoError(t, generator.Close())
+	})
+
+	resetTrap.MustWait(ctx).MustRelease(ctx)
+	require.Empty(t, notifEnq.Sent())
+
+	require.NoError(t, db.UpsertNotificationReportGeneratorLog(ctx, database.UpsertNotificationReportGeneratorLogParams{
+		NotificationTemplateID: notifications.TemplateAIModelsUnpricedReport,
+		LastGeneratedAt:        clk.Now().Add(-unpricedAIModelsReportFrequency - time.Minute),
+	}))
+	seedUnpricedUsage(t, db, "anthropic", database.AIProviderTypeAnthropic, "claude-opus-4-8", clk.Now())
+
+	advance := clk.Advance(delay)
+	resetTrap.MustWait(ctx).MustRelease(ctx)
+	advance.MustWait(ctx)
+
+	sent := notifEnq.Sent()
+	require.Len(t, sent, 1)
+	require.Equal(t, notifications.TemplateAIModelsUnpricedReport, sent[0].TemplateID)
+}
 
 func TestReportFailedWorkspaceBuilds(t *testing.T) {
 	t.Parallel()

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
-	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -33,39 +32,6 @@ var (
 	jobError     = sql.NullString{String: "badness", Valid: true}
 	jobErrorCode = sql.NullString{String: "ERR-42", Valid: true}
 )
-
-func TestReportGenerator_Ticks(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-	_, logger, db, _, notifEnq, clk := setup(t)
-	seedOwner(t, db)
-
-	resetTrap := clk.Trap().TickerReset()
-	defer resetTrap.Close()
-
-	generator := NewReportGenerator(ctx, logger, db, notifEnq, clk)
-	t.Cleanup(func() {
-		require.NoError(t, generator.Close())
-	})
-
-	resetTrap.MustWait(ctx).MustRelease(ctx)
-	require.Empty(t, notifEnq.Sent())
-
-	require.NoError(t, db.UpsertNotificationReportGeneratorLog(ctx, database.UpsertNotificationReportGeneratorLogParams{
-		NotificationTemplateID: notifications.TemplateAIModelsUnpricedReport,
-		LastGeneratedAt:        clk.Now().Add(-unpricedAIModelsReportFrequency - time.Minute),
-	}))
-	seedUnpricedUsage(t, db, "anthropic", database.AIProviderTypeAnthropic, "claude-opus-4-8", clk.Now())
-
-	advance := clk.Advance(delay)
-	resetTrap.MustWait(ctx).MustRelease(ctx)
-	advance.MustWait(ctx)
-
-	sent := notifEnq.Sent()
-	require.Len(t, sent, 1)
-	require.Equal(t, notifications.TemplateAIModelsUnpricedReport, sent[0].TemplateID)
-}
 
 func TestReportFailedWorkspaceBuilds(t *testing.T) {
 	t.Parallel()

--- a/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
+++ b/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
@@ -34,7 +34,7 @@ func TestReportGenerator_TicksUnpricedAIModels(t *testing.T) {
 		require.NoError(t, generator.Close())
 	})
 
-	// Wait for the forced initial run to finish.
+	// The generator runs once immediately without waiting for the ticker delay.
 	resetTrap.MustWait(ctx).MustRelease(ctx)
 	require.Empty(t, notifEnq.Sent())
 

--- a/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
+++ b/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
@@ -38,7 +38,8 @@ func TestReportGenerator_TicksUnpricedAIModels(t *testing.T) {
 	resetTrap.MustWait(ctx).MustRelease(ctx)
 	require.Empty(t, notifEnq.Sent())
 
-	// Make the report eligible and give the next ticker run a model to report.
+	// The initial run records the current time. Backdate it beyond the weekly
+	// frequency so the report is eligible on the next 15-minute ticker run.
 	require.NoError(t, db.UpsertNotificationReportGeneratorLog(ctx, database.UpsertNotificationReportGeneratorLogParams{
 		NotificationTemplateID: notifications.TemplateAIModelsUnpricedReport,
 		LastGeneratedAt:        clk.Now().Add(-unpricedAIModelsReportFrequency - time.Minute),

--- a/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
+++ b/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
@@ -26,6 +26,8 @@ func TestReportGenerator_TicksUnpricedAIModels(t *testing.T) {
 	_, logger, db, _, notifEnq, clk := setup(t)
 	seedOwner(t, db)
 
+	// The ticker is reset after each generator run, so this trap signals when
+	// the immediate or ticker-driven run has finished.
 	resetTrap := clk.Trap().TickerReset()
 	defer resetTrap.Close()
 

--- a/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
+++ b/coderd/notifications/reports/generator_unpriced_ai_models_internal_test.go
@@ -16,7 +16,44 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
+
+func TestReportGenerator_TicksUnpricedAIModels(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	_, logger, db, _, notifEnq, clk := setup(t)
+	seedOwner(t, db)
+
+	resetTrap := clk.Trap().TickerReset()
+	defer resetTrap.Close()
+
+	generator := NewReportGenerator(ctx, logger, db, notifEnq, clk)
+	t.Cleanup(func() {
+		require.NoError(t, generator.Close())
+	})
+
+	// Wait for the forced initial run to finish.
+	resetTrap.MustWait(ctx).MustRelease(ctx)
+	require.Empty(t, notifEnq.Sent())
+
+	// Make the report eligible and give the next ticker run a model to report.
+	require.NoError(t, db.UpsertNotificationReportGeneratorLog(ctx, database.UpsertNotificationReportGeneratorLogParams{
+		NotificationTemplateID: notifications.TemplateAIModelsUnpricedReport,
+		LastGeneratedAt:        clk.Now().Add(-unpricedAIModelsReportFrequency - time.Minute),
+	}))
+	seedUnpricedUsage(t, db, "anthropic", database.AIProviderTypeAnthropic, "claude-opus-4-8", clk.Now())
+
+	// Advance to the first ticker-driven run and wait for it to finish.
+	advance := clk.Advance(delay)
+	resetTrap.MustWait(ctx).MustRelease(ctx)
+	advance.MustWait(ctx)
+
+	sent := notifEnq.Sent()
+	require.Len(t, sent, 1)
+	require.Equal(t, notifications.TemplateAIModelsUnpricedReport, sent[0].TemplateID)
+}
 
 func TestReportUnpricedAIModels(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Adds shared lifecycle coverage for the notification report generator introduced in the parent PR.

The test verifies that `NewReportGenerator` completes its forced initial run, resets the 15-minute ticker, and invokes an eligible report after the mock clock advances.

Depends on #28419.

---

Created by Coder Agents on behalf of @evgeniy-scherbina.
