### PR TITLE
chore: oxlint jsx-no-target-blank

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -90,6 +90,7 @@
 		"require-yield": "error",
 
 		// --- security ---
+		"jsx-no-target-blank": "error",
 		"no-eval": "error",
 
 		// --- performance ---
@@ -196,7 +197,6 @@
 		"no-extraneous-class": "off", // complexity/noStaticOnlyClass (small)
 		"no-empty-interface": "off", // suspicious/noEmptyInterface (small)
 		"no-danger": "off", // security/noDangerouslySetInnerHtml (small: Biome suppression to migrate)
-		"jsx-no-target-blank": "off", // security/noBlankTarget (small)
 		"no-noninteractive-tabindex": "off", // a11y/noNoninteractiveTabindex (small)
 		"media-has-caption": "off", // a11y/useMediaCaption (small)
 		"interactive-supports-focus": "off", // a11y/useFocusableInteractive (small)

--- a/site/src/pages/WorkspacePage/AgentAlert.tsx
+++ b/site/src/pages/WorkspacePage/AgentAlert.tsx
@@ -24,7 +24,7 @@ export const AgentAlert: FC<AgentAlertProps> = ({
 				<div className="mb-2">{detail}</div>
 				{troubleshootingURL && (
 					<Button size="sm" asChild>
-						<a href={troubleshootingURL} target="_blank" rel="noopener">
+						<a href={troubleshootingURL} target="_blank" rel="noreferrer">
 							View docs to troubleshoot
 						</a>
 					</Button>


### PR DESCRIPTION
* enables [jsx-no-target-blank](https://oxc.rs/docs/guide/usage/linter/rules/eslint/jsx-no-target-blank) oxc rule
* fixes one instance of this in code

from mdn: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noreferrer
> The noreferrer keyword ... instructs the browser, when navigating to the target resource, to omit the referrer header and otherwise leak no referrer information — and additionally to behave as if the `noopener` keyword were also specified.

see also https://mathiasbynens.github.io/rel-noopener/#recommendations