### PR TITLE
feat(site): implement new workspace header and controls section

### DIFF
--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
@@ -123,7 +123,7 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 			<DropdownMenu open={open} onOpenChange={setOpen}>
 				<DropdownMenuTrigger asChild>
 					<Button
-						size="icon-lg"
+						size="icon"
 						variant="subtle"
 						data-testid="workspace-options-button"
 						aria-controls="workspace-options"

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -19,6 +19,7 @@ import {
 	WorkspaceBuildProgress,
 } from "./WorkspaceBuildProgress";
 import { WorkspaceDeletedBanner } from "./WorkspaceDeletedBanner";
+import { WorkspaceHeader } from "./WorkspaceHeader";
 import { WorkspaceTopbar } from "./WorkspaceTopbar";
 
 interface WorkspaceProps {
@@ -109,17 +110,9 @@ export const Workspace: FC<WorkspaceProps> = ({
 				template={template}
 				permissions={permissions}
 				latestVersion={latestVersion}
-				isUpdating={isUpdating}
-				isRestarting={isRestarting}
-				handleStart={handleStart}
-				handleStop={handleStop}
 				handleRestart={handleRestart}
 				handleUpdate={handleUpdate}
-				handleCancel={handleCancel}
-				handleRetry={handleRetry}
-				handleDebug={handleDebug}
 				handleDormantActivate={handleDormantActivate}
-				handleToggleFavorite={handleToggleFavorite}
 			/>
 
 			<div className="flex flex-1 min-h-0">
@@ -169,6 +162,22 @@ export const Workspace: FC<WorkspaceProps> = ({
 							/>
 						)}
 						<div className="flex flex-col gap-6 max-w-[1200px] m-auto">
+							<WorkspaceHeader
+								workspace={workspace}
+								permissions={permissions}
+								isUpdating={isUpdating}
+								isRestarting={isRestarting}
+								handleStart={handleStart}
+								handleStop={handleStop}
+								handleRestart={handleRestart}
+								handleUpdate={handleUpdate}
+								handleCancel={handleCancel}
+								handleRetry={handleRetry}
+								handleDebug={handleDebug}
+								handleDormantActivate={handleDormantActivate}
+								handleToggleFavorite={handleToggleFavorite}
+							/>
+
 							{workspace.latest_build.status === "deleted" && (
 								<WorkspaceDeletedBanner
 									createWorkspaceLink={createWorkspaceLink}

--- a/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
@@ -192,9 +192,8 @@ export const FavoriteButton: FC<FavoriteButtonProps> = ({
 	isFavorite,
 }) => {
 	return (
-		<TopbarButton onClick={() => onToggle(workspaceID)}>
+		<TopbarButton size="icon" onClick={() => onToggle(workspaceID)}>
 			{isFavorite ? <StarOffIcon /> : <StarIcon />}
-			{isFavorite ? "Unfavorite" : "Favorite"}
 		</TopbarButton>
 	);
 };

--- a/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
@@ -28,9 +28,8 @@ export const ShareButton: FC<ShareButtonProps> = ({
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<TopbarButton data-testid="workspace-share-button">
+				<TopbarButton size="icon" data-testid="workspace-share-button">
 					<Share2Icon />
-					Share
 				</TopbarButton>
 			</PopoverTrigger>
 			<PopoverContent align="end" className="w-[580px] p-4">

--- a/site/src/pages/WorkspacePage/WorkspaceHeader.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceHeader.stories.tsx
@@ -1,0 +1,298 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+import { expect, userEvent, within } from "storybook/test";
+import { deploymentConfigQueryKey } from "#/api/queries/deployment";
+import { agentLogsKey, buildLogsKey } from "#/api/queries/workspaces";
+import * as Mocks from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+	withDesktopViewport,
+} from "#/testHelpers/storybook";
+import { WorkspaceHeader } from "./WorkspaceHeader";
+
+const meta: Meta<typeof WorkspaceHeader> = {
+	title: "pages/WorkspacePage/WorkspaceHeader",
+	component: WorkspaceHeader,
+	args: {
+		workspace: Mocks.MockWorkspace,
+		isUpdating: false,
+		isRestarting: false,
+		permissions: {
+			readWorkspace: true,
+			shareWorkspace: true,
+			updateWorkspace: true,
+			updateWorkspaceVersion: true,
+			deleteFailedWorkspace: true,
+		},
+		handleStart: action("start"),
+		handleStop: action("stop"),
+		handleRestart: action("restart"),
+		handleUpdate: action("update"),
+		handleCancel: action("cancel"),
+		handleRetry: action("retry"),
+		handleDebug: action("debug"),
+		handleDormantActivate: action("activate"),
+		handleToggleFavorite: action("favorite"),
+	},
+	decorators: [withDashboardProvider, withDesktopViewport, withAuthProvider],
+	parameters: {
+		user: Mocks.MockUserOwner,
+		queries: [
+			{
+				key: deploymentConfigQueryKey,
+				data: Mocks.MockDeploymentConfig,
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof WorkspaceHeader>;
+
+export const Starting: Story = {
+	args: {
+		workspace: Mocks.MockStartingWorkspace,
+	},
+};
+
+export const Running: Story = {
+	args: {
+		workspace: Mocks.MockWorkspace,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: Mocks.MockWorkspace.name }),
+		).toBeVisible();
+		await expect(canvas.getByText(/Workspace status:/)).toBeVisible();
+		await expect(canvas.getByRole("button", { name: "Stop" })).toBeVisible();
+	},
+};
+
+export const RunningUpdateAvailable: Story = {
+	name: "Running (Update available)",
+	args: {
+		workspace: {
+			...Mocks.MockWorkspace,
+			outdated: true,
+		},
+	},
+};
+
+export const RunningRequireActiveVersion: Story = {
+	name: "Running (No required update)",
+	args: {
+		workspace: {
+			...Mocks.MockWorkspace,
+			template_require_active_version: true,
+		},
+	},
+};
+
+export const RunningUpdateRequired: Story = {
+	name: "Running (Update Required)",
+	args: {
+		workspace: {
+			...Mocks.MockWorkspace,
+			template_require_active_version: true,
+			outdated: true,
+		},
+	},
+};
+
+export const Stopping: Story = {
+	args: {
+		workspace: Mocks.MockStoppingWorkspace,
+	},
+};
+
+export const Stopped: Story = {
+	args: {
+		workspace: Mocks.MockStoppedWorkspace,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", {
+				name: Mocks.MockStoppedWorkspace.name,
+			}),
+		).toBeVisible();
+		await expect(canvas.getByRole("button", { name: "Start" })).toBeVisible();
+	},
+};
+
+export const StoppedUpdateAvailable: Story = {
+	name: "Stopped (Update available)",
+	args: {
+		workspace: {
+			...Mocks.MockStoppedWorkspace,
+			outdated: true,
+		},
+	},
+};
+
+export const StoppedRequireActiveVersion: Story = {
+	name: "Stopped (No required update)",
+	args: {
+		workspace: {
+			...Mocks.MockStoppedWorkspace,
+			template_require_active_version: true,
+		},
+	},
+};
+
+export const StoppedUpdateRequired: Story = {
+	name: "Stopped (Update Required)",
+	args: {
+		workspace: {
+			...Mocks.MockStoppedWorkspace,
+			template_require_active_version: true,
+			outdated: true,
+		},
+	},
+};
+
+export const Updating: Story = {
+	args: {
+		workspace: Mocks.MockOutdatedWorkspace,
+		isUpdating: true,
+	},
+};
+
+export const Restarting: Story = {
+	args: {
+		workspace: Mocks.MockStoppingWorkspace,
+		isRestarting: true,
+	},
+};
+
+export const Canceling: Story = {
+	args: {
+		workspace: Mocks.MockCancelingWorkspace,
+	},
+};
+
+export const Deleting: Story = {
+	args: {
+		workspace: Mocks.MockDeletingWorkspace,
+	},
+};
+
+export const Deleted: Story = {
+	args: {
+		workspace: Mocks.MockDeletedWorkspace,
+	},
+};
+
+export const Outdated: Story = {
+	args: {
+		workspace: Mocks.MockOutdatedWorkspace,
+	},
+};
+
+export const Failed: Story = {
+	args: {
+		workspace: Mocks.MockFailedWorkspace,
+	},
+};
+
+export const FailedWithDebug: Story = {
+	args: {
+		workspace: Mocks.MockFailedWorkspace,
+		permissions: {
+			readWorkspace: true,
+			shareWorkspace: true,
+			updateWorkspace: true,
+			updateWorkspaceVersion: true,
+			deleteFailedWorkspace: true,
+		},
+	},
+};
+
+export const CancelShownForOwner: Story = {
+	args: {
+		workspace: {
+			...Mocks.MockStartingWorkspace,
+			template_allow_user_cancel_workspace_jobs: false,
+		},
+	},
+};
+
+export const CancelShownForUser: Story = {
+	args: {
+		workspace: Mocks.MockStartingWorkspace,
+	},
+	parameters: {
+		user: Mocks.MockUserMember,
+	},
+};
+
+export const CancelHiddenForUser: Story = {
+	args: {
+		workspace: {
+			...Mocks.MockStartingWorkspace,
+			template_allow_user_cancel_workspace_jobs: false,
+		},
+	},
+	parameters: {
+		user: Mocks.MockUserMember,
+	},
+};
+
+export const FavoriteHiddenForNonOwner: Story = {
+	args: {
+		workspace: Mocks.MockWorkspace,
+	},
+	parameters: {
+		user: Mocks.MockUserMember,
+	},
+};
+
+export const OpenDownloadLogs: Story = {
+	args: {
+		workspace: Mocks.MockWorkspace,
+	},
+	parameters: {
+		queries: [
+			{
+				key: buildLogsKey(Mocks.MockWorkspace.id),
+				data: generateLogs(200),
+			},
+			{
+				key: agentLogsKey(Mocks.MockWorkspaceAgent.id),
+				data: generateLogs(400),
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Workspace actions" }),
+		);
+		const screen = within(document.body);
+		await userEvent.click(screen.getByText("Download logs…"));
+		await expect(screen.getByTestId("dialog")).toBeInTheDocument();
+	},
+};
+
+export const CanDeleteDormantWorkspace: Story = {
+	args: {
+		workspace: Mocks.MockDormantWorkspace,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Workspace actions" }),
+		);
+		const screen = within(document.body);
+		const deleteButton = screen.getByText("Delete…");
+		await expect(deleteButton).toBeEnabled();
+	},
+};
+
+function generateLogs(count: number) {
+	return Array.from({ length: count }, (_, i) => ({
+		output: `log ${i + 1}`,
+	}));
+}

--- a/site/src/pages/WorkspacePage/WorkspaceHeader.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceHeader.tsx
@@ -1,0 +1,19 @@
+import type { ComponentProps, FC } from "react";
+import { WorkspaceStatusIndicator } from "#/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator";
+import { WorkspaceActions } from "./WorkspaceActions/WorkspaceActions";
+
+type WorkspaceHeaderProps = ComponentProps<typeof WorkspaceActions>;
+
+export const WorkspaceHeader: FC<WorkspaceHeaderProps> = (props) => {
+	const { workspace } = props;
+
+	return (
+		<div className="flex flex-col md:flex-row flex-wrap items-start justify-between gap-4">
+			<div className="flex items-center flex-wrap gap-6">
+				<h1 className="text-3xl font-semibold">{workspace.name}</h1>
+				<WorkspaceStatusIndicator workspace={workspace} />
+			</div>
+			<WorkspaceActions {...props} />
+		</div>
+	);
+};

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -56,7 +56,7 @@ const renderWorkspacePage = async (
 		path: "/:username/:workspace",
 	});
 
-	await screen.findByText(workspace.name);
+	await screen.findByRole("heading", { name: workspace.name });
 
 	return result;
 };

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
@@ -63,15 +63,6 @@ export const Example: Story = {
 	},
 };
 
-export const Outdated: Story = {
-	args: {
-		workspace: {
-			...baseWorkspace,
-			outdated: true,
-		},
-	},
-};
-
 export const ReadyWithDeadline: Story = {
 	args: {
 		workspace: {
@@ -182,10 +173,6 @@ export const Dormant: Story = {
 		workspace: {
 			...baseWorkspace,
 			deleting_at: new Date("2024/01/01").toISOString(),
-			latest_build: {
-				...baseWorkspace.latest_build,
-				status: "failed",
-			},
 		},
 	},
 };

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -28,12 +28,10 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
-import { WorkspaceStatusIndicator } from "#/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator";
 import { cn } from "#/utils/cn";
 import { displayDormantDeletion } from "#/utils/dormant";
 import { formatDate } from "#/utils/time";
 import type { WorkspacePermissions } from "../../modules/workspaces/permissions";
-import { WorkspaceActions } from "./WorkspaceActions/WorkspaceActions";
 import { WorkspaceNotifications } from "./WorkspaceNotifications/WorkspaceNotifications";
 import { WorkspaceScheduleControls } from "./WorkspaceScheduleControls";
 
@@ -44,21 +42,13 @@ const BREADCRUMB_SEGMENT_CLASS = cn(
 const BREADCRUMB_TEXT_CLASS = "overflow-x-hidden text-ellipsis";
 
 interface WorkspaceTopbarProps {
-	isUpdating: boolean;
-	isRestarting: boolean;
 	workspace: TypesGen.Workspace;
 	template: TypesGen.Template;
 	permissions: WorkspacePermissions;
 	latestVersion?: TypesGen.TemplateVersion;
-	handleStart: (buildParameters?: TypesGen.WorkspaceBuildParameter[]) => void;
-	handleStop: () => void;
 	handleRestart: (buildParameters?: TypesGen.WorkspaceBuildParameter[]) => void;
 	handleUpdate: () => void;
-	handleCancel: () => void;
 	handleDormantActivate: () => void;
-	handleRetry: (buildParameters?: TypesGen.WorkspaceBuildParameter[]) => void;
-	handleDebug: (buildParameters?: TypesGen.WorkspaceBuildParameter[]) => void;
-	handleToggleFavorite: () => void;
 }
 
 export const WorkspaceTopbar: FC<WorkspaceTopbarProps> = ({
@@ -66,17 +56,9 @@ export const WorkspaceTopbar: FC<WorkspaceTopbarProps> = ({
 	template,
 	latestVersion,
 	permissions,
-	isUpdating,
-	isRestarting,
-	handleStart,
-	handleStop,
 	handleRestart,
 	handleUpdate,
-	handleCancel,
 	handleDormantActivate,
-	handleToggleFavorite,
-	handleRetry,
-	handleDebug,
 }) => {
 	const { entitlements, organizations, showOrganizations } = useDashboard();
 	const getLink = useLinks();
@@ -230,24 +212,6 @@ export const WorkspaceTopbar: FC<WorkspaceTopbarProps> = ({
 						onRestartWorkspace={handleRestart}
 						onUpdateWorkspace={handleUpdate}
 						onActivateWorkspace={handleDormantActivate}
-					/>
-
-					<WorkspaceStatusIndicator workspace={workspace} />
-
-					<WorkspaceActions
-						workspace={workspace}
-						permissions={permissions}
-						isUpdating={isUpdating}
-						isRestarting={isRestarting}
-						handleStart={handleStart}
-						handleStop={handleStop}
-						handleRestart={handleRestart}
-						handleUpdate={handleUpdate}
-						handleCancel={handleCancel}
-						handleRetry={handleRetry}
-						handleDebug={handleDebug}
-						handleDormantActivate={handleDormantActivate}
-						handleToggleFavorite={handleToggleFavorite}
 					/>
 				</div>
 			)}


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

The longer-term goal is to remove the top bar from workspace pages. Rather than combine that entire migration into one large change, this PR takes the first incremental step by establishing the new workspace header inside the page content.

- Adds a new `WorkspaceHeader` with the workspace name, status, and controls.
- Moves workspace status and action ownership out of `WorkspaceTopbar`.
- Keeps the existing workspace lifecycle actions and permission checks intact.
- Uses compact icon buttons for share, favorite, and overflow actions.
- Adds Storybook coverage for workspace lifecycle states, permissions, action visibility, and selected interactions.
- Simplifies the props and responsibilities of `WorkspaceTopbar`.

| Old | New |
| --- | --- |
| <img width="3248" height="2122" alt="workspace-header-old" src="https://github.com/user-attachments/assets/80896632-6e8f-45eb-963c-650bd781f9f4" /> | <img width="3248" height="2122" alt="workspace-header-new" src="https://github.com/user-attachments/assets/a1fa6140-1692-4724-85f7-7d5e26aaed53" /> | 
