### PR TITLE
refactor(coderd/templatebuilder): parse rendered HCL with hclparse and support multiple agents

### DIFF
--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -81,10 +81,16 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		}, nil
 	}
 
-	agentName, err := ExtractAgentResourceName(mainTF)
+	agents, err := ExtractAgentResourceNames(mainTF)
 	if err != nil {
-		return nil, xerrors.Errorf("extract agent name: %w", err)
+		return nil, xerrors.Errorf("extract agents: %w", err)
 	}
+	if len(agents) == 0 {
+		return nil, xerrors.New("no coder_agent resource found in rendered template")
+	}
+	// Wire modules to the base's first agent. Multiple agents are supported
+	// here without erroring; per-module agent selection is a follow-up.
+	agentName := agents[0].Reference
 
 	catalog, err := loadCatalogMap()
 	if err != nil {

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -194,7 +194,7 @@ func ExtractAgentResourceName(rendered []byte) (string, error) {
 // rendered HCL, in declaration order. Because it walks parsed blocks,
 // commented-out references and module strings inside heredocs are naturally
 // ignored. The input is expected to be rendered output from our own curated
-// base templates, not arbitrary user HCL; unparseable input yields no names.
+// base templates, not arbitrary user HCL; unparsable input yields no names.
 func ExtractModuleNames(rendered []byte) []string {
 	body, err := parseRenderedHCL(rendered)
 	if err != nil {

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -3,9 +3,10 @@ package templatebuilder
 import (
 	"bytes"
 	"io/fs"
-	"regexp"
 	"text/template"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"golang.org/x/xerrors"
 )
 
@@ -109,58 +110,101 @@ func renderTemplate(fsys fs.FS, templatePath string, data any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// agentResourcePattern matches `resource "coder_agent" "<name>"` in HCL.
-var agentResourcePattern = regexp.MustCompile(`resource\s+"coder_agent"\s+"(\w+)"`)
+// parseRenderedHCL parses rendered Terraform into an hclsyntax body. The input
+// is expected to be rendered output from our own curated base templates, so a
+// parse error indicates a bug in a template rather than untrusted user input.
+func parseRenderedHCL(rendered []byte) (*hclsyntax.Body, error) {
+	file, diags := hclsyntax.ParseConfig(rendered, "rendered.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, xerrors.Errorf("parse rendered template HCL: %s", diags.Error())
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, xerrors.New("unexpected HCL body type")
+	}
+	return body, nil
+}
 
-// agentCountPattern detects whether a coder_agent block uses count or
-// for_each, which means references to it require an index (e.g. [0]).
-var agentCountPattern = regexp.MustCompile(
-	`resource\s+"coder_agent"\s+"\w+"\s*\{[^}]*\b(?:count|for_each)\s*=`,
-)
+// ExtractedAgent describes a coder_agent resource found in rendered HCL.
+type ExtractedAgent struct {
+	// Name is the Terraform resource name (the second block label).
+	Name string
+	// Reference is the form to use in module templates: Name, suffixed with
+	// [0] when the agent uses count or for_each and therefore requires an
+	// index (e.g. coder_agent.dev[0].id).
+	Reference string
+}
+
+// ExtractAgentResourceNames returns every coder_agent resource declared in
+// rendered HCL, in declaration order. Unlike the singular helper it does not
+// error on multiple agents: enumerating them all lets a base declare more than
+// one agent. Reading count/for_each from each block body is robust to nested
+// blocks (env {}, metadata {}). The input is expected to be rendered output
+// from our own curated base templates, not arbitrary user HCL.
+func ExtractAgentResourceNames(rendered []byte) ([]ExtractedAgent, error) {
+	body, err := parseRenderedHCL(rendered)
+	if err != nil {
+		return nil, err
+	}
+	var agents []ExtractedAgent
+	for _, block := range body.Blocks {
+		if block.Type != "resource" || len(block.Labels) < 2 || block.Labels[0] != "coder_agent" {
+			continue
+		}
+		ref := block.Labels[1]
+		if _, ok := block.Body.Attributes["count"]; ok {
+			ref += "[0]"
+		} else if _, ok := block.Body.Attributes["for_each"]; ok {
+			ref += "[0]"
+		}
+		agents = append(agents, ExtractedAgent{Name: block.Labels[1], Reference: ref})
+	}
+	return agents, nil
+}
 
 // ExtractAgentResourceName finds the coder_agent resource declaration in
 // rendered HCL and returns the reference form to use in module templates.
 // When the agent uses count or for_each, the returned name includes an
 // index suffix (e.g. "dev[0]") so that module templates can reference it
 // as coder_agent.<name>.id. Returns an error unless exactly one
-// coder_agent resource is found; the builder only supports single-agent
-// templates. The input is expected to be rendered output from our own
-// curated base templates, not arbitrary user HCL.
-func ExtractAgentResourceName(hcl []byte) (string, error) {
-	matches := agentResourcePattern.FindAllSubmatch(hcl, -1)
-	switch len(matches) {
+// coder_agent resource is found; callers that support multiple agents
+// should use ExtractAgentResourceNames instead. The input is expected to be
+// rendered output from our own curated base templates, not arbitrary user HCL.
+func ExtractAgentResourceName(rendered []byte) (string, error) {
+	agents, err := ExtractAgentResourceNames(rendered)
+	if err != nil {
+		return "", err
+	}
+	switch len(agents) {
 	case 0:
 		return "", xerrors.New("no coder_agent resource found in rendered template")
 	case 1:
-		name := string(matches[0][1])
-		if agentCountPattern.Match(hcl) {
-			name += "[0]"
-		}
-		return name, nil
+		return agents[0].Reference, nil
 	default:
-		names := make([]string, 0, len(matches))
-		for _, m := range matches {
-			names = append(names, string(m[1]))
+		names := make([]string, 0, len(agents))
+		for _, a := range agents {
+			names = append(names, a.Name)
 		}
 		return "", xerrors.Errorf("expected exactly one coder_agent resource, found %d: %v",
-			len(matches), names)
+			len(agents), names)
 	}
 }
 
-// moduleBlockPattern matches a `module "<name>"` block declaration anchored to
-// the start of a line in HCL.
-var moduleBlockPattern = regexp.MustCompile(`(?m)^[ \t]*module[ \t]+"([^"]+)"`)
-
 // ExtractModuleNames returns the labels of every module block declared in
-// rendered HCL, in declaration order. Matching is anchored to the start of a
-// line so commented-out references or string literals are ignored. The input
-// is expected to be rendered output from our own curated base templates, not
-// arbitrary user HCL.
-func ExtractModuleNames(hcl []byte) []string {
-	matches := moduleBlockPattern.FindAllSubmatch(hcl, -1)
-	names := make([]string, 0, len(matches))
-	for _, m := range matches {
-		names = append(names, string(m[1]))
+// rendered HCL, in declaration order. Because it walks parsed blocks,
+// commented-out references and module strings inside heredocs are naturally
+// ignored. The input is expected to be rendered output from our own curated
+// base templates, not arbitrary user HCL; unparseable input yields no names.
+func ExtractModuleNames(rendered []byte) []string {
+	body, err := parseRenderedHCL(rendered)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, block := range body.Blocks {
+		if block.Type == "module" && len(block.Labels) >= 1 {
+			names = append(names, block.Labels[0])
+		}
 	}
 	return names
 }

--- a/coderd/templatebuilder/render_test.go
+++ b/coderd/templatebuilder/render_test.go
@@ -294,10 +294,61 @@ resource "coder_agent" "second" {}
 	})
 }
 
-// TestExtractModuleNames covers the regex-based module block extractor on the
+func TestExtractAgentResourceNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MultipleInOrder", func(t *testing.T) {
+		t.Parallel()
+		hcl := []byte(`
+resource "coder_agent" "main" {
+  os = "linux"
+}
+resource "coder_agent" "gpu" {
+  os = "linux"
+  metadata {
+    key = "gpu"
+  }
+}
+`)
+		agents, err := templatebuilder.ExtractAgentResourceNames(hcl)
+		require.NoError(t, err)
+		require.Equal(t, []templatebuilder.ExtractedAgent{
+			{Name: "main", Reference: "main"},
+			{Name: "gpu", Reference: "gpu"},
+		}, agents)
+	})
+
+	t.Run("CountAfterNestedBlock", func(t *testing.T) {
+		t.Parallel()
+		// count declared after a nested block: the reference must still be
+		// indexed, which the previous regex missed.
+		hcl := []byte(`resource "coder_agent" "dev" {
+  os = "linux"
+  metadata {
+    key = "cpu"
+  }
+  count = data.coder_workspace.me.start_count
+}`)
+		agents, err := templatebuilder.ExtractAgentResourceNames(hcl)
+		require.NoError(t, err)
+		require.Equal(t, []templatebuilder.ExtractedAgent{
+			{Name: "dev", Reference: "dev[0]"},
+		}, agents)
+	})
+
+	t.Run("NoAgents", func(t *testing.T) {
+		t.Parallel()
+		agents, err := templatebuilder.ExtractAgentResourceNames(
+			[]byte(`resource "docker_container" "workspace" {}`))
+		require.NoError(t, err)
+		require.Empty(t, agents)
+	})
+}
+
+// TestExtractModuleNames covers the module block extractor on the
 // shapes it must handle for our curated templates: real blocks in declaration
-// order, and commented-out blocks (whose line starts with `#`) ignored because
-// matching is anchored to the start of a line.
+// order, and commented-out blocks ignored because the HCL parser does not
+// treat comments as blocks.
 func TestExtractModuleNames(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556).

## Summary

Replaces the Template Builder's regex-based extraction of information from base-template Terraform with an `hclsyntax` parse of the rendered output, and removes the single-`coder_agent` assumption from the compose core.

## What changed

- `render.go`: parse rendered Terraform via `hclsyntax.ParseConfig` instead of regex.
  - Added `ExtractedAgent{Name, Reference}` and `ExtractAgentResourceNames`, which enumerates every `coder_agent` in declaration order and reads `count`/`for_each` from each block body. This is robust to nested blocks (`env {}`, `metadata {}`), fixing a case the old `[^}]*` regex missed.
  - Kept singular `ExtractAgentResourceName` as a compatibility wrapper that still errors unless exactly one agent exists.
  - `ExtractModuleNames` now walks parsed `module` blocks rather than line-anchored regex.
- `compose.go`: `Compose` wires modules to the base's first/default agent instead of erroring when a base declares multiple agents. Single-agent output is byte-identical.
- `render_test.go`: added `TestExtractAgentResourceNames` (multiple-in-order, `count` after a nested block, no agents).

## Scope

Parsing/compose layer only. Per-module agent **selection** (SDK/UI) is intentionally out of scope and left as follow-up.

## Testing

- `go test ./coderd/templatebuilder/` passes (golden snapshots unchanged).
- `golangci-lint run ./coderd/templatebuilder/` reports 0 issues.
- `go build ./coderd/...` succeeds. No new dependencies (`hashicorp/hcl/v2` already vendored).

<details>
<summary>Design context</summary>

- The `.tf.tmpl` files are Go templates and only become valid HCL after rendering, so parsing happens on rendered output (which the extractors already operated on).
- `base.json` stays authoritative; no manifest fields are inferred or removed here. A survey found `os` is mostly inferable from `coder_agent.os` (except `scratch`, which uses a dynamic `data.coder_provisioner.me.os`), and that `variables` cannot be safely inferred because base variables are Go-template inputs, not Terraform `variable` blocks. These were left out to keep the change minimal.
- Multiple agents are supported by wiring modules to the first agent in document order; single-agent bases are unaffected because first == only.

</details>

---
🤖 Generated with Coder Agents on behalf of @jeremyruppel.
