### PR TITLE
chore(site): enable oxlint jsx-no-useless-fragment rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -118,6 +118,7 @@
 		"no-ex-assign": "error",
 		"no-class-assign": "error",
 		"jsx-no-comment-textnodes": "error",
+		"jsx-no-useless-fragment": "error",
 		"no-compare-neg-zero": "error",
 		"no-labels": "error",
 		"no-const-enum": "error",
@@ -179,7 +180,6 @@
 		// small < medium < large < xl.
 		// ==========================================================
 		"no-autofocus": "off", // a11y/noAutofocus (large)
-		"jsx-no-useless-fragment": "off", // complexity/noUselessFragments (large)
 		"no-invalid-void-type": "off", // suspicious/noConfusingVoidType (large)
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)

--- a/site/src/components/Markdown/InlineMarkdown.tsx
+++ b/site/src/components/Markdown/InlineMarkdown.tsx
@@ -46,7 +46,7 @@ export const InlineMarkdown: FC<InlineMarkdownProps> = (props) => {
 			]}
 			unwrapDisallowed
 			components={{
-				p: ({ children }) => <>{children}</>,
+				p: ({ children }) => children,
 
 				a: ({ href, children }) => {
 					const isExternal = href?.startsWith("http");

--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -67,7 +67,7 @@ export const Markdown: FC<MarkdownProps> = (props) => {
 					// When pre is wrapping a code, the SyntaxHighlighter is already going
 					// to wrap it with a pre so we don't need it
 					if (firstChild.type === "element" && firstChild.tagName === "code") {
-						return <>{children}</>;
+						return children;
 					}
 					return <pre>{children}</pre>;
 				},

--- a/site/src/contexts/DiffsWorkerPoolProvider.tsx
+++ b/site/src/contexts/DiffsWorkerPoolProvider.tsx
@@ -28,7 +28,7 @@ export const DiffsWorkerPoolProvider: FC<DiffsWorkerPoolProviderProps> = ({
 	children,
 }) => {
 	if (!hasWorkerSupport()) {
-		return <>{children}</>;
+		return children;
 	}
 
 	const poolOptions: WorkerPoolOptions = {

--- a/site/src/modules/permissions/RequirePermission.tsx
+++ b/site/src/modules/permissions/RequirePermission.tsx
@@ -42,5 +42,5 @@ export const RequirePermission: FC<RequirePermissionProps> = ({
 		);
 	}
 
-	return <>{children}</>;
+	return children;
 };

--- a/site/src/modules/resources/ResourceCard.test.tsx
+++ b/site/src/modules/resources/ResourceCard.test.tsx
@@ -7,7 +7,10 @@ import { ResourceCard } from "./ResourceCard";
 describe("Resource Card", () => {
 	it("renders daily cost and metadata tiles", async () => {
 		render(
-			<ResourceCard resource={MockWorkspaceResource} agentRow={() => <></>} />,
+			<ResourceCard
+				resource={MockWorkspaceResource}
+				agentRow={() => <div />}
+			/>,
 		);
 		expect(
 			screen.getByText(MockWorkspaceResource.daily_cost),
@@ -45,7 +48,7 @@ describe("Resource Card", () => {
 			],
 		};
 
-		render(<ResourceCard resource={mockResource} agentRow={() => <></>} />);
+		render(<ResourceCard resource={mockResource} agentRow={() => <div />} />);
 		expect(screen.getByText(mockResource.daily_cost)).toBeInTheDocument();
 		expect(
 			screen.getByText(mockResource.metadata?.[0].value),
@@ -90,7 +93,7 @@ describe("Resource Card", () => {
 			],
 		};
 
-		render(<ResourceCard resource={mockResource} agentRow={() => <></>} />);
+		render(<ResourceCard resource={mockResource} agentRow={() => <div />} />);
 		expect(screen.queryByText(mockResource.daily_cost)).not.toBeInTheDocument();
 		expect(
 			screen.getByText(mockResource.metadata?.[0].value),

--- a/site/src/modules/resources/ResourceCard.tsx
+++ b/site/src/modules/resources/ResourceCard.tsx
@@ -94,7 +94,7 @@ export const ResourceCard: FC<ResourceCardProps> = ({ resource, agentRow }) => {
 															</CopyableValue>
 														);
 													}
-													return <>{children}</>;
+													return children;
 												},
 											}}
 										>

--- a/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
@@ -74,7 +74,7 @@ export const TemplateFiles: FC<TemplateFilesProps> = ({
 						}}
 						Label={({ path, filename, isFolder }) => {
 							if (isFolder) {
-								return <>{filename}</>;
+								return filename;
 							}
 
 							const hasDiff = fileInfo(path).hasDiff;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -259,7 +259,7 @@ const LeadingIcon: FC<ToolCallLeadingIconProps> = ({
 }) => {
 	const { active } = useToolCallContext();
 	if (children) {
-		return <>{children}</>;
+		return children;
 	}
 	if (!name) {
 		return null;
@@ -444,7 +444,7 @@ const Content: FC<ToolCallContentProps> = ({ children }) => {
 	if (!collapsible || !expanded) {
 		return null;
 	}
-	return <>{children}</>;
+	return children;
 };
 
 export const ToolCall = {

--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.test.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.test.tsx
@@ -20,8 +20,8 @@ const renderPage = async (searchParams: URLSearchParams) => {
 		path: "/templates/new",
 		// We need this because after creation, the user will be redirected to here
 		extraRoutes: [
-			{ path: "templates/:organization/:template/files", element: <></> },
-			{ path: "templates/:template/files", element: <></> },
+			{ path: "templates/:organization/:template/files", element: null },
+			{ path: "templates/:template/files", element: null },
 		],
 	});
 	// It is lazy loaded, so we have to wait for it to be rendered to not get an

--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesPage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesPage.test.tsx
@@ -32,7 +32,7 @@ const renderTemplateVariablesPage = async () => {
 	renderWithTemplateSettingsLayout(<TemplateVariablesPage />, {
 		route: `/templates/${MockTemplate.name}/variables`,
 		path: "/templates/:template/variables",
-		extraRoutes: [{ path: `/templates/${MockTemplate.name}`, element: <></> }],
+		extraRoutes: [{ path: `/templates/${MockTemplate.name}`, element: null }],
 	});
 	await waitForLoaderToBeRemoved();
 };

--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
@@ -89,48 +89,44 @@ const TokensTableBody: FC<TokensTableBodyProps> = ({
 	if (hasLoaded && (!tokens || tokens.length === 0)) {
 		return <TableEmpty message="No tokens found" />;
 	}
-	return (
-		<>
-			{tokens?.map((token) => (
-				<TableRow key={token.id} data-testid={`token-${token.id}`} tabIndex={0}>
-					<TableCell>
-						<span className="text-content-secondary">{token.id}</span>
-					</TableCell>
+	return tokens?.map((token) => (
+		<TableRow key={token.id} data-testid={`token-${token.id}`} tabIndex={0}>
+			<TableCell>
+				<span className="text-content-secondary">{token.id}</span>
+			</TableCell>
 
-					<TableCell>
-						<span className="text-content-secondary">{token.token_name}</span>
-					</TableCell>
+			<TableCell>
+				<span className="text-content-secondary">{token.token_name}</span>
+			</TableCell>
 
-					<TableCell>{lastUsedOrNever(token.last_used)}</TableCell>
+			<TableCell>{lastUsedOrNever(token.last_used)}</TableCell>
 
-					<TableCell>
-						<span className="text-content-secondary" data-pixel="ignore">
-							{dayjs(token.expires_at).fromNow()}
-						</span>
-					</TableCell>
+			<TableCell>
+				<span className="text-content-secondary" data-pixel="ignore">
+					{dayjs(token.expires_at).fromNow()}
+				</span>
+			</TableCell>
 
-					<TableCell>
-						<span className="text-content-secondary">
-							{dayjs(token.created_at).fromNow()}
-						</span>
-					</TableCell>
+			<TableCell>
+				<span className="text-content-secondary">
+					{dayjs(token.created_at).fromNow()}
+				</span>
+			</TableCell>
 
-					<TableCell>
-						<span className="text-content-secondary">
-							<Button
-								onClick={() => {
-									onDelete(token);
-								}}
-								size="icon"
-								variant="destructive"
-								aria-label="Delete token"
-							>
-								<TrashIcon className="size-icon-sm" />
-							</Button>
-						</span>
-					</TableCell>
-				</TableRow>
-			))}
-		</>
-	);
+			<TableCell>
+				<span className="text-content-secondary">
+					<Button
+						onClick={() => {
+							onDelete(token);
+						}}
+						size="icon"
+						variant="destructive"
+						aria-label="Delete token"
+					>
+						<TrashIcon className="size-icon-sm" />
+					</Button>
+				</span>
+			</TableCell>
+		</TableRow>
+	));
 };

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.tsx
@@ -119,15 +119,11 @@ const ProxiesTableBody: FC<ProxiesTableBodyProps> = ({
 	if (hasLoaded && proxies?.length === 0) {
 		return <TableEmpty message="No workspace proxies found" />;
 	}
-	return (
-		<>
-			{proxies?.map((proxy) => (
-				<ProxyRow
-					latency={proxyLatencies?.[proxy.id]}
-					key={proxy.id}
-					proxy={proxy}
-				/>
-			))}
-		</>
-	);
+	return proxies?.map((proxy) => (
+		<ProxyRow
+			latency={proxyLatencies?.[proxy.id]}
+			key={proxy.id}
+			proxy={proxy}
+		/>
+	));
 };

--- a/site/src/pages/UsersPage/UsersTable.tsx
+++ b/site/src/pages/UsersPage/UsersTable.tsx
@@ -120,123 +120,113 @@ const UsersTableBody: React.FC<UsersTableProps> = ({
 		return <TableEmpty message="No users found" />;
 	}
 
-	return (
-		<>
-			{users?.map((user) => (
-				<TableRow key={user.id} data-testid={`user-${user.id}`}>
-					<TableCell>
-						<AvatarData
-							title={user.username}
-							subtitle={
-								user.is_service_account ? "Service Account" : user.email
-							}
-							src={user.avatar_url}
-						/>
-					</TableCell>
+	return users?.map((user) => (
+		<TableRow key={user.id} data-testid={`user-${user.id}`}>
+			<TableCell>
+				<AvatarData
+					title={user.username}
+					subtitle={user.is_service_account ? "Service Account" : user.email}
+					src={user.avatar_url}
+				/>
+			</TableCell>
 
-					<UserRoleCell roles={user.roles} />
+			<UserRoleCell roles={user.roles} />
 
-					<UserGroupsCell userGroups={groupsByUserId?.get(user.id)} />
+			<UserGroupsCell userGroups={groupsByUserId?.get(user.id)} />
 
-					<TableCell
-						className={cn(
-							"capitalize",
-							user.status === "suspended" && "text-content-secondary",
-						)}
-					>
-						<div>{user.status}</div>
-						{(user.status === "active" || user.status === "dormant") && (
-							<LastSeen at={user.last_seen_at} className="text-xs" />
-						)}
-					</TableCell>
+			<TableCell
+				className={cn(
+					"capitalize",
+					user.status === "suspended" && "text-content-secondary",
+				)}
+			>
+				<div>{user.status}</div>
+				{(user.status === "active" || user.status === "dormant") && (
+					<LastSeen at={user.last_seen_at} className="text-xs" />
+				)}
+			</TableCell>
 
-					{canEditUsers && (
-						<TableCell>
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										size="icon-lg"
-										variant="subtle"
-										aria-label="Open menu"
+			{canEditUsers && (
+				<TableCell>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button size="icon-lg" variant="subtle" aria-label="Open menu">
+								<EllipsisVerticalIcon aria-hidden="true" />
+								<span className="sr-only">Open menu</span>
+							</Button>
+						</DropdownMenuTrigger>
+
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem asChild>
+								<Link
+									to={`/workspaces?filter=${encodeURIComponent(`owner:${user.username}`)}`}
+								>
+									View workspaces
+								</Link>
+							</DropdownMenuItem>
+
+							{canViewActivity && (
+								<DropdownMenuItem asChild disabled={!canViewActivity}>
+									<Link
+										to={`/audit?filter=${encodeURIComponent(`username:${user.username}`)}`}
 									>
-										<EllipsisVerticalIcon aria-hidden="true" />
-										<span className="sr-only">Open menu</span>
-									</Button>
-								</DropdownMenuTrigger>
+										View activity {!canViewActivity && <PremiumBadge />}
+									</Link>
+								</DropdownMenuItem>
+							)}
 
-								<DropdownMenuContent align="end">
-									<DropdownMenuItem asChild>
-										<Link
-											to={`/workspaces?filter=${encodeURIComponent(`owner:${user.username}`)}`}
-										>
-											View workspaces
-										</Link>
-									</DropdownMenuItem>
+							<DropdownMenuItem asChild>
+								<Link to={user.username}>Edit</Link>
+							</DropdownMenuItem>
 
-									{canViewActivity && (
-										<DropdownMenuItem asChild disabled={!canViewActivity}>
-											<Link
-												to={`/audit?filter=${encodeURIComponent(`username:${user.username}`)}`}
-											>
-												View activity {!canViewActivity && <PremiumBadge />}
-											</Link>
-										</DropdownMenuItem>
-									)}
+							<DropdownMenuItem
+								disabled={
+									isUpdatingUserRoles ||
+									(user.login_type === "oidc" && oidcRoleSyncEnabled)
+								}
+								onClick={() => onEditUserRoles(user)}
+							>
+								Edit roles
+							</DropdownMenuItem>
 
-									<DropdownMenuItem asChild>
-										<Link to={user.username}>Edit</Link>
-									</DropdownMenuItem>
+							{user.status !== "suspended" && (
+								<DropdownMenuItem
+									disabled={user.login_type !== "password"}
+									onClick={() => onResetUserPassword(user)}
+								>
+									Reset password&hellip;
+								</DropdownMenuItem>
+							)}
 
-									<DropdownMenuItem
-										disabled={
-											isUpdatingUserRoles ||
-											(user.login_type === "oidc" && oidcRoleSyncEnabled)
-										}
-										onClick={() => onEditUserRoles(user)}
-									>
-										Edit roles
-									</DropdownMenuItem>
+							{user.status === "active" || user.status === "dormant" ? (
+								<DropdownMenuItem
+									data-testid="suspend-button"
+									onClick={() => onSuspendUser(user)}
+								>
+									Suspend&hellip;
+								</DropdownMenuItem>
+							) : (
+								<DropdownMenuItem onClick={() => onActivateUser(user)}>
+									Activate&hellip;
+								</DropdownMenuItem>
+							)}
 
-									{user.status !== "suspended" && (
-										<DropdownMenuItem
-											disabled={user.login_type !== "password"}
-											onClick={() => onResetUserPassword(user)}
-										>
-											Reset password&hellip;
-										</DropdownMenuItem>
-									)}
+							<DropdownMenuSeparator />
 
-									{user.status === "active" || user.status === "dormant" ? (
-										<DropdownMenuItem
-											data-testid="suspend-button"
-											onClick={() => onSuspendUser(user)}
-										>
-											Suspend&hellip;
-										</DropdownMenuItem>
-									) : (
-										<DropdownMenuItem onClick={() => onActivateUser(user)}>
-											Activate&hellip;
-										</DropdownMenuItem>
-									)}
-
-									<DropdownMenuSeparator />
-
-									<DropdownMenuItem
-										className="text-content-destructive focus:text-content-destructive"
-										onClick={() => onDeleteUser(user)}
-										disabled={user.id === me}
-									>
-										<TrashIcon className="size-icon-xs" />
-										Delete&hellip;
-									</DropdownMenuItem>
-								</DropdownMenuContent>
-							</DropdownMenu>
-						</TableCell>
-					)}
-				</TableRow>
-			))}
-		</>
-	);
+							<DropdownMenuItem
+								className="text-content-destructive focus:text-content-destructive"
+								onClick={() => onDeleteUser(user)}
+								disabled={user.id === me}
+							>
+								<TrashIcon className="size-icon-xs" />
+								Delete&hellip;
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</TableCell>
+			)}
+		</TableRow>
+	));
 };
 
 type UsersTableSkeletonProps = {

--- a/site/src/pages/WorkspacePage/ResourceMetadata.tsx
+++ b/site/src/pages/WorkspacePage/ResourceMetadata.tsx
@@ -58,7 +58,7 @@ export const ResourceMetadata: FC<ResourceMetadataProps> = ({
 													</CopyableValue>
 												);
 											}
-											return <>{children}</>;
+											return children;
 										},
 									}}
 								>

--- a/site/src/testHelpers/hooks.tsx
+++ b/site/src/testHelpers/hooks.tsx
@@ -94,7 +94,7 @@ export async function renderHookWithAuth<Result, Props>(
 	let currentLocation!: Location;
 	const LocationLeaker: FC<PropsWithChildren> = ({ children }) => {
 		currentLocation = useLocation();
-		return <>{children}</>;
+		return children;
 	};
 
 	let forceUpdateRenderHookChildren!: () => void;


### PR DESCRIPTION
Enables the `jsx-no-useless-fragment` oxlint rule (previously parked in the migration backlog in `site/.oxlintrc.jsonc`).

## Changes

- Flipped `jsx-no-useless-fragment` from `"off"` (backlog) to `"error"`.
- Fixed the 19 violations across 14 files:
  - Single-child fragments returned from components / render props are unwrapped (`return <>{children}</>` → `return children`, `<>{filename}</>` → `filename`).
  - Fragment-wrapped `.map()` returns now return the array directly.
  - Empty fragments in tests become `null` for route `element` props (typed `ReactNode`) and `<div />` for `agentRow` (typed to return `JSX.Element`, so `null` does not type-check).

Biome still enforces `noUselessFragments` via its recommended set, so it is left untouched, matching the existing per-rule migration precedent (other already-migrated oxlint rules are not dropped from Biome yet either). The existing `biome-ignore` in `MultiSelectCombobox.tsx` is unaffected, since oxlint's rule does not flag that case.

## Verification

- `oxlint --deny-warnings` — green
- Biome lint/format — green on changed files
- `tsc --noEmit` — passes
- Affected component tests pass (`ResourceCard`, `CreateTemplatePage`, `TemplateVariablesPage`)

---
🤖 Generated with Coder Agents on behalf of @jeremyruppel.
