### PR TITLE
fix(coderd/oauth2provider): pin revoked-token refreshes and stop echoing a scope that names nothing

### DIFF
--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -138,7 +138,9 @@ func narrowAccessScope(ctx context.Context, logger slog.Logger, phase string, ap
 func scopeStringToAPIKeyScopes(scope string) (database.APIKeyScopes, error) {
 	names := strings.Fields(scope)
 	if len(names) == 0 {
-		return nil, xerrors.Errorf("'%s': %w", scope, errUnmintableScope)
+		// Fixed message rather than an echo: CHECK (scope <> '') admits a
+		// whitespace-only value, which names nothing worth reporting back.
+		return nil, xerrors.Errorf("the grant names no scope: %w", errUnmintableScope)
 	}
 
 	scopes := make(database.APIKeyScopes, 0, len(names))

--- a/coderd/oauth2provider/tokens_internal_test.go
+++ b/coderd/oauth2provider/tokens_internal_test.go
@@ -76,12 +76,19 @@ func TestScopeStringToAPIKeyScopes(t *testing.T) {
 
 	// Unreachable through the NOT NULL column, but pinned: apikey.Generate reads
 	// an empty list as unrestricted, so anything but an error widens the grant.
+	// CHECK (scope <> '') admits every value here but the first.
 	t.Run("EmptyRejected", func(t *testing.T) {
 		t.Parallel()
 
-		for _, scope := range []string{"", "   "} {
+		var first string
+		for _, scope := range []string{"", "   ", "\t", "\n", " \t\r\n "} {
 			_, err := scopeStringToAPIKeyScopes(scope)
 			require.ErrorIs(t, err, errUnmintableScope, "scope %q", scope)
+			if first == "" {
+				first = err.Error()
+			}
+			assert.Equal(t, first, err.Error(),
+				"a scope naming nothing has nothing to echo, so the message cannot vary with it")
 		}
 	})
 }

--- a/coderd/oauth2provider/tokens_test.go
+++ b/coderd/oauth2provider/tokens_test.go
@@ -355,6 +355,24 @@ func TestOAuth2TokenExchangeScope(t *testing.T) {
 			"an operator cannot act on this without knowing which stored name is the problem")
 	})
 
+	// The same stale row reached through a refresh rather than a code. A grant
+	// outlives the code that issued it, so this is the likelier way a name
+	// removed from the enum surfaces.
+	t.Run("StoredScopeOutsideEnumRejectedOnRefresh", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		app := seedAppWithSecret(t, db, sql.NullString{String: scopeInCatalog, Valid: true})
+		refreshToken := seedRefreshToken(ctx, t, db, app, owner.UserID, scopeOutOfCatalog)
+
+		status, body := postTokenRequest(ctx, t, client, refreshForm(app, refreshToken))
+
+		description := requireTokenGrantError(t, status, body)
+		require.Contains(t, description, oauth2provider.ReasonUnmintableScope)
+		require.Contains(t, description, scopeOutOfCatalog,
+			"an operator cannot act on this without knowing which stored name is the problem")
+	})
+
 	t.Run("AllowlistNarrowedAfterAuthorizationRejected", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)

--- a/coderd/oauth2provider/tokens_test.go
+++ b/coderd/oauth2provider/tokens_test.go
@@ -581,6 +581,96 @@ func TestOAuth2TokenExchangeReplay(t *testing.T) {
 	requireTokenAuthenticates(ctx, t, client, token.AccessToken)
 }
 
