### PR TITLE
fix(enterprise): validate model price provider filters

### DIFF
--- a/enterprise/cli/exp_aimodelprices_test.go
+++ b/enterprise/cli/exp_aimodelprices_test.go
@@ -502,6 +502,37 @@ func TestAIModelPricesList(t *testing.T) {
 		require.Equal(t, def[0], all[1])
 	})
 
+	t.Run("RejectsUnsupportedProvider", func(t *testing.T) {
+		t.Parallel()
+
+		client := setupAIModelPricesCLI(t)
+
+		// When: an unsupported provider type is passed.
+		inv, conf := newCLI(t, "exp", "ai-model-prices", "list", "--provider", "unknown-provider")
+		clitest.SetupConfig(t, client, conf) //nolint:gocritic // requires owner
+		err := inv.Run()
+
+		// Then: the API rejects it.
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `Provider "unknown-provider" is not supported.`)
+	})
+
+	t.Run("RejectsOpenAICompat", func(t *testing.T) {
+		t.Parallel()
+
+		client := setupAIModelPricesCLI(t)
+
+		// When: the openai-compat provider is passed, which is excluded from
+		// model pricing.
+		inv, conf := newCLI(t, "exp", "ai-model-prices", "list", "--provider", "openai-compat")
+		clitest.SetupConfig(t, client, conf) //nolint:gocritic // requires owner
+		err := inv.Run()
+
+		// Then: the API rejects it.
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `Provider "openai-compat" is not supported.`)
+	})
+
 	t.Run("RejectsAnUnknownSource", func(t *testing.T) {
 		t.Parallel()
 

--- a/enterprise/coderd/aimodelprices.go
+++ b/enterprise/coderd/aimodelprices.go
@@ -42,6 +42,18 @@ var aiModelPriceSources = []string{
 func (api *API) listAIModelPrices(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	provider := r.URL.Query().Get("provider")
+	if provider != "" && !slices.Contains(providers.Supported, database.AIProviderType(provider)) {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid AI model price provider.",
+			Validations: []codersdk.ValidationError{{
+				Field:  "provider",
+				Detail: fmt.Sprintf("Provider %q is not supported. Supported providers: %s.", provider, strings.Join(providers.SupportedStrings(), ", ")),
+			}},
+		})
+		return
+	}
+
 	// An absent source leaves the listing unfiltered.
 	source := r.URL.Query().Get("source")
 	if source != "" && !slices.Contains(aiModelPriceSources, source) {
@@ -56,7 +68,7 @@ func (api *API) listAIModelPrices(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	dbPrices, err := api.Database.GetAIModelPrices(ctx, database.GetAIModelPricesParams{
-		Provider: r.URL.Query().Get("provider"),
+		Provider: provider,
 		Model:    r.URL.Query().Get("model"),
 		Source:   source,
 	})

--- a/enterprise/coderd/aimodelprices_test.go
+++ b/enterprise/coderd/aimodelprices_test.go
@@ -392,6 +392,51 @@ func TestListAIModelPrices(t *testing.T) {
 		require.Equal(t, int64(6_250_000), *seeded[0].CacheWritePrice)
 	})
 
+	t.Run("RejectsUnsupportedProvider", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: an entitled deployment.
+		ownerClient, _ := setupAIModelPricesTest(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// When: the prices are listed with an unsupported provider type.
+		//nolint:gocritic // Reading AI model prices is owner-only.
+		_, err := codersdk.NewExperimentalClient(ownerClient).ListAIModelPrices(ctx,
+			codersdk.AIModelPricesFilter{Provider: "unknown-provider"})
+
+		// Then: a 400 comes back naming the field and supported provider types.
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+		require.Equal(t, "Invalid AI model price provider.", sdkErr.Message)
+		require.Len(t, sdkErr.Validations, 1)
+		require.Equal(t, "provider", sdkErr.Validations[0].Field)
+		require.Equal(t, `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`, sdkErr.Validations[0].Detail)
+	})
+
+	t.Run("RejectsOpenAICompat", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: an entitled deployment.
+		ownerClient, _ := setupAIModelPricesTest(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// When: the prices are listed filtered by the openai-compat provider,
+		// which is a generic passthrough excluded from model pricing.
+		//nolint:gocritic // Reading AI model prices is owner-only.
+		_, err := codersdk.NewExperimentalClient(ownerClient).ListAIModelPrices(ctx,
+			codersdk.AIModelPricesFilter{Provider: "openai-compat"})
+
+		// Then: a 400 comes back naming the field and supported provider types.
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+		require.Equal(t, "Invalid AI model price provider.", sdkErr.Message)
+		require.Len(t, sdkErr.Validations, 1)
+		require.Equal(t, "provider", sdkErr.Validations[0].Field)
+		require.Equal(t, `Provider "openai-compat" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`, sdkErr.Validations[0].Detail)
+	})
+
 	t.Run("RejectsAnUnknownSource", func(t *testing.T) {
 		t.Parallel()
 
@@ -498,11 +543,6 @@ func TestListAIModelPrices(t *testing.T) {
 				name:   "ByProviderAndModel",
 				filter: codersdk.AIModelPricesFilter{Provider: "anthropic", Model: "model-a"},
 				want:   []string{"anthropic/model-a"},
-			},
-			{
-				name:   "UnknownProviderMatchesNothing",
-				filter: codersdk.AIModelPricesFilter{Provider: "unknown-provider"},
-				want:   nil,
 			},
 			{
 				// The override is skipped, leaving the price book's row.


### PR DESCRIPTION
The AI model prices list endpoint accepted unsupported provider values and returned an empty result instead of an error.

Validate the provider filter against the supported model price provider types and return the same supported provider guidance used by updates.

> [!NOTE]
> Generated by Coder Agents for @ssncferreira.
