### PR TITLE
refactor(site/src): migrate click info popovers to hover tooltips

### DIFF
--- a/site/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/site/src/components/InfoTooltip/InfoTooltip.tsx
@@ -9,7 +9,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 
-type InfoTooltipType = "info" | "warning";
+export type InfoTooltipType = "info" | "warning";
 
 type InfoTooltipSize = "small" | "medium";
 

--- a/site/src/modules/resources/AgentLatency.tsx
+++ b/site/src/modules/resources/AgentLatency.tsx
@@ -2,12 +2,12 @@ import { cn } from "cn";
 import type { FC } from "react";
 import type { DERPRegion, WorkspaceAgent } from "#/api/typesGenerated";
 import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverText,
-	HelpPopoverTitle,
-	HelpPopoverTrigger,
-} from "#/components/HelpPopover/HelpPopover";
+	Tooltip,
+	TooltipContent,
+	TooltipMessage,
+	TooltipTitle,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { getLatencyColor } from "#/utils/latency";
 
 const getDisplayLatency = (agent: WorkspaceAgent) => {
@@ -41,22 +41,18 @@ export const AgentLatency: FC<AgentLatencyProps> = ({ agent }) => {
 	}
 
 	return (
-		<HelpPopover>
-			<HelpPopoverTrigger asChild>
-				<button
-					type="button"
-					aria-label="latency"
-					className={cn("cursor-pointer", latency.color)}
-				>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button type="button" aria-label="latency" className={latency.color}>
 					{Math.round(latency.latency_ms)}ms
 				</button>
-			</HelpPopoverTrigger>
-			<HelpPopoverContent>
-				<HelpPopoverTitle>Latency</HelpPopoverTitle>
-				<HelpPopoverText>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-xs">
+				<TooltipTitle>Latency</TooltipTitle>
+				<TooltipMessage>
 					This is the latency overhead on non peer to peer connections. The
 					first row is the preferred relay.
-				</HelpPopoverText>
+				</TooltipMessage>
 				<div className="flex-col gap-1 mt-4">
 					{Object.entries(agent.latency)
 						.sort(([, a], [, b]) => a.latency_ms - b.latency_ms)
@@ -73,7 +69,7 @@ export const AgentLatency: FC<AgentLatencyProps> = ({ agent }) => {
 							</div>
 						))}
 				</div>
-			</HelpPopoverContent>
-		</HelpPopover>
+			</TooltipContent>
+		</Tooltip>
 	);
 };

