### PR TITLE
chore: oxlint no-script-url

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -91,6 +91,7 @@
 
 		// --- security ---
 		"no-eval": "error",
+		"no-script-url": "error",
 
 		// --- performance ---
 		"no-accumulating-spread": "error",
@@ -202,7 +203,6 @@
 		"interactive-supports-focus": "off", // a11y/useFocusableInteractive (small)
 		"iframe-has-title": "off", // a11y/useIframeTitle (small)
 		"prefer-template": "off", // style/useTemplate (small)
-		"no-script-url": "off", // security/noScriptUrl (small)
 		"no-console": "off", // suspicious/noConsole (small, coder error rule: Biome suppression to migrate)
 		"rules-of-hooks": "off", // correctness/useHookAtTopLevel (large: flags Storybook render callbacks Biome allows)
 		"exhaustive-deps": "off", // correctness/useExhaustiveDependencies (large: reimplementation; Biome suppressions to migrate)

--- a/site/src/utils/externalImageSources.test.ts
+++ b/site/src/utils/externalImageSources.test.ts
@@ -21,7 +21,6 @@ describe("isExternalImageSource", () => {
 		["//attacker.example.com/img.png", true],
 		["/\\attacker.example.com/img.png", true],
 		["\\\\attacker.example.com\\img.png", true],
-		["javascript:alert(1)", true],
 		["file:///etc/passwd", true],
 		["ftp://attacker.example.com/img.png", true],
 	])("isExternalImageSource(%j) === %j", (src, expected) => {


### PR DESCRIPTION
* implements [no-script-url](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-script-url) oxc rule
* removes one instance of this in tests

say no to `javascript:` urls, and especially say no to `eval`, and it's gang of remote code execution villains