### PR TITLE
fix: validate mcp input

### DIFF
--- a/coderd/mcp/mcp.go
+++ b/coderd/mcp/mcp.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	stdslog "log/slog"
 	"net/http"
 
@@ -139,8 +141,9 @@ func RegisterSDKTool(srv *mcp.Server, sdkTool toolsdk.GenericTool, tb toolsdk.De
 	}
 
 	inputSchema := map[string]any{
-		"type":       "object",
-		"properties": sdkTool.Schema.Properties,
+		"type":                 "object",
+		"properties":           sdkTool.Schema.Properties,
+		"additionalProperties": false,
 	}
 	if len(sdkTool.Schema.Required) > 0 {
 		inputSchema["required"] = sdkTool.Schema.Required
@@ -161,7 +164,24 @@ func RegisterSDKTool(srv *mcp.Server, sdkTool toolsdk.GenericTool, tb toolsdk.De
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		result, err := sdkTool.Handler(ctx, tb, req.Params.Arguments)
 		if err != nil {
-			return nil, err
+			var validationErr *toolsdk.ArgumentValidationError
+			if !errors.As(err, &validationErr) {
+				return nil, err
+			}
+			content, marshalErr := json.Marshal(struct {
+				Error          string         `json:"error"`
+				ExpectedSchema map[string]any `json:"expectedSchema"`
+			}{
+				Error:          validationErr.Error(),
+				ExpectedSchema: inputSchema,
+			})
+			if marshalErr != nil {
+				return nil, xerrors.Errorf("marshal MCP tool argument validation response: %w", marshalErr)
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+				IsError: true,
+			}, nil
 		}
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/coderd/mcp/mcp_test.go
+++ b/coderd/mcp/mcp_test.go
@@ -2,6 +2,7 @@ package mcp_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/aisdk-go"
 	mcpserver "github.com/coder/coder/v2/coderd/mcp"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/toolsdk"
@@ -162,6 +164,144 @@ func TestMCPHTTP_ModernProtocol(t *testing.T) {
 	tools, err := session.ListTools(ctx, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, tools.Tools)
+}
+
+func TestMCPHTTP_ToolArgumentValidation(t *testing.T) {
+	t.Parallel()
+
+	server, err := mcpserver.NewServer(testutil.Logger(t))
+	require.NoError(t, err)
+	require.NoError(t, server.RegisterTools(codersdk.New(testutil.MustURL(t, "http://not-used"))))
+
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+
+	connectCtx := testutil.Context(t, testutil.WaitShort)
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := mcpClient.Connect(connectCtx, &sdkmcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, session.Close())
+	})
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		keyword   string
+		property  string
+	}{
+		{
+			name: "MissingRequiredProperty",
+			arguments: map[string]any{
+				"user":            "me",
+				"rich_parameters": map[string]any{},
+			},
+			keyword:  "required:",
+			property: "name",
+		},
+		{
+			name: "IncorrectPropertyType",
+			arguments: map[string]any{
+				"user":            false,
+				"name":            "example",
+				"rich_parameters": map[string]any{},
+			},
+			keyword:  "type:",
+			property: "user",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
+
+			result, err := session.CallTool(ctx, &sdkmcp.CallToolParams{
+				Name:      toolsdk.ToolNameCreateWorkspace,
+				Arguments: test.arguments,
+			})
+			require.NoError(t, err)
+			require.True(t, result.IsError)
+			require.Len(t, result.Content, 1)
+			content, ok := result.Content[0].(*sdkmcp.TextContent)
+			require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+			var payload struct {
+				Error          string         `json:"error"`
+				ExpectedSchema map[string]any `json:"expectedSchema"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(content.Text), &payload))
+			require.Contains(t, payload.Error, "invalid arguments: $:")
+			require.Contains(t, payload.Error, test.keyword)
+			require.Contains(t, payload.Error, test.property)
+			require.Equal(t, "object", payload.ExpectedSchema["type"])
+			require.Equal(t, false, payload.ExpectedSchema["additionalProperties"])
+			properties, ok := payload.ExpectedSchema["properties"].(map[string]any)
+			require.True(t, ok)
+			require.Contains(t, properties, test.property)
+		})
+	}
+}
+
+func TestRegisterSDKTool(t *testing.T) {
+	t.Parallel()
+
+	type arguments struct {
+		Fail  bool   `json:"fail"`
+		Value string `json:"value"`
+	}
+	type response struct {
+		Value string `json:"value"`
+	}
+	tool := toolsdk.Tool[arguments, response]{
+		Tool: aisdk.Tool{
+			Name: "test_typed_tool",
+			Schema: aisdk.Schema{
+				Properties: map[string]any{
+					"fail":  map[string]any{"type": "boolean"},
+					"value": map[string]any{"type": "string"},
+				},
+				Required: []string{"value"},
+			},
+		},
+		Handler: func(_ context.Context, _ toolsdk.Deps, args arguments) (response, error) {
+			if args.Fail {
+				return response{}, assert.AnError
+			}
+			return response{Value: args.Value}, nil
+		},
+	}.Generic()
+
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	mcpserver.RegisterSDKTool(server, tool, toolsdk.Deps{})
+	serverTransport, clientTransport := sdkmcp.NewInMemoryTransports()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, serverSession.Close())
+	})
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, clientSession.Close())
+	})
+
+	result, err := clientSession.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      tool.Name,
+		Arguments: map[string]any{"value": "hello"},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	content, ok := result.Content[0].(*sdkmcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"value":"hello"}`, content.Text)
+
+	_, err = clientSession.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      tool.Name,
+		Arguments: map[string]any{"fail": true, "value": "hello"},
+	})
+	require.ErrorContains(t, err, assert.AnError.Error())
 }
 
 func TestMCPHTTP_UnsupportedProtocolVersion(t *testing.T) {

--- a/codersdk/toolsdk/chats.go
+++ b/codersdk/toolsdk/chats.go
@@ -80,7 +80,7 @@ type CreateChatArgs struct {
 	Prompt         string            `json:"prompt"`
 	OrganizationID string            `json:"organization_id"`
 	ModelConfigID  string            `json:"model_config_id"`
-	Labels         map[string]string `json:"labels"`
+	Labels         map[string]string `json:"labels,omitempty"`
 }
 
 var CreateChat = Tool[CreateChatArgs, ChatToolStatus]{
@@ -519,7 +519,7 @@ var AwaitChat = Tool[AwaitChatArgs, AwaitChatResponse]{
 }
 
 type ListChatsArgs struct {
-	Labels map[string]string `json:"labels"`
+	Labels map[string]string `json:"labels,omitempty"`
 	Query  string            `json:"query"`
 	Limit  int               `json:"limit"`
 }
@@ -774,7 +774,7 @@ Only user-facing text content is returned (including lifecycle hook notices); to
 type SendChatMessageArgs struct {
 	ChatID       string                    `json:"chat_id"`
 	Text         string                    `json:"text"`
-	BusyBehavior codersdk.ChatBusyBehavior `json:"busy_behavior"`
+	BusyBehavior codersdk.ChatBusyBehavior `json:"busy_behavior,omitempty"`
 }
 
 type SendChatMessageResponse struct {

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -8,10 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
@@ -210,14 +214,59 @@ var (
 // or return values. The original TypedHandlerFunc is wrapped to handle type
 // conversion.
 func (t Tool[Arg, Ret]) Generic() GenericTool {
+	getArgumentSchema := sync.OnceValues(func() (*jsonschema.Resolved, error) {
+		if t.Schema.Properties == nil {
+			return nil, xerrors.Errorf("compile argument schema for tool %q: schema properties cannot be nil", t.Name)
+		}
+		inputSchema := map[string]any{
+			"type":                 "object",
+			"properties":           t.Schema.Properties,
+			"additionalProperties": false,
+		}
+		if len(t.Schema.Required) > 0 {
+			inputSchema["required"] = t.Schema.Required
+		}
+		schemaJSON, err := json.Marshal(inputSchema)
+		if err != nil {
+			return nil, xerrors.Errorf("marshal argument schema for tool %q: %w", t.Name, err)
+		}
+		var schema jsonschema.Schema
+		if err := json.Unmarshal(schemaJSON, &schema); err != nil {
+			return nil, xerrors.Errorf("decode argument schema for tool %q: %w", t.Name, err)
+		}
+		compiled, err := schema.Resolve(nil)
+		if err != nil {
+			return nil, xerrors.Errorf("compile argument schema for tool %q: %w", t.Name, err)
+		}
+		return compiled, nil
+	})
+
 	return GenericTool{
 		Tool:               t.Tool,
 		MCPAnnotations:     t.MCPAnnotations,
 		UserClientOptional: t.UserClientOptional,
 		Handler: wrap(func(ctx context.Context, deps Deps, args json.RawMessage) (json.RawMessage, error) {
+			compiledSchema, err := getArgumentSchema()
+			if err != nil {
+				return nil, err
+			}
+			if len(args) == 0 {
+				args = json.RawMessage("{}")
+			}
+			var untypedArgs any
+			if err := json.Unmarshal(args, &untypedArgs); err != nil {
+				return nil, newArgumentValidationError(map[string]string{
+					"$": xerrors.Errorf("decode JSON arguments: %w", err).Error(),
+				}, err)
+			}
+			if err := compiledSchema.Validate(untypedArgs); err != nil {
+				return nil, newArgumentValidationError(map[string]string{"$": err.Error()}, nil)
+			}
 			var typedArgs Arg
 			if err := json.Unmarshal(args, &typedArgs); err != nil {
-				return nil, xerrors.Errorf("failed to unmarshal args: %w", err)
+				return nil, newArgumentValidationError(map[string]string{
+					"$": xerrors.Errorf("decode as tool argument type: %w", err).Error(),
+				}, err)
 			}
 			ret, err := t.Handler(ctx, deps, typedArgs)
 			var buf bytes.Buffer
@@ -243,6 +292,44 @@ type GenericTool struct {
 	// user authentication token. If true, the tool will be available even when
 	// running in an unauthenticated mode with just an agent token.
 	UserClientOptional bool
+}
+
+// ArgumentValidationError reports that tool arguments do not satisfy the
+// declared schema or cannot be decoded into the tool's argument type.
+type ArgumentValidationError struct {
+	details map[string]string
+	cause   error
+}
+
+func newArgumentValidationError(details map[string]string, cause error) *ArgumentValidationError {
+	if len(details) == 0 {
+		details = map[string]string{"$": "arguments do not satisfy the tool schema"}
+	}
+	return &ArgumentValidationError{details: details, cause: cause}
+}
+
+func (e *ArgumentValidationError) Error() string {
+	details := make([]string, 0, len(e.details))
+	for _, path := range slices.Sorted(maps.Keys(e.details)) {
+		var qualifiedPath string
+		switch {
+		case path == "":
+			qualifiedPath = "$"
+		case strings.HasPrefix(path, "$"):
+			qualifiedPath = path
+		case strings.HasPrefix(path, "/"):
+			qualifiedPath = "$" + path
+		default:
+			qualifiedPath = "$/" + path
+		}
+		details = append(details, qualifiedPath+": "+e.details[path])
+	}
+	return "invalid arguments: " + strings.Join(details, "; ")
+}
+
+// Unwrap returns the underlying JSON decoding error, when present.
+func (e *ArgumentValidationError) Unwrap() error {
+	return e.cause
 }
 
 // GenericHandlerFunc is a function that handles a tool call.
@@ -453,7 +540,7 @@ type CreateWorkspaceArgs struct {
 	TemplateID              string            `json:"template_id,omitempty"`
 	TemplateVersionID       string            `json:"template_version_id,omitempty"`
 	TemplateVersionPresetID string            `json:"template_version_preset_id,omitempty"`
-	User                    string            `json:"user"`
+	User                    string            `json:"user,omitempty"`
 }
 
 // richParametersFromMap converts the map shape used on tool args into the
@@ -514,11 +601,12 @@ be ready before trying to use or connect to the workspace.
 					"description": "Name of the workspace to create.",
 				},
 				"rich_parameters": map[string]any{
-					"type":        "object",
-					"description": "Key/value pairs of rich parameters to pass to the template version to create the workspace.",
+					"type":                 "object",
+					"description":          "Key/value pairs of rich parameters to pass to the template version to create the workspace.",
+					"additionalProperties": map[string]any{"type": "string"},
 				},
 			},
-			Required: []string{"user", "name", "rich_parameters"},
+			Required: []string{"name", "rich_parameters"},
 		},
 	},
 	MCPAnnotations: mcpMutationAnnotations,
@@ -851,8 +939,9 @@ connect to the workspace.
 					"description": "(Optional) ID of a template version preset to apply. Only valid for start transitions. Obtain available presets from coder_get_template. Presets are scoped to the template version they were created on; pass template_version_id with the same version the preset came from when the workspace's current build is on a different version, otherwise the build may apply mismatched parameter defaults. When set, the preset's parameter values take precedence over conflicting entries in rich_parameters.",
 				},
 				"rich_parameters": map[string]any{
-					"type":        "object",
-					"description": "(Optional) Key/value pairs of rich parameters to apply to the build. Only valid for start transitions.",
+					"type":                 "object",
+					"description":          "(Optional) Key/value pairs of rich parameters to apply to the build. Only valid for start transitions.",
+					"additionalProperties": map[string]any{"type": "string"},
 				},
 			},
 			Required: []string{"workspace_id", "transition"},
@@ -1570,8 +1659,9 @@ var UploadTarFile = Tool[UploadTarFileArgs, codersdk.UploadResponse]{
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
 				"files": map[string]any{
-					"type":        "object",
-					"description": "A map of file names to file contents.",
+					"type":                 "object",
+					"description":          "A map of file names to file contents.",
+					"additionalProperties": map[string]any{"type": "string"},
 				},
 			},
 			Required: []string{"files"},
@@ -2109,7 +2199,7 @@ var WorkspacePortForward = Tool[WorkspacePortForwardArgs, WorkspacePortForwardRe
 					"description": workspaceAgentDescription,
 				},
 				"port": map[string]any{
-					"type":        "number",
+					"type":        "integer",
 					"description": "The port to forward.",
 				},
 			},

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -179,6 +180,211 @@ func TestGenericToolMCPAnnotations(t *testing.T) {
 			assert.Equal(t, tc.idempotentHint, found.MCPAnnotations.IdempotentHint)
 			assert.Equal(t, tc.openWorldHint, found.MCPAnnotations.OpenWorldHint)
 		})