--- a/site/src/modules/resources/AgentStatus.stories.tsx
+++ b/site/src/modules/resources/AgentStatus.stories.tsx
@@ -27,9 +27,9 @@ async function expectTooltip(
 	hasTroubleshootLink: boolean,
 ) {
 	const icon = screen.getByRole("status", { name: ariaLabel });
-	await userEvent.click(icon);
+	await userEvent.hover(icon);
 	await waitFor(() => {
-		const tooltip = screen.getByRole("dialog");
+		const tooltip = screen.getByRole("tooltip");
 		expect(tooltip).toHaveTextContent(title);
 		expect(tooltip).toHaveTextContent(detail);
 		if (hasTroubleshootLink) {

--- a/site/src/modules/resources/AgentStatus.tsx
+++ b/site/src/modules/resources/AgentStatus.tsx
@@ -5,17 +5,12 @@ import type {
 	WorkspaceAgent,
 	WorkspaceAgentDevcontainer,
 } from "#/api/typesGenerated";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverText,
-	HelpPopoverTitle,
-	HelpPopoverTrigger,
-} from "#/components/HelpPopover/HelpPopover";
 import { Link } from "#/components/Link/Link";
 import {
 	Tooltip,
 	TooltipContent,
+	TooltipMessage,
+	TooltipTitle,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import {
@@ -57,9 +52,11 @@ const AgentWarningTooltip: FC<AgentWarningTooltipProps> = ({
 	variant = "warning",
 }) => {
 	return (
-		<HelpPopover>
-			<HelpPopoverTrigger asChild role="status" aria-label={ariaLabel}>
+		<Tooltip>
+			<TooltipTrigger asChild>
 				<TriangleAlertIcon
+					role="status"
+					aria-label={ariaLabel}
 					className={cn(
 						"relative size-3.5",
 						variant === "warning"
@@ -67,15 +64,16 @@ const AgentWarningTooltip: FC<AgentWarningTooltipProps> = ({
 							: "text-content-destructive",
 					)}
 				/>
-			</HelpPopoverTrigger>
-			<HelpPopoverContent>
-				<HelpPopoverTitle>{title}</HelpPopoverTitle>
-				<HelpPopoverText>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-xs">
+				<TooltipTitle>{title}</TooltipTitle>
+				<TooltipMessage>
 					{detail}
 					{troubleshootingURL && (
 						<>
 							{" "}
 							<Link
+								size="sm"
 								target="_blank"
 								rel="noreferrer"
 								href={troubleshootingURL}
@@ -86,9 +84,9 @@ const AgentWarningTooltip: FC<AgentWarningTooltipProps> = ({
 							</Link>
 						</>
 					)}
-				</HelpPopoverText>
-			</HelpPopoverContent>
-		</HelpPopover>
+				</TooltipMessage>
+			</TooltipContent>
+		</Tooltip>
 	);
 };
 

--- a/site/src/modules/users/UserHelpPopovers.tsx
+++ b/site/src/modules/users/UserHelpPopovers.tsx
@@ -1,51 +1,37 @@
 import type { FC } from "react";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
+import { Link } from "#/components/Link/Link";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 
 export const RolesHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger size="small" />
-			<HelpPopoverContent>
-				<HelpPopoverTitle>What is a role?</HelpPopoverTitle>
-				<HelpPopoverText>
-					Coder role-based access control (RBAC) provides fine-grained access
-					management. View our docs on how to use the available roles.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/admin/users/groups-roles")}>
-						User Roles
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip size="small">
+			<TooltipTitle>What is a role?</TooltipTitle>
+			<TooltipMessage>
+				Coder role-based access control (RBAC) provides fine-grained access
+				management. View our docs on how to use the available roles.
+				<br />
+				<Link size="sm" href={docs("/admin/users/groups-roles")}>
+					User Roles
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };
 
 export const GroupsHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger size="small" />
-			<HelpPopoverContent>
-				<HelpPopoverTitle>What is a group?</HelpPopoverTitle>
-				<HelpPopoverText>
-					Groups can be used with template RBAC to give groups of users access
-					to specific templates. View our docs on how to use groups.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/admin/users/groups-roles")}>
-						Groups
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip size="small">
+			<TooltipTitle>What is a group?</TooltipTitle>
+			<TooltipMessage>
+				Groups can be used with template RBAC to give groups of users access to
+				specific templates. View our docs on how to use groups.
+				<br />
+				<Link size="sm" href={docs("/admin/users/groups-roles")}>
+					Groups
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };

--- a/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -46,7 +46,7 @@ export const WorkspaceOutdatedTooltip: FC<WorkspaceOutdatedTooltipProps> = ({
 			{children ? (
 				<HelpPopoverTrigger asChild>
 					<span
-						className="flex items-center gap-1.5 cursor-help"
+						className="flex items-center gap-1.5"
 						onClick={stopPropagation}
 						onKeyDown={stopPropagation}
 						onKeyUp={stopPropagation}

--- a/site/src/pages/AIBridgePage/AIBridgeHelpPopover.tsx
+++ b/site/src/pages/AIBridgePage/AIBridgeHelpPopover.tsx
@@ -1,32 +1,21 @@
 import type { FC } from "react";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
+import { Link } from "#/components/Link/Link";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 
 export const AIBridgeHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger />
-
-			<HelpPopoverContent>
-				<HelpPopoverTitle>What is AI Gateway?</HelpPopoverTitle>
-				<HelpPopoverText>
-					AI Gateway is a smart gateway for AI that provides centralized
-					management, auditing, and attribution for LLM usage.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/ai-coder/ai-gateway")}>
-						Read the docs
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip>
+			<TooltipTitle>What is AI Gateway?</TooltipTitle>
+			<TooltipMessage>
+				AI Gateway is a smart gateway for AI that provides centralized
+				management, auditing, and attribution for LLM usage.
+				<br />
+				<Link size="sm" href={docs("/ai-coder/ai-gateway")}>
+					Read the docs
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };

--- a/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
+++ b/site/src/pages/AIBridgePage/NetworkRequestStates.tsx
@@ -9,7 +9,7 @@ import { TooltipMessage } from "#/components/Tooltip/Tooltip";
 export const NetworkMonitoringDisabled: FC = () => (
 	<span className="inline-flex items-center gap-1 whitespace-nowrap text-content-secondary">
 		Disabled
-		<InfoTooltip>
+		<InfoTooltip size="small">
 			<TooltipMessage>
 				Network request monitoring was not active for this session.
 			</TooltipMessage>

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -302,7 +302,7 @@ const UsageSection: FC<{ section: UsageSectionData }> = ({ section }) => {
 								<TooltipTrigger asChild>
 									<button
 										type="button"
-										className="mt-0.5 inline-flex size-3.5 shrink-0 cursor-help items-center justify-center rounded-sm border-none bg-transparent p-0 text-content-secondary/70 outline-hidden transition-colors hover:text-content-primary focus-visible:ring-2 focus-visible:ring-content-link"
+										className="mt-0.5 inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm border-none bg-transparent p-0 text-content-secondary/70 outline-hidden transition-colors hover:text-content-primary focus-visible:ring-2 focus-visible:ring-content-link"
 										aria-label={`${section.title} help`}
 									>
 										<InfoIcon className="size-3.5" />

--- a/site/src/pages/AuditPage/AuditHelpPopover.tsx
+++ b/site/src/pages/AuditPage/AuditHelpPopover.tsx
@@ -1,32 +1,20 @@
 import type { FC } from "react";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
+import { Link } from "#/components/Link/Link";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 
 export const AuditHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger />
-
-			<HelpPopoverContent>
-				<HelpPopoverTitle>What is an audit log?</HelpPopoverTitle>
-				<HelpPopoverText>
-					An audit log is a record of events and changes made throughout a
-					system.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/admin/security/audit-logs")}>
-						Events we track
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip>
+			<TooltipTitle>What is an audit log?</TooltipTitle>
+			<TooltipMessage>
+				An audit log is a record of events and changes made throughout a system.
+				<br />
+				<Link size="sm" href={docs("/admin/security/audit-logs")}>
+					Events we track
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };

--- a/site/src/pages/ConnectionLogPage/ConnectionLogHelpPopover.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogHelpPopover.tsx
@@ -1,33 +1,22 @@
 import type { FC } from "react";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
+import { Link } from "#/components/Link/Link";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 
 export const ConnectionLogHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger />
-
-			<HelpPopoverContent>
-				<HelpPopoverTitle>Why are some events missing?</HelpPopoverTitle>
-				<HelpPopoverText>
-					The connection log is a best-effort log of workspace access. Some
-					events are reported by workspace agents, and receipt of these events
-					by the server is not guaranteed.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/admin/monitoring/connection-logs")}>
-						Connection log documentation
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip>
+			<TooltipTitle>Why are some events missing?</TooltipTitle>
+			<TooltipMessage>
+				The connection log is a best-effort log of workspace access. Some events
+				are reported by workspace agents, and receipt of these events by the
+				server is not guaranteed.
+				<br />
+				<Link size="sm" href={docs("/admin/monitoring/connection-logs")}>
+					Connection log documentation
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -29,16 +29,13 @@ import {
 	ComboboxTrigger,
 } from "#/components/Combobox/Combobox";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Link } from "#/components/Link/Link";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Switch } from "#/components/Switch/Switch";
+import { TooltipMessage } from "#/components/Tooltip/Tooltip";
 import { useDebouncedFunction } from "#/hooks/debounce";
 import type { ExternalAuthPollingState } from "#/hooks/useExternalAuth";
 import { useSyncFormParameters } from "#/modules/hooks/useSyncFormParameters";
@@ -440,22 +437,22 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					<span className="flex flex-row items-center gap-2">
 						<h1 className="text-3xl font-semibold m-0">New workspace</h1>
 
-						<HelpPopover>
-							<HelpPopoverIconTrigger />
-							<HelpPopoverContent className="max-w-xs text-sm">
+						<InfoTooltip>
+							<TooltipMessage>
 								Dynamic Parameters enhances Coder's existing parameter system
 								with real-time validation, conditional parameter behavior, and
 								richer input types.
 								<br />
 								<Link
+									size="sm"
 									href={docs(
 										"/admin/templates/extending-templates/dynamic-parameters",
 									)}
 								>
 									View docs
 								</Link>
-							</HelpPopoverContent>
-						</HelpPopover>
+							</TooltipMessage>
+						</InfoTooltip>
 					</span>
 				</header>
 

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.tsx
@@ -25,12 +25,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "#/components/Dialog/Dialog";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverText,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Link } from "#/components/Link/Link";
@@ -49,6 +44,7 @@ import {
 	TableRow,
 } from "#/components/Table/Table";
 import { TableEmpty } from "#/components/TableEmpty/TableEmpty";
+import { TooltipMessage } from "#/components/Tooltip/Tooltip";
 import { IdpUnseenClaimWarning } from "#/modules/idpSync/IdpUnseenClaimWarning";
 import { docs } from "#/utils/docs";
 import { isUUID } from "#/utils/uuid";
@@ -463,14 +459,11 @@ const OrganizationRow: FC<OrganizationRowProps> = ({
 
 const AssignDefaultOrgHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger />
-			<HelpPopoverContent>
-				<HelpPopoverText>
-					Disabling will remove all users from the default organization if a
-					mapping for the default organization is not defined.
-				</HelpPopoverText>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip>
+			<TooltipMessage>
+				Disabling will remove all users from the default organization if a
+				mapping for the default organization is not defined.
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };

--- a/site/src/pages/GroupsPage/StatusIconTooltip.stories.tsx
+++ b/site/src/pages/GroupsPage/StatusIconTooltip.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof StatusIconTooltip>;
 export const Info: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await userEvent.click(canvas.getByRole("button", { name: "More info" }));
+		await userEvent.hover(canvas.getByRole("button", { name: "More info" }));
 		await expect(
 			await within(document.body).findByText(
 				"Spend compared to the budget for the active period.",

--- a/site/src/pages/GroupsPage/StatusIconTooltip.tsx
+++ b/site/src/pages/GroupsPage/StatusIconTooltip.tsx
@@ -1,30 +1,16 @@
-import { InfoIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverText,
-} from "#/components/HelpPopover/HelpPopover";
+	InfoTooltip,
+	type InfoTooltipType,
+} from "#/components/InfoTooltip/InfoTooltip";
+import { TooltipMessage } from "#/components/Tooltip/Tooltip";
 
-type StatusIconKind = "info" | "warning";
-
-const statusIcon: Record<StatusIconKind, ReactNode> = {
-	info: <InfoIcon className="text-content-secondary" />,
-	warning: <TriangleAlertIcon className="text-content-warning" />,
-};
-
-/** A popover tooltip anchored to a status icon, styled per `kind`. */
+/** A hover tooltip anchored to a status icon, styled per `kind`. */
 export const StatusIconTooltip: FC<{
 	message: ReactNode;
-	kind?: StatusIconKind;
+	kind?: InfoTooltipType;
 }> = ({ message, kind = "info" }) => (
-	<HelpPopover>
-		<HelpPopoverIconTrigger size="small" hoverEffect={false}>
-			{statusIcon[kind]}
-		</HelpPopoverIconTrigger>
-		<HelpPopoverContent>
-			<HelpPopoverText>{message}</HelpPopoverText>
-		</HelpPopoverContent>
-	</HelpPopover>
+	<InfoTooltip type={kind} size="small">
+		<TooltipMessage>{message}</TooltipMessage>
+	</InfoTooltip>
 );

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageView.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageView.tsx
@@ -7,19 +7,13 @@ import type {
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Label } from "#/components/Label/Label";
+import { Link } from "#/components/Link/Link";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { Separator } from "#/components/Separator/Separator";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { useClipboard } from "#/hooks/useClipboard";
 import {
 	Diagnostics,
@@ -201,27 +195,22 @@ const ParametersSkeleton: React.FC = () => {
 
 const TestHelpPopover: React.FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger size="small" />
-			<HelpPopoverContent>
-				<HelpPopoverTitle>Testing your Open in Coder settings</HelpPopoverTitle>
-				<HelpPopoverText>
-					This button will open the workspace creation page in a new tab with
-					the parameters that you have supplied. Use this to debug your{" "}
-					<strong>Open in Coder</strong> button before using it.
-				</HelpPopoverText>
-				<HelpPopoverText>
-					Note: Even if you have set creation mode to auto, this button will not
-					automatically create a workspace so that you have the opportunity to
-					inspect the parameters and check for errors.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/admin/templates/open-in-coder")}>
-						Templates &ndash; Open in Coder
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip size="small">
+			<TooltipTitle>Testing your Open in Coder settings</TooltipTitle>
+			<TooltipMessage>
+				This button will open the workspace creation page in a new tab with the
+				parameters that you have supplied. Use this to debug your{" "}
+				<strong>Open in Coder</strong> button before using it.
+				<br />
+				Note: Even if you have set creation mode to auto, this button will not
+				automatically create a workspace so that you have the opportunity to
+				inspect the parameters and check for errors.
+				<br />
+				<Link size="sm" href={docs("/admin/templates/open-in-coder")}>
+					Templates &ndash; Open in Coder
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };
 

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -35,19 +35,15 @@ import {
 	type DateRangeValue,
 } from "#/components/DateRangePicker/DateRangePicker";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Link } from "#/components/Link/Link";
 import { Loader } from "#/components/Loader/Loader";
 import {
 	Tooltip,
 	TooltipArrow,
 	TooltipContent,
+	TooltipMessage,
+	TooltipTitle,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
@@ -283,20 +279,15 @@ const ActiveUsersPanel: FC<ActiveUsersPanelProps> = ({
 			<PanelHeader>
 				<PanelTitle className="flex items-center gap-2">
 					{interval === "day" ? "Daily" : "Weekly"} Active Users
-					<HelpPopover>
-						<HelpPopoverIconTrigger size="small" />
-						<HelpPopoverContent>
-							<HelpPopoverTitle>
-								How do we calculate active users?
-							</HelpPopoverTitle>
-							<HelpPopoverText>
-								When a connection is initiated to a user&apos;s workspace they
-								are considered an active user. e.g. apps, web terminal, SSH.
-								This is for measuring user activity and has no connection to
-								license consumption.
-							</HelpPopoverText>
-						</HelpPopoverContent>
-					</HelpPopover>
+					<InfoTooltip size="small">
+						<TooltipTitle>How do we calculate active users?</TooltipTitle>
+						<TooltipMessage>
+							When a connection is initiated to a user's workspace they are
+							considered an active user. e.g. apps, web terminal, SSH. This is
+							for measuring user activity and has no connection to license
+							consumption.
+						</TooltipMessage>
+					</InfoTooltip>
 				</PanelTitle>
 			</PanelHeader>
 			<PanelContent error={error} data={data}>
@@ -327,15 +318,12 @@ const UsersLatencyPanel: FC<UsersLatencyPanelProps> = ({
 			<PanelHeader>
 				<PanelTitle className="flex items-center gap-2">
 					Latency by user
-					<HelpPopover>
-						<HelpPopoverIconTrigger size="small" />
-						<HelpPopoverContent>
-							<HelpPopoverTitle>How is latency calculated?</HelpPopoverTitle>
-							<HelpPopoverText>
-								The median round trip time of user connections to workspaces.
-							</HelpPopoverText>
-						</HelpPopoverContent>
-					</HelpPopover>
+					<InfoTooltip size="small">
+						<TooltipTitle>How is latency calculated?</TooltipTitle>
+						<TooltipMessage>
+							The median round trip time of user connections to workspaces.
+						</TooltipMessage>
+					</InfoTooltip>
 				</PanelTitle>
 			</PanelHeader>
 			<PanelContent error={error} data={data?.report.users}>
@@ -382,16 +370,13 @@ const UsersActivityPanel: FC<UsersActivityPanelProps> = ({
 			<PanelHeader>
 				<PanelTitle className="flex items-center gap-2">
 					Activity by user
-					<HelpPopover>
-						<HelpPopoverIconTrigger size="small" />
-						<HelpPopoverContent>
-							<HelpPopoverTitle>How is activity calculated?</HelpPopoverTitle>
-							<HelpPopoverText>
-								When a connection is initiated to a user&apos;s workspace they
-								are considered an active user. e.g. apps, web terminal, SSH
-							</HelpPopoverText>
-						</HelpPopoverContent>
-					</HelpPopover>
+					<InfoTooltip size="small">
+						<TooltipTitle>How is activity calculated?</TooltipTitle>
+						<TooltipMessage>
+							When a connection is initiated to a user's workspace they are
+							considered an active user. e.g. apps, web terminal, SSH
+						</TooltipMessage>
+					</InfoTooltip>
 				</PanelTitle>
 			</PanelHeader>
 			<PanelContent error={error} data={data?.report.users}>

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
@@ -54,7 +54,7 @@ export const VersionRow: FC<VersionRowProps> = ({
 								version <strong>{version.name}</strong>
 							</span>
 							{version.message && (
-								<InfoTooltip>
+								<InfoTooltip size="small">
 									<TooltipTitle>Message</TooltipTitle>
 									<TooltipMessage>{version.message}</TooltipMessage>
 								</InfoTooltip>

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -7,17 +7,11 @@ import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { FormFields } from "#/components/Form/Form";
 import { FormField } from "#/components/FormField/FormField";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Label } from "#/components/Label/Label";
+import { Link } from "#/components/Link/Link";
 import { Textarea } from "#/components/Textarea/Textarea";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import type { PublishVersionData } from "#/pages/TemplateVersionEditorPage/types";
 import { docs } from "#/utils/docs";
 import { getFormHelpers } from "#/utils/formUtils";
@@ -134,25 +128,22 @@ export const PublishTemplateVersionDialog: FC<
 									</Label>
 								</div>
 
-								<HelpPopover>
-									<HelpPopoverIconTrigger />
-									<HelpPopoverContent>
-										<HelpPopoverTitle>Active versions</HelpPopoverTitle>
-										<HelpPopoverText>
-											Templates can enforce that the active version be used for
-											all workspaces <EnterpriseBadge />
-										</HelpPopoverText>
-										<HelpPopoverLinksGroup>
-											<HelpPopoverLink
-												href={docs(
-													"/admin/templates/managing-templates#template-update-policies",
-												)}
-											>
-												Review the documentation
-											</HelpPopoverLink>
-										</HelpPopoverLinksGroup>
-									</HelpPopoverContent>
-								</HelpPopover>
+								<InfoTooltip>
+									<TooltipTitle>Active versions</TooltipTitle>
+									<TooltipMessage>
+										Templates can enforce that the active version be used for
+										all workspaces <EnterpriseBadge />
+										<br />
+										<Link
+											size="sm"
+											href={docs(
+												"/admin/templates/managing-templates#template-update-policies",
+											)}
+										>
+											Review the documentation
+										</Link>
+									</TooltipMessage>
+								</InfoTooltip>
 							</div>
 						</FormFields>
 					</div>

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.stories.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.stories.tsx
@@ -181,7 +181,7 @@ export const PublishDialogActiveVersionHelp: Story = {
 		// The dialog and popover are portaled, so query against the document body.
 		const body = within(canvasElement.ownerDocument.body);
 		const trigger = await body.findByRole("button", { name: "More info" });
-		await userEvent.click(trigger);
+		await userEvent.hover(trigger);
 		await expect(await body.findByText("Active versions")).toBeInTheDocument();
 		await expect(
 			body.getByRole("link", { name: "Review the documentation" }),

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -16,15 +16,7 @@ import { AvatarDataSkeleton } from "#/components/Avatar/AvatarDataSkeleton";
 import { Badge } from "#/components/Badge/Badge";
 import { DeprecatedBadge } from "#/components/Badge/PresetBadges";
 import { Button } from "#/components/Button/Button";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Link } from "#/components/Link/Link";
 import { Margins } from "#/components/Margins/Margins";
 import {
@@ -45,6 +37,7 @@ import {
 	TableLoaderSkeleton,
 	TableRowSkeleton,
 } from "#/components/TableLoader/TableLoader";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
 import type { WorkspacePermissions } from "#/modules/permissions/workspaces";
@@ -85,21 +78,17 @@ const ClassicParameterFlowAlert: FC<{ templateCount: number }> = ({
 
 const TemplateHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger />
-			<HelpPopoverContent>
-				<HelpPopoverTitle>What is a template?</HelpPopoverTitle>
-				<HelpPopoverText>
-					With templates you can create a common configuration for your
-					workspaces using Terraform.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/admin/templates")}>
-						Manage templates
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip>
+			<TooltipTitle>What is a template?</TooltipTitle>
+			<TooltipMessage>
+				With templates you can create a common configuration for your workspaces
+				using Terraform.
+				<br />
+				<Link size="sm" href={docs("/admin/templates")}>
+					Manage templates
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -1,4 +1,3 @@
-import { CircleHelpIcon } from "lucide-react";
 import type { FC } from "react";
 import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "react-query";
@@ -13,6 +12,7 @@ import type {
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
 import { Link } from "#/components/Link/Link";
 import { Loader } from "#/components/Loader/Loader";
 import {
@@ -20,12 +20,7 @@ import {
 	SettingsHeaderDescription,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "#/components/Tooltip/Tooltip";
+import { TooltipMessage } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 import { pageTitle } from "#/utils/page";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
@@ -281,26 +276,22 @@ const WorkspaceParametersPage: FC = () => {
 			<SettingsHeader>
 				<SettingsHeaderTitle
 					tooltip={
-						<TooltipProvider delayDuration={100}>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<CircleHelpIcon className="size-icon-xs text-content-secondary" />
-								</TooltipTrigger>
-								<TooltipContent className="max-w-xs text-sm">
-									Dynamic Parameters enhances Coder's existing parameter system
-									with real-time validation, conditional parameter behavior, and
-									richer input types.
-									<br />
-									<Link
-										href={docs(
-											"/admin/templates/extending-templates/dynamic-parameters",
-										)}
-									>
-										View docs
-									</Link>
-								</TooltipContent>
-							</Tooltip>
-						</TooltipProvider>
+						<InfoTooltip>
+							<TooltipMessage>
+								Dynamic Parameters enhances Coder's existing parameter system
+								with real-time validation, conditional parameter behavior, and
+								richer input types.
+								<br />
+								<Link
+									size="sm"
+									href={docs(
+										"/admin/templates/extending-templates/dynamic-parameters",
+									)}
+								>
+									View docs
+								</Link>
+							</TooltipMessage>
+						</InfoTooltip>
 					}
 				>
 					Parameters

--- a/site/src/pages/WorkspacesPage/WorkspaceHelpPopover.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspaceHelpPopover.tsx
@@ -1,34 +1,25 @@
 import type { FC } from "react";
-import {
-	HelpPopover,
-	HelpPopoverContent,
-	HelpPopoverIconTrigger,
-	HelpPopoverLink,
-	HelpPopoverLinksGroup,
-	HelpPopoverText,
-	HelpPopoverTitle,
-} from "#/components/HelpPopover/HelpPopover";
+import { InfoTooltip } from "#/components/InfoTooltip/InfoTooltip";
+import { Link } from "#/components/Link/Link";
+import { TooltipMessage, TooltipTitle } from "#/components/Tooltip/Tooltip";
 import { docs } from "#/utils/docs";
 
 export const WorkspaceHelpPopover: FC = () => {
 	return (
-		<HelpPopover>
-			<HelpPopoverIconTrigger />
-			<HelpPopoverContent>
-				<HelpPopoverTitle>What is a workspace?</HelpPopoverTitle>
-				<HelpPopoverText>
-					A workspace is your development environment in the cloud. It includes
-					the infrastructure and tools you need to work on your project.
-				</HelpPopoverText>
-				<HelpPopoverLinksGroup>
-					<HelpPopoverLink href={docs("/user-guides")}>
-						Create Workspaces
-					</HelpPopoverLink>
-					<HelpPopoverLink href={docs("/user-guides/workspace-access")}>
-						Connect with SSH
-					</HelpPopoverLink>
-				</HelpPopoverLinksGroup>
-			</HelpPopoverContent>
-		</HelpPopover>
+		<InfoTooltip>
+			<TooltipTitle>What is a workspace?</TooltipTitle>
+			<TooltipMessage>
+				A workspace is your development environment in the cloud. It includes
+				the infrastructure and tools you need to work on your project.
+				<br />
+				<Link size="sm" href={docs("/user-guides")}>
+					Create Workspaces
+				</Link>
+				<br />
+				<Link size="sm" href={docs("/user-guides/workspace-access")}>
+					Connect with SSH
+				</Link>
+			</TooltipMessage>
+		</InfoTooltip>
 	);
 };


### PR DESCRIPTION
Part 2 of 2 of the tooltip cleanup (split for review). **Stacked on #28903** — review/merge that first.

Migrates the click-based `HelpPopover` info affordances across pages and modules to the hover `InfoTooltip` (and the base `Tooltip` for the agent status/latency indicators) added in #28903, so help text reveals on hover consistently.

Converted: Audit, Connection log, AI Gateway, Workspaces, Templates, Template embed, Publish version, IdP group/org sync, Create workspace, Workspace parameters, Template insights, User roles/groups, Active users, and the agent status/latency/warning indicators. Also removes the leftover `cursor-help` "?" cursor from tooltip triggers.

Genuinely interactive popovers stay click based (a hover tooltip is the wrong primitive): the workspace/agent "outdated → Update" popovers, the SSH / port-forward / build-parameter menus, and the breadcrumb hovercards.

### Before / After

Representative example (the same shared component every migrated call site now uses). Help reveals on hover (was click), uses the info / warning icon (was a `?`), opens to the right, and links match the body text size.

| | Before — click popover | After — hover tooltip |
|---|---|---|
| Info | <img width="320" src="https://raw.githubusercontent.com/coder/coder/429b230efbe38bfa3f7fc2bac5c8fad71fa50e4a/.assets/before-info.png" /> | <img width="320" src="https://raw.githubusercontent.com/coder/coder/429b230efbe38bfa3f7fc2bac5c8fad71fa50e4a/.assets/after-info.png" /> |
| Warning | <img width="320" src="https://raw.githubusercontent.com/coder/coder/429b230efbe38bfa3f7fc2bac5c8fad71fa50e4a/.assets/before-warning.png" /> | <img width="320" src="https://raw.githubusercontent.com/coder/coder/429b230efbe38bfa3f7fc2bac5c8fad71fa50e4a/.assets/after-warning.png" /> |

<details>
<summary>Design decisions</summary>

- Two families exist and were easy to confuse: hover `Tooltip` (transient labels) and click `HelpPopover` (rich content). This work moves every genuine info/help reveal onto the hover family and keeps interactive surfaces on the click family.
- Icon size is preserved per call site via the `size` prop (`small` = 12px, `medium` = 16px) to match the previous `HelpPopoverIconTrigger` sizes.
- Links inside tooltips use `Link size="sm"` so they match the `text-xs` body, with a small top margin for separation.
- Left as click popovers: `AgentOutdatedTooltip`, `SubAgentOutdatedTooltip`, `WorkspaceOutdatedTooltip` (contain an Update action with controlled open state), `SSHButton` / `PortForwardButton` / `BuildParametersPopover` (button-triggered menus/forms), and the `WorkspaceTopbar` breadcrumb hovercards (navigation links).

</details>

### Stack

- **Base (1/2):** #28903 — the `InfoTooltip` component + shared delay.
- **This PR (2/2):** the call-site migrations.

---

🤖 Generated with Coder Agents on behalf of @chrifro.
