### PR TITLE
perf(site): limit count-only workspace queries to one row

### DIFF
--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -99,7 +99,7 @@ const noBudgetStatus = aiSpendStatus({
 
 const userWorkspacesRequest = {
 	q: `owner:me organization:${MockDefaultOrganization.name}`,
-	limit: 0,
+	limit: 1,
 };
 const noWorkspaceQuota = {
 	credits_consumed: 0,

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -69,7 +69,7 @@ export const UsageIndicator: FC = () => {
 	const workspacesQuery = useQuery({
 		...workspaces({
 			q: `owner:me organization:${organizationName}`,
-			limit: 0,
+			limit: 1,
 		}),
 		enabled: hasWorkspaceQuotaUsage && organizationName !== "",
 	});

--- a/site/src/pages/OrganizationSettingsPage/DisableWorkspaceSharingDialog.tsx
+++ b/site/src/pages/OrganizationSettingsPage/DisableWorkspaceSharingDialog.tsx
@@ -39,7 +39,7 @@ export const DisableWorkspaceSharingDialog: FC<
 		queryFn: async () => {
 			const response = await API.getWorkspaces({
 				q: `organization:${organizationId} shared:true`,
-				limit: 0, // Avoid fetching workspaces as we only need the count.
+				limit: 1, // Only the count is needed.
 			});
 			return response.count;
 		},

--- a/site/src/pages/OrganizationSettingsPage/DisableWorkspaceSharingDialog.tsx
+++ b/site/src/pages/OrganizationSettingsPage/DisableWorkspaceSharingDialog.tsx
@@ -39,7 +39,7 @@ export const DisableWorkspaceSharingDialog: FC<
 		queryFn: async () => {
 			const response = await API.getWorkspaces({
 				q: `organization:${organizationId} shared:true`,
-				limit: 1, // Only the count is needed.
+				limit: 1, // This dialog reads only the count.
 			});
 			return response.count;
 		},

--- a/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof TemplatePageHeader> = {
 			{
 				key: workspacesKey({
 					q: `organization:${MockTemplate.organization_name} template:${MockTemplate.name}`,
+					limit: 1,
 				}),
 				data: {
 					workspaces: [],
@@ -57,6 +58,7 @@ export const HasWorkspaces: Story = {
 			{
 				key: workspacesKey({
 					q: `organization:${MockTemplate.organization_name} template:${MockTemplate.name}`,
+					limit: 1,
 				}),
 				data: {
 					workspaces: [MockWorkspace],

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -69,7 +69,7 @@ const TemplateMenu: FC<TemplateMenuProps> = ({
 	const getLink = useLinks();
 	const queryText = `organization:${organizationName} template:${templateName}`;
 	const workspaceCountQuery = useQuery({
-		...workspaces({ q: queryText }),
+		...workspaces({ q: queryText, limit: 1 }),
 		select: (res) => res.count,
 	});
 	const safeToDeleteTemplate = workspaceCountQuery.data === 0;


### PR DESCRIPTION
Three components query `GET /api/v2/workspaces` and read only `count`. Two of them pass `limit: 0`, which means no limit. The third passes no limit at all. The server then expands and returns the full workspace graph for the deployment. The component reads one integer from that response.

`limit: 1` keeps the count correct. The query computes the count before it applies the page limit, in `total_count AS (SELECT count(*) FROM filtered_workspaces)` in `coderd/database/queries/workspaces.sql`. The response then holds one row instead of every row. `findMatchWorkspace` in `site/src/api/queries/workspaces.ts` already uses this pattern.

Changed consumers:

- `DisableWorkspaceSharingDialog` (`limit: 0`)
- Agents `UsageIndicator` (`limit: 0`)
- `TemplatePageHeader` template-delete guard (no limit)

The story mock keys now match the new request shapes.

I measured this on a seeded 4,000-workspace deployment. A 100-workspace template query dropped from 54.9 ms, 40 DB statements, and 12.3 ms of DB time to 18.7 ms, 17 statements, and 1.9 ms of DB time. The unlimited variant took about 1.36 s, returned 77 MB, and expanded 4,001 rows. These consumers no longer send that request. I checked that `limit=0` and `limit=1` return the same count for all three filter shapes.

<details>
<summary>Investigation notes</summary>

### Why these consumers were expensive

`limit: 0` and an absent limit both mean no limit. See `coderd/pagination.go`. The handler then runs the primary query with `WithSummary=true`. It also runs the full `workspaceData(..., allWorkspaceRelated())` fan-out for each returned row. That fan-out issues 13 queries: builds, jobs, resources, metadata, agents, apps, scripts, log sources, and statuses. The handler then serializes the whole graph.

Direct-path medians for a site owner with 4,000 workspaces were: 25.4 ms at limit=1, 25.6 ms at limit=25, and 56.2 ms at limit=0. The page size barely matters, because the query evaluates `total_count` and the ordered CTE before LIMIT. Count-only callers also paid the fan-out for each matched row.

### What this change fixes

- Fixed: count-only callers no longer request the full graph. The remaining cost is one row of fan-out plus the primary query.
- Out of scope: the ~25 ms floor in the primary query at this scale. Every paginated request pays the global count before LIMIT.
- Out of scope: a server-side cap on `limit=0`. That change affects CLI, MCP, and prebuild consumers, and it needs a separate decision.
- Out of scope: the lite workspace projection work (GRU-82).

### Alternatives I rejected

- A server-side count-only mode, such as a `count_only=true` parameter or a `/count` endpoint. This saves about one row of fan-out per request compared with `limit: 1`. It costs Swagger, `make gen`, apidocgen, SDK work, generated TS types, and tests. That is about ten times this diff.
- Dedicated count SQL that drops the latest-build and template laterals. This needs new SQL, codegen, dbauthz wiring, and rework of filters that reference lateral columns: `status`, `has-agent`, `param:*`, and `outdated`. This belongs with the lite projection work.

### Caveats

- The gap between `Count` and the rendered rows does not change. `Count` runs before template authorization, and secondary template authorization can then drop rendered rows. Count-only consumers already accepted this behavior, and `limit: 1` neither fixes nor worsens it.
- The empty-result path returns the summary row only, with `count=0` and `workspaces=[]`. That is already correct for these consumers, and the delete guard checks `count === 0`.

### Measurement method

I used a throwaway test harness that exercised the real HTTP handler through `coderdtest` and the SDK. The harness ran against a seeded Postgres 18 instance, and `pg_stat_statements` attributed the cost per request. I deleted the harness, and the repo tree is clean.

</details>

This PR was created by Coder Agents.