+	}
+}
+
+func TestGenericToolArgumentValidation(t *testing.T) {
+	t.Parallel()
+
+	type arguments struct {
+		Mode  string `json:"mode"`
+		Value int64  `json:"value"`
+	}
+	tests := []struct {
+		name      string
+		arguments string
+		contains  []string
+	}{
+		{
+			name:      "MissingRequiredProperty",
+			arguments: `{"mode":"allowed"}`,
+			contains:  []string{"required", "value"},
+		},
+		{
+			name:      "IncorrectPropertyType",
+			arguments: `{"mode":"allowed","value":false}`,
+			contains:  []string{"type", "value"},
+		},
+		{
+			name:      "BelowMinimum",
+			arguments: `{"mode":"allowed","value":0}`,
+			contains:  []string{"minimum", "value"},
+		},
+		{
+			name:      "InvalidEnumValue",
+			arguments: `{"mode":"denied","value":1}`,
+			contains:  []string{"enum", "mode"},
+		},
+		{
+			name:      "UnknownProperty",
+			arguments: `{"mode":"allowed","value":1,"unknown":true}`,
+			contains:  []string{"unexpected additional properties", "unknown"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			called := false
+			tool := toolsdk.Tool[arguments, struct{}]{
+				Tool: aisdk.Tool{
+					Name: "test_validation",
+					Schema: aisdk.Schema{
+						Properties: map[string]any{
+							"mode": map[string]any{
+								"type": "string",
+								"enum": []string{"allowed"},
+							},
+							"value": map[string]any{
+								"type":    "integer",
+								"minimum": 1,
+							},
+						},
+						Required: []string{"mode", "value"},
+					},
+				},
+				Handler: func(context.Context, toolsdk.Deps, arguments) (struct{}, error) {
+					called = true
+					return struct{}{}, nil
+				},
+			}.Generic()
+
+			result, err := tool.Handler(t.Context(), toolsdk.Deps{}, json.RawMessage(test.arguments))
+			require.Nil(t, result)
+			var validationErr *toolsdk.ArgumentValidationError
+			require.ErrorAs(t, err, &validationErr)
+			for _, expected := range test.contains {
+				require.ErrorContains(t, validationErr, expected)
+			}
+			require.False(t, called)
+		})
+	}
+}
+
+func TestGenericToolArgumentValidation_TypedDecode(t *testing.T) {
+	t.Parallel()
+
+	type arguments struct {
+		Port int `json:"port"`
+	}
+	called := false
+	tool := toolsdk.Tool[arguments, struct{}]{
+		Tool: aisdk.Tool{
+			Name: "test_typed_decode",
+			Schema: aisdk.Schema{
+				Properties: map[string]any{
+					"port": map[string]any{"type": "number"},
+				},
+				Required: []string{"port"},
+			},
+		},
+		Handler: func(context.Context, toolsdk.Deps, arguments) (struct{}, error) {
+			called = true
+			return struct{}{}, nil
+		},
+	}.Generic()
+
+	result, err := tool.Handler(t.Context(), toolsdk.Deps{}, json.RawMessage(`{"port":8080.5}`))
+	require.Nil(t, result)
+	var validationErr *toolsdk.ArgumentValidationError
+	require.True(t, errors.As(err, &validationErr))
+	require.ErrorContains(t, validationErr, "cannot unmarshal number")
+	require.False(t, called)
+}
+
+func TestGenericToolArgumentValidation_PreservesLargeInteger(t *testing.T) {
+	t.Parallel()
+
+	type arguments struct {
+		Value int64 `json:"value"`
+	}
+	const value = int64(9007199254740993)
+	var received int64
+	tool := toolsdk.Tool[arguments, struct{}]{
+		Tool: aisdk.Tool{
+			Name: "test_large_integer",
+			Schema: aisdk.Schema{
+				Properties: map[string]any{
+					"value": map[string]any{"type": "integer"},
+				},
+				Required: []string{"value"},
+			},
+		},
+		Handler: func(_ context.Context, _ toolsdk.Deps, args arguments) (struct{}, error) {
+			received = args.Value
+			return struct{}{}, nil
+		},
+	}.Generic()
+
+	result, err := tool.Handler(t.Context(), toolsdk.Deps{}, json.RawMessage(`{"value":9007199254740993}`))
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(result))
+	require.Equal(t, value, received)
+}
+
+func TestGenericToolArgumentValidation_OmittedArguments(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	tool := toolsdk.Tool[toolsdk.NoArgs, struct{}]{
+		Tool: aisdk.Tool{
+			Name:   "test_omitted_arguments",
+			Schema: aisdk.Schema{Properties: map[string]any{}},
+		},
+		Handler: func(context.Context, toolsdk.Deps, toolsdk.NoArgs) (struct{}, error) {
+			called = true
+			return struct{}{}, nil
+		},
+	}.Generic()
+
+	result, err := tool.Handler(t.Context(), toolsdk.Deps{}, nil)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(result))
+	require.True(t, called)
+}
+
+func TestGenericToolArgumentValidation_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	type arguments struct {
+		Labels map[string]string `json:"labels"`
+	}
+	tool := toolsdk.Tool[arguments, struct{}]{
+		Tool: aisdk.Tool{
+			Name: "test_concurrent_validation",
+			Schema: aisdk.Schema{
+				Properties: map[string]any{
+					"labels": map[string]any{
+						"type": "object",
+						"patternProperties": map[string]any{
+							"^label_": map[string]any{"type": "string"},
+						},
+					},
+				},
+				Required: []string{"labels"},
+			},
+		},
+		Handler: func(context.Context, toolsdk.Deps, arguments) (struct{}, error) {
+			return struct{}{}, nil
+		},
+	}.Generic()
+
+	const callers = 32
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Go(func() {
+			<-start
+			_, err := tool.Handler(t.Context(), toolsdk.Deps{}, json.RawMessage(`{"labels":{"label_one":"value"}}`))
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
 	}
 }
 
