### PR TITLE
fix(helm): Expose deployment strategy type + rollingUpdate configs

### DIFF
--- a/helm/ai-gateway/templates/_aigateway.tpl
+++ b/helm/ai-gateway/templates/_aigateway.tpl
@@ -34,11 +34,10 @@ Deployment to merge into the libcoder template.
 */}}
 {{- define "coder-ai-gateway.deployment" -}}
 spec:
+  {{- with .Values.coder.deploymentStrategy }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     spec:
       automountServiceAccountToken: false

--- a/helm/ai-gateway/values.schema.json
+++ b/helm/ai-gateway/values.schema.json
@@ -7,7 +7,7 @@
     "nameOverride": {"type": "string"},
     "coder": {
       "type": "object", "additionalProperties": false,
-      "required": ["env", "envFrom", "image", "initContainers", "annotations", "labels", "podAnnotations", "podLabels", "serviceAccount", "securityContext", "podSecurityContext", "volumes", "volumeMounts", "replicaCount", "lifecycle", "resources", "startupProbe", "livenessProbe", "readinessProbe", "certs", "affinity", "tolerations", "nodeSelector", "topologySpreadConstraints", "priorityClassName", "command"],
+      "required": ["env", "envFrom", "image", "initContainers", "annotations", "labels", "podAnnotations", "podLabels", "serviceAccount", "securityContext", "podSecurityContext", "volumes", "volumeMounts", "replicaCount", "deploymentStrategy", "lifecycle", "resources", "startupProbe", "livenessProbe", "readinessProbe", "certs", "affinity", "tolerations", "nodeSelector", "topologySpreadConstraints", "priorityClassName", "command"],
       "properties": {
         "env": {"type": "array", "items": {"type": "object", "required": ["name"]}},
         "envFrom": {"type": "array", "items": {"type": "object"}},
@@ -41,6 +41,20 @@
         "volumes": {"type": "array"},
         "volumeMounts": {"type": "array"},
         "replicaCount": {"type": "integer", "minimum": 0},
+        "deploymentStrategy": {
+          "type": "object", "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": {"enum": ["Recreate", "RollingUpdate"]},
+            "rollingUpdate": {
+              "type": "object", "additionalProperties": false,
+              "properties": {
+                "maxSurge": {"oneOf": [{"type": "string"}, {"type": "integer", "minimum": 0}]},
+                "maxUnavailable": {"oneOf": [{"type": "string"}, {"type": "integer", "minimum": 0}]}
+              }
+            }
+          }
+        },
         "lifecycle": {"type": "object"},
         "resources": {"type": "object"},
         "startupProbe": {"$ref": "#/definitions/healthProbe"},

--- a/helm/ai-gateway/values.yaml
+++ b/helm/ai-gateway/values.yaml
@@ -101,6 +101,24 @@ coder:
   # coder.replicaCount -- The number of AI Gateway pods.
   replicaCount: 1
 
+  # coder.deploymentStrategy -- The deployment strategy to use for rolling updates.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  deploymentStrategy:
+    # coder.deploymentStrategy.type -- The type of deployment strategy to use.
+    # Valid values are "Recreate" or "RollingUpdate" (default).
+    type: RollingUpdate
+    # coder.deploymentStrategy.rollingUpdate -- Configuration for rolling updates.
+    # Only applicable when type is "RollingUpdate".
+    rollingUpdate:
+      # coder.deploymentStrategy.rollingUpdate.maxSurge -- The maximum number of
+      # pods that can be scheduled above the desired number of pods.
+      # Can be an absolute number or a percentage of desired pods.
+      maxSurge: 1
+      # coder.deploymentStrategy.rollingUpdate.maxUnavailable -- The maximum number
+      # of pods that can be unavailable during the update.
+      # Can be an absolute number or a percentage of desired pods.
+      maxUnavailable: 0
+
   # coder.lifecycle -- Container lifecycle handlers, allowing for lifecycle
   # events such as postStart and preStop. See:
   # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/

--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/auto_access_url_1_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/auto_access_url_2_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/auto_access_url_3_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/command_args_coder.golden
+++ b/helm/coder/tests/testdata/command_args_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/command_coder.golden
+++ b/helm/coder/tests/testdata/command_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/custom_resources.golden
+++ b/helm/coder/tests/testdata/custom_resources.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/custom_resources_coder.golden
+++ b/helm/coder/tests/testdata/custom_resources_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/default_values_coder.golden
+++ b/helm/coder/tests/testdata/default_values_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/env_from_coder.golden
+++ b/helm/coder/tests/testdata/env_from_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -129,6 +129,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/extra_templates_coder.golden
+++ b/helm/coder/tests/testdata/extra_templates_coder.golden
@@ -129,6 +129,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/host_aliases.golden
+++ b/helm/coder/tests/testdata/host_aliases.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/host_aliases_coder.golden
+++ b/helm/coder/tests/testdata/host_aliases_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -124,6 +124,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/labels_annotations_coder.golden
+++ b/helm/coder/tests/testdata/labels_annotations_coder.golden
@@ -124,6 +124,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/listenerset.golden
+++ b/helm/coder/tests/testdata/listenerset.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/listenerset_coder.golden
+++ b/helm/coder/tests/testdata/listenerset_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/listenerset_redirect.golden
+++ b/helm/coder/tests/testdata/listenerset_redirect.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/listenerset_redirect_coder.golden
+++ b/helm/coder/tests/testdata/listenerset_redirect_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/namespace_rbac.golden
+++ b/helm/coder/tests/testdata/namespace_rbac.golden
@@ -310,6 +310,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/namespace_rbac_coder.golden
+++ b/helm/coder/tests/testdata/namespace_rbac_coder.golden
@@ -310,6 +310,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/partial_resources.golden
+++ b/helm/coder/tests/testdata/partial_resources.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/partial_resources_coder.golden
+++ b/helm/coder/tests/testdata/partial_resources_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/pod_securitycontext.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/pod_securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/pprof_address_override.golden
+++ b/helm/coder/tests/testdata/pprof_address_override.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/pprof_address_override_coder.golden
+++ b/helm/coder/tests/testdata/pprof_address_override_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/priority_class_name.golden
+++ b/helm/coder/tests/testdata/priority_class_name.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/priority_class_name_coder.golden
+++ b/helm/coder/tests/testdata/priority_class_name_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/probes_custom.golden
+++ b/helm/coder/tests/testdata/probes_custom.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/probes_custom_coder.golden
+++ b/helm/coder/tests/testdata/probes_custom_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/probes_disabled.golden
+++ b/helm/coder/tests/testdata/probes_disabled.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/probes_disabled_coder.golden
+++ b/helm/coder/tests/testdata/probes_disabled_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -119,6 +119,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/prometheus_address_override.golden
+++ b/helm/coder/tests/testdata/prometheus_address_override.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/prometheus_address_override_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_address_override_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/prometheus_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_coder.golden
@@ -119,6 +119,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -122,6 +122,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -122,6 +122,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/sa_disabled.golden
+++ b/helm/coder/tests/testdata/sa_disabled.golden
@@ -106,6 +106,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/sa_disabled_coder.golden
+++ b/helm/coder/tests/testdata/sa_disabled_coder.golden
@@ -106,6 +106,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -133,6 +133,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/sa_extra_rules_coder.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules_coder.golden
@@ -133,6 +133,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/securitycontext.golden
+++ b/helm/coder/tests/testdata/securitycontext.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/securitycontext_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/svc_loadbalancer.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/svc_loadbalancer_class.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class.golden
@@ -121,6 +121,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
@@ -121,6 +121,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/svc_nodeport.golden
+++ b/helm/coder/tests/testdata/svc_nodeport.golden
@@ -119,6 +119,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/svc_nodeport_coder.golden
+++ b/helm/coder/tests/testdata/svc_nodeport_coder.golden
@@ -119,6 +119,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -125,6 +125,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/tls_coder.golden
+++ b/helm/coder/tests/testdata/tls_coder.golden
@@ -125,6 +125,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/topology.golden
+++ b/helm/coder/tests/testdata/topology.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/topology_coder.golden
+++ b/helm/coder/tests/testdata/topology_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/tests/testdata/workspace_proxy_coder.golden
+++ b/helm/coder/tests/testdata/workspace_proxy_coder.golden
@@ -120,6 +120,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -232,6 +232,24 @@ coder:
   # This is an Enterprise feature. Contact sales@coder.com.
   replicaCount: 1
 
+  # coder.deploymentStrategy -- The deployment strategy to use for rolling updates.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  deploymentStrategy:
+    # coder.deploymentStrategy.type -- The type of deployment strategy to use.
+    # Valid values are "Recreate" or "RollingUpdate" (default).
+    type: RollingUpdate
+    # coder.deploymentStrategy.rollingUpdate -- Configuration for rolling updates.
+    # Only applicable when type is "RollingUpdate".
+    rollingUpdate:
+      # coder.deploymentStrategy.rollingUpdate.maxSurge -- The maximum number of
+      # pods that can be scheduled above the desired number of pods.
+      # Can be an absolute number or a percentage of desired pods.
+      maxSurge: 25%
+      # coder.deploymentStrategy.rollingUpdate.maxUnavailable -- The maximum number
+      # of pods that can be unavailable during the update.
+      # Can be an absolute number or a percentage of desired pods.
+      maxUnavailable: 25%
+
   # coder.workspaceProxy -- Whether or not this deployment of Coder is a Coder
   # Workspace Proxy. Workspace Proxies reduce the latency between the user and
   # their workspace for web connections (workspace apps and web terminal) and

--- a/helm/libcoder/templates/_coder.yaml
+++ b/helm/libcoder/templates/_coder.yaml
@@ -12,6 +12,10 @@ metadata:
   annotations: {{ toYaml .Values.coder.annotations | nindent 4}}
 spec:
   replicas: {{ .Values.coder.replicaCount }}
+  {{- with .Values.coder.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "coder.selectorLabels" . | nindent 6 }}

--- a/helm/provisioner/tests/testdata/command.golden
+++ b/helm/provisioner/tests/testdata/command.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/command_args.golden
+++ b/helm/provisioner/tests/testdata/command_args.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/command_args_coder.golden
+++ b/helm/provisioner/tests/testdata/command_args_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/command_coder.golden
+++ b/helm/provisioner/tests/testdata/command_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/custom_resources.golden
+++ b/helm/provisioner/tests/testdata/custom_resources.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/custom_resources_coder.golden
+++ b/helm/provisioner/tests/testdata/custom_resources_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/default_values.golden
+++ b/helm/provisioner/tests/testdata/default_values.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/default_values_coder.golden
+++ b/helm/provisioner/tests/testdata/default_values_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/extra_templates.golden
+++ b/helm/provisioner/tests/testdata/extra_templates.golden
@@ -100,6 +100,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/extra_templates_coder.golden
+++ b/helm/provisioner/tests/testdata/extra_templates_coder.golden
@@ -100,6 +100,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/labels_annotations.golden
+++ b/helm/provisioner/tests/testdata/labels_annotations.golden
@@ -95,6 +95,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/labels_annotations_coder.golden
+++ b/helm/provisioner/tests/testdata/labels_annotations_coder.golden
@@ -95,6 +95,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/name_override.golden
+++ b/helm/provisioner/tests/testdata/name_override.golden
@@ -100,6 +100,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: other-coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/name_override_coder.golden
+++ b/helm/provisioner/tests/testdata/name_override_coder.golden
@@ -100,6 +100,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: other-coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/name_override_existing_sa.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa.golden
@@ -20,6 +20,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: other-coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/name_override_existing_sa_coder.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa_coder.golden
@@ -20,6 +20,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: other-coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/partial_resources.golden
+++ b/helm/provisioner/tests/testdata/partial_resources.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/partial_resources_coder.golden
+++ b/helm/provisioner/tests/testdata/partial_resources_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/provisionerd_key.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/provisionerd_key_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/provisionerd_psk.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk_coder.golden
@@ -91,6 +91,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/sa.golden
+++ b/helm/provisioner/tests/testdata/sa.golden
@@ -92,6 +92,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/sa_coder.golden
+++ b/helm/provisioner/tests/testdata/sa_coder.golden
@@ -92,6 +92,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/sa_disabled.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled.golden
@@ -20,6 +20,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/tests/testdata/sa_disabled_coder.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled_coder.golden
@@ -20,6 +20,11 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: release-name
       app.kubernetes.io/name: coder-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -121,6 +121,24 @@ coder:
   # This is an Enterprise feature. Contact sales@coder.com.
   replicaCount: 1
 
+  # coder.deploymentStrategy -- The deployment strategy to use for rolling updates.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  deploymentStrategy:
+    # coder.deploymentStrategy.type -- The type of deployment strategy to use.
+    # Valid values are "Recreate" or "RollingUpdate" (default).
+    type: RollingUpdate
+    # coder.deploymentStrategy.rollingUpdate -- Configuration for rolling updates.
+    # Only applicable when type is "RollingUpdate".
+    rollingUpdate:
+      # coder.deploymentStrategy.rollingUpdate.maxSurge -- The maximum number of
+      # pods that can be scheduled above the desired number of pods.
+      # Can be an absolute number or a percentage of desired pods.
+      maxSurge: 25%
+      # coder.deploymentStrategy.rollingUpdate.maxUnavailable -- The maximum number
+      # of pods that can be unavailable during the update.
+      # Can be an absolute number or a percentage of desired pods.
+      maxUnavailable: 25%
+
   # coder.lifecycle -- container lifecycle handlers for the Coder container, allowing
   # for lifecycle events such as postStart and preStop events
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/


### PR DESCRIPTION
Exposes the Kubernetes deployment strategy and rollingUpdate configurations as mutable options in the Helm values files for all three charts (coder, provisioner, ai-gateway).

- Updated libcoder deployment template to include strategy section
- Added deploymentStrategy values to coder, provisioner, and ai-gateway charts
- Updated ai-gateway template to use values instead of hardcoded strategy
- Updated ai-gateway schema to validate deploymentStrategy values
- Regenerated all test golden files