### PR TITLE
fix(site): focus chat after panels collapse

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -39,6 +39,7 @@ import {
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
 } from "./AgentChatPageView";
+import type { ChatMessageInputRef } from "./components/AgentChatInput";
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import { buildLongConversation } from "./components/ChatConversation/storyFixtures";
@@ -666,6 +667,43 @@ index abc1234..def5678 100644
 					.calls.length,
 			).toBeGreaterThan(callsBefore);
 		});
+	},
+};
+
+const collapsePanelsSend = fn();
+
+const CollapsingPanelsFocusStory: FC = () => {
+	const [showSidebarPanel, setShowSidebarPanel] = useState(true);
+	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
+
+	return (
+		<StoryAgentChatPageView
+			isSidebarCollapsed
+			showSidebarPanel={showSidebarPanel}
+			onSetShowSidebarPanel={setShowSidebarPanel}
+			editing={{
+				chatInputRef,
+				handleSendFromInput: collapsePanelsSend,
+			}}
+		/>
+	);
+};
+
+/** Closing the right panel while the left sidebar is collapsed returns focus to chat. */
+export const CollapsingAllSidePanelsFocusesChat: Story = {
+	render: () => <CollapsingPanelsFocusStory />,
+	beforeEach: () => {
+		collapsePanelsSend.mockClear();
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Toggle panel" }));
+
+		const composer = canvas.getByRole("textbox", { name: "Chat message" });
+		await expect(composer).toHaveFocus();
+
+		await userEvent.type(composer, "Send after collapsing{Enter}");
+		await expect(collapsePanelsSend).toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -5,6 +5,7 @@ import {
 	type ReactNode,
 	type RefObject,
 	useEffect,
+	useRef,
 	useState,
 } from "react";
 import { useQueryClient } from "react-query";
@@ -424,6 +425,21 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	};
 
 	const [isRightPanelExpanded, setIsRightPanelExpanded] = useState(false);
+	const previousPanelsRef = useRef({
+		isSidebarCollapsed,
+		showSidebarPanel,
+	});
+	useEffect(() => {
+		const previous = previousPanelsRef.current;
+		const didCollapseLeftSidebar =
+			!previous.isSidebarCollapsed && isSidebarCollapsed;
+		const didCloseRightPanel = previous.showSidebarPanel && !showSidebarPanel;
+		previousPanelsRef.current = { isSidebarCollapsed, showSidebarPanel };
+
+		if ((didCollapseLeftSidebar || didCloseRightPanel) && !showSidebarPanel) {
+			editing.chatInputRef.current?.focus();
+		}
+	}, [editing.chatInputRef, isSidebarCollapsed, showSidebarPanel]);
 	// The turn already running when the page loaded must not anchor the
 	// scroller, even if its prompt is older than the newest messages page and
 	// only renders after the user pages up. Message ids are allocated from one


### PR DESCRIPTION
When the Agents left sidebar and right panel were both closed, focus remained on the right-panel toggle. Pressing Enter then reopened the panel instead of submitting the chat message.

Move focus to the chat composer when the right panel closes, or when the left sidebar collapses while the right panel is already closed. A Storybook interaction covers the original sequence and verifies Enter submits after both panels are gone.

> Generated by Coder Agents on behalf of @tracyjohnsonux.
