### PR TITLE
fix(coderd/notifications): HTML-escape the email template values (#28397)

### DIFF
--- a/coderd/notifications/dispatch/smtp/html.gotmpl
+++ b/coderd/notifications/dispatch/smtp/html.gotmpl
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ .Labels._subject }}</title>
+    <title>{{ .Labels._subject | html }}</title>
   </head>
   <body style="margin: 0; padding: 0; font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; color: #020617; background: #f8fafc;">
     <div style="max-width: 600px; margin: 20px auto; padding: 60px; border: 1px solid #e2e8f0; border-radius: 8px; background-color: #fff; text-align: left; font-size: 14px; line-height: 1.5;">
@@ -11,23 +11,23 @@
         <img src="{{ logo_url | html }}" alt="{{ app_name | html }} Logo" style="height: 40px;" />
       </div>
       <h1 style="text-align: center; font-size: 24px; font-weight: 400; margin: 8px 0 32px; line-height: 1.5;">
-        {{ .Labels._subject }}
+        {{ .Labels._subject | html }}
       </h1>
       <div style="line-height: 1.5;">
-        <p>Hi {{ .UserName }},</p>
+        <p>Hi {{ .UserName | html }},</p>
         {{ .Labels._body }}
       </div>
       <div style="text-align: center; margin-top: 32px;">
         {{ range $action := .Actions }}
-        <a href="{{ $action.URL }}" style="display: inline-block; padding: 13px 24px; background-color: #020617; color: #f8fafc; text-decoration: none; border-radius: 8px; margin: 0 4px;">
-          {{ $action.Label }}
+        <a href="{{ $action.URL | html }}" style="display: inline-block; padding: 13px 24px; background-color: #020617; color: #f8fafc; text-decoration: none; border-radius: 8px; margin: 0 4px;">
+          {{ $action.Label | html }}
         </a>
         {{ end }}
       </div>
       <div style="border-top: 1px solid #e2e8f0; color: #475569; font-size: 12px; margin-top: 64px; padding-top: 24px; line-height: 1.6;">
-        <p>&copy;&nbsp;{{ current_year }}&nbsp;Coder. All rights reserved&nbsp;-&nbsp;<a href="{{ base_url }}" style="color: #2563eb; text-decoration: none;">{{ base_url }}</a></p>
-        <p><a href="{{ base_url }}/settings/notifications" style="color: #2563eb; text-decoration: none;">Click here to manage your notification settings</a></p>
-        <p><a href="{{ base_url }}/settings/notifications?disabled={{ .NotificationTemplateID }}" style="color: #2563eb; text-decoration: none;">Stop receiving emails like this</a></p>
+        <p>&copy;&nbsp;{{ current_year | html }}&nbsp;Coder. All rights reserved&nbsp;-&nbsp;<a href="{{ base_url | html }}" style="color: #2563eb; text-decoration: none;">{{ base_url | html }}</a></p>
+        <p><a href="{{ base_url | html }}/settings/notifications" style="color: #2563eb; text-decoration: none;">Click here to manage your notification settings</a></p>
+        <p><a href="{{ base_url | html }}/settings/notifications?disabled={{ .NotificationTemplateID | html }}" style="color: #2563eb; text-decoration: none;">Stop receiving emails like this</a></p>
       </div>
     </div>
   </body>

--- a/coderd/notifications/dispatch/smtp_internal_test.go
+++ b/coderd/notifications/dispatch/smtp_internal_test.go
@@ -10,7 +10,99 @@ import (
 
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
+	markdown "github.com/coder/coder/v2/coderd/render"
 )