@@ -1040,9 +1246,9 @@ func TestTools(t *testing.T) {
 
 		t.Run("RejectsInvalidTemplateID", func(t *testing.T) {
 			_, err := testTool(t, toolsdk.CreateWorkspace, tb, toolsdk.CreateWorkspaceArgs{
-				User:       "me",
-				Name:       testutil.GetRandomNameHyphenated(t),
-				TemplateID: "not-a-uuid",
+				Name:           testutil.GetRandomNameHyphenated(t),
+				TemplateID:     "not-a-uuid",
+				RichParameters: map[string]string{},
 			})
 			require.ErrorContains(t, err, "template_id must be a valid UUID")
 		})
@@ -1052,6 +1258,7 @@ func TestTools(t *testing.T) {
 				User:              "me",
 				Name:              testutil.GetRandomNameHyphenated(t),
 				TemplateVersionID: "not-a-uuid",
+				RichParameters:    map[string]string{},
 			})
 			require.ErrorContains(t, err, "template_version_id must be a valid UUID")
 		})
@@ -1062,6 +1269,7 @@ func TestTools(t *testing.T) {
 				Name:                    testutil.GetRandomNameHyphenated(t),
 				TemplateVersionID:       uuid.NewString(),
 				TemplateVersionPresetID: "not-a-uuid",
+				RichParameters:          map[string]string{},
 			})
 			require.ErrorContains(t, err, "template_version_preset_id must be a valid UUID")
 		})
