### PR TITLE
fix: deflake config-ssh tests with per-invocation contexts

### DIFF
--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -67,7 +67,6 @@ func TestConfigSSH(t *testing.T) {
 	}
 
 	logger := testutil.Logger(t)
-	ctx := testutil.Context(t, testutil.WaitMedium)
 	const hostname = "test-coder."
 	const expectedKey = "ConnectionAttempts"
 	const removeKey = "ConnectTimeout"
@@ -138,7 +137,10 @@ func TestConfigSSH(t *testing.T) {
 	stdout := expecter.NewAttachedToInvocation(t, inv)
 	stdin := testutil.NewWriterAttachedToInvocation(t, logger.Named("stdin"), inv)
 
-	waiter := clitest.StartWithWaiter(t, inv)
+	// Created here so setup does not drain it. WaitLong because config-ssh
+	// fsyncs the SSH config and fsync ignores the context.
+	ctx := testutil.Context(t, testutil.WaitLong)
+	waiter := clitest.StartWithWaiter(t, inv.WithContext(ctx))
 
 	matches := []struct {
 		match, write string
@@ -980,7 +982,6 @@ func TestConfigSSH_NoWildcard(t *testing.T) {
 		t.Skip("See coder/internal#117")
 	}
 
-	ctx := testutil.Context(t, testutil.WaitMedium)
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	user := coderdtest.CreateFirstUser(t, client)
 
@@ -1007,6 +1008,7 @@ func TestConfigSSH_NoWildcard(t *testing.T) {
 	sshConfigPath := sshConfigFileName(t)
 
 	runConfigSSH := func() {
+		t.Helper()
 		inv, root := clitest.New(t,
 			"config-ssh",
 			"--ssh-config-file", sshConfigPath,
@@ -1016,6 +1018,8 @@ func TestConfigSSH_NoWildcard(t *testing.T) {
 		)
 		//nolint:gocritic // This has always ran with the admin user.
 		clitest.SetupConfig(t, client, root)
+		// A fresh budget per run, so setup and the first run do not drain it.
+		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
Closes [PLAT-563](https://linear.app/codercom/issue/PLAT-563/flake-testconfigssh-multiple-variants)

## Problem

`TestConfigSSH` and `TestConfigSSH_NoWildcard` both failed at `cli/configssh.go:568` with `context deadline exceeded` in [this run](https://github.com/coder/coder/actions/runs/33414383561/job/99561585574).

- Both commands made their API calls promptly, then went silent for ~18.4s, then printed `Updated ".../.ssh/config"` and failed the next HTTP call.
- The only code in that window is `atomic.WriteFile`, which calls `f.Sync()`. fsync takes no context and cannot be cancelled.
- Both gaps ended in the same millisecond while other goroutines in both processes kept logging on schedule, so this was a shared filesystem stall, not CPU starvation or a crashed server.
- `configssh.go:568` is the reporting site, not the fault site. The fsync drained the context, so the next request failed before dialing.
- Both tests made this easier to hit by creating one `WaitMedium` context before server, agent, and workspace setup, so the command ran on whatever budget was left over.

## Fix

- One context per `config-ssh` invocation, created just before it runs, so setup and prior runs cannot drain it.
- `WaitMedium` (15s) to `WaitLong` (25s), to cover a slow disk on top of the HTTP calls.
- `TestConfigSSH` passes that context to the invocation, so `StartWithWaiter` inherits it instead of injecting a second, independent `WaitMedium` deadline.

Failed 20/20 under 4.8x CPU oversubscription before the change, 0/20 after.

This buys margin, it does not remove the failure mode: an uncancellable fsync still sits inside a context-bounded command. The higher-leverage follow-up is CI side (the Postgres container runs `log_statement=all` on Docker's json-file driver, and `$RUNNER_TEMP` is not on tmpfs for Linux). Filing that separately.
