### PR TITLE
fix(site): remove unused MCPConnectSummaryViewModel export

### DIFF
--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/debugPanelUtils.ts
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/debugPanelUtils.ts
@@ -436,7 +436,7 @@ export const compactDuration = (ms: number): string => {
 // View-model types for coerced debug payloads.
 // ---------------------------------------------------------------------------
 
-export interface MCPConnectSummaryViewModel {
+interface MCPConnectSummaryViewModel {
 	slug: string;
 	outcome: string;
 	durationMs: number | undefined;


### PR DESCRIPTION
Main CI's `lint` job fails deterministically because knip flags `MCPConnectSummaryViewModel` in `site/src/pages/AgentsPage/components/RightPanel/DebugPanel/debugPanelUtils.ts` as an unused exported type. The interface added in #28402 is only referenced inside its defining module, so this removes the unnecessary `export` modifier, matching the adjacent non-exported `RunSummaryViewModel`.

Validated at this head with `cd site && pnpm lint` (biome, oxlint, tsc, dpdm, react-compiler check, knip) exiting 0, plus a red-green check confirming the parent commit `5cc2f2c103a` reproduces the exact knip failure. Remote dogfood UAT ran and passed, including the DebugPanel Storybook interaction tests.

Fixes CODAGT-993.

> Xum acted on Mike's behalf for this pull request.

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=high -->

