### PR TITLE
fix(enterprise/coderd): reject system user AI budget overrides

### DIFF
--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -803,6 +803,14 @@ func (api *API) userAIBudgetOverride(rw http.ResponseWriter, r *http.Request) {
 func (api *API) upsertUserAIBudgetOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	user := httpmw.UserParam(r)
+	if user.IsSystem {
+		api.Logger.Warn(ctx, "disallowed setting AI budget override for system user", slog.F("user_id", user.ID))
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			Message: "Forbidden",
+			Detail:  "Cannot set an AI budget override for a system user.",
+		})
+		return
+	}
 
 	var req codersdk.UpsertUserAIBudgetOverrideRequest
 	if !httpapi.Read(ctx, rw, r, &req) {

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -3024,6 +3024,37 @@ func TestUserAIBudgetOverride(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
 	})
 
+	t.Run("Upsert/RejectsSystemUser", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
+		ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{DeploymentValues: dv},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
+			},
+		})
+		adminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// The system user prebuilds is an implicit member of the default organization's Everyone group.
+		_, err := adminClient.UpsertUserAIBudgetOverride(ctx, database.PrebuildsSystemUserID, codersdk.UpsertUserAIBudgetOverrideRequest{
+			GroupID:          owner.OrganizationID,
+			SpendLimitMicros: 500_000_000,
+		})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+		require.Equal(t, "Cannot set an AI budget override for a system user.", sdkErr.Detail)
+
+		_, err = adminClient.UserAIBudgetOverride(ctx, database.PrebuildsSystemUserID)
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
+	})
+
 	t.Run("Get/AbsentReturns404", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Description

System users cannot authenticate with the AI gateway, but the API allowed user AI budget overrides to be configured for them.

The override endpoint now rejects system users with a clear forbidden response.

## Changes

- Reject user AI budget overrides for system users.
- Add API regression coverage.

Related to: https://linear.app/codercom/issue/AIGOV-595
Related to: https://github.com/coder/coder/pull/28698

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.