+// A revoked token must refresh as invalid_grant rather than as a server fault.
+// Deleting either row cascades the token row away, so the prefix lookup is
+// what refuses these. They are pinned anyway: the property a client depends on
+// is the response, not which statement notices, and the cascades that produce
+// it are schema the refresh does not control.
+func TestOAuth2RefreshRevokedToken(t *testing.T) {
+	t.Parallel()
+
+	db, pubsub := dbtestutil.NewDB(t)
+	client := coderdtest.New(t, &coderdtest.Options{
+		Database: db,
+		Pubsub:   pubsub,
+	})
+	owner := coderdtest.CreateFirstUser(t, client)
+
+	t.Run("KeyDeleted", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		app := seedAppWithSecret(t, db, sql.NullString{String: scopeInCatalog, Valid: true})
+		code, verifier := authorizeCode(ctx, t, client, app.ID.String(), "workspace:ssh")
+		token := exchangeCode(ctx, t, client, app, code, verifier)
+
+		keyID := tokenRow(ctx, t, db, token.RefreshToken).APIKeyID
+		require.NoError(t, client.DeleteAPIKey(ctx, owner.UserID.String(), keyID))
+
+		status, body := postTokenRequest(ctx, t, client, refreshForm(app, token.RefreshToken))
+		requireTokenGrantError(t, status, body)
+	})
+
+	t.Run("AppSecretDeleted", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		app := seedAppWithSecret(t, db, sql.NullString{String: scopeInCatalog, Valid: true})
+		code, verifier := authorizeCode(ctx, t, client, app.ID.String(), "workspace:ssh")
+		token := exchangeCode(ctx, t, client, app, code, verifier)
+
+		require.NoError(t, client.DeleteOAuth2ProviderAppSecret(ctx, app.ID, app.SecretID))
+
+		status, body := postTokenRequest(ctx, t, client, refreshForm(app, token.RefreshToken))
+		requireTokenGrantError(t, status, body)
+	})
+
+	// The third revocation path FR12 names. It never reaches the grant: the
+	// client_id no longer resolves, so authentication refuses first.
+	t.Run("AppDeleted", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		app := seedAppWithSecret(t, db, sql.NullString{String: scopeInCatalog, Valid: true})
+		code, verifier := authorizeCode(ctx, t, client, app.ID.String(), "workspace:ssh")
+		token := exchangeCode(ctx, t, client, app, code, verifier)
+
+		require.NoError(t, client.DeleteOAuth2ProviderApp(ctx, app.ID))
+
+		status, body := postTokenRequest(ctx, t, client, refreshForm(app, token.RefreshToken))
+		require.Equal(t, http.StatusUnauthorized, status, body)
+		require.Contains(t, body, string(codersdk.OAuth2ErrorCodeInvalidClient), body)
+	})
+}
+
+// A token row whose api_key_id names no key. The FK cascade makes that
+// unreachable through any API, so the constraints come off to seed it, and
+// this test takes a database of its own because disabling them applies to
+// every table in it. The refresh reads nothing from api_keys before the
+// returning-row delete, so the missing key surfaces there as invalid_grant;
+// a read of the key ahead of the delete answered HTTP 500 here.
+func TestOAuth2RefreshKeyMissing(t *testing.T) {
+	t.Parallel()
+
+	db, pubsub := dbtestutil.NewDB(t)
+	client := coderdtest.New(t, &coderdtest.Options{
+		Database: db,
+		Pubsub:   pubsub,
+	})
+	owner := coderdtest.CreateFirstUser(t, client)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	app := seedAppWithSecret(t, db, sql.NullString{String: scopeInCatalog, Valid: true})
+	refreshToken := seedRefreshToken(ctx, t, db, app, owner.UserID, "workspace:ssh")
+
+	dbtestutil.DisableForeignKeysAndTriggers(t, db)
+	require.NoError(t, db.DeleteAPIKeyByID(dbauthz.AsSystemRestricted(ctx),
+		tokenRow(ctx, t, db, refreshToken).APIKeyID))
+
+	status, body := postTokenRequest(ctx, t, client, refreshForm(app, refreshToken))
+	requireTokenGrantError(t, status, body)
+}
+
 // barrierStore holds each redemption at a chosen read until every redemption
 // has read, so both reach the delete with the same stale view. Starting the
 // requests together is not enough on its own: nothing stops one handler from


### PR DESCRIPTION
**TL;DR**

Last of three in [PLAT-481](https://linear.app/codercom/issue/PLAT-481), which closes PLAT-470. Refreshing a revoked token returned **HTTP 500** until #28752 stopped reading the `api_keys` row ahead of deleting it. This PR pins the response a client sees on every revocation path, and stops echoing a stored scope that names nothing.

| PR | What it does |
|---|---|
| #28751 | A refresh may name a narrower `scope`. |
| #28752 | Refresh token redemption is single-use under concurrency. |
| **this** | A revoked token's refresh is pinned as `invalid_grant`, and a stored scope that names nothing stops being echoed back. |

- Diff is against #28752, not main.
- No handler change for the error class, no new sentinel, no migration, no docs: the error class is not documented behavior.

---

**The error class** (FR12, AC13, AC14)

- **The fix lives in #28752.** Earlier revisions of this PR mapped `sql.ErrNoRows` from `GetAPIKeyByID` to `errBadToken`. Review of #28752 pointed out that the read itself was redundant, since the token row carries both the key id and the user id, and removing it collapsed the race window instead of relabeling its error. The returning-row delete is now the first statement to touch the key and already answers `invalid_grant` when it finds nothing.
- **The two revocation paths a client can reach** both cascade the `oauth2_provider_app_tokens` row away, so the prefix lookup answers `errBadToken` first. Deleting the API key and deleting the app secret are pinned here anyway: the property a client depends on is the response, not which statement notices it, and the cascades that make them pass are schema this function does not control.
- **The case that answered 500** is a token row whose `api_key_id` names no key. The FK cascade makes that unreachable through any API, so `TestOAuth2RefreshKeyMissing` disables the constraints to seed it, and takes a database of its own because disabling them applies to every table. It now reaches the delete and answers 400.
- FR12 names a third path, deleting the app. It never reaches the grant: the `client_id` no longer resolves, so `ExtractOAuth2ProviderAppWithOAuth2Errors` answers 401 `invalid_client` first. `AppDeleted` pins that, and the spec is corrected.

**The scope that names nothing**

- `CHECK (scope <> '')` admits a whitespace-only scope, and `scopeStringToAPIKeyScopes` echoed it into `error_description` as an empty pair of quotes. There is no name to report, so the rejection carries a fixed message instead.
- This PR no longer carries the `error_description` charset work the earlier revisions did. #28751 sanitizes every token-endpoint description to the RFC 6749 §5.2 set at `writeTokenError`, and #28740 landed `checkScopeStillCovered` returning its sentinel bare rather than naming the app's registered scopes, so both halves are below this PR now.
- `StoredScopeOutsideEnumRejectedOnRefresh` covers an unmintable stored scope reached through a refresh rather than through an authorization code, which is the likelier way a name dropped from the enum surfaces: a grant outlives the code that issued it.

Stack: #28237, #28740, #28744, #28751, #28752, this PR.
