### PR TITLE
feat(coderd/templatebuilder): add base agent metadata and per-module agent targeting

### DIFF
--- a/coderd/templatebuilder/bases.go
+++ b/coderd/templatebuilder/bases.go
@@ -44,6 +44,16 @@ type BaseManifest struct {
 	OS             string             `json:"os"`
 	DefaultContext BaseDefaultContext `json:"default_context"`
 	Variables      []ModuleVariable   `json:"variables"`
+	Agents         []BaseAgent        `json:"agents,omitempty"`
+}
+
+// BaseAgent is a coder_agent declared in base.json. Name must match the
+// resource label in the base's main.tf.tmpl.
+type BaseAgent struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	// Default is the agent modules attach to when they do not name one.
+	Default bool `json:"default,omitempty"`
 }
 
 // BaseDefaultContext holds default render values stored in base.json.
@@ -161,8 +171,35 @@ func parseManifest(parent fs.FS, dirName string) (BaseManifest, error) {
 	if _, ok := validBaseOS[manifest.OS]; !ok && manifest.OS != "" {
 		return BaseManifest{}, xerrors.Errorf("base %q has unknown os %q", manifest.ID, manifest.OS)
 	}
+	if err := validateBaseAgents(manifest); err != nil {
+		return BaseManifest{}, err
+	}
 
 	return manifest, nil
+}
+
+// validateBaseAgents requires a multi-agent base to mark exactly one default,
+// so module wiring never depends on base.json array order.
+func validateBaseAgents(manifest BaseManifest) error {
+	seen := make(map[string]bool, len(manifest.Agents))
+	defaults := 0
+	for i, a := range manifest.Agents {
+		if a.Name == "" {
+			return xerrors.Errorf("base %q agent %d has empty name", manifest.ID, i)
+		}
+		if seen[a.Name] {
+			return xerrors.Errorf("base %q has duplicate agent name %q", manifest.ID, a.Name)
+		}
+		seen[a.Name] = true
+		if a.Default {
+			defaults++
+		}
+	}
+	if len(manifest.Agents) > 1 && defaults != 1 {
+		return xerrors.Errorf("base %q declares %d agents but marks %d as default; exactly one required",
+			manifest.ID, len(manifest.Agents), defaults)
+	}
+	return nil
 }
 
 // parseTemplatesFromFS walks the filesystem and pre-parses all .tf.tmpl files
@@ -259,6 +296,33 @@ func BaseVariables(exampleID string) []ModuleVariable {
 		return nil
 	}
 	return bases[exampleID].Manifest.Variables
+}
+
+// BaseAgents returns the agents declared in a base's manifest, or nil.
+func BaseAgents(exampleID string) []BaseAgent {
+	bases, err := loadBases()
+	if err != nil || bases[exampleID] == nil {
+		return nil
+	}
+	return bases[exampleID].Manifest.Agents
+}
+
+// BaseDefaultAgentName returns the default agent's name: the one marked
+// default, else the first declared. Empty if the base declares none.
+func BaseDefaultAgentName(exampleID string) string {
+	return defaultAgentName(BaseAgents(exampleID))
+}
+
+func defaultAgentName(agents []BaseAgent) string {
+	for _, a := range agents {
+		if a.Default {
+			return a.Name
+		}
+	}
+	if len(agents) > 0 {
+		return agents[0].Name
+	}
+	return ""
 }
 
 // baseIncludedModules derives, for each base, the catalog module IDs the base

--- a/coderd/templatebuilder/bases/aws-linux/base.json
+++ b/coderd/templatebuilder/bases/aws-linux/base.json
@@ -2,5 +2,11 @@
 	"id": "aws-linux",
 	"display_name": "AWS EC2 (Linux)",
 	"os": "linux",
-	"default_context": {}
+	"default_context": {},
+	"agents": [
+		{
+			"name": "dev",
+			"default": true
+		}
+	]
 }

