### PR TITLE
test: deflake chat plan mode audit transaction failure test

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -4625,7 +4625,7 @@ func (api *API) putChatPlanModeInstructions(rw http.ResponseWriter, r *http.Requ
 		aReq.New.PlanModeInstructions = sanitizedInstructions
 		noChange = aReq.New.PlanModeInstructions == aReq.Old.PlanModeInstructions
 		return nil
-	}, nil)
+	}, database.DefaultTXOptions().WithID("chat_plan_mode_instructions_write"))
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating plan mode instructions.",

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -341,24 +341,24 @@ func (s *failNextAcquireLockStore) AcquireLock(ctx context.Context, id int64) er
 	return s.Store.AcquireLock(ctx, id)
 }
 
-// failNextChatInstructionTransactionStore lets a test force transaction setup
-// to fail before the callback runs.
-type failNextChatInstructionTransactionStore struct {
+type failNextTxStore struct {
 	database.Store
 
+	txID                string
 	failNextTransaction *atomic.Bool
 }
 
-func newFailNextChatInstructionTransactionStore(store database.Store) *failNextChatInstructionTransactionStore {
-	return &failNextChatInstructionTransactionStore{
+func newFailNextTxStore(store database.Store, txID string) *failNextTxStore {
+	return &failNextTxStore{
 		Store:               store,
+		txID:                txID,
 		failNextTransaction: &atomic.Bool{},
 	}
 }
 
-func (s *failNextChatInstructionTransactionStore) InTx(function func(database.Store) error, txOpts *database.TxOptions) error {
-	if s.failNextTransaction.CompareAndSwap(true, false) {
-		return stderrors.New("forced chat instruction transaction failure")
+func (s *failNextTxStore) InTx(function func(database.Store) error, txOpts *database.TxOptions) error {
+	if txOpts != nil && txOpts.TxIdentifier == s.txID && s.failNextTransaction.CompareAndSwap(true, false) {
+		return stderrors.New("forced transaction failure for " + s.txID)
 	}
 	return s.Store.InTx(function, txOpts)
 }
@@ -15308,7 +15308,7 @@ func TestChatPlanModeInstructions(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		rawDB, pubsub := dbtestutil.NewDB(t)
-		store := newFailNextChatInstructionTransactionStore(rawDB)
+		store := newFailNextTxStore(rawDB, "chat_plan_mode_instructions_write")
 		mAudit := audit.NewMock()
 		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 			Database:         store,


### PR DESCRIPTION
`TestChatPlanModeInstructions/AuditTransactionFailureRejectsWrite` flaked on CI because the test store failed the next `InTx` call from any caller. Background services started by `coderd.New` share the store, and on slow runners the workspace build orchestrator's startup transaction consumed the one-shot failure flag before the PUT under test ran, so the request succeeded and the test's expected 500 never happened. Both captured CI failures show the injected sentinel error surfacing in the orchestrator log (`workspace_build_orchestrator: failed to process orchestrations error="forced chat instruction transaction failure"`) milliseconds before the assertion failure.

Tag the plan mode instructions write transaction with a `TxIdentifier` and key the injected failure on that identifier, so only the transaction under test can trip it. 160 race-enabled runs of the subtest under load pass with the fix.

Closes https://linear.app/codercom/issue/CODAGT-992/flake-testchatplanmodeinstructionsaudittransactionfailurerejectswrite
