### PR TITLE
chore(site): remove stale shadcn attribution comments

### DIFF
--- a/site/src/components/Avatar/Avatar.tsx
+++ b/site/src/components/Avatar/Avatar.tsx
@@ -1,7 +1,4 @@
 /**
- * Copied from shadc/ui on 12/16/2024
- * @see {@link https://ui.shadcn.com/docs/components/avatar}
- *
  * This component was updated to support the variants and match the styles from
  * the Figma design:
  * @see {@link https://www.figma.com/design/WfqIgsTFXN2BscBSSyXWF8/Coder-kit?node-id=711-383&t=xqxOSUk48GvDsjGK-0}

--- a/site/src/components/Badge/Badge.tsx
+++ b/site/src/components/Badge/Badge.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadcn/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/badge}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/site/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 12/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/breadcrumb}
- */
 import { MoreHorizontalIcon } from "lucide-react";
 import { NavLink } from "react-router";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Button/Button.tsx
+++ b/site/src/components/Button/Button.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 11/06/2024
- * @see {@link https://ui.shadcn.com/docs/components/button}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Chart/Chart.tsx
+++ b/site/src/components/Chart/Chart.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 01/13/2025
- * @see {@link https://ui.shadcn.com/docs/components/chart}
- */
 import { createContext, type Ref, useContext, useId, useMemo } from "react";
 import * as RechartsPrimitive from "recharts";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Checkbox/Checkbox.tsx
+++ b/site/src/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 04/03/2025
- * @see {@link https://ui.shadcn.com/docs/components/checkbox}
- */
 import { CheckIcon, MinusIcon } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Collapsible/Collapsible.tsx
+++ b/site/src/components/Collapsible/Collapsible.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 12/26/2024
- * @see {@link https://ui.shadcn.com/docs/components/collapsible}
- */
 import { Collapsible as CollapsiblePrimitive } from "radix-ui";
 
 const Collapsible = CollapsiblePrimitive.Root;

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/dialog}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { Button } from "#/components/Button/Button";

--- a/site/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/site/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,7 +1,4 @@
 /**
- * Copied from shadc/ui on 12/19/2024
- * @see {@link https://ui.shadcn.com/docs/components/dropdown-menu}
- *
  * This component was updated to match the styles from the Figma design:
  * @see {@link https://www.figma.com/design/WfqIgsTFXN2BscBSSyXWF8/Coder-kit?node-id=656-2354&t=CiGt5le3yJEwMH4M-0}
  */

--- a/site/src/components/Input/Input.tsx
+++ b/site/src/components/Input/Input.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/input}
- */
 import type { ComponentPropsWithRef, FC } from "react";
 import { cn } from "#/utils/cn";
 

--- a/site/src/components/Label/Label.tsx
+++ b/site/src/components/Label/Label.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/label}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { Label as LabelPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Popover/Popover.tsx
+++ b/site/src/components/Popover/Popover.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadcn/ui and modified on 12/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/popover}
- */
 import { Popover as PopoverPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";
 

--- a/site/src/components/RadioGroup/RadioGroup.tsx
+++ b/site/src/components/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 04/04/2025
- * @see {@link https://ui.shadcn.com/docs/components/radio-group}
- */
 import { CircleIcon } from "lucide-react";
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";

--- a/site/src/components/ScrollArea/ScrollArea.tsx
+++ b/site/src/components/ScrollArea/ScrollArea.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 03/05/2025
- * @see {@link https://ui.shadcn.com/docs/components/scroll-area}
- */
 import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";
 

--- a/site/src/components/Select/Select.tsx
+++ b/site/src/components/Select/Select.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 13/01/2025
- * @see {@link https://ui.shadcn.com/docs/components/select}
- */
 import {
 	CheckIcon,
 	ChevronUpIcon,

--- a/site/src/components/Separator/Separator.tsx
+++ b/site/src/components/Separator/Separator.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 06/20/2025
- * @see {@link https://ui.shadcn.com/docs/components/separator}
- */
 import { Separator as SeparatorPrimitive } from "radix-ui";
 import type * as React from "react";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Skeleton/Skeleton.tsx
+++ b/site/src/components/Skeleton/Skeleton.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadcn/ui on 06/20/2025.
- * @see {@link https://ui.shadcn.com/docs/components/skeleton}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/utils/cn";
 

--- a/site/src/components/Slider/Slider.tsx
+++ b/site/src/components/Slider/Slider.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 04/16/2025
- * @see {@link https://ui.shadcn.com/docs/components/slider}
- */
 import { Slider as SliderPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";
 

--- a/site/src/components/Switch/Switch.tsx
+++ b/site/src/components/Switch/Switch.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/switch}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { Switch as SwitchPrimitives } from "radix-ui";
 import { cn } from "#/utils/cn";

--- a/site/src/components/Table/Table.tsx
+++ b/site/src/components/Table/Table.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 02/03/2025
- * @see {@link https://ui.shadcn.com/docs/components/table}
- */
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/utils/cn";
 

--- a/site/src/components/Textarea/Textarea.tsx
+++ b/site/src/components/Textarea/Textarea.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/textarea}
- */
 import { cn } from "#/utils/cn";
 
 export const Textarea: React.FC<React.ComponentPropsWithRef<"textarea">> = ({

--- a/site/src/components/Tooltip/Tooltip.tsx
+++ b/site/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,3 @@
-/**
- * Copied from shadc/ui on 02/05/2025
- * @see {@link https://ui.shadcn.com/docs/components/tooltip}
- */
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { cn } from "#/utils/cn";
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Removes stale shadcn/ui source and date attribution comments from shared frontend components. These comments no longer provide useful implementation context.
