### PR TITLE
docs(docs/admin/templates/extending-templates): document module caching and the disable toggle

### DIFF
--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -852,6 +852,23 @@ You may see warnings in the provisioner logs:
 
 If encountered, reduce the size of the module by removing unnecessary files.
 
+You can hit the same error for a different reason: if the active template
+version has no cached module archive at all, the workspace creation form
+shows a warning for every module in the template, for example:
+
+```txt
+Module not loaded. Did you run `terraform init`?
+Module 'jetbrains' in file "main.tf:149,1-19" cannot be resolved. This module will be ignored.
+```
+
+This happens for template versions published before Coder started archiving
+modules for Dynamic Parameters. **Workspace builds still succeed**, since
+Terraform fetches modules from their original sources during the build
+regardless of the cache; only the form's ability to evaluate module-backed
+parameter values is affected. To fix it,
+[publish a new template version](../managing-templates/index.md#refresh-template-data),
+which re-runs `terraform init` and populates the archive for that version.
+
 This archive is the same one Coder reuses across workspace builds to avoid
 re-downloading modules. See [module caching](./modules.md#module-caching) for
 how to disable that behavior for a template.

--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -812,7 +812,7 @@ Enabling Dynamic Parameters on an existing template requires administrators to p
 This will resolve the necessary template metadata to render the form.
 To publish one without editing the template's Terraform, [refresh the template data](../managing-templates/index.md#refresh-template-data).
 
-### Reverting to classic parameters
+### Revert to classic parameters
 
 The classic parameter flow is deprecated and will be removed in a future release.
 If a template does not work with Dynamic Parameters, you can opt that template out.

--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -851,3 +851,7 @@ You may see warnings in the provisioner logs:
 ```
 
 If encountered, reduce the size of the module by removing unnecessary files.
+
+This archive is the same one Coder reuses across workspace builds to avoid
+re-downloading modules. See [module caching](./modules.md#module-caching) for
+how to disable that behavior for a template.

--- a/docs/admin/templates/extending-templates/modules.md
+++ b/docs/admin/templates/extending-templates/modules.md
@@ -67,7 +67,12 @@ being slow or temporarily unavailable.
 Coder limits cached module archives to 20MB per template version. If your
 modules exceed this limit, some are skipped and unavailable for [Dynamic
 Parameters](./dynamic-parameters.md#module-not-loaded-errors-when-using-dynamic-parameters)
-evaluation, though builds still fetch the skipped modules directly.
+evaluation, though builds still fetch the skipped modules directly. Template
+versions published before Coder started archiving modules have no cache at
+all, which produces the same ["Module not
+loaded"](./dynamic-parameters.md#module-not-loaded-errors-when-using-dynamic-parameters)
+warnings for every module in the workspace creation form; publishing a new
+template version fixes this.
 
 To force Coder to re-download modules on every workspace build instead of
 using the cached archive, select **Disable Terraform module caching** in a

--- a/docs/admin/templates/extending-templates/modules.md
+++ b/docs/admin/templates/extending-templates/modules.md
@@ -1,4 +1,4 @@
-# Reusing template code
+# Reuse template code
 
 To reuse code across different Coder templates, such as common scripts or
 resource definitions, we suggest using
@@ -189,7 +189,7 @@ If you are running Coder on Docker or Kubernetes, `git` is pre-installed in the
 Coder image. However, you still need to mount credentials. This can be done via
 a Docker volume mount or Kubernetes secrets.
 
-#### Passing git credentials in Kubernetes
+#### Pass git credentials in Kubernetes
 
 First, create a `.gitconfig` and `.git-credentials` file on your local machine.
 You might want to do this in a temporary directory to avoid conflicting with

--- a/docs/admin/templates/extending-templates/modules.md
+++ b/docs/admin/templates/extending-templates/modules.md
@@ -52,6 +52,33 @@ across templates. Some of the modules we publish are,
 For a full list of available modules please check
 [Coder module registry](https://registry.coder.com/modules).
 
+## Module caching
+
+Module caching is enabled by default for all templates. When you publish a
+new template version, Coder runs `terraform init` to resolve every module the
+template references, then archives the resulting `.terraform/modules`
+directory and stores it alongside that template version. On every subsequent
+workspace build, Coder provisioners reuse this cached archive instead of
+re-fetching modules from their original sources (a git repository, the Coder
+registry, or another Terraform registry). This avoids redundant network and
+disk I/O on each build and prevents build failures caused by a module source
+being slow or temporarily unavailable.
+
+Coder limits cached module archives to 20MB per template version. If your
+modules exceed this limit, some are skipped and unavailable for [Dynamic
+Parameters](./dynamic-parameters.md#module-not-loaded-errors-when-using-dynamic-parameters)
+evaluation, though builds still fetch the skipped modules directly.
+
+To force Coder to re-download modules on every workspace build instead of
+using the cached archive, select **Disable Terraform module caching** in a
+template's **Settings** > **General** page, or set `disable_module_cache` to
+`true` with the [templates API](../../../reference/api/templates.md#update-template-settings-by-id).
+
+> [!WARNING]
+> Disabling module caching makes workspace builds slower and less
+> predictable, since Terraform re-resolves and downloads every module on each
+> build. This isn't recommended for production templates.
+
 ## Offline installations
 
 In offline and restricted deployments, there are three ways to fetch modules.


### PR DESCRIPTION
Coder caches resolved Terraform modules per template version and reuses them across workspace builds instead of re-fetching from origin. This is enabled by default and can be disabled per-template with `disable_module_cache`, but neither the caching behavior nor the toggle were documented anywhere outside the generated API reference.

Documents module caching in the Terraform Modules guide (what gets cached, the 20MB archive limit, and how to disable it), and cross-links it from the existing "Module not loaded" troubleshooting entry in the Dynamic Parameters doc, since both describe the same module archive.

Also documents a second cause of "Module not loaded" warnings: template versions published before Coder started archiving modules for Dynamic Parameters have no cache at all, so every module in the template shows the warning in the workspace creation form. Workspace builds still succeed, since Terraform fetches modules from their original sources during the build regardless of the cache; only the form's ability to evaluate module-backed parameter values is affected. Publishing a new template version regenerates the archive and resolves it.

<details>
<summary>Verification notes</summary>

Behavior confirmed by reading the source, not assumed:

- `coderd/provisionerdserver/provisionerdserver.go`: skips fetching `CachedModuleFiles` for a workspace build when `template.DisableModuleCache` is set. The same file's comment ("Older templates (before dynamic parameters) will not have cached module files") confirms why some template versions have no archive at all.
- `provisioner/terraform/provision.go` + `provisionerd/runner/init.go`: the cached archive is extracted into `.terraform/modules` before `terraform init` runs, so modules already present are not re-downloaded; anything missing (e.g. skipped for size, or no archive at all) is still fetched normally by Terraform during the build.
- `provisioner/terraform/modules.go`: `MaximumModuleArchiveSize` = 20MB.
- `coderd/database/migrations/000416_workspace_module_reuse_toggle.up.sql`: `disable_module_cache` defaults to `false`, i.e. caching is on by default.
- `site/.../TemplateSettingsForm.tsx`: exact dashboard label and warning copy reused verbatim in the doc.

</details>

> Generated by Coder Agents
