### PR TITLE
fix(site): remove member-facing Models nav item

### DIFF
--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -5,15 +5,10 @@ import {
 	reactRouterParameters,
 } from "storybook-addon-remix-react-router";
 import { buildInfoKey } from "#/api/queries/buildInfo";
-import { chatModels } from "#/api/queries/chats";
 import { deploymentStatsQueryKey } from "#/api/queries/deployment";
 import { organizationsPermissions } from "#/api/queries/organizations";
 import { updateCheckQueryKey } from "#/api/queries/updateCheck";
 import type { UpdateCheckResponse } from "#/api/typesGenerated";
-import {
-	MockChatModel,
-	MockChatModelProviderDescriptor,
-} from "#/testHelpers/chatModels";
 import {
 	MockBuildInfo,
 	MockDefaultOrganization,
@@ -52,17 +47,6 @@ const mcpServersRouter = reactRouterParameters({
 	routing: [
 		{ path: "/", useStoryElement: true },
 		{ path: "/ai/settings", element: <h1>AI settings for sharers</h1> },
-	],
-});
-
-const modelSettingsRouter = reactRouterParameters({
-	location: { path: "/" },
-	routing: [
-		{ path: "/", useStoryElement: true },
-		{
-			path: "/ai/settings/models",
-			element: <h1>Organization models</h1>,
-		},
 	],
 });
 
@@ -122,57 +106,6 @@ export const ForMember: Story = {
 			canvas.queryByRole("link", { name: "Models" }),
 		).not.toBeInTheDocument();
 	},
-};
-
-export const CustomOrganizationRoleCanOpenModels: Story = {
-	parameters: {
-		pixel: { matrix: pixelWithDesktop },
-		user: MockUserMember,
-		permissions: MockNoPermissions,
-		reactRouter: modelSettingsRouter,
-		queries: [
-			{ key: buildInfoKey, data: MockBuildInfo },
-			{ key: updateCheckQueryKey, data: MockUpdateCheck },
-			{ key: deploymentStatsQueryKey, data: MockDeploymentStats },
-			{
-				key: organizationsPermissions([MockDefaultOrganization.id]).queryKey,
-				data: {
-					[MockDefaultOrganization.id]: {
-						...MockNoOrganizationPermissions,
-						viewChatModelConfigs: true,
-					},
-				},
-			},
-		],
-	},
-	play: openModels,
-};
-
-export const ACLReadableMemberCanOpenModels: Story = {
-	parameters: {
-		pixel: { matrix: pixelWithDesktop },
-		user: MockUserMember,
-		permissions: MockNoPermissions,
-		reactRouter: modelSettingsRouter,
-		queries: [
-			{ key: buildInfoKey, data: MockBuildInfo },
-			{ key: updateCheckQueryKey, data: MockUpdateCheck },
-			{ key: deploymentStatsQueryKey, data: MockDeploymentStats },
-			{
-				key: chatModels(MockDefaultOrganization.id).queryKey,
-				data: {
-					models: [
-						{
-							...MockChatModel,
-							organization_id: MockDefaultOrganization.id,
-						},
-					],
-					providers: [MockChatModelProviderDescriptor],
-				},
-			},
-		],
-	},
-	play: openModels,
 };
 
 export const CustomOrganizationRoleCanOpenMCPServers: Story = {
@@ -243,15 +176,3 @@ export const SkipToMainContent: Story = {
 		await expect(main).toHaveFocus();
 	},
 };
-
-async function openModels({ canvasElement }: { canvasElement: HTMLElement }) {
-	const user = userEvent.setup();
-	const canvas = within(canvasElement);
-	await expect(
-		canvas.queryByRole("button", { name: "Admin settings" }),
-	).not.toBeInTheDocument();
-	await user.click(canvas.getByRole("link", { name: "Models" }));
-	await expect(
-		await canvas.findByRole("heading", { name: "Organization models" }),
-	).toBeInTheDocument();
-}

