### PR TITLE
fix(site/src/pages/AgentsPage): remove bottom border from chat notice banners

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -930,7 +930,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										role="status"
 										aria-label={unavailableModelNotice}
 										aria-live="polite"
-										className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
+										className="flex shrink-0 items-center gap-2 bg-surface-orange px-4 py-2 text-xs text-content-primary"
 									>
 										<TriangleAlertIcon className="size-4 shrink-0 text-content-warning" />
 										{unavailableModelNotice}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -940,14 +940,14 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									<div
 										role="status"
 										aria-live="polite"
-										className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
+										className="flex shrink-0 items-center gap-2 bg-surface-orange px-4 py-2 text-xs text-content-primary"
 									>
 										<TriangleAlertIcon className="size-4 shrink-0 text-content-warning" />
 										{chatOwnerWarning}
 									</div>
 								)}
 								{isArchived && (
-									<div className="flex shrink-0 items-center gap-2 border-b border-border-default bg-surface-secondary px-4 py-2 text-xs text-content-secondary">
+									<div className="flex shrink-0 items-center gap-2 bg-surface-secondary px-4 py-2 text-xs text-content-secondary">
 										<ArchiveIcon className="size-4 shrink-0" />
 										This agent has been archived and is read-only.
 									</div>


### PR DESCRIPTION
Removes the `border-b` classes from the notice banners on the agent chat page. The border clashed with the banner backgrounds and looked bad against the conversation below.

Banners updated:
- Unavailable-model notice (`unavailableModelNotice`)
- Read-only chat owner warning (`chatOwnerWarning`)
- Archived chat notice

Each keeps its background, icon, and spacing; only the bottom border is removed.

---

*This PR was generated by Coder Agents on behalf of @tracyjohnsonux.*