### PR TITLE
docs: capitalize Coder Workspaces as a named product

### DIFF
--- a/docs/.style/style-guide/word-choice.md
+++ b/docs/.style/style-guide/word-choice.md
@@ -15,30 +15,46 @@ When the prose refers to the Coder command-line interface as a tool, wrap it in 
 The bare lowercase `coder` (no backticks) is wrong.
 It reads as a misspelling of the product name.
 
-| Do                              | Don't                                          |
-|---------------------------------|------------------------------------------------|
-| Coder                           | coder (referring to the product, no backticks) |
-| `coder` (the CLI, in backticks) | coder (the CLI, no backticks)                  |
-| AI Gateway                      | AI gateway, AIGateway, AI Bridge               |
-| Workspace Proxy                 | workspace proxy (referring to the feature)     |
-| workspace                       | Workspace (referring to the generic concept)   |
-| template                        | Template (referring to the generic concept)    |
-| agent                           | Agent (referring to the generic concept)       |
-| provisioner                     | Provisioner (referring to the generic concept) |
+| Do                              | Don't                                                                                |
+|----------------------------------|----------------------------------------------------------------------------------------|
+| Coder                            | coder (referring to the product, no backticks)                                         |
+| `coder` (the CLI, in backticks)  | coder (the CLI, no backticks)                                                           |
+| AI Gateway                       | AI gateway, AIGateway, AI Bridge                                                        |
+| Coder Agents                     | Coder agents, coder agents (referring to the product)                                  |
+| Coder Workspaces                 | Coder workspaces, coder workspaces (referring to the product)                          |
+| Workspace Proxy                  | workspace proxy (referring to the feature)                                             |
+| workspace                        | Workspace (referring to the object a developer creates, configures, and connects to)   |
+| template                         | Template (referring to the generic concept)                                            |
+| agent                            | Agent (referring to the generic concept)                                               |
+| provisioner                      | Provisioner (referring to the generic concept)                                         |
 
 **Do**:
 
 > Run `coder login` to authenticate against the Coder server.
 >
 > Open the AI Gateway integration page to configure model providers.
+>
+> Coder Workspaces are cloud development environments defined with Terraform.
+> Create a workspace from a template, then connect to it with your IDE.
 
 **Don't**:
 
 > Run coder login to authenticate against the coder server.
 >
 > Open the ai gateway integration page to configure model providers.
+>
+> Coder workspaces are cloud development environments defined with Terraform.
+> (Lowercase "workspaces" here reads as the generic object, not the named product.)
 
-*Enforced by `Coder.ProductTerms` (planned).*
+> [!NOTE]
+> `Coder Workspaces` and `Coder Agents` name the products: the platform capability that Coder markets and ships as a whole.
+> A bare `workspace` or `agent` names the object a developer or a template creates: the on-demand environment the developer connects to, or the process that runs inside it.
+> Capitalize the product name whenever the prose introduces or markets the capability (a page heading like "Coder Workspaces," a comparison of product tiers, a `docs/README.md`-style overview).
+> Keep the generic object lowercase everywhere else, including in step-by-step instructions ("create a workspace," "the agent starts").
+> This mirrors coder.com's marketing usage, where `Coder Workspaces` sits alongside `Coder Agents`, `AI Gateway`, and `Agent Firewall` as one of four named products.
+
+*Enforced by `Coder.ProductTerms` (planned).
+The planned rule's term list must include `Coder Workspaces` and `Coder Agents` alongside the other named products.*
 
 The [glossary](../../reference/glossary.md) is the fuller registry of these names and disambiguates collisions like the several senses of "agent".
 When you add, rename, or deprecate a product or feature name, update the glossary in the same change.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -114,8 +114,14 @@ Refer to [Coder Desktop](../user-guides/desktop/index.md).
 
 ### Coder extension for VS Code
 
