### PR TITLE
feat(site/src/pages/DeploymentSettingsPage/PremiumPage): restyle trial request form

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/PremiumPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/PremiumPageView.stories.tsx
@@ -31,10 +31,10 @@ export const NoLicense: Story = {
 			}),
 		).toBeInTheDocument();
 		await expect(canvas.getByLabelText(/^Business email/)).toBeVisible();
-		// The acknowledgement gates submission.
+		// The button stays enabled and surfaces validation errors on submit.
 		await expect(
 			canvas.getByRole("button", { name: "Start a trial" }),
-		).toBeDisabled();
+		).toBeEnabled();
 		// Requesting a trial replaces the old contact-sales upsell.
 		await expect(
 			canvas.queryByRole("link", { name: /contact sales/i }),

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.stories.tsx
@@ -43,15 +43,22 @@ const selectOption = async (
 };
 
 export const Default: Story = {
-	play: async ({ canvasElement }) => {
+	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		const submit = canvas.getByRole("button", { name: "Start a trial" });
 
-		await expect(submit).toBeDisabled();
+		// The button stays enabled so submitting surfaces validation errors
+		// instead of silently blocking the user.
+		await expect(submit).toBeEnabled();
 
-		await userEvent.click(canvas.getByRole("checkbox"));
+		await userEvent.click(submit);
 
-		await waitFor(() => expect(submit).toBeEnabled());
+		await waitFor(() =>
+			expect(
+				canvas.getByText("Please acknowledge the database requirements."),
+			).toBeInTheDocument(),
+		);
+		await expect(args.onSubmit).not.toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.tsx
@@ -84,6 +84,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 		},
 	});
 	const getFieldHelpers = getFormHelpers<TrialFormValues>(form, error);
+	const acknowledgedField = getFieldHelpers("acknowledged");
 
 	return (
 		<form
@@ -96,6 +97,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					<FormField
 						label="First name"
 						placeholder="Jane"
+						required
 						field={getFieldHelpers("first_name", {
 							maxLength: MAX_NAME_LENGTH,
 						})}
@@ -104,6 +106,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					<FormField
 						label="Last name"
 						placeholder="Doe"
+						required
 						field={getFieldHelpers("last_name", { maxLength: MAX_NAME_LENGTH })}
 						disabled={isSubmitting}
 					/>
@@ -113,6 +116,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					label="Business email"
 					type="email"
 					placeholder="you@company.com"
+					required
 					field={getFieldHelpers("email", { maxLength: MAX_EMAIL_LENGTH })}
 					onChange={onChangeTrimmed(form)}
 					disabled={isSubmitting}
@@ -122,6 +126,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					<FormField
 						label="Company"
 						placeholder="Acme Inc."
+						required
 						field={getFieldHelpers("company_name", {
 							maxLength: MAX_COMPANY_NAME_LENGTH,
 						})}
@@ -130,6 +135,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					<FormField
 						label="Job title"
 						placeholder="Platform Engineer"
+						required
 						field={getFieldHelpers("job_title", {
 							maxLength: MAX_JOB_TITLE_LENGTH,
 						})}
@@ -142,11 +148,13 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 						type="tel"
 						label="Phone number"
 						placeholder="+1 415 5552671"
+						required
 						field={getFieldHelpers("phone_number")}
 						disabled={isSubmitting}
 					/>
 					<SelectField
 						label="Number of developers"
+						required
 						field={getFieldHelpers("developers")}
 						onValueChange={(value) => form.setFieldValue("developers", value)}
 						placeholder="Select..."
@@ -162,6 +170,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 
 				<SelectField
 					label="Country"
+					required
 					field={getFieldHelpers("country")}
 					onValueChange={(value) => form.setFieldValue("country", value)}
 					placeholder="Select..."
@@ -174,31 +183,39 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					))}
 				</SelectField>
 			</div>
