### PR TITLE
chore: enable oxlint no-explicit-any and disable the Biome equivalent

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -68,6 +68,7 @@
 				}
 			},
 			"suspicious": {
+				"noExplicitAny": "off", // oxlint owns no-explicit-any
 				"noArrayIndexKey": "off",
 				"noThenProperty": "off",
 				"noTemplateCurlyInString": "off",

--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -155,6 +155,7 @@
 		"prefer-namespace-keyword": "error",
 		"approx-constant": "error",
 		"no-export": "error",
+		"no-explicit-any": "error",
 
 		// ==========================================================
 		// Migration backlog (temporary; shrinks as we go).
@@ -173,7 +174,6 @@
 		"no-autofocus": "off", // a11y/noAutofocus (large)
 		"jsx-no-useless-fragment": "off", // complexity/noUselessFragments (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
-		"no-explicit-any": "off", // suspicious/noExplicitAny (medium: Biome suppressions to migrate)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"new-for-builtins": "off", // correctness/noInvalidBuiltinInstantiation (medium)
 		"no-empty-object-type": "off", // complexity/noBannedTypes (medium)

--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -241,8 +241,7 @@ export async function verifyConfigFlagString(
 	const configOption = page.locator(
 		`table.options-table .option-${flag} .option-value-string`,
 	);
-	// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
-	await expect(configOption).toHaveText(opt.value as any);
+	await expect(configOption).toHaveText(opt.value as string);
 }
 
 export async function verifyConfigFlagArray(
@@ -256,8 +255,7 @@ export async function verifyConfigFlagArray(
 	);
 
 	// Verify array of options with simple dots
-	// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
-	for (const item of opt.value as any) {
+	for (const item of opt.value as string[]) {
 		await expect(configOption.locator("li", { hasText: item })).toBeVisible();
 	}
 }
@@ -273,8 +271,7 @@ export async function verifyConfigFlagEntries(
 	);
 
 	// Verify array of options with green marks.
-	// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
-	Object.entries(opt.value as any)
+	Object.entries(opt.value as Record<string, string>)
 		.sort((a, b) => a[0].localeCompare(b[0]))
 		.map(async ([item]) => {
 			await expect(

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -71,10 +71,14 @@ export type LoginOptions = {
 	password: string;
 };
 
+// The current user is stashed on the Playwright context under a symbol key so
+// helpers can read it back without reaching for `any`.
+type ContextWithUser = BrowserContext &
+	Record<symbol, LoginOptions | undefined>;
+
 export async function login(page: Page, options: LoginOptions = users.owner) {
 	const ctx = page.context();
-	// biome-ignore lint/suspicious/noExplicitAny: reset the current user
-	(ctx as any)[Symbol.for("currentUser")] = undefined;
+	(ctx as ContextWithUser)[Symbol.for("currentUser")] = undefined;
 	await ctx.clearCookies();
 	await page.goto("/login", { waitUntil: "domcontentloaded" });
 	await page.getByLabel("Email").fill(options.email);
@@ -89,14 +93,12 @@ export async function login(page: Page, options: LoginOptions = users.owner) {
 	// login. See https://github.com/coder/coder/pull/27107.
 	await page.waitForURL((url) => url.pathname === "/workspaces");
 	await expect(page).toHaveTitle("Workspaces - Coder");
-	// biome-ignore lint/suspicious/noExplicitAny: update once logged in
-	(ctx as any)[Symbol.for("currentUser")] = options;
+	(ctx as ContextWithUser)[Symbol.for("currentUser")] = options;
 }
 
 function currentUser(page: Page): LoginOptions {
 	const ctx = page.context();
-	// biome-ignore lint/suspicious/noExplicitAny: get the current user
-	const user = (ctx as any)[Symbol.for("currentUser")];
+	const user = (ctx as ContextWithUser)[Symbol.for("currentUser")];
 
 	if (!user) {
 		throw new Error("page context does not have a user. did you call `login`?");

--- a/site/src/pages/DeploymentSettingsPage/optionValue.ts
+++ b/site/src/pages/DeploymentSettingsPage/optionValue.ts
@@ -67,7 +67,10 @@ export function optionValue(
 			return experimentMap;
 		}
 		default:
-			// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
-			return option.value as any;
+			return option.value as
+				| number
+				| string
+				| string[]
+				| Record<string, boolean>;
 	}
 }

--- a/site/src/pages/TemplateVersionEditorPage/MonacoEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/MonacoEditor.tsx
@@ -12,6 +12,20 @@ export interface MonacoEditorProps {
 	onChange?: (value: string) => void;
 }
 
+// Monaco exposes the keybinding service only as a private field, so we describe
+// the shape we use instead of reaching for `any`.
+type StandaloneKeybindingService = {
+	addDynamicKeybinding(
+		commandId: string,
+		keybinding: number,
+		handler: () => void,
+	): void;
+};
+
+type EditorWithKeybindingService = monaco.editor.IStandaloneCodeEditor & {
+	readonly _standaloneKeybindingService: StandaloneKeybindingService;
+};
+
 export const MonacoEditor: FC<MonacoEditorProps> = ({
 	onChange,
 	value,
@@ -56,8 +70,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
 			onMount={(editor) => {
 				// This jank allows for Ctrl + Enter to work outside the editor.
 				// We use this keybind to trigger a build.
-				// biome-ignore lint/suspicious/noExplicitAny: Private type in Monaco!
-				(editor as any)._standaloneKeybindingService.addDynamicKeybinding(
+				(
+					editor as EditorWithKeybindingService
+				)._standaloneKeybindingService.addDynamicKeybinding(
 					"-editor.action.insertLineAfter",
 					monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
 					() => {},


### PR DESCRIPTION
Promotes the oxlint `no-explicit-any` rule from the migration backlog to `error` and disables Biome's analogous `suspicious/noExplicitAny`, so oxlint becomes the sole enforcer of this rule.

The eight existing `biome-ignore lint/suspicious/noExplicitAny` suppressions are removed and their `as any` casts replaced with precise types (no `any`, no `as unknown as` double-casts):

- `optionValue.ts`: the default branch now asserts to the `OptionValue` children union.
- `MonacoEditor.tsx`: a typed intersection describes Monaco's private `_standaloneKeybindingService`.
- `e2e/helpers.ts`: a `BrowserContext` intersection types the symbol-keyed current user.
- `e2e/api.ts`: `opt.value` (typed `unknown`) is asserted directly to `string` / `string[]` / `Record<string, string>`.

`pnpm run lint` (Biome, oxlint, tsc, circular-deps, compiler, knip) and `pnpm run format` pass clean.

<details>
<summary>Implementation plan</summary>

## Goal

Enable the oxlint rule `no-explicit-any` (mapped to Biome `suspicious/noExplicitAny`), disable the analogous Biome rule, and fix all resulting violations by removing the explicit `any` types (not by migrating suppression comments).

## Findings

- The oxlint rule was parked in the migration backlog: `"no-explicit-any": "off", // suspicious/noExplicitAny`.
- Running oxlint with the rule as error surfaced exactly 8 violations, all in places already carrying `// biome-ignore lint/suspicious/noExplicitAny` comments:
  - `src/pages/DeploymentSettingsPage/optionValue.ts` (1)
  - `src/pages/TemplateVersionEditorPage/MonacoEditor.tsx` (1)
  - `e2e/helpers.ts` (3)
  - `e2e/api.ts` (3)
- Biome's `noExplicitAny` is a recommended rule (implicitly on); disabling it means adding an explicit `"off"` in the root `biome.jsonc`.
- `e2e/**` is type-checked by `lint:types` (`tsc -p .`), so e2e fixes must type-check.

## Constraints

- Remove the `biome-ignore` comments and fix the `any`s (do not migrate suppressions).
- Do not cast through `unknown` (no `x as unknown as Y`). Single direct assertions from an already-`unknown` value and subtype intersection casts are used instead.

## Changes

1. `site/.oxlintrc.jsonc`: move `no-explicit-any` to the active suspicious section as `"error"`; drop the backlog entry.
2. `biome.jsonc`: add `"noExplicitAny": "off"` under `linter.rules.suspicious`.
3. Fix the 8 violation sites and remove the 8 `biome-ignore` comments across the 4 source files.

## Validation

- `pnpm run lint:oxlint` → 0 errors
- `pnpm run lint:check` (Biome) → clean
- `pnpm run lint:types` (`tsc -p .`) → clean (covers `src` and `e2e`)
- `optionValue.test.ts` → 16 tests pass
- full `pnpm run lint` and `pnpm run format` → clean

</details>

---

Generated by Coder Agents on behalf of @jeremyruppel.
