### PR TITLE
fix(codersdk/toolsdk): align chat model listing org default with chat creation

### DIFF
--- a/codersdk/toolsdk/chats.go
+++ b/codersdk/toolsdk/chats.go
@@ -181,13 +181,36 @@ func defaultChatOrganization(ctx context.Context, deps Deps) (uuid.UUID, error) 
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("list chats to determine organization: %w", err)
 	}
+	if len(chats) == 0 {
+		// The chat list excludes archived chats by default. A user whose
+		// chats are all archived still has a most recently updated
+		// organization, so fall back to archived chats before erroring.
+		chats, err = expClient.ListChats(ctx, &codersdk.ListChatsOptions{
+			Query:  "archived:true",
+			Source: codersdk.ChatListSourceCreatedByMe,
+			Pagination: codersdk.Pagination{
+				Limit: 100,
+			},
+		})
+		if err != nil {
+			return uuid.Nil, xerrors.Errorf("list archived chats to determine organization: %w", err)
+		}
+	}
 	// Pinned chats sort before recently updated chats. If the user has 100
 	// pinned chats, this batch may not contain their latest chat, which is an
-	// acceptable tradeoff for keeping organization selection to one request.
+	// acceptable tradeoff for keeping organization selection to one page.
 	var latest *codersdk.Chat
+	consider := func(chat *codersdk.Chat) {
+		if latest == nil || chat.UpdatedAt.After(latest.UpdatedAt) {
+			latest = chat
+		}
+	}
 	for i := range chats {
-		if latest == nil || chats[i].UpdatedAt.After(latest.UpdatedAt) {
-			latest = &chats[i]
+		consider(&chats[i])
+		// Subagent activity bumps only the child row's UpdatedAt, so roots
+		// alone can misreport the most recently updated organization.
+		for j := range chats[i].Children {
+			consider(&chats[i].Children[j])
 		}
 	}
 	if latest != nil {

--- a/codersdk/toolsdk/chats.go
+++ b/codersdk/toolsdk/chats.go
@@ -101,7 +101,7 @@ The chat runs asynchronously. Poll coder_get_chat for status and read the transc
 				},
 				"model_config_id": map[string]any{
 					"type":        "string",
-					"description": "Optional chat model config UUID from coder_list_chat_model_configs. Defaults to the organization's default model.",
+					"description": "Optional chat model config UUID from coder_list_chat_model_configs. Must belong to the chat's organization. Defaults to the organization's default model.",
 				},
 				"labels": map[string]any{
 					"type":                 "object",
@@ -126,7 +126,7 @@ The chat runs asynchronously. Poll coder_get_chat for status and read the transc
 			}
 		} else {
 			var err error
-			orgID, err = defaultCreateChatOrganization(ctx, deps)
+			orgID, err = defaultChatOrganization(ctx, deps)
 			if err != nil {
 				return ChatToolStatus{}, err
 			}
@@ -155,7 +155,10 @@ The chat runs asynchronously. Poll coder_get_chat for status and read the transc
 	},
 }
 
-func defaultCreateChatOrganization(ctx context.Context, deps Deps) (uuid.UUID, error) {
+// defaultChatOrganization resolves the organization used by chat tools when
+// organization_id is omitted, keeping coder_create_chat and
+// coder_list_chat_model_configs consistent for multi-organization users.
+func defaultChatOrganization(ctx context.Context, deps Deps) (uuid.UUID, error) {
 	me, err := deps.coderClient.User(ctx, codersdk.Me)
 	if err != nil {
 		return uuid.Nil, err
@@ -898,7 +901,8 @@ type ListChatModelConfigsArgs struct {
 }
 
 type ListChatModelConfigsResponse struct {
-	ModelConfigs []ChatModelConfigSummary `json:"model_configs"`
+	OrganizationID string                   `json:"organization_id"`
+	ModelConfigs   []ChatModelConfigSummary `json:"model_configs"`
 }
 
 var ListChatModelConfigs = Tool[ListChatModelConfigsArgs, ListChatModelConfigsResponse]{
@@ -906,12 +910,14 @@ var ListChatModelConfigs = Tool[ListChatModelConfigsArgs, ListChatModelConfigsRe
 		Name: ToolNameListChatModelConfigs,
 		Description: `List the enabled chat models available for Coder Agents chats. Use a model config ID with coder_create_chat to pick a model.
 
+Model configs are organization-scoped. The response includes the organization_id the models belong to; pass it as coder_create_chat's organization_id together with the chosen model config ID.
+
 Per-user provider credentials are validated when creating a chat, so coder_create_chat can still reject a listed model with an explanatory error.`,
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
 				"organization_id": map[string]any{
 					"type":        "string",
-					"description": "Optional organization UUID. Defaults to the authenticated user's first organization.",
+					"description": "Optional organization UUID. Defaults to the organization of the authenticated user's most recently updated chat. If the user has never created a chat, defaults only when they belong to one organization.",
 				},
 			},
 			Required: []string{},
@@ -927,14 +933,11 @@ Per-user provider credentials are validated when creating a chat, so coder_creat
 				return ListChatModelConfigsResponse{}, xerrors.New("organization_id must be a valid UUID")
 			}
 		} else {
-			me, err := deps.coderClient.User(ctx, codersdk.Me)
+			var err error
+			organizationID, err = defaultChatOrganization(ctx, deps)
 			if err != nil {
-				return ListChatModelConfigsResponse{}, xerrors.Errorf("get authenticated user: %w", err)
+				return ListChatModelConfigsResponse{}, err
 			}
-			if len(me.OrganizationIDs) == 0 {
-				return ListChatModelConfigsResponse{}, xerrors.New("authenticated user belongs to no organization; pass organization_id explicitly")
-			}
-			organizationID = me.OrganizationIDs[0]
 		}
 
 		response, err := codersdk.NewExperimentalClient(deps.coderClient).ChatModels(ctx, organizationID)
@@ -957,6 +960,9 @@ Per-user provider credentials are validated when creating a chat, so coder_creat
 				IsDefault:   config.IsDefault,
 			})
 		}