--- a/coderd/templatebuilder/bases/aws-windows/base.json
+++ b/coderd/templatebuilder/bases/aws-windows/base.json
@@ -2,5 +2,11 @@
 	"id": "aws-windows",
 	"display_name": "AWS EC2 (Windows)",
 	"os": "windows",
-	"default_context": {}
+	"default_context": {},
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
+	]
 }

--- a/coderd/templatebuilder/bases/azure-linux/base.json
+++ b/coderd/templatebuilder/bases/azure-linux/base.json
@@ -2,5 +2,11 @@
 	"id": "azure-linux",
 	"display_name": "Azure VM (Linux)",
 	"os": "linux",
-	"default_context": {}
+	"default_context": {},
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
+	]
 }

--- a/coderd/templatebuilder/bases/digitalocean-linux/base.json
+++ b/coderd/templatebuilder/bases/digitalocean-linux/base.json
@@ -21,5 +21,11 @@
 			"sensitive": false,
 			"computed": false
 		}
+	],
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
 	]
 }

--- a/coderd/templatebuilder/bases/docker/base.json
+++ b/coderd/templatebuilder/bases/docker/base.json
@@ -15,5 +15,11 @@
 			"sensitive": false,
 			"computed": false
 		}
+	],
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
 	]
 }

--- a/coderd/templatebuilder/bases/gcp-linux/base.json
+++ b/coderd/templatebuilder/bases/gcp-linux/base.json
@@ -12,5 +12,11 @@
 			"sensitive": false,
 			"computed": false
 		}
+	],
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
 	]
 }

--- a/coderd/templatebuilder/bases/gcp-windows/base.json
+++ b/coderd/templatebuilder/bases/gcp-windows/base.json
@@ -12,5 +12,11 @@
 			"sensitive": false,
 			"computed": false
 		}
+	],
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
 	]
 }

--- a/coderd/templatebuilder/bases/kubernetes/base.json
+++ b/coderd/templatebuilder/bases/kubernetes/base.json
@@ -32,5 +32,11 @@
 			"sensitive": false,
 			"computed": false
 		}
+	],
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
 	]
 }

--- a/coderd/templatebuilder/bases/quickstart/base.json
+++ b/coderd/templatebuilder/bases/quickstart/base.json
@@ -2,5 +2,11 @@
 	"id": "quickstart",
 	"display_name": "Coder Quickstart",
 	"os": "linux",
-	"default_context": {}
+	"default_context": {},
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
+	]
 }

--- a/coderd/templatebuilder/bases/scratch/base.json
+++ b/coderd/templatebuilder/bases/scratch/base.json
@@ -2,5 +2,11 @@
 	"id": "scratch",
 	"display_name": "Scratch",
 	"os": "linux",
-	"default_context": {}
+	"default_context": {},
+	"agents": [
+		{
+			"name": "main",
+			"default": true
+		}
+	]
 }

--- a/coderd/templatebuilder/bases_internal_test.go
+++ b/coderd/templatebuilder/bases_internal_test.go
@@ -271,4 +271,88 @@ func TestParseBasesFromFS(t *testing.T) {
 		require.Equal(t, "windows", bases["winbox"].Manifest.OS)
 		require.Equal(t, BaseOSWindows, validBaseOS[bases["winbox"].Manifest.OS])
 	})
