### PR TITLE
fix(coderd/notifications/reports): use priceable provider allowlist

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5146,11 +5146,11 @@ func (q *querier) GetUnexpiredLicenses(ctx context.Context) ([]database.License,
 	return q.db.GetUnexpiredLicenses(ctx)
 }
 
-func (q *querier) GetUnpricedAIModelsSince(ctx context.Context, since database.GetUnpricedAIModelsSinceParams) ([]database.GetUnpricedAIModelsSinceRow, error) {
+func (q *querier) GetUnpricedAIModelsSince(ctx context.Context, arg database.GetUnpricedAIModelsSinceParams) ([]database.GetUnpricedAIModelsSinceRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAiModelPrice); err != nil {
 		return nil, err
 	}
-	return q.db.GetUnpricedAIModelsSince(ctx, since)
+	return q.db.GetUnpricedAIModelsSince(ctx, arg)
 }
 
 func (q *querier) GetUserAIBudgetOverride(ctx context.Context, userID uuid.UUID) (database.UserAIBudgetOverride, error) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5146,7 +5146,7 @@ func (q *querier) GetUnexpiredLicenses(ctx context.Context) ([]database.License,
 	return q.db.GetUnexpiredLicenses(ctx)
 }
 
-func (q *querier) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]database.GetUnpricedAIModelsSinceRow, error) {
+func (q *querier) GetUnpricedAIModelsSince(ctx context.Context, since database.GetUnpricedAIModelsSinceParams) ([]database.GetUnpricedAIModelsSinceRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAiModelPrice); err != nil {
 		return nil, err
 	}

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -7135,7 +7135,7 @@ func (s *MethodTestSuite) TestAIBridge() {
 
 	s.Run("GetUnpricedAIModelsSince", s.Mocked(func(db *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		db.EXPECT().GetUnpricedAIModelsSince(gomock.Any(), gomock.Any()).Return([]database.GetUnpricedAIModelsSinceRow{}, nil).AnyTimes()
-		check.Args(time.Time{}).Asserts(rbac.ResourceAiModelPrice, policy.ActionRead)
+		check.Args(database.GetUnpricedAIModelsSinceParams{}).Asserts(rbac.ResourceAiModelPrice, policy.ActionRead)
 	}))
 
 	s.Run("GetOrganizationGroupsAISpend", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3232,7 +3232,7 @@ func (m queryMetricsStore) GetUnexpiredLicenses(ctx context.Context) ([]database
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]database.GetUnpricedAIModelsSinceRow, error) {
+func (m queryMetricsStore) GetUnpricedAIModelsSince(ctx context.Context, since database.GetUnpricedAIModelsSinceParams) ([]database.GetUnpricedAIModelsSinceRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetUnpricedAIModelsSince(ctx, since)
 	m.queryLatencies.WithLabelValues("GetUnpricedAIModelsSince").Observe(time.Since(start).Seconds())

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6090,18 +6090,18 @@ func (mr *MockStoreMockRecorder) GetUnexpiredLicenses(ctx any) *gomock.Call {
 }
 
 // GetUnpricedAIModelsSince mocks base method.
-func (m *MockStore) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]database.GetUnpricedAIModelsSinceRow, error) {
+func (m *MockStore) GetUnpricedAIModelsSince(ctx context.Context, arg database.GetUnpricedAIModelsSinceParams) ([]database.GetUnpricedAIModelsSinceRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnpricedAIModelsSince", ctx, since)
+	ret := m.ctrl.Call(m, "GetUnpricedAIModelsSince", ctx, arg)
 	ret0, _ := ret[0].([]database.GetUnpricedAIModelsSinceRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUnpricedAIModelsSince indicates an expected call of GetUnpricedAIModelsSince.
-func (mr *MockStoreMockRecorder) GetUnpricedAIModelsSince(ctx, since any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetUnpricedAIModelsSince(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnpricedAIModelsSince", reflect.TypeOf((*MockStore)(nil).GetUnpricedAIModelsSince), ctx, since)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnpricedAIModelsSince", reflect.TypeOf((*MockStore)(nil).GetUnpricedAIModelsSince), ctx, arg)
 }
 
 // GetUserAIBudgetOverride mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -912,7 +912,7 @@ type sqlcQuerier interface {
 	GetUnexpiredLicenses(ctx context.Context) ([]License, error)
 	// Returns the models used since the given time that hold no price, most used
 	// first. openai-compat providers cannot be priced, so their models are excluded.
-	GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]GetUnpricedAIModelsSinceRow, error)
+	GetUnpricedAIModelsSince(ctx context.Context, arg GetUnpricedAIModelsSinceParams) ([]GetUnpricedAIModelsSinceRow, error)
 	GetUserAIBudgetOverride(ctx context.Context, userID uuid.UUID) (UserAIBudgetOverride, error)
 	GetUserAIProviderKeyByProviderID(ctx context.Context, arg GetUserAIProviderKeyByProviderIDParams) (UserAIProviderKey, error)
 	// GetUserAIProviderKeys is used by dbcrypt key rotation. Request paths should use

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3427,7 +3427,7 @@ JOIN ai_providers AS providers
 	ON providers.name = interceptions.provider_name
 	AND providers.deleted = false
 WHERE interceptions.started_at >= $1::timestamptz
-	AND providers.type != 'openai-compat'
+	AND providers.type::text = ANY($2::text[])
 	AND NOT EXISTS (
 		SELECT 1
 		FROM ai_model_prices AS prices
@@ -3438,6 +3438,11 @@ GROUP BY providers.type, interceptions.model
 ORDER BY token_count DESC, provider_type ASC, model ASC
 `
 
+type GetUnpricedAIModelsSinceParams struct {
+	Since              time.Time `db:"since" json:"since"`
+	PriceableProviders []string  `db:"priceable_providers" json:"priceable_providers"`
+}
+
 type GetUnpricedAIModelsSinceRow struct {
 	ProviderType string `db:"provider_type" json:"provider_type"`
 	Model        string `db:"model" json:"model"`
@@ -3446,8 +3451,8 @@ type GetUnpricedAIModelsSinceRow struct {
 
 // Returns the models used since the given time that hold no price, most used
 // first. openai-compat providers cannot be priced, so their models are excluded.
-func (q *sqlQuerier) GetUnpricedAIModelsSince(ctx context.Context, since time.Time) ([]GetUnpricedAIModelsSinceRow, error) {
-	rows, err := q.db.QueryContext(ctx, getUnpricedAIModelsSince, since)
+func (q *sqlQuerier) GetUnpricedAIModelsSince(ctx context.Context, arg GetUnpricedAIModelsSinceParams) ([]GetUnpricedAIModelsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, getUnpricedAIModelsSince, arg.Since, pq.Array(arg.PriceableProviders))
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -502,7 +502,7 @@ JOIN ai_providers AS providers
 	ON providers.name = interceptions.provider_name
 	AND providers.deleted = false
 WHERE interceptions.started_at >= @since::timestamptz
-	AND providers.type != 'openai-compat'
+	AND providers.type::text = ANY(@priceable_providers::text[])
 	AND NOT EXISTS (
 		SELECT 1
 		FROM ai_model_prices AS prices

--- a/coderd/notifications/reports/generator.go
+++ b/coderd/notifications/reports/generator.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/aibridge/prices/providers"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
@@ -374,7 +375,10 @@ func reportUnpricedAIModels(ctx context.Context, logger slog.Logger, db database
 	}
 
 	// Fetch the models used without a price.
-	unpricedModels, err := db.GetUnpricedAIModelsSince(ctx, dbtime.Time(since).UTC())
+	unpricedModels, err := db.GetUnpricedAIModelsSince(ctx, database.GetUnpricedAIModelsSinceParams{
+		Since:              dbtime.Time(since).UTC(),
+		PriceableProviders: providers.SupportedStrings(),
+	})
 	if err != nil {
 		return xerrors.Errorf("unable to fetch unpriced AI models: %w", err)
 	}


### PR DESCRIPTION
Uses the model-pricing provider allowlist as the source of truth for unpriced-model notifications.

The report query now accepts `providers.SupportedStrings()`, so provider types remain opt-in for both custom pricing and notifications. This preserves notifications for arbitrary model names under priceable provider types while excluding provider types the pricing API cannot configure.

Depends on #28419.

---

Created by Coder Agents on behalf of @evgeniy-scherbina.
