### PR TITLE
fix(site/src/pages/DeploymentSettingsPage): gate browser-only paywall on entitlement

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPage.tsx
@@ -14,6 +14,9 @@ const SecuritySettingsPage: FC = () => {
 
 			<SecuritySettingsPageView
 				options={deploymentConfig.options}
+				isBrowserOnlyEntitled={
+					entitlements.features.browser_only.entitlement !== "not_entitled"
+				}
 				featureBrowserOnlyEnabled={entitlements.features.browser_only.enabled}
 			/>
 		</>

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
@@ -49,6 +49,7 @@ const meta: Meta<typeof SecuritySettingsPageView> = {
 				hidden: false,
 			},
 		],
+		isBrowserOnlyEntitled: true,
 		featureBrowserOnlyEnabled: true,
 	},
 };
@@ -66,6 +67,50 @@ export const Page: Story = {
 			"href",
 			docs("/admin/networking#browser-only-connections"),
 		);
+		await expect(
+			canvas.getByRole("heading", {
+				name: /Browser-Only Connections Enabled/,
+			}),
+		).toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: /Start trial for free/ }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const EntitledAndTurnedOff: Story = {
+	args: {
+		isBrowserOnlyEntitled: true,
+		featureBrowserOnlyEnabled: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", {
+				name: /Browser-Only Connections Disabled/,
+			}),
+		).toBeInTheDocument();
+		await expect(
+			canvas.queryByRole("link", { name: /Start trial for free/ }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const NotEntitled: Story = {
+	args: {
+		isBrowserOnlyEntitled: false,
+		featureBrowserOnlyEnabled: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", {
+				name: /Browser-Only Connections Disabled/,
+			}),
+		).toBeInTheDocument();
+		await expect(
+			canvas.getByRole("link", { name: /Start trial for free/ }),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -21,11 +21,15 @@ import OptionsTable from "../OptionsTable";
 
 type SecuritySettingsPageViewProps = {
 	options: SerpentOption[];
+	/** True when the license covers browser-only connections. */
+	isBrowserOnlyEntitled: boolean;
+	/** True when the deployment has browser-only connections turned on. */
 	featureBrowserOnlyEnabled: boolean;
 };
 
 export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 	options,
+	isBrowserOnlyEntitled,
 	featureBrowserOnlyEnabled,
 }) => {
 	const tlsOptions = options.filter((o) =>
@@ -78,7 +82,7 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				{!featureBrowserOnlyEnabled ? (
+				{!isBrowserOnlyEntitled ? (
 					<PremiumPaywallSmall
 						source="browser_only"
 						message="Browser-Only Connections"


### PR DESCRIPTION
DEVEX-828

## TL;DR

If you already paid for Coder, stop showing you an ad asking you to pay for Coder.

The Security settings page was showing the "upgrade to Premium" box to customers who already have Premium. It now only shows to deployments with no license.

## Problem

The Security settings page rendered the premium paywall whenever `entitlements.features.browser_only.enabled` was false:

```tsx
featureBrowserOnlyEnabled={entitlements.features.browser_only.enabled}
...
{!featureBrowserOnlyEnabled ? <PremiumPaywallSmall ... /> : null}
```

`Feature.Enabled` is not "the license covers this feature". For `browser_only` the server sets it from the deployment's own config:

```go
// enterprise/coderd/coderd.go
codersdk.FeatureBrowserOnly: api.BrowserOnly,
```

`license.LicensesEntitlements` then only forces `Enabled` to false when the feature is not entitled. So `enabled === true` requires a license **and** `CODER_BROWSER_ONLY=true`, and any licensed premium or trial deployment that leaves browser-only connections turned off (the default) was shown an upgrade paywall for a feature it already owns.

## Fix

Gate the paywall on the entitlement and keep `enabled` for the Enabled/Disabled badge, matching the pattern already used by the External Auth settings page:

```tsx
isBrowserOnlyEntitled={
  entitlements.features.browser_only.entitlement !== "not_entitled"
}
```

`grace_period` counts as entitled, so expiring licenses do not flip to a paywall either.

Verified against `license.LicensesEntitlements` with `CODER_BROWSER_ONLY` off, which is the state in the report:

| Deployment | `entitlement` | `enabled` | Paywall before | Paywall after |
|---|---|---|---|---|
| Community (no license) | `not_entitled` | false | shown | shown |
| Premium trial | `entitled` | false | shown | hidden |
| Premium | `entitled` | false | shown | hidden |
| Enterprise | `entitled` | false | shown | hidden |
| Premium, grace period | `grace_period` | false | shown | hidden |

With browser-only turned on, entitled deployments keep the Enabled badge and no paywall.

## Proof

Before, premium license with browser-only connections turned off:

<img width="900" alt="paywall shown on a licensed deployment" src="https://raw.githubusercontent.com/david-fraley/coder/devex-828-proof/before-licensed-paywall.png" />

After, same state:

<img width="900" alt="no paywall on a licensed deployment" src="https://raw.githubusercontent.com/david-fraley/coder/devex-828-proof/after-licensed-no-paywall.png" />

After, community deployment still gets the paywall:

<img width="900" alt="paywall shown on a community deployment" src="https://raw.githubusercontent.com/david-fraley/coder/devex-828-proof/after-community-paywall.png" />

Both states are covered by new `play` assertions in `SecuritySettingsPageView.stories.tsx` (`EntitledAndTurnedOff`, `NotEntitled`).

## Notes

- Overlaps with #28658, which removes the paywall from this page entirely. This PR keeps the paywall for community deployments and only stops it from showing on licensed ones.
- Out of scope: this page hardcodes `canViewPremium`, while other paywall surfaces pass `permissions.viewAllLicenses`.

<details>
<summary>Investigation notes</summary>

1. `SecuritySettingsPage.tsx` passed `entitlements.features.browser_only.enabled` into the view as the paywall condition.
2. `enterprise/coderd/coderd.go` builds the enablements map from deployment config, so `browser_only` enablement is `api.BrowserOnly` (`CODER_BROWSER_ONLY`).
3. `enterprise/coderd/license/license.go` applies `Enabled: enablements[featureName] || featureName.AlwaysEnable()` for licensed features and only downgrades `Enabled` to false for not-entitled features. Entitlement and enablement are therefore independent signals, and only entitlement should drive an upgrade prompt.
4. `ExternalAuthSettingsPageView` and `AppearanceSettingsPage` already gate their paywalls on `entitlement !== "not_entitled"`; this page was the outlier.

</details>

---

Generated by Coder Agents on behalf of @david-fraley.
