### PR TITLE
feat: display retained Agent Time usage

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3777,6 +3777,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v2/deployment/agent-time": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "General"
+                ],
+                "summary": "Get deployment Agent Time",
+                "operationId": "get-deployment-agent-time",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.DeploymentAgentTime"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/v2/deployment/config": {
             "get": {
                 "produces": [
@@ -22811,6 +22836,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.DeploymentAgentTime": {
+            "type": "object",
+            "properties": {
+                "total_runtime_ms": {
                     "type": "integer"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3336,6 +3336,27 @@
 				}
 			}
 		},
+		"/api/v2/deployment/agent-time": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["General"],
+				"summary": "Get deployment Agent Time",
+				"operationId": "get-deployment-agent-time",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.DeploymentAgentTime"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/v2/deployment/config": {
 			"get": {
 				"produces": ["application/json"],
@@ -20726,6 +20747,14 @@
 					"type": "string"
 				},
 				"port": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.DeploymentAgentTime": {
+			"type": "object",
+			"properties": {
+				"total_runtime_ms": {
 					"type": "integer"
 				}
 			}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1437,6 +1437,7 @@ func New(options *Options) *API {
 		r.Route("/deployment", func(r chi.Router) {
 			r.Use(apiKeyMiddleware)
 			r.Get("/config", api.deploymentValues)
+			r.Get("/agent-time", api.deploymentAgentTime)
 			r.Get("/stats", api.deploymentStats)
 			r.Get("/ssh", api.sshConfig)
 			r.Post("/premium-funnel-events", api.postPremiumFunnelEvent)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3862,6 +3862,13 @@ func (q *querier) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaul
 	return q.db.GetDefaultProxyConfig(ctx)
 }
 
+func (q *querier) GetDeploymentAgentTimeMsInRange(ctx context.Context, arg database.GetDeploymentAgentTimeMsInRangeParams) (int64, error) {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+		return 0, err
+	}
+	return q.db.GetDeploymentAgentTimeMsInRange(ctx, arg)
+}
+
 func (q *querier) GetDeploymentID(ctx context.Context) (string, error) {
 	// No authz checks
 	return q.db.GetDeploymentID(ctx)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -6755,6 +6755,15 @@ func (s *MethodTestSuite) TestUserSkills() {
 }
 
 func (s *MethodTestSuite) TestUsageEvents() {
+	s.Run("GetDeploymentAgentTimeMsInRange", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		params := database.GetDeploymentAgentTimeMsInRangeParams{
+			StartTime: time.Time{},
+			EndTime:   time.Time{},
+		}
+		db.EXPECT().GetDeploymentAgentTimeMsInRange(gomock.Any(), params).Return(int64(0), nil)
+		check.Args(params).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+	}))
+
 	s.Run("InsertUsageEvent", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		params := database.InsertUsageEventParams{
 			ID:        "1",

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1992,6 +1992,14 @@ func (m queryMetricsStore) GetDefaultProxyConfig(ctx context.Context) (database.
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetDeploymentAgentTimeMsInRange(ctx context.Context, arg database.GetDeploymentAgentTimeMsInRangeParams) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetDeploymentAgentTimeMsInRange(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetDeploymentAgentTimeMsInRange").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetDeploymentAgentTimeMsInRange").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetDeploymentID(ctx context.Context) (string, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetDeploymentID(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3734,6 +3734,21 @@ func (mr *MockStoreMockRecorder) GetDefaultProxyConfig(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultProxyConfig", reflect.TypeOf((*MockStore)(nil).GetDefaultProxyConfig), ctx)
 }
 
+// GetDeploymentAgentTimeMsInRange mocks base method.
+func (m *MockStore) GetDeploymentAgentTimeMsInRange(ctx context.Context, arg database.GetDeploymentAgentTimeMsInRangeParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeploymentAgentTimeMsInRange", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeploymentAgentTimeMsInRange indicates an expected call of GetDeploymentAgentTimeMsInRange.
+func (mr *MockStoreMockRecorder) GetDeploymentAgentTimeMsInRange(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentAgentTimeMsInRange", reflect.TypeOf((*MockStore)(nil).GetDeploymentAgentTimeMsInRange), ctx, arg)
+}
+
 // GetDeploymentID mocks base method.
 func (m *MockStore) GetDeploymentID(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -567,6 +567,9 @@ type sqlcQuerier interface {
 	GetDefaultChatModelConfig(ctx context.Context, organizationID uuid.UUID) (ChatModelConfig, error)
 	GetDefaultOrganization(ctx context.Context) (Organization, error)
 	GetDefaultProxyConfig(ctx context.Context) (GetDefaultProxyConfigRow, error)
+	// Reports retained Agent Time to deployment administrators. Deliberately
+	// includes soft-deleted messages and messages from archived chats.
+	GetDeploymentAgentTimeMsInRange(ctx context.Context, arg GetDeploymentAgentTimeMsInRangeParams) (int64, error)
 	GetDeploymentID(ctx context.Context) (string, error)
 	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
 	GetDeploymentWorkspaceAgentUsageStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentUsageStatsRow, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -11219,6 +11219,92 @@ func TestGetTotalChatMessageRuntimeMsInRange(t *testing.T) {
 	require.EqualValues(t, 79, total)
 }
 
+func TestGetDeploymentAgentTimeMsInRange(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+
+	rangeStart := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	rangeEnd := rangeStart.Add(time.Hour)
+	params := database.GetDeploymentAgentTimeMsInRangeParams{
+		StartTime: rangeStart,
+		EndTime:   rangeEnd,
+	}
+
+	total, err := db.GetDeploymentAgentTimeMsInRange(ctx, params)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, total)
+
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		UserID: user.ID, OrganizationID: org.ID,
+	})
+	_ = dbgen.ChatProvider(t, db, database.ChatProvider{
+		Provider:    "openai",
+		DisplayName: "OpenAI",
+	})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+		Model:        "test-model",
+		ContextLimit: 8192,
+	})
+	newChat := func(archived bool) database.Chat {
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+		})
+		_, err := sqlDB.ExecContext(ctx, "UPDATE chats SET archived = $1 WHERE id = $2", archived, chat.ID)
+		require.NoError(t, err)
+		return chat
+	}
+	activeChat := newChat(false)
+	otherChat := newChat(false)
+	archivedChat := newChat(true)
+	deletedChat := newChat(false)
+
+	insertMessage := func(chatID uuid.UUID, runtimeMs sql.NullInt64, createdAt time.Time, deleted bool) {
+		t.Helper()
+		message := dbgen.ChatMessage(t, db, database.ChatMessage{
+			ChatID:        chatID,
+			CreatedBy:     uuid.NullUUID{UUID: user.ID, Valid: true},
+			ModelConfigID: uuid.NullUUID{UUID: model.ID, Valid: true},
+			Role:          database.ChatMessageRoleAssistant,
+			RuntimeMs:     runtimeMs,
+		})
+		_, err := sqlDB.ExecContext(ctx,
+			"UPDATE chat_messages SET created_at = $1, deleted = $2 WHERE id = $3",
+			createdAt, deleted, message.ID)
+		require.NoError(t, err)
+	}
+	runtimeMs := func(value int64) sql.NullInt64 {
+		return sql.NullInt64{Int64: value, Valid: true}
+	}
+
+	insertMessage(activeChat.ID, runtimeMs(1), rangeStart, false)
+	insertMessage(otherChat.ID, runtimeMs(2), rangeStart.Add(15*time.Minute), false)
+	insertMessage(activeChat.ID, runtimeMs(4), rangeStart.Add(20*time.Minute), true)
+	insertMessage(archivedChat.ID, runtimeMs(8), rangeStart.Add(25*time.Minute), false)
+	insertMessage(activeChat.ID, runtimeMs(16), rangeEnd.Add(-time.Second), false)
+	insertMessage(activeChat.ID, sql.NullInt64{}, rangeStart.Add(30*time.Minute), false)
+	insertMessage(activeChat.ID, runtimeMs(0), rangeStart.Add(31*time.Minute), false)
+	insertMessage(activeChat.ID, runtimeMs(32), rangeStart.Add(-time.Second), false)
+	insertMessage(activeChat.ID, runtimeMs(64), rangeEnd, false)
+	insertMessage(deletedChat.ID, runtimeMs(128), rangeStart.Add(35*time.Minute), false)
+
+	total, err = db.GetDeploymentAgentTimeMsInRange(ctx, params)
+	require.NoError(t, err)
+	require.EqualValues(t, 159, total)
+
+	_, err = sqlDB.ExecContext(ctx, "DELETE FROM chats WHERE id = $1", deletedChat.ID)
+	require.NoError(t, err)
+
+	total, err = db.GetDeploymentAgentTimeMsInRange(ctx, params)
+	require.NoError(t, err)
+	require.EqualValues(t, 31, total)
+}
+
 func TestListUsageEventCreatedAtsByTypeSince(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10193,6 +10193,27 @@ func (q *sqlQuerier) GetDatabaseNow(ctx context.Context) (time.Time, error) {
 	return now, err
 }
 
+const getDeploymentAgentTimeMsInRange = `-- name: GetDeploymentAgentTimeMsInRange :one
+SELECT COALESCE(SUM(cm.runtime_ms), 0)::bigint AS total_runtime_ms
+FROM chat_messages cm
+WHERE cm.created_at >= $1::timestamptz
+  AND cm.created_at < $2::timestamptz
+`
+
+type GetDeploymentAgentTimeMsInRangeParams struct {
+	StartTime time.Time `db:"start_time" json:"start_time"`
+	EndTime   time.Time `db:"end_time" json:"end_time"`
+}
+
+// Reports retained Agent Time to deployment administrators. Deliberately
+// includes soft-deleted messages and messages from archived chats.
+func (q *sqlQuerier) GetDeploymentAgentTimeMsInRange(ctx context.Context, arg GetDeploymentAgentTimeMsInRangeParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getDeploymentAgentTimeMsInRange, arg.StartTime, arg.EndTime)
+	var total_runtime_ms int64
+	err := row.Scan(&total_runtime_ms)
+	return total_runtime_ms, err
+}
+
 const getLastChatMessageByRole = `-- name: GetLastChatMessageByRole :one
 SELECT
     id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, runtime_ms, deleted, provider_response_id, revision, reasoning_effort, search_tsv, search_tsv_config

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -2231,6 +2231,14 @@ WHERE cm.created_at >= @start_time::timestamptz
   AND cm.created_at < @end_time::timestamptz
   AND cm.runtime_ms IS NOT NULL;
 
+-- name: GetDeploymentAgentTimeMsInRange :one
+-- Reports retained Agent Time to deployment administrators. Deliberately
+-- includes soft-deleted messages and messages from archived chats.
+SELECT COALESCE(SUM(cm.runtime_ms), 0)::bigint AS total_runtime_ms
+FROM chat_messages cm
+WHERE cm.created_at >= @start_time::timestamptz
+  AND cm.created_at < @end_time::timestamptz;
+
 -- name: GetChatsByWorkspaceIDs :many
 SELECT *
 FROM chats_expanded

--- a/coderd/deployment.go
+++ b/coderd/deployment.go
@@ -2,7 +2,9 @@ package coderd
 
 import (
 	"net/http"
+	"time"
 
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -35,6 +37,40 @@ func (api *API) deploymentValues(rw http.ResponseWriter, r *http.Request) {
 			Options: api.DeploymentOptions,
 		},
 	)
+}
+
+// @Summary Get deployment Agent Time
+// @ID get-deployment-agent-time
+// @Security CoderSessionToken
+// @Produce json
+// @Tags General
+// @Success 200 {object} codersdk.DeploymentAgentTime
+// @Router /api/v2/deployment/agent-time [get]
+func (api *API) deploymentAgentTime(rw http.ResponseWriter, r *http.Request) {
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	startTime := time.Unix(0, 0).UTC()
+	endTime := api.Clock.Now().UTC()
+	if feature, ok := api.Entitlements.Feature(codersdk.FeatureAgentRuntimeHours); ok && feature.UsagePeriod != nil {
+		startTime = feature.UsagePeriod.Start
+		endTime = feature.UsagePeriod.End
+	}
+
+	totalRuntimeMs, err := api.Database.GetDeploymentAgentTimeMsInRange(r.Context(), database.GetDeploymentAgentTimeMsInRangeParams{
+		StartTime: startTime,
+		EndTime:   endTime,
+	})
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.DeploymentAgentTime{
+		TotalRuntimeMs: totalRuntimeMs,
+	})
 }
 
 // @Summary Get deployment stats

--- a/coderd/deployment_test.go
+++ b/coderd/deployment_test.go
@@ -2,13 +2,23 @@ package coderd_test
 
 import (
 	"context"
+	"database/sql"
+	"net/http"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 func TestDeploymentValues(t *testing.T) {
@@ -48,6 +58,159 @@ func TestDeploymentValues(t *testing.T) {
 	require.Empty(t, scrubbed.Values.SCIMAPIKey.Value())
 	require.Empty(t, scrubbed.Values.ExternalTokenEncryptionKeys.Value())
 	require.Empty(t, scrubbed.Values.Provisioner.DaemonPSK.Value())
+}
+
+type deploymentAgentTimeErrorStore struct {
+	database.Store
+}
+
+func (deploymentAgentTimeErrorStore) GetDeploymentAgentTimeMsInRange(context.Context, database.GetDeploymentAgentTimeMsInRangeParams) (int64, error) {
+	return 0, xerrors.New("forced Agent Time query failure")
+}
+
+func insertDeploymentAgentTimeMessage(
+	t *testing.T,
+	db database.Store,
+	sqlDB *sql.DB,
+	userID uuid.UUID,
+	organizationID uuid.UUID,
+	modelConfigID uuid.UUID,
+	runtimeMs int64,
+	createdAt time.Time,
+	archived bool,
+	deleted bool,
+) int64 {
+	t.Helper()
+
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    organizationID,
+		OwnerID:           userID,
+		LastModelConfigID: modelConfigID,
+	})
+	_, err := sqlDB.ExecContext(t.Context(), "UPDATE chats SET archived = $1 WHERE id = $2", archived, chat.ID)
+	require.NoError(t, err)
+
+	message := dbgen.ChatMessage(t, db, database.ChatMessage{
+		ChatID:        chat.ID,
+		CreatedBy:     uuid.NullUUID{UUID: userID, Valid: true},
+		ModelConfigID: uuid.NullUUID{UUID: modelConfigID, Valid: true},
+		Role:          database.ChatMessageRoleAssistant,
+		RuntimeMs:     sql.NullInt64{Int64: runtimeMs, Valid: true},
+	})
+	_, err = sqlDB.ExecContext(t.Context(),
+		"UPDATE chat_messages SET created_at = $1, deleted = $2 WHERE id = $3",
+		createdAt, deleted, message.ID)
+	require.NoError(t, err)
+	return message.ID
+}
+
+func TestDeploymentAgentTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CommunityRetainedUsageAndAuthorization", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		now := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+		db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+		client := coderdtest.New(t, &coderdtest.Options{
+			Clock:    clock,
+			Database: db,
+		})
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+			OrganizationID: firstUser.OrganizationID,
+			CreatedBy:      uuid.NullUUID{UUID: firstUser.UserID, Valid: true},
+		})
+
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 10, now.Add(-365*24*time.Hour), false, false)
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 20, now.Add(-time.Hour), true, true)
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 40, now.Add(time.Hour), false, false)
+
+		agentTime, err := client.DeploymentAgentTime(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 30, agentTime.TotalRuntimeMs)
+
+		memberClient, _ := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		_, err = memberClient.DeploymentAgentTime(ctx)
+		var sdkError *codersdk.Error
+		require.ErrorAs(t, err, &sdkError)
+		require.Equal(t, http.StatusForbidden, sdkError.StatusCode())
+
+		_, err = codersdk.New(client.URL).DeploymentAgentTime(ctx)
+		require.ErrorAs(t, err, &sdkError)
+		require.Equal(t, http.StatusUnauthorized, sdkError.StatusCode())
+	})
+
+	t.Run("LicensedUsagePeriod", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		now := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+		periodStart := now.Add(-20 * 24 * time.Hour)
+		periodEnd := now.Add(-10 * 24 * time.Hour)
+		clock := quartz.NewMock(t)
+		clock.Set(now)
+		db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+		client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+			Clock:    clock,
+			Database: db,
+		})
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		api.Entitlements.Modify(func(current *codersdk.Entitlements) {
+			current.HasLicense = true
+			current.Features[codersdk.FeatureAgentRuntimeHours] = codersdk.Feature{
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     true,
+				UsagePeriod: &codersdk.UsagePeriod{
+					IssuedAt: periodStart.Add(-time.Hour),
+					Start:    periodStart,
+					End:      periodEnd,
+				},
+			}
+		})
+		model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+			OrganizationID: firstUser.OrganizationID,
+			CreatedBy:      uuid.NullUUID{UUID: firstUser.UserID, Valid: true},
+		})
+
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 1, periodStart.Add(-time.Second), false, false)
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 2, periodStart, false, false)
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 4, periodStart.Add(time.Hour), false, false)
+		insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 8, periodEnd, false, false)
+
+		agentTime, err := client.DeploymentAgentTime(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 6, agentTime.TotalRuntimeMs)
+	})
+
+	t.Run("DatabaseFailure", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+		logger := testutil.Logger(t)
+		client := coderdtest.New(t, &coderdtest.Options{
+			Database: deploymentAgentTimeErrorStore{Store: db},
+			Logger:   &logger,
+		})
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{
+			OrganizationID: firstUser.OrganizationID,
+			CreatedBy:      uuid.NullUUID{UUID: firstUser.UserID, Valid: true},
+		})
+		messageID := insertDeploymentAgentTimeMessage(t, db, sqlDB, firstUser.UserID, firstUser.OrganizationID, model.ID, 10, time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC), false, false)
+		_, err := sqlDB.ExecContext(ctx, "UPDATE chat_messages SET content = $1 WHERE id = $2", `[{"type":"text","text":"secret chat content"}]`, messageID)
+		require.NoError(t, err)
+
+		_, err = client.DeploymentAgentTime(ctx)
+		var sdkError *codersdk.Error
+		require.ErrorAs(t, err, &sdkError)
+		require.Equal(t, http.StatusInternalServerError, sdkError.StatusCode())
+		require.NotContains(t, err.Error(), "secret chat content")
+	})
 }
 
 func TestDeploymentStats(t *testing.T) {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1514,6 +1514,11 @@ type DeploymentConfig struct {
 	Options serpent.OptionSet `json:"options,omitempty"`
 }
 
+// DeploymentAgentTime reports the Agent Time retained by the deployment.
+type DeploymentAgentTime struct {
+	TotalRuntimeMs int64 `json:"total_runtime_ms"`
+}
+
 func (c *DeploymentValues) Options() serpent.OptionSet {
 	// The deploymentGroup variables are used to organize the myriad server options.
 	var (
@@ -5267,6 +5272,22 @@ func (c *Client) DeploymentConfig(ctx context.Context) (*DeploymentConfig, error
 		Options: conf.Options(),
 	}
 	return resp, ReadBodyAsJSON(res, resp)
+}
+
+// DeploymentAgentTime returns the Agent Time retained by the deployment.
+func (c *Client) DeploymentAgentTime(ctx context.Context) (DeploymentAgentTime, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/deployment/agent-time", nil)
+	if err != nil {
+		return DeploymentAgentTime{}, xerrors.Errorf("execute request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return DeploymentAgentTime{}, ReadBodyAsError(res)
+	}
+
+	var agentTime DeploymentAgentTime
+	return agentTime, ReadBodyAsJSON(res, &agentTime)
 }
 
 func (c *Client) DeploymentStats(ctx context.Context) (DeploymentStats, error) {

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"runtime"
 	"strings"
 	"testing"
@@ -149,6 +150,50 @@ func TestDeploymentValues_HighlyConfigurable(t *testing.T) {
 	for opt := range excludes {
 		t.Errorf("Excluded option %q is not in the deployment config. Remove it?", opt)
 	}
+}
+
+func TestDeploymentAgentTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/v2/deployment/agent-time", r.URL.Path)
+			rw.Header().Set("Content-Type", "application/json")
+			assert.NoError(t, json.NewEncoder(rw).Encode(codersdk.DeploymentAgentTime{
+				TotalRuntimeMs: 1234,
+			}))
+		}))
+		defer server.Close()
+
+		serverURL, err := url.Parse(server.URL)
+		require.NoError(t, err)
+		got, err := codersdk.New(serverURL).DeploymentAgentTime(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, int64(1234), got.TotalRuntimeMs)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusInternalServerError)
+			assert.NoError(t, json.NewEncoder(rw).Encode(codersdk.Response{
+				Message: "failed to load Agent Time",
+			}))
+		}))
+		defer server.Close()
+
+		serverURL, err := url.Parse(server.URL)
+		require.NoError(t, err)
+		_, err = codersdk.New(serverURL).DeploymentAgentTime(t.Context())
+		var sdkError *codersdk.Error
+		require.ErrorAs(t, err, &sdkError)
+		require.Equal(t, http.StatusInternalServerError, sdkError.StatusCode())
+	})
 }
 
 func TestAIBudgetPeriodAdjective(t *testing.T) {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -118,6 +118,37 @@ curl -X POST http://coder-server:8080/api/v2/csp/reports \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get deployment Agent Time
+
+### Code samples
+
+```sh
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/deployment/agent-time \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/v2/deployment/agent-time`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "total_runtime_ms": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                 |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.DeploymentAgentTime](schemas.md#codersdkdeploymentagenttime) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get deployment config
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7431,6 +7431,20 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `agent_name` | string  | false    |              |             |
 | `port`       | integer | false    |              |             |
 
+## codersdk.DeploymentAgentTime
+
+```json
+{
+  "total_runtime_ms": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description |
+|--------------------|---------|----------|--------------|-------------|
+| `total_runtime_ms` | integer | false    |              |             |
+
 ## codersdk.DeploymentConfig
 
 ```json

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2468,6 +2468,11 @@ class ApiMethods {
 		return response.data;
 	};
 
+	getDeploymentAgentTime = async (): Promise<TypesGen.DeploymentAgentTime> => {
+		const response = await this.axios.get("/api/v2/deployment/agent-time");
+		return response.data;
+	};
+
 	getDeploymentStats = async (): Promise<TypesGen.DeploymentStats> => {
 		const response = await this.axios.get("/api/v2/deployment/stats");
 		return response.data;

--- a/site/src/api/queries/deployment.test.ts
+++ b/site/src/api/queries/deployment.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { UsagePeriod } from "#/api/typesGenerated";
+import { deploymentAgentTime } from "./deployment";
+
+const usagePeriod: UsagePeriod = {
+	issued_at: "2026-08-01T00:00:00Z",
+	start: "2026-08-01T00:00:00Z",
+	end: "2026-09-01T00:00:00Z",
+};
+
+describe("deploymentAgentTime", () => {
+	it("keys usage by the license period", () => {
+		expect(deploymentAgentTime().queryKey).toEqual(["deployment", "agentTime"]);
+		expect(deploymentAgentTime(usagePeriod).queryKey).toEqual([
+			"deployment",
+			"agentTime",
+			usagePeriod.start,
+			usagePeriod.end,
+		]);
+		expect(
+			deploymentAgentTime({
+				...usagePeriod,
+				start: "2026-09-01T00:00:00Z",
+				end: "2026-10-01T00:00:00Z",
+			}).queryKey,
+		).not.toEqual(deploymentAgentTime(usagePeriod).queryKey);
+	});
+});

--- a/site/src/api/queries/deployment.ts
+++ b/site/src/api/queries/deployment.ts
@@ -18,6 +18,17 @@ export const deploymentDAUs = () => {
 	};
 };
 
+const deploymentAgentTimeQueryKey = ["deployment", "agentTime"] as const;
+
+export const deploymentAgentTime = () => {
+	return {
+		queryKey: deploymentAgentTimeQueryKey,
+		queryFn: API.getDeploymentAgentTime,
+		staleTime: 5 * 60 * 1_000,
+		refetchOnWindowFocus: false,
+	};
+};
+
 export const deploymentStatsQueryKey = ["deployment", "stats"];
 
 export const deploymentStats = () => {

--- a/site/src/api/queries/deployment.ts
+++ b/site/src/api/queries/deployment.ts
@@ -1,4 +1,5 @@
 import { API } from "#/api/api";
+import type { UsagePeriod } from "#/api/typesGenerated";
 import { disabledRefetchOptions } from "./util";
 
 export const deploymentConfigQueryKey = ["deployment", "config"];
@@ -20,12 +21,13 @@ export const deploymentDAUs = () => {
 
 const deploymentAgentTimeQueryKey = ["deployment", "agentTime"] as const;
 
-export const deploymentAgentTime = () => {
+export const deploymentAgentTime = (usagePeriod?: UsagePeriod) => {
 	return {
-		queryKey: deploymentAgentTimeQueryKey,
+		queryKey: usagePeriod
+			? [...deploymentAgentTimeQueryKey, usagePeriod.start, usagePeriod.end]
+			: deploymentAgentTimeQueryKey,
 		queryFn: API.getDeploymentAgentTime,
 		staleTime: 5 * 60 * 1_000,
-		refetchOnWindowFocus: false,
 	};
 };
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4747,6 +4747,14 @@ export interface DeleteWorkspaceAgentPortShareRequest {
 
 // From codersdk/deployment.go
 /**
+ * DeploymentAgentTime reports the Agent Time retained by the deployment.
+ */
+export interface DeploymentAgentTime {
+	readonly total_runtime_ms: number;
+}
+
+// From codersdk/deployment.go
+/**
  * DeploymentConfig contains both the deployment values and how they're set.
  */
 export interface DeploymentConfig {

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.stories.tsx
@@ -5,6 +5,7 @@ import { chatPersonalModelOverridesAdminSettings } from "#/api/queries/chats";
 import { deploymentAgentTime } from "#/api/queries/deployment";
 import type { Entitlements } from "#/api/typesGenerated";
 import { DashboardContext } from "#/modules/dashboard/DashboardProvider";
+import { CONTACT_SALES_LINK } from "#/modules/licenses/trialLicense";
 import {
 	MockAgentRuntimeHoursFeature,
 	MockAppearanceConfig,
@@ -91,9 +92,14 @@ export const CommunityUsageWithUnrelatedLicense: Story = {
 		await expect(canvas.getByText("10.3 hours")).toBeVisible();
 		await expect(
 			canvas.getByRole("link", {
-				name: "Upgrade for unlimited concurrent chats",
+				name: "Contact sales to add Agent Runtime",
 			}),
-		).toHaveAttribute("href", "/deployment/premium");
+		).toHaveAttribute("href", CONTACT_SALES_LINK);
+		await expect(
+			canvas.queryByRole("link", {
+				name: "Upgrade for unlimited concurrent agents",
+			}),
+		).not.toBeInTheDocument();
 		await expect(canvas.getByText("5")).toBeVisible();
 	},
 };

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { chatPersonalModelOverridesAdminSettings } from "#/api/queries/chats";
+import { deploymentAgentTime } from "#/api/queries/deployment";
+import type { Entitlements } from "#/api/typesGenerated";
+import { DashboardContext } from "#/modules/dashboard/DashboardProvider";
+import {
+	MockAgentRuntimeHoursFeature,
+	MockAppearanceConfig,
+	MockBuildInfo,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import { withAuthProvider } from "#/testHelpers/storybook";
+import CoderAgentsPage from "./CoderAgentsPage";
+
+const actualMs = (10 * 60 + 18) * 60_000;
+const communityRuntimeFeature = {
+	...MockAgentRuntimeHoursFeature,
+	entitlement: "not_entitled",
+	enabled: false,
+	limit: undefined,
+	soft_limit: undefined,
+	hard_limit: undefined,
+	actual: undefined,
+	actual_ms: undefined,
+	usage_period: undefined,
+} satisfies Entitlements["features"]["agent_runtime_hours"];
+const entitlementsWithUnrelatedLicense: Entitlements = {
+	...MockEntitlements,
+	has_license: true,
+	features: {
+		...MockEntitlements.features,
+		agent_runtime_hours: communityRuntimeFeature,
+	},
+};
+
+const meta = {
+	title: "pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage",
+	component: CoderAgentsPage,
+	decorators: [
+		withAuthProvider,
+		(Story) => (
+			<DashboardContext.Provider
+				value={{
+					entitlements: entitlementsWithUnrelatedLicense,
+					experiments: [],
+					appearance: MockAppearanceConfig,
+					buildInfo: MockBuildInfo,
+					organizations: [MockDefaultOrganization],
+					showOrganizations: false,
+					canViewOrganizationSettings: false,
+				}}
+			>
+				<Story />
+			</DashboardContext.Provider>
+		),
+	],
+	parameters: {
+		layout: "fullscreen",
+		user: MockUserOwner,
+		permissions: { editDeploymentConfig: true },
+		reactRouter: reactRouterParameters({
+			location: { path: "/ai/settings/coder-agents" },
+			routing: [{ path: "*", useStoryElement: true }],
+		}),
+	},
+} satisfies Meta<typeof CoderAgentsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CommunityUsageWithUnrelatedLicense: Story = {
+	parameters: {
+		queries: [
+			{
+				key: deploymentAgentTime().queryKey,
+				data: { total_runtime_ms: actualMs },
+			},
+			{
+				key: chatPersonalModelOverridesAdminSettings().queryKey,
+				data: { allow_users: true },
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Agent hours used")).toBeVisible();
+		await expect(canvas.getByText("10.3 hours")).toBeVisible();
+		await expect(
+			canvas.getByRole("link", {
+				name: "Upgrade for unlimited concurrent chats",
+			}),
+		).toHaveAttribute("href", "/deployment/premium");
+		await expect(canvas.getByText("5")).toBeVisible();
+	},
+};
+
+export const MalformedUsage: Story = {
+	parameters: {
+		queries: [
+			{
+				key: deploymentAgentTime().queryKey,
+				data: { total_runtime_ms: Number.NaN },
+			},
+			{
+				key: chatPersonalModelOverridesAdminSettings().queryKey,
+				data: { allow_users: true },
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("Agent Time usage is unavailable."),
+		).toBeVisible();
+		await expect(canvas.queryByText(/N\/A .*hours/)).not.toBeInTheDocument();
+		await expect(
+			canvas.getByRole("switch", { name: "Allow personal model overrides" }),
+		).toBeVisible();
+	},
+};

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.stories.tsx
@@ -10,6 +10,7 @@ import {
 	MockAgentRuntimeHoursFeature,
 	MockAppearanceConfig,
 	MockBuildInfo,
+	MockCommunityAgentRuntimeHoursFeature,
 	MockDefaultOrganization,
 	MockEntitlements,
 	MockUserOwner,
@@ -18,23 +19,20 @@ import { withAuthProvider } from "#/testHelpers/storybook";
 import CoderAgentsPage from "./CoderAgentsPage";
 
 const actualMs = (10 * 60 + 18) * 60_000;
-const communityRuntimeFeature = {
-	...MockAgentRuntimeHoursFeature,
-	entitlement: "not_entitled",
-	enabled: false,
-	limit: undefined,
-	soft_limit: undefined,
-	hard_limit: undefined,
-	actual: undefined,
-	actual_ms: undefined,
-	usage_period: undefined,
+const zeroHourRuntimeFeature = {
+	...MockCommunityAgentRuntimeHoursFeature,
+	entitlement: "entitled",
+	limit: 0,
+	actual: 0,
+	actual_ms: 0,
+	usage_period: MockAgentRuntimeHoursFeature.usage_period,
 } satisfies Entitlements["features"]["agent_runtime_hours"];
-const entitlementsWithUnrelatedLicense: Entitlements = {
+const entitlementsWithZeroHourAgentRuntime: Entitlements = {
 	...MockEntitlements,
 	has_license: true,
 	features: {
 		...MockEntitlements.features,
-		agent_runtime_hours: communityRuntimeFeature,
+		agent_runtime_hours: zeroHourRuntimeFeature,
 	},
 };
 
@@ -46,7 +44,7 @@ const meta = {
 		(Story) => (
 			<DashboardContext.Provider
 				value={{
-					entitlements: entitlementsWithUnrelatedLicense,
+					entitlements: entitlementsWithZeroHourAgentRuntime,
 					experiments: [],
 					appearance: MockAppearanceConfig,
 					buildInfo: MockBuildInfo,
@@ -73,11 +71,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const CommunityUsageWithUnrelatedLicense: Story = {
+export const UsageWithZeroHourLicense: Story = {
 	parameters: {
 		queries: [
 			{
-				key: deploymentAgentTime().queryKey,
+				key: deploymentAgentTime(zeroHourRuntimeFeature.usage_period).queryKey,
 				data: { total_runtime_ms: actualMs },
 			},
 			{
@@ -90,6 +88,7 @@ export const CommunityUsageWithUnrelatedLicense: Story = {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("Agent hours used")).toBeVisible();
 		await expect(canvas.getByText("10.3 hours")).toBeVisible();
+		await expect(canvas.queryByText("10.3 / 0 hours")).not.toBeInTheDocument();
 		await expect(
 			canvas.getByRole("link", {
 				name: "Contact sales to add Agent Runtime",
@@ -108,7 +107,7 @@ export const MalformedUsage: Story = {
 	parameters: {
 		queries: [
 			{
-				key: deploymentAgentTime().queryKey,
+				key: deploymentAgentTime(zeroHourRuntimeFeature.usage_period).queryKey,
 				data: { total_runtime_ms: Number.NaN },
 			},
 			{

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
@@ -9,6 +9,7 @@ import {
 	updateChatComputerUseProvider,
 	updateChatPersonalModelOverridesAdminSettings,
 } from "#/api/queries/chats";
+import { deploymentAgentTime } from "#/api/queries/deployment";
 import { organizationsPermissions } from "#/api/queries/organizations";
 import { Loader } from "#/components/Loader/Loader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
@@ -25,7 +26,7 @@ import { OrganizationAgentSettings } from "./OrganizationAgentSettings";
 
 const CoderAgentsPage: FC = () => {
 	const { permissions } = useAuthenticated();
-	const { experiments, organizations } = useDashboard();
+	const { entitlements, experiments, organizations } = useDashboard();
 	const queryClient = useQueryClient();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const canEditDeploymentConfig = permissions.editDeploymentConfig;
@@ -49,6 +50,10 @@ const CoderAgentsPage: FC = () => {
 	const showVirtualDesktopSettings = experiments.includes(
 		"chat-virtual-desktop",
 	);
+	const agentTimeQuery = useQuery({
+		...deploymentAgentTime(),
+		enabled: canEditDeploymentConfig,
+	});
 	const personalOverridesQuery = useQuery({
 		...chatPersonalModelOverridesAdminSettings(),
 		enabled: canEditDeploymentConfig,
@@ -70,6 +75,13 @@ const CoderAgentsPage: FC = () => {
 	const saveComputerUseProviderMutation = useMutation(
 		updateChatComputerUseProvider(queryClient),
 	);
+	const agentRuntimeHoursFeature = entitlements.features.agent_runtime_hours;
+	const hasAgentRuntimeLicense = agentRuntimeHoursFeature
+		? agentRuntimeHoursFeature.usage_period !== undefined
+		: undefined;
+	const isAgentRuntimeUsageUnavailable =
+		agentTimeQuery.data !== undefined &&
+		!Number.isFinite(agentTimeQuery.data.total_runtime_ms);
 	const canAccessOrganizationSettings =
 		accessibleOrganizationsQuery.organizations.length > 0;
 	const isFeatureVisible =
@@ -116,6 +128,14 @@ const CoderAgentsPage: FC = () => {
 				isOrganizationAccessLoading={accessibleOrganizationsQuery.isLoading}
 				organizationSettings={organizationSettings}
 				canEditDeploymentConfig={canEditDeploymentConfig}
+				hasAgentRuntimeLicense={hasAgentRuntimeLicense}
+				agentRuntimeHoursFeature={agentRuntimeHoursFeature}
+				agentRuntimeTotalMs={agentTimeQuery.data?.total_runtime_ms}
+				isAgentRuntimeUsageLoading={agentTimeQuery.isLoading}
+				isAgentRuntimeUsageUnavailable={isAgentRuntimeUsageUnavailable}
+				agentRuntimeUsageError={agentTimeQuery.error}
+				onRetryAgentRuntimeUsage={() => void agentTimeQuery.refetch()}
+				isRetryingAgentRuntimeUsage={agentTimeQuery.isFetching}
 				adminOverridesData={personalOverridesQuery.data}
 				adminOverridesError={personalOverridesQuery.error}
 				onRetryAdminOverrides={() => void personalOverridesQuery.refetch()}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
@@ -50,8 +50,9 @@ const CoderAgentsPage: FC = () => {
 	const showVirtualDesktopSettings = experiments.includes(
 		"chat-virtual-desktop",
 	);
+	const agentRuntimeHoursFeature = entitlements.features.agent_runtime_hours;
 	const agentTimeQuery = useQuery({
-		...deploymentAgentTime(),
+		...deploymentAgentTime(agentRuntimeHoursFeature?.usage_period),
 		enabled: canEditDeploymentConfig,
 	});
 	const personalOverridesQuery = useQuery({
@@ -75,7 +76,6 @@ const CoderAgentsPage: FC = () => {
 	const saveComputerUseProviderMutation = useMutation(
 		updateChatComputerUseProvider(queryClient),
 	);
-	const agentRuntimeHoursFeature = entitlements.features.agent_runtime_hours;
 	const hasAgentRuntimeLicense = agentRuntimeHoursFeature
 		? agentRuntimeHoursFeature.usage_period !== undefined
 		: undefined;
@@ -128,6 +128,7 @@ const CoderAgentsPage: FC = () => {
 				isOrganizationAccessLoading={accessibleOrganizationsQuery.isLoading}
 				organizationSettings={organizationSettings}
 				canEditDeploymentConfig={canEditDeploymentConfig}
+				hasDeploymentLicense={entitlements.has_license}
 				hasAgentRuntimeLicense={hasAgentRuntimeLicense}
 				agentRuntimeHoursFeature={agentRuntimeHoursFeature}
 				agentRuntimeTotalMs={agentTimeQuery.data?.total_runtime_ms}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage.tsx
@@ -77,7 +77,10 @@ const CoderAgentsPage: FC = () => {
 		updateChatComputerUseProvider(queryClient),
 	);
 	const hasAgentRuntimeLicense = agentRuntimeHoursFeature
-		? agentRuntimeHoursFeature.usage_period !== undefined
+		? agentRuntimeHoursFeature.enabled &&
+			agentRuntimeHoursFeature.usage_period !== undefined &&
+			(agentRuntimeHoursFeature.limit === undefined ||
+				agentRuntimeHoursFeature.limit > 0)
 		: undefined;
 	const isAgentRuntimeUsageUnavailable =
 		agentTimeQuery.data !== undefined &&

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { PREMIUM_PAGE_PATH } from "#/components/Paywall/Paywall";
 import {
 	MockAgentRuntimeHoursFeature,
 	MockDefaultOrganization,
@@ -53,6 +54,7 @@ const defaultArgs: CoderAgentsPageViewProps = {
 	isOrganizationAccessLoading: false,
 	organizationSettings: <div>Organization override controls</div>,
 	canEditDeploymentConfig: true,
+	hasDeploymentLicense: false,
 	hasAgentRuntimeLicense: false,
 	agentRuntimeHoursFeature: communityRuntimeFeature,
 	agentRuntimeTotalMs: actualMs,
@@ -118,7 +120,7 @@ export const Default: Story = {
 			canvas.getByRole("link", {
 				name: "Upgrade for unlimited concurrent agents",
 			}),
-		).toHaveAttribute("href", "/deployment/premium");
+		).toHaveAttribute("href", PREMIUM_PAGE_PATH);
 		await userEvent.hover(
 			canvas.getByRole("button", {
 				name: "Agent hours used information",

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -4,6 +4,7 @@ import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { PREMIUM_PAGE_PATH } from "#/components/Paywall/Paywall";
 import {
 	MockAgentRuntimeHoursFeature,
+	MockCommunityAgentRuntimeHoursFeature,
 	MockDefaultOrganization,
 	MockOrganization2,
 } from "#/testHelpers/entities";
@@ -13,17 +14,6 @@ import {
 } from "./CoderAgentsPageView";
 
 const actualMs = (10 * 60 + 18) * 60_000;
-const communityRuntimeFeature = {
-	...MockAgentRuntimeHoursFeature,
-	entitlement: "not_entitled",
-	enabled: false,
-	limit: undefined,
-	soft_limit: undefined,
-	hard_limit: undefined,
-	actual: undefined,
-	actual_ms: undefined,
-	usage_period: undefined,
-} satisfies CoderAgentsPageViewProps["agentRuntimeHoursFeature"];
 const licensedFiniteRuntimeFeature = {
 	...MockAgentRuntimeHoursFeature,
 	limit: 100,
@@ -56,7 +46,7 @@ const defaultArgs: CoderAgentsPageViewProps = {
 	canEditDeploymentConfig: true,
 	hasDeploymentLicense: false,
 	hasAgentRuntimeLicense: false,
-	agentRuntimeHoursFeature: communityRuntimeFeature,
+	agentRuntimeHoursFeature: MockCommunityAgentRuntimeHoursFeature,
 	agentRuntimeTotalMs: actualMs,
 	isAgentRuntimeUsageLoading: false,
 	isAgentRuntimeUsageUnavailable: false,

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -104,13 +104,35 @@ export const Default: Story = {
 	args: { onSaveAdvisorConfig: fn() },
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		await expect(canvas.getByRole("heading", { name: "Usage" })).toBeVisible();
+		const usage = canvas.getByRole("region", { name: "Coder Agents usage" });
+		await expect(
+			usage.compareDocumentPosition(
+				canvas.getByRole("heading", { name: "Organization settings" }),
+			) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+		await expect(
+			within(usage).getByRole("heading", { name: "Usage" }),
+		).toBeVisible();
 		await expect(canvas.getByText("10.3 hours")).toBeVisible();
 		await expect(
 			canvas.getByRole("link", {
-				name: "Upgrade for unlimited concurrent chats",
+				name: "Upgrade for unlimited concurrent agents",
 			}),
 		).toHaveAttribute("href", "/deployment/premium");
+		await userEvent.hover(
+			canvas.getByRole("button", {
+				name: "Agent hours used information",
+			}),
+		);
+		await waitFor(async () => {
+			await expect(screen.getByRole("tooltip")).toHaveTextContent(
+				"Total agent time used across all chats. Time from archived chats is excluded once deleted based on the conversation retention period.",
+			);
+		});
+		await userEvent.keyboard("{Escape}");
+		await waitFor(async () => {
+			await expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
 		await userEvent.hover(
 			canvas.getByRole("button", {
 				name: "Max concurrent agents information",
@@ -228,8 +250,8 @@ export const LicensedFiniteAllocation: Story = {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByText("10.3 / 100 hours")).toBeVisible();
 		await expect(
-			canvas.getByRole("link", { name: "View license" }),
-		).toHaveAttribute("href", "/deployment/licenses");
+			canvas.queryByRole("link", { name: "View license" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import {
+	MockAgentRuntimeHoursFeature,
 	MockDefaultOrganization,
 	MockOrganization2,
 } from "#/testHelpers/entities";
@@ -9,6 +10,40 @@ import {
 	CoderAgentsPageView,
 	type CoderAgentsPageViewProps,
 } from "./CoderAgentsPageView";
+
+const actualMs = (10 * 60 + 18) * 60_000;
+const communityRuntimeFeature = {
+	...MockAgentRuntimeHoursFeature,
+	entitlement: "not_entitled",
+	enabled: false,
+	limit: undefined,
+	soft_limit: undefined,
+	hard_limit: undefined,
+	actual: undefined,
+	actual_ms: undefined,
+	usage_period: undefined,
+} satisfies CoderAgentsPageViewProps["agentRuntimeHoursFeature"];
+const licensedFiniteRuntimeFeature = {
+	...MockAgentRuntimeHoursFeature,
+	limit: 100,
+	soft_limit: undefined,
+	hard_limit: 120,
+	actual: 10,
+	actual_ms: undefined,
+} satisfies CoderAgentsPageViewProps["agentRuntimeHoursFeature"];
+const licensedUnlimitedRuntimeFeature = {
+	...MockAgentRuntimeHoursFeature,
+	limit: undefined,
+	soft_limit: undefined,
+	hard_limit: undefined,
+	actual: 10,
+	actual_ms: undefined,
+} satisfies CoderAgentsPageViewProps["agentRuntimeHoursFeature"];
+const licensedHardLimitRuntimeFeature = {
+	...licensedFiniteRuntimeFeature,
+	actual: 120,
+	actual_ms: undefined,
+} satisfies CoderAgentsPageViewProps["agentRuntimeHoursFeature"];
 
 const defaultArgs: CoderAgentsPageViewProps = {
 	organization: MockDefaultOrganization,
@@ -18,6 +53,14 @@ const defaultArgs: CoderAgentsPageViewProps = {
 	isOrganizationAccessLoading: false,
 	organizationSettings: <div>Organization override controls</div>,
 	canEditDeploymentConfig: true,
+	hasAgentRuntimeLicense: false,
+	agentRuntimeHoursFeature: communityRuntimeFeature,
+	agentRuntimeTotalMs: actualMs,
+	isAgentRuntimeUsageLoading: false,
+	isAgentRuntimeUsageUnavailable: false,
+	agentRuntimeUsageError: undefined,
+	onRetryAgentRuntimeUsage: fn(),
+	isRetryingAgentRuntimeUsage: false,
 	adminOverridesData: { allow_users: true },
 	onSaveAdminOverrides: fn(),
 	isSavingAdminOverrides: false,
@@ -61,6 +104,23 @@ export const Default: Story = {
 	args: { onSaveAdvisorConfig: fn() },
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("heading", { name: "Usage" })).toBeVisible();
+		await expect(canvas.getByText("10.3 hours")).toBeVisible();
+		await expect(
+			canvas.getByRole("link", {
+				name: "Upgrade for unlimited concurrent chats",
+			}),
+		).toHaveAttribute("href", "/deployment/premium");
+		await userEvent.hover(
+			canvas.getByRole("button", {
+				name: "Max concurrent agents information",
+			}),
+		);
+		await waitFor(async () => {
+			await expect(screen.getByRole("tooltip")).toHaveTextContent(
+				"Number of agents that can run at the same time.",
+			);
+		});
 		await expect(
 			canvas.getByRole("heading", { name: "Organization settings" }),
 		).toBeVisible();
@@ -88,6 +148,128 @@ export const WithoutAdvisor: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.queryByText("Advisor")).not.toBeInTheDocument();
+	},
+};
+
+export const UsageLoading: Story = {
+	args: {
+		hasAgentRuntimeLicense: undefined,
+		agentRuntimeHoursFeature: undefined,
+		isAgentRuntimeUsageLoading: true,
+		agentRuntimeTotalMs: undefined,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("status", { name: "Loading Agent Time usage" }),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("switch", { name: "Allow personal model overrides" }),
+		).toBeVisible();
+	},
+};
+
+export const UsageLoadError: Story = {
+	args: {
+		hasAgentRuntimeLicense: undefined,
+		agentRuntimeHoursFeature: undefined,
+		agentRuntimeUsageError: new Error("Failed to load Agent Time usage."),
+		agentRuntimeTotalMs: undefined,
+		onRetryAgentRuntimeUsage: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("alert")).toHaveTextContent(
+			"Failed to load Agent Time usage.",
+		);
+		await expect(
+			canvas.queryByText("Agent Time usage is unavailable."),
+		).not.toBeInTheDocument();
+		await userEvent.click(canvas.getByRole("button", { name: "Retry" }));
+		await expect(args.onRetryAgentRuntimeUsage).toHaveBeenCalled();
+		await expect(
+			canvas.getByRole("switch", { name: "Allow personal model overrides" }),
+		).toBeVisible();
+	},
+};
+
+export const UsageUnavailable: Story = {
+	args: {
+		hasAgentRuntimeLicense: undefined,
+		agentRuntimeHoursFeature: undefined,
+		isAgentRuntimeUsageUnavailable: true,
+		agentRuntimeTotalMs: undefined,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("Agent Time usage is unavailable."),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("switch", { name: "Allow personal model overrides" }),
+		).toBeVisible();
+	},
+};
+
+export const ZeroUsage: Story = {
+	args: { agentRuntimeTotalMs: 0 },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("0.0 hours")).toBeVisible();
+	},
+};
+
+export const LicensedFiniteAllocation: Story = {
+	args: {
+		hasAgentRuntimeLicense: true,
+		agentRuntimeHoursFeature: licensedFiniteRuntimeFeature,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("10.3 / 100 hours")).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: "View license" }),
+		).toHaveAttribute("href", "/deployment/licenses");
+	},
+};
+
+export const LicensedHardLimitReached: Story = {
+	args: {
+		hasAgentRuntimeLicense: true,
+		agentRuntimeHoursFeature: licensedHardLimitRuntimeFeature,
+		agentRuntimeTotalMs: 120 * 3_600_000,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const usage = within(
+			canvas.getByRole("region", { name: "Coder Agents usage" }),
+		);
+		await expect(usage.getByText("120.0 / 100 hours")).toBeVisible();
+		await expect(usage.getByText("5")).toBeVisible();
+		await userEvent.hover(
+			usage.getByRole("button", {
+				name: "Max concurrent agents information",
+			}),
+		);
+		await waitFor(async () => {
+			await expect(screen.getByRole("tooltip")).toHaveTextContent(
+				"You've reached your limit: concurrent chats are now capped at 5 (down from unlimited).",
+			);
+		});
+	},
+};
+
+export const LicensedUnlimitedAllocation: Story = {
+	args: {
+		hasAgentRuntimeLicense: true,
+		agentRuntimeHoursFeature: licensedUnlimitedRuntimeFeature,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("10.3 / Unlimited hours")).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: "View usage documentation" }),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
@@ -147,19 +147,13 @@ const CoderAgentsUsage: FC<CoderAgentsUsageProps> = ({
 			<div className="flex items-center justify-between gap-4">
 				<div>
 					<h2 className="m-0 text-base font-medium">Usage</h2>
-					<Link asChild showExternalIcon={false} size="lg" className="mt-1">
-						<RouterLink
-							to={
-								hasAgentRuntimeLicense === false
-									? "/deployment/premium"
-									: "/deployment/licenses"
-							}
-						>
-							{hasAgentRuntimeLicense === false
-								? "Upgrade for unlimited concurrent chats"
-								: "View license"}
-						</RouterLink>
-					</Link>
+					{hasAgentRuntimeLicense === false && (
+						<Link asChild showExternalIcon={false} size="lg" className="mt-1">
+							<RouterLink to="/deployment/premium">
+								Upgrade for unlimited concurrent agents
+							</RouterLink>
+						</Link>
+					)}
 				</div>
 			</div>
 
@@ -191,8 +185,24 @@ const CoderAgentsUsage: FC<CoderAgentsUsageProps> = ({
 				<>
 					<dl className="m-0 mt-5 grid gap-4 sm:grid-cols-2">
 						<div>
-							<dt className="text-xs font-medium text-content-secondary">
-								Agent hours used
+							<dt className="flex items-center gap-1 text-xs font-medium text-content-secondary">
+								<span>Agent hours used</span>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											aria-label="Agent hours used information"
+											className="m-0 inline-flex appearance-none border-0 bg-transparent p-0 text-content-secondary"
+										>
+											<InfoIcon className="size-3" />
+										</button>
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-xs">
+										Total agent time used across all chats. Time from archived
+										chats is excluded once deleted based on the conversation
+										retention period.
+									</TooltipContent>
+								</Tooltip>
 							</dt>
 							<dd className="m-0 mt-1 text-sm font-medium text-content-primary">
 								{hasAgentRuntimeLicense
@@ -279,13 +289,28 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 }) => {
 	return (
 		<div className="flex max-w-4xl flex-col gap-10">
-			<SettingsHeader>
-				<SettingsHeaderTitle>Coder Agents</SettingsHeaderTitle>
-				<SettingsHeaderDescription>
-					Configure organization model choices and deployment-wide Coder Agents
-					capabilities.
-				</SettingsHeaderDescription>
-			</SettingsHeader>
+			<div>
+				<SettingsHeader>
+					<SettingsHeaderTitle>Coder Agents</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Configure organization model choices and deployment-wide Coder
+						Agents capabilities.
+					</SettingsHeaderDescription>
+				</SettingsHeader>
+
+				{canEditDeploymentConfig && (
+					<CoderAgentsUsage
+						hasAgentRuntimeLicense={hasAgentRuntimeLicense}
+						feature={agentRuntimeHoursFeature}
+						totalRuntimeMs={agentRuntimeTotalMs}
+						isLoading={isAgentRuntimeUsageLoading}
+						isUnavailable={isAgentRuntimeUsageUnavailable}
+						error={agentRuntimeUsageError}
+						onRetry={onRetryAgentRuntimeUsage}
+						isRetrying={isRetryingAgentRuntimeUsage}
+					/>
+				)}
+			</div>
 
 			{isOrganizationAccessLoading ? (
 				<Loader label="Loading organization settings" />
@@ -360,16 +385,6 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 							organization.
 						</p>
 					</div>
-					<CoderAgentsUsage
-						hasAgentRuntimeLicense={hasAgentRuntimeLicense}
-						feature={agentRuntimeHoursFeature}
-						totalRuntimeMs={agentRuntimeTotalMs}
-						isLoading={isAgentRuntimeUsageLoading}
-						isUnavailable={isAgentRuntimeUsageUnavailable}
-						error={agentRuntimeUsageError}
-						onRetry={onRetryAgentRuntimeUsage}
-						isRetrying={isRetryingAgentRuntimeUsage}
-					/>
 					<div className="flex flex-col gap-6 rounded-lg border border-solid border-border px-6 py-7">
 						<AdminPersonalModelOverridesSettings
 							adminSettings={adminOverridesData}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
@@ -12,6 +12,7 @@ import {
 	getOrganizationLabel,
 	OrganizationAutocomplete,
 } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
+import { PREMIUM_PAGE_PATH } from "#/components/Paywall/Paywall";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -23,6 +24,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { CONTACT_SALES_LINK } from "#/modules/licenses/trialLicense";
 import { AdvisorSettings } from "#/pages/AgentsPage/components/AdvisorSettings";
 import { VirtualDesktopSettings } from "#/pages/AgentsPage/components/VirtualDesktopSettings";
 import { docs } from "#/utils/docs";
@@ -42,6 +44,7 @@ export interface CoderAgentsPageViewProps {
 	isOrganizationAccessLoading: boolean;
 	organizationSettings?: ReactNode;
 	canEditDeploymentConfig: boolean;
+	hasDeploymentLicense: boolean;
 	hasAgentRuntimeLicense?: boolean;
 	agentRuntimeHoursFeature?: TypesGen.Feature;
 	agentRuntimeTotalMs?: number;
@@ -99,6 +102,7 @@ const formatAgentHours = (actualMs: number | undefined): string => {
 };
 
 type CoderAgentsUsageProps = {
+	hasDeploymentLicense: boolean;
 	hasAgentRuntimeLicense?: boolean;
 	feature?: TypesGen.Feature;
 	totalRuntimeMs?: number;
@@ -110,6 +114,7 @@ type CoderAgentsUsageProps = {
 };
 
 const CoderAgentsUsage: FC<CoderAgentsUsageProps> = ({
+	hasDeploymentLicense,
 	hasAgentRuntimeLicense,
 	feature,
 	totalRuntimeMs,
@@ -147,13 +152,25 @@ const CoderAgentsUsage: FC<CoderAgentsUsageProps> = ({
 			<div className="flex items-center justify-between gap-4">
 				<div>
 					<h2 className="m-0 text-base font-medium">Usage</h2>
-					{hasAgentRuntimeLicense === false && (
-						<Link asChild showExternalIcon={false} size="lg" className="mt-1">
-							<RouterLink to="/deployment/premium">
-								Upgrade for unlimited concurrent agents
-							</RouterLink>
-						</Link>
-					)}
+					{hasAgentRuntimeLicense === false &&
+						(hasDeploymentLicense ? (
+							<Link
+								href={CONTACT_SALES_LINK}
+								target="_blank"
+								rel="noreferrer"
+								showExternalIcon={false}
+								size="lg"
+								className="mt-1"
+							>
+								Contact sales to add Agent Runtime
+							</Link>
+						) : (
+							<Link asChild showExternalIcon={false} size="lg" className="mt-1">
+								<RouterLink to={PREMIUM_PAGE_PATH}>
+									Upgrade for unlimited concurrent agents
+								</RouterLink>
+							</Link>
+						))}
 				</div>
 			</div>
 
@@ -256,6 +273,7 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 	isOrganizationAccessLoading,
 	organizationSettings,
 	canEditDeploymentConfig,
+	hasDeploymentLicense,
 	hasAgentRuntimeLicense,
 	agentRuntimeHoursFeature,
 	agentRuntimeTotalMs,
@@ -300,6 +318,7 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 
 				{canEditDeploymentConfig && (
 					<CoderAgentsUsage
+						hasDeploymentLicense={hasDeploymentLicense}
 						hasAgentRuntimeLicense={hasAgentRuntimeLicense}
 						feature={agentRuntimeHoursFeature}
 						totalRuntimeMs={agentRuntimeTotalMs}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.tsx
@@ -1,8 +1,12 @@
+import { InfoIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import type { UseMutateFunction } from "react-query";
+import { Link as RouterLink } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Button } from "#/components/Button/Button";
+import { Link } from "#/components/Link/Link";
 import { Loader } from "#/components/Loader/Loader";
 import {
 	getOrganizationLabel,
@@ -13,8 +17,15 @@ import {
 	SettingsHeaderDescription,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { AdvisorSettings } from "#/pages/AgentsPage/components/AdvisorSettings";
 import { VirtualDesktopSettings } from "#/pages/AgentsPage/components/VirtualDesktopSettings";
+import { docs } from "#/utils/docs";
 import {
 	AdminPersonalModelOverridesSettings,
 	type SavePersonalModelOverridesAdminSetting,
@@ -31,6 +42,14 @@ export interface CoderAgentsPageViewProps {
 	isOrganizationAccessLoading: boolean;
 	organizationSettings?: ReactNode;
 	canEditDeploymentConfig: boolean;
+	hasAgentRuntimeLicense?: boolean;
+	agentRuntimeHoursFeature?: TypesGen.Feature;
+	agentRuntimeTotalMs?: number;
+	isAgentRuntimeUsageLoading: boolean;
+	isAgentRuntimeUsageUnavailable: boolean;
+	agentRuntimeUsageError?: unknown;
+	onRetryAgentRuntimeUsage: () => void;
+	isRetryingAgentRuntimeUsage: boolean;
 	adminOverridesData?: TypesGen.ChatPersonalModelOverridesAdminSettings;
 	adminOverridesError?: unknown;
 	onRetryAdminOverrides?: () => void;
@@ -63,6 +82,160 @@ export interface CoderAgentsPageViewProps {
 	computerUseProviderSaveError: Error | null;
 }
 
+const maxConcurrentAgents = 5;
+const concurrentAgentsTooltip =
+	"Number of agents that can run at the same time.";
+const concurrentAgentsHardLimitTooltip = `${concurrentAgentsTooltip} You've reached your limit: concurrent chats are now capped at ${maxConcurrentAgents} (down from unlimited).`;
+
+const formatAgentHours = (actualMs: number | undefined): string => {
+	if (actualMs === undefined || !Number.isFinite(actualMs)) {
+		return "N/A";
+	}
+	const hours = Math.floor(Math.max(actualMs, 0) / 360_000) / 10;
+	return hours.toLocaleString("en-US", {
+		minimumFractionDigits: 1,
+		maximumFractionDigits: 1,
+	});
+};
+
+type CoderAgentsUsageProps = {
+	hasAgentRuntimeLicense?: boolean;
+	feature?: TypesGen.Feature;
+	totalRuntimeMs?: number;
+	isLoading: boolean;
+	isUnavailable: boolean;
+	error?: unknown;
+	onRetry: () => void;
+	isRetrying: boolean;
+};
+
+const CoderAgentsUsage: FC<CoderAgentsUsageProps> = ({
+	hasAgentRuntimeLicense,
+	feature,
+	totalRuntimeMs,
+	isLoading,
+	isUnavailable,
+	error,
+	onRetry,
+	isRetrying,
+}) => {
+	const usedHours = formatAgentHours(totalRuntimeMs);
+	const hardLimitReached =
+		feature?.enabled === true &&
+		feature.hard_limit !== undefined &&
+		feature.actual !== undefined &&
+		feature.actual >= feature.hard_limit;
+	const concurrentAgents =
+		hasAgentRuntimeLicense && feature?.enabled && !hardLimitReached
+			? "Unlimited"
+			: maxConcurrentAgents.toLocaleString("en-US");
+	const allocation =
+		feature?.limit === undefined
+			? "Unlimited"
+			: Number.isFinite(feature.limit)
+				? feature.limit.toLocaleString("en-US")
+				: "N/A";
+	const hasUsageData =
+		hasAgentRuntimeLicense !== undefined && totalRuntimeMs !== undefined;
+	const hasLoadError = error != null;
+
+	return (
+		<section
+			aria-label="Coder Agents usage"
+			className="rounded-lg border border-solid border-border px-6 py-5"
+		>
+			<div className="flex items-center justify-between gap-4">
+				<div>
+					<h2 className="m-0 text-base font-medium">Usage</h2>
+					<Link asChild showExternalIcon={false} size="lg" className="mt-1">
+						<RouterLink
+							to={
+								hasAgentRuntimeLicense === false
+									? "/deployment/premium"
+									: "/deployment/licenses"
+							}
+						>
+							{hasAgentRuntimeLicense === false
+								? "Upgrade for unlimited concurrent chats"
+								: "View license"}
+						</RouterLink>
+					</Link>
+				</div>
+			</div>
+
+			{hasLoadError && (
+				<div className="mt-5 flex flex-col gap-2">
+					<ErrorAlert error={error} />
+					<Button
+						disabled={isRetrying}
+						onClick={onRetry}
+						size="sm"
+						type="button"
+						variant="outline"
+						className="w-fit"
+					>
+						Retry
+					</Button>
+				</div>
+			)}
+			{hasLoadError && !hasUsageData ? null : isLoading ? (
+				<div className="mt-5 flex items-center gap-2 text-sm text-content-secondary">
+					<Spinner size="sm" loading label="Loading Agent Time usage" />
+					<span>Loading Agent Time usage...</span>
+				</div>
+			) : isUnavailable || !hasUsageData ? (
+				<p role="status" className="m-0 mt-5 text-sm text-content-secondary">
+					Agent Time usage is unavailable.
+				</p>
+			) : (
+				<>
+					<dl className="m-0 mt-5 grid gap-4 sm:grid-cols-2">
+						<div>
+							<dt className="text-xs font-medium text-content-secondary">
+								Agent hours used
+							</dt>
+							<dd className="m-0 mt-1 text-sm font-medium text-content-primary">
+								{hasAgentRuntimeLicense
+									? `${usedHours} / ${allocation} hours`
+									: `${usedHours} hours`}
+							</dd>
+						</div>
+						<div>
+							<dt className="flex items-center gap-1 text-xs font-medium text-content-secondary">
+								<span>Max concurrent agents</span>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											aria-label="Max concurrent agents information"
+											className="m-0 inline-flex appearance-none border-0 bg-transparent p-0 text-content-secondary"
+										>
+											<InfoIcon className="size-3" />
+										</button>
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-xs">
+										{hardLimitReached
+											? concurrentAgentsHardLimitTooltip
+											: concurrentAgentsTooltip}
+									</TooltipContent>
+								</Tooltip>
+							</dt>
+							<dd className="m-0 mt-1 text-sm font-medium text-content-primary">
+								{concurrentAgents}
+							</dd>
+						</div>
+					</dl>
+					<p className="m-0 mt-4 text-sm text-content-secondary">
+						<Link href={docs("/ai-coder/agents/licensing-usage")}>
+							View usage documentation
+						</Link>
+					</p>
+				</>
+			)}
+		</section>
+	);
+};
+
 export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 	organization,
 	organizations,
@@ -73,6 +246,14 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 	isOrganizationAccessLoading,
 	organizationSettings,
 	canEditDeploymentConfig,
+	hasAgentRuntimeLicense,
+	agentRuntimeHoursFeature,
+	agentRuntimeTotalMs,
+	isAgentRuntimeUsageLoading,
+	isAgentRuntimeUsageUnavailable,
+	agentRuntimeUsageError,
+	onRetryAgentRuntimeUsage,
+	isRetryingAgentRuntimeUsage,
 	adminOverridesData,
 	adminOverridesError,
 	onRetryAdminOverrides,
@@ -179,6 +360,16 @@ export const CoderAgentsPageView: FC<CoderAgentsPageViewProps> = ({
 							organization.
 						</p>
 					</div>
+					<CoderAgentsUsage
+						hasAgentRuntimeLicense={hasAgentRuntimeLicense}
+						feature={agentRuntimeHoursFeature}
+						totalRuntimeMs={agentRuntimeTotalMs}
+						isLoading={isAgentRuntimeUsageLoading}
+						isUnavailable={isAgentRuntimeUsageUnavailable}
+						error={agentRuntimeUsageError}
+						onRetry={onRetryAgentRuntimeUsage}
+						isRetrying={isRetryingAgentRuntimeUsage}
+					/>
 					<div className="flex flex-col gap-6 rounded-lg border border-solid border-border px-6 py-7">
 						<AdminPersonalModelOverridesSettings
 							adminSettings={adminOverridesData}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -112,6 +112,7 @@ const AgentsRouteElement = () => (
 		requestedOrganizationDenied={false}
 		isOrganizationAccessLoading={false}
 		canEditDeploymentConfig
+		hasDeploymentLicense={false}
 		hasAgentRuntimeLicense={false}
 		agentRuntimeTotalMs={0}
 		isAgentRuntimeUsageLoading={false}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -112,6 +112,12 @@ const AgentsRouteElement = () => (
 		requestedOrganizationDenied={false}
 		isOrganizationAccessLoading={false}
 		canEditDeploymentConfig
+		hasAgentRuntimeLicense={false}
+		agentRuntimeTotalMs={0}
+		isAgentRuntimeUsageLoading={false}
+		isAgentRuntimeUsageUnavailable={false}
+		onRetryAgentRuntimeUsage={fn()}
+		isRetryingAgentRuntimeUsage={false}
 		adminOverridesData={{ allow_users: false }}
 		onSaveAdminOverrides={fn()}
 		isSavingAdminOverrides={false}

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2692,6 +2692,11 @@ export const mockApiError = ({
 	},
 });
 
+export const MockCommunityAgentRuntimeHoursFeature: TypesGen.Feature = {
+	enabled: false,
+	entitlement: "not_entitled",
+};
+
 export const MockAgentRuntimeHoursFeature: TypesGen.Feature = {
 	enabled: true,
 	entitlement: "entitled",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3840,6 +3840,10 @@ export const MockTemplateVersionExternalAuthAzure: TypesGen.TemplateVersionExter
 		display_name: "Azure",
 	};
 
+export const MockDeploymentAgentTime: TypesGen.DeploymentAgentTime = {
+	total_runtime_ms: (10 * 60 + 18) * 60_000,
+};
+
 export const MockDeploymentStats: TypesGen.DeploymentStats = {
 	aggregated_from: "2023-03-06T19:08:55.211625Z",
 	collected_at: "2023-03-06T19:12:55.211625Z",

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -398,6 +398,10 @@ export const handlers = [
 		return HttpResponse.json(M.MockAppearanceConfig);
 	}),
 
+	http.get("/api/v2/deployment/agent-time", () => {
+		return HttpResponse.json(M.MockDeploymentAgentTime);
+	}),
+
 	http.get("/api/v2/deployment/stats", () => {
 		return HttpResponse.json(M.MockDeploymentStats);
 	}),


### PR DESCRIPTION
closes CODAGT-960

## Summary

<img width="985" height="441" alt="Screenshot 2026-08-28 at 2 28 25 PM" src="https://github.com/user-attachments/assets/7107f0ea-a56a-4e75-bb9c-504ba39ebb19" />

Display retained Coder Agent Time in the Coder Agents deployment settings page using the existing design from #28489.

## Problem

The previous design sourced the displayed total from entitlement usage reporting and was stacked on #28488. That value can lag retained chat data and couples the card to an unrelated API-boundary change.

## Fix

Add a deployment-admin endpoint that sums retained `chat_messages.runtime_ms` over the licensed usage period, or all retained history for Community deployments. Wire the Usage card to that endpoint while continuing to use entitlement metadata for allocation and concurrent-agent enforcement. This does not add a migration or change the existing usage-event publisher.

Refs #28489
