### PR TITLE
fix(cli): improve confirmation prompt handling

### DIFF
--- a/cli/cliui/prompt.go
+++ b/cli/cliui/prompt.go
@@ -125,8 +125,12 @@ func Prompt(inv *serpent.Invocation, opts PromptOptions) (string, error) {
 	case err := <-errCh:
 		return "", err
 	case line := <-lineCh:
-		if opts.IsConfirm && line != "yes" && line != "y" {
-			return line, xerrors.Errorf("got %q: %w", line, ErrCanceled)
+		if opts.IsConfirm {
+			answer := strings.ToLower(strings.TrimSpace(line))
+			if answer != ConfirmYes && answer != "y" {
+				return line, xerrors.Errorf("got %q: %w", line, ErrCanceled)
+			}
+			line = ConfirmYes
 		}
 		if opts.Validate != nil {
 			err := opts.Validate(line)

--- a/cli/cliui/prompt_test.go
+++ b/cli/cliui/prompt_test.go
@@ -58,6 +58,53 @@ func TestPrompt(t *testing.T) {
 		require.Equal(t, "yes", resp)
 	})
 
+	t.Run("ConfirmNormalizesInput", func(t *testing.T) {
+		t.Parallel()
+
+		for _, input := range []string{"Yes", "YES", " yes ", "Y", " y "} {
+			input := input
+			t.Run(input, func(t *testing.T) {
+				t.Parallel()
+
+				ctx := testutil.Context(t, testutil.WaitShort)
+				ptty := ptytest.New(t)
+				doneChan := make(chan string)
+				go func() {
+					resp, err := newPrompt(ctx, ptty, cliui.PromptOptions{
+						Text:      "Example",
+						IsConfirm: true,
+					}, nil)
+					assert.NoError(t, err)
+					doneChan <- resp
+				}()
+				ptty.ExpectMatch(ctx, "Example")
+				ptty.WriteLine(input)
+				resp := testutil.TryReceive(ctx, t, doneChan)
+				require.Equal(t, "yes", resp)
+			})
+		}
+	})
+
+	t.Run("ConfirmDefaultNoReturnsCanceled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		ptty := ptytest.New(t)
+		doneChan := make(chan error)
+		go func() {
+			_, err := newPrompt(ctx, ptty, cliui.PromptOptions{
+				Text:      "Example",
+				IsConfirm: true,
+				Default:   cliui.ConfirmNo,
+			}, nil)
+			doneChan <- err
+		}()
+		ptty.ExpectMatch(ctx, "Example")
+		ptty.WriteLine("")
+		err := testutil.TryReceive(ctx, t, doneChan)
+		require.ErrorIs(t, err, cliui.ErrCanceled)
+	})
+
 	t.Run("Skip", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)

--- a/cli/root.go
+++ b/cli/root.go
@@ -233,6 +233,7 @@ func (r *RootCmd) RunWithSubcommands(subcommands []*serpent.Command) {
 			err = exitErr.err
 		}
 		if errors.Is(err, cliui.ErrCanceled) {
+			_, _ = fmt.Fprintln(os.Stderr, "Aborted.")
 			//nolint:revive,gocritic
 			os.Exit(code)
 		}


### PR DESCRIPTION
## Description

Confirmation prompts only accept lowercase `yes` or `y`, and canceled commands exit without feedback.

Normalize confirmation input and print `Aborted.` when a command exits because confirmation was declined.

## Changes

- Accept uppercase and whitespace-padded confirmation input.
- Normalize accepted confirmation responses.
- Print `Aborted.` when confirmation is declined.

> [!NOTE]
> Generated by Coder Agents on behalf of @ssncferreira.
