### PR TITLE
feat: allow custom prices for openai-compatible models

### DIFF
--- a/coderd/aibridge/prices/providers/providers.go
+++ b/coderd/aibridge/prices/providers/providers.go
@@ -2,11 +2,11 @@ package providers
 
 import "github.com/coder/coder/v2/coderd/database"
 
-// Supported lists the providers a model price may be set for.
+// Supported lists the providers included in the generated model price book.
 //
-// openai-compat is excluded: it is a generic passthrough, so the upstream
-// vendor is unknown and a price cannot be attributed to it. Listed explicitly
-// rather than derived from ai_provider_type so a new provider is opt-in.
+// openai-compat is excluded because it is a generic passthrough and does not
+// identify an upstream vendor. Listed explicitly rather than derived from
+// ai_provider_type so a new provider is opt-in.
 var Supported = []database.AIProviderType{
 	database.AIProviderTypeAnthropic,
 	database.AIProviderTypeAzure,
@@ -18,7 +18,7 @@ var Supported = []database.AIProviderType{
 	database.AIProviderTypeVercel,
 }
 
-// SupportedStrings returns the supported providers as plain strings.
+// SupportedStrings returns the generated price book providers as strings.
 func SupportedStrings() []string {
 	ids := make([]string, len(Supported))
 	for i, provider := range Supported {

--- a/docs/ai-coder/ai-gateway/cost-controls.md
+++ b/docs/ai-coder/ai-gateway/cost-controls.md
@@ -291,8 +291,8 @@ coder exp ai-model-prices update prices.json
 >   across upgrades, so it does not pick up later price books.
 > - A price is keyed by provider type and model, so every configured provider
 >   of that type shares it.
-> - `openai-compat` providers cannot be priced. They pass through to any
->   upstream vendor, so a single price would be wrong for most of them.
+> - You can set prices for `openai-compat` providers manually, but the shipped price book does not include them.
+>   Note that two `openai-compat` providers using the same model ID share a price, which can misattribute costs when the upstream providers charge different prices.
 > - This command is experimental and can change without notice.
 
 ## Monitor spend

--- a/enterprise/cli/exp_aimodelprices.go
+++ b/enterprise/cli/exp_aimodelprices.go
@@ -48,7 +48,9 @@ Coder's price book:
     }
   ]
   * A price is keyed by provider type and model, so every configured
-    provider of that type shares it.
+    provider of that type shares it. If two openai-compat providers use the
+    same model ID, they cannot have different prices. This can misattribute
+    costs when the upstream providers charge different prices.
   * Prices are micro-units per million tokens, so 3000000 is $3.00 per
     million tokens.
   * A 'null' price is unknown and adds no cost. An explicit 0 declares the

--- a/enterprise/coderd/aimodelprices.go
+++ b/enterprise/coderd/aimodelprices.go
@@ -26,6 +26,16 @@ var aiModelPriceSources = []string{
 	string(codersdk.AIModelPriceSourceFilterAll),
 }
 
+// aiModelPriceUpsertProviders lists the provider types accepted for
+// operator-set prices. An openai-compat provider can represent any upstream
+// vendor, but prices are keyed by provider type and model. Two such providers
+// using the same model share a price, which can misattribute costs when the
+// upstream prices differ.
+var aiModelPriceUpsertProviders = append(
+	providers.SupportedStrings(),
+	string(database.AIProviderTypeOpenaiCompat),
+)
+
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 // @Summary List AI model prices
@@ -190,7 +200,7 @@ func validateAIModelPrices(requested []codersdk.AIModelPriceUpsert, raw []map[st
 		}}
 	}
 
-	supportedProviders := strings.Join(providers.SupportedStrings(), ", ")
+	supportedProviders := strings.Join(aiModelPriceUpsertProviders, ", ")
 	seen := make(map[modelKey]struct{}, len(requested))
 	var validations []codersdk.ValidationError
 
@@ -204,7 +214,7 @@ func validateAIModelPrices(requested []codersdk.AIModelPriceUpsert, raw []map[st
 				Field:  field + ".provider",
 				Detail: fmt.Sprintf("Provider is required. Supported providers: %s.", supportedProviders),
 			})
