### PR TITLE
chore: add Claude Fable 5.1 and other new models to the known models catalog

### DIFF
--- a/coderd/aibridge/prices/data/prices.json
+++ b/coderd/aibridge/prices/data/prices.json
@@ -9,6 +9,14 @@
   },
   {
     "provider": "anthropic",
+    "model": "claude-fable-5-1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "anthropic",
     "model": "claude-haiku-4-5",
     "input_price": 1000000,
     "output_price": 5000000,
@@ -117,6 +125,14 @@
     "input_price": 10000000,
     "output_price": 50000000,
     "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "azure",
+    "model": "claude-fable-5-1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
     "cache_write_price": 12500000
   },
   {
@@ -825,6 +841,14 @@
   },
   {
     "provider": "bedrock",
+    "model": "anthropic.claude-fable-5-1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "bedrock",
     "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
     "input_price": 1000000,
     "output_price": 5000000,
@@ -1069,6 +1093,14 @@
     "input_price": 10000000,
     "output_price": 50000000,
     "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "bedrock",
+    "model": "global.anthropic.claude-fable-5-1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
     "cache_write_price": 12500000
   },
   {
@@ -1585,6 +1617,14 @@
   },
   {
     "provider": "bedrock",
+    "model": "us.anthropic.claude-fable-5-1",
+    "input_price": 11000000,
+    "output_price": 55000000,
+    "cache_read_price": 275000,
+    "cache_write_price": 13750000
+  },
+  {
+    "provider": "bedrock",
     "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
     "input_price": 1000000,
     "output_price": 5000000,
@@ -1850,9 +1890,9 @@
   {
     "provider": "copilot",
     "model": "gemini-3.6-flash",
-    "input_price": 1500000,
-    "output_price": 7500000,
-    "cache_read_price": 150000,
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
     "cache_write_price": null
   },
   {
@@ -1941,15 +1981,15 @@
     "input_price": 200000,
     "output_price": 1200000,
     "cache_read_price": 20000,
-    "cache_write_price": null
+    "cache_write_price": 250000
   },
   {
     "provider": "copilot",
     "model": "gpt-5.6-sol",
-    "input_price": 2500000,
-    "output_price": 15000000,
-    "cache_read_price": 250000,
-    "cache_write_price": 3125000
+    "input_price": 2000000,
+    "output_price": 10000000,
+    "cache_read_price": 200000,
+    "cache_write_price": 2500000
   },
   {
     "provider": "copilot",
@@ -1957,7 +1997,7 @@
     "input_price": 2000000,
     "output_price": 12000000,
     "cache_read_price": 200000,
-    "cache_write_price": null
+    "cache_write_price": 2500000
   },
   {
     "provider": "copilot",
@@ -2252,14 +2292,6 @@
     "model": "gemini-omni-flash-preview",
     "input_price": 1500000,
     "output_price": 17500000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "google",
-    "model": "gemini-robotics-er-1.6-preview",
-    "input_price": 1000000,
-    "output_price": 5000000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -2657,14 +2689,6 @@
   },
   {
     "provider": "openrouter",
-    "model": "allenai/olmo-3-32b-think",
-    "input_price": 150000,
-    "output_price": 500000,
-    "cache_read_price": null,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
     "model": "amazon/nova-2-lite-v1",
     "input_price": 300000,
     "output_price": 2500000,
@@ -2706,7 +2730,7 @@
   {
     "provider": "openrouter",
     "model": "anthracite-org/magnum-v4-72b",
-    "input_price": 3000000,
+    "input_price": 2500000,
     "output_price": 5000000,
     "cache_read_price": null,
     "cache_write_price": null
@@ -2725,6 +2749,14 @@
     "input_price": 10000000,
     "output_price": 50000000,
     "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "openrouter",
+    "model": "anthropic/claude-fable-5.1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
     "cache_write_price": 12500000
   },
   {
@@ -2777,14 +2809,6 @@
   },
   {
     "provider": "openrouter",
-    "model": "anthropic/claude-opus-4.7-fast",
-    "input_price": 30000000,
-    "output_price": 150000000,
-    "cache_read_price": 3000000,
-    "cache_write_price": 37500000
-  },
-  {
-    "provider": "openrouter",
     "model": "anthropic/claude-opus-4.8",
     "input_price": 5000000,
     "output_price": 25000000,
@@ -2793,27 +2817,11 @@
   },
   {
     "provider": "openrouter",
-    "model": "anthropic/claude-opus-4.8-fast",
-    "input_price": 10000000,
-    "output_price": 50000000,
-    "cache_read_price": 1000000,
-    "cache_write_price": 12500000
-  },
-  {
-    "provider": "openrouter",
     "model": "anthropic/claude-opus-5",
     "input_price": 5000000,
     "output_price": 25000000,
     "cache_read_price": 500000,
     "cache_write_price": 6250000
-  },
-  {
-    "provider": "openrouter",
-    "model": "anthropic/claude-opus-5-fast",
-    "input_price": 10000000,
-    "output_price": 50000000,
-    "cache_read_price": 1000000,
-    "cache_write_price": 12500000
   },
   {
     "provider": "openrouter",
@@ -2850,17 +2858,9 @@
   {
     "provider": "openrouter",
     "model": "arcee-ai/trinity-large-thinking",
-    "input_price": 220000,
-    "output_price": 850000,
+    "input_price": 250000,
+    "output_price": 800000,
     "cache_read_price": 60000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "arcee-ai/virtuoso-large",
-    "input_price": 750000,
-    "output_price": 1200000,
-    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3034,9 +3034,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v3.2",
-    "input_price": 260000,
-    "output_price": 380000,
-    "cache_read_price": 130000,
+    "input_price": 269000,
+    "output_price": 400000,
+    "cache_read_price": 134500,
     "cache_write_price": null
   },
   {
@@ -3050,17 +3050,17 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash",
-    "input_price": 79520,
-    "output_price": 159040,
-    "cache_read_price": 15904,
+    "input_price": 71680,
+    "output_price": 143360,
+    "cache_read_price": 14336,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash-0731",
-    "input_price": 60000,
-    "output_price": 120000,
-    "cache_read_price": 12000,
+    "input_price": 65000,
+    "output_price": 180000,
+    "cache_read_price": 16000,
     "cache_write_price": null
   },
   {
@@ -3074,17 +3074,17 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro",
-    "input_price": 870000,
-    "output_price": 1740000,
-    "cache_read_price": 72500,
+    "input_price": 1024164,
+    "output_price": 2048328,
+    "cache_read_price": 85347,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro-0813",
-    "input_price": 1122000,
-    "output_price": 3366000,
-    "cache_read_price": 37400,
+    "input_price": 660000,
+    "output_price": 1980000,
+    "cache_read_price": 22000,
     "cache_write_price": null
   },
   {
@@ -3250,10 +3250,10 @@
   {
     "provider": "openrouter",
     "model": "google/gemini-3.7-flash",
-    "input_price": 375000,
-    "output_price": 1875000,
-    "cache_read_price": 37500,
-    "cache_write_price": 20833
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
+    "cache_write_price": 41667
   },
   {
     "provider": "openrouter",
@@ -3361,10 +3361,26 @@
   },
   {
     "provider": "openrouter",
+    "model": "ibm-granite/granite-4.2-8b",
+    "input_price": 100000,
+    "output_price": 150000,
+    "cache_read_price": 50000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
     "model": "inception/mercury-2",
     "input_price": 250000,
     "output_price": 750000,
     "cache_read_price": 25000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "inception/mercury-2.5-preview",
+    "input_price": 40000,
+    "output_price": 150000,
+    "cache_read_price": 4000,
     "cache_write_price": null
   },
   {
@@ -3377,10 +3393,10 @@
   },
   {
     "provider": "openrouter",
-    "model": "kwaipilot/kat-coder-air-v2.5",
-    "input_price": 150000,
-    "output_price": 600000,
-    "cache_read_price": 30000,
+    "model": "inclusionai/ling-3.0-flash-fin:free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3410,7 +3426,7 @@
   {
     "provider": "openrouter",
     "model": "mancer/weaver",
-    "input_price": 500000,
+    "input_price": 400000,
     "output_price": 750000,
     "cache_read_price": null,
     "cache_write_price": null
@@ -3467,16 +3483,16 @@
     "provider": "openrouter",
     "model": "meta-llama/llama-4-maverick",
     "input_price": 200000,
-    "output_price": 800000,
+    "output_price": 696000,
     "cache_read_price": null,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "meta-llama/llama-4-scout",
-    "input_price": 110000,
-    "output_price": 340000,
-    "cache_read_price": 55000,
+    "input_price": 100000,
+    "output_price": 300000,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3490,8 +3506,8 @@
   {
     "provider": "openrouter",
     "model": "meta/muse-glimmer-30b",
-    "input_price": 350000,
-    "output_price": 1500000,
+    "input_price": 300000,
+    "output_price": 1200000,
     "cache_read_price": 40000,
     "cache_write_price": null
   },
@@ -3626,9 +3642,9 @@
   {
     "provider": "openrouter",
     "model": "mistralai/devstral-2512",
-    "input_price": 440000,
-    "output_price": 2200000,
-    "cache_read_price": 44000,
+    "input_price": 400000,
+    "output_price": 2000000,
+    "cache_read_price": 40000,
     "cache_write_price": null
   },
   {
@@ -3645,14 +3661,6 @@
     "input_price": 100000,
     "output_price": 100000,
     "cache_read_price": 10000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "openrouter",
-    "model": "mistralai/ministral-8b",
-    "input_price": 110000,
-    "output_price": 110000,
-    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -3802,9 +3810,9 @@
   {
     "provider": "openrouter",
     "model": "moonshotai/kimi-k2.5",
-    "input_price": 600000,
-    "output_price": 3000000,
-    "cache_read_price": 100000,
+    "input_price": 450000,
+    "output_price": 2250000,
+    "cache_read_price": 70000,
     "cache_write_price": null
   },
   {
@@ -3930,9 +3938,9 @@
   {
     "provider": "openrouter",
     "model": "nvidia/nemotron-3-ultra-550b-a55b",
-    "input_price": 600000,
-    "output_price": 3600000,
-    "cache_read_price": 200000,
+    "input_price": 500000,
+    "output_price": 2200000,
+    "cache_read_price": 100000,
     "cache_write_price": null
   },
   {
@@ -4730,8 +4738,8 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3-vl-30b-a3b-instruct",
-    "input_price": 130000,
-    "output_price": 520000,
+    "input_price": 150000,
+    "output_price": 600000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4770,8 +4778,8 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.5-122b-a10b",
-    "input_price": 260000,
-    "output_price": 2080000,
+    "input_price": 290000,
+    "output_price": 2400000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -4834,9 +4842,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.6-27b",
-    "input_price": 320000,
-    "output_price": 3200000,
-    "cache_read_price": null,
+    "input_price": 600000,
+    "output_price": 3600000,
+    "cache_read_price": 120000,
     "cache_write_price": null
   },
   {
@@ -5050,9 +5058,9 @@
   {
     "provider": "openrouter",
     "model": "tencent/hy3",
-    "input_price": 132000,
-    "output_price": 528000,
-    "cache_read_price": 33000,
+    "input_price": 82500,
+    "output_price": 330000,
+    "cache_read_price": 20625,
     "cache_write_price": null
   },
   {
@@ -5065,18 +5073,18 @@
   },
   {
     "provider": "openrouter",
-    "model": "thedrummer/cydonia-24b-v4.1",
-    "input_price": 300000,
-    "output_price": 500000,
-    "cache_read_price": 150000,
+    "model": "tencent/hy4-preview",
+    "input_price": 834000,
+    "output_price": 2501000,
+    "cache_read_price": 42000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
-    "model": "thedrummer/rocinante-12b",
-    "input_price": 250000,
+    "model": "thedrummer/cydonia-24b-v4.1",
+    "input_price": 300000,
     "output_price": 500000,
-    "cache_read_price": null,
+    "cache_read_price": 150000,
     "cache_write_price": null
   },
   {
@@ -5098,9 +5106,9 @@
   {
     "provider": "openrouter",
     "model": "thinkingmachines/inkling",
-    "input_price": 950000,
+    "input_price": 1000000,
     "output_price": 4050000,
-    "cache_read_price": 160000,
+    "cache_read_price": 170000,
     "cache_write_price": null
   },
   {
@@ -5298,9 +5306,9 @@
   {
     "provider": "openrouter",
     "model": "z-ai/glm-5.1",
-    "input_price": 1260000,
-    "output_price": 3960000,
-    "cache_read_price": 234000,
+    "input_price": 966000,
+    "output_price": 3036000,
+    "cache_read_price": 179400,
     "cache_write_price": null
   },
   {
@@ -5348,7 +5356,7 @@
     "model": "~anthropic/claude-fable-latest",
     "input_price": 10000000,
     "output_price": 50000000,
-    "cache_read_price": 1000000,
+    "cache_read_price": 250000,
     "cache_write_price": 12500000
   },
   {
@@ -5378,18 +5386,18 @@
   {
     "provider": "openrouter",
     "model": "~deepseek/deepseek-v4-flash-latest",
-    "input_price": 30000,
-    "output_price": 100000,
-    "cache_read_price": 7000,
+    "input_price": 49980,
+    "output_price": 99960,
+    "cache_read_price": 9996,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "~google/gemini-flash-latest",
-    "input_price": 375000,
-    "output_price": 1875000,
-    "cache_read_price": 37500,
-    "cache_write_price": 20833
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
+    "cache_write_price": 41667
   },
   {
     "provider": "openrouter",
@@ -5434,9 +5442,9 @@
   {
     "provider": "openrouter",
     "model": "~z-ai/glm-latest",
-    "input_price": 1400000,
-    "output_price": 4400000,
-    "cache_read_price": 260000,
+    "input_price": 1170000,
+    "output_price": 3960000,
+    "cache_read_price": 234000,
     "cache_write_price": null
   },
   {
@@ -5644,16 +5652,16 @@
     "model": "alibaba/qwen3.8-2.4t-a95b",
     "input_price": 2000000,
     "output_price": 6000000,
-    "cache_read_price": 200000,
+    "cache_read_price": 250000,
     "cache_write_price": null
   },
   {
     "provider": "vercel",
     "model": "alibaba/qwen3.8-27b",
-    "input_price": 550000,
-    "output_price": 3300000,
-    "cache_read_price": 110000,
-    "cache_write_price": null
+    "input_price": 500000,
+    "output_price": 3000000,
+    "cache_read_price": 100000,
+    "cache_write_price": 625000
   },
   {
     "provider": "vercel",
@@ -5662,6 +5670,14 @@
     "output_price": 470000,
     "cache_read_price": 16000,
     "cache_write_price": 200000
+  },
+  {
+    "provider": "vercel",
+    "model": "alibaba/qwen3.8-flash-next",
+    "input_price": 120000,
+    "output_price": 400000,
+    "cache_read_price": 10000,
+    "cache_write_price": null
   },
   {
     "provider": "vercel",
@@ -5717,6 +5733,14 @@
     "input_price": 10000000,
     "output_price": 50000000,
     "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "vercel",
+    "model": "anthropic/claude-fable-5.1",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 250000,
     "cache_write_price": 12500000
   },
   {
@@ -5865,14 +5889,6 @@
   },
   {
     "provider": "vercel",
-    "model": "deepseek/deepseek-v3",
-    "input_price": 270000,
-    "output_price": 1120000,
-    "cache_read_price": 135000,
-    "cache_write_price": null
-  },
-  {
-    "provider": "vercel",
     "model": "deepseek/deepseek-v3.1",
     "input_price": 250000,
     "output_price": 950000,
@@ -5930,9 +5946,9 @@
   {
     "provider": "vercel",
     "model": "deepseek/deepseek-v4-pro",
-    "input_price": 1740000,
-    "output_price": 3480000,
-    "cache_read_price": 140000,
+    "input_price": 660000,
+    "output_price": 1980000,
+    "cache_read_price": 22000,
     "cache_write_price": null
   },
   {
@@ -6117,6 +6133,22 @@
     "input_price": 60000,
     "output_price": 180000,
     "cache_read_price": 12000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "inclusionai/ling-3.0-flash-fin",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "inclusionai/ling-3.0-flash-fin-free",
+    "input_price": 0,
+    "output_price": 0,
+    "cache_read_price": null,
     "cache_write_price": null
   },
   {
@@ -6444,7 +6476,7 @@
     "model": "moonshotai/kimi-k2.7-code",
     "input_price": 950000,
     "output_price": 4000000,
-    "cache_read_price": 190000,
+    "cache_read_price": 160000,
     "cache_write_price": null
   },
   {
@@ -6515,8 +6547,8 @@
     "provider": "vercel",
     "model": "nvidia/nemotron-3.5-lightning",
     "input_price": 50000,
-    "output_price": 150000,
-    "cache_read_price": 50000,
+    "output_price": 200000,
+    "cache_read_price": 10000,
     "cache_write_price": null
   },
   {
@@ -7234,9 +7266,17 @@
   {
     "provider": "vercel",
     "model": "tencent/hy3",
-    "input_price": 132000,
-    "output_price": 528000,
-    "cache_read_price": 33000,
+    "input_price": 140000,
+    "output_price": 580000,
+    "cache_read_price": 35000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "tencent/hy4-preview",
+    "input_price": 834000,
+    "output_price": 2501000,
+    "cache_read_price": 42000,
     "cache_write_price": null
   },
   {
@@ -7269,6 +7309,14 @@
     "input_price": 435000,
     "output_price": 870000,
     "cache_read_price": 3600,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "xiaomi/mimo-v2.5-pro-ultraspeed",
+    "input_price": 1305000,
+    "output_price": 2610000,
+    "cache_read_price": 10800,
     "cache_write_price": null
   },
   {
@@ -7372,7 +7420,7 @@
     "model": "zai/glm-5.3",
     "input_price": 1400000,
     "output_price": 4400000,
-    "cache_read_price": 260000,
+    "cache_read_price": 140000,
     "cache_write_price": null
   },
   {

--- a/scripts/aibridgepricesgen/curation.json
+++ b/scripts/aibridgepricesgen/curation.json
@@ -1,11 +1,19 @@
 {
 	"anthropic": [
 		{
+			"modelIdentifier": "claude-fable-5-1",
+			"reasoningEffort": "high"
+		},
+		{
 			"modelIdentifier": "claude-fable-5",
 			"reasoningEffort": "high"
 		},
 		{
 			"modelIdentifier": "claude-mythos-5",
+			"reasoningEffort": "high"
+		},
+		{
+			"modelIdentifier": "claude-opus-5",
 			"reasoningEffort": "high"
 		},
 		{
@@ -42,6 +50,9 @@
 		}
 	],
 	"azure": [
+		{
+			"modelIdentifier": "claude-fable-5-1"
+		},
 		{
 			"modelIdentifier": "claude-fable-5"
 		},
@@ -90,6 +101,10 @@
 			"aliases": ["global.anthropic.claude-opus-5"]
 		},
 		{
+			"modelIdentifier": "anthropic.claude-fable-5-1",
+			"aliases": ["global.anthropic.claude-fable-5-1"]
+		},
+		{
 			"modelIdentifier": "anthropic.claude-fable-5",
 			"aliases": ["global.anthropic.claude-fable-5"]
 		},
@@ -105,6 +120,9 @@
 	"google": [
 		{
 			"modelIdentifier": "gemini-flash-latest"
+		},
+		{
+			"modelIdentifier": "gemini-3.7-flash"
 		},
 		{
 			"modelIdentifier": "gemini-3.6-flash"
@@ -164,7 +182,13 @@
 			"modelIdentifier": "moonshotai/kimi-k3"
 		},
 		{
+			"modelIdentifier": "z-ai/glm-5.3"
+		},
+		{
 			"modelIdentifier": "z-ai/glm-5.2"
+		},
+		{
+			"modelIdentifier": "anthropic/claude-fable-5.1"
 		},
 		{
 			"modelIdentifier": "anthropic/claude-fable-5"
@@ -214,7 +238,13 @@
 			"modelIdentifier": "moonshotai/kimi-k3"
 		},
 		{
+			"modelIdentifier": "zai/glm-5.3"
+		},
+		{
 			"modelIdentifier": "zai/glm-5.2"
+		},
+		{
+			"modelIdentifier": "anthropic/claude-fable-5.1"
 		},
 		{
 			"modelIdentifier": "anthropic/claude-fable-5"

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
@@ -2,6 +2,19 @@
 	"anthropic": [
 		{
 			"provider": "anthropic",
+			"modelIdentifier": "claude-fable-5-1",
+			"displayName": "Claude Fable 5.1",
+			"aliases": [],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 128000,
+			"reasoningEffort": "high",
+			"inputCost": 10,
+			"outputCost": 50,
+			"cacheReadCost": 0.25,
+			"cacheWriteCost": 12.5
+		},
+		{
+			"provider": "anthropic",
 			"modelIdentifier": "claude-fable-5",
 			"displayName": "Claude Fable 5",
 			"aliases": [],
@@ -25,6 +38,19 @@
 			"outputCost": 50,
 			"cacheReadCost": 1,
 			"cacheWriteCost": 12.5
+		},
+		{
+			"provider": "anthropic",
+			"modelIdentifier": "claude-opus-5",
+			"displayName": "Claude Opus 5",
+			"aliases": [],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 128000,
+			"reasoningEffort": "high",
+			"inputCost": 5,
+			"outputCost": 25,
+			"cacheReadCost": 0.5,
+			"cacheWriteCost": 6.25
 		},
 		{
 			"provider": "anthropic",
@@ -119,6 +145,18 @@
 		}
 	],
 	"azure": [
+		{
+			"provider": "azure",
+			"modelIdentifier": "claude-fable-5-1",
+			"displayName": "Claude Fable 5.1",
+			"aliases": [],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 128000,
+			"inputCost": 10,
+			"outputCost": 50,
+			"cacheReadCost": 0.25,
+			"cacheWriteCost": 12.5
+		},
 		{
 			"provider": "azure",
 			"modelIdentifier": "claude-fable-5",
@@ -288,6 +326,18 @@
 		},
 		{
 			"provider": "bedrock",
+			"modelIdentifier": "anthropic.claude-fable-5-1",
+			"displayName": "Claude Fable 5.1",
+			"aliases": ["global.anthropic.claude-fable-5-1"],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 128000,
+			"inputCost": 10,
+			"outputCost": 50,
+			"cacheReadCost": 0.25,
+			"cacheWriteCost": 12.5
+		},
+		{
+			"provider": "bedrock",
 			"modelIdentifier": "anthropic.claude-fable-5",
 			"displayName": "Claude Fable 5",
 			"aliases": ["global.anthropic.claude-fable-5"],
@@ -328,6 +378,17 @@
 			"provider": "google",
 			"modelIdentifier": "gemini-flash-latest",
 			"displayName": "Gemini Flash Latest",
+			"aliases": [],
+			"contextLimit": 1048576,
+			"maxOutputTokens": 65536,
+			"inputCost": 0.75,
+			"outputCost": 3.75,
+			"cacheReadCost": 0.075
+		},
+		{
+			"provider": "google",
+			"modelIdentifier": "gemini-3.7-flash",
+			"displayName": "Gemini 3.7 Flash",
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 65536,
@@ -517,6 +578,17 @@
 		},
 		{
 			"provider": "openrouter",
+			"modelIdentifier": "z-ai/glm-5.3",
+			"displayName": "GLM-5.3",
+			"aliases": [],
+			"contextLimit": 1310720,
+			"maxOutputTokens": 131072,
+			"inputCost": 1.4,
+			"outputCost": 4.4,
+			"cacheReadCost": 0.26
+		},
+		{
+			"provider": "openrouter",
 			"modelIdentifier": "z-ai/glm-5.2",
 			"displayName": "GLM-5.2",
 			"aliases": [],
@@ -525,6 +597,18 @@
 			"inputCost": 1.19,
 			"outputCost": 3.74,
 			"cacheReadCost": 0.221
+		},
+		{
+			"provider": "openrouter",
+			"modelIdentifier": "anthropic/claude-fable-5.1",
+			"displayName": "Claude Fable 5.1",
+			"aliases": [],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 128000,
+			"inputCost": 10,
+			"outputCost": 50,
+			"cacheReadCost": 0.25,
+			"cacheWriteCost": 12.5
 		},
 		{
 			"provider": "openrouter",
@@ -605,9 +689,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 0.07952,
-			"outputCost": 0.15904,
-			"cacheReadCost": 0.015904
+			"inputCost": 0.07168,
+			"outputCost": 0.14336,
+			"cacheReadCost": 0.014336
 		},
 		{
 			"provider": "openrouter",
@@ -616,9 +700,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 0.87,
-			"outputCost": 1.74,
-			"cacheReadCost": 0.0725
+			"inputCost": 1.024164,
+			"outputCost": 2.048328,
+			"cacheReadCost": 0.085347
 		},
 		{
 			"provider": "openrouter",
@@ -704,6 +788,17 @@
 		},
 		{
 			"provider": "vercel",
+			"modelIdentifier": "zai/glm-5.3",
+			"displayName": "GLM 5.3",
+			"aliases": [],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 1000000,
+			"inputCost": 1.4,
+			"outputCost": 4.4,
+			"cacheReadCost": 0.14
+		},
+		{
+			"provider": "vercel",
 			"modelIdentifier": "zai/glm-5.2",
 			"displayName": "GLM 5.2",
 			"aliases": [],
@@ -712,6 +807,18 @@
 			"inputCost": 0.8,
 			"outputCost": 2.55,
 			"cacheReadCost": 0.16
+		},
+		{
+			"provider": "vercel",
+			"modelIdentifier": "anthropic/claude-fable-5.1",
+			"displayName": "Claude Fable 5.1",
+			"aliases": [],
+			"contextLimit": 1000000,
+			"maxOutputTokens": 128000,
+			"inputCost": 10,
+			"outputCost": 50,
+			"cacheReadCost": 0.25,
+			"cacheWriteCost": 12.5
 		},
 		{
 			"provider": "vercel",
@@ -801,11 +908,11 @@
 			"modelIdentifier": "deepseek/deepseek-v4-pro",
 			"displayName": "DeepSeek V4 Pro",
 			"aliases": [],
-			"contextLimit": 1048600,
-			"maxOutputTokens": 1048600,
-			"inputCost": 1.74,
-			"outputCost": 3.48,
-			"cacheReadCost": 0.14
+			"contextLimit": 1000000,
+			"maxOutputTokens": 384000,
+			"inputCost": 0.66,
+			"outputCost": 1.98,
+			"cacheReadCost": 0.022
 		}
 	]
 }

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.test.ts
@@ -24,8 +24,10 @@ describe("knownModelsGenerated", () => {
 			}),
 		);
 		expect(thinkingMode).toEqual({
+			"claude-fable-5-1": "reasoningEffort",
 			"claude-fable-5": "reasoningEffort",
 			"claude-mythos-5": "reasoningEffort",
+			"claude-opus-5": "reasoningEffort",
 			"claude-opus-4-8": "reasoningEffort",
 			"claude-opus-4-7": "reasoningEffort",
 			"claude-opus-4-6": "reasoningEffort",


### PR DESCRIPTION
Add the models that landed on models.dev since the August curation pass to the Agents-page known models list, so they appear as suggestions when an admin adds a chat model in `/agents` settings.

| Model | Providers |
|---|---|
| Claude Fable 5.1 | anthropic, azure, bedrock (plus `global.` alias), openrouter, vercel |
| Claude Opus 5 | anthropic (already curated on the other providers) |
| Gemini 3.7 Flash | google |
| GLM 5.3 | openrouter, vercel |

Fable 5.1 and Opus 5 use `reasoningEffort: high` like their curated siblings, and new entries sort ahead of the models they supersede. `knownModelsGenerated.json` and `coderd/aibridge/prices/data/prices.json` are both regenerated with `make gen/aibridge-prices` from the same models.dev snapshot; the `prices.json` changes are upstream drift since the last weekly refresh.

Left out pending a decision: azure now lists `claude-mythos-5` upstream but it is not curated for azure here, and `copilot` has no curation entries at all.

> Xum opened this PR on behalf of @ibetitsmike.
