### PR TITLE
fix: allow Copilot BYOK passthrough

### DIFF
--- a/aibridge/bridge_test.go
+++ b/aibridge/bridge_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge"
@@ -248,21 +249,13 @@ func TestPassthroughRoutesForProviders(t *testing.T) {
 			expectPath: "/v1/models",
 		},
 		{
-			name:        "copilot_ping",
-			requestPath: "/copilot/_ping",
-			provider: func(_ *testing.T, baseURL string) provider.Provider {
-				return aibridge.NewCopilotProvider(config.Copilot{BaseURL: baseURL})
-			},
-			expectPath: "/_ping",
-		},
-		{
-			name:          "copilot_auto",
+			name:          "copilot_unknown_route",
 			requestMethod: http.MethodPost,
-			requestPath:   "/copilot/auto",
+			requestPath:   "/copilot/future/endpoint",
 			provider: func(_ *testing.T, baseURL string) provider.Provider {
 				return aibridge.NewCopilotProvider(config.Copilot{BaseURL: baseURL})
 			},
-			expectPath: "/auto",
+			expectPath: "/future/endpoint",
 		},
 	}
 
@@ -292,6 +285,46 @@ func TestPassthroughRoutesForProviders(t *testing.T) {
 			assert.Contains(t, resp.Body.String(), upstreamRespBody)
 		})
 	}
+}
+
+func TestBridgedRouteTakesPrecedenceOverPassthroughCatchAll(t *testing.T) {
+	t.Parallel()
+
+	upstreamCalled := false
+	interceptorCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Given: a provider with a bridged route and a passthrough catch-all.
+	prov := &testutil.MockProvider{
+		NameStr:     "test",
+		URL:         upstream.URL,
+		Bridged:     []string{"/responses"},
+		Passthrough: []string{"/"},
+		InterceptorFunc: func(http.ResponseWriter, *http.Request, trace.Tracer) (intercept.Interceptor, error) {
+			interceptorCalled = true
+			return nil, xerrors.New("test interceptor error")
+		},
+	}
+	bridge, err := aibridge.NewRequestBridge(
+		t.Context(),
+		[]provider.Provider{prov},
+		nil, nil, slogtest.Make(t, nil), nil, bridgeTestTracer,
+	)
+	require.NoError(t, err)
+
+	// When: a request targets the bridged route.
+	req := httptest.NewRequest(http.MethodPost, "/test/responses", nil)
+	resp := httptest.NewRecorder()
+	bridge.ServeHTTP(resp, req)
+
+	// Then: the interceptor handles it, not the passthrough upstream.
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.True(t, interceptorCalled)
+	assert.False(t, upstreamCalled)
 }
 
 func TestWebSocketUpgradeRejected(t *testing.T) {

--- a/aibridge/provider/copilot.go
+++ b/aibridge/provider/copilot.go
@@ -89,16 +89,11 @@ func (*Copilot) BridgedRoutes() []string {
 	}
 }
 
+// PassthroughRoutes allows all non-bridged routes because Copilot is always
+// BYOK. The upstream enforces the user's permissions, so an allowlist is not
+// needed to prevent access to privileged operations using shared credentials.
 func (*Copilot) PassthroughRoutes() []string {
-	return []string{
-		"/_ping",
-		"/auto",
-		"/models",
-		"/models/",
-		"/agents/",
-		"/mcp/",
-		"/.well-known/",
-	}
+	return []string{"/"}
 }
 
 func (*Copilot) AuthHeader() string {

--- a/aibridge/provider/provider.go
+++ b/aibridge/provider/provider.go
@@ -75,8 +75,9 @@ type Provider interface {
 	// BridgedRoutes returns a slice of [http.ServeMux]-compatible routes which will have special handling.
 	// See https://pkg.go.dev/net/http#hdr-Patterns-ServeMux.
 	BridgedRoutes() []string
-	// PassthroughRoutes returns a slice of whitelisted [http.ServeMux]-compatible* routes which are
-	// not currently intercepted and must be handled by the upstream directly.
+	// PassthroughRoutes returns a slice of [http.ServeMux]-compatible* routes which are
+	// not currently intercepted and must be handled by the upstream directly. Providers
+	// using centralized credentials should restrict these routes to known-safe operations.
 	//
 	// * only path routes can be specified, not ones containing HTTP methods. (i.e. GET /route).
 	// By default, these passthrough routes will accept any HTTP method.

--- a/docs/ai-coder/ai-gateway/reference.md
+++ b/docs/ai-coder/ai-gateway/reference.md
@@ -112,12 +112,17 @@ The Anthropic provider also serves the AWS Bedrock provider type.
 
 #### Passthrough
 
+All Copilot routes other than the intercepted routes listed above pass through to the configured upstream provider.
+Examples include:
+
 - `/models(/*)`
+- `/_ping`
+- `/auto`
 - `/agents/*`
 - `/mcp/*`
 - `/.well-known/*`
 
-Any route that is not listed above returns `404`.
+AI Gateway authentication is still required.
 
 ## Troubleshooting
 

--- a/docs/ai-coder/ai-gateway/reference.md
+++ b/docs/ai-coder/ai-gateway/reference.md
@@ -113,16 +113,6 @@ The Anthropic provider also serves the AWS Bedrock provider type.
 #### Passthrough
 
 All Copilot routes other than the intercepted routes listed above pass through to the configured upstream provider.
-Examples include:
-
-- `/models(/*)`
-- `/_ping`
-- `/auto`
-- `/agents/*`
-- `/mcp/*`
-- `/.well-known/*`
-
-AI Gateway authentication is still required.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

Copilot is always BYOK, so requests use the end user's provider credential rather than a shared centralized credential. Restricting Copilot passthrough to an explicit route allowlist does not provide the same security benefit as it does for centralized providers and causes new Copilot endpoints to fail until they are added manually.

Allow all non-bridged Copilot routes to pass through to the configured upstream. More specific bridged inference routes continue to take precedence.

## Changes

- Replace the Copilot passthrough allowlist with a catch-all route.
- Clarify that providers using centralized credentials should restrict passthrough routes to known-safe operations.
- Cover known and unknown Copilot passthrough routes.
- Verify bridged routes take precedence over the passthrough catch-all.

Related to https://github.com/coder/coder/pull/28494
Related to [internal Slack thread](https://codercom.slack.com/archives/C014JH42DBJ/p1787574835172749).

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.
