### PR TITLE
fix(site): allow Antigravity IDE token substitution (#28784)

### DIFF
--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -85,6 +85,24 @@ describe("getAppHref", () => {
 		expect(href).toBe("vscode://example.com?token=user-session-token");
 	});
 
+	it("replaces the session token for Antigravity IDE URLs", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: `antigravity-ide://coder.coder-remote/open?token=${SESSION_TOKEN_PLACEHOLDER}`,
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+			token: "user-session-token",
+		});
+		expect(href).toBe(
+			"antigravity-ide://coder.coder-remote/open?token=user-session-token",
+		);
+	});
+
 	it("doesn't return the URL with the session token replaced when using the HTTP protocol", () => {
 		const externalApp = {
 			...MockWorkspaceApp,

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -26,6 +26,7 @@ const ALLOWED_EXTERNAL_APP_PROTOCOLS = [
 	"kiro:",
 	"positron:",
 	"antigravity:",
+	"antigravity-ide:",
 ];
 
 type GetVSCodeHrefParams = {


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/28784 to `release/2.34`.

Allows Antigravity IDE workspace links to receive the generated session token. Generated by Coder Agents on behalf of @35C4n0r.