+
+	t.Run("ParsesAgents", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/multi/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "multi", "os": "linux", "agents": [{"name": "main"}, {"name": "gpu", "default": true}]}`),
+			},
+			"bases/multi/main.tf.tmpl": &fstest.MapFile{
+				Data: []byte(`resource "coder_agent" "main" {}
+resource "coder_agent" "gpu" {}`),
+			},
+			"bases/multi/README.md": &fstest.MapFile{
+				Data: []byte("# Multi\n"),
+			},
+		}
+
+		bases, err := parseBasesFromFS(fsys)
+		require.NoError(t, err)
+		agents := bases["multi"].Manifest.Agents
+		require.Equal(t, []BaseAgent{{Name: "main"}, {Name: "gpu", Default: true}}, agents)
+	})
+
+	t.Run("RejectsEmptyAgentName", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": ""}]}`),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "empty name")
+	})
+
+	t.Run("RejectsDuplicateAgentName", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": "main"}, {"name": "main"}]}`),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "duplicate agent name")
+	})
+
+	t.Run("RejectsMultipleDefaultAgents", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": "a", "default": true}, {"name": "b", "default": true}]}`),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "exactly one required")
+	})
+
+	t.Run("RejectsMultiAgentWithoutDefault", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"bases/bad/base.json": &fstest.MapFile{
+				Data: []byte(`{"id": "bad", "os": "linux", "agents": [{"name": "a"}, {"name": "b"}]}`),
+			},
+		}
+
+		_, err := parseBasesFromFS(fsys)
+		require.ErrorContains(t, err, "exactly one required")
+	})
+}
+
+func TestDefaultAgentName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", defaultAgentName(nil))
+	require.Equal(t, "main", defaultAgentName([]BaseAgent{{Name: "main"}, {Name: "gpu"}}),
+		"first agent is the default when none is marked")
+	require.Equal(t, "gpu", defaultAgentName([]BaseAgent{{Name: "main"}, {Name: "gpu", Default: true}}),
+		"the marked agent is the default")
 }

--- a/coderd/templatebuilder/bases_test.go
+++ b/coderd/templatebuilder/bases_test.go
@@ -184,3 +184,48 @@ func TestBaseIncludedModules(t *testing.T) {
 	// Unknown IDs derive nothing.
 	require.Nil(t, templatebuilder.BaseIncludedModules("some-unknown-id"))
 }