-		return ListChatModelConfigsResponse{ModelConfigs: summaries}, nil
+		return ListChatModelConfigsResponse{
+			OrganizationID: organizationID.String(),
+			ModelConfigs:   summaries,
+		}, nil
 	},
 }

--- a/codersdk/toolsdk/chats.go
+++ b/codersdk/toolsdk/chats.go
@@ -181,21 +181,20 @@ func defaultChatOrganization(ctx context.Context, deps Deps) (uuid.UUID, error) 
 	if err != nil {
 		return uuid.Nil, xerrors.Errorf("list chats to determine organization: %w", err)
 	}
-	if len(chats) == 0 {
-		// The chat list excludes archived chats by default. A user whose
-		// chats are all archived still has a most recently updated
-		// organization, so fall back to archived chats before erroring.
-		chats, err = expClient.ListChats(ctx, &codersdk.ListChatsOptions{
-			Query:  "archived:true",
-			Source: codersdk.ChatListSourceCreatedByMe,
-			Pagination: codersdk.Pagination{
-				Limit: 100,
-			},
-		})
-		if err != nil {
-			return uuid.Nil, xerrors.Errorf("list archived chats to determine organization: %w", err)
-		}
+	// The chat list excludes archived chats by default and archiving bumps
+	// updated_at, so the most recently updated chat can be archived even
+	// when active chats exist. Fetch both states and scan the union.
+	archivedChats, err := expClient.ListChats(ctx, &codersdk.ListChatsOptions{
+		Query:  "archived:true",
+		Source: codersdk.ChatListSourceCreatedByMe,
+		Pagination: codersdk.Pagination{
+			Limit: 100,
+		},
+	})
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("list archived chats to determine organization: %w", err)
 	}
+	chats = append(chats, archivedChats...)
 	// Pinned chats sort before recently updated chats. If the user has 100
 	// pinned chats, this batch may not contain their latest chat, which is an
 	// acceptable tradeoff for keeping organization selection to one page.

--- a/codersdk/toolsdk/chats_test.go
+++ b/codersdk/toolsdk/chats_test.go
@@ -79,6 +79,7 @@ func TestChatTools(t *testing.T) {
 	t.Run("ListChatModelConfigs", func(t *testing.T) {
 		result, err := testTool(t, toolsdk.ListChatModelConfigs, tb, toolsdk.ListChatModelConfigsArgs{})
 		require.NoError(t, err)
+		require.Equal(t, firstUser.OrganizationID.String(), result.OrganizationID)
 		require.Len(t, result.ModelConfigs, 1)
 		require.Equal(t, defaultModelConfig.ID.String(), result.ModelConfigs[0].ID)
 		require.Equal(t, coderdtest.TestChatModelOpenAICompat, result.ModelConfigs[0].Model)
@@ -113,6 +114,7 @@ func TestChatTools(t *testing.T) {
 			OrganizationID: organization.ID.String(),
 		})
 		require.NoError(t, err)
+		require.Equal(t, organization.ID.String(), result.OrganizationID)
 		require.Len(t, result.ModelConfigs, 1)
 		require.Equal(t, model.ID.String(), result.ModelConfigs[0].ID)
 	})
