### PR TITLE
chore(site): upgrade `browserslist` minimums

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -178,9 +178,9 @@
 		"vitest": "4.1.10"
 	},
 	"browserslist": [
-		"chrome 110",
-		"firefox 111",
-		"safari 16.0"
+		"chrome 111",
+		"firefox 128",
+		"safari 16.4"
 	],
 	"resolutions": {
 		"optionator": "0.9.3",


### PR DESCRIPTION
Update `site/package.json` `browserslist` from Chrome 110 / Firefox 111 / Safari 16.0 (pinned January 2024) to...

```json
"chrome 111",
"firefox 128",
"safari 16.4"
```

This is the real floor today. Anything lower is a support claim the CSS will not honor.

| | Current `browserslist` | Tailwind 4.3 (already in the repo) | Vite 8 default |
|---|---|---|---|
| Chrome | 110 (Feb 2023) | **111** (Mar 2023) | 111 |
| Firefox | 111 (Mar 2023) | **128** (Jul 2024) | 114 |
| Safari | 16.0 (Sep 2022) | **16.4** (Mar 2023) | 16.4 |

Vite (`baseline-widely-available`) is already targeting Chrome 111 / Firefox 114 / Safari 16.4 because `vite.config.mts` does not override `build.target`. Tailwind is the stricter constraint: v4 depends on cascade layers, `@property`, and `color-mix()`, and [documents](https://tailwindcss.com/docs/compatibility) Chrome 111, Safari 16.4, and Firefox 128. Firefox 111 in `browserslist` is the mismatch that matters.

Firefox 128 is also the right enterprise pin. It still covers Firefox ESR 140 (supported until mid-October 2026). Current ESR is 153. Do not go above 128 until we are ready to drop ESR 140.

`last 2 versions` is a bad query here: Chrome ships every four weeks, so that is only about eight weeks of Chrome. `baseline newly available` is too new for locked-down customers.
