### PR TITLE
chore: enable oxlint new-for-builtins and disable the Biome equivalent

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,6 +21,7 @@
 				"noStaticElementInteractions": "off"
 			},
 			"correctness": {
+				"noInvalidBuiltinInstantiation": "off", // oxlint owns new-for-builtins
 				"noUnusedImports": "warn",
 				"useUniqueElementIds": "off", // TODO: This is new but we want to fix it
 				"noNestedComponentDefinitions": "off", // TODO: Investigate, since it is used by shadcn components

--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -155,6 +155,7 @@
 		"prefer-namespace-keyword": "error",
 		"approx-constant": "error",
 		"no-export": "error",
+		"new-for-builtins": "error",
 
 		// ==========================================================
 		// Migration backlog (temporary; shrinks as we go).
@@ -175,7 +176,6 @@
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-explicit-any": "off", // suspicious/noExplicitAny (medium: Biome suppressions to migrate)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
-		"new-for-builtins": "off", // correctness/noInvalidBuiltinInstantiation (medium)
 		"no-empty-object-type": "off", // complexity/noBannedTypes (medium)
 		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/XAxis.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/XAxis.tsx
@@ -161,7 +161,7 @@ const XGrid: FC<XGridProps> = ({ columns, ...htmlProps }) => {
 				htmlProps.className,
 			)}
 		>
-			{[...Array(columns).keys()].map((key) => (
+			{Array.from({ length: columns }, (_, key) => (
 				<div
 					key={key}
 					className="flex-shrink-0 bg-repeat-y bg-right"

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/pasteHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/pasteHelpers.test.ts
@@ -111,12 +111,12 @@ describe("isLargePaste", () => {
 	});
 
 	it("returns false for 9 lines of short text", () => {
-		const text = Array(9).fill("short line").join("\n");
+		const text = new Array(9).fill("short line").join("\n");
 		expect(isLargePaste(text)).toBe(false);
 	});
 
 	it("returns true for 10+ lines", () => {
-		const text = Array(10).fill("line").join("\n");
+		const text = new Array(10).fill("line").join("\n");
 		expect(isLargePaste(text)).toBe(true);
 	});
 
@@ -131,7 +131,7 @@ describe("isLargePaste", () => {
 	});
 
 	it("returns false when text has 9 lines and 999 characters", () => {
-		const text = [...Array(8).fill("x".repeat(110)), "x".repeat(111)].join(
+		const text = [...new Array(8).fill("x".repeat(110)), "x".repeat(111)].join(
 			"\n",
 		);
 		expect(text.length).toBe(999);
@@ -139,7 +139,7 @@ describe("isLargePaste", () => {
 	});
 
 	it("returns true for text meeting both thresholds", () => {
-		const text = Array(15).fill("x".repeat(100)).join("\n");
+		const text = new Array(15).fill("x".repeat(100)).join("\n");
 		expect(isLargePaste(text)).toBe(true);
 	});
 });

--- a/site/src/pages/AgentsPage/components/TextPreviewDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/TextPreviewDialog.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
 
 export const LongContent: Story = {
 	args: {
-		content: Array(100)
+		content: new Array(100)
 			.fill(
 				"This is a line of pasted text that demonstrates how the dialog handles very long content.",
 			)

--- a/site/src/utils/schedule.tsx
+++ b/site/src/utils/schedule.tsx
@@ -199,7 +199,9 @@ export function getMaxDeadline(ws: Workspace | undefined): dayjs.Dayjs {
 	// note: we count runtime from updated_at as started_at counts from the start of
 	// the workspace build process, which can take a while.
 	if (ws === undefined) {
-		throw Error("Cannot calculate max deadline because workspace is undefined");
+		throw new Error(
+			"Cannot calculate max deadline because workspace is undefined",
+		);
 	}
 	const startedAt = dayjs(ws.latest_build.updated_at);
 	return startedAt.add(deadlineExtensionMax);


### PR DESCRIPTION
Promotes the oxlint `new-for-builtins` rule from the migration backlog to `error` and disables Biome's analogous `correctness/noInvalidBuiltinInstantiation`, so oxlint becomes the sole enforcer of this rule.

Fixes the seven violations by requiring `new` for builtin instantiations:

- `XAxis.tsx`: replace `[...Array(columns).keys()].map(...)` with `Array.from({ length: columns }, (_, key) => ...)`, folding the range and map into one dense-array construction.
- `pasteHelpers.test.ts` (×4) and `TextPreviewDialog.stories.tsx` (×1): `Array(n).fill(...)` becomes `new Array(n).fill(...)`.
- `schedule.tsx`: `throw Error(...)` becomes `throw new Error(...)`.

`pnpm run lint` (Biome, oxlint, tsc, circular-deps, compiler, knip) and `pnpm run format` pass clean; the affected `pasteHelpers` and `schedule` unit tests pass.

---

Generated by Coder Agents on behalf of @jeremyruppel.
