### PR TITLE
refactor(site): move `<ActiveUserChart />` to better location and update tooltips

### DIFF
--- a/site/src/components/ActiveUserChart/ActiveUserChart.tsx
+++ b/site/src/components/ActiveUserChart/ActiveUserChart.tsx
@@ -6,13 +6,6 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from "#/components/Chart/Chart";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
 import { formatDate } from "#/utils/time";
 
 const chartConfig = {
@@ -109,29 +102,5 @@ export const ActiveUserChart: FC<ActiveUserChartProps> = ({ data }) => {
 				/>
 			</AreaChart>
 		</ChartContainer>
-	);
-};
-
-type ActiveUsersTitleProps = {
-	interval: "day" | "week";
-};
-
-export const ActiveUsersTitle: FC<ActiveUsersTitleProps> = ({ interval }) => {
-	return (
-		<div className="flex items-center gap-2">
-			{interval === "day" ? "Daily" : "Weekly"} Active Users
-			<HelpPopover>
-				<HelpPopoverIconTrigger size="small" />
-				<HelpPopoverContent>
-					<HelpPopoverTitle>How do we calculate active users?</HelpPopoverTitle>
-					<HelpPopoverText>
-						When a connection is initiated to a user&apos;s workspace they are
-						considered an active user. e.g. apps, web terminal, SSH. This is for
-						measuring user activity and has no connection to license
-						consumption.
-					</HelpPopoverText>
-				</HelpPopoverContent>
-			</HelpPopover>
-		</div>
 	);
 };

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/ActiveUserChart.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/ActiveUserChart.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ActiveUserChart } from "./ActiveUserChart";
 
 const meta: Meta<typeof ActiveUserChart> = {
-	title: "components/ActiveUserChart",
+	title: "pages/TemplatePage/TemplateInsightsPage/ActiveUserChart",
 	component: ActiveUserChart,
 	args: {
 		data: [

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/ActiveUserChart.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/ActiveUserChart.tsx
@@ -14,6 +14,7 @@ const chartConfig = {
 		color: "hsl(var(--highlight-purple))",
 	},
 } satisfies ChartConfig;
+
 interface ActiveUserChartProps {
 	data: { date: string; amount: number }[];
 }

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -28,10 +28,7 @@ import type {
 	UserActivityInsightsResponse,
 	UserLatencyInsightsResponse,
 } from "#/api/typesGenerated";
-import {
-	ActiveUserChart,
-	ActiveUsersTitle,
-} from "#/components/ActiveUserChart/ActiveUserChart";
+import { ActiveUserChart } from "#/components/ActiveUserChart/ActiveUserChart";
 import { Avatar } from "#/components/Avatar/Avatar";
 import {
 	DateRangePicker as DailyPicker,
@@ -285,8 +282,22 @@ const ActiveUsersPanel: FC<ActiveUsersPanelProps> = ({
 	return (
 		<Panel {...panelProps}>
 			<PanelHeader>
-				<PanelTitle>
-					<ActiveUsersTitle interval={interval} />
+				<PanelTitle className="flex items-center gap-2">
+					{interval === "day" ? "Daily" : "Weekly"} Active Users
+					<HelpPopover>
+						<HelpPopoverIconTrigger size="small" />
+						<HelpPopoverContent>
+							<HelpPopoverTitle>
+								How do we calculate active users?
+							</HelpPopoverTitle>
+							<HelpPopoverText>
+								When a connection is initiated to a user&apos;s workspace they
+								are considered an active user. e.g. apps, web terminal, SSH.
+								This is for measuring user activity and has no connection to
+								license consumption.
+							</HelpPopoverText>
+						</HelpPopoverContent>
+					</HelpPopover>
 				</PanelTitle>
 			</PanelHeader>
 			<PanelContent error={error} data={data}>

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -28,7 +28,6 @@ import type {
 	UserActivityInsightsResponse,
 	UserLatencyInsightsResponse,
 } from "#/api/typesGenerated";
-import { ActiveUserChart } from "#/components/ActiveUserChart/ActiveUserChart";
 import { Avatar } from "#/components/Avatar/Avatar";
 import {
 	DateRangePicker as DailyPicker,
@@ -63,6 +62,7 @@ import {
 	subtractTime,
 } from "#/utils/time";
 import { getTemplatePageTitle } from "../utils";
+import { ActiveUserChart } from "./ActiveUserChart";
 import { type InsightsInterval, IntervalMenu } from "./IntervalMenu";
 import { lastWeeks } from "./utils";
 import { numberOfWeeksOptions, WeekPicker } from "./WeekPicker";


### PR DESCRIPTION
This component lived in a really odd spot under `site/src/components/`. I've gone ahead and moved this to colocate with its only use and next to the page. Following codebase standards more cleanly.