### PR TITLE
fix: sync pinned chat MCP context resources on agent push

### DIFF
--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -993,10 +993,10 @@ type Snapshot struct {
 	// (ID, Kind, Source, ContentHash, Status) for every
 	// drift-relevant resource. MCP resources (KindMCPConfig and
 	// KindMCPServer) are excluded because they describe live,
-	// agent-global runtime capabilities discovered at turn time,
-	// not pinned prompt content; see driftResources. Identical
-	// inputs always produce identical hashes; see
-	// ComputeAggregateHash.
+	// agent-global runtime capabilities that coderd live-syncs
+	// onto bound chats on each push, not pinned prompt content;
+	// see driftResources. Identical inputs always produce
+	// identical hashes; see ComputeAggregateHash.
 	AggregateHash [32]byte
 	// Resources is sorted by ID for deterministic encoding.
 	Resources []Resource
@@ -1012,12 +1012,13 @@ type Snapshot struct {
 // driftResources returns the subset of resources that participate in
 // chat-context drift detection. MCP resources (the .mcp.json config and
 // connected MCP servers) are deliberately excluded: an agent connects to
-// its MCP servers asynchronously after startup, and the chat model
-// discovers their tools live at turn time, not from pinned prompt
-// content. Hashing them would dirty an already-hydrated chat the moment
-// a server finished connecting, even though nothing the user pinned
-// changed. Instruction files and skills, whose content is pinned into
-// the chat, stay drift-relevant.
+// its MCP servers asynchronously after startup, and hashing them would
+// dirty an already-hydrated chat the moment a server finished
+// connecting, even though nothing the user pinned changed. Instead,
+// coderd live-syncs the pinned MCP rows of every bound chat on each push
+// (SyncAgentChatsContextMCPResources), so MCP capability tracks the
+// agent without user-visible drift. Instruction files and skills, whose
+// content is pinned into the chat, stay drift-relevant.
 func driftResources(resources []Resource) []Resource {
 	out := make([]Resource, 0, len(resources))
 	for _, r := range resources {

--- a/agent/agentcontext/resolve.go
+++ b/agent/agentcontext/resolve.go
@@ -989,14 +989,9 @@ type Snapshot struct {
 	// placeholder (the first real resolve is version 1), which the push
 	// loop withholds.
 	Version uint64
-	// AggregateHash is sha256 over a canonical encoding of
-	// (ID, Kind, Source, ContentHash, Status) for every
-	// drift-relevant resource. MCP resources (KindMCPConfig and
-	// KindMCPServer) are excluded because they describe live,
-	// agent-global runtime capabilities that coderd live-syncs
-	// onto bound chats on each push, not pinned prompt content;
-	// see driftResources. Identical inputs always produce
-	// identical hashes; see ComputeAggregateHash.
+	// AggregateHash is SHA-256 over canonical (ID, Kind, Source, ContentHash,
+	// Status) tuples for drift-relevant resources. MCP resources are excluded
+	// because coderd live-syncs them onto bound chats; see driftResources.
 	AggregateHash [32]byte
 	// Resources is sorted by ID for deterministic encoding.
 	Resources []Resource
@@ -1009,16 +1004,9 @@ type Snapshot struct {
 	SnapshotError string
 }
 
-// driftResources returns the subset of resources that participate in
-// chat-context drift detection. MCP resources (the .mcp.json config and
-// connected MCP servers) are deliberately excluded: an agent connects to
-// its MCP servers asynchronously after startup, and hashing them would
-// dirty an already-hydrated chat the moment a server finished
-// connecting, even though nothing the user pinned changed. Instead,
-// coderd live-syncs the pinned MCP rows of every bound chat on each push
-// (SyncAgentChatsContextMCPResources), so MCP capability tracks the
-// agent without user-visible drift. Instruction files and skills, whose
-// content is pinned into the chat, stay drift-relevant.
+// driftResources excludes MCP resources because agents discover them
+// asynchronously and coderd live-syncs them onto bound chats. Instructions
+// and skills remain drift-relevant because their content is pinned.
 func driftResources(resources []Resource) []Resource {
 	out := make([]Resource, 0, len(resources))
 	for _, r := range resources {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -7345,6 +7345,16 @@ func (q *querier) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Context, wo
 	return q.db.SoftDeleteWorkspaceAgentsByWorkspaceID(ctx, workspaceID)
 }
 
+func (q *querier) SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
+	// System-level operation: an agent context push fans the MCP resource
+	// sync out across every hydrated chat bound to the agent, so it
+	// authorizes at the resource level rather than per-chat.
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceChat); err != nil {
+		return nil, err
+	}
+	return q.db.SyncAgentChatsContextMCPResources(ctx, agentID)
+}
+
 func (q *querier) TouchChatDebugRunUpdatedAt(ctx context.Context, arg database.TouchChatDebugRunUpdatedAtParams) error {
 	chat, err := q.db.GetChatByID(ctx, arg.ChatID)
 	if err != nil {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -7346,9 +7346,8 @@ func (q *querier) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Context, wo
 }
 
 func (q *querier) SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
-	// System-level operation: an agent context push fans the MCP resource
-	// sync out across every hydrated chat bound to the agent, so it
-	// authorizes at the resource level rather than per-chat.
+	// The push can update multiple chats bound to the agent, so authorize the
+	// chat resource class.
 	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceChat); err != nil {
 		return nil, err
 	}

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -670,6 +670,12 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().MarkChatsContextDirtyByAgent(gomock.Any(), arg).Return(rows, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceChat, policy.ActionUpdate).Returns(rows)
 	}))
+	s.Run("SyncAgentChatsContextMCPResources", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		agentID := uuid.New()
+		synced := []uuid.UUID{uuid.New()}
+		dbm.EXPECT().SyncAgentChatsContextMCPResources(gomock.Any(), agentID).Return(synced, nil).AnyTimes()
+		check.Args(agentID).Asserts(rbac.ResourceChat, policy.ActionUpdate).Returns(synced)
+	}))
 	s.Run("SetChatContextSnapshot", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})
 		arg := database.SetChatContextSnapshotParams{ID: chat.ID}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -5152,6 +5152,14 @@ func (m queryMetricsStore) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Co
 	return r0
 }
 
