### PR TITLE
refactor(site): fold `<Badges />` into `Badge/PresetBadges`

### DIFF
--- a/site/src/components/Badge/Badge.stories.tsx
+++ b/site/src/components/Badge/Badge.stories.tsx
@@ -5,9 +5,9 @@ import {
 	SettingsIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
-import { Badges } from "#/components/Badges/Badges";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Badge } from "./Badge";
+import { BadgeGroup } from "./PresetBadges";
 
 const meta: Meta<typeof Badge> = {
 	title: "components/Badge",
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof Badge>;
 
 export const Default: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge size="xs">
 				<DatabaseIcon />
 				Text
@@ -31,13 +31,13 @@ export const Default: Story = {
 				<DatabaseIcon />
 				Text
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
 export const Warning: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="warning" size="xs">
 				Warning
 				<TriangleAlertIcon />
@@ -50,13 +50,13 @@ export const Warning: Story = {
 				<TriangleAlertIcon />
 				Warning
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
 export const Destructive: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="destructive" size="xs">
 				Destructive
 				<TriangleAlertIcon />
@@ -69,13 +69,13 @@ export const Destructive: Story = {
 				<TriangleAlertIcon />
 				Destructive
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
 export const Info: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="info" size="xs">
 				Info
 			</Badge>
@@ -85,13 +85,13 @@ export const Info: Story = {
 			<Badge variant="info" size="md">
 				Info
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
 export const Green: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="green" size="xs">
 				Green
 			</Badge>
@@ -101,13 +101,13 @@ export const Green: Story = {
 			<Badge variant="green" size="md">
 				Green
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
 export const Purple: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="purple" size="xs">
 				Purple
 			</Badge>
@@ -117,13 +117,13 @@ export const Purple: Story = {
 			<Badge variant="purple" size="md">
 				Purple
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
 export const Magenta: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="magenta" size="xs">
 				Magenta
 			</Badge>
@@ -133,7 +133,7 @@ export const Magenta: Story = {
 			<Badge variant="magenta" size="md">
 				Magenta
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };
 
@@ -157,7 +157,7 @@ export const MediumWithIcon: Story = {
 
 export const StatusWithIcon: Story = {
 	render: () => (
-		<Badges>
+		<BadgeGroup>
 			<Badge variant="info" size="md" role="status">
 				<Spinner loading />
 				Running
@@ -170,6 +170,6 @@ export const StatusWithIcon: Story = {
 				<TriangleAlertIcon />
 				Failed
 			</Badge>
-		</Badges>
+		</BadgeGroup>
 	),
 };

--- a/site/src/components/Badge/Badge.stories.tsx
+++ b/site/src/components/Badge/Badge.stories.tsx
@@ -6,8 +6,7 @@ import {
 	TriangleAlertIcon,
 } from "lucide-react";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { Badge } from "./Badge";
-import { BadgeGroup } from "./PresetBadges";
+import { Badge, BadgeGroup } from "./Badge";
 
 const meta: Meta<typeof Badge> = {
 	title: "components/Badge",

--- a/site/src/components/Badge/Badge.tsx
+++ b/site/src/components/Badge/Badge.tsx
@@ -93,3 +93,9 @@ export const Badge: React.FC<BadgeProps> = ({
 		/>
 	);
 };
+
+export const BadgeGroup: React.FC<React.PropsWithChildren> = ({ children }) => {
+	return (
+		<div className="flex flex-row items-center gap-2 mb-4">{children}</div>
+	);
+};

--- a/site/src/components/Badge/Badge.tsx
+++ b/site/src/components/Badge/Badge.tsx
@@ -94,7 +94,9 @@ export const Badge: React.FC<BadgeProps> = ({
 	);
 };
 
-export const BadgeGroup: React.FC<React.PropsWithChildren> = ({ children }) => {
+export const BadgeGroup: React.FC<React.PropsWithChildren> = ({
+	children,
+}) => {
 	return (
 		<div className="flex flex-row items-center gap-2 mb-4">{children}</div>
 	);

--- a/site/src/components/Badge/Badge.tsx
+++ b/site/src/components/Badge/Badge.tsx
@@ -94,9 +94,7 @@ export const Badge: React.FC<BadgeProps> = ({
 	);
 };
 
-export const BadgeGroup: React.FC<React.PropsWithChildren> = ({
-	children,
-}) => {
+export const BadgeGroup: React.FC<React.PropsWithChildren> = ({ children }) => {
 	return (
 		<div className="flex flex-row items-center gap-2 mb-4">{children}</div>
 	);

--- a/site/src/components/Badge/PresetBadges.stories.tsx
+++ b/site/src/components/Badge/PresetBadges.stories.tsx
@@ -1,48 +1,52 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
 	AlphaBadge,
-	Badges,
+	BadgeGroup,
 	DeprecatedBadge,
 	DisabledBadge,
 	EnabledBadge,
 	EnterpriseBadge,
 	PremiumBadge,
-} from "./Badges";
+} from "./PresetBadges";
 
-const meta: Meta<typeof Badges> = {
-	title: "components/Badges",
-	component: Badges,
-	args: {},
+const meta: Meta<typeof BadgeGroup> = {
+	title: "components/Badge/PresetBadges",
+	component: BadgeGroup,
 };
 
 export default meta;
-type Story = StoryObj<typeof Badges>;
+type Story = StoryObj<typeof BadgeGroup>;
 
 export const Enabled: Story = {
 	args: {
 		children: <EnabledBadge />,
 	},
 };
+
 export const Disabled: Story = {
 	args: {
 		children: <DisabledBadge />,
 	},
 };
+
 export const Premium: Story = {
 	args: {
 		children: <PremiumBadge />,
 	},
 };
+
 export const Alpha: Story = {
 	args: {
 		children: <AlphaBadge />,
 	},
 };
+
 export const Enterprise: Story = {
 	args: {
 		children: <EnterpriseBadge />,
 	},
 };
+
 export const Deprecated: Story = {
 	args: {
 		children: <DeprecatedBadge />,

--- a/site/src/components/Badge/PresetBadges.stories.tsx
+++ b/site/src/components/Badge/PresetBadges.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BadgeGroup } from "./Badge";
 import {
 	AlphaBadge,
-	BadgeGroup,
 	DeprecatedBadge,
 	DisabledBadge,
 	EnabledBadge,

--- a/site/src/components/Badge/PresetBadges.tsx
+++ b/site/src/components/Badge/PresetBadges.tsx
@@ -1,6 +1,7 @@
-import { Badge } from "#/components/Badge/Badge";
+import type { ComponentPropsWithRef, FC, PropsWithChildren } from "react";
+import { Badge } from "./Badge";
 
-export const EnabledBadge: React.FC = () => {
+export const EnabledBadge: FC = () => {
 	return (
 		<Badge className="option-enabled" variant="green">
 			Enabled
@@ -8,7 +9,7 @@ export const EnabledBadge: React.FC = () => {
 	);
 };
 
-export const DisabledBadge: React.FC<React.ComponentPropsWithRef<"div">> = ({
+export const DisabledBadge: FC<ComponentPropsWithRef<"div">> = ({
 	...props
 }) => {
 	return (
@@ -18,29 +19,25 @@ export const DisabledBadge: React.FC<React.ComponentPropsWithRef<"div">> = ({
 	);
 };
 
-export const EnterpriseBadge: React.FC = () => {
+export const EnterpriseBadge: FC = () => {
 	return <Badge variant="purple">Enterprise</Badge>;
 };
 
-interface PremiumBadgeProps {
-	children?: React.ReactNode;
-}
-
-export const PremiumBadge: React.FC<PremiumBadgeProps> = ({
+export const PremiumBadge: FC<PropsWithChildren> = ({
 	children = "Premium",
 }) => {
 	return <Badge variant="magenta">{children}</Badge>;
 };
 
-export const AlphaBadge: React.FC = () => {
+export const AlphaBadge: FC = () => {
 	return <Badge variant="purple">Alpha</Badge>;
 };
 
-export const DeprecatedBadge: React.FC = () => {
+export const DeprecatedBadge: FC = () => {
 	return <Badge variant="warning">Deprecated</Badge>;
 };
 
-export const Badges: React.FC<React.PropsWithChildren> = ({ children }) => {
+export const BadgeGroup: FC<PropsWithChildren> = ({ children }) => {
 	return (
 		<div className="flex flex-row items-center gap-2 mb-4">{children}</div>
 	);

--- a/site/src/components/Badge/PresetBadges.tsx
+++ b/site/src/components/Badge/PresetBadges.tsx
@@ -1,7 +1,6 @@
-import type { ComponentPropsWithRef, FC, PropsWithChildren } from "react";
 import { Badge } from "./Badge";
 
-export const EnabledBadge: FC = () => {
+export const EnabledBadge: React.FC = () => {
 	return (
 		<Badge className="option-enabled" variant="green">
 			Enabled
@@ -9,7 +8,7 @@ export const EnabledBadge: FC = () => {
 	);
 };
 
-export const DisabledBadge: FC<ComponentPropsWithRef<"div">> = ({
+export const DisabledBadge: React.FC<React.ComponentPropsWithRef<"div">> = ({
 	...props
 }) => {
 	return (
@@ -19,26 +18,20 @@ export const DisabledBadge: FC<ComponentPropsWithRef<"div">> = ({
 	);
 };
 
-export const EnterpriseBadge: FC = () => {
+export const EnterpriseBadge: React.FC = () => {
 	return <Badge variant="purple">Enterprise</Badge>;
 };
 
-export const PremiumBadge: FC<PropsWithChildren> = ({
+export const PremiumBadge: React.FC<React.PropsWithChildren> = ({
 	children = "Premium",
 }) => {
 	return <Badge variant="magenta">{children}</Badge>;
 };
 
-export const AlphaBadge: FC = () => {
+export const AlphaBadge: React.FC = () => {
 	return <Badge variant="purple">Alpha</Badge>;
 };
 
-export const DeprecatedBadge: FC = () => {
+export const DeprecatedBadge: React.FC = () => {
 	return <Badge variant="warning">Deprecated</Badge>;
-};
-
-export const BadgeGroup: FC<PropsWithChildren> = ({ children }) => {
-	return (
-		<div className="flex flex-row items-center gap-2 mb-4">{children}</div>
-	);
 };

--- a/site/src/components/Form/Form.tsx
+++ b/site/src/components/Form/Form.tsx
@@ -6,7 +6,7 @@ import {
 	type ReactNode,
 	useContext,
 } from "react";
-import { AlphaBadge, DeprecatedBadge } from "#/components/Badges/Badges";
+import { AlphaBadge, DeprecatedBadge } from "#/components/Badge/PresetBadges";
 import { cn } from "#/utils/cn";
 
 type FormContextValue = { direction?: "horizontal" | "vertical" };

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
@@ -1,10 +1,10 @@
 import type { FC } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
 import {
-	Badges,
+	BadgeGroup,
 	DisabledBadge,
 	EnabledBadge,
-} from "#/components/Badges/Badges";
+} from "#/components/Badge/PresetBadges";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -60,14 +60,14 @@ export const NetworkSettingsPageView: FC<NetworkSettingsPageViewProps> = ({
 				</SettingsHeaderDescription>
 			</SettingsHeader>
 
-			<Badges>
+			<BadgeGroup>
 				{useDeploymentOptions(options, "Wildcard Access URL")[0].value !==
 				"" ? (
 					<EnabledBadge />
 				) : (
 					<DisabledBadge />
 				)}
-			</Badges>
+			</BadgeGroup>
 		</div>
 	</div>
 );

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
+import { BadgeGroup } from "#/components/Badge/Badge";
 import {
-	BadgeGroup,
 	DisabledBadge,
 	EnabledBadge,
 } from "#/components/Badge/PresetBadges";

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.tsx
@@ -1,10 +1,7 @@
 import type { FC } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
 import { BadgeGroup } from "#/components/Badge/Badge";
-import {
-	DisabledBadge,
-	EnabledBadge,
-} from "#/components/Badge/PresetBadges";
+import { DisabledBadge, EnabledBadge } from "#/components/Badge/PresetBadges";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,

--- a/site/src/pages/DeploymentSettingsPage/Option.tsx
+++ b/site/src/pages/DeploymentSettingsPage/Option.tsx
@@ -1,6 +1,6 @@
 import { WrenchIcon } from "lucide-react";
 import type { FC, HTMLAttributes, PropsWithChildren } from "react";
-import { DisabledBadge, EnabledBadge } from "#/components/Badges/Badges";
+import { DisabledBadge, EnabledBadge } from "#/components/Badge/PresetBadges";
 import { cn } from "#/utils/cn";
 
 export const OptionName: FC<PropsWithChildren> = ({ children }) => {

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -1,10 +1,10 @@
 import type { FC } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
 import {
-	Badges,
+	BadgeGroup,
 	DisabledBadge,
 	EnabledBadge,
-} from "#/components/Badges/Badges";
+} from "#/components/Badge/PresetBadges";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -68,9 +68,9 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 						className="items-center"
 					>
 						Browser-Only Connections{" "}
-						<Badges>
+						<BadgeGroup>
 							{featureBrowserOnlyEnabled ? <EnabledBadge /> : <DisabledBadge />}
-						</Badges>
+						</BadgeGroup>
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Block all workspace access via SSH, port forward, and other

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
+import { BadgeGroup } from "#/components/Badge/Badge";
 import {
-	BadgeGroup,
 	DisabledBadge,
 	EnabledBadge,
 } from "#/components/Badge/PresetBadges";

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -1,10 +1,7 @@
 import type { FC } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
 import { BadgeGroup } from "#/components/Badge/Badge";
-import {
-	DisabledBadge,
-	EnabledBadge,
-} from "#/components/Badge/PresetBadges";
+import { DisabledBadge, EnabledBadge } from "#/components/Badge/PresetBadges";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
@@ -1,10 +1,10 @@
 import type { JSX } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
 import {
-	Badges,
+	BadgeGroup,
 	DisabledBadge,
 	EnabledBadge,
-} from "#/components/Badges/Badges";
+} from "#/components/Badge/PresetBadges";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
@@ -52,7 +52,9 @@ export const UserAuthSettingsPageView = ({
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<Badges>{oidcEnabled ? <EnabledBadge /> : <DisabledBadge />}</Badges>
+				<BadgeGroup>
+					{oidcEnabled ? <EnabledBadge /> : <DisabledBadge />}
+				</BadgeGroup>
 
 				{oidcEnabled && (
 					<OptionsTable
@@ -77,7 +79,9 @@ export const UserAuthSettingsPageView = ({
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<Badges>{githubEnabled ? <EnabledBadge /> : <DisabledBadge />}</Badges>
+				<BadgeGroup>
+					{githubEnabled ? <EnabledBadge /> : <DisabledBadge />}
+				</BadgeGroup>
 
 				{githubEnabled && (
 					<OptionsTable

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
@@ -1,10 +1,7 @@
 import type { JSX } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
 import { BadgeGroup } from "#/components/Badge/Badge";
-import {
-	DisabledBadge,
-	EnabledBadge,
-} from "#/components/Badge/PresetBadges";
+import { DisabledBadge, EnabledBadge } from "#/components/Badge/PresetBadges";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "react";
 import type { SerpentOption } from "#/api/typesGenerated";
+import { BadgeGroup } from "#/components/Badge/Badge";
 import {
-	BadgeGroup,
 	DisabledBadge,
 	EnabledBadge,
 } from "#/components/Badge/PresetBadges";

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -2,7 +2,7 @@ import { EllipsisVerticalIcon, PlusIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Link as RouterLink, useNavigate } from "react-router";
 import type { AssignableRoles, Organization, Role } from "#/api/typesGenerated";
-import { PremiumBadge } from "#/components/Badges/Badges";
+import { PremiumBadge } from "#/components/Badge/PresetBadges";
 import { Button, Button as ShadcnButton } from "#/components/Button/Button";
 import {
 	DropdownMenu,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersTable.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersTable.tsx
@@ -6,7 +6,7 @@ import type {
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
-import { PremiumBadge } from "#/components/Badges/Badges";
+import { PremiumBadge } from "#/components/Badge/PresetBadges";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -20,7 +20,7 @@ import type {
 	TemplateVersion,
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { DeprecatedBadge } from "#/components/Badges/Badges";
+import { DeprecatedBadge } from "#/components/Badge/PresetBadges";
 import { Button, Button as ShadcnButton } from "#/components/Button/Button";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { DeleteDialog } from "#/components/Dialog/DeleteDialog/DeleteDialog";

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -7,7 +7,7 @@ import {
 	type UpdateTemplateMeta,
 	WorkspaceAppSharingLevels,
 } from "#/api/typesGenerated";
-import { PremiumBadge } from "#/components/Badges/Badges";
+import { PremiumBadge } from "#/components/Badge/PresetBadges";
 import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import {

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -1,7 +1,7 @@
 import { useFormik } from "formik";
 import type { FC } from "react";
 import * as Yup from "yup";
-import { EnterpriseBadge } from "#/components/Badges/Badges";
+import { EnterpriseBadge } from "#/components/Badge/PresetBadges";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { FormFields } from "#/components/Form/Form";

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -7,7 +7,7 @@ import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { AvatarDataSkeleton } from "#/components/Avatar/AvatarDataSkeleton";
-import { DeprecatedBadge } from "#/components/Badges/Badges";
+import { DeprecatedBadge } from "#/components/Badge/PresetBadges";
 import { Button } from "#/components/Button/Button";
 import {
 	HelpPopover,

--- a/site/src/pages/UsersPage/UsersTable.tsx
+++ b/site/src/pages/UsersPage/UsersTable.tsx
@@ -6,7 +6,7 @@ import type { GroupsByUserId } from "#/api/queries/groups";
 import type * as TypesGen from "#/api/typesGenerated";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { AvatarDataSkeleton } from "#/components/Avatar/AvatarDataSkeleton";
-import { PremiumBadge } from "#/components/Badges/Badges";
+import { PremiumBadge } from "#/components/Badge/PresetBadges";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,


### PR DESCRIPTION
Enabled, Premium, and the other labeled badges are thin Badge wrappers, not a second primitive. Move them into Badge/PresetBadges and rename the layout wrapper to BadgeGroup.