### PR TITLE
refactor(site): render update-check notice via shared Toaster

### DIFF
--- a/site/src/components/Toaster/Toaster.tsx
+++ b/site/src/components/Toaster/Toaster.tsx
@@ -39,7 +39,7 @@ export const Toaster = ({ ...props }: SonnerProps) => {
 						"[&_svg]:size-icon-xs [&_span]:text-xs text-content-primary",
 					),
 					closeButton:
-						"absolute top-4 right-3 bg-transparent border-none p-0 text-content-primary",
+						"absolute top-4 right-3 bg-transparent border-none p-0 text-content-secondary hover:text-content-primary",
 					// Loading styles require a bit more love, the icon doesn't render inline.
 					loader: "left-5! top-7! -translate-x-[none]!",
 					loading: "pl-[30px]!",

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -25,6 +25,7 @@ import {
 	withAuthProvider,
 	withDashboardProvider,
 	withProxyProvider,
+	withToaster,
 } from "#/testHelpers/storybook";
 import { DashboardFullPage, DashboardLayout } from "./DashboardLayout";
 
@@ -53,7 +54,12 @@ const mcpServersRouter = reactRouterParameters({
 const meta: Meta<typeof DashboardLayout> = {
 	title: "modules/dashboard/DashboardLayout",
 	component: DashboardLayout,
-	decorators: [withAuthProvider, withDashboardProvider, withProxyProvider()],
+	decorators: [
+		withAuthProvider,
+		withDashboardProvider,
+		withProxyProvider(),
+		withToaster,
+	],
 	parameters: {
 		layout: "fullscreen",
 		pixel: { matrix: pixelWithTablet },
@@ -97,7 +103,7 @@ export const ForMember: Story = {
 			canvas.getByRole("heading", { name: "Workspaces" }),
 		).toBeVisible();
 		await expect(
-			screen.queryByTestId("update-check-notice"),
+			screen.queryByText(/is now available/),
 		).not.toBeInTheDocument();
 		await expect(
 			canvas.queryByRole("button", { name: "Admin settings" }),
@@ -156,11 +162,10 @@ export const UpdateAvailable: Story = {
 		localStorage.removeItem("dismissedVersion");
 	},
 	play: async () => {
-		const notice = await screen.findByTestId("update-check-notice");
-		await expect(notice).toBeVisible();
+		// The update notice now renders through the shared Toaster portal.
 		await expect(
-			screen.getByText(/Coder v0\.12\.9 is now available/),
-		).toBeVisible();
+			await screen.findByText(/Coder v0\.12\.9 is now available/),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/modules/dashboard/DashboardLayout.stories.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.stories.tsx
@@ -9,6 +9,7 @@ import { deploymentStatsQueryKey } from "#/api/queries/deployment";
 import { organizationsPermissions } from "#/api/queries/organizations";
 import { updateCheckQueryKey } from "#/api/queries/updateCheck";
 import type { UpdateCheckResponse } from "#/api/typesGenerated";
+import { Toaster } from "#/components/Toaster/Toaster";
 import {
 	MockBuildInfo,
 	MockDefaultOrganization,
@@ -25,7 +26,6 @@ import {
 	withAuthProvider,
 	withDashboardProvider,
 	withProxyProvider,
-	withToaster,
 } from "#/testHelpers/storybook";
 import { DashboardFullPage, DashboardLayout } from "./DashboardLayout";
 
@@ -58,7 +58,14 @@ const meta: Meta<typeof DashboardLayout> = {
 		withAuthProvider,
 		withDashboardProvider,
 		withProxyProvider(),
-		withToaster,
+		// Render the Toaster before the story so it subscribes to sonner before
+		// the update notice emits its toast from a mount effect.
+		(Story) => (
+			<>
+				<Toaster />
+				<Story />
+			</>
+		),
 	],
 	parameters: {
 		layout: "fullscreen",

--- a/site/src/modules/dashboard/DashboardLayout.test.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
+import { Toaster } from "#/components/Toaster/Toaster";
 import {
 	MockEntitlements,
 	MockNoPermissions,
@@ -65,10 +66,16 @@ test("Show the new Coder version notification", async () => {
 			});
 		}),
 	);
-	renderWithAuth(<DashboardLayout />, {
-		children: [{ element: <h1>Test page</h1> }],
-	});
-	await screen.findByTestId("update-check-notice");
+	renderWithAuth(
+		<>
+			<DashboardLayout />
+			<Toaster />
+		</>,
+		{
+			children: [{ element: <h1>Test page</h1> }],
+		},
+	);
+	await screen.findByText(/Coder v0\.12\.9 is now available/);
 });
 
 test("hides AI Governance seat warnings for non-admin users", async () => {

--- a/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.stories.tsx
+++ b/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.stories.tsx
@@ -1,12 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
-import { withToaster } from "#/testHelpers/storybook";
+import { Toaster } from "#/components/Toaster/Toaster";
 import { UpdateCheckNotice } from "./UpdateCheckNotice";
 
 const meta: Meta<typeof UpdateCheckNotice> = {
 	title: "modules/dashboard/UpdateCheckNotice",
 	component: UpdateCheckNotice,
-	decorators: [withToaster],
+	// Render the Toaster before the story so it subscribes to sonner before the
+	// notice emits its toast from a mount effect; earlier emits are dropped.
+	decorators: [
+		(Story) => (
+			<>
+				<Toaster />
+				<Story />
+			</>
+		),
+	],
 	args: {
 		version: "v0.12.9",
 		releaseNotesUrl: "https://github.com/coder/coder/releases/tag/v0.12.9",

--- a/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.stories.tsx
+++ b/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
+import { withToaster } from "#/testHelpers/storybook";
 import { UpdateCheckNotice } from "./UpdateCheckNotice";
 
 const meta: Meta<typeof UpdateCheckNotice> = {
 	title: "modules/dashboard/UpdateCheckNotice",
 	component: UpdateCheckNotice,
+	decorators: [withToaster],
 	args: {
 		version: "v0.12.9",
 		releaseNotesUrl: "https://github.com/coder/coder/releases/tag/v0.12.9",
@@ -20,23 +22,23 @@ export default meta;
 type Story = StoryObj<typeof UpdateCheckNotice>;
 
 export const AboveDeploymentBanner: Story = {
-	play: async ({ canvasElement, args }) => {
-		const canvas = within(canvasElement);
+	play: async ({ args }) => {
+		// The toast renders in a portal on document.body, so query the screen.
 		await expect(
-			canvas.getByText(/Coder v0\.12\.9 is now available/),
-		).toBeVisible();
+			await screen.findByText(/Coder v0\.12\.9 is now available/),
+		).toBeInTheDocument();
 		await expect(
-			canvas.getByRole("link", { name: "release notes" }),
+			screen.getByRole("link", { name: "Release notes" }),
 		).toHaveAttribute(
 			"href",
 			"https://github.com/coder/coder/releases/tag/v0.12.9",
 		);
 		await expect(
-			canvas.getByRole("link", { name: "upgrade instructions" }),
-		).toBeVisible();
+			screen.getByRole("link", { name: "Upgrade instructions" }),
+		).toBeInTheDocument();
 
-		await userEvent.click(canvas.getByRole("button", { name: "Dismiss" }));
-		await expect(args.onDismiss).toHaveBeenCalled();
+		await userEvent.click(screen.getByRole("button", { name: "Close toast" }));
+		await waitFor(() => expect(args.onDismiss).toHaveBeenCalled());
 	},
 };
 

--- a/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.stories.tsx
+++ b/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.stories.tsx
@@ -37,13 +37,13 @@ export const AboveDeploymentBanner: Story = {
 			await screen.findByText(/Coder v0\.12\.9 is now available/),
 		).toBeInTheDocument();
 		await expect(
-			screen.getByRole("link", { name: "Release notes" }),
+			screen.getByRole("link", { name: "View release notes" }),
 		).toHaveAttribute(
 			"href",
 			"https://github.com/coder/coder/releases/tag/v0.12.9",
 		);
 		await expect(
-			screen.getByRole("link", { name: "Upgrade instructions" }),
+			screen.getByRole("link", { name: "View upgrade instructions" }),
 		).toBeInTheDocument();
 
 		await userEvent.click(screen.getByRole("button", { name: "Close toast" }));

--- a/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.tsx
+++ b/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.tsx
@@ -1,7 +1,7 @@
-import { InfoIcon, XIcon } from "lucide-react";
+import { SparkleIcon } from "lucide-react";
 import type { FC } from "react";
-import { Button } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 import { docs } from "#/utils/docs";
 
 type UpdateCheckNoticeProps = {
@@ -11,56 +11,62 @@ type UpdateCheckNoticeProps = {
 	aboveDeploymentBanner?: boolean;
 };
 
+// A stable id keeps repeated renders from stacking duplicate toasts; sonner
+// updates the existing toast instead of creating a new one.
+const UPDATE_CHECK_TOAST_ID = "update-check-notice";
+
+/**
+ * Surfaces an available Coder update through the shared Toaster. It renders no
+ * DOM itself; it drives a persistent toast that stays until the user closes it
+ * with the toast's close button, whose dismissal persists through `onDismiss`.
+ */
 export const UpdateCheckNotice: FC<UpdateCheckNoticeProps> = ({
 	version,
 	releaseNotesUrl,
 	onDismiss,
 	aboveDeploymentBanner = false,
 }) => {
-	return (
-		<div
-			data-testid="update-check-notice"
-			role="status"
-			className={cn(
-				"fixed right-6 z-50 flex max-w-[420px] items-start gap-4 rounded border border-solid border-highlight-sky bg-surface-primary p-4 text-sm text-content-primary shadow-sm",
-				// 60px keeps a 24px gap above the 36px deployment banner.
-				aboveDeploymentBanner ? "bottom-[60px]" : "bottom-6",
-			)}
-		>
-			<InfoIcon className="mt-0.5 size-icon-sm shrink-0 text-highlight-sky" />
-			<div className="flex flex-col gap-1">
-				<p className="m-0 font-semibold">Coder {version} is now available. </p>
-				<p className="m-0 flex-1 leading-5">
-					View the{" "}
+	// Keep the latest onDismiss without re-running the effect when its identity
+	// changes on each render of the parent.
+	const onDismissRef = useRef(onDismiss);
+	onDismissRef.current = onDismiss;
+
+	useEffect(() => {
+		toast(`Coder ${version} is now available`, {
+			id: UPDATE_CHECK_TOAST_ID,
+			duration: Number.POSITIVE_INFINITY,
+			// A sparkle nods at the new release instead of the generic info icon.
+			icon: <SparkleIcon className="text-content-primary" />,
+			// Clear the deployment banner so the toast doesn't overlap it.
+			className: aboveDeploymentBanner ? "mb-9" : undefined,
+			description: (
+				<span className="flex flex-col items-start">
 					<a
 						href={releaseNotesUrl}
 						target="_blank"
 						rel="noreferrer"
-						className="text-content-link underline hover:no-underline"
+						className="text-content-link"
 					>
-						release notes
-					</a>{" "}
-					and{" "}
+						Release notes
+					</a>
 					<a
 						href={docs("/install/upgrade")}
 						target="_blank"
 						rel="noreferrer"
-						className="text-content-link underline hover:no-underline"
+						className="text-content-link"
 					>
-						upgrade instructions
-					</a>{" "}
-					for more information.
-				</p>
-			</div>
-			<Button
-				aria-label="Dismiss"
-				size="icon"
-				variant="subtle"
-				onClick={onDismiss}
-				className="-m-2"
-			>
-				<XIcon />
-			</Button>
-		</div>
-	);
+						Upgrade instructions
+					</a>
+				</span>
+			),
+			// The close button dismisses the toast; persist so it stays gone.
+			onDismiss: () => onDismissRef.current(),
+		});
+
+		return () => {
+			toast.dismiss(UPDATE_CHECK_TOAST_ID);
+		};
+	}, [version, releaseNotesUrl, aboveDeploymentBanner]);
+
+	return null;
 };

--- a/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.tsx
+++ b/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.tsx
@@ -47,7 +47,7 @@ export const UpdateCheckNotice: FC<UpdateCheckNoticeProps> = ({
 						rel="noreferrer"
 						className="text-content-link"
 					>
-						Release notes
+						View release notes
 					</a>
 					<a
 						href={docs("/install/upgrade")}
@@ -55,7 +55,7 @@ export const UpdateCheckNotice: FC<UpdateCheckNoticeProps> = ({
 						rel="noreferrer"
 						className="text-content-link"
 					>
-						Upgrade instructions
+						View upgrade instructions
 					</a>
 				</span>
 			),

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -179,13 +179,10 @@ export const withAuthProvider = (Story: FC, { parameters }: StoryContext) => {
 	);
 };
 
-// Render the Toaster before the story so it subscribes to sonner's toast
-// stream before any story emits a toast from a mount effect. Toasts emitted
-// before the Toaster subscribes are dropped.
 export const withToaster = (Story: FC) => (
 	<>
-		<Toaster />
 		<Story />
+		<Toaster />
 	</>
 );
 

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -179,10 +179,13 @@ export const withAuthProvider = (Story: FC, { parameters }: StoryContext) => {
 	);
 };
 
+// Render the Toaster before the story so it subscribes to sonner's toast
+// stream before any story emits a toast from a mount effect. Toasts emitted
+// before the Toaster subscribes are dropped.
 export const withToaster = (Story: FC) => (
 	<>
-		<Story />
 		<Toaster />
+		<Story />
 	</>
 );
 


### PR DESCRIPTION
Replaces the hand-rolled `UpdateCheckNotice` fixed card with a [`sonner`](https://sonner.emilkowal.ski/) toast rendered through the shared `Toaster`, so the "a new release is available" prompt uses the standard toast design instead of bespoke markup.

The toast shows a Lucide sparkle icon, the release version from the update-check API, and stacked "Release notes" / "Upgrade instructions" links. It stays until dismissed via the toast's close button, whose click persists the dismissed version (unchanged `useUpdateCheck` behavior). The shared `Toaster` close button now uses `content-secondary` with `content-primary` on hover.

| Before | After |
| --- | --- |
| ![Before: production update banner](https://raw.githubusercontent.com/coder/coder/pr-asset-update-check-toast/before.png?v=2) | ![After: update notice via shared Toaster](https://raw.githubusercontent.com/coder/coder/pr-asset-update-check-toast/after.png?v=3) |

<details>
<summary>Implementation notes / decision log</summary>

- **Why a rewrite:** `UpdateCheckNotice` previously re-implemented toast styling and positioning by hand (`fixed`, `z-50`, custom border/shadow, own dismiss button) instead of the shared `Toaster`. It now renders no DOM and drives a single `toast(...)` keyed by a stable id.
- **Persistence:** sonner fires `onDismiss` when the close button is clicked (not on programmatic `toast.dismiss`), so closing persists the dismissed version while unmount cleanup does not.
- **`onDismissRef`:** `useUpdateCheck` returns a fresh `dismiss` each render; a ref keeps `onDismiss` out of the effect deps so the toast is not re-emitted every render (and satisfies exhaustive-deps).
- **Deployment-banner clearance:** `mb-9` replaces the old `bottom-[60px]` offset so the toast clears the 36px deployment banner.
- **`withToaster` ordering:** sonner drops toasts emitted before the `Toaster` subscribes. In production the root `Toaster` mounts long before the async update-check resolves, but stories/tests seed data synchronously, so the shared `withToaster` helper now renders the `Toaster` before the story. Tests query the portal by text instead of the removed `data-testid`.

Generated with Coder Agents on behalf of @chrifro.
</details>