### PR TITLE
fix(coderd/database): exclude system users from AI budgets

### DIFF
--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -715,8 +715,8 @@ type sqlcQuerier interface {
 	// belong to @organization_id, on or after period_start until NOW.
 	// spend_limit_micros is the per-member limit, null when the group has no budget.
 	// total_spend_limit_micros is the combined budget of the members attributed to
-	// the group, with each member's override replacing their share. It is null when
-	// the group has no budget.
+	// the group, with each member's override replacing their share. System users
+	// are excluded. It is null when the group has no budget.
 	// The period_start parameter is normalized to its UTC calendar day.
 	// TODO(AIGOV-527): unify effective group resolution in a single place.
 	GetOrganizationGroupsAISpend(ctx context.Context, arg GetOrganizationGroupsAISpendParams) ([]GetOrganizationGroupsAISpendRow, error)
@@ -728,8 +728,8 @@ type sqlcQuerier interface {
 	// membership status for the prebuilds system user (org membership, group existence, group membership).
 	GetOrganizationsWithPrebuildStatus(ctx context.Context, arg GetOrganizationsWithPrebuildStatusParams) ([]GetOrganizationsWithPrebuildStatusRow, error)
 	// Returns, per effective group, the number of users at or over their spend
-	// limit since period_start. Only users with an enforceable limit (override or
-	// budgeted group) count, and the unlimited Everyone fallback does not.
+	// limit since period_start. Only non-system users with an enforceable limit
+	// (override or budgeted group) count, and the unlimited Everyone fallback does not.
 	// TODO(AIGOV-527): unify effective group resolution in a single place.
 	GetOverBudgetUsersPerGroup(ctx context.Context, periodStart time.Time) ([]GetOverBudgetUsersPerGroupRow, error)
 	GetParameterSchemasByJobID(ctx context.Context, jobID uuid.UUID) ([]ParameterSchema, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -14373,8 +14373,8 @@ func TestGetOrganizationGroupsAISpend(t *testing.T) {
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		// Given: an org with two members whose implicit Everyone group carries the
-		// only budget.
+		// Given: an org with two members and the prebuilds system user whose
+		// implicit Everyone group carries the only budget.
 		org := dbgen.Organization(t, db, database.Organization{})
 		for range 2 {
 			user := dbgen.User(t, db, database.User{})
@@ -14383,6 +14383,10 @@ func TestGetOrganizationGroupsAISpend(t *testing.T) {
 				OrganizationID: org.ID,
 			})
 		}
+		dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         database.PrebuildsSystemUserID,
+			OrganizationID: org.ID,
+		})
 		// The Everyone group has ID equal to the organization ID and must be
 		// inserted explicitly for the group_ai_budgets FK constraint.
 		//nolint:gocritic // Requires system context.
@@ -14402,7 +14406,7 @@ func TestGetOrganizationGroupsAISpend(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Then: every org member counts toward the total.
+		// Then: only non-system org members count toward the total.
 		require.Len(t, got, 1)
 		require.Equal(t, sql.NullInt64{Int64: 100, Valid: true}, got[0].SpendLimitMicros, "spend_limit_micros")
 		require.Equal(t, sql.NullInt64{Int64: 200, Valid: true}, got[0].TotalSpendLimitMicros, "total_spend_limit_micros")
@@ -15321,6 +15325,28 @@ func TestGetOverBudgetUsersPerGroup(t *testing.T) {
 				_, err := db.UpsertGroupAIBudget(ctx, database.UpsertGroupAIBudgetParams{GroupID: group.ID, SpendLimitMicros: 0})
 				require.NoError(t, err)
 				return []database.GetOverBudgetUsersPerGroupRow{{GroupID: group.ID, OverBudgetUsers: 1}}
+			},
+		},
+		{
+			// A system user in a budgeted group is not counted.
+			name: "SystemUserNotCounted",
+			setup: func(t *testing.T, ctx context.Context, db database.Store) []database.GetOverBudgetUsersPerGroupRow {
+				org := dbgen.Organization(t, db, database.Organization{})
+				group := dbgen.Group(t, db, database.Group{OrganizationID: org.ID})
+				dbgen.OrganizationMember(t, db, database.OrganizationMember{
+					OrganizationID: org.ID,
+					UserID:         database.PrebuildsSystemUserID,
+				})
+				dbgen.GroupMember(t, db, database.GroupMemberTable{
+					GroupID: group.ID,
+					UserID:  database.PrebuildsSystemUserID,
+				})
+				_, err := db.UpsertGroupAIBudget(ctx, database.UpsertGroupAIBudgetParams{
+					GroupID:          group.ID,
+					SpendLimitMicros: 0,
+				})
+				require.NoError(t, err)
+				return nil
 			},
 		},
 		{

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3192,6 +3192,7 @@ candidate_users AS (
 	SELECT DISTINCT member.user_id
 	FROM group_members_expanded member
 	WHERE member.group_id IN (SELECT id FROM queried_groups)
+		AND member.user_is_system = false
 ),
 user_highest_group AS (
 	-- Per user, the highest-limit group they belong to. Uses
@@ -3286,8 +3287,8 @@ type GetOrganizationGroupsAISpendRow struct {
 // belong to @organization_id, on or after period_start until NOW.
 // spend_limit_micros is the per-member limit, null when the group has no budget.
 // total_spend_limit_micros is the combined budget of the members attributed to
-// the group, with each member's override replacing their share. It is null when
-// the group has no budget.
+// the group, with each member's override replacing their share. System users
+// are excluded. It is null when the group has no budget.
 // The period_start parameter is normalized to its UTC calendar day.
 // TODO(AIGOV-527): unify effective group resolution in a single place.
 func (q *sqlQuerier) GetOrganizationGroupsAISpend(ctx context.Context, arg GetOrganizationGroupsAISpendParams) ([]GetOrganizationGroupsAISpendRow, error) {
@@ -3321,12 +3322,16 @@ func (q *sqlQuerier) GetOrganizationGroupsAISpend(ctx context.Context, arg GetOr
 
 const getOverBudgetUsersPerGroup = `-- name: GetOverBudgetUsersPerGroup :many
 WITH budgeted_users AS (
-	-- Users with an override or membership in a budgeted group.
-	SELECT user_id FROM user_ai_budget_overrides
+	-- Non-system users with an override or membership in a budgeted group.
+	SELECT override.user_id
+	FROM user_ai_budget_overrides override
+	JOIN users ON users.id = override.user_id
+	WHERE users.is_system = false
 	UNION
 	SELECT DISTINCT member.user_id
 	FROM group_ai_budgets budget
 	JOIN group_members_expanded member ON member.group_id = budget.group_id
+	WHERE member.user_is_system = false
 ),
 user_highest_group AS (
 	-- Per user, their highest-limit group ("highest" budget policy).
@@ -3384,8 +3389,8 @@ type GetOverBudgetUsersPerGroupRow struct {
 }
 
 // Returns, per effective group, the number of users at or over their spend
-// limit since period_start. Only users with an enforceable limit (override or
-// budgeted group) count, and the unlimited Everyone fallback does not.
+// limit since period_start. Only non-system users with an enforceable limit
+// (override or budgeted group) count, and the unlimited Everyone fallback does not.
 // TODO(AIGOV-527): unify effective group resolution in a single place.
 func (q *sqlQuerier) GetOverBudgetUsersPerGroup(ctx context.Context, periodStart time.Time) ([]GetOverBudgetUsersPerGroupRow, error) {
 	rows, err := q.db.QueryContext(ctx, getOverBudgetUsersPerGroup, periodStart)

--- a/coderd/database/queries/aicostcontrol.sql
+++ b/coderd/database/queries/aicostcontrol.sql
@@ -182,8 +182,8 @@ WHERE user_id = @user_id
 -- belong to @organization_id, on or after period_start until NOW.
 -- spend_limit_micros is the per-member limit, null when the group has no budget.
 -- total_spend_limit_micros is the combined budget of the members attributed to
--- the group, with each member's override replacing their share. It is null when
--- the group has no budget.
+-- the group, with each member's override replacing their share. System users
+-- are excluded. It is null when the group has no budget.
 -- The period_start parameter is normalized to its UTC calendar day.
 -- TODO(AIGOV-527): unify effective group resolution in a single place.
 WITH queried_groups AS (
@@ -199,6 +199,7 @@ candidate_users AS (
 	SELECT DISTINCT member.user_id
 	FROM group_members_expanded member
 	WHERE member.group_id IN (SELECT id FROM queried_groups)
+		AND member.user_is_system = false
 ),
 user_highest_group AS (
 	-- Per user, the highest-limit group they belong to. Uses
@@ -383,16 +384,20 @@ ORDER BY effective.user_id;
 
 -- name: GetOverBudgetUsersPerGroup :many
 -- Returns, per effective group, the number of users at or over their spend
--- limit since period_start. Only users with an enforceable limit (override or
--- budgeted group) count, and the unlimited Everyone fallback does not.
+-- limit since period_start. Only non-system users with an enforceable limit
+-- (override or budgeted group) count, and the unlimited Everyone fallback does not.
 -- TODO(AIGOV-527): unify effective group resolution in a single place.
 WITH budgeted_users AS (
-	-- Users with an override or membership in a budgeted group.
-	SELECT user_id FROM user_ai_budget_overrides
+	-- Non-system users with an override or membership in a budgeted group.
+	SELECT override.user_id
+	FROM user_ai_budget_overrides override
+	JOIN users ON users.id = override.user_id
+	WHERE users.is_system = false
 	UNION
 	SELECT DISTINCT member.user_id
 	FROM group_ai_budgets budget
 	JOIN group_members_expanded member ON member.group_id = budget.group_id
+	WHERE member.user_is_system = false
 ),
 user_highest_group AS (
 	-- Per user, their highest-limit group ("highest" budget policy).


### PR DESCRIPTION
## Description

Group AI budget totals counted system users, including the prebuilds user, even though they are excluded from the displayed member count.

The budget queries now exclude system users when calculating group totals and over-budget user counts.

## Changes

- Exclude system users from group AI budget totals.
- Exclude system users from over-budget user counts.
- Add database regression coverage.

Closes https://linear.app/codercom/issue/AIGOV-595

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.
