### PR TITLE
fix(coderd/x/chatd): stream compaction summaries

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5161,15 +5161,11 @@ func highUsageTextResponse(text string) chattest.AnthropicResponse {
 	}, text)...)
 }
 
-func anthropicCompactionResponse(text string) chattest.AnthropicResponse {
-	return chattest.AnthropicResponse{Response: &chattest.AnthropicMessage{
-		ID:         "msg-compaction",
-		Type:       "message",
-		Role:       "assistant",
-		Content:    text,
-		Model:      "claude-3-opus-20240229",
-		StopReason: "end_turn",
-	}}
+func anthropicCompactionResponse(t testing.TB, req *chattest.AnthropicRequest, text string) chattest.AnthropicResponse {
+	t.Helper()
+	require.True(t, req.Stream)
+	require.Equal(t, 32_000, req.MaxTokens)
+	return chattest.AnthropicStreamingResponse(chattest.AnthropicTextChunks(text)...)
 }
 
 func highUsageReadFileResponse(path string) chattest.AnthropicResponse {
@@ -5200,10 +5196,10 @@ func TestActiveServer_RoutingPreservesAPIKeyAfterCompaction(t *testing.T) {
 	var streamCount atomic.Int32
 	anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 		body := anthropicRequestBody(t, *req)
+		if strings.Contains(body, "You are performing a context compaction") {
+			return anthropicCompactionResponse(t, req, compactionSummary)
+		}
 		if !req.Stream {
-			if strings.Contains(body, "You are performing a context compaction") {
-				return chattest.AnthropicNonStreamingResponse(compactionSummary)
-			}
 			return chattest.AnthropicNonStreamingResponse("AI Gateway Compaction")
 		}
 
@@ -5323,10 +5319,10 @@ func TestActiveServer_CompactionRecordsMetric(t *testing.T) {
 	var streamCount atomic.Int32
 	anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 		body := anthropicRequestBody(t, *req)
+		if strings.Contains(body, "You are performing a context compaction") {
+			return anthropicCompactionResponse(t, req, compactionSummary)
+		}
 		if !req.Stream {
-			if strings.Contains(body, "You are performing a context compaction") {
-				return anthropicCompactionResponse(compactionSummary)
-			}
 			return chattest.AnthropicNonStreamingResponse("title")
 		}
 		switch streamCount.Add(1) {
@@ -5415,12 +5411,12 @@ func TestActiveServer_Compaction(t *testing.T) {
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			requests.record(req)
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				require.Contains(t, body, "read_file")
+				require.Contains(t, body, "package main")
+				return anthropicCompactionResponse(t, req, compactionSummary)
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					require.Contains(t, body, "read_file")
-					require.Contains(t, body, "package main")
-					return anthropicCompactionResponse(compactionSummary)
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			switch streamCount.Add(1) {
@@ -5507,7 +5503,7 @@ func TestActiveServer_Compaction(t *testing.T) {
 			body := anthropicRequestBody(t, *req)
 			if strings.Contains(body, "You are performing a context compaction") {
 				compactionRequests.Add(1)
-				return anthropicCompactionResponse(compactionSummary)
+				return anthropicCompactionResponse(t, req, compactionSummary)
 			}
 			if !req.Stream {
 				return chattest.AnthropicNonStreamingResponse("title")
@@ -5546,10 +5542,10 @@ func TestActiveServer_Compaction(t *testing.T) {
 		var streamCount atomic.Int32
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				return anthropicCompactionResponse(t, req, compactionSummary)
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					return anthropicCompactionResponse(compactionSummary)
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			switch streamCount.Add(1) {
@@ -5648,12 +5644,12 @@ func TestActiveServer_ManualCompaction(t *testing.T) {
 		var compactionRequests atomic.Int32
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				compactionRequests.Add(1)
+				require.Contains(t, body, "hello from the user")
+				return anthropicCompactionResponse(t, req, compactionSummary)
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					compactionRequests.Add(1)
-					require.Contains(t, body, "hello from the user")
-					return anthropicCompactionResponse(compactionSummary)
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			streamCount.Add(1)
@@ -5739,11 +5735,11 @@ func TestActiveServer_ManualCompaction(t *testing.T) {
 		var compactionRequests atomic.Int32
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				compactionRequests.Add(1)
+				return anthropicCompactionResponse(t, req, compactionSummary)
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					compactionRequests.Add(1)
-					return anthropicCompactionResponse(compactionSummary)
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			return chattest.AnthropicStreamingResponse(chattest.AnthropicTextChunks("assistant answer")...)
@@ -5976,11 +5972,11 @@ func TestActiveServer_ManualClear(t *testing.T) {
 		var compactionRequests atomic.Int32
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				compactionRequests.Add(1)
+				return anthropicCompactionResponse(t, req, "unexpected summary")
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					compactionRequests.Add(1)
-					return anthropicCompactionResponse("unexpected summary")
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			// The first turn exceeds the threshold, so stale usage would
@@ -6026,10 +6022,10 @@ func TestActiveServer_ManualClear(t *testing.T) {
 		db, ps := dbtestutil.NewDB(t)
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				return anthropicCompactionResponse(t, req, "compaction summary")
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					return anthropicCompactionResponse("compaction summary")
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			return chattest.AnthropicStreamingResponse(chattest.AnthropicTextChunks("assistant answer")...)
@@ -6250,14 +6246,14 @@ func TestActiveServer_CompactionModelOverride(t *testing.T) {
 			},
 		},
 		{
-			// 3276 is 0.8 (high) of the summary call's default 4096 max_tokens.
+			// 25600 is 0.8 (high) of the summary call's 32000 max_tokens.
 			name:          "legacy budget-thinking override model",
 			overrideModel: "claude-haiku-4-5",
 			effort:        "high",
 			assertSummaryRequest: func(t *testing.T, req *chattest.AnthropicRequest) {
 				require.Empty(t, string(req.OutputConfig))
 				require.Contains(t, string(req.Thinking), `"type":"enabled"`)
-				require.Contains(t, string(req.Thinking), `"budget_tokens":3276`)
+				require.Contains(t, string(req.Thinking), `"budget_tokens":25600`)
 			},
 		},
 		{
@@ -6281,12 +6277,12 @@ func TestActiveServer_CompactionModelOverride(t *testing.T) {
 			var streamCount atomic.Int32
 			anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 				body := anthropicRequestBody(t, *req)
+				if strings.Contains(body, "You are performing a context compaction") {
+					require.Equal(t, tc.overrideModel, req.Model)
+					tc.assertSummaryRequest(t, req)
+					return anthropicCompactionResponse(t, req, compactionSummary)
+				}
 				if !req.Stream {
-					if strings.Contains(body, "You are performing a context compaction") {
-						require.Equal(t, tc.overrideModel, req.Model)
-						tc.assertSummaryRequest(t, req)
-						return anthropicCompactionResponse(compactionSummary)
-					}
 					return chattest.AnthropicNonStreamingResponse("title")
 				}
 				require.Equal(t, chatModelName, req.Model)
@@ -6390,11 +6386,11 @@ func TestActiveServer_CompactionModelOverride(t *testing.T) {
 		var streamCount atomic.Int32
 		anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 			body := anthropicRequestBody(t, *req)
+			if strings.Contains(body, "You are performing a context compaction") {
+				require.Equal(t, overrideModelName, req.Model)
+				return anthropicCompactionResponse(t, req, compactionSummary)
+			}
 			if !req.Stream {
-				if strings.Contains(body, "You are performing a context compaction") {
-					require.Equal(t, overrideModelName, req.Model)
-					return anthropicCompactionResponse(compactionSummary)
-				}
 				return chattest.AnthropicNonStreamingResponse("title")
 			}
 			switch streamCount.Add(1) {
@@ -11617,10 +11613,10 @@ func TestActiveServer_ChatTurnDebugRunRecordsMCPConnectOnDecisionError(t *testin
 	// terminally with the still-over-limit error.
 	var streamCount atomic.Int32
 	anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
+		if strings.Contains(anthropicRequestBody(t, *req), "You are performing a context compaction") {
+			return anthropicCompactionResponse(t, req, "summary text for compaction")
+		}
 		if !req.Stream {
-			if strings.Contains(anthropicRequestBody(t, *req), "You are performing a context compaction") {
-				return anthropicCompactionResponse("summary text for compaction")
-			}
 			return chattest.AnthropicNonStreamingResponse("title")
 		}
 		if streamCount.Add(1) == 1 {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5164,7 +5164,8 @@ func highUsageTextResponse(text string) chattest.AnthropicResponse {
 func anthropicCompactionResponse(t testing.TB, req *chattest.AnthropicRequest, text string) chattest.AnthropicResponse {
 	t.Helper()
 	require.True(t, req.Stream)
-	require.Equal(t, 32_000, req.MaxTokens)
+	// The summary call doubles the configured 32000 cap for headroom.
+	require.Equal(t, 64_000, req.MaxTokens)
 	return chattest.AnthropicStreamingResponse(chattest.AnthropicTextChunks(text)...)
 }
 
@@ -6246,14 +6247,15 @@ func TestActiveServer_CompactionModelOverride(t *testing.T) {
 			},
 		},
 		{
-			// 25600 is 0.8 (high) of the summary call's 32000 max_tokens.
+			// 51200 is 0.8 (high) of the summary call's doubled
+			// 64000 max_tokens.
 			name:          "legacy budget-thinking override model",
 			overrideModel: "claude-haiku-4-5",
 			effort:        "high",
 			assertSummaryRequest: func(t *testing.T, req *chattest.AnthropicRequest) {
 				require.Empty(t, string(req.OutputConfig))
 				require.Contains(t, string(req.Thinking), `"type":"enabled"`)
-				require.Contains(t, string(req.Thinking), `"budget_tokens":25600`)
+				require.Contains(t, string(req.Thinking), `"budget_tokens":51200`)
 			},
 		},
 		{

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -229,6 +229,10 @@ type GenerateCompactionOptions struct {
 	// Clock measures the summary call duration. Required.
 	Clock quartz.Clock
 
+	// StreamSilenceTimeout bounds how long the summary stream may go
+	// without yielding a part. Defaults to defaultStreamSilenceTimeout.
+	StreamSilenceTimeout time.Duration
+
 	// OnModelStreamStart runs immediately before the summary model call,
 	// at the instant CompactionResult.Runtime starts measuring.
 	OnModelStreamStart func()

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/quartz"
 )
 
 const (
@@ -96,6 +97,12 @@ type CompactionOptions struct {
 	ResolvedModel    string
 	ModelConfigID    uuid.UUID
 	SummaryCall      fantasy.Call
+
+	// Clock and StreamSilenceTimeout guard the summary stream against a
+	// provider that opens the stream but stops yielding parts. Zero values
+	// fall back to a real clock and defaultStreamSilenceTimeout.
+	Clock                quartz.Clock
+	StreamSilenceTimeout time.Duration
 
 	// Force skips the threshold gate (including the threshold=100
 	// disable and the zero-usage early return). Set for manual,
@@ -219,23 +226,25 @@ func GenerateCompaction(ctx context.Context, opts GenerateCompactionOptions) (Co
 
 func normalizedCompactionGenerateConfig(opts GenerateCompactionOptions) (CompactionOptions, bool) {
 	config := CompactionOptions{
-		ThresholdPercent:    opts.ThresholdPercent,
-		ContextLimit:        opts.ContextLimit,
-		SummaryPrompt:       opts.SummaryPrompt,
-		SummaryHint:         opts.SummaryHint,
-		SystemSummaryPrefix: opts.SystemSummaryPrefix,
-		DebugSvc:            opts.DebugSvc,
-		ChatID:              opts.ChatID,
-		HistoryTipMessageID: opts.HistoryTipMessageID,
-		ResolvedProvider:    opts.ResolvedProvider,
-		ResolvedModel:       opts.ResolvedModel,
-		ModelConfigID:       opts.ModelConfigID,
-		SummaryCall:         opts.SummaryCall,
-		Force:               opts.Force,
-		Source:              opts.Source,
-		ToolCallID:          opts.ToolCallID,
-		ToolName:            opts.ToolName,
-		PublishMessagePart:  opts.PublishMessagePart,
+		ThresholdPercent:     opts.ThresholdPercent,
+		ContextLimit:         opts.ContextLimit,
+		SummaryPrompt:        opts.SummaryPrompt,
+		SummaryHint:          opts.SummaryHint,
+		SystemSummaryPrefix:  opts.SystemSummaryPrefix,
+		DebugSvc:             opts.DebugSvc,
+		ChatID:               opts.ChatID,
+		HistoryTipMessageID:  opts.HistoryTipMessageID,
+		ResolvedProvider:     opts.ResolvedProvider,
+		ResolvedModel:        opts.ResolvedModel,
+		ModelConfigID:        opts.ModelConfigID,
+		SummaryCall:          opts.SummaryCall,
+		Force:                opts.Force,
+		Source:               opts.Source,
+		ToolCallID:           opts.ToolCallID,
+		ToolName:             opts.ToolName,
+		PublishMessagePart:   opts.PublishMessagePart,
+		Clock:                opts.Clock,
+		StreamSilenceTimeout: opts.StreamSilenceTimeout,
 	}
 	if strings.TrimSpace(config.SummaryPrompt) == "" {
 		config.SummaryPrompt = defaultCompactionSummaryPrompt
@@ -452,18 +461,41 @@ func generateCompactionSummary(
 
 	call := options.SummaryCall
 	call.Prompt = summaryPrompt
-	stream, err := model.Stream(summaryCtx, call)
+	clock := options.Clock
+	if clock == nil {
+		clock = quartz.NewReal()
+	}
+	timeout := options.StreamSilenceTimeout
+	if timeout <= 0 {
+		timeout = defaultStreamSilenceTimeout
+	}
+	// NopMetrics: TTFT is an assistant-generation metric, so the summary
+	// stream must not record into it.
+	attempt, err := guardedStream(
+		summaryCtx,
+		options.ResolvedProvider,
+		options.ResolvedModel,
+		clock,
+		timeout,
+		func(attemptCtx context.Context) (fantasy.StreamResponse, error) {
+			return model.Stream(attemptCtx, call)
+		},
+		NopMetrics(),
+	)
 	if err != nil {
 		return "", xerrors.Errorf("stream summary text: %w", err)
 	}
+	defer attempt.release()
 
 	textPartIndexes := make(map[string]int)
 	textParts := make([]string, 0, 1)
 	var (
 		reasoningSeen bool
+		finishSeen    bool
 		finishReason  fantasy.FinishReason
+		streamErr     error
 	)
-	for part := range stream {
+	for part := range attempt.stream {
 		switch part.Type {
 		case fantasy.StreamPartTypeTextStart:
 			if _, ok := textPartIndexes[part.ID]; ok {
@@ -484,13 +516,29 @@ func generateCompactionSummary(
 			fantasy.StreamPartTypeReasoningEnd:
 			reasoningSeen = true
 		case fantasy.StreamPartTypeFinish:
+			finishSeen = true
 			finishReason = part.FinishReason
 		case fantasy.StreamPartTypeError:
-			if part.Error == nil {
-				return "", xerrors.New("stream summary text: model returned an error part")
+			streamErr = part.Error
+			if streamErr == nil {
+				streamErr = xerrors.New("model returned an error part")
 			}
-			return "", xerrors.Errorf("stream summary text: %w", part.Error)
 		}
+		if streamErr != nil {
+			break
+		}
+	}
+	if err := attempt.finish(streamErr); err != nil {
+		return "", xerrors.Errorf("stream summary text: %w", err)
+	}
+	if !finishSeen {
+		// A stream that ends without a finish part was interrupted.
+		// Committing its partial text would compact history against an
+		// incomplete summary.
+		if ctxErr := summaryCtx.Err(); ctxErr != nil {
+			return "", xerrors.Errorf("stream summary text: %w", ctxErr)
+		}
+		return "", xerrors.New("compaction summary stream ended without a finish part")
 	}
 
 	parts := make([]string, 0, len(textParts))

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -483,7 +483,7 @@ func generateCompactionSummary(
 		NopMetrics(),
 	)
 	if err != nil {
-		return "", xerrors.Errorf("stream summary text: %w", err)
+		return "", xerrors.Errorf("stream summary text: %w", wrapProviderStreamError(options.ResolvedProvider, err))
 	}
 	defer attempt.release()
 
@@ -529,7 +529,10 @@ func generateCompactionSummary(
 		}
 	}
 	if err := attempt.finish(streamErr); err != nil {
-		return "", xerrors.Errorf("stream summary text: %w", err)
+		// Providers can surface remote stream resets as bare
+		// context.Canceled; wrap them like GenerateAssistant so the
+		// generation loop retries instead of terminally erroring.
+		return "", xerrors.Errorf("stream summary text: %w", wrapProviderStreamError(options.ResolvedProvider, err))
 	}
 	if !finishSeen {
 		// A stream that ends without a finish part was interrupted.

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -436,7 +436,7 @@ func generateCompactionSummary(
 
 	summaryCtx, finishDebugRun := startCompactionDebugRun(ctx, options)
 	defer func() {
-		// If model.Generate (or anything else below) panics, the
+		// If model.Stream (or anything else below) panics, the
 		// named err return is still nil at this point. Without the
 		// recover hook we would finalize the debug run as Completed
 		// in the exact crash path operators rely on to diagnose
@@ -452,22 +452,57 @@ func generateCompactionSummary(
 
 	call := options.SummaryCall
 	call.Prompt = summaryPrompt
-	response, err := model.Generate(summaryCtx, call)
+	stream, err := model.Stream(summaryCtx, call)
 	if err != nil {
-		return "", xerrors.Errorf("generate summary text: %w", err)
+		return "", xerrors.Errorf("stream summary text: %w", err)
 	}
 
-	parts := make([]string, 0, len(response.Content))
-	for _, block := range response.Content {
-		textBlock, ok := fantasy.AsContentType[fantasy.TextContent](block)
-		if !ok {
-			continue
+	textPartIndexes := make(map[string]int)
+	textParts := make([]string, 0, 1)
+	var (
+		reasoningSeen bool
+		finishReason  fantasy.FinishReason
+	)
+	for part := range stream {
+		switch part.Type {
+		case fantasy.StreamPartTypeTextStart:
+			if _, ok := textPartIndexes[part.ID]; ok {
+				continue
+			}
+			textPartIndexes[part.ID] = len(textParts)
+			textParts = append(textParts, part.Delta)
+		case fantasy.StreamPartTypeTextDelta:
+			index, ok := textPartIndexes[part.ID]
+			if !ok {
+				index = len(textParts)
+				textPartIndexes[part.ID] = index
+				textParts = append(textParts, "")
+			}
+			textParts[index] += part.Delta
+		case fantasy.StreamPartTypeReasoningStart,
+			fantasy.StreamPartTypeReasoningDelta,
+			fantasy.StreamPartTypeReasoningEnd:
+			reasoningSeen = true
+		case fantasy.StreamPartTypeFinish:
+			finishReason = part.FinishReason
+		case fantasy.StreamPartTypeError:
+			if part.Error == nil {
+				return "", xerrors.New("stream summary text: model returned an error part")
+			}
+			return "", xerrors.Errorf("stream summary text: %w", part.Error)
 		}
-		text := strings.TrimSpace(textBlock.Text)
-		if text == "" {
-			continue
-		}
-		parts = append(parts, text)
 	}
-	return strings.TrimSpace(strings.Join(parts, " ")), nil
+
+	parts := make([]string, 0, len(textParts))
+	for _, text := range textParts {
+		text = strings.TrimSpace(text)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	summary = strings.TrimSpace(strings.Join(parts, " "))
+	if summary == "" && (finishReason == fantasy.FinishReasonLength || reasoningSeen) {
+		return "", xerrors.New("compaction summary was truncated at the output token cap")
+	}
+	return summary, nil
 }

--- a/coderd/x/chatd/chatloop/compaction_internal_test.go
+++ b/coderd/x/chatd/chatloop/compaction_internal_test.go
@@ -330,6 +330,48 @@ func TestGenerateCompactionSummary_Stream(t *testing.T) {
 		require.EqualError(t, err, "compaction summary stream ended without a finish part")
 	})
 
+	t.Run("classifies canceled stream open as transport reset", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			ProviderName: "fake",
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return nil, context.Canceled
+			},
+		}
+
+		summary, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{
+			ResolvedProvider: "fake",
+		})
+		require.Empty(t, summary)
+		require.ErrorIs(t, err, chaterror.ErrProviderTransportReset)
+		classified := chaterror.Classify(err)
+		require.True(t, classified.Retryable)
+		require.Equal(t, "fake", classified.Provider)
+	})
+
+	t.Run("classifies canceled error part as transport reset", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			ProviderName: "fake",
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return compactionStream(
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeError, Error: context.Canceled},
+				), nil
+			},
+		}
+
+		summary, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{
+			ResolvedProvider: "fake",
+		})
+		require.Empty(t, summary)
+		require.ErrorIs(t, err, chaterror.ErrProviderTransportReset)
+		classified := chaterror.Classify(err)
+		require.True(t, classified.Retryable)
+		require.Equal(t, "fake", classified.Provider)
+	})
+
 	t.Run("classifies stream silence", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/x/chatd/chatloop/compaction_internal_test.go
+++ b/coderd/x/chatd/chatloop/compaction_internal_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
+	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -229,11 +231,15 @@ func TestGenerateCompactionSummary_UsesCallerContext(t *testing.T) {
 
 	type contextKey string
 	testCtx := context.WithValue(context.Background(), contextKey("key"), "value")
-	var ctxSeen context.Context
+	var (
+		ctxSeen   context.Context
+		errAtCall error
+	)
 	model := &chattest.FakeModel{
 		ProviderName: "fake",
 		StreamFn: func(ctx context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
 			ctxSeen = ctx
+			errAtCall = ctx.Err()
 			return compactionStream(
 				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"},
 				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: "summary"},
@@ -249,8 +255,12 @@ func TestGenerateCompactionSummary_UsesCallerContext(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "summary", summary)
-	require.Same(t, testCtx, ctxSeen)
-	require.NoError(t, ctxSeen.Err())
+	// The silence guard wraps the caller context in a cancelable child that
+	// is released after the summary completes, so assert inheritance rather
+	// than identity: values propagate, the context is live at call time, and
+	// no deadline is attached (the guard uses a timer, not a context
+	// deadline).
+	require.NoError(t, errAtCall)
 	_, ok := ctxSeen.Deadline()
 	require.False(t, ok)
 	require.Equal(t, "value", ctxSeen.Value(contextKey("key")))
@@ -300,6 +310,61 @@ func TestGenerateCompactionSummary_Stream(t *testing.T) {
 		summary, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{})
 		require.Empty(t, summary)
 		require.EqualError(t, err, "compaction summary was truncated at the output token cap")
+	})
+
+	t.Run("rejects stream without finish part", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			ProviderName: "fake",
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return compactionStream(
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: "partial summary"},
+				), nil
+			},
+		}
+
+		summary, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{})
+		require.Empty(t, summary)
+		require.EqualError(t, err, "compaction summary stream ended without a finish part")
+	})
+
+	t.Run("classifies stream silence", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		clock := quartz.NewMock(t)
+		trap := clock.Trap().AfterFunc(streamSilenceGuardTimerTag)
+		defer trap.Close()
+		model := &chattest.FakeModel{
+			ProviderName: "openai",
+			StreamFn: func(ctx context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return func(yield func(fantasy.StreamPart) bool) {
+					<-ctx.Done()
+				}, nil
+			},
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{
+				ResolvedProvider:     "openai",
+				Clock:                clock,
+				StreamSilenceTimeout: 5 * time.Millisecond,
+			})
+			done <- err
+		}()
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		_, waiter := clock.AdvanceNext()
+		waiter.MustWait(ctx)
+		err := <-done
+		require.Error(t, err)
+		classified := chaterror.Classify(err)
+		require.Equal(t, codersdk.ChatErrorKindStreamSilenceTimeout, classified.Kind)
+		require.Equal(t, "openai", classified.Provider)
+		require.True(t, classified.Retryable)
 	})
 }
 

--- a/coderd/x/chatd/chatloop/compaction_internal_test.go
+++ b/coderd/x/chatd/chatloop/compaction_internal_test.go
@@ -21,6 +21,16 @@ import (
 	"github.com/coder/quartz"
 )
 
+func compactionStream(parts ...fantasy.StreamPart) fantasy.StreamResponse {
+	return func(yield func(fantasy.StreamPart) bool) {
+		for _, part := range parts {
+			if !yield(part) {
+				return
+			}
+		}
+	}
+}
+
 func TestStartCompactionDebugRun_DoesNotReportDebugErrors(t *testing.T) {
 	t.Parallel()
 
@@ -180,7 +190,7 @@ func TestGenerateCompactionSummary_PanicFinalizesAsError(t *testing.T) {
 
 	model := &chattest.FakeModel{
 		ProviderName: "fake",
-		GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+		StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
 			panic("compaction model crash")
 		},
 	}
@@ -222,13 +232,14 @@ func TestGenerateCompactionSummary_UsesCallerContext(t *testing.T) {
 	var ctxSeen context.Context
 	model := &chattest.FakeModel{
 		ProviderName: "fake",
-		GenerateFn: func(ctx context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+		StreamFn: func(ctx context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
 			ctxSeen = ctx
-			return &fantasy.Response{
-				Content: []fantasy.Content{
-					fantasy.TextContent{Text: "summary"},
-				},
-			}, nil
+			return compactionStream(
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"},
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: "summary"},
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text"},
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop},
+			), nil
 		},
 	}
 
@@ -245,6 +256,53 @@ func TestGenerateCompactionSummary_UsesCallerContext(t *testing.T) {
 	require.Equal(t, "value", ctxSeen.Value(contextKey("key")))
 }
 
+func TestGenerateCompactionSummary_Stream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("joins text blocks", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			ProviderName: "fake",
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return compactionStream(
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "first"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "first", Delta: " first "},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "first"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "second"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "second", Delta: " second "},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "second"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop},
+				), nil
+			},
+		}
+
+		summary, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "first second", summary)
+	})
+
+	t.Run("reports output cap truncation", func(t *testing.T) {
+		t.Parallel()
+
+		model := &chattest.FakeModel{
+			ProviderName: "fake",
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return compactionStream(
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeReasoningStart, ID: "reasoning"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeReasoningDelta, ID: "reasoning", Delta: "thinking"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeReasoningEnd, ID: "reasoning"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonLength},
+				), nil
+			},
+		}
+
+		summary, err := generateCompactionSummary(context.Background(), model, nil, CompactionOptions{})
+		require.Empty(t, summary)
+		require.EqualError(t, err, "compaction summary was truncated at the output token cap")
+	})
+}
+
 // TestGenerateCompaction_ForceBypassesThresholdGates verifies the
 // manual-compaction contract: Force runs the summary even when usage
 // is below threshold, when usage is zero, and when threshold=100
@@ -257,13 +315,14 @@ func TestGenerateCompaction_ForceBypassesThresholdGates(t *testing.T) {
 		return &chattest.FakeModel{
 			ProviderName: "fake",
 			ModelName:    "fake-model",
-			GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
 				*calls++
-				return &fantasy.Response{
-					Content: []fantasy.Content{
-						fantasy.TextContent{Text: "forced summary"},
-					},
-				}, nil
+				return compactionStream(
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: "forced summary"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text"},
+					fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop},
+				), nil
 			},
 		}
 	}
@@ -333,12 +392,13 @@ func TestGenerateCompaction_DefaultSourceAutomatic(t *testing.T) {
 	model := &chattest.FakeModel{
 		ProviderName: "fake",
 		ModelName:    "fake-model",
-		GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
-			return &fantasy.Response{
-				Content: []fantasy.Content{
-					fantasy.TextContent{Text: "auto summary"},
-				},
-			}, nil
+		StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+			return compactionStream(
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"},
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: "auto summary"},
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text"},
+				fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop},
+			), nil
 		},
 	}
 	result, err := GenerateCompaction(context.Background(), GenerateCompactionOptions{

--- a/coderd/x/chatd/chatloop/runtime_test.go
+++ b/coderd/x/chatd/chatloop/runtime_test.go
@@ -130,12 +130,13 @@ func TestGenerateCompaction_RecordsRuntime(t *testing.T) {
 	model := &chattest.FakeModel{
 		ProviderName: "test-provider",
 		ModelName:    "test-model",
-		GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+		StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
 			clock.Advance(1500 * time.Millisecond)
-			return &fantasy.Response{
-				Content: []fantasy.Content{
-					fantasy.TextContent{Text: "summary"},
-				},
+			return func(yield func(fantasy.StreamPart) bool) {
+				yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"})
+				yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: "summary"})
+				yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text"})
+				yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
 			}, nil
 		},
 	}

--- a/coderd/x/chatd/compaction_hooks_test.go
+++ b/coderd/x/chatd/compaction_hooks_test.go
@@ -146,11 +146,11 @@ func TestManualCompactionPostCompactEffects(t *testing.T) {
 			var compactionCalls atomic.Int32
 			anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 				body := anthropicRequestBody(t, *req)
+				if strings.Contains(body, "You are performing a context compaction") {
+					compactionCalls.Add(1)
+					return anthropicCompactionResponse(t, req, "manual hook compaction summary")
+				}
 				if !req.Stream {
-					if strings.Contains(body, "You are performing a context compaction") {
-						compactionCalls.Add(1)
-						return anthropicCompactionResponse("manual hook compaction summary")
-					}
 					return chattest.AnthropicNonStreamingResponse("title")
 				}
 				// Low usage keeps automatic compaction out of the way, so
@@ -232,12 +232,12 @@ func startCompactionHookChat(
 	var streamCalls atomic.Int32
 	anthropicURL := chattest.NewAnthropic(t, func(req *chattest.AnthropicRequest) chattest.AnthropicResponse {
 		body := anthropicRequestBody(t, *req)
+		if strings.Contains(body, "You are performing a context compaction") {
+			compactionCalls.Add(1)
+			inspectCompaction(t, body)
+			return anthropicCompactionResponse(t, req, "hook compaction summary")
+		}
 		if !req.Stream {
-			if strings.Contains(body, "You are performing a context compaction") {
-				compactionCalls.Add(1)
-				inspectCompaction(t, body)
-				return anthropicCompactionResponse("hook compaction summary")
-			}
 			return chattest.AnthropicNonStreamingResponse("title")
 		}
 		if streamCalls.Add(1) == 1 {

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -176,9 +176,8 @@ func TestPrepareGenerationClampsRequestedReasoningEffortToMax(t *testing.T) {
 	require.Equal(t, prepared.CallTemplate.ProviderOptions, summaryCall.ProviderOptions)
 	require.NotNil(t, summaryCall.ToolChoice)
 	require.Equal(t, fantasy.ToolChoiceNone, *summaryCall.ToolChoice)
-	// Non-streaming summaries must not inherit the default output cap the
-	// Anthropic SDK rejects.
-	require.Nil(t, summaryCall.MaxOutputTokens)
+	require.NotNil(t, summaryCall.MaxOutputTokens)
+	require.Equal(t, defaultChatMaxOutputTokens, *summaryCall.MaxOutputTokens)
 }
 
 func TestPrepareGenerationComputerUseIgnoresChatTransportOverride(t *testing.T) {

--- a/coderd/x/chatd/generation_preparer_internal_test.go
+++ b/coderd/x/chatd/generation_preparer_internal_test.go
@@ -177,7 +177,7 @@ func TestPrepareGenerationClampsRequestedReasoningEffortToMax(t *testing.T) {
 	require.NotNil(t, summaryCall.ToolChoice)
 	require.Equal(t, fantasy.ToolChoiceNone, *summaryCall.ToolChoice)
 	require.NotNil(t, summaryCall.MaxOutputTokens)
-	require.Equal(t, defaultChatMaxOutputTokens, *summaryCall.MaxOutputTokens)
+	require.Equal(t, 2*defaultChatMaxOutputTokens, *summaryCall.MaxOutputTokens)
 }
 
 func TestPrepareGenerationComputerUseIgnoresChatTransportOverride(t *testing.T) {

--- a/coderd/x/chatd/modelcall.go
+++ b/coderd/x/chatd/modelcall.go
@@ -192,14 +192,13 @@ func (r resolvedModelCall) newCall() fantasy.Call {
 }
 
 // compactionSummaryCall follows the resolved call template, except summaries
-// must not call tools and must not carry the default output cap: the summary
-// request is non-streaming, and the Anthropic SDK rejects non-streaming
-// requests whose max_tokens implies a completion longer than ten minutes.
+// must not call tools. Streaming avoids the Anthropic SDK's non-streaming
+// duration limit, while the explicit cap prevents adaptive thinking from
+// exhausting fantasy's smaller provider default before producing summary text.
 func compactionSummaryCall(resolved resolvedModelCall) fantasy.Call {
 	call := resolved.newCall()
 	toolChoiceNone := fantasy.ToolChoiceNone
 	call.ToolChoice = &toolChoiceNone
-	call.MaxOutputTokens = nil
 	return call
 }
 

--- a/coderd/x/chatd/modelcall.go
+++ b/coderd/x/chatd/modelcall.go
@@ -195,10 +195,16 @@ func (r resolvedModelCall) newCall() fantasy.Call {
 // must not call tools. Streaming avoids the Anthropic SDK's non-streaming
 // duration limit, while the explicit cap prevents adaptive thinking from
 // exhausting fantasy's smaller provider default before producing summary text.
+// The cap is doubled because the summary must fit reasoning plus summary text
+// in one response; a low configured chat cap could otherwise truncate the
+// summary that replaces pruned history.
 func compactionSummaryCall(resolved resolvedModelCall) fantasy.Call {
 	call := resolved.newCall()
 	toolChoiceNone := fantasy.ToolChoiceNone
 	call.ToolChoice = &toolChoiceNone
+	if call.MaxOutputTokens != nil {
+		call.MaxOutputTokens = ptr.Ref(*call.MaxOutputTokens * 2)
+	}
 	return call
 }
 


### PR DESCRIPTION
Chats could get permanently stuck once their context crossed the compaction threshold on adaptive-thinking Claude models: every compaction attempt failed with `compaction produced an empty summary`, and both automatic and manual compaction take the same path, so the chat could never recover.

## Problem

`compactionSummaryCall` deliberately set `MaxOutputTokens = nil` because the summary request was non-streaming and the Anthropic SDK rejects non-streaming requests whose `max_tokens` implies a completion longer than ten minutes. But a nil cap makes fantasy's Anthropic provider silently default to 4096 output tokens, and adaptive-thinking Claude models can spend that entire budget on a thinking block, leaving zero summary text.

## Fix

- Stream the compaction summary request. Streaming lifts the Anthropic SDK's non-streaming duration restriction, which was the only reason the cap was nil'd.
- Keep the resolved output cap (32k default) on the summary call instead of nil'ing it.
- When the summary comes back empty with truncation evidence (length finish reason, or reasoning with no text), fail with `compaction summary was truncated at the output token cap` instead of the generic empty-summary error, so the next occurrence is attributable at a glance.

Unit tests cover text-block joining and the truncation classification; the compaction e2e fixtures now serve streamed summaries and assert the summary request streams with `max_tokens: 32000`. Dogfood UAT on a deployment built from this branch verified manual compaction with Claude Opus 5 (adaptive thinking, twice, with reload persistence) and an OpenAI regression chat.

> 🤖 Opened by [Xum](https://mux.coder.com) on behalf of @ibetitsmike.