-The editor extension that connects VS Code, and forks such as Cursor and Devin Desktop (formerly Windsurf), to Coder workspaces.
+The editor extension that connects VS Code, and forks such as Cursor and Devin Desktop (formerly Windsurf), to workspaces.
 Refer to [VS Code](../user-guides/workspace-access/vscode.md).
+
+### Coder Workspaces
+
+The self-hosted platform capability for running cloud development environments, defined with Terraform, on infrastructure you control.
+Not to be confused with a [workspace](#workspace), the individual on-demand development environment a developer creates from a template.
+Refer to [About Coder](../README.md#coder-workspaces).
 
 ### `coder_agent`
 
@@ -544,6 +550,7 @@ Refer to [Web terminal](../user-guides/workspace-access/web-terminal.md).
 ### Workspace
 
 A developer's on-demand development environment, such as a virtual machine, container, or Kubernetes pod, provisioned from a template.
+Not to be confused with [Coder Workspaces](#coder-workspaces), the platform capability.
 Refer to [Workspace management](../user-guides/workspace-management.md).
 
 ### Workspace agent


### PR DESCRIPTION
## Summary

The style guide documented bare "workspace" as always lowercase and listed `Workspace` as a Don't in every case. coder.com's marketing site (`ai-governance.tsx`, `WorkspacesMasthead.tsx`, and others) treats `Coder Workspaces` as a distinct named product, on par with `Coder Agents`, `AI Gateway`, and `Agent Firewall`.

This isn't just a marketing-only convention: `docs/README.md`, `docs/ai-coder/ide-agents.md`, and `docs/ai-coder/ai-governance.md` in this repo already capitalize `Coder Workspaces` as a product heading/name. The style guide hadn't caught up to that existing usage.

This PR resolves the inconsistency by adding `Coder Workspaces` (and its existing but previously undocumented sibling `Coder Agents`) as named-product exceptions in the word-choice Do/Don't table, parallel to the existing `Workspace Proxy` exception. Bare `workspace` and `agent` stay lowercase when they name the generic object a developer creates or the process that runs inside it.

## Changes

- `docs/.style/style-guide/word-choice.md`: added `Coder Agents` and `Coder Workspaces` rows to the Do/Don't table, a note explaining the product-vs-object split (mirrors the existing `agent` / `Coder Agents` distinction), and updated Do/Don't prose examples. Noted that the planned `Coder.ProductTerms` Vale rule's term list needs to include both names.
- `docs/reference/glossary.md`: added a `Coder Workspaces` entry, and cross-referenced it from the existing `Workspace` entry (mirroring how `Coder Agents` is cross-referenced from `workspace agent`).

`voice-and-tone.md` and `capitalization-and-punctuation.md` didn't need changes: neither makes a claim about this term that the new rule contradicts.

## Scope

This PR only updates the style guide and glossary. A follow-up PR will apply the resulting convention across existing pages, including `docs/ai-coder/agent-relay/index.md` and `docs/ai-coder/agent-relay/cursor.md`, which is where this was first raised in review.

<details>
<summary>Decision log</summary>

**Options considered:**

1. Add `Coder Workspaces` as a named-product exception (parallel to `Workspace Proxy`), capitalizing the product while bare `workspace` stays lowercase in prose.
2. Leave the rule as-is and document the deliberate split so contributors understand why marketing capitalizes it and docs prose doesn't.

**Decision: option 1.** The style guide's own stated principle already covers this: "Feature names are capitalized as proper nouns when the prose names the feature. The underlying generic concept stays lowercase." That's exactly the `Coder Agents` vs. `agent` split the glossary already documents. `Coder Workspaces` fits the same pattern, and multiple existing docs pages already capitalize it that way, so option 2 would have required documenting a split that doesn't actually hold in practice.

**Files checked for consistency:** `voice-and-tone.md`, `capitalization-and-punctuation.md`, `docs/reference/glossary.md`. Only the glossary needed a matching update.
</details>

---

This PR was generated by a Coder Agent on behalf of @mattvollmer.