@@ -1441,6 +1649,7 @@ func TestTools(t *testing.T) {
 		_, err = testTool(t, toolsdk.WorkspaceEditFile, tb, toolsdk.WorkspaceEditFileArgs{
 			Workspace: workspace.Name,
 			Path:      filePath,
+			Edits:     []workspacesdk.FileEdit{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must specify at least one edit")
@@ -1484,6 +1693,7 @@ func TestTools(t *testing.T) {
 
 		_, err = testTool(t, toolsdk.WorkspaceEditFiles, tb, toolsdk.WorkspaceEditFilesArgs{
 			Workspace: workspace.Name,
+			Files:     []workspacesdk.FileEdits{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must specify at least one file")
@@ -1736,7 +1946,12 @@ func testTool[Arg, Ret any](t *testing.T, tool toolsdk.Tool[Arg, Ret], tb toolsd
 	require.NoError(t, err, "failed to marshal args")
 	result, err := tool.Generic().Handler(t.Context(), tb, toolArgs)
 	var ret Ret
-	require.NoError(t, json.Unmarshal(result, &ret), "failed to unmarshal result %q", string(result))
+	if err == nil {
+		require.NotEmpty(t, result, "tool returned an empty successful result")
+	}
+	if len(result) > 0 {
+		require.NoError(t, json.Unmarshal(result, &ret), "failed to unmarshal result %q", string(result))
+	}
 	return ret, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -513,7 +513,7 @@ require (
 	github.com/charmbracelet/x/exp/strings v0.1.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
-	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/google/jsonschema-go v0.4.3
 	github.com/linkdata/deadlock v0.5.5 // indirect
 	github.com/minio/simdjson-go v0.4.5 // indirect
 	github.com/petermattis/goid v0.0.0-20260226131333-17d1149c6ac6 // indirect


### PR DESCRIPTION
Addresses [CODAGT-994](https://linear.app/codercom/issue/CODAGT-994/return-validation-errors-for-invalid-mcp-tool-arguments).

The MCP server currently does not validate tool call arguments against the MCP JSON schema.

Additionally, when a client passes invalid arguments to a Coder MCP server tool call, currently the server returns only:

```json
{
  "error": "MCP tool request failed."
}
```

In this PR we start validating arguments and returning an informative validation error instead:

```json
{
  "error": "invalid arguments: ...",
  "expectedSchema": { ... }
}
```