+
+// Benign values, so a test measures only what its own payload injected.
+func templateHelpers() map[string]any {
+	return map[string]any{
+		"base_url":     func() string { return "https://coder.example.com" },
+		"current_year": func() string { return "2026" },
+		"logo_url":     func() string { return "https://coder.example.com/logo.png" },
+		"app_name":     func() string { return "Coder" },
+	}
+}
+
+func TestSMTPHTMLTemplateEscapesUntrustedValues(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		title    string
+		userName string
+		actions  []types.TemplateAction
+		injected string
+	}{
+		{
+			name:     "EntityEncodedAnchorInSubject",
+			title:    `Template "&lt;a href="https://attacker.example/login"&gt;Re-authenticate now&lt;/a&gt;" deleted`,
+			userName: "Bobby",
+			injected: `<a href="https://attacker.example/login">Re-authenticate now</a>`,
+		},
+		{
+			name:     "EntityEncodedImageInSubject",
+			title:    `Workspace "&lt;img src=x onerror="alert(1)"&gt;" marked dormant`,
+			userName: "Bobby",
+			injected: `<img src=x onerror="alert(1)">`,
+		},
+		{
+			name:     "RawHTMLInUserName",
+			title:    "Account suspended",
+			userName: `Bobby <img src=x onerror="alert(1)">`,
+			injected: `<img src=x onerror="alert(1)">`,
+		},
+		{
+			name:     "RawHTMLInActionLabel",
+			title:    "Account suspended",
+			userName: "Bobby",
+			actions: []types.TemplateAction{
+				{Label: `<img src=x onerror="alert(1)">`, URL: "https://coder.example.com/"},
+			},
+			injected: `<img src=x onerror="alert(1)">`,
+		},
+		{
+			name:     "RawHTMLInActionURL",
+			title:    "Account suspended",
+			userName: "Bobby",
+			actions: []types.TemplateAction{
+				{Label: "Open Coder", URL: `https://coder.example.com/?x=<script>alert(1)</script>`},
+			},
+			injected: `<script>alert(1)</script>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Decodes the entities, so the title arrives as live markup.
+			subject, err := markdown.PlaintextFromMarkdown(tc.title)
+			require.NoError(t, err)
+
+			// Actions are set as the template sees them. The enqueuer renders
+			// them into JSON first, which rejects a `"` of its own accord.
+			payload := types.MessagePayload{
+				NotificationTemplateID: "00000000-0000-0000-0000-000000000000",
+				UserName:               tc.userName,
+				Actions:                tc.actions,
+				Labels: map[string]string{
+					"_subject": subject,
+					"_body":    "<p>Test body</p>",
+				},
+			}
+
+			got, err := render.GoTemplate(htmlTemplate, payload, templateHelpers())
+			require.NoError(t, err)
+
+			escaped := html.EscapeString(tc.injected)
+			require.NotEqual(t, tc.injected, escaped,
+				"case carries no HTML to escape, so it guards nothing")
+
+			require.NotContains(t, got, tc.injected,
+				"untrusted markup reached the rendered email: %s", got)
+			require.Contains(t, got, escaped,
+				"the value must still be displayed, entity encoded: %s", got)
+		})
+	}
+}
 
 func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {
 	t.Parallel()
@@ -28,12 +120,9 @@ func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {
 			"_body":    "<p>Test body</p>",
 		},
 	}
-	helpers := map[string]any{
-		"base_url":     func() string { return "https://coder.example.com" },
-		"current_year": func() string { return "2026" },
-		"logo_url":     func() string { return logoURL },
-		"app_name":     func() string { return appName },
-	}
+	helpers := templateHelpers()
+	helpers["logo_url"] = func() string { return logoURL }
+	helpers["app_name"] = func() string { return appName }
 
 	got, err := render.GoTemplate(htmlTemplate, payload, helpers)
 	require.NoError(t, err)
