### PR TITLE
chore(site): enable no-empty-object-type oxlint rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -38,6 +38,7 @@
 		"no-sequences": "error",
 		"no-unsafe-function-type": "error",
 		"no-wrapper-object-types": "error",
+		"no-empty-object-type": "error",
 		"no-extra-boolean-cast": "error",
 		"no-useless-catch": "error",
 		"no-useless-constructor": "error",
@@ -179,7 +180,6 @@
 		"jsx-no-useless-fragment": "off", // complexity/noUselessFragments (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
-		"no-empty-object-type": "off", // complexity/noBannedTypes (medium)
 		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
 		"no-unused-vars": "off", // correctness/noUnusedVariables + noUnusedImports (small: dead-store "used" semantics differ)

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -661,7 +661,7 @@ const ParameterUsageLabel: FC<ParameterUsageLabelProps> = ({
 	return <TextValue>{usage.value}</TextValue>;
 };
 
-interface PanelProps extends HTMLAttributes<HTMLDivElement> {}
+type PanelProps = HTMLAttributes<HTMLDivElement>;
 
 const Panel: FC<PanelProps> = ({ children, className, ...attrs }) => {
 	return (


### PR DESCRIPTION
Enables the `no-empty-object-type` oxlint rule in `site/.oxlintrc.jsonc`, moving it out of the migration backlog.

## Changes

- Promote `no-empty-object-type` from `"off"` (backlog) to `"error"`, grouped with the related `no-unsafe-function-type` and `no-wrapper-object-types` rules that also map to Biome's `noBannedTypes`.
- Fix the single violation in `TemplateInsightsPage.tsx`: convert the empty `interface PanelProps extends HTMLAttributes<HTMLDivElement> {}` to a type alias `type PanelProps = HTMLAttributes<HTMLDivElement>`. It is still extended by other interfaces and used as `FC<PanelProps>`.

Biome's `noBannedTypes` is left untouched, consistent with the two sibling rules that already map to it.

## Verification

- `pnpm run lint:oxlint` reports 0 warnings and 0 errors.
- `biome check` passes on the edited file.
- `tsc --noEmit` reports no errors for the edited file.

---

_This PR was generated by Coder Agents on behalf of @jeremyruppel._
