### PR TITLE
chore(site): enable oxlint no-use-before-define rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -157,6 +157,10 @@
 		"no-export": "error",
 		"new-for-builtins": "error",
 		"no-explicit-any": "error",
+		"no-use-before-define": [
+			"error",
+			{ "functions": false, "classes": false, "variables": false }
+		],
 
 		// ==========================================================
 		// Migration backlog (temporary; shrinks as we go).
@@ -171,7 +175,6 @@
 		// Effort = approximate work before enabling:
 		// small < medium < large < xl.
 		// ==========================================================
-		"no-use-before-define": "off", // correctness/noInvalidUseBeforeDeclaration (xl: oxlint is lexical, Biome is control-flow-aware)
 		"no-autofocus": "off", // a11y/noAutofocus (large)
 		"jsx-no-useless-fragment": "off", // complexity/noUselessFragments (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)

--- a/site/src/components/MultiUserSelect/MultiUserSelect.tsx
+++ b/site/src/components/MultiUserSelect/MultiUserSelect.tsx
@@ -83,69 +83,6 @@ export const MultiMemberSelect: FC<MemberAutocompleteProps> = ({
 	);
 };
 
-type InnerAutocompleteProps<T extends SelectedUser> =
-	CommonMultiSelectProps<T> & {
-		/** The error is null if not loaded or no error. */
-		error: unknown;
-		setFilter: (filter: string) => void;
-		/** Users are undefined if not loaded or errored. */
-		users: readonly T[] | undefined;
-	};
-
-const InnerMultiSelect = <T extends SelectedUser>({
-	className,
-	error,
-	onChange,
-	selected,
-	setFilter,
-	users,
-}: InnerAutocompleteProps<T>) => {
-	const [inputValue, setInputValue] = useState("");
-	const { debounced, cancelDebounce } = useDebouncedFunction(
-		(nextFilter: string) => {
-			setFilter(nextFilter);
-		},
-		DEBOUNCE_MS,
-	);
-
-	return (
-		<div className={cn("flex flex-col gap-4", className)}>
-			<SearchField
-				className="h-12 w-full rounded-lg"
-				value={inputValue}
-				aria-label="Search users"
-				onChange={(query) => {
-					setInputValue(query);
-					debounced(query);
-				}}
-				onClear={() => {
-					cancelDebounce();
-					setInputValue("");
-					setFilter("");
-				}}
-				placeholder="Search users..."
-			/>
-			<div className="h-96 w-full rounded-lg border border-border border-solid">
-				<div className="h-full overflow-hidden p-px">
-					<div
-						className="h-full overflow-y-auto overflow-x-hidden overscroll-contain"
-						onWheel={(event) => {
-							event.stopPropagation();
-						}}
-					>
-						<UsersTable
-							error={error}
-							onChange={onChange}
-							selected={selected}
-							users={users}
-						/>
-					</div>
-				</div>
-			</div>
-		</div>
-	);
-};
-
 type UsersTable<T extends SelectedUser> = {
 	error: unknown;
 	onChange: (user: T, checked: boolean) => void;
@@ -213,6 +150,69 @@ const UsersTable = <T extends SelectedUser>({
 					</UserRow>
 				);
 			})}
+		</div>
+	);
+};
+
+type InnerAutocompleteProps<T extends SelectedUser> =
+	CommonMultiSelectProps<T> & {
+		/** The error is null if not loaded or no error. */
+		error: unknown;
+		setFilter: (filter: string) => void;
+		/** Users are undefined if not loaded or errored. */
+		users: readonly T[] | undefined;
+	};
+
+const InnerMultiSelect = <T extends SelectedUser>({
+	className,
+	error,
+	onChange,
+	selected,
+	setFilter,
+	users,
+}: InnerAutocompleteProps<T>) => {
+	const [inputValue, setInputValue] = useState("");
+	const { debounced, cancelDebounce } = useDebouncedFunction(
+		(nextFilter: string) => {
+			setFilter(nextFilter);
+		},
+		DEBOUNCE_MS,
+	);
+
+	return (
+		<div className={cn("flex flex-col gap-4", className)}>
+			<SearchField
+				className="h-12 w-full rounded-lg"
+				value={inputValue}
+				aria-label="Search users"
+				onChange={(query) => {
+					setInputValue(query);
+					debounced(query);
+				}}
+				onClear={() => {
+					cancelDebounce();
+					setInputValue("");
+					setFilter("");
+				}}
+				placeholder="Search users..."
+			/>
+			<div className="h-96 w-full rounded-lg border border-border border-solid">
+				<div className="h-full overflow-hidden p-px">
+					<div
+						className="h-full overflow-y-auto overflow-x-hidden overscroll-contain"
+						onWheel={(event) => {
+							event.stopPropagation();
+						}}
+					>
+						<UsersTable
+							error={error}
+							onChange={onChange}
+							selected={selected}
+							users={users}
+						/>
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
## What

Enables the oxlint `no-use-before-define` rule, moving it out of the migration backlog in `site/.oxlintrc.jsonc`.

## Why / approach

At its default settings the rule reports **1019 violations across 254 files** (the "xl" rating in the backlog comment), because oxlint's check is lexical while Biome's `correctness/noInvalidUseBeforeDeclaration` is control-flow-aware. Almost all of those are runtime-safe patterns Biome deliberately ignores (hoisted function declarations and components/consts referenced before their later definition).

Scoping the rule with `{ "functions": false, "classes": false, "variables": false }` makes oxlint ignore references whose declaration is in an upper scope, which approximates Biome's behavior. This collapses the count to a single divergence.

Verified equivalence with a probe: the tuned rule still catches a genuine same-scope temporal-dead-zone reference (matching Biome) while ignoring the hoisting/closure-safe upper-scope pattern (also matching Biome).

The one remaining case, `UsersTable` referenced before its definition in `MultiUserSelect.tsx`, is reordered so the definition precedes its only caller. Biome did not flag this case.

## Verification

- `pnpm run lint:oxlint` → 0 errors
- Biome clean on the changed file
- `tsc -p .` clean

<details>
<summary>Exploration notes: option tuning results</summary>

| Options | Errors |
|---|---|
| `"error"` (defaults) | 1019 |
| `{ functions: false, classes: false }` | 727 |
| `{ functions: false, classes: false, variables: false }` | 1 |

The remaining 1 was resolved by reordering `MultiUserSelect.tsx`.
</details>

Generated by Coder Agents.