@@ -42,6 +131,65 @@ func TestSMTPHTMLTemplateEscapesAppearanceHelpers(t *testing.T) {
 	require.True(t, strings.Contains(got, html.EscapeString(logoURL)), "logo URL must be HTML escaped")
 	require.False(t, strings.Contains(got, appName), "raw application name must not be rendered")
 	require.False(t, strings.Contains(got, logoURL), "raw logo URL must not be rendered")
+}
+
+// The template escapes every value it interpolates except _body, which is
+// trusted rendered Markdown. The three values here cannot carry markup in
+// production, so this test is the only thing that fails if their escaping is
+// removed.
+func TestSMTPHTMLTemplateEscapesTrustedValues(t *testing.T) {
+	t.Parallel()
+
+	const injected = `a"onclick=alert(1)`
+
+	for _, tc := range []struct {
+		name  string
+		apply func(*types.MessagePayload, map[string]any)
+	}{
+		{
+			// net/url preserves a quote in the query and --access-url is
+			// validated for its scheme only, so an operator can land this.
+			name: "BaseURL",
+			apply: func(_ *types.MessagePayload, h map[string]any) {
+				h["base_url"] = func() string { return "https://coder.example.com/?q=" + injected }
+			},
+		},
+		{
+			name: "CurrentYear",
+			apply: func(_ *types.MessagePayload, h map[string]any) {
+				h["current_year"] = func() string { return injected }
+			},
+		},
+		{
+			name: "NotificationTemplateID",
+			apply: func(p *types.MessagePayload, _ map[string]any) {
+				p.NotificationTemplateID = injected
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := types.MessagePayload{
+				NotificationTemplateID: "00000000-0000-0000-0000-000000000000",
+				UserName:               "Test User",
+				Labels: map[string]string{
+					"_subject": "Test notification",
+					"_body":    "<p>Test body</p>",
+				},
+			}
+			helpers := templateHelpers()
+			tc.apply(&payload, helpers)
+
+			got, err := render.GoTemplate(htmlTemplate, payload, helpers)
+			require.NoError(t, err)
+
+			require.NotContains(t, got, injected,
+				"raw value reached the rendered email: %s", got)
+			require.Contains(t, got, html.EscapeString(injected),
+				"the value must still be displayed, entity encoded: %s", got)
+		})
+	}
 }
 
 func TestValidateFromAddr(t *testing.T) {

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -252,7 +252,9 @@ func (n *notifier) prepare(ctx context.Context, msg database.AcquireNotification
 	// Label and data values are user-controlled while the templates around them
 	// are not, so Markdown structure in a value is neutralized before it reaches
 	// the template. The dispatcher still receives the unescaped payload, because
-	// the webhook contract surfaces enqueued values verbatim.
+	// the webhook contract surfaces enqueued values verbatim. smtp/html.gotmpl
+	// escapes at its own sinks, which it must: PlaintextFromMarkdown strips this
+	// escaping back out of _subject.
 	escaped := payload.EscapedForMarkdown()
 
 	var title, body string

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskCompleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskCompleted.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' completed</title>
+    <title>Task &#39;my-workspace&#39; completed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' completed
+        Task &#39;my-workspace&#39; completed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskFailed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskFailed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' failed</title>
+    <title>Task &#39;my-workspace&#39; failed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' failed
+        Task &#39;my-workspace&#39; failed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskIdle.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskIdle.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' is idle</title>
+    <title>Task &#39;my-workspace&#39; is idle</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' is idle
+        Task &#39;my-workspace&#39; is idle
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskPaused.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskPaused.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-task' is paused</title>
+    <title>Task &#39;my-task&#39; is paused</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-task' is paused
+        Task &#39;my-task&#39; is paused
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskResumed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskResumed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-task' has resumed</title>
+    <title>Task &#39;my-task&#39; has resumed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-task' has resumed
+        Task &#39;my-task&#39; has resumed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskWorking.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTaskWorking.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Task 'my-workspace' is working</title>
+    <title>Task &#39;my-workspace&#39; is working</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Task 'my-workspace' is working
+        Task &#39;my-workspace&#39; is working
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeleted.html.golden
@@ -27,7 +27,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Template "Bobby's Template" deleted</title>
+    <title>Template &#34;Bobby&#39;s Template&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -42,7 +42,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Template "Bobby's Template" deleted
+        Template &#34;Bobby&#39;s Template&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeprecated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateTemplateDeprecated.html.golden
@@ -35,7 +35,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Template 'alpha' has been deprecated</title>
+    <title>Template &#39;alpha&#39; has been deprecated</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -50,7 +50,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Template 'alpha' has been deprecated
+        Template &#39;alpha&#39; has been deprecated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountActivated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountActivated.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" activated</title>
+    <title>User account &#34;bobby&#34; activated</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" activated
+        User account &#34;bobby&#34; activated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountCreated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountCreated.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" created</title>
+    <title>User account &#34;bobby&#34; created</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" created
+        User account &#34;bobby&#34; created
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountDeleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountDeleted.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" deleted</title>
+    <title>User account &#34;bobby&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" deleted
+        User account &#34;bobby&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountSuspended.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountSuspended.html.golden
@@ -30,7 +30,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>User account "bobby" suspended</title>
+    <title>User account &#34;bobby&#34; suspended</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +45,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        User account "bobby" suspended
+        User account &#34;bobby&#34; suspended
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserRequestedOneTimePasscode.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserRequestedOneTimePasscode.html.golden
@@ -56,10 +56,10 @@ argin: 8px 0 32px; line-height: 1.5;">
       <div style=3D"text-align: center; margin-top: 32px;">
        =20
         <a href=3D"http://test.com/reset-password/change?otp=3Dfad9020b-656=
-2-4cdb-87f1-0486f1bea415&email=3Dbobby%2Fdrop-table%2Buser%40coder.com" sty=
-le=3D"display: inline-block; padding: 13px 24px; background-color: #020617;=
- color: #f8fafc; text-decoration: none; border-radius: 8px; margin: 0 4px;"=
->
+2-4cdb-87f1-0486f1bea415&amp;email=3Dbobby%2Fdrop-table%2Buser%40coder.com"=
+ style=3D"display: inline-block; padding: 13px 24px; background-color: #020=
+617; color: #f8fafc; text-decoration: none; border-radius: 8px; margin: 0 4=
+px;">
           Reset password
         </a>
        =20

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutoUpdated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutoUpdated.html.golden
@@ -30,7 +30,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" updated automatically</title>
+    <title>Workspace &#34;bobby-workspace&#34; updated automatically</title=
+>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +46,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" updated automatically
+        Workspace &#34;bobby-workspace&#34; updated automatically
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutobuildFailed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceAutobuildFailed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" autobuild failed</title>
+    <title>Workspace &#34;bobby-workspace&#34; autobuild failed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" autobuild failed
+        Workspace &#34;bobby-workspace&#34; autobuild failed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceCreated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceCreated.html.golden
@@ -28,7 +28,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace 'bobby-workspace' has been created</title>
+    <title>Workspace &#39;bobby-workspace&#39; has been created</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -43,7 +43,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace 'bobby-workspace' has been created
+        Workspace &#39;bobby-workspace&#39; has been created
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted.html.golden
@@ -31,7 +31,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" deleted</title>
+    <title>Workspace &#34;bobby-workspace&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +46,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" deleted
+        Workspace &#34;bobby-workspace&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted_CustomAppearance.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDeleted_CustomAppearance.html.golden
@@ -31,7 +31,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" deleted</title>
+    <title>Workspace &#34;bobby-workspace&#34; deleted</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +46,7 @@ ication Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" deleted
+        Workspace &#34;bobby-workspace&#34; deleted
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDormant.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceDormant.html.golden
@@ -34,7 +34,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" marked as dormant</title>
+    <title>Workspace &#34;bobby-workspace&#34; marked as dormant</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -49,7 +49,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" marked as dormant
+        Workspace &#34;bobby-workspace&#34; marked as dormant
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManualBuildFailed.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManualBuildFailed.html.golden
@@ -29,7 +29,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" manual build failed</title>
+    <title>Workspace &#34;bobby-workspace&#34; manual build failed</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -44,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" manual build failed
+        Workspace &#34;bobby-workspace&#34; manual build failed
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManuallyUpdated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceManuallyUpdated.html.golden
@@ -31,7 +31,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace 'bobby-workspace' has been manually updated</title>
+    <title>Workspace &#39;bobby-workspace&#39; has been manually updated</t=
+itle>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +47,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace 'bobby-workspace' has been manually updated
+        Workspace &#39;bobby-workspace&#39; has been manually updated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceMarkedForDeletion.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceMarkedForDeletion.html.golden
@@ -30,7 +30,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Workspace "bobby-workspace" marked for deletion</title>
+    <title>Workspace &#34;bobby-workspace&#34; marked for deletion</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -45,7 +45,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Workspace "bobby-workspace" marked for deletion
+        Workspace &#34;bobby-workspace&#34; marked for deletion
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk.html.golden
@@ -27,7 +27,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" is low on volume space</title>
+    <title>Your workspace &#34;bobby-workspace&#34; is low on volume space<=
+/title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -42,7 +43,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" is low on volume space
+        Your workspace &#34;bobby-workspace&#34; is low on volume space
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk_MultipleVolumes.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfDisk_MultipleVolumes.html.golden
@@ -31,7 +31,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" is low on volume space</title>
+    <title>Your workspace &#34;bobby-workspace&#34; is low on volume space<=
+/title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -46,7 +47,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" is low on volume space
+        Your workspace &#34;bobby-workspace&#34; is low on volume space
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfMemory.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateWorkspaceOutOfMemory.html.golden
@@ -28,7 +28,8 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your workspace "bobby-workspace" is low on memory</title>
+    <title>Your workspace &#34;bobby-workspace&#34; is low on memory</title=
+>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -43,7 +44,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your workspace "bobby-workspace" is low on memory
+        Your workspace &#34;bobby-workspace&#34; is low on memory
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountActivated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountActivated.html.golden
@@ -27,7 +27,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your account "bobby" has been activated</title>
+    <title>Your account &#34;bobby&#34; has been activated</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -42,7 +42,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your account "bobby" has been activated
+        Your account &#34;bobby&#34; has been activated
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountSuspended.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateYourAccountSuspended.html.golden
@@ -25,7 +25,7 @@ Content-Type: text/html; charset=UTF-8
     <meta charset=3D"UTF-8" />
     <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
 =3D1.0" />
-    <title>Your account "bobby" has been suspended</title>
+    <title>Your account &#34;bobby&#34; has been suspended</title>
   </head>
   <body style=3D"margin: 0; padding: 0; font-family: -apple-system, system-=
 ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarel=
@@ -40,7 +40,7 @@ er Logo" style=3D"height: 40px;" />
       </div>
       <h1 style=3D"text-align: center; font-size: 24px; font-weight: 400; m=
 argin: 8px 0 32px; line-height: 1.5;">
-        Your account "bobby" has been suspended
+        Your account &#34;bobby&#34; has been suspended
       </h1>
       <div style=3D"line-height: 1.5;">
         <p>Hi Bobby,</p>


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/28397

Original PR: #28397 — fix(coderd/notifications): HTML-escape the email template values
Merge commit: 2236710badb55e1fe60109aff32e4408513e1bb1
Requested by: @BobbyHo

Opened manually because the Backport workflow run for `release/2.34` failed: https://github.com/coder/coder/actions/runs/32985803559/job/98231735640

## Why the automatic backport failed

Two separate things went wrong in that run, and only one of them is about conflicts.

The cherry-pick hit nine `modify/delete` conflicts (below). That alone is not fatal — the same happened for `release/2.36` and `release/2.37`, where the job still pushed a placeholder branch and opened a PR for manual resolution.

What actually failed the job was the push:

```
! [remote rejected] backport/28397-to-2.34 -> backport/28397-to-2.34
  (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
```

This cherry-pick touches no files under `.github/workflows/`, so this is GitHub timing out while determining scope rather than a genuine permission gap. The push was retried by hand for this PR and succeeded unchanged. The net effect of the failure was that no branch and no PR were created for 2.34 at all, so this one is opened from scratch rather than fixed up in place. The `release/2.35` job (#28644) failed the same way.

## Manual resolution: 9 golden files dropped

`release/2.34` already carries #28606 (the 2.34 backport of #28340), so the `notifier.go` hunk applies cleanly. What remains is a genuine `modify/delete` conflict on nine golden files:

```
TemplateAIBudgetLimitReachedUser.html.golden
TemplateAIBudgetWarningUser.html.golden
TemplateUserAccountActivatedServiceAccount.html.golden
TemplateUserAccountCreatedServiceAccount.html.golden
TemplateUserAccountCreatedWithoutAccountType.html.golden
TemplateUserAccountDeletedServiceAccount.html.golden
TemplateUserAccountSuspendedServiceAccount.html.golden
TemplateWorkspaceAutostopReminder.html.golden
TemplateWorkspaceDormant_NoAutoDelete.html.golden
```

These are fixtures for notification templates and test cases that postdate the 2.34 branch point — AI budgets, service accounts, the autostop reminder, and the no-auto-delete variant of the dormancy notice. `coderd/notifications/` on `release/2.34` contains no reference to `AIBudget`, `BudgetLimitReached`, `BudgetWarning`, `ServiceAccount`, `AccountType`, `AutostopReminder` or `NoAutoDelete`, so there is no template to render them and no test case that reads them. **All nine were removed rather than added**; carrying them over would leave orphan fixtures.

Note that `TemplateWorkspaceDormant.html.golden` does exist on 2.34 and is updated normally by this PR. Only the `_NoAutoDelete` variant of that test case is dropped.

This is the only deviation from the original PR. Verified with a diff-of-diffs: excluding those nine paths, this commit matches #28397 line for line. The only textual differences are blob hashes and hunk line offsets — `notifier.go` sits one line higher on this branch, so the hunk header reads `@@ -252` instead of `@@ -253`. The escaping changes to `html.gotmpl`, `notifier.go` and `smtp_internal_test.go` are fully intact.

Net: 30 files, +226/−71 (upstream: 39 files, +244/−89 — the delta is exactly the nine goldens). The smtp golden directory holds 36 files before and after, so nothing was added or lost.

## Verification

- `go vet ./coderd/notifications/...` — clean
- `go test ./coderd/notifications/dispatch/...` — pass, including the three new `TestSMTPHTMLTemplateEscapes*` tests
- `go test ./coderd/notifications/ -run TestNotificationTemplates_Golden` — pass across all affected goldens

## Related backports

- #28603 — `release/2.37`
- #28604 — `release/2.36`
- #28644 — `release/2.35`
- #28643 — `release/2.29` (still needs manual resolution)