-		case !slices.Contains(providers.Supported, database.AIProviderType(price.Provider)):
+		case !slices.Contains(aiModelPriceUpsertProviders, price.Provider):
 			validations = append(validations, codersdk.ValidationError{
 				Field:  field + ".provider",
 				Detail: fmt.Sprintf("Provider %q is not supported. Supported providers: %s.", price.Provider, supportedProviders),

--- a/enterprise/coderd/aimodelprices_internal_test.go
+++ b/enterprise/coderd/aimodelprices_internal_test.go
@@ -48,24 +48,20 @@ func TestValidateAIModelPrices(t *testing.T) {
 			name: "MissingProvider",
 			body: `{"prices":[{"model":"my-model",` + allPrices + `}]}`,
 			want: []codersdk.ValidationError{
-				{Field: "prices[0].provider", Detail: "Provider is required. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel."},
+				{Field: "prices[0].provider", Detail: "Provider is required. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel, openai-compat."},
 			},
 		},
 		{
 			name: "UnsupportedProvider",
 			body: `{"prices":[{"provider":"unknown-provider","model":"my-model",` + allPrices + `}]}`,
 			want: []codersdk.ValidationError{
-				{Field: "prices[0].provider", Detail: `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`},
+				{Field: "prices[0].provider", Detail: `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel, openai-compat.`},
 			},
 		},
 		{
-			// openai-compat is a generic passthrough, so a price cannot be
-			// attributed to the model behind it.
-			name: "OpenAICompatRejected",
+			name: "OpenAICompat",
 			body: `{"prices":[{"provider":"openai-compat","model":"my-model",` + allPrices + `}]}`,
-			want: []codersdk.ValidationError{
-				{Field: "prices[0].provider", Detail: `Provider "openai-compat" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`},
-			},
+			want: nil,
 		},
 		{
 			name: "MissingModel",
@@ -135,7 +131,7 @@ func TestValidateAIModelPrices(t *testing.T) {
 			body: `{"prices":[{"provider":"openrouter","model":"anthropic/my-model",` + allPrices + `},` +
 				`{"provider":"openrouter/anthropic","model":"my-model",` + allPrices + `}]}`,
 			want: []codersdk.ValidationError{
-				{Field: "prices[1].provider", Detail: `Provider "openrouter/anthropic" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`},
+				{Field: "prices[1].provider", Detail: `Provider "openrouter/anthropic" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel, openai-compat.`},
 			},
 		},
 		{
@@ -150,7 +146,7 @@ func TestValidateAIModelPrices(t *testing.T) {
 			name: "ReportsProviderBeforePrices",
 			body: `{"prices":[{"provider":"unknown-provider","model":"my-model"}]}`,
 			want: []codersdk.ValidationError{
-				{Field: "prices[0].provider", Detail: `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`},
+				{Field: "prices[0].provider", Detail: `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel, openai-compat.`},
 				{Field: "prices[0]", Detail: "At least one price must be set. Use 0 to declare a model free of charge."},
 			},
 		},
@@ -160,7 +156,7 @@ func TestValidateAIModelPrices(t *testing.T) {
 			body: `{"prices":[{"provider":"unknown-provider","model":"a",` + allPrices + `},` +
 				`{"provider":"anthropic","model":"",` + allPrices + `}]}`,
 			want: []codersdk.ValidationError{
-				{Field: "prices[0].provider", Detail: `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel.`},
+				{Field: "prices[0].provider", Detail: `Provider "unknown-provider" is not supported. Supported providers: anthropic, azure, bedrock, copilot, google, openai, openrouter, vercel, openai-compat.`},
 				{Field: "prices[1].model", Detail: "Model is required."},
 			},
 		},

--- a/enterprise/coderd/aimodelprices_test.go
+++ b/enterprise/coderd/aimodelprices_test.go
@@ -231,6 +231,32 @@ func TestUpsertAIModelPrices(t *testing.T) {
 		require.Nil(t, prices[0].CacheWritePrice)
 	})
 
+	t.Run("SetsOpenAICompatPrice", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: an openai-compat model that the generated price book does not
+		// cover.
+		ownerClient, _ := setupAIModelPricesTest(t)
+		exp := codersdk.NewExperimentalClient(ownerClient)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// When: an operator sets its price.
+		//nolint:gocritic // Managing AI model prices is owner-only.
+		require.NoError(t, exp.UpsertAIModelPrices(ctx, codersdk.UpsertAIModelPricesRequest{
+			Prices: []codersdk.AIModelPriceUpsert{newAIModelPrice("openai-compat", "my-model", 3_000_000)},
+		}))
+
+		// Then: the custom price is stored for the provider type and model.
+		prices, err := exp.ListAIModelPrices(ctx, codersdk.AIModelPricesFilter{
+			Provider: "openai-compat",
+			Model:    "my-model",
+		})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, codersdk.AIModelPriceSourceCustom, prices[0].Source)
+		require.Equal(t, int64(3_000_000), *prices[0].InputPrice)
+	})
+
 	t.Run("UpdatesAPriceItSet", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Description

Allow operators to set custom model prices for `openai-compat` providers through the experimental CLI and API while keeping them excluded from the shipped models.dev price book.

## Changes

- Accept manual prices for `openai-compat` models.
- Document the shared provider-type pricing behavior in CLI help and cost-control documentation.
- Keep `openai-compat` excluded from generated price-book providers.

> [!NOTE]
> ⚠️ Prices are keyed by provider type and model. Note that two `openai-compat` providers using the same model ID share one price and cannot be assigned different prices, which can misattribute costs when their upstream prices differ.

Generated by Coder Agents on behalf of @ssncferreira.

Related to internal slack thread https://codercom.slack.com/archives/C04M9CNGHGF/p1787854861854289