--- a/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { expect, fn, userEvent, within } from "storybook/test";
-import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { fn, userEvent, within } from "storybook/test";
 import {
 	MockPrimaryWorkspaceProxy,
 	MockProxyLatencies,
@@ -43,7 +42,6 @@ const meta: Meta<typeof MobileMenu> = {
 		supportLinks: MockSupportLinks,
 		onSignOut: fn(),
 		isDefaultOpen: true,
-		canViewModels: false,
 		adminPermissions: {
 			canViewDeployment: true,
 			canViewOrganizations: true,
@@ -95,38 +93,6 @@ export const Member: Story = {
 	args: {
 		user: MockUserMember,
 		adminPermissions: {},
-	},
-};
-
-export const MemberWithModelAccess: Story = {
-	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/" },
-			routing: [
-				{ path: "/", useStoryElement: true },
-				{
-					path: "/ai/settings/models",
-					element: <h1>Organization models</h1>,
-				},
-			],
-		}),
-	},
-	args: {
-		user: MockUserMember,
-		adminPermissions: {},
-		canViewModels: true,
-	},
-	play: async ({ canvasElement }) => {
-		const user = userEvent.setup();
-		const canvas = within(canvasElement);
-		const body = within(canvasElement.ownerDocument.body);
-		await expect(
-			body.queryByRole("menuitem", { name: /admin settings/i }),
-		).not.toBeInTheDocument();
-		await user.click(body.getByRole("menuitem", { name: "Models" }));
-		await expect(
-			await canvas.findByRole("heading", { name: "Organization models" }),
-		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -43,7 +43,6 @@ const itemStyles = {
 
 type MobileMenuProps = {
 	proxyContextValue?: ProxyContextValue;
-	canViewModels: boolean;
 	adminPermissions: AdminSettingsPermissions;
 	user?: TypesGen.User;
 	supportLinks?: readonly TypesGen.LinkConfig[];
@@ -53,7 +52,6 @@ type MobileMenuProps = {
 
 export const MobileMenu: FC<MobileMenuProps> = ({
 	adminPermissions,
-	canViewModels,
 	proxyContextValue,
 	user,
 	supportLinks,
@@ -89,11 +87,6 @@ export const MobileMenu: FC<MobileMenuProps> = ({
 				<DropdownMenuItem asChild className={itemStyles.default}>
 					<Link to="/agents">Agents</Link>
 				</DropdownMenuItem>
-				{canViewModels && (
-					<DropdownMenuItem asChild className={itemStyles.default}>
-						<Link to="/ai/settings/models">Models</Link>
-					</DropdownMenuItem>
-				)}
 				<DropdownMenuSeparator />
 				<ProxySettingsSub proxyContextValue={proxyContextValue} />
 

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -10,7 +10,6 @@ import {
 	canViewDeploymentSettings,
 } from "#/modules/permissions";
 import { useCanShareOrganizationMCPServers } from "#/pages/AISettingsPage/MCPServersPage/organizationSharing";
-import { useAccessibleModelOrganizations } from "#/pages/AISettingsPage/ModelsPage/organizationModels";
 import { useFeatureVisibility } from "../useFeatureVisibility";
 import { NavbarView } from "./NavbarView";
 
@@ -22,8 +21,6 @@ export const Navbar: React.FC = () => {
 	const { user: me, permissions, signOut } = useAuthenticated();
 	const featureVisibility = useFeatureVisibility();
 	const proxyContextValue = useProxy();
-	const accessibleModelOrgsQuery =
-		useAccessibleModelOrganizations(organizations);
 	const canAccessAnyModel = canAccessAnyChatModelConfig(permissions);
 
 	const canViewDeployment = canViewDeploymentSettings(permissions);
@@ -51,8 +48,6 @@ export const Navbar: React.FC = () => {
 	);
 	const canViewAISettings =
 		canViewSiteWideAISettings || organizationMCPSharing.canShare;
-	const canViewModels =
-		!canViewAISettings && accessibleModelOrgsQuery.organizations.length > 0;
 	const canCreateChat = permissions.createChat;
 
 	const uniqueLinks = new Map<string, LinkConfig>();
@@ -76,7 +71,6 @@ export const Navbar: React.FC = () => {
 				canViewAIBridge,
 				canViewHealth,
 			}}
-			canViewModels={canViewModels}
 			canCreateChat={canCreateChat}
 			canViewLicenses={permissions.viewAllLicenses}
 			proxyContextValue={proxyContextValue}

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -72,7 +72,6 @@ const meta: Meta<typeof NavbarView> = {
 			canViewAIBridge: true,
 			canViewHealth: true,
 		},
-		canViewModels: false,
 		canCreateChat: true,
 		canViewLicenses: false,
 		supportLinks: [],
@@ -326,39 +325,6 @@ export const ForUserWithoutOrganization: Story = {
 		user: MockUserMember,
 		adminPermissions: {},
 		canCreateChat: false,
-	},
-};
-
-export const ForMemberWithModelAccess: Story = {
-	parameters: {
-		pixel: { matrix: pixelWithDesktop },
-		reactRouter: reactRouterParameters({
-			location: { path: "/" },
-			routing: [
-				{ path: "/", useStoryElement: true },
-				{
-					path: "/ai/settings/models",
-					element: <h1>Organization models</h1>,
-				},
-			],
-		}),
-	},
-	args: {
-		user: MockUserMember,
-		adminPermissions: {},
-		canViewModels: true,
-		canCreateChat: false,
-	},
-	play: async ({ canvasElement }) => {
-		const user = userEvent.setup();
-		const canvas = within(canvasElement);
-		await expect(
-			canvas.queryByRole("button", { name: "Admin settings" }),
-		).not.toBeInTheDocument();
-		await user.click(canvas.getByRole("link", { name: "Models" }));
-		await expect(
-			await canvas.findByRole("heading", { name: "Organization models" }),
-		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -33,7 +33,6 @@ interface NavbarViewProps {
 	onSignOut: () => void;
 	adminPermissions: AdminSettingsPermissions;
 	canCreateChat: boolean;
-	canViewModels: boolean;
 	canViewLicenses: boolean;
 	proxyContextValue?: ProxyContextValue;
 }
@@ -51,7 +50,6 @@ export const NavbarView: FC<NavbarViewProps> = ({
 	onSignOut,
 	adminPermissions,
 	canCreateChat,
-	canViewModels,
 	canViewLicenses,
 	proxyContextValue,
 }) => {
@@ -84,7 +82,6 @@ export const NavbarView: FC<NavbarViewProps> = ({
 			<NavItems
 				className="ml-4 hidden md:flex"
 				user={user}
-				canViewModels={canViewModels}
 				canCreateChat={canCreateChat}
 			/>
 
@@ -151,7 +148,6 @@ export const NavbarView: FC<NavbarViewProps> = ({
 				<div className="md:hidden">
 					<MobileMenu
 						proxyContextValue={proxyContextValue}
-						canViewModels={canViewModels}
 						adminPermissions={adminPermissions}
 						user={user}
 						supportLinks={supportLinks}
@@ -166,16 +162,10 @@ export const NavbarView: FC<NavbarViewProps> = ({
 interface NavItemsProps {
 	className?: string;
 	user: TypesGen.User;
-	canViewModels: boolean;
 	canCreateChat: boolean;
 }
 
-const NavItems: FC<NavItemsProps> = ({
-	className,
-	user,
-	canCreateChat,
-	canViewModels,
-}) => {
+const NavItems: FC<NavItemsProps> = ({ className, user, canCreateChat }) => {
 	const location = useLocation();
 
 	return (
@@ -200,16 +190,6 @@ const NavItems: FC<NavItemsProps> = ({
 				Templates
 			</NavLink>
 			<TasksNavItem user={user} />
-			{canViewModels && (
-				<NavLink
-					className={({ isActive }) =>
-						cn(linkStyles.default, { [linkStyles.active]: isActive })
-					}
-					to="/ai/settings/models"
-				>
-					Models
-				</NavLink>
-			)}
 			{canCreateChat && (
 				<NavLink
 					className={({ isActive }) => {


### PR DESCRIPTION
Members with model access but no AI settings permissions got a dedicated top-level **Models** item in the navbar. The chat model selector already shows which models are available, so this removes the dashboard entry point entirely.

Also drops the per-organization chat models fan-out the navbar performed on every dashboard load just to decide whether to render the link. Admins still reach the models page via **Admin settings → AI**.
