### PR TITLE
chore: refresh AI model price book

### DIFF
--- a/coderd/aibridge/prices/data/prices.json
+++ b/coderd/aibridge/prices/data/prices.json
@@ -1146,26 +1146,26 @@
   {
     "provider": "bedrock",
     "model": "global.openai.gpt-5.6-luna",
-    "input_price": 220000,
-    "output_price": 1320000,
-    "cache_read_price": 22000,
-    "cache_write_price": 275000
+    "input_price": 200000,
+    "output_price": 1200000,
+    "cache_read_price": 20000,
+    "cache_write_price": 250000
   },
   {
     "provider": "bedrock",
     "model": "global.openai.gpt-5.6-sol",
-    "input_price": 5500000,
-    "output_price": 33000000,
-    "cache_read_price": 550000,
-    "cache_write_price": 6875000
+    "input_price": 4000000,
+    "output_price": 20000000,
+    "cache_read_price": 400000,
+    "cache_write_price": 5000000
   },
   {
     "provider": "bedrock",
     "model": "global.openai.gpt-5.6-terra",
-    "input_price": 2200000,
-    "output_price": 13200000,
-    "cache_read_price": 220000,
-    "cache_write_price": 2750000
+    "input_price": 2000000,
+    "output_price": 12000000,
+    "cache_read_price": 200000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "bedrock",
@@ -1458,10 +1458,10 @@
   {
     "provider": "bedrock",
     "model": "openai.gpt-5.6-sol",
-    "input_price": 5500000,
-    "output_price": 33000000,
-    "cache_read_price": 550000,
-    "cache_write_price": 6875000
+    "input_price": 4400000,
+    "output_price": 22000000,
+    "cache_read_price": 440000,
+    "cache_write_price": 5500000
   },
   {
     "provider": "bedrock",
@@ -1946,10 +1946,10 @@
   {
     "provider": "copilot",
     "model": "gpt-5.6-sol",
-    "input_price": 5000000,
-    "output_price": 30000000,
-    "cache_read_price": 500000,
-    "cache_write_price": 6250000
+    "input_price": 2500000,
+    "output_price": 15000000,
+    "cache_read_price": 250000,
+    "cache_write_price": 3125000
   },
   {
     "provider": "copilot",
@@ -2202,9 +2202,9 @@
   {
     "provider": "google",
     "model": "gemini-3.6-flash",
-    "input_price": 1500000,
-    "output_price": 7500000,
-    "cache_read_price": 150000,
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
     "cache_write_price": null
   },
   {
@@ -2234,17 +2234,17 @@
   {
     "provider": "google",
     "model": "gemini-flash-latest",
-    "input_price": 1500000,
-    "output_price": 9000000,
-    "cache_read_price": 150000,
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
     "cache_write_price": null
   },
   {
     "provider": "google",
     "model": "gemini-flash-lite-latest",
-    "input_price": 250000,
-    "output_price": 1500000,
-    "cache_read_price": 25000,
+    "input_price": 300000,
+    "output_price": 2500000,
+    "cache_read_price": 30000,
     "cache_write_price": null
   },
   {
@@ -2506,10 +2506,10 @@
   {
     "provider": "openai",
     "model": "gpt-5.6",
-    "input_price": 5000000,
-    "output_price": 30000000,
-    "cache_read_price": 500000,
-    "cache_write_price": 6250000
+    "input_price": 4000000,
+    "output_price": 20000000,
+    "cache_read_price": 400000,
+    "cache_write_price": 5000000
   },
   {
     "provider": "openai",
@@ -2522,10 +2522,10 @@
   {
     "provider": "openai",
     "model": "gpt-5.6-sol",
-    "input_price": 5000000,
-    "output_price": 30000000,
-    "cache_read_price": 500000,
-    "cache_write_price": 6250000
+    "input_price": 4000000,
+    "output_price": 20000000,
+    "cache_read_price": 400000,
+    "cache_write_price": 5000000
   },
   {
     "provider": "openai",
@@ -2977,14 +2977,6 @@
   },
   {
     "provider": "openrouter",
-    "model": "deepcogito/cogito-v2.1-671b",
-    "input_price": 1250000,
-    "output_price": 1250000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "deepseek/deepseek-chat",
     "input_price": 257400,
     "output_price": 1028700,
@@ -3002,9 +2994,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat-v3.1",
-    "input_price": 250000,
-    "output_price": 950000,
-    "cache_read_price": 130000,
+    "input_price": 550000,
+    "output_price": 1650000,
+    "cache_read_price": 550000,
     "cache_write_price": null
   },
   {
@@ -3036,15 +3028,15 @@
     "model": "deepseek/deepseek-v3.1-terminus",
     "input_price": 270000,
     "output_price": 1000000,
-    "cache_read_price": null,
+    "cache_read_price": 135000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v3.2",
-    "input_price": 269000,
-    "output_price": 400000,
-    "cache_read_price": 134500,
+    "input_price": 260000,
+    "output_price": 380000,
+    "cache_read_price": 130000,
     "cache_write_price": null
   },
   {
@@ -3058,33 +3050,41 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash",
-    "input_price": 88606,
-    "output_price": 177212,
-    "cache_read_price": 17721,
+    "input_price": 79520,
+    "output_price": 159040,
+    "cache_read_price": 15904,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash-0731",
-    "input_price": 140000,
-    "output_price": 280000,
-    "cache_read_price": 28000,
+    "input_price": 60000,
+    "output_price": 120000,
+    "cache_read_price": 12000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "deepseek/deepseek-v4-flash-vision-exp",
+    "input_price": 220000,
+    "output_price": 660000,
+    "cache_read_price": 7000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro",
-    "input_price": 1600000,
-    "output_price": 3200000,
-    "cache_read_price": 135000,
+    "input_price": 870000,
+    "output_price": 1740000,
+    "cache_read_price": 72500,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro-0813",
-    "input_price": 1188000,
-    "output_price": 3564000,
-    "cache_read_price": 39600,
+    "input_price": 1122000,
+    "output_price": 3366000,
+    "cache_read_price": 37400,
     "cache_write_price": null
   },
   {
@@ -3289,14 +3289,6 @@
   },
   {
     "provider": "openrouter",
-    "model": "google/gemma-3n-e4b-it",
-    "input_price": 60000,
-    "output_price": 120000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "google/gemma-4-26b-a4b-it",
     "input_price": 70000,
     "output_price": 340000,
@@ -3377,34 +3369,10 @@
   },
   {
     "provider": "openrouter",
-    "model": "inclusionai/ling-2.6-1t",
-    "input_price": 75000,
-    "output_price": 625000,
-    "cache_read_price": 15000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "inclusionai/ling-2.6-flash",
-    "input_price": 10000,
-    "output_price": 30000,
-    "cache_read_price": 2000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "inclusionai/ling-3.0-flash",
     "input_price": 21000,
     "output_price": 63000,
     "cache_read_price": 4200,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "inclusionai/ring-2.6-1t",
-    "input_price": 75000,
-    "output_price": 625000,
-    "cache_read_price": 15000,
     "cache_write_price": null
   },
   {
@@ -3436,6 +3404,14 @@
     "model": "liquid/lfm-2.5-2.6b:free",
     "input_price": 0,
     "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "mancer/weaver",
+    "input_price": 500000,
+    "output_price": 750000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -3482,9 +3458,9 @@
   {
     "provider": "openrouter",
     "model": "meta-llama/llama-3.3-70b-instruct",
-    "input_price": 100000,
-    "output_price": 320000,
-    "cache_read_price": null,
+    "input_price": 710000,
+    "output_price": 710000,
+    "cache_read_price": 710000,
     "cache_write_price": null
   },
   {
@@ -3498,9 +3474,9 @@
   {
     "provider": "openrouter",
     "model": "meta-llama/llama-4-scout",
-    "input_price": 100000,
-    "output_price": 300000,
-    "cache_read_price": null,
+    "input_price": 110000,
+    "output_price": 340000,
+    "cache_read_price": 55000,
     "cache_write_price": null
   },
   {
@@ -3533,6 +3509,14 @@
     "input_price": 1250000,
     "output_price": 4250000,
     "cache_read_price": 150000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "meta/muse-spark-1.2-contributor",
+    "input_price": 100000,
+    "output_price": 200000,
+    "cache_read_price": 2000,
     "cache_write_price": null
   },
   {
@@ -3594,9 +3578,9 @@
   {
     "provider": "openrouter",
     "model": "minimax/minimax-m2.5",
-    "input_price": 225000,
-    "output_price": 900000,
-    "cache_read_price": 60000,
+    "input_price": 270000,
+    "output_price": 1080000,
+    "cache_read_price": 27000,
     "cache_write_price": null
   },
   {
@@ -3609,6 +3593,14 @@
   },
   {
     "provider": "openrouter",
+    "model": "minimax/minimax-m2.7:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
     "model": "minimax/minimax-m3",
     "input_price": 300000,
     "output_price": 1200000,
@@ -3617,10 +3609,26 @@
   },
   {
     "provider": "openrouter",
+    "model": "minimax/minimax-m3:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
     "model": "mistralai/codestral-2508",
     "input_price": 300000,
     "output_price": 900000,
     "cache_read_price": 30000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "mistralai/devstral-2512",
+    "input_price": 440000,
+    "output_price": 2200000,
+    "cache_read_price": 44000,
     "cache_write_price": null
   },
   {
@@ -3637,6 +3645,14 @@
     "input_price": 100000,
     "output_price": 100000,
     "cache_read_price": 10000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "mistralai/ministral-8b",
+    "input_price": 110000,
+    "output_price": 110000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3738,8 +3754,8 @@
   {
     "provider": "openrouter",
     "model": "mistralai/mistral-small-3.2-24b-instruct",
-    "input_price": 93750,
-    "output_price": 250000,
+    "input_price": 75000,
+    "output_price": 200000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -3786,9 +3802,9 @@
   {
     "provider": "openrouter",
     "model": "moonshotai/kimi-k2.5",
-    "input_price": 450000,
-    "output_price": 2250000,
-    "cache_read_price": 70000,
+    "input_price": 600000,
+    "output_price": 3000000,
+    "cache_read_price": 100000,
     "cache_write_price": null
   },
   {
@@ -3802,9 +3818,9 @@
   {
     "provider": "openrouter",
     "model": "moonshotai/kimi-k2.7-code",
-    "input_price": 710000,
-    "output_price": 3500000,
-    "cache_read_price": 150000,
+    "input_price": 660000,
+    "output_price": 3400000,
+    "cache_read_price": 180000,
     "cache_write_price": null
   },
   {
@@ -3884,15 +3900,7 @@
     "model": "nvidia/nemotron-3-nano-30b-a3b",
     "input_price": 50000,
     "output_price": 200000,
-    "cache_read_price": 30000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "nvidia/nemotron-3-nano-30b-a3b:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
+    "cache_read_price": 25000,
     "cache_write_price": null
   },
   {
@@ -3954,22 +3962,6 @@
   {
     "provider": "openrouter",
     "model": "nvidia/nemotron-3.5-lightning:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "nvidia/nemotron-nano-12b-v2-vl:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "nvidia/nemotron-nano-9b-v2:free",
     "input_price": 0,
     "output_price": 0,
     "cache_read_price": null,
@@ -4298,18 +4290,18 @@
   {
     "provider": "openrouter",
     "model": "openai/gpt-5.6-sol",
-    "input_price": 2500000,
-    "output_price": 15000000,
-    "cache_read_price": 250000,
-    "cache_write_price": 3125000
+    "input_price": 2000000,
+    "output_price": 10000000,
+    "cache_read_price": 200000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "openrouter",
     "model": "openai/gpt-5.6-sol-pro",
-    "input_price": 2500000,
-    "output_price": 15000000,
-    "cache_read_price": 250000,
-    "cache_write_price": 3125000
+    "input_price": 2000000,
+    "output_price": 10000000,
+    "cache_read_price": 200000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "openrouter",
@@ -4354,9 +4346,9 @@
   {
     "provider": "openrouter",
     "model": "openai/gpt-oss-120b",
-    "input_price": 30000,
+    "input_price": 37000,
     "output_price": 170000,
-    "cache_read_price": 30000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -4365,14 +4357,6 @@
     "input_price": 30000,
     "output_price": 130000,
     "cache_read_price": 30000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "openai/gpt-oss-20b:free",
-    "input_price": 0,
-    "output_price": 0,
-    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -4577,18 +4561,10 @@
   },
   {
     "provider": "openrouter",
-    "model": "qwen/qwen-plus-2025-07-28:thinking",
-    "input_price": 260000,
-    "output_price": 780000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "qwen/qwen2.5-vl-72b-instruct",
-    "input_price": 800000,
-    "output_price": 1000000,
-    "cache_read_price": 400000,
+    "input_price": 250000,
+    "output_price": 750000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -4610,9 +4586,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-235b-a22b-2507",
-    "input_price": 90000,
-    "output_price": 550000,
-    "cache_read_price": null,
+    "input_price": 87500,
+    "output_price": 350000,
+    "cache_read_price": 17500,
     "cache_write_price": null
   },
   {
@@ -4626,8 +4602,8 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-30b-a3b",
-    "input_price": 130000,
-    "output_price": 520000,
+    "input_price": 120000,
+    "output_price": 500000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4722,9 +4698,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-next-80b-a3b-instruct",
-    "input_price": 90000,
+    "input_price": 100000,
     "output_price": 1100000,
-    "cache_read_price": null,
+    "cache_read_price": 70000,
     "cache_write_price": null
   },
   {
@@ -4858,16 +4834,16 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.6-27b",
-    "input_price": 600000,
-    "output_price": 3600000,
-    "cache_read_price": 120000,
+    "input_price": 320000,
+    "output_price": 3200000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.6-35b-a3b",
-    "input_price": 140000,
-    "output_price": 1000000,
+    "input_price": 100000,
+    "output_price": 900000,
     "cache_read_price": 50000,
     "cache_write_price": null
   },
@@ -4930,10 +4906,18 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.8-27b",
-    "input_price": 450000,
-    "output_price": 3200000,
-    "cache_read_price": 50000,
-    "cache_write_price": null
+    "input_price": 425000,
+    "output_price": 2550000,
+    "cache_read_price": 85000,
+    "cache_write_price": 531250
+  },
+  {
+    "provider": "openrouter",
+    "model": "qwen/qwen3.8-flash",
+    "input_price": 150000,
+    "output_price": 470000,
+    "cache_read_price": 16000,
+    "cache_write_price": 200000
   },
   {
     "provider": "openrouter",
@@ -5041,6 +5025,30 @@
   },
   {
     "provider": "openrouter",
+    "model": "tencent/hy-mt2-1.8b",
+    "input_price": 44000,
+    "output_price": 177000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "tencent/hy-mt2-30b-a3b",
+    "input_price": 74000,
+    "output_price": 295000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "tencent/hy-mt2-7b",
+    "input_price": 74000,
+    "output_price": 295000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
     "model": "tencent/hy3",
     "input_price": 132000,
     "output_price": 528000,
@@ -5101,6 +5109,22 @@
     "input_price": 450000,
     "output_price": 1200000,
     "cache_read_price": 100000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "thinkingmachines/inkling-small:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "thinkingmachines/inkling:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -5226,9 +5250,9 @@
   {
     "provider": "openrouter",
     "model": "z-ai/glm-4.6",
-    "input_price": 500000,
-    "output_price": 2000000,
-    "cache_read_price": 100000,
+    "input_price": 430000,
+    "output_price": 1750000,
+    "cache_read_price": 80000,
     "cache_write_price": null
   },
   {
@@ -5274,17 +5298,17 @@
   {
     "provider": "openrouter",
     "model": "z-ai/glm-5.1",
-    "input_price": 966000,
-    "output_price": 3036000,
-    "cache_read_price": 179400,
+    "input_price": 1260000,
+    "output_price": 3960000,
+    "cache_read_price": 234000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "z-ai/glm-5.2",
-    "input_price": 966000,
-    "output_price": 3036000,
-    "cache_read_price": 193200,
+    "input_price": 1190000,
+    "output_price": 3740000,
+    "cache_read_price": 221000,
     "cache_write_price": null
   },
   {
@@ -5301,6 +5325,14 @@
     "input_price": 1400000,
     "output_price": 4400000,
     "cache_read_price": 260000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "z-ai/glm-5.3-flash",
+    "input_price": 75000,
+    "output_price": 250000,
+    "cache_read_price": 15000,
     "cache_write_price": null
   },
   {
@@ -5346,9 +5378,9 @@
   {
     "provider": "openrouter",
     "model": "~deepseek/deepseek-v4-flash-latest",
-    "input_price": 65000,
-    "output_price": 140000,
-    "cache_read_price": 14000,
+    "input_price": 30000,
+    "output_price": 100000,
+    "cache_read_price": 7000,
     "cache_write_price": null
   },
   {
@@ -5370,18 +5402,18 @@
   {
     "provider": "openrouter",
     "model": "~moonshotai/kimi-latest",
-    "input_price": 2600000,
-    "output_price": 13000000,
-    "cache_read_price": 290000,
+    "input_price": 2550000,
+    "output_price": 12750000,
+    "cache_read_price": 256000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "~openai/gpt-latest",
-    "input_price": 2500000,
-    "output_price": 15000000,
-    "cache_read_price": 250000,
-    "cache_write_price": 3125000
+    "input_price": 2000000,
+    "output_price": 10000000,
+    "cache_read_price": 200000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "openrouter",
@@ -5625,6 +5657,14 @@
   },
   {
     "provider": "vercel",
+    "model": "alibaba/qwen3.8-flash",
+    "input_price": 160000,
+    "output_price": 470000,
+    "cache_read_price": 16000,
+    "cache_write_price": 200000
+  },
+  {
+    "provider": "vercel",
     "model": "alibaba/qwen3.8-max",
     "input_price": 2000000,
     "output_price": 6000000,
@@ -5793,14 +5833,6 @@
   },
   {
     "provider": "vercel",
-    "model": "arcee-ai/trinity-mini",
-    "input_price": 45000,
-    "output_price": 150000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
     "model": "bytedance/seed-1.6",
     "input_price": 250000,
     "output_price": 2000000,
@@ -5882,9 +5914,17 @@
   {
     "provider": "vercel",
     "model": "deepseek/deepseek-v4-flash-0731",
-    "input_price": 130000,
-    "output_price": 260000,
-    "cache_read_price": 28000,
+    "input_price": 76000,
+    "output_price": 153000,
+    "cache_read_price": 14000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "deepseek/deepseek-v4-flash-vision-exp",
+    "input_price": 220000,
+    "output_price": 660000,
+    "cache_read_price": 7000,
     "cache_write_price": null
   },
   {
@@ -5898,9 +5938,9 @@
   {
     "provider": "vercel",
     "model": "deepseek/deepseek-v4-pro-0813",
-    "input_price": 1320000,
-    "output_price": 3960000,
-    "cache_read_price": 132000,
+    "input_price": 660000,
+    "output_price": 1980000,
+    "cache_read_price": 66000,
     "cache_write_price": null
   },
   {
@@ -6005,6 +6045,14 @@
     "input_price": 300000,
     "output_price": 2500000,
     "cache_read_price": 30000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "google/gemini-3.5-transcribe",
+    "input_price": 2000000,
+    "output_price": 12000000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -6233,6 +6281,14 @@
   },
   {
     "provider": "vercel",
+    "model": "minimax/minimax-m2.7-free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
     "model": "minimax/minimax-m2.7-highspeed",
     "input_price": 600000,
     "output_price": 2400000,
@@ -6245,6 +6301,14 @@
     "input_price": 300000,
     "output_price": 1200000,
     "cache_read_price": 60000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "minimax/minimax-m3-free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": 0,
     "cache_write_price": null
   },
   {
@@ -6268,22 +6332,6 @@
     "model": "mistral/devstral-small-2",
     "input_price": 100000,
     "output_price": 300000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "mistral/magistral-medium",
-    "input_price": 2000000,
-    "output_price": 5000000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "mistral/magistral-small",
-    "input_price": 500000,
-    "output_price": 1500000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -6467,8 +6515,8 @@
     "provider": "vercel",
     "model": "nvidia/nemotron-3.5-lightning",
     "input_price": 50000,
-    "output_price": 200000,
-    "cache_read_price": 10000,
+    "output_price": 150000,
+    "cache_read_price": 50000,
     "cache_write_price": null
   },
   {
@@ -6581,14 +6629,6 @@
     "input_price": 250000,
     "output_price": 1000000,
     "cache_read_price": 125000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "openai/gpt-4o-mini-search-preview",
-    "input_price": 150000,
-    "output_price": 600000,
-    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -6842,18 +6882,18 @@
   {
     "provider": "vercel",
     "model": "openai/gpt-5.6-sol",
-    "input_price": 2500000,
-    "output_price": 15000000,
-    "cache_read_price": 250000,
-    "cache_write_price": 3125000
+    "input_price": 2000000,
+    "output_price": 10000000,
+    "cache_read_price": 200000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "vercel",
     "model": "openai/gpt-5.6-sol-fast",
-    "input_price": 5000000,
-    "output_price": 30000000,
-    "cache_read_price": 500000,
-    "cache_write_price": 3125000
+    "input_price": 4000000,
+    "output_price": 20000000,
+    "cache_read_price": 400000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "vercel",
@@ -6921,10 +6961,18 @@
   },
   {
     "provider": "vercel",
+    "model": "openai/gpt-oss-safeguard-120b",
+    "input_price": 150000,
+    "output_price": 600000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
     "model": "openai/gpt-oss-safeguard-20b",
-    "input_price": 75000,
-    "output_price": 300000,
-    "cache_read_price": 37000,
+    "input_price": 70000,
+    "output_price": 200000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -6973,14 +7021,6 @@
     "input_price": 2000000,
     "output_price": 8000000,
     "cache_read_price": 500000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "openai/o3-deep-research",
-    "input_price": 10000000,
-    "output_price": 40000000,
-    "cache_read_price": 2500000,
     "cache_write_price": null
   },
   {
@@ -7057,6 +7097,102 @@
   },
   {
     "provider": "vercel",
+    "model": "spacexai/grok-4.1-fast-non-reasoning",
+    "input_price": 200000,
+    "output_price": 500000,
+    "cache_read_price": 50000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.1-fast-reasoning",
+    "input_price": 200000,
+    "output_price": 500000,
+    "cache_read_price": 50000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.20-multi-agent",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.20-multi-agent-beta",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.20-non-reasoning",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.20-non-reasoning-beta",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 400000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.20-reasoning",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.20-reasoning-beta",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.3",
+    "input_price": 1250000,
+    "output_price": 2500000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.5",
+    "input_price": 2000000,
+    "output_price": 6000000,
+    "cache_read_price": 300000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-4.6",
+    "input_price": 2000000,
+    "output_price": 6000000,
+    "cache_read_price": 500000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "spacexai/grok-build-0.1",
+    "input_price": 1000000,
+    "output_price": 2000000,
+    "cache_read_price": 200000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
     "model": "stepfun/step-3.5-flash",
     "input_price": 90000,
     "output_price": 300000,
@@ -7073,10 +7209,34 @@
   },
   {
     "provider": "vercel",
+    "model": "tencent/hy-mt2-lite",
+    "input_price": 44000,
+    "output_price": 177000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "tencent/hy-mt2-plus",
+    "input_price": 74000,
+    "output_price": 295000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "tencent/hy-mt2-pro",
+    "input_price": 74000,
+    "output_price": 295000,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
     "model": "tencent/hy3",
-    "input_price": 140000,
-    "output_price": 580000,
-    "cache_read_price": 35000,
+    "input_price": 132000,
+    "output_price": 528000,
+    "cache_read_price": 33000,
     "cache_write_price": null
   },
   {
@@ -7093,102 +7253,6 @@
     "input_price": 500000,
     "output_price": 1200000,
     "cache_read_price": 100000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.1-fast-non-reasoning",
-    "input_price": 200000,
-    "output_price": 500000,
-    "cache_read_price": 50000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.1-fast-reasoning",
-    "input_price": 200000,
-    "output_price": 500000,
-    "cache_read_price": 50000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.20-multi-agent",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.20-multi-agent-beta",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.20-non-reasoning",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.20-non-reasoning-beta",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 400000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.20-reasoning",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.20-reasoning-beta",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.3",
-    "input_price": 1250000,
-    "output_price": 2500000,
-    "cache_read_price": 200000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.5",
-    "input_price": 2000000,
-    "output_price": 6000000,
-    "cache_read_price": 300000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-4.6",
-    "input_price": 2000000,
-    "output_price": 6000000,
-    "cache_read_price": 500000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
-    "model": "xai/grok-build-0.1",
-    "input_price": 1000000,
-    "output_price": 2000000,
-    "cache_read_price": 200000,
     "cache_write_price": null
   },
   {
@@ -7309,6 +7373,14 @@
     "input_price": 1400000,
     "output_price": 4400000,
     "cache_read_price": 260000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "zai/glm-5.3-flash",
+    "input_price": 150000,
+    "output_price": 500000,
+    "cache_read_price": 30000,
     "cache_write_price": null
   },
   {

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
@@ -331,9 +331,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 65536,
-			"inputCost": 1.5,
-			"outputCost": 9,
-			"cacheReadCost": 0.15
+			"inputCost": 0.75,
+			"outputCost": 3.75,
+			"cacheReadCost": 0.075
 		},
 		{
 			"provider": "google",
@@ -342,9 +342,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 65536,
-			"inputCost": 1.5,
-			"outputCost": 7.5,
-			"cacheReadCost": 0.15
+			"inputCost": 0.75,
+			"outputCost": 3.75,
+			"cacheReadCost": 0.075
 		}
 	],
 	"openai": [
@@ -356,10 +356,10 @@
 			"contextLimit": 1050000,
 			"maxOutputTokens": 128000,
 			"reasoningEffort": "medium",
-			"inputCost": 5,
-			"outputCost": 30,
-			"cacheReadCost": 0.5,
-			"cacheWriteCost": 6.25
+			"inputCost": 4,
+			"outputCost": 20,
+			"cacheReadCost": 0.4,
+			"cacheWriteCost": 5
 		},
 		{
 			"provider": "openai",
@@ -465,10 +465,10 @@
 			"aliases": [],
 			"contextLimit": 1050000,
 			"maxOutputTokens": 128000,
-			"inputCost": 2.5,
-			"outputCost": 15,
-			"cacheReadCost": 0.25,
-			"cacheWriteCost": 3.125
+			"inputCost": 2,
+			"outputCost": 10,
+			"cacheReadCost": 0.2,
+			"cacheWriteCost": 2.5
 		},
 		{
 			"provider": "openrouter",
@@ -500,10 +500,9 @@
 			"displayName": "GPT OSS 120B",
 			"aliases": [],
 			"contextLimit": 131072,
-			"maxOutputTokens": 131072,
-			"inputCost": 0.03,
-			"outputCost": 0.17,
-			"cacheReadCost": 0.03
+			"maxOutputTokens": 117964,
+			"inputCost": 0.037,
+			"outputCost": 0.17
 		},
 		{
 			"provider": "openrouter",
@@ -511,7 +510,7 @@
 			"displayName": "Kimi K3",
 			"aliases": [],
 			"contextLimit": 1048576,
-			"maxOutputTokens": 1048576,
+			"maxOutputTokens": 943718,
 			"inputCost": 3,
 			"outputCost": 15,
 			"cacheReadCost": 0.3
@@ -522,10 +521,10 @@
 			"displayName": "GLM-5.2",
 			"aliases": [],
 			"contextLimit": 1048576,
-			"maxOutputTokens": 131072,
-			"inputCost": 0.966,
-			"outputCost": 3.036,
-			"cacheReadCost": 0.1932
+			"maxOutputTokens": 262144,
+			"inputCost": 1.19,
+			"outputCost": 3.74,
+			"cacheReadCost": 0.221
 		},
 		{
 			"provider": "openrouter",
@@ -606,9 +605,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 0.088606,
-			"outputCost": 0.177212,
-			"cacheReadCost": 0.017721
+			"inputCost": 0.07952,
+			"outputCost": 0.15904,
+			"cacheReadCost": 0.015904
 		},
 		{
 			"provider": "openrouter",
@@ -616,10 +615,10 @@
 			"displayName": "DeepSeek V4 Pro",
 			"aliases": [],
 			"contextLimit": 1048576,
-			"maxOutputTokens": 393216,
-			"inputCost": 1.6,
-			"outputCost": 3.2,
-			"cacheReadCost": 0.135
+			"maxOutputTokens": 384000,
+			"inputCost": 0.87,
+			"outputCost": 1.74,
+			"cacheReadCost": 0.0725
 		},
 		{
 			"provider": "openrouter",
@@ -639,7 +638,7 @@
 			"displayName": "Qwen3 Coder Next",
 			"aliases": [],
 			"contextLimit": 262144,
-			"maxOutputTokens": 262144,
+			"maxOutputTokens": 235929,
 			"inputCost": 0.12,
 			"outputCost": 0.8,
 			"cacheReadCost": 0.07
@@ -653,10 +652,10 @@
 			"aliases": [],
 			"contextLimit": 1050000,
 			"maxOutputTokens": 128000,
-			"inputCost": 2.5,
-			"outputCost": 15,
-			"cacheReadCost": 0.25,
-			"cacheWriteCost": 3.125
+			"inputCost": 2,
+			"outputCost": 10,
+			"cacheReadCost": 0.2,
+			"cacheWriteCost": 2.5
 		},
 		{
 			"provider": "vercel",


### PR DESCRIPTION
## Price book changes

36 models added, 27 models removed, 47 models changed.

<details>
<summary>Added</summary>

- openrouter/deepseek/deepseek-v4-flash-vision-exp
- openrouter/mancer/weaver
- openrouter/meta/muse-spark-1.2-contributor
- openrouter/minimax/minimax-m2.7:free
- openrouter/minimax/minimax-m3:free
- openrouter/mistralai/devstral-2512
- openrouter/mistralai/ministral-8b
- openrouter/qwen/qwen3.8-flash
- openrouter/tencent/hy-mt2-1.8b
- openrouter/tencent/hy-mt2-30b-a3b
- openrouter/tencent/hy-mt2-7b
- openrouter/thinkingmachines/inkling-small:free
- openrouter/thinkingmachines/inkling:free
- openrouter/z-ai/glm-5.3-flash
- vercel/alibaba/qwen3.8-flash
- vercel/deepseek/deepseek-v4-flash-vision-exp
- vercel/google/gemini-3.5-transcribe
- vercel/minimax/minimax-m2.7-free
- vercel/minimax/minimax-m3-free
- vercel/openai/gpt-oss-safeguard-120b
- vercel/spacexai/grok-4.1-fast-non-reasoning
- vercel/spacexai/grok-4.1-fast-reasoning
- vercel/spacexai/grok-4.20-multi-agent
- vercel/spacexai/grok-4.20-multi-agent-beta
- vercel/spacexai/grok-4.20-non-reasoning
- vercel/spacexai/grok-4.20-non-reasoning-beta
- vercel/spacexai/grok-4.20-reasoning
- vercel/spacexai/grok-4.20-reasoning-beta
- vercel/spacexai/grok-4.3
- vercel/spacexai/grok-4.5
- vercel/spacexai/grok-4.6
- vercel/spacexai/grok-build-0.1
- vercel/tencent/hy-mt2-lite
- vercel/tencent/hy-mt2-plus
- vercel/tencent/hy-mt2-pro
- vercel/zai/glm-5.3-flash
</details>

<details>
<summary>Removed</summary>

- openrouter/deepcogito/cogito-v2.1-671b
- openrouter/google/gemma-3n-e4b-it
- openrouter/inclusionai/ling-2.6-1t
- openrouter/inclusionai/ling-2.6-flash
- openrouter/inclusionai/ring-2.6-1t
- openrouter/nvidia/nemotron-3-nano-30b-a3b:free
- openrouter/nvidia/nemotron-nano-12b-v2-vl:free
- openrouter/nvidia/nemotron-nano-9b-v2:free
- openrouter/openai/gpt-oss-20b:free
- openrouter/qwen/qwen-plus-2025-07-28:thinking
- vercel/arcee-ai/trinity-mini
- vercel/mistral/magistral-medium
- vercel/mistral/magistral-small
- vercel/openai/gpt-4o-mini-search-preview
- vercel/openai/o3-deep-research
- vercel/xai/grok-4.1-fast-non-reasoning
- vercel/xai/grok-4.1-fast-reasoning
- vercel/xai/grok-4.20-multi-agent
- vercel/xai/grok-4.20-multi-agent-beta
- vercel/xai/grok-4.20-non-reasoning
- vercel/xai/grok-4.20-non-reasoning-beta
- vercel/xai/grok-4.20-reasoning
- vercel/xai/grok-4.20-reasoning-beta
- vercel/xai/grok-4.3
- vercel/xai/grok-4.5
- vercel/xai/grok-4.6
- vercel/xai/grok-build-0.1
</details>

<details>
<summary>Changed</summary>

- bedrock/global.openai.gpt-5.6-luna
- bedrock/global.openai.gpt-5.6-sol
- bedrock/global.openai.gpt-5.6-terra
- bedrock/openai.gpt-5.6-sol
- copilot/gpt-5.6-sol
- google/gemini-3.6-flash
- google/gemini-flash-latest
- google/gemini-flash-lite-latest
- openai/gpt-5.6
- openai/gpt-5.6-sol
- openrouter/deepseek/deepseek-chat-v3.1
- openrouter/deepseek/deepseek-v3.1-terminus
- openrouter/deepseek/deepseek-v3.2
- openrouter/deepseek/deepseek-v4-flash
- openrouter/deepseek/deepseek-v4-flash-0731
- openrouter/deepseek/deepseek-v4-pro
- openrouter/deepseek/deepseek-v4-pro-0813
- openrouter/meta-llama/llama-3.3-70b-instruct
- openrouter/meta-llama/llama-4-scout
- openrouter/minimax/minimax-m2.5
- openrouter/mistralai/mistral-small-3.2-24b-instruct
- openrouter/moonshotai/kimi-k2.5
- openrouter/moonshotai/kimi-k2.7-code
- openrouter/nvidia/nemotron-3-nano-30b-a3b
- openrouter/openai/gpt-5.6-sol
- openrouter/openai/gpt-5.6-sol-pro
- openrouter/openai/gpt-oss-120b
- openrouter/qwen/qwen2.5-vl-72b-instruct
- openrouter/qwen/qwen3-235b-a22b-2507
- openrouter/qwen/qwen3-30b-a3b
- openrouter/qwen/qwen3-next-80b-a3b-instruct
- openrouter/qwen/qwen3.6-27b
- openrouter/qwen/qwen3.6-35b-a3b
- openrouter/qwen/qwen3.8-27b
- openrouter/z-ai/glm-4.6
- openrouter/z-ai/glm-5.1
- openrouter/z-ai/glm-5.2
- openrouter/~deepseek/deepseek-v4-flash-latest
- openrouter/~moonshotai/kimi-latest
- openrouter/~openai/gpt-latest
- vercel/deepseek/deepseek-v4-flash-0731
- vercel/deepseek/deepseek-v4-pro-0813
- vercel/nvidia/nemotron-3.5-lightning
- vercel/openai/gpt-5.6-sol
- vercel/openai/gpt-5.6-sol-fast
- vercel/openai/gpt-oss-safeguard-20b
- vercel/tencent/hy3
</details>

## Review notes

Regenerated by `make gen/aibridge-prices` from the live [models.dev](https://models.dev) catalog. Both artifacts come from one snapshot, so they ship together:

- `coderd/aibridge/prices/data/prices.json`
- `site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json`

These are customer-visible cost numbers taken from upstream data, so this PR is never merged automatically. The summary above lists what moved; check the diff for exact figures before approving.

Opened automatically by the [aigateway-prices-refresh workflow](https://github.com/coder/coder/actions/runs/33072075172).