### PR TITLE
test(site/src/api): expect v2 MCP ACL path

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -559,7 +559,7 @@ describe("api.ts", () => {
 			).resolves.toBeUndefined();
 
 			const aclPath =
-				"/api/experimental/organizations/organization%2Fid/mcp-servers/server%2Fid/acl";
+				"/api/v2/organizations/organization%2Fid/mcp-servers/server%2Fid/acl";
 			const aclAvailablePath =
 				"/api/v2/organizations/organization%2Fid/mcp-servers/server%2Fid/acl/available";
 			expect(axiosInstance.get).toHaveBeenNthCalledWith(1, aclPath);


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

The MCP server ACL client uses the promoted `/api/v2` route, but its path assertion still expected the experimental compatibility route.

Update the assertion to match the v2 endpoint and restore the JavaScript test suite.