+func (m queryMetricsStore) SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
+	start := time.Now()
+	r0, r1 := m.s.SyncAgentChatsContextMCPResources(ctx, agentID)
+	m.queryLatencies.WithLabelValues("SyncAgentChatsContextMCPResources").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "SyncAgentChatsContextMCPResources").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) TouchChatDebugRunUpdatedAt(ctx context.Context, arg database.TouchChatDebugRunUpdatedAtParams) error {
 	start := time.Now()
 	r0 := m.s.TouchChatDebugRunUpdatedAt(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -9781,6 +9781,21 @@ func (mr *MockStoreMockRecorder) SoftDeleteWorkspaceAgentsByWorkspaceID(ctx, wor
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SoftDeleteWorkspaceAgentsByWorkspaceID", reflect.TypeOf((*MockStore)(nil).SoftDeleteWorkspaceAgentsByWorkspaceID), ctx, workspaceID)
 }
 
+// SyncAgentChatsContextMCPResources mocks base method.
+func (m *MockStore) SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncAgentChatsContextMCPResources", ctx, agentID)
+	ret0, _ := ret[0].([]uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SyncAgentChatsContextMCPResources indicates an expected call of SyncAgentChatsContextMCPResources.
+func (mr *MockStoreMockRecorder) SyncAgentChatsContextMCPResources(ctx, agentID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncAgentChatsContextMCPResources", reflect.TypeOf((*MockStore)(nil).SyncAgentChatsContextMCPResources), ctx, agentID)
+}
+
 // TouchChatDebugRunUpdatedAt mocks base method.
 func (m *MockStore) TouchChatDebugRunUpdatedAt(ctx context.Context, arg database.TouchChatDebugRunUpdatedAtParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1405,6 +1405,20 @@ type sqlcQuerier interface {
 	// Agent context rows are hard-deleted for the same reason as in
 	// SoftDeletePriorWorkspaceAgents.
 	SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) error
+	// MCP resources are excluded from the context drift hash: they describe
+	// live, agent-global runtime capability that an agent discovers
+	// asynchronously after startup, not pinned prompt content. A push that
+	// only changes MCP servers therefore never dirties a chat, so this
+	// statement keeps the pinned copies current instead: every hydrated,
+	// non-archived chat bound to the agent has its mcp_config/mcp_server
+	// rows replaced with the agent's current set. Chats whose MCP rows
+	// already match are left untouched. Runs inside the push transaction
+	// after the agent's own resource rows are rewritten. Changed chats are
+	// row-locked (in id order) before the rewrite so a concurrent rebind
+	// re-pin (clear-then-copy) serializes against it instead of
+	// interleaving. Returns the chat IDs whose rows changed so the caller
+	// can notify watchers.
+	SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error)
 	// Overrides updated_at on the parent run without touching any
 	// other column. Used by tests that need to stamp a run with a
 	// specific timestamp after the InsertChatDebugStep CTE has

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -1405,19 +1405,9 @@ type sqlcQuerier interface {
 	// Agent context rows are hard-deleted for the same reason as in
 	// SoftDeletePriorWorkspaceAgents.
 	SoftDeleteWorkspaceAgentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) error
-	// MCP resources are excluded from the context drift hash: they describe
-	// live, agent-global runtime capability that an agent discovers
-	// asynchronously after startup, not pinned prompt content. A push that
-	// only changes MCP servers therefore never dirties a chat, so this
-	// statement keeps the pinned copies current instead: every hydrated,
-	// non-archived chat bound to the agent has its mcp_config/mcp_server
-	// rows replaced with the agent's current set. Chats whose MCP rows
-	// already match are left untouched. Runs inside the push transaction
-	// after the agent's own resource rows are rewritten. Changed chats are
-	// row-locked (in id order) before the rewrite so a concurrent rebind
-	// re-pin (clear-then-copy) serializes against it instead of
-	// interleaving. Returns the chat IDs whose rows changed so the caller
-	// can notify watchers.
+	// MCP resources bypass context drift and are live-synced on each push.
+	// Changed chats are locked in ID order so concurrent clear-then-copy re-pins
+	// cannot interleave with the replacement.
 	SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error)
 	// Overrides updated_at on the parent run without touching any
 	// other column. Used by tests that need to stamp a run with a

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -11660,19 +11660,9 @@ upserted AS (
 SELECT id FROM locked
 `
 
-// MCP resources are excluded from the context drift hash: they describe
-// live, agent-global runtime capability that an agent discovers
-// asynchronously after startup, not pinned prompt content. A push that
-// only changes MCP servers therefore never dirties a chat, so this
-// statement keeps the pinned copies current instead: every hydrated,
-// non-archived chat bound to the agent has its mcp_config/mcp_server
-// rows replaced with the agent's current set. Chats whose MCP rows
-// already match are left untouched. Runs inside the push transaction
-// after the agent's own resource rows are rewritten. Changed chats are
-// row-locked (in id order) before the rewrite so a concurrent rebind
-// re-pin (clear-then-copy) serializes against it instead of
-// interleaving. Returns the chat IDs whose rows changed so the caller
-// can notify watchers.
+// MCP resources bypass context drift and are live-synced on each push.
+// Changed chats are locked in ID order so concurrent clear-then-copy re-pins
+// cannot interleave with the replacement.
 func (q *sqlQuerier) SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
 	rows, err := q.db.QueryContext(ctx, syncAgentChatsContextMCPResources, agentID)
 	if err != nil {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -11584,6 +11584,118 @@ func (q *sqlQuerier) SoftDeleteContextFileMessages(ctx context.Context, chatID u
 	return err
 }
 
+const syncAgentChatsContextMCPResources = `-- name: SyncAgentChatsContextMCPResources :many
+WITH agent_mcp AS (
+    SELECT source, body_kind, body, content_hash, size_bytes, status, error, source_path
+    FROM workspace_agent_context_resources
+    WHERE workspace_agent_id = $1::uuid
+        AND body_kind IN ('mcp_config', 'mcp_server')
+),
+changed AS (
+    SELECT chats.id
+    FROM chats
+    WHERE chats.agent_id = $1::uuid
+        AND chats.archived = false
+        AND chats.context_aggregate_hash IS NOT NULL
+        AND (
+            EXISTS (
+                SELECT 1 FROM agent_mcp m
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM chat_context_resources ccr
+                    WHERE ccr.chat_id = chats.id
+                        AND ccr.source = m.source
+                        AND ccr.body_kind = m.body_kind
+                        AND ccr.content_hash = m.content_hash
+                        AND ccr.status = m.status
+                        AND ccr.error = m.error
+                )
+            )
+            OR EXISTS (
+                SELECT 1 FROM chat_context_resources ccr
+                WHERE ccr.chat_id = chats.id
+                    AND ccr.body_kind IN ('mcp_config', 'mcp_server')
+                    AND NOT EXISTS (
+                        SELECT 1 FROM agent_mcp m
+                        WHERE m.source = ccr.source
+                            AND m.body_kind = ccr.body_kind
+                            AND m.content_hash = ccr.content_hash
+                            AND m.status = ccr.status
+                            AND m.error = ccr.error
+                    )
+            )
+        )
+),
+locked AS (
+    SELECT id FROM chats
+    WHERE id IN (SELECT id FROM changed)
+    ORDER BY id
+    FOR UPDATE
+),
+deleted AS (
+    DELETE FROM chat_context_resources
+    USING locked
+    WHERE chat_context_resources.chat_id = locked.id
+        AND chat_context_resources.body_kind IN ('mcp_config', 'mcp_server')
+        AND chat_context_resources.source NOT IN (SELECT source FROM agent_mcp)
+),
+upserted AS (
+    INSERT INTO chat_context_resources (
+        chat_id, source, body_kind, body, content_hash, size_bytes, status, error, source_path
+    )
+    SELECT
+        locked.id, m.source, m.body_kind, m.body, m.content_hash,
+        m.size_bytes, m.status, m.error, m.source_path
+    FROM locked
+    CROSS JOIN agent_mcp m
+    ON CONFLICT (chat_id, source) DO UPDATE SET
+        body_kind = EXCLUDED.body_kind,
+        body = EXCLUDED.body,
+        content_hash = EXCLUDED.content_hash,
+        size_bytes = EXCLUDED.size_bytes,
+        status = EXCLUDED.status,
+        error = EXCLUDED.error,
+        source_path = EXCLUDED.source_path,
+        updated_at = now()
+)
+SELECT id FROM locked
+`
+
+// MCP resources are excluded from the context drift hash: they describe
+// live, agent-global runtime capability that an agent discovers
+// asynchronously after startup, not pinned prompt content. A push that
+// only changes MCP servers therefore never dirties a chat, so this
+// statement keeps the pinned copies current instead: every hydrated,
+// non-archived chat bound to the agent has its mcp_config/mcp_server
+// rows replaced with the agent's current set. Chats whose MCP rows
+// already match are left untouched. Runs inside the push transaction
+// after the agent's own resource rows are rewritten. Changed chats are
+// row-locked (in id order) before the rewrite so a concurrent rebind
+// re-pin (clear-then-copy) serializes against it instead of
+// interleaving. Returns the chat IDs whose rows changed so the caller
+// can notify watchers.
+func (q *sqlQuerier) SyncAgentChatsContextMCPResources(ctx context.Context, agentID uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := q.db.QueryContext(ctx, syncAgentChatsContextMCPResources, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const unarchiveChatByID = `-- name: UnarchiveChatByID :many
 WITH updated_chats AS (
     UPDATE chats SET

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -1648,6 +1648,94 @@ WHERE agent_id = @agent_id::uuid
     AND context_dirty_since IS NULL
 RETURNING id, owner_id;
 
+-- name: SyncAgentChatsContextMCPResources :many
+-- MCP resources are excluded from the context drift hash: they describe
+-- live, agent-global runtime capability that an agent discovers
+-- asynchronously after startup, not pinned prompt content. A push that
+-- only changes MCP servers therefore never dirties a chat, so this
+-- statement keeps the pinned copies current instead: every hydrated,
+-- non-archived chat bound to the agent has its mcp_config/mcp_server
+-- rows replaced with the agent's current set. Chats whose MCP rows
+-- already match are left untouched. Runs inside the push transaction
+-- after the agent's own resource rows are rewritten. Changed chats are
+-- row-locked (in id order) before the rewrite so a concurrent rebind
+-- re-pin (clear-then-copy) serializes against it instead of
+-- interleaving. Returns the chat IDs whose rows changed so the caller
+-- can notify watchers.
+WITH agent_mcp AS (
+    SELECT source, body_kind, body, content_hash, size_bytes, status, error, source_path
+    FROM workspace_agent_context_resources
+    WHERE workspace_agent_id = @agent_id::uuid
+        AND body_kind IN ('mcp_config', 'mcp_server')
+),
+changed AS (
+    SELECT chats.id
+    FROM chats
+    WHERE chats.agent_id = @agent_id::uuid
+        AND chats.archived = false
+        AND chats.context_aggregate_hash IS NOT NULL
+        AND (
+            EXISTS (
+                SELECT 1 FROM agent_mcp m
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM chat_context_resources ccr
+                    WHERE ccr.chat_id = chats.id
+                        AND ccr.source = m.source
+                        AND ccr.body_kind = m.body_kind
+                        AND ccr.content_hash = m.content_hash
+                        AND ccr.status = m.status
+                        AND ccr.error = m.error
+                )
+            )
+            OR EXISTS (
+                SELECT 1 FROM chat_context_resources ccr
+                WHERE ccr.chat_id = chats.id
+                    AND ccr.body_kind IN ('mcp_config', 'mcp_server')
+                    AND NOT EXISTS (
+                        SELECT 1 FROM agent_mcp m
+                        WHERE m.source = ccr.source
+                            AND m.body_kind = ccr.body_kind
+                            AND m.content_hash = ccr.content_hash
+                            AND m.status = ccr.status
+                            AND m.error = ccr.error
+                    )
+            )
+        )
+),
+locked AS (
+    SELECT id FROM chats
+    WHERE id IN (SELECT id FROM changed)
+    ORDER BY id
+    FOR UPDATE
+),
+deleted AS (
+    DELETE FROM chat_context_resources
+    USING locked
+    WHERE chat_context_resources.chat_id = locked.id
+        AND chat_context_resources.body_kind IN ('mcp_config', 'mcp_server')
+        AND chat_context_resources.source NOT IN (SELECT source FROM agent_mcp)
+),
+upserted AS (
+    INSERT INTO chat_context_resources (
+        chat_id, source, body_kind, body, content_hash, size_bytes, status, error, source_path
+    )
+    SELECT
+        locked.id, m.source, m.body_kind, m.body, m.content_hash,
+        m.size_bytes, m.status, m.error, m.source_path
+    FROM locked
+    CROSS JOIN agent_mcp m
+    ON CONFLICT (chat_id, source) DO UPDATE SET
+        body_kind = EXCLUDED.body_kind,
+        body = EXCLUDED.body,
+        content_hash = EXCLUDED.content_hash,
+        size_bytes = EXCLUDED.size_bytes,
+        status = EXCLUDED.status,
+        error = EXCLUDED.error,
+        source_path = EXCLUDED.source_path,
+        updated_at = now()
+)
+SELECT id FROM locked;
+
 -- name: InsertAgentContextResourcesIntoChat :exec
 -- Copies an agent's current context resources onto a single chat. Pair
 -- with DeleteChatContextResourcesByChatID (clear-then-copy, in a

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -1649,19 +1649,9 @@ WHERE agent_id = @agent_id::uuid
 RETURNING id, owner_id;
 
 -- name: SyncAgentChatsContextMCPResources :many
--- MCP resources are excluded from the context drift hash: they describe
--- live, agent-global runtime capability that an agent discovers
--- asynchronously after startup, not pinned prompt content. A push that
--- only changes MCP servers therefore never dirties a chat, so this
--- statement keeps the pinned copies current instead: every hydrated,
--- non-archived chat bound to the agent has its mcp_config/mcp_server
--- rows replaced with the agent's current set. Chats whose MCP rows
--- already match are left untouched. Runs inside the push transaction
--- after the agent's own resource rows are rewritten. Changed chats are
--- row-locked (in id order) before the rewrite so a concurrent rebind
--- re-pin (clear-then-copy) serializes against it instead of
--- interleaving. Returns the chat IDs whose rows changed so the caller
--- can notify watchers.
+-- MCP resources bypass context drift and are live-synced on each push.
+-- Changed chats are locked in ID order so concurrent clear-then-copy re-pins
+-- cannot interleave with the replacement.
 WITH agent_mcp AS (
     SELECT source, body_kind, body, content_hash, size_bytes, status, error, source_path
     FROM workspace_agent_context_resources

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -444,10 +444,11 @@ func (p *Server) resolveWorkspaceMCPTools(
 // context snapshot (chat_context_resources). Each tool still proxies its calls
 // back through the workspace agent connection; the snapshot carries tool
 // definitions, not a way to execute them, so execution requires a reachable
-// agent. There is no per-chat cache to invalidate: a server removed or renamed
-// in the workspace surfaces as a dirty chat on the agent's next push, and the
-// user refreshes to re-pin, so a nil invalidate callback (a 404 no-op) is
-// correct here.
+// agent. There is no per-chat cache to invalidate: MCP resources are excluded
+// from the drift hash, so a server added, removed, or renamed in the workspace
+// is live-synced onto the pinned rows by the agent's next push
+// (SyncAgentChatsContextMCPResources), making a nil invalidate callback (a 404
+// no-op) correct here.
 func (p *Server) pinnedWorkspaceMCPTools(
 	ctx context.Context,
 	chat database.Chat,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -441,14 +441,8 @@ func (p *Server) resolveWorkspaceMCPTools(
 }
 
 // pinnedWorkspaceMCPTools builds workspace MCP tools from the chat's pinned
-// context snapshot (chat_context_resources). Each tool still proxies its calls
-// back through the workspace agent connection; the snapshot carries tool
-// definitions, not a way to execute them, so execution requires a reachable
-// agent. There is no per-chat cache to invalidate: MCP resources are excluded
-// from the drift hash, so a server added, removed, or renamed in the workspace
-// is live-synced onto the pinned rows by the agent's next push
-// (SyncAgentChatsContextMCPResources), making a nil invalidate callback (a 404
-// no-op) correct here.
+// definitions. Calls still proxy through the agent connection, and agent pushes
+// live-sync definitions, so no invalidation callback is needed.
 func (p *Server) pinnedWorkspaceMCPTools(
 	ctx context.Context,
 	chat database.Chat,

--- a/coderd/x/chatd/context_hydration.go
+++ b/coderd/x/chatd/context_hydration.go
@@ -31,13 +31,19 @@ func latestAgentSnapshot(ctx context.Context, db database.Store, agentID uuid.UU
 
 // HydrateAndMarkChatsDirty implements agentapi.ContextDirtyMarker. It runs
 // inside the PushContextState transaction: it stamps the pushed snapshot hash
-// on chats for the agent that have not been hydrated yet, then flips
-// already-pinned chats whose hash differs to dirty. It returns a callback
-// that publishes a context watch event for every chat it touched; the caller
-// invokes it only after the transaction commits, and the callback is a no-op
-// when no chat was hydrated or dirtied. Hydrated chats start clean (no dirty
-// marker), but still need the event: watching clients cached their details
-// without pinned resources and refetch only on context events.
+// on chats for the agent that have not been hydrated yet, flips
+// already-pinned chats whose hash differs to dirty, and syncs the pinned
+// mcp_config/mcp_server rows of already-pinned chats to the agent's current
+// set. MCP resources are excluded from the drift hash (they are live runtime
+// capability, discovered asynchronously after agent startup), so without the
+// sync a chat pinned before the agent's MCP engine finished connecting would
+// never gain its MCP servers: the later push carries an unchanged hash and
+// neither hydrates nor dirties the chat. It returns a callback that publishes
+// a context watch event for every chat it touched; the caller invokes it only
+// after the transaction commits, and the callback is a no-op when no chat was
+// hydrated, dirtied, or synced. Hydrated chats start clean (no dirty marker),
+// but still need the event: watching clients cached their details without
+// pinned resources and refetch only on context events.
 //
 // The pinned hash on dirtied chats is intentionally left unchanged; the
 // refresh endpoint re-pins it.
@@ -64,12 +70,35 @@ func (p *Server) HydrateAndMarkChatsDirty(ctx context.Context, tx database.Store
 	if err != nil {
 		return nil, xerrors.Errorf("mark chats context dirty: %w", err)
 	}
+	// MCP resources track the agent's live set rather than the drift
+	// hash, so already-pinned chats have their mcp rows synced on every
+	// push. Freshly hydrated chats just copied the full current set, so
+	// the sync never selects them.
+	synced, err := tx.SyncAgentChatsContextMCPResources(ctx, agentID)
+	if err != nil {
+		return nil, xerrors.Errorf("sync agent chats mcp context resources: %w", err)
+	}
+
 	// Hydrated chats had a NULL hash and dirtied chats a non-NULL one, so
-	// the two sets never overlap.
-	touched := make([]uuid.UUID, 0, len(hydrated)+len(dirtied))
-	touched = append(touched, hydrated...)
+	// those two sets never overlap; a dirtied chat can also be MCP-synced,
+	// so dedupe before publishing.
+	seen := make(map[uuid.UUID]struct{}, len(hydrated)+len(dirtied)+len(synced))
+	touched := make([]uuid.UUID, 0, len(hydrated)+len(dirtied)+len(synced))
+	appendTouched := func(id uuid.UUID) {
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		touched = append(touched, id)
+	}
+	for _, id := range hydrated {
+		appendTouched(id)
+	}
 	for _, d := range dirtied {
-		touched = append(touched, d.ID)
+		appendTouched(d.ID)
+	}
+	for _, id := range synced {
+		appendTouched(id)
 	}
 	if len(touched) == 0 {
 		return func() {}, nil

--- a/coderd/x/chatd/context_hydration.go
+++ b/coderd/x/chatd/context_hydration.go
@@ -29,24 +29,9 @@ func latestAgentSnapshot(ctx context.Context, db database.Store, agentID uuid.UU
 	}
 }
 
-// HydrateAndMarkChatsDirty implements agentapi.ContextDirtyMarker. It runs
-// inside the PushContextState transaction: it stamps the pushed snapshot hash
-// on chats for the agent that have not been hydrated yet, flips
-// already-pinned chats whose hash differs to dirty, and syncs the pinned
-// mcp_config/mcp_server rows of already-pinned chats to the agent's current
-// set. MCP resources are excluded from the drift hash (they are live runtime
-// capability, discovered asynchronously after agent startup), so without the
-// sync a chat pinned before the agent's MCP engine finished connecting would
-// never gain its MCP servers: the later push carries an unchanged hash and
-// neither hydrates nor dirties the chat. It returns a callback that publishes
-// a context watch event for every chat it touched; the caller invokes it only
-// after the transaction commits, and the callback is a no-op when no chat was
-// hydrated, dirtied, or synced. Hydrated chats start clean (no dirty marker),
-// but still need the event: watching clients cached their details without
-// pinned resources and refetch only on context events.
-//
-// The pinned hash on dirtied chats is intentionally left unchanged; the
-// refresh endpoint re-pins it.
+// HydrateAndMarkChatsDirty pins context for unpinned chats, marks drifted chats
+// dirty, and live-syncs MCP resources. Its post-commit callback publishes one
+// context event per affected chat without changing dirty chats' pinned hash.
 func (p *Server) HydrateAndMarkChatsDirty(ctx context.Context, tx database.Store, agentID uuid.UUID, aggregateHash []byte, snapshotError string, now time.Time) (func(), error) {
 	//nolint:gocritic // An agent does not own the chats bound to it.
 	ctx = dbauthz.AsChatd(ctx)
@@ -70,18 +55,13 @@ func (p *Server) HydrateAndMarkChatsDirty(ctx context.Context, tx database.Store
 	if err != nil {
 		return nil, xerrors.Errorf("mark chats context dirty: %w", err)
 	}
-	// MCP resources track the agent's live set rather than the drift
-	// hash, so already-pinned chats have their mcp rows synced on every
-	// push. Freshly hydrated chats just copied the full current set, so
-	// the sync never selects them.
+	// MCP resources bypass drift detection, so sync them on every agent push.
 	synced, err := tx.SyncAgentChatsContextMCPResources(ctx, agentID)
 	if err != nil {
 		return nil, xerrors.Errorf("sync agent chats mcp context resources: %w", err)
 	}
 
-	// Hydrated chats had a NULL hash and dirtied chats a non-NULL one, so
-	// those two sets never overlap; a dirtied chat can also be MCP-synced,
-	// so dedupe before publishing.
+	// A dirtied chat can also be MCP-synced, so publish it only once.
 	seen := make(map[uuid.UUID]struct{}, len(hydrated)+len(dirtied)+len(synced))
 	touched := make([]uuid.UUID, 0, len(hydrated)+len(dirtied)+len(synced))
 	appendTouched := func(id uuid.UUID) {

--- a/coderd/x/chatd/context_hydration_internal_test.go
+++ b/coderd/x/chatd/context_hydration_internal_test.go
@@ -109,8 +109,9 @@ func TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied(t *testing.T) {
 
 	hydratedChat := database.Chat{ID: uuid.New(), OwnerID: ownerID, ContextAggregateHash: hash}
 	dirtiedChat := database.Chat{ID: uuid.New(), OwnerID: ownerID, ContextAggregateHash: []byte{0x99}}
+	syncedChat := database.Chat{ID: uuid.New(), OwnerID: ownerID, ContextAggregateHash: hash}
 
-	events := make(chan codersdk.ChatWatchEvent, 2)
+	events := make(chan codersdk.ChatWatchEvent, 3)
 	cancelSub, err := ps.SubscribeWithErr(
 		coderdpubsub.ChatWatchEventChannel(ownerID),
 		coderdpubsub.HandleChatWatchEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
@@ -130,20 +131,25 @@ func TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied(t *testing.T) {
 		AggregateHash: hash,
 		DirtySince:    sql.NullTime{Time: now, Valid: true},
 	}).Return([]database.MarkChatsContextDirtyByAgentRow{{ID: dirtiedChat.ID, OwnerID: ownerID}}, nil)
+	// The MCP sync reports the dirtied chat too; the publish path must
+	// dedupe it so each touched chat gets exactly one event.
+	db.EXPECT().SyncAgentChatsContextMCPResources(gomock.Any(), agentID).
+		Return([]uuid.UUID{syncedChat.ID, dirtiedChat.ID}, nil)
 	db.EXPECT().GetChatByID(gomock.Any(), hydratedChat.ID).Return(hydratedChat, nil)
 	db.EXPECT().GetChatByID(gomock.Any(), dirtiedChat.ID).Return(dirtiedChat, nil)
+	db.EXPECT().GetChatByID(gomock.Any(), syncedChat.ID).Return(syncedChat, nil)
 
 	publish, err := server.HydrateAndMarkChatsDirty(ctx, db, agentID, hash, "", now)
 	require.NoError(t, err)
 	publish()
 
-	gotChatIDs := make([]uuid.UUID, 0, 2)
-	for range 2 {
+	gotChatIDs := make([]uuid.UUID, 0, 3)
+	for range 3 {
 		event := testutil.RequireReceive(ctx, t, events)
 		require.Equal(t, codersdk.ChatWatchEventKindContextDirty, event.Kind)
 		gotChatIDs = append(gotChatIDs, event.Chat.ID)
 	}
-	require.ElementsMatch(t, []uuid.UUID{hydratedChat.ID, dirtiedChat.ID}, gotChatIDs)
+	require.ElementsMatch(t, []uuid.UUID{hydratedChat.ID, dirtiedChat.ID, syncedChat.ID}, gotChatIDs)
 }
 
 // TestEnsureChatContextPinnedOnFirstTurn covers the lazy-bind pinning path. An

--- a/coderd/x/chatd/context_hydration_internal_test.go
+++ b/coderd/x/chatd/context_hydration_internal_test.go
@@ -90,10 +90,8 @@ func TestHydrateChatContextOnCreate(t *testing.T) {
 	})
 }
 
-// TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied covers the
-// agent-push path: a chat hydrated by the push (first pin, no dirty marker)
-// and a chat flipped to dirty must both get a context watch event, because
-// watching clients refetch pinned resources only on those events.
+// TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied verifies one
+// event per hydrated, dirtied, or MCP-synced chat.
 func TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -131,8 +129,7 @@ func TestHydrateAndMarkChatsDirtyPublishesForHydratedAndDirtied(t *testing.T) {
 		AggregateHash: hash,
 		DirtySince:    sql.NullTime{Time: now, Valid: true},
 	}).Return([]database.MarkChatsContextDirtyByAgentRow{{ID: dirtiedChat.ID, OwnerID: ownerID}}, nil)
-	// The MCP sync reports the dirtied chat too; the publish path must
-	// dedupe it so each touched chat gets exactly one event.
+	// Return the dirtied chat from the sync to verify event deduplication.
 	db.EXPECT().SyncAgentChatsContextMCPResources(gomock.Any(), agentID).
 		Return([]uuid.UUID{syncedChat.ID, dirtiedChat.ID}, nil)
 	db.EXPECT().GetChatByID(gomock.Any(), hydratedChat.ID).Return(hydratedChat, nil)

--- a/coderd/x/chatd/context_integration_test.go
+++ b/coderd/x/chatd/context_integration_test.go
@@ -277,15 +277,9 @@ func TestChatContextDirtyFromAgentPush(t *testing.T) {
 	require.False(t, got.Context.Dirty, "re-push of the pinned hash stays clean")
 }
 
-// TestChatContextMCPSyncFromAgentPush is an end-to-end regression for MCP
-// resources going stale on pinned chats. MCP resources are excluded from the
-// drift hash, so after a workspace restart a chat re-pinned before the
-// agent's MCP engine finished connecting used to keep zero MCP servers
-// forever: the later push carried the same hash and neither hydrated nor
-// dirtied the chat. Every same-hash push must now live-sync the pinned
-// mcp rows of all bound chats (add, update, and remove) without marking
-// them dirty, while prompt resources stay pinned until an explicit
-// refresh.
+// TestChatContextMCPSyncFromAgentPush verifies that agent pushes live-sync MCP
+// resources across bound chats without dirtying them, while prompt resources
+// remain pinned until refresh.
 func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 	t.Parallel()
 
@@ -329,10 +323,7 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 		})
 	}
 	chat := newBoundChat()
-	// A second bound chat proves the sync fans out to every chat bound to
-	// the agent, not just one.
 	secondChat := newBoundChat()
-	// An agent-less chat guards the agent scoping of the sync query.
 	otherChat := dbgen.Chat(t, db, database.Chat{
 		OrganizationID:    user.OrganizationID,
 		OwnerID:           user.UserID,
@@ -400,9 +391,7 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = aAPI.DRPCConn().Close() }()
 
-	// The agent's first push happens before its MCP engine finished
-	// connecting: instruction only, no MCP servers. This is the snapshot a
-	// restarted workspace's chat re-pins against.
+	// Model an initial push before the MCP engine connects.
 	hash := []byte{0x01, 0x02}
 	resp, err := aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
 		Version:       1,
@@ -416,10 +405,7 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 	requireClean(chat.ID, "chat hydrates clean from the MCP-less snapshot")
 	require.Len(t, pinnedResources(chat.ID), 1, "no MCP rows before the engine connects")
 
-	// The MCP engine finishes connecting and the agent pushes again. The
-	// drift hash is unchanged (MCP is excluded from it), so this used to be
-	// a no-op for pinned chats; it must now sync the MCP rows onto every
-	// bound chat without dirtying them.
+	// A same-hash push must sync MCP rows without dirtying bound chats.
 	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
 		Version:       2,
 		AggregateHash: hash,
@@ -440,8 +426,6 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 	}
 	require.Empty(t, pinnedResources(otherChat.ID), "agent-less chat stays untouched")
 
-	// The single-chat GET reports the synced server with its (unprefixed)
-	// tools, so the UI inventory matches without a manual refresh.
 	var mcpRes *codersdk.ChatContextResource
 	for i, r := range got.Context.Resources {
 		if r.Kind == codersdk.ChatContextResourceKindMCPServer {
@@ -456,7 +440,6 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 	}
 	require.ElementsMatch(t, []string{"query", "search"}, toolNames)
 
-	// A same-hash push with a changed tool list updates the synced row.
 	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
 		Version:       3,
 		AggregateHash: hash,
@@ -470,7 +453,6 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 	requireClean(chat.ID, "tool-list change must not dirty the chat")
 	require.Equal(t, toolsV2Hash, pinnedResources(chat.ID)[mcpSource].ContentHash, "changed tool list syncs")
 
-	// A same-hash push without the server removes the stale row.
 	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
 		Version:       4,
 		AggregateHash: hash,
@@ -485,9 +467,7 @@ func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
 		require.NotContains(t, pinned, mcpSource)
 	}
 
-	// A push whose drift hash differs marks the chat dirty as before, and
-	// still syncs the MCP rows: prompt content stays pinned until refresh,
-	// MCP capability tracks the agent.
+	// Drifted pushes still sync MCP rows while leaving prompt rows pinned.
 	driftedHash := []byte{0x03, 0x04}
 	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
 		Version:       5,

--- a/coderd/x/chatd/context_integration_test.go
+++ b/coderd/x/chatd/context_integration_test.go
@@ -277,6 +277,239 @@ func TestChatContextDirtyFromAgentPush(t *testing.T) {
 	require.False(t, got.Context.Dirty, "re-push of the pinned hash stays clean")
 }
 
+// TestChatContextMCPSyncFromAgentPush is an end-to-end regression for MCP
+// resources going stale on pinned chats. MCP resources are excluded from the
+// drift hash, so after a workspace restart a chat re-pinned before the
+// agent's MCP engine finished connecting used to keep zero MCP servers
+// forever: the later push carried the same hash and neither hydrated nor
+// dirtied the chat. Every same-hash push must now live-sync the pinned
+// mcp rows of all bound chats (add, update, and remove) without marking
+// them dirty, while prompt resources stay pinned until an explicit
+// refresh.
+func TestChatContextMCPSyncFromAgentPush(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		DeploymentValues:         coderdtest.DeploymentValues(t),
+		IncludeProvisionerDaemon: true,
+	})
+	db := api.Database
+	aibridgedtest.StartTestAIBridgeDaemon(t.Context(), t, api, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
+
+	agentToken := uuid.NewString()
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+		Parse:          echo.ParseComplete,
+		ProvisionPlan:  echo.PlanComplete,
+		ProvisionApply: echo.ApplyComplete,
+		ProvisionGraph: echo.ProvisionGraphWithAgent(agentToken),
+	})
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+	ws, err := client.Workspace(ctx, workspace.ID)
+	require.NoError(t, err)
+	require.Len(t, ws.LatestBuild.Resources, 1)
+	require.Len(t, ws.LatestBuild.Resources[0].Agents, 1)
+	agentID := ws.LatestBuild.Resources[0].Agents[0].ID
+
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	newBoundChat := func() database.Chat {
+		return dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    user.OrganizationID,
+			OwnerID:           user.UserID,
+			WorkspaceID:       uuid.NullUUID{UUID: workspace.ID, Valid: true},
+			AgentID:           uuid.NullUUID{UUID: agentID, Valid: true},
+			LastModelConfigID: model.ID,
+			Status:            database.ChatStatusWaiting,
+		})
+	}
+	chat := newBoundChat()
+	// A second bound chat proves the sync fans out to every chat bound to
+	// the agent, not just one.
+	secondChat := newBoundChat()
+	// An agent-less chat guards the agent scoping of the sync query.
+	otherChat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    user.OrganizationID,
+		OwnerID:           user.UserID,
+		LastModelConfigID: model.ID,
+		Status:            database.ChatStatusWaiting,
+	})
+
+	agentsSource := "/home/coder/workspace/AGENTS.md"
+	mcpSource := "grafana"
+	agentsHash := []byte{0x11}
+	toolsV1Hash := []byte{0x21}
+	toolsV2Hash := []byte{0x22}
+	instructionResource := func() *agentproto.ContextResource {
+		return &agentproto.ContextResource{
+			Source:      agentsSource,
+			ContentHash: agentsHash,
+			SizeBytes:   8,
+			Status:      agentproto.ContextResource_OK,
+			Body: &agentproto.ContextResource_InstructionFile{
+				InstructionFile: &agentproto.InstructionFileBody{Content: []byte("hello-v1")},
+			},
+		}
+	}
+	mcpServerResource := func(hash []byte, toolNames ...string) *agentproto.ContextResource {
+		tools := make([]*agentproto.MCPTool, 0, len(toolNames))
+		for _, name := range toolNames {
+			tools = append(tools, &agentproto.MCPTool{
+				// The agent reports tool names prefixed with "<server>__".
+				Name:        mcpSource + "__" + name,
+				Description: name + " tool",
+			})
+		}
+		return &agentproto.ContextResource{
+			Source:      mcpSource,
+			ContentHash: hash,
+			SizeBytes:   32,
+			Status:      agentproto.ContextResource_OK,
+			Body: &agentproto.ContextResource_McpServer{
+				McpServer: &agentproto.MCPServerBody{ServerName: mcpSource, Tools: tools},
+			},
+		}
+	}
+	pinnedResources := func(id uuid.UUID) map[string]database.ChatContextResource {
+		t.Helper()
+		//nolint:gocritic // Test reads the chat-owned rows as the chatd subject; ctx carries no per-user actor.
+		rows, lerr := db.ListChatContextResourcesByChatID(dbauthz.AsChatd(ctx), id)
+		require.NoError(t, lerr)
+		out := make(map[string]database.ChatContextResource, len(rows))
+		for _, r := range rows {
+			out[r.Source] = r
+		}
+		return out
+	}
+	requireClean := func(id uuid.UUID, msg string) codersdk.Chat {
+		t.Helper()
+		got, gerr := expClient.GetChat(ctx, id)
+		require.NoError(t, gerr)
+		require.NotNil(t, got.Context, msg)
+		require.False(t, got.Context.Dirty, msg)
+		return got
+	}
+
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(agentToken))
+	aAPI, _, err := agentClient.ConnectRPC210(ctx)
+	require.NoError(t, err)
+	defer func() { _ = aAPI.DRPCConn().Close() }()
+
+	// The agent's first push happens before its MCP engine finished
+	// connecting: instruction only, no MCP servers. This is the snapshot a
+	// restarted workspace's chat re-pins against.
+	hash := []byte{0x01, 0x02}
+	resp, err := aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       1,
+		Initial:       true,
+		AggregateHash: hash,
+		Resources:     []*agentproto.ContextResource{instructionResource()},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	requireClean(chat.ID, "chat hydrates clean from the MCP-less snapshot")
+	require.Len(t, pinnedResources(chat.ID), 1, "no MCP rows before the engine connects")
+
+	// The MCP engine finishes connecting and the agent pushes again. The
+	// drift hash is unchanged (MCP is excluded from it), so this used to be
+	// a no-op for pinned chats; it must now sync the MCP rows onto every
+	// bound chat without dirtying them.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       2,
+		AggregateHash: hash,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpServerResource(toolsV1Hash, "query", "search"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	got := requireClean(chat.ID, "same-hash MCP push must not dirty the chat")
+	for _, id := range []uuid.UUID{chat.ID, secondChat.ID} {
+		pinned := pinnedResources(id)
+		require.Len(t, pinned, 2, "MCP row synced onto chat %s", id)
+		require.Equal(t, toolsV1Hash, pinned[mcpSource].ContentHash)
+		require.Equal(t, database.WorkspaceAgentContextBodyKindMcpServer, pinned[mcpSource].BodyKind)
+	}
+	require.Empty(t, pinnedResources(otherChat.ID), "agent-less chat stays untouched")
+
+	// The single-chat GET reports the synced server with its (unprefixed)
+	// tools, so the UI inventory matches without a manual refresh.
+	var mcpRes *codersdk.ChatContextResource
+	for i, r := range got.Context.Resources {
+		if r.Kind == codersdk.ChatContextResourceKindMCPServer {
+			mcpRes = &got.Context.Resources[i]
+		}
+	}
+	require.NotNil(t, mcpRes, "GET reports the synced MCP server")
+	require.Equal(t, mcpSource, mcpRes.Source)
+	toolNames := make([]string, 0, len(mcpRes.Tools))
+	for _, tool := range mcpRes.Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	require.ElementsMatch(t, []string{"query", "search"}, toolNames)
+
+	// A same-hash push with a changed tool list updates the synced row.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       3,
+		AggregateHash: hash,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpServerResource(toolsV2Hash, "query", "search", "annotate"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+	requireClean(chat.ID, "tool-list change must not dirty the chat")
+	require.Equal(t, toolsV2Hash, pinnedResources(chat.ID)[mcpSource].ContentHash, "changed tool list syncs")
+
+	// A same-hash push without the server removes the stale row.
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       4,
+		AggregateHash: hash,
+		Resources:     []*agentproto.ContextResource{instructionResource()},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+	requireClean(chat.ID, "server removal must not dirty the chat")
+	for _, id := range []uuid.UUID{chat.ID, secondChat.ID} {
+		pinned := pinnedResources(id)
+		require.Len(t, pinned, 1, "removed server deleted from chat %s", id)
+		require.NotContains(t, pinned, mcpSource)
+	}
+
+	// A push whose drift hash differs marks the chat dirty as before, and
+	// still syncs the MCP rows: prompt content stays pinned until refresh,
+	// MCP capability tracks the agent.
+	driftedHash := []byte{0x03, 0x04}
+	resp, err = aAPI.PushContextState(ctx, &agentproto.PushContextStateRequest{
+		Version:       5,
+		AggregateHash: driftedHash,
+		Resources: []*agentproto.ContextResource{
+			instructionResource(),
+			mcpServerResource(toolsV1Hash, "query"),
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+
+	got, err = expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Context)
+	require.True(t, got.Context.Dirty, "drift still marks the chat dirty")
+	pinned := pinnedResources(chat.ID)
+	require.Len(t, pinned, 2)
+	require.Equal(t, toolsV1Hash, pinned[mcpSource].ContentHash, "MCP row syncs even on a dirty chat")
+	require.Equal(t, agentsHash, pinned[agentsSource].ContentHash, "prompt rows stay pinned while dirty")
+}
+
 // TestChatContextRefreshFromAgentToken covers the in-workspace
 // `coder exp chat context refresh` (no chat argument) path, which authenticates
 // with the agent token instead of a user session. The agent endpoint re-pins


### PR DESCRIPTION
## Problem

Chats pin a copy of the bound agent's context resources, and turn-time MCP tool discovery, the system prompt, and the UI context inventory all read only that pinned copy. MCP resources are deliberately excluded from the context drift hash so servers connecting asynchronously do not dirty every chat, but nothing else ever updated the pinned MCP rows either. Since #28441 re-pins context on every bind, a restarted chat almost always pins during the new agent's MCP handshake window and captures zero MCP servers; the next context push carries an unchanged hash, so the chat is never re-hydrated and permanently loses its MCP tools until a manual context refresh.

## Fix

Add a `SyncAgentChatsContextMCPResources` query and run it inside every accepted `PushContextState` transaction via `HydrateAndMarkChatsDirty`. For hydrated, non-archived chats bound to the pushing agent whose pinned `mcp_config`/`mcp_server` rows differ from the agent's current set, it row-locks the changed chats (serializing against the rebind re-pin), replaces the stale rows, and publishes the existing `context_dirty` watch event so open UIs refetch. Instruction and skill content keeps the pin-until-refresh drift model; MCP capability now live-tracks the agent, matching the documented design intent.

> 🤖 Xum (an AI agent) created this pull request on behalf of @ibetitsmike.

