### PR TITLE
fix: remove premium paywall for browser-only connections

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -11,7 +11,6 @@ import {
 	SettingsHeaderDocsLink,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
-import { PremiumPaywallSmall } from "#/modules/paywall/PremiumPaywallSmall";
 import {
 	deploymentGroupHasParent,
 	useDeploymentOptions,
@@ -77,20 +76,6 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 						/>
 					</SettingsHeaderDescription>
 				</SettingsHeader>
-
-				{!featureBrowserOnlyEnabled ? (
-					<PremiumPaywallSmall
-						source="browser_only"
-						message="Browser-Only Connections"
-						description="Block all workspace access via SSH, port forward, and other non-browser connections."
-						features={[
-							"Restrict access to web-based connections",
-							"Block SSH and port-forward entirely",
-							"Enforce browser-only compliance policies",
-						]}
-						canViewPremium
-					/>
-				) : null}
 			</div>
 
 			{tlsOptions.length > 0 && (


### PR DESCRIPTION
DEVEX-828

remove premiumpaywall entirely from the SecuritySettingPageView. Something not adding up with frontend logic and screenshot, but can reproduce and the experience is bad with intrusive paywall.

repro before: 
<img width="1876" height="1084" alt="Screenshot 2026-08-26 at 12 29 25 PM" src="https://github.com/user-attachments/assets/1102cee4-5ff4-4cc3-a0ed-3ca3b98a2473" />


fix after:
<img width="752" height="485" alt="Screenshot 2026-08-26 at 12 45 27 PM" src="https://github.com/user-attachments/assets/339621de-12e8-452b-b78e-7d0314f8a2fb" />