+
+// TestBaseAgents checks the accessors and that each base's declared agents
+// match the coder_agent resources it renders.
+func TestBaseAgents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Accessors", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t,
+			[]templatebuilder.BaseAgent{{Name: "dev", Default: true}},
+			templatebuilder.BaseAgents("aws-linux"))
+		require.Equal(t, "dev", templatebuilder.BaseDefaultAgentName("aws-linux"))
+		require.Equal(t, "main", templatebuilder.BaseDefaultAgentName("docker"))
+		require.Empty(t, templatebuilder.BaseAgents("some-unknown-id"))
+		require.Equal(t, "", templatebuilder.BaseDefaultAgentName("some-unknown-id"))
+	})
+
+	t.Run("MatchRenderedTemplate", func(t *testing.T) {
+		t.Parallel()
+		for _, id := range templatebuilder.BaseTemplateIDs() {
+			t.Run(id, func(t *testing.T) {
+				t.Parallel()
+				rendered, err := templatebuilder.RenderBaseTemplate(
+					id, "main.tf.tmpl", testRenderContext(id))
+				require.NoError(t, err)
+
+				extracted, err := templatebuilder.ExtractAgentResourceNames(rendered)
+				require.NoError(t, err)
+				renderedNames := make([]string, 0, len(extracted))
+				for _, a := range extracted {
+					renderedNames = append(renderedNames, a.Name)
+				}
+
+				declared := templatebuilder.BaseAgents(id)
+				declaredNames := make([]string, 0, len(declared))
+				for _, a := range declared {
+					declaredNames = append(declaredNames, a.Name)
+				}
+
+				require.ElementsMatch(t, renderedNames, declaredNames,
+					"base %q base.json agents must match its rendered coder_agent resources", id)
+			})
+		}
+	})
+}

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -30,6 +30,9 @@ type ComposeRequest struct {
 // to render into its module block.
 type ComposeModule struct {
 	ID string
+	// AgentName is the base coder_agent the module attaches to; empty uses the
+	// base default. Must name an agent the base declares.
+	AgentName string
 	// Variables maps variable names to HCL literal values for
 	// non-sensitive, non-computed variables.
 	Variables map[string]string
@@ -51,9 +54,8 @@ type ComposeResult struct {
 	ExtraFiles map[string][]byte
 }
 
-// Compose renders a base template and selected modules into Terraform
-// source files. It extracts the coder_agent resource name from the
-// rendered base HCL and wires it into each module block.
+// Compose renders a base template and the selected modules into Terraform
+// source files.
 func Compose(req ComposeRequest) (*ComposeResult, error) {
 	// Validated at server start (codersdk.DeploymentValues.Validate). Normalize
 	// here too so a direct caller that bypasses the boot check gets the same
@@ -81,16 +83,22 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		}, nil
 	}
 
-	agents, err := ExtractAgentResourceNames(mainTF)
+	extractedAgents, err := ExtractAgentResourceNames(mainTF)
 	if err != nil {
 		return nil, xerrors.Errorf("extract agents: %w", err)
 	}
-	if len(agents) == 0 {
+	if len(extractedAgents) == 0 {
 		return nil, xerrors.New("no coder_agent resource found in rendered template")
 	}
-	// Wire modules to the base's first agent. Multiple agents are supported
-	// here without erroring; per-module agent selection is a follow-up.
-	agentName := agents[0].Reference
+	agentRefByName := make(map[string]string, len(extractedAgents))
+	for _, a := range extractedAgents {
+		agentRefByName[a.Name] = a.Reference
+	}
+	// Bases that declare no agents fall back to the first rendered agent.
+	defaultName := BaseDefaultAgentName(req.BaseTemplateID)
+	if defaultName == "" {
+		defaultName = extractedAgents[0].Name
+	}
 
 	catalog, err := loadCatalogMap()
 	if err != nil {
@@ -103,7 +111,7 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 		return nil, err
 	}
 
-	modulesTF, err := renderModules(req.Modules, catalog, registryBase, agentName)
+	modulesTF, err := renderModules(req.Modules, catalog, registryBase, agentRefByName, defaultName)
 	if err != nil {
 		return nil, err
 	}
@@ -267,16 +275,27 @@ func validateModules(requested []ComposeModule, catalog map[string]ModuleManifes
 	return nil
 }
 
-// renderModules renders each module template and concatenates the
-// results with newline separators.
+// renderModules renders the selected module blocks, each attached to its
+// resolved agent.
 func renderModules(
 	requested []ComposeModule,
 	catalog map[string]ModuleManifest,
-	registryURL, agentName string,
+	registryURL string,
+	agentRefByName map[string]string,
+	defaultName string,
 ) ([]byte, error) {
 	var buf bytes.Buffer
 	for _, cm := range requested {
 		manifest := catalog[cm.ID]
+
+		agentName := cm.AgentName
+		if agentName == "" {
+			agentName = defaultName
+		}
+		agentRef, ok := agentRefByName[agentName]
+		if !ok {
+			return nil, xerrors.Errorf("module %q references unknown agent %q", cm.ID, agentName)
+		}
 
 		modFS, err := ModuleTemplateFS(cm.ID)
 		if err != nil {
@@ -290,7 +309,7 @@ func renderModules(
 		modCtx := ModuleRenderContext{
 			RegistryBase:      registryURL,
 			PinnedVersion:     manifest.PinnedVersion,
-			AgentResourceName: agentName,
+			AgentResourceName: agentRef,
 			Variables:         vars,
 		}
 

--- a/coderd/templatebuilder/compose_internal_test.go
+++ b/coderd/templatebuilder/compose_internal_test.go
@@ -155,3 +155,26 @@ func TestMergeModuleVariables(t *testing.T) {
 		require.Equal(t, "13337", merged["port"])
 	})
 }
+
+// TestRenderModulesAgentTargeting covers multi-agent routing directly: no
+// curated base has more than one agent, so Compose cannot exercise it.
+func TestRenderModulesAgentTargeting(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := loadCatalogMap()
+	require.NoError(t, err)
+
+	agentRefByName := map[string]string{"main": "main", "gpu": "gpu[0]"}
+	modulesTF, err := renderModules(
+		[]ComposeModule{
+			{ID: "code-server", AgentName: "gpu"},
+			{ID: "git-commit-signing"},
+		},
+		catalog, "registry.coder.com", agentRefByName, "main",
+	)
+	require.NoError(t, err)
+
+	out := string(modulesTF)
+	require.Contains(t, out, "coder_agent.gpu[0].id")
+	require.Contains(t, out, "coder_agent.main.id")
+}

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -68,6 +68,32 @@ func TestCompose(t *testing.T) {
 		require.Contains(t, string(result.ModulesTF), `coder_agent.dev[0].id`)
 	})
 
+	t.Run("ExplicitAgentName", func(t *testing.T) {
+		t.Parallel()
+		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "registry.coder.com",
+			Modules: []templatebuilder.ComposeModule{
+				{ID: "git-commit-signing", AgentName: "main"},
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(result.ModulesTF), `coder_agent.main.id`)
+	})
+
+	t.Run("UnknownAgentName", func(t *testing.T) {
+		t.Parallel()
+		_, err := templatebuilder.Compose(templatebuilder.ComposeRequest{
+			BaseTemplateID: "docker",
+			RegistryURL:    "registry.coder.com",
+			Modules: []templatebuilder.ComposeModule{
+				{ID: "git-commit-signing", AgentName: "nonexistent"},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `unknown agent "nonexistent"`)
+	})
+
 	t.Run("AWSLinuxExtraFiles", func(t *testing.T) {
 		t.Parallel()
 		result, err := templatebuilder.Compose(templatebuilder.ComposeRequest{


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556). Follows the hclparse/multi-agent extraction change (#28787).

## Summary

Adds agent metadata to base templates and lets composed modules target a specific `coder_agent`, replacing the previous "always wire to the first agent" behavior. Single-agent output is unchanged.

## What changed

- `bases.go`: `BaseManifest.Agents []BaseAgent` (`{name, display_name, default}`), parse-time validation (non-empty unique names; a multi-agent base must mark exactly one default), and `BaseAgents` / `BaseDefaultAgentName` accessors.
- `bases/*/base.json`: every base declares its `coder_agent` (`aws-linux` → `dev`, others → `main`), marked default.
- `compose.go`: `ComposeModule.AgentName`. Each module resolves its target agent (empty → base default; unknown → error) and renders against that agent's reference.

## Scope

Backend/manifest only. Exposing agents over the SDK/HTTP API and per-module selection in the wizard UI are follow-ups. `ComposeModule.AgentName` has no producer yet, so every module currently takes the default path.

## Testing

- Manifest validation (empty / duplicate / multiple-default / multi-agent-without-default).
- `BaseAgents`/`BaseDefaultAgentName` accessors, plus a guard that each base's declared agents match the `coder_agent` resources it renders.
- `renderModules` multi-agent routing (two modules → two different agents, including the `[0]` reference for a counted agent) — the curated single-agent bases can't exercise this via `Compose`.
- Explicit-agent round-trip and unknown-agent error at the `Compose` level.
- `go test ./coderd/templatebuilder/`, `go vet`, `golangci-lint`, `go build ./coderd/...` all clean; golden outputs unchanged; no `go.mod`/`make gen` changes.

<details>
<summary>Design notes</summary>

- Agents stay **declared** in `base.json` rather than derived from the rendered template. Deriving is possible (`ExtractAgentResourceNames` already reads the labels), but 4 bases render invalid HCL under the default context (required vars like `project_id`/`namespace` render empty), and an explicit `agents` array is a discoverable home for the `default`/`display_name` metadata a multi-agent base needs. `TestBaseAgents/MatchRenderedTemplate` guards drift between the manifest and the template.
- Requiring exactly one `default` for multi-agent bases keeps module wiring from silently depending on `base.json` array order.
- `BaseAgent.DisplayName` is present but unused; it is the label the upcoming wizard UI will render, kept here so the schema is stable for the follow-up.

</details>

---
🤖 Generated by Coder Agents on behalf of @jeremyruppel.
