### PR TITLE
docs(coderd/x/chatd): document the /clear ClearContext transition and endpoint

### DIFF
--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -119,7 +119,7 @@ I don't recommend reading the rest of section thoroughly if this is your first t
 - `Interrupt(reason)` requests cancellation of an active generation or closes pending dynamic-tool action. It preserves queued backlog.
 - `CompleteRequiresAction(results)` inserts submitted tool-result messages followed by any caller-provided suffix messages, clears `requires_action_deadline_at`, and lands in `running`. It preserves queued messages.
 - `RequestCompaction` records a manual compaction request on an idle or errored chat by setting `compaction_requested_at` and landing in `running` without inserting any message. It clears `last_error` per the leave-error rule, advances `history_version` to the transaction's new `snapshot_version`, and resets `generation_attempt`, so the compaction turn gets a full retry budget and message part episode keys that cannot collide with episodes retained from the previous turn. The chat worker picks the chat up like any other running chat and consumes the request. See [Manual compaction](#manual-compaction).
-- TODO(PR author): document `ClearContext`, the synchronous manual context reset added for the `/clear` command. Key facts: allowed from `W -> W` and `E0 -> W`; inserts the caller-built compressed boundary triplet (hidden model-only sentinel user row, visible synthetic `chat_cleared` tool call, tool result); lands in `waiting` with no worker turn and no model call; clears `last_error` and any pending `compaction_requested_at`; leaves ownership untouched; the message insert trigger advances `history_version` and resets `generation_attempt`. `E1` is rejected because no waiting-with-queue state exists and a synchronous clear has no turn after which the queue would drain.
+- `ClearContext(messages)` commits a manual context reset synchronously, without involving the chat worker. It inserts the caller-built compressed clear boundary triplet (a hidden model-only sentinel user row, plus visible synthetic `chat_cleared` tool-call and tool-result messages), clears `last_error` and any pending `compaction_requested_at`, leaves ownership untouched, and lands in `waiting`. No worker turn or model call follows; the message insert trigger advances `history_version` and resets `generation_attempt`. `E1` is rejected because no waiting-with-queue state exists and a synchronous clear has no turn after which the queue would drain.
 
 ### Transitions used by the chat worker
 
@@ -141,8 +141,6 @@ Now comes maybe the densest part of this document. It's a diagram that shows all
 
 A transition between input state `A` and output state `B` is allowed only if it's listed in the diagram below (`A --> B: Transition Name`). If a transition is not allowed, the core state machine implementation must reject it.
 
-TODO(PR author): add the new `ClearContext` transition edges to the diagram: `W --> W: ClearContext` and `E0 --> W: ClearContext`.
-
 ```mermaid
 stateDiagram-v2
     direction LR
@@ -154,12 +152,14 @@ stateDiagram-v2
     W --> R0: SendMessage
     W --> R0: EditMessage
     W --> R0: RequestCompaction
+    W --> W: ClearContext
     W --> E0: FinishError
     W --> XW: SetArchived(true)
 
     E0 --> R0: SendMessage
     E0 --> R0: EditMessage
     E0 --> R0: RequestCompaction
+    E0 --> W: ClearContext
     E0 --> XE0: SetArchived(true)
 
     E1 --> R1: SendMessage
@@ -575,7 +575,12 @@ No other input states are supported: generating chats get a conflict error, and 
 
 ### `POST /api/experimental/chats/{chat}/clear`
 
-TODO(PR author): document the manual context clear endpoint added for the `/clear` command. Key facts: uses `ClearContext` (`W -> W`, `E0 -> W`); commits synchronously inside the API transaction with no worker round-trip and no model call; the transcript is preserved and only future prompts stop seeing pre-clear history; the prompt-assembly query needs no change because the clear boundary reuses the compressed model-only anchor shape; boundary detection (`latestContextBoundaryIndex`) recognizes both `chat_summarized` and `chat_cleared`, so clear and compaction never reach across each other's boundary; "nothing to clear" rolls back with a conflict when no active model-visible non-system message follows the latest boundary; owner-only for symmetry with `/compact`.
+This endpoint uses `ClearContext`:
+
+- `W -> ClearContext -> W`
+- `E0 -> ClearContext -> W`
+
+No other input states are supported: generating chats and chats with queued messages get a conflict error, and archived chats are rejected. Unlike `/compact`, there is no worker round-trip and no model call: the endpoint builds the boundary triplet itself and commits it synchronously inside the API transaction. The transcript is preserved; only future prompts stop seeing pre-clear history. Clearing from an error state clears `last_error`, so a context-overflowed chat gets an instant recovery path that discards the oversized history instead of summarizing it. The prompt-assembly query needs no changes because the clear boundary reuses the compressed model-only anchor shape produced by compaction. Boundary detection (`latestContextBoundaryIndex`) recognizes both `chat_summarized` and `chat_cleared` boundaries, so clear and compaction never reach across each other's boundary. If no active model-visible non-system message follows the latest boundary, the transaction rolls back with a "nothing to clear" conflict, so an empty or already-cleared chat never gains a duplicate boundary. The endpoint is owner-only for symmetry with `/compact`. The web UI surfaces it as the `/clear` slash command.
 
 ## Pubsub
 


### PR DESCRIPTION
> [!NOTE]
> Xum acted on Mike's behalf in this pull request.
<!-- xum-attribution: model=claude-fable-5 thinking=high -->

Requested follow-up to #24745, which intentionally left `TODO(PR author)` placeholders in `coderd/x/chatd/ARCHITECTURE.md`. Replaces them with the actual documentation: the `ClearContext` entry in the HTTP transition list, the `W --> W` / `E0 --> W` edges in the execution state diagram, and the `POST /api/experimental/chats/{chat}/clear` endpoint section.

Documentation only. Every claim was verified against the merged implementation (`chatstate/transition.go`, `chatstate/transitions.go`, `chatd.go`, `message_conversion.go`, `exp_chats.go`).

