### PR TITLE
fix(site/src/testHelpers): point MCP server ACL msw handlers at v2 paths

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -559,7 +559,7 @@ describe("api.ts", () => {
 			).resolves.toBeUndefined();
 
 			const aclPath =
-				"/api/experimental/organizations/organization%2Fid/mcp-servers/server%2Fid/acl";
+				"/api/v2/organizations/organization%2Fid/mcp-servers/server%2Fid/acl";
 			const aclAvailablePath =
 				"/api/v2/organizations/organization%2Fid/mcp-servers/server%2Fid/acl/available";
 			expect(axiosInstance.get).toHaveBeenNthCalledWith(1, aclPath);

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -87,11 +87,11 @@ export const handlers = [
 		() => HttpResponse.json(M.MockMCPServerConfigACLAvailable),
 	),
 	http.get(
-		"/api/experimental/organizations/:organizationId/mcp-servers/:serverId/acl",
+		"/api/v2/organizations/:organizationId/mcp-servers/:serverId/acl",
 		() => HttpResponse.json(M.MockMCPServerConfigACL),
 	),
 	http.patch(
-		"/api/experimental/organizations/:organizationId/mcp-servers/:serverId/acl",
+		"/api/v2/organizations/:organizationId/mcp-servers/:serverId/acl",
 		() => new HttpResponse(null, { status: 204 }),
 	),
 


### PR DESCRIPTION
~~test-js is failing on main~~ Main is fixed: #28657 landed the same `api.test.ts` expectation update, so this PR no longer unbreaks anything and is not urgent.

What remains here is the other half of the original fix: `site/src/testHelpers/handlers.ts` still registers the MCP server ACL GET/PATCH msw handlers at `/api/experimental/...`, but since #28498 the client calls `/api/v2/...`, so those handlers can never intercept a request. Any future test or story that exercises the ACL endpoints through the shared msw handlers would hit an unhandled-request error instead of the mock. This points them at the v2 paths the client actually uses.

Validation: `pnpm exec vitest run --project=unit src/api/api.test.ts` passes 43/43 on this branch (merged with current main).

> Xum acted on Mike's behalf.
<!-- xum-attribution: model=claude-fable-5 thinking=high -->

