### PR TITLE
feat(site): enable autoFocus for emoji icon picker

### DIFF
--- a/site/src/@types/emoji-mart.d.ts
+++ b/site/src/@types/emoji-mart.d.ts
@@ -38,6 +38,7 @@ declare module "@emoji-mart/react" {
 		emojiVersion?: string;
 		getSpritesheetURL?: (set: string) => string;
 		onEmojiSelect: (emoji: EmojiData) => void;
+		autoFocus?: boolean;
 	}
 
 	const EmojiMart: React.FC<EmojiMartProps>;

--- a/site/src/components/IconField/IconField.tsx
+++ b/site/src/components/IconField/IconField.tsx
@@ -125,6 +125,7 @@ export const IconField: FC<IconFieldProps> = ({
 										onPickEmoji(picked);
 										setOpen(false);
 									}}
+									autoFocus
 								/>
 							</Suspense>
 						</PopoverContent>


### PR DESCRIPTION
This auto-focuses the input in the emoji picker. This is already a feature of emoji-mart, we just forgot to type it.

I also deliberately didn't include stories because that would be testing emoji-mart functionality, no value

https://github.com/user-attachments/assets/74e95903-55e8-4302-83f9-a677baa39a41