-			<div className="flex gap-2 items-start text-sm text-content-primary">
-				<Checkbox
-					id={acknowledgementId}
-					checked={form.values.acknowledged}
-					onCheckedChange={(checked) =>
-						form.setFieldValue("acknowledged", checked === true)
-					}
-					disabled={isSubmitting}
-				/>
-				<div>
-					<label htmlFor={acknowledgementId} className="cursor-pointer">
-						I understand that Coder trial features increase database load, and
-						that Coder recommends an external PostgreSQL database for production
-						deployments.
-					</label>{" "}
-					<a
-						href={docs(DATABASE_DOCS_LINK)}
-						target="_blank"
-						rel="noreferrer"
-						className="text-content-link hover:underline"
-						aria-label="Learn more about external PostgreSQL databases"
-					>
-						Learn more
-					</a>
+			<div className="flex flex-col gap-1">
+				<div className="flex gap-2 items-start text-sm text-content-primary">
+					<Checkbox
+						id={acknowledgementId}
+						className="data-[state=unchecked]:bg-transparent"
+						checked={form.values.acknowledged}
+						onCheckedChange={(checked) =>
+							form.setFieldValue("acknowledged", checked === true)
+						}
+						disabled={isSubmitting}
+					/>
+					<div>
+						<label htmlFor={acknowledgementId} className="cursor-pointer">
+							I understand that Coder trial features increase database load, and
+							that Coder recommends an external PostgreSQL database for
+							production deployments.
+						</label>{" "}
+						<a
+							href={docs(DATABASE_DOCS_LINK)}
+							target="_blank"
+							rel="noreferrer"
+							className="text-content-link hover:underline"
+							aria-label="Learn more about external PostgreSQL databases"
+						>
+							Learn more
+						</a>
+					</div>
 				</div>
+				{acknowledgedField.error && (
+					<span className="text-xs text-content-destructive">
+						{acknowledgedField.helperText}
+					</span>
+				)}
 			</div>
 
 			<div className="flex flex-col gap-2">
@@ -206,7 +223,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					type="submit"
 					size="lg"
 					className="w-full"
-					disabled={!form.values.acknowledged || isSubmitting}
+					disabled={isSubmitting}
 				>
 					<Spinner loading={isSubmitting} />
 					Start a trial

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.tsx
@@ -228,7 +228,7 @@ export const TrialRequestForm: FC<TrialRequestFormProps> = ({
 					<Spinner loading={isSubmitting} />
 					Start a trial
 				</Button>
-				<p className="m-0 text-xs text-content-secondary leading-relaxed">
+				<p className="m-0 text-2xs font-normal text-content-secondary leading-relaxed">
 					<PrivacyPolicyNotice /> Opt-out at any time.
 				</p>
 			</div>


### PR DESCRIPTION
Restyles the Premium trial request form (`/deployment/premium`) to match the conventions used by other forms such as `/users/create`.

- The **Start a trial** button stays enabled and surfaces validation errors on submit, instead of being disabled until the database acknowledgement is checked. The acknowledgement error now renders inline below the checkbox.
- Required fields are marked with the shared `*` indicator via the `required` prop on `FormField`/`SelectField`.
- The acknowledgement checkbox no longer has a background color in its rest (unchecked) state, so it blends with the surrounding surface.
- The privacy-policy notice is now `text-2xs` (10px) regular weight.

Stories are updated to reflect the always-enabled submit button.

## Proof

Form with required-field markers and transparent checkbox:

<img width="900" alt="Premium trial form" src="https://raw.githubusercontent.com/coder/coder/coder-agents-proof-28872/01-form.png" />

Clicking **Start a trial** with empty fields keeps the button enabled and shows inline validation errors:

<img width="900" alt="Trial form validation errors on submit" src="https://raw.githubusercontent.com/coder/coder/coder-agents-proof-28872/02-validation-errors.png" />

_Opened by Coder Agents on behalf of @chrifro._