@@ -691,7 +693,9 @@ func TestChatTools(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, provider.Enabled)
 
-		result, err := testTool(t, toolsdk.ListChatModelConfigs, tb, toolsdk.ListChatModelConfigsArgs{})
+		result, err := testTool(t, toolsdk.ListChatModelConfigs, tb, toolsdk.ListChatModelConfigsArgs{
+			OrganizationID: firstUser.OrganizationID.String(),
+		})
 		require.NoError(t, err)
 		var ids []string
 		for _, config := range result.ModelConfigs {
@@ -708,7 +712,9 @@ func TestChatTools(t *testing.T) {
 		err := client.DeleteAIProvider(ctx, deletedProviderConfig.AIProviderID.String())
 		require.NoError(t, err)
 
-		result, err := testTool(t, toolsdk.ListChatModelConfigs, tb, toolsdk.ListChatModelConfigsArgs{})
+		result, err := testTool(t, toolsdk.ListChatModelConfigs, tb, toolsdk.ListChatModelConfigsArgs{
+			OrganizationID: firstUser.OrganizationID.String(),
+		})
 		require.NoError(t, err)
 		var ids []string
 		for _, config := range result.ModelConfigs {
@@ -844,6 +850,60 @@ func TestChatTools(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = testTool(t, toolsdk.CreateChat, memberDeps, toolsdk.CreateChatArgs{Prompt: "hi"})
+		require.ErrorContains(t, err, "belongs to multiple organizations")
+		require.ErrorContains(t, err, "organization_id is required")
+	})
+
+	t.Run("ListChatModelConfigsUsesLastUpdatedOrganization", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		organization := dbgen.Organization(t, api.Database, database.Organization{})
+		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+			OrganizationID: organization.ID,
+			UserID:         member.ID,
+		})
+
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:    codersdk.AIProviderTypeOpenAICompat,
+			Name:    "recent-org-" + uuid.NewString(),
+			BaseURL: chattest.OpenAI(t),
+			Enabled: true,
+			APIKeys: []string{"test-api-key"},
+		})
+		require.NoError(t, err)
+		contextLimit := int64(4096)
+		model, err := expClient.CreateChatModel(ctx, organization.ID, codersdk.CreateChatModelRequest{
+			AIProviderID: &provider.ID,
+			Model:        "gpt-4o-recent-org",
+			ContextLimit: &contextLimit,
+		})
+		require.NoError(t, err)
+		dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    organization.ID,
+			OwnerID:           member.ID,
+			LastModelConfigID: model.ID,
+		})
+
+		memberDeps, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
+		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
+		require.NoError(t, err)
+		require.Equal(t, organization.ID.String(), result.OrganizationID)
+		require.Len(t, result.ModelConfigs, 1)
+		require.Equal(t, model.ID.String(), result.ModelConfigs[0].ID)
+	})
+
+	t.Run("ListChatModelConfigsRequiresOrganizationForNewMultiOrgUser", func(t *testing.T) {
+		organization := dbgen.Organization(t, api.Database, database.Organization{})
+		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+			OrganizationID: organization.ID,
+			UserID:         member.ID,
+		})
+		memberDeps, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
+
+		_, err = testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
 		require.ErrorContains(t, err, "belongs to multiple organizations")
 		require.ErrorContains(t, err, "organization_id is required")
 	})

--- a/codersdk/toolsdk/chats_test.go
+++ b/codersdk/toolsdk/chats_test.go
@@ -908,7 +908,7 @@ func TestChatTools(t *testing.T) {
 		require.ErrorContains(t, err, "organization_id is required")
 	})
 
