### PR TITLE
fix(site): deflake storybook interaction stories racing radix layer close

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -74,6 +74,7 @@ Some end-to-end tests require a license. The Storybook MCP at `http://localhost:
 - Assert observable behavior with semantic queries. Do not assert Tailwind classes or implementation details.
 - Use `data-testid` only when an element has no suitable role or accessible name.
 - Do not depend on smooth scrolling in tests. Use instant behavior or control the scroll position directly.
+- After an interaction closes a modal Radix layer (Select listbox, modal popover), use `selectRadixOption` or `waitForRadixLayerClose` from `testHelpers/storybook` before the next interaction or ByRole assertion. Do not silence the resulting `pointer-events: none` error with `pointerEventsCheck: 0`; that option is only for hovering elements that are intentionally `pointer-events: none` (for example a disabled button with a tooltip, as in `AppLink.stories.tsx`).
 - Keep stories current when components change.
 
 ## Performance

--- a/site/src/components/DateTimeRangePicker/DateTimeRangePicker.stories.tsx
+++ b/site/src/components/DateTimeRangePicker/DateTimeRangePicker.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
+import { waitForRadixLayerClose } from "#/testHelpers/storybook";
 import { DateTimeRangePicker } from "./DateTimeRangePicker";
 import type { DateTimeRangeValue } from "./dateTimeRange";
 
@@ -200,6 +201,11 @@ export const ApplyCustomRange: Story = {
 		);
 		await userEvent.click(await screen.findByRole("option", { name: "AM" }));
 
+		// The option click closes the meridiem listbox; wait for Radix to
+		// restore pointer events before clicking Apply.
+		await waitForRadixLayerClose(() =>
+			screen.getByRole("button", { name: "Apply" }),
+		);
 		await waitFor(() => {
 			expect(applyButton).toBeEnabled();
 		});

--- a/site/src/components/DateTimeRangePicker/DateTimeRangePicker.stories.tsx
+++ b/site/src/components/DateTimeRangePicker/DateTimeRangePicker.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
-import { waitForRadixLayerClose } from "#/testHelpers/storybook";
+import { selectRadixOption } from "#/testHelpers/storybook";
 import { DateTimeRangePicker } from "./DateTimeRangePicker";
 import type { DateTimeRangeValue } from "./dateTimeRange";
 
@@ -196,16 +196,8 @@ export const ApplyCustomRange: Story = {
 		);
 
 		// Flip the To meridiem to exercise the select.
-		await userEvent.click(
-			screen.getByRole("combobox", { name: "To AM or PM" }),
-		);
-		await userEvent.click(await screen.findByRole("option", { name: "AM" }));
+		await selectRadixOption(screen, "To AM or PM", "AM");
 
-		// The option click closes the meridiem listbox; wait for Radix to
-		// restore pointer events before clicking Apply.
-		await waitForRadixLayerClose(() =>
-			screen.getByRole("button", { name: "Apply" }),
-		);
 		await waitFor(() => {
 			expect(applyButton).toBeEnabled();
 		});

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -16,7 +16,11 @@ import {
 	MockUserOwner,
 	mockApiError,
 } from "#/testHelpers/entities";
-import { withAuthProvider, withToaster } from "#/testHelpers/storybook";
+import {
+	waitForRadixLayerClose,
+	withAuthProvider,
+	withToaster,
+} from "#/testHelpers/storybook";
 import type TasksPage from "../../../pages/TasksPage/TasksPage";
 import { TaskPrompt } from "./TaskPrompt";
 
@@ -281,6 +285,11 @@ export const SelectTemplateVersion: Story = {
 				name: /v2.0.0/i,
 			});
 			await userEvent.click(versionOption);
+			// The option click closes the listbox; wait for Radix to restore
+			// pointer events before the next step clicks submit.
+			await waitForRadixLayerClose(() =>
+				canvas.getByRole("button", { name: /run task/i }),
+			);
 		});
 
 		await step("Submit form", async () => {
@@ -649,6 +658,11 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 			expect(options[0]).toContainHTML("Claude Code Dev");
 
 			await userEvent.click(options[0]);
+			// Each option click closes a listbox; wait for Radix to restore
+			// pointer events before the next step opens another select.
+			await waitForRadixLayerClose(() =>
+				canvas.getByRole("combobox", { name: /select template/i }),
+			);
 		});
 
 		await step("Switch template", async () => {
@@ -659,6 +673,9 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 				name: /codex/i,
 			});
 			await userEvent.click(codexTemplateOption);
+			await waitForRadixLayerClose(() =>
+				canvas.getByRole("combobox", { name: /preset/i }),
+			);
 		});
 
 		await step("Presets are present in new template", async () => {
@@ -670,6 +687,9 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 			expect(options[0]).toContainHTML("Codex Dev");
 
 			await userEvent.click(options[0]);
+			await waitForRadixLayerClose(() =>
+				canvas.getByRole("combobox", { name: /select template/i }),
+			);
 		});
 
 		await step("Switch template back", async () => {
@@ -680,6 +700,9 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 				name: /claude code/i,
 			});
 			await userEvent.click(codexTemplateOption);
+			await waitForRadixLayerClose(() =>
+				canvas.getByRole("combobox", { name: /preset/i }),
+			);
 		});
 
 		await step("Presets are present in original template", async () => {

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -17,6 +17,7 @@ import {
 	mockApiError,
 } from "#/testHelpers/entities";
 import {
+	selectRadixOption,
 	waitForRadixLayerClose,
 	withAuthProvider,
 	withToaster,
@@ -278,18 +279,7 @@ export const SelectTemplateVersion: Story = {
 		});
 
 		await step("Select version", async () => {
-			const body = within(canvasElement.ownerDocument.body);
-			const versionSelect = await canvas.findByLabelText(/template version/i);
-			await userEvent.click(versionSelect);
-			const versionOption = await body.findByRole("option", {
-				name: /v2.0.0/i,
-			});
-			await userEvent.click(versionOption);
-			// The option click closes the listbox; wait for Radix to restore
-			// pointer events before the next step clicks submit.
-			await waitForRadixLayerClose(() =>
-				canvas.getByRole("button", { name: /run task/i }),
-			);
+			await selectRadixOption(canvas, /template version/i, /v2.0.0/i);
 		});
 
 		await step("Submit form", async () => {
@@ -658,8 +648,8 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 			expect(options[0]).toContainHTML("Claude Code Dev");
 
 			await userEvent.click(options[0]);
-			// Each option click closes a listbox; wait for Radix to restore
-			// pointer events before the next step opens another select.
+			// Manual open/pick here (the steps assert on the open listbox), so
+			// wait for the closed layer's cleanup before the next step.
 			await waitForRadixLayerClose(() =>
 				canvas.getByRole("combobox", { name: /select template/i }),
 			);

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -489,13 +489,9 @@ export const CheckExternalAuthOnChangingVersions: Story = {
 		});
 
 		await step("Change into version without external auth", async () => {
-			const body = within(canvasElement.ownerDocument.body);
-			const versionSelect = await canvas.findByLabelText(/template version/i);
-			await userEvent.click(versionSelect);
-			const versionOption = await body.findByRole("option", {
-				name: /no external/i,
-			});
-			await userEvent.click(versionOption);
+			// selectRadixOption waits out the closed layer's aria-hidden
+			// cleanup, so the negative ByRole assertion below is meaningful.
+			await selectRadixOption(canvas, /template version/i, /no external/i);
 		});
 
 		await step("Don't render external authentication", async () => {
@@ -650,9 +646,7 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 			await userEvent.click(options[0]);
 			// Manual open/pick here (the steps assert on the open listbox), so
 			// wait for the closed layer's cleanup before the next step.
-			await waitForRadixLayerClose(() =>
-				canvas.getByRole("combobox", { name: /select template/i }),
-			);
+			await waitForRadixLayerClose(canvas, "combobox", /select template/i);
 		});
 
 		await step("Switch template", async () => {
@@ -663,9 +657,7 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 				name: /codex/i,
 			});
 			await userEvent.click(codexTemplateOption);
-			await waitForRadixLayerClose(() =>
-				canvas.getByRole("combobox", { name: /preset/i }),
-			);
+			await waitForRadixLayerClose(canvas, "combobox", /preset/i);
 		});
 
 		await step("Presets are present in new template", async () => {
@@ -677,9 +669,7 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 			expect(options[0]).toContainHTML("Codex Dev");
 
 			await userEvent.click(options[0]);
-			await waitForRadixLayerClose(() =>
-				canvas.getByRole("combobox", { name: /select template/i }),
-			);
+			await waitForRadixLayerClose(canvas, "combobox", /select template/i);
 		});
 
 		await step("Switch template back", async () => {
@@ -690,9 +680,7 @@ export const CheckPresetsWhenChangingTemplate: Story = {
 				name: /claude code/i,
 			});
 			await userEvent.click(codexTemplateOption);
-			await waitForRadixLayerClose(() =>
-				canvas.getByRole("combobox", { name: /preset/i }),
-			);
+			await waitForRadixLayerClose(canvas, "combobox", /preset/i);
 		});
 
 		await step("Presets are present in original template", async () => {

--- a/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPageView.stories.tsx
@@ -3,6 +3,7 @@ import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockDefaultOrganization } from "#/testHelpers/entities";
+import { waitForRadixLayerClose } from "#/testHelpers/storybook";
 import AddMCPServerPageView from "./AddMCPServerPageView";
 
 const meta: Meta<typeof AddMCPServerPageView> = {
@@ -61,6 +62,11 @@ export const Default: Story = {
 		await userEvent.click(body.getByRole("option", { name: "OAuth2" }));
 		await expect(canvas.getByLabelText(/client id/i)).toBeInTheDocument();
 
+		// The option click closes the listbox; wait for Radix to restore
+		// pointer events before clicking Add server.
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("button", { name: "Add server" }),
+		);
 		await userEvent.click(addButton);
 		await waitFor(() => {
 			expect(args.onCreateServer).toHaveBeenCalledWith(

--- a/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPageView.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockDefaultOrganization } from "#/testHelpers/entities";
-import { waitForRadixLayerClose } from "#/testHelpers/storybook";
+import { selectRadixOption } from "#/testHelpers/storybook";
 import AddMCPServerPageView from "./AddMCPServerPageView";
 
 const meta: Meta<typeof AddMCPServerPageView> = {
@@ -55,18 +55,9 @@ export const Default: Story = {
 		await userEvent.click(
 			canvas.getByRole("button", { name: /authentication/i }),
 		);
-		const body = within(canvasElement.ownerDocument.body);
-		await userEvent.click(
-			canvas.getByRole("combobox", { name: /authentication method/i }),
-		);
-		await userEvent.click(body.getByRole("option", { name: "OAuth2" }));
+		await selectRadixOption(canvas, /authentication method/i, "OAuth2");
 		await expect(canvas.getByLabelText(/client id/i)).toBeInTheDocument();
 
-		// The option click closes the listbox; wait for Radix to restore
-		// pointer events before clicking Add server.
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("button", { name: "Add server" }),
-		);
 		await userEvent.click(addButton);
 		await waitFor(() => {
 			expect(args.onCreateServer).toHaveBeenCalledWith(

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.stories.tsx
@@ -17,6 +17,7 @@ import {
 	mockApiError,
 } from "#/testHelpers/entities";
 import {
+	waitForRadixLayerClose,
 	withAuthProvider,
 	withDashboardProvider,
 	withToaster,
@@ -965,6 +966,11 @@ export const AddFailurePreservesEnteredValues: Story = {
 			canvas.getByRole("combobox", { name: /authentication method/i }),
 		);
 		await userEvent.click(body.getByRole("option", { name: "OAuth2" }));
+		// The option click closes the listbox; wait for Radix to restore
+		// pointer events before typing into the next field.
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("textbox", { name: /client id/i }),
+		);
 		await userEvent.type(canvas.getByLabelText(/client id/i), "client-id");
 		await userEvent.type(canvas.getByLabelText(/client secret/i), "secret");
 		await userEvent.click(canvas.getByRole("button", { name: "Add server" }));

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.stories.tsx
@@ -17,7 +17,7 @@ import {
 	mockApiError,
 } from "#/testHelpers/entities";
 import {
-	waitForRadixLayerClose,
+	selectRadixOption,
 	withAuthProvider,
 	withDashboardProvider,
 	withToaster,
@@ -962,15 +962,7 @@ export const AddFailurePreservesEnteredValues: Story = {
 		await userEvent.click(
 			canvas.getByRole("button", { name: /authentication/i }),
 		);
-		await userEvent.click(
-			canvas.getByRole("combobox", { name: /authentication method/i }),
-		);
-		await userEvent.click(body.getByRole("option", { name: "OAuth2" }));
-		// The option click closes the listbox; wait for Radix to restore
-		// pointer events before typing into the next field.
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("textbox", { name: /client id/i }),
-		);
+		await selectRadixOption(canvas, /authentication method/i, "OAuth2");
 		await userEvent.type(canvas.getByLabelText(/client id/i), "client-id");
 		await userEvent.type(canvas.getByLabelText(/client secret/i), "secret");
 		await userEvent.click(canvas.getByRole("button", { name: "Add server" }));

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPage.stories.tsx
@@ -18,6 +18,7 @@ import {
 } from "#/testHelpers/entities";
 import {
 	selectRadixOption,
+	waitForRadixLayerClose,
 	withAuthProvider,
 	withDashboardProvider,
 	withToaster,
@@ -1339,6 +1340,11 @@ export const UpdateOnlyOrgAdminCanUpdateMCPServer: Story = {
 		expect(
 			body.queryByRole("option", { name: "User OIDC identity" }),
 		).not.toBeInTheDocument();
+		// Close the listbox and wait out the layer cleanup; while the page
+		// is aria-hidden the negative ByRole assertions below would pass
+		// vacuously.
+		await userEvent.keyboard("{Escape}");
+		await waitForRadixLayerClose(canvas, "button", "Update server");
 		expect(
 			canvas.queryByRole("button", { name: "Delete" }),
 		).not.toBeInTheDocument();

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -22,6 +22,7 @@ import {
 	MockOrganizationPermissions,
 } from "#/testHelpers/entities";
 import {
+	selectRadixOption,
 	waitForRadixLayerClose,
 	withDashboardProvider,
 	withToaster,
@@ -538,17 +539,11 @@ export const ReasoningEffortInProviderConfiguration: Story = {
 		await userEvent.click(
 			await screen.findByRole("option", { name: "Medium" }),
 		);
-
-		// Each option click closes the listbox; wait for Radix to restore
-		// pointer events before the next click.
 		await waitForRadixLayerClose(() =>
 			canvas.getByRole("combobox", { name: /max reasoning effort/i }),
 		);
-		await userEvent.click(maxSelect);
-		await userEvent.click(await screen.findByRole("option", { name: "Max" }));
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("button", { name: /add model/i }),
-		);
+
+		await selectRadixOption(canvas, /max reasoning effort/i, "Max");
 
 		await userEvent.click(canvas.getByRole("button", { name: /add model/i }));
 		await expect(args.onCreateModel).toHaveBeenCalledWith(
@@ -567,22 +562,9 @@ export const ReasoningEffortValidationError: Story = {
 		await userEvent.click(
 			canvas.getByRole("button", { name: /provider configuration/i }),
 		);
-		const defaultSelect = canvas.getByRole("combobox", {
-			name: /default reasoning effort/i,
-		});
-		const maxSelect = canvas.getByRole("combobox", {
-			name: /max reasoning effort/i,
-		});
 
-		await userEvent.click(defaultSelect);
-		await userEvent.click(await screen.findByRole("option", { name: "High" }));
-		// The option click closes the listbox; wait for Radix to restore
-		// pointer events before opening the next select.
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("combobox", { name: /max reasoning effort/i }),
-		);
-		await userEvent.click(maxSelect);
-		await userEvent.click(await screen.findByRole("option", { name: "Low" }));
+		await selectRadixOption(canvas, /default reasoning effort/i, "High");
+		await selectRadixOption(canvas, /max reasoning effort/i, "Low");
 
 		// Formik validation runs asynchronously after the value change.
 		await waitFor(() => {
@@ -614,24 +596,16 @@ export const GoogleThinkingLevelBudgetMutualExclusion: Story = {
 		await expect(budget).toBeEnabled();
 		await expect(level).toBeEnabled();
 
-		await userEvent.click(level);
-		await userEvent.click(await screen.findByRole("option", { name: "Low" }));
+		await selectRadixOption(canvas, /thinking config thinking level/i, "Low");
 		await expect(budget).toBeDisabled();
 
-		// Each option click closes the listbox; wait for Radix to restore
-		// pointer events before the next pointer interaction.
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("combobox", { name: /thinking config thinking level/i }),
-		);
-		await userEvent.click(level);
-		await userEvent.click(
-			await screen.findByRole("option", { name: "Default" }),
+		await selectRadixOption(
+			canvas,
+			/thinking config thinking level/i,
+			"Default",
 		);
 		await expect(budget).toBeEnabled();
 
-		await waitForRadixLayerClose(() =>
-			canvas.getByLabelText(/thinking config thinking budget/i),
-		);
 		await userEvent.type(budget, "2048");
 		await expect(level).toBeDisabled();
 

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -21,7 +21,11 @@ import {
 	MockDefaultOrganization,
 	MockOrganizationPermissions,
 } from "#/testHelpers/entities";
-import { withDashboardProvider, withToaster } from "#/testHelpers/storybook";
+import {
+	waitForRadixLayerClose,
+	withDashboardProvider,
+	withToaster,
+} from "#/testHelpers/storybook";
 import {
 	modelOrganizationSearchParam,
 	OrganizationModelsContext,
@@ -158,12 +162,32 @@ export const LeaveWithUnsavedChanges: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await userEvent.type(canvas.getByLabelText(/model identifier/i), "gpt-5");
+		// The identifier combobox only commits the typed value to the form
+		// on blur, and the navigation blocker only arms once the resulting
+		// dirty state commits a render. Clicking the link relies on its own
+		// pointerdown blur and can navigate away before the blocker arms
+		// under CPU load, so blur explicitly and wait for the prompt's
+		// beforeunload leg (registered in the same commit) to observe the
+		// dirty state before navigating.
+		await userEvent.tab();
+		await waitFor(
+			() => {
+				const probe = new Event("beforeunload", { cancelable: true });
+				window.dispatchEvent(probe);
+				expect(probe.defaultPrevented).toBe(true);
+			},
+			{ timeout: 10_000 },
+		);
 		await userEvent.click(
 			canvas.getByRole("link", { name: /back to models/i }),
 		);
-		const dialog = await screen.findByRole("dialog", {
-			name: /unsaved changes/i,
-		});
+		// The blocker dialog mounts asynchronously; the default 1s timeout
+		// is too tight when the suite runs under full pre-push CPU load.
+		const dialog = await screen.findByRole(
+			"dialog",
+			{ name: /unsaved changes/i },
+			{ timeout: 10_000 },
+		);
 		await expect(dialog).toBeInTheDocument();
 	},
 };
@@ -515,8 +539,16 @@ export const ReasoningEffortInProviderConfiguration: Story = {
 			await screen.findByRole("option", { name: "Medium" }),
 		);
 
+		// Each option click closes the listbox; wait for Radix to restore
+		// pointer events before the next click.
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("combobox", { name: /max reasoning effort/i }),
+		);
 		await userEvent.click(maxSelect);
 		await userEvent.click(await screen.findByRole("option", { name: "Max" }));
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("button", { name: /add model/i }),
+		);
 
 		await userEvent.click(canvas.getByRole("button", { name: /add model/i }));
 		await expect(args.onCreateModel).toHaveBeenCalledWith(
@@ -544,14 +576,22 @@ export const ReasoningEffortValidationError: Story = {
 
 		await userEvent.click(defaultSelect);
 		await userEvent.click(await screen.findByRole("option", { name: "High" }));
+		// The option click closes the listbox; wait for Radix to restore
+		// pointer events before opening the next select.
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("combobox", { name: /max reasoning effort/i }),
+		);
 		await userEvent.click(maxSelect);
 		await userEvent.click(await screen.findByRole("option", { name: "Low" }));
 
-		await expect(
-			canvas.getByText(
-				"Default reasoning effort must not exceed the max reasoning effort.",
-			),
-		).toBeVisible();
+		// Formik validation runs asynchronously after the value change.
+		await waitFor(() => {
+			expect(
+				canvas.getByText(
+					"Default reasoning effort must not exceed the max reasoning effort.",
+				),
+			).toBeVisible();
+		});
 	},
 };
 
@@ -578,12 +618,20 @@ export const GoogleThinkingLevelBudgetMutualExclusion: Story = {
 		await userEvent.click(await screen.findByRole("option", { name: "Low" }));
 		await expect(budget).toBeDisabled();
 
+		// Each option click closes the listbox; wait for Radix to restore
+		// pointer events before the next pointer interaction.
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("combobox", { name: /thinking config thinking level/i }),
+		);
 		await userEvent.click(level);
 		await userEvent.click(
 			await screen.findByRole("option", { name: "Default" }),
 		);
 		await expect(budget).toBeEnabled();
 
+		await waitForRadixLayerClose(() =>
+			canvas.getByLabelText(/thinking config thinking budget/i),
+		);
 		await userEvent.type(budget, "2048");
 		await expect(level).toBeDisabled();
 

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelForm.stories.tsx
@@ -171,13 +171,16 @@ export const LeaveWithUnsavedChanges: Story = {
 		// beforeunload leg (registered in the same commit) to observe the
 		// dirty state before navigating.
 		await userEvent.tab();
+		// 4s, not 10s: this and the dialog wait below must fit the 15s test
+		// timeout together, and the probe settles in milliseconds once the
+		// dirty render commits.
 		await waitFor(
 			() => {
 				const probe = new Event("beforeunload", { cancelable: true });
 				window.dispatchEvent(probe);
 				expect(probe.defaultPrevented).toBe(true);
 			},
-			{ timeout: 10_000 },
+			{ timeout: 4_000 },
 		);
 		await userEvent.click(
 			canvas.getByRole("link", { name: /back to models/i }),
@@ -539,9 +542,7 @@ export const ReasoningEffortInProviderConfiguration: Story = {
 		await userEvent.click(
 			await screen.findByRole("option", { name: "Medium" }),
 		);
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("combobox", { name: /max reasoning effort/i }),
-		);
+		await waitForRadixLayerClose(canvas, "combobox", /max reasoning effort/i);
 
 		await selectRadixOption(canvas, /max reasoning effort/i, "Max");
 

--- a/site/src/pages/CreateUserPage/CreateUserPage.stories.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserPage.stories.tsx
@@ -117,12 +117,12 @@ async function fillForm(
 		await user.type(canvas.getByLabelText(/email/i), "someone@coder.com");
 	}
 
+	// The login-type trigger has no accessible name (queried by testid), so
+	// this flow cannot use selectRadixOption.
 	await user.click(canvas.getByTestId("login-type-input"));
 	await user.click(
 		await body.findByRole("option", { name: new RegExp(loginType, "i") }),
 	);
-	// The option click closes the login-type listbox; wait for Radix to
-	// make the rest of the page interactive again before continuing.
 	await waitForRadixLayerClose(() =>
 		canvas.getByRole("button", { name: /save/i }),
 	);

--- a/site/src/pages/CreateUserPage/CreateUserPage.stories.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserPage.stories.tsx
@@ -8,7 +8,11 @@ import {
 	MockUserMember,
 	mockApiError,
 } from "#/testHelpers/entities";
-import { withDashboardProvider, withToaster } from "#/testHelpers/storybook";
+import {
+	waitForRadixLayerClose,
+	withDashboardProvider,
+	withToaster,
+} from "#/testHelpers/storybook";
 import CreateUserPage from "./CreateUserPage";
 
 const meta = {
@@ -116,6 +120,11 @@ async function fillForm(
 	await user.click(canvas.getByTestId("login-type-input"));
 	await user.click(
 		await body.findByRole("option", { name: new RegExp(loginType, "i") }),
+	);
+	// The option click closes the login-type listbox; wait for Radix to
+	// make the rest of the page interactive again before continuing.
+	await waitForRadixLayerClose(() =>
+		canvas.getByRole("button", { name: /save/i }),
 	);
 
 	if (isPasswordLogin) {

--- a/site/src/pages/CreateUserPage/CreateUserPage.stories.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserPage.stories.tsx
@@ -9,7 +9,7 @@ import {
 	mockApiError,
 } from "#/testHelpers/entities";
 import {
-	waitForRadixLayerClose,
+	selectRadixOption,
 	withDashboardProvider,
 	withToaster,
 } from "#/testHelpers/storybook";
@@ -110,22 +110,13 @@ async function fillForm(
 	loginType: "password" | "service account" = "password",
 ) {
 	const isPasswordLogin = loginType === "password";
-	const body = within(document.body);
 
 	await user.type(await canvas.findByLabelText("Username"), "someuser");
 	if (isPasswordLogin) {
 		await user.type(canvas.getByLabelText(/email/i), "someone@coder.com");
 	}
 
-	// The login-type trigger has no accessible name (queried by testid), so
-	// this flow cannot use selectRadixOption.
-	await user.click(canvas.getByTestId("login-type-input"));
-	await user.click(
-		await body.findByRole("option", { name: new RegExp(loginType, "i") }),
-	);
-	await waitForRadixLayerClose(() =>
-		canvas.getByRole("button", { name: /save/i }),
-	);
+	await selectRadixOption(canvas, /login type/i, new RegExp(loginType, "i"));
 
 	if (isPasswordLogin) {
 		await user.type(

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { mockApiError } from "#/testHelpers/entities";
+import { waitForRadixLayerClose } from "#/testHelpers/storybook";
 import { TrialRequestForm } from "./TrialRequestForm";
 
 const meta: Meta<typeof TrialRequestForm> = {
@@ -40,6 +41,11 @@ const selectOption = async (
 		await canvas.findByRole("combobox", { name: comboboxName }),
 	);
 	await userEvent.click(await body.findByRole("option", { name: optionName }));
+	// The option click closes the listbox; wait for Radix to make the rest
+	// of the page interactive again before the caller's next step.
+	await waitForRadixLayerClose(() =>
+		canvas.getByRole("combobox", { name: comboboxName }),
+	);
 };
 
 export const Default: Story = {

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/TrialRequestForm.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { mockApiError } from "#/testHelpers/entities";
-import { waitForRadixLayerClose } from "#/testHelpers/storybook";
+import { selectRadixOption } from "#/testHelpers/storybook";
 import { TrialRequestForm } from "./TrialRequestForm";
 
 const meta: Meta<typeof TrialRequestForm> = {
@@ -28,24 +28,12 @@ const COMPLETE_REQUEST = {
 	developers: "51 - 100",
 };
 
-/** Radix Select portals its listbox into document.body. */
 const selectOption = async (
 	canvasElement: HTMLElement,
 	comboboxName: RegExp,
 	optionName: RegExp,
 ) => {
-	const canvas = within(canvasElement);
-	const body = within(canvasElement.ownerDocument.body);
-
-	await userEvent.click(
-		await canvas.findByRole("combobox", { name: comboboxName }),
-	);
-	await userEvent.click(await body.findByRole("option", { name: optionName }));
-	// The option click closes the listbox; wait for Radix to make the rest
-	// of the page interactive again before the caller's next step.
-	await waitForRadixLayerClose(() =>
-		canvas.getByRole("combobox", { name: comboboxName }),
-	);
+	await selectRadixOption(within(canvasElement), comboboxName, optionName);
 };
 
 export const Default: Story = {

--- a/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.stories.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.stories.tsx
@@ -6,6 +6,7 @@ import type {
 	UpdateUserAppearanceSettingsRequest,
 	UserAppearanceSettings,
 } from "#/api/typesGenerated";
+import { selectRadixOption } from "#/testHelpers/storybook";
 import { CONCRETE_THEMES } from "#/theme";
 import { AppearanceForm } from "./AppearanceForm";
 
@@ -243,18 +244,12 @@ export const SelectSingleFromSync: Story = {
 		onSubmit: resolvedSubmit(),
 	},
 	play: async ({ canvasElement, args }) => {
-		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 		const dropdown = await canvas.findByRole("combobox", {
 			name: "Theme mode",
 		});
 
-		await user.click(dropdown);
-		await user.click(
-			await within(document.body).findByRole("option", {
-				name: "Single theme",
-			}),
-		);
+		await selectRadixOption(canvas, "Theme mode", "Single theme");
 
 		await waitFor(() => {
 			expect(args.onSubmit).toHaveBeenCalledWith({

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
-import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { MockWorkspace } from "#/testHelpers/entities";
-import { waitForRadixLayerClose } from "#/testHelpers/storybook";
+import { selectRadixOption } from "#/testHelpers/storybook";
 import { WorkspaceSettingsPageView } from "./WorkspaceSettingsPageView";
 
 const meta: Meta<typeof WorkspaceSettingsPageView> = {
@@ -35,18 +35,8 @@ export const UpdateAutomaticUpdatesPolicy: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 
-		await userEvent.click(
-			canvas.getByRole("combobox", { name: /update policy/i }),
-		);
-		await userEvent.click(
-			await screen.findByRole("option", { name: /always/i }),
-		);
+		await selectRadixOption(canvas, /update policy/i, /always/i);
 
-		// The option click closes the listbox; wait for Radix to restore
-		// pointer events before clicking Save.
-		await waitForRadixLayerClose(() =>
-			canvas.getByRole("button", { name: /save/i }),
-		);
 		await userEvent.click(canvas.getByRole("button", { name: /save/i }));
 
 		await waitFor(() =>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 import { MockWorkspace } from "#/testHelpers/entities";
+import { waitForRadixLayerClose } from "#/testHelpers/storybook";
 import { WorkspaceSettingsPageView } from "./WorkspaceSettingsPageView";
 
 const meta: Meta<typeof WorkspaceSettingsPageView> = {
@@ -41,6 +42,11 @@ export const UpdateAutomaticUpdatesPolicy: Story = {
 			await screen.findByRole("option", { name: /always/i }),
 		);
 
+		// The option click closes the listbox; wait for Radix to restore
+		// pointer events before clicking Save.
+		await waitForRadixLayerClose(() =>
+			canvas.getByRole("button", { name: /save/i }),
+		);
 		await userEvent.click(canvas.getByRole("button", { name: /save/i }));
 
 		await waitFor(() =>

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -1,7 +1,7 @@
 import type { StoryContext } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useQueryClient } from "react-query";
-import { expect, waitFor } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { withDefaultFeatures } from "#/api/api";
 import { getAuthorizationKey } from "#/api/queries/authCheck";
 import { hasFirstUserKey, meKey } from "#/api/queries/users";
@@ -46,6 +46,29 @@ export const waitForRadixLayerClose = async (
 			expect(window.getComputedStyle(target).pointerEvents).not.toBe("none");
 		},
 		{ timeout: 10_000 },
+	);
+};
+
+/**
+ * Open a Radix Select and pick an option, then wait for the closed layer's
+ * cleanup so the caller's next interaction cannot race it. Use this instead
+ * of hand-rolling click-combobox/click-option so the wait cannot be
+ * forgotten; drop to waitForRadixLayerClose only for irregular flows (for
+ * example asserting on the open listbox before picking).
+ */
+export const selectRadixOption = async (
+	canvas: ReturnType<typeof within>,
+	comboboxName: string | RegExp,
+	optionName: string | RegExp,
+): Promise<void> => {
+	const combobox = await canvas.findByRole("combobox", {
+		name: comboboxName,
+	});
+	await userEvent.click(combobox);
+	const body = within(combobox.ownerDocument.body);
+	await userEvent.click(await body.findByRole("option", { name: optionName }));
+	await waitForRadixLayerClose(() =>
+		canvas.getByRole("combobox", { name: comboboxName }),
 	);
 };
 

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -1,6 +1,7 @@
 import type { StoryContext } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useQueryClient } from "react-query";
+import { expect, waitFor } from "storybook/test";
 import { withDefaultFeatures } from "#/api/api";
 import { getAuthorizationKey } from "#/api/queries/authCheck";
 import { hasFirstUserKey, meKey } from "#/api/queries/users";
@@ -25,6 +26,28 @@ import {
 	MockOrganizationPermissions,
 	MockProxyLatencies,
 } from "./entities";
+
+/**
+ * Wait for Radix to finish tearing down a just-closed layer (Select
+ * listbox, Popover, and similar). While the layer is open, Radix marks
+ * the rest of the page `aria-hidden` and disables pointer events on it,
+ * and it undoes both asynchronously after the closing interaction. A
+ * pointer interaction or role query issued before that cleanup lands
+ * flakes under CPU load, so re-query the next interaction target until
+ * it is back in the accessibility tree and accepts pointer input.
+ */
+export const waitForRadixLayerClose = async (
+	getTarget: () => HTMLElement,
+): Promise<void> => {
+	await waitFor(
+		() => {
+			// getTarget must re-query by role so an aria-hidden target throws.
+			const target = getTarget();
+			expect(window.getComputedStyle(target).pointerEvents).not.toBe("none");
+		},
+		{ timeout: 10_000 },
+	);
+};
 
 export const withDashboardProvider = (
 	Story: FC,

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -28,21 +28,26 @@ import {
 } from "./entities";
 
 /**
- * Wait for Radix to finish tearing down a just-closed layer (Select
- * listbox, Popover, and similar). While the layer is open, Radix marks
- * the rest of the page `aria-hidden` and disables pointer events on it,
- * and it undoes both asynchronously after the closing interaction. A
- * pointer interaction or role query issued before that cleanup lands
- * flakes under CPU load, so re-query the next interaction target until
- * it is back in the accessibility tree and accepts pointer input.
+ * Wait for Radix to finish tearing down a just-closed modal layer (Select
+ * listbox, modal Popover, and similar). While the layer is open, Radix
+ * marks the rest of the page `aria-hidden` and disables pointer events on
+ * it, and it undoes both asynchronously after the closing interaction. A
+ * pointer interaction, or any ByRole query (positive or negative), issued
+ * before that cleanup lands is racy, so re-query the next interaction
+ * target by role until it is back in the accessibility tree and accepts
+ * pointer input. The role query is built internally so the aria-hidden
+ * half of the check cannot be bypassed with a non-role getter.
  */
 export const waitForRadixLayerClose = async (
-	getTarget: () => HTMLElement,
+	canvas: ReturnType<typeof within>,
+	role: string,
+	name: string | RegExp,
 ): Promise<void> => {
 	await waitFor(
 		() => {
-			// getTarget must re-query by role so an aria-hidden target throws.
-			const target = getTarget();
+			// getByRole excludes aria-hidden subtrees, so this throws until
+			// the page is unmarked.
+			const target = canvas.getByRole(role, { name });
 			expect(window.getComputedStyle(target).pointerEvents).not.toBe("none");
 		},
 		{ timeout: 10_000 },
@@ -67,9 +72,7 @@ export const selectRadixOption = async (
 	await userEvent.click(combobox);
 	const body = within(combobox.ownerDocument.body);
 	await userEvent.click(await body.findByRole("option", { name: optionName }));
-	await waitForRadixLayerClose(() =>
-		canvas.getByRole("combobox", { name: comboboxName }),
-	);
+	await waitForRadixLayerClose(canvas, "combobox", comboboxName);
 };
 
 export const withDashboardProvider = (

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -241,6 +241,13 @@ export default defineConfig({
 					setupFiles: [".storybook/vitest.setup.ts"],
 					// Stop early on systemic failures.
 					bail: 5,
+					// Interaction stories run under full CPU contention inside
+					// `make pre-push` (concurrently with the Go tests), which
+					// surfaces timing races that never fire standalone. Fix
+					// root-caused races deterministically in the stories, but
+					// retry to absorb the load-sensitivity tail: deterministic
+					// failures still fail every retry and block the push.
+					retry: 2,
 					// Cap concurrent browser iframes. The default
 					// (os.availableParallelism, 96 on dev workspaces)
 					// overwhelms vite's transform pipeline on cold cache.

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -241,13 +241,6 @@ export default defineConfig({
 					setupFiles: [".storybook/vitest.setup.ts"],
 					// Stop early on systemic failures.
 					bail: 5,
-					// Interaction stories run under full CPU contention inside
-					// `make pre-push` (concurrently with the Go tests), which
-					// surfaces timing races that never fire standalone. Fix
-					// root-caused races deterministically in the stories, but
-					// retry to absorb the load-sensitivity tail: deterministic
-					// failures still fail every retry and block the push.
-					retry: 2,
 					// Cap concurrent browser iframes. The default
 					// (os.availableParallelism, 96 on dev workspaces)
 					// overwhelms vite's transform pipeline on cold cache.


### PR DESCRIPTION
Interaction stories across nine files flake when the suite runs under CPU load. (`make pre-push` runs `test-storybook` sequentially after the Go batch precisely to limit contention: the load that broke my pushes was host-level, from concurrent worktree activity on the same machine, which a busy-loop harness reproduces. The races are real regardless of the load source: any sufficiently busy machine exposes them.) They pass on idle runs, which is why they survived review; under load they fail often enough to block every push from a hook-enabled checkout (see #28869 for the missing CI lane).

Reproduced with a load harness (busy-loop processes pinning all cores). After fixing the initially observed failures, a full-suite discovery run under the harness with `--retry=0 --bail=0` surfaced the complete tail; every failure across all waves is the same class and every affected story is fixed here deterministically.

## Two failure classes

**1. Radix layer-close races (12 stories in 8 files).** Clicking an option closes a Radix Select, but Radix restores pointer events and unmarks the page `aria-hidden` asynchronously after the close. A pointer interaction (or role query) issued immediately afterwards races that cleanup:

```
Unable to perform pointer interaction as the element has `pointer-events: none`:
BUTTON#config.reasoningEffort.max(label=Max Reasoning Effort)
```

Fixed structurally: `selectRadixOption(canvas, combobox, option)` in `testHelpers/storybook.tsx` owns the whole open → pick → wait sequence so the wait cannot be forgotten; plain flows use it, and irregular flows (assertions on the open listbox, unnamed triggers) use the underlying `waitForRadixLayerClose(getTarget)`, which re-queries the next interaction target by role (so an `aria-hidden` target throws) until it also accepts pointer input: the same condition user-event's `assertPointerEvents` gates on. Applied in `TrialRequestForm` (`selectOption` helper), `DateTimeRangePicker` (`ApplyCustomRange`), `ModelForm` (`ReasoningEffortInProviderConfiguration`, `ReasoningEffortValidationError`, `GoogleThinkingLevelBudgetMutualExclusion`), `CreateUserPage` (`fillForm`, 4 stories), `TaskPrompt` (`SelectTemplateVersion`, `CheckPresetsWhenChangingTemplate`), `AddMCPServerPageView` (`Default`), `MCPServersPage` (`AddFailurePreservesEnteredValues`), and `WorkspaceSettingsPageView` (`UpdateAutomaticUpdatesPolicy`).

**2. Navigation-blocker arming race (`ModelForm > Leave With Unsaved Changes`).** The model identifier field is a catalog combobox that only commits the typed value to formik **on blur**, so typing alone never marks the form dirty. The story previously depended on the "Back to models" click's own `pointerdown` blur committing the value and the navigation blocker arming in the resulting render, before the same click's navigation ran. Under load the navigation wins, the story unmounts to the "No Preview" splash, and no dialog ever exists. The story now blurs explicitly (`userEvent.tab()`), then waits for the unsaved-changes prompt's `beforeunload` leg (registered in the same commit as the blocker) to observe the dirty state via a cancelable synthetic event before navigating. Standalone runtime dropped from flaky-10s to ~0.5s. The same-commit coupling of the two legs in `useUnsavedChangesPrompt` is what makes the probe sound.

The window where a real user could out-click the blocker is a single frame after blur, so this is treated as a test-determinism fix, not a product fix.

## Review round 1: retry guard removed, class audit completed

An earlier revision added `retry: 2` for the interaction project; review (CRF-1/2) correctly called it an unbounded erosion of the gate resting on a wrong claim about make's scheduling, and it is removed. In its place the class is closed structurally: reviewer CRF-4 flagged 18 more shape-matched sites in 8 untouched files, and a modality audit showed 17 of them cannot race (cmdk in the site's non-modal Popover, or inline multi-select lists that never mark the page) while exactly one (`AppearanceForm > SelectSingleFromSync`, a real modal Radix Select) raced and is fixed here.

One prior observation stands corrected in the same spirit: `CreateUserPage` fails deterministically whenever the file runs fast (isolated or loaded) because `fillForm` proceeded immediately after the login-type pick; idle full-suite runs passed only because per-story gaps gave Radix's cleanup wall-clock time.

## Validation

- Load harness with `--retry=0`: repeated runs of every affected file under full CPU contention, all green (previously failing every run).
- Full-suite run under the harness (`--retry=0 --bail=0`): green after the final round (the same sweep previously surfaced every failure fixed here).
- Full interaction suite standalone: 457 files / 3545 tests green.
- `biome check` and `tsc --noEmit` clean; FE1-FE10 self-audit clean (FE10 note: the `getComputedStyle(...).pointerEvents` check mirrors user-event's own gate).

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