-	t.Run("DefaultOrganizationFallsBackToArchivedChats", func(t *testing.T) {
+	t.Run("DefaultOrganizationAllChatsArchived", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		organization := dbgen.Organization(t, api.Database, database.Organization{})
 		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
@@ -923,6 +923,39 @@ func TestChatTools(t *testing.T) {
 		})
 		memberExpClient := codersdk.NewExperimentalClient(memberClient)
 		err := memberExpClient.UpdateChat(ctx, chat.ID, codersdk.UpdateChatRequest{
+			Archived: new(true),
+		})
+		require.NoError(t, err)
+
+		memberDeps, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
+		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
+		require.NoError(t, err)
+		require.Equal(t, organization.ID.String(), result.OrganizationID)
+	})
+
+	t.Run("DefaultOrganizationPrefersNewerArchivedChat", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		organization := dbgen.Organization(t, api.Database, database.Organization{})
+		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+			OrganizationID: organization.ID,
+			UserID:         member.ID,
+		})
+		activeChat := dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    firstUser.OrganizationID,
+			OwnerID:           member.ID,
+			LastModelConfigID: defaultModelConfig.ID,
+		})
+		archivedChat := dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    organization.ID,
+			OwnerID:           member.ID,
+			LastModelConfigID: defaultModelConfig.ID,
+		})
+		require.True(t, archivedChat.UpdatedAt.After(activeChat.UpdatedAt))
+		// Archiving bumps updated_at, so the archived chat stays newest.
+		memberExpClient := codersdk.NewExperimentalClient(memberClient)
+		err := memberExpClient.UpdateChat(ctx, archivedChat.ID, codersdk.UpdateChatRequest{
 			Archived: new(true),
 		})
 		require.NoError(t, err)

--- a/codersdk/toolsdk/chats_test.go
+++ b/codersdk/toolsdk/chats_test.go
@@ -908,6 +908,68 @@ func TestChatTools(t *testing.T) {
 		require.ErrorContains(t, err, "organization_id is required")
 	})
 
+	t.Run("DefaultOrganizationFallsBackToArchivedChats", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		organization := dbgen.Organization(t, api.Database, database.Organization{})
+		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+			OrganizationID: organization.ID,
+			UserID:         member.ID,
+		})
+		chat := dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    organization.ID,
+			OwnerID:           member.ID,
+			LastModelConfigID: defaultModelConfig.ID,
+		})
+		memberExpClient := codersdk.NewExperimentalClient(memberClient)
+		err := memberExpClient.UpdateChat(ctx, chat.ID, codersdk.UpdateChatRequest{
+			Archived: new(true),
+		})
+		require.NoError(t, err)
+
+		memberDeps, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
+		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
+		require.NoError(t, err)
+		require.Equal(t, organization.ID.String(), result.OrganizationID)
+	})
+
+	t.Run("DefaultOrganizationConsidersChildChats", func(t *testing.T) {
+		organization := dbgen.Organization(t, api.Database, database.Organization{})
+		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		dbgen.OrganizationMember(t, api.Database, database.OrganizationMember{
+			OrganizationID: organization.ID,
+			UserID:         member.ID,
+		})
+		childOrgRoot := dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    organization.ID,
+			OwnerID:           member.ID,
+			LastModelConfigID: defaultModelConfig.ID,
+		})
+		rootOrgChat := dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    firstUser.OrganizationID,
+			OwnerID:           member.ID,
+			LastModelConfigID: defaultModelConfig.ID,
+		})
+		child := dbgen.Chat(t, api.Database, database.Chat{
+			OrganizationID:    organization.ID,
+			OwnerID:           member.ID,
+			LastModelConfigID: defaultModelConfig.ID,
+			ParentChatID:      uuid.NullUUID{UUID: childOrgRoot.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: childOrgRoot.ID, Valid: true},
+		})
+		// The child must be the newest chat while its root stays older than
+		// the other organization's root, or the scenario is not exercised.
+		require.True(t, child.UpdatedAt.After(rootOrgChat.UpdatedAt))
+		require.True(t, rootOrgChat.UpdatedAt.After(childOrgRoot.UpdatedAt))
+
+		memberDeps, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
+		result, err := testTool(t, toolsdk.ListChatModelConfigs, memberDeps, toolsdk.ListChatModelConfigsArgs{})
+		require.NoError(t, err)
+		require.Equal(t, organization.ID.String(), result.OrganizationID)
+	})
+
 	t.Run("CreateChatZeroOrgUser", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 


### PR DESCRIPTION
`coder_list_chat_model_configs` defaulted to the authenticated user's first organization while `coder_create_chat` defaults to the organization of the user's most recently updated chat (#28543). For multi-organization users, the documented flow (list models, pass `model_config_id` to `coder_create_chat`) could pick a model from one organization and create the chat in another, failing with `Invalid model_config_id: model config not found or disabled`, or silently land the chat in an unintended organization.

Share the recent-usage organization default between both tools and return the resolved `organization_id` from the listing so callers can pass a consistent organization/model pair explicitly. The recency scan covers both archive states (archiving bumps `updated_at`, and the list excludes archived chats by default) and embedded child chats (subagent activity bumps only the child row's `updated_at`).

Related to https://linear.app/codercom/issue/CODAGT-970/expose-mcp-tools-for-organization-selection (broader MCP organization discovery remains open there).

> Xum (an AI agent) authored this pull request on behalf of @ibetitsmike.
