### PR TITLE
fix(site): use links for template page actions

### DIFF
--- a/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { workspacesKey } from "#/api/queries/workspaces";
 import {
 	MockTemplate,
@@ -59,6 +59,13 @@ export const Example: Story = {
 		await expect(
 			menu.getByRole("menuitem", { name: "Duplicate…" }),
 		).toHaveAttribute("href", `/templates/new?fromTemplate=${MockTemplate.id}`);
+
+		await userEvent.keyboard("{Escape}");
+		await waitFor(() => {
+			expect(
+				menu.queryByRole("menuitem", { name: "Settings" }),
+			).not.toBeInTheDocument();
+		});
 	},
 };
 

--- a/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import { workspacesKey } from "#/api/queries/workspaces";
 import {
 	MockTemplate,
@@ -41,7 +41,26 @@ const meta: Meta<typeof TemplatePageHeader> = {
 export default meta;
 type Story = StoryObj<typeof TemplatePageHeader>;
 
-export const Example: Story = {};
+export const Example: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Open menu" }));
+
+		const menu = within(document.body);
+		await expect(
+			menu.getByRole("menuitem", { name: "Settings" }),
+		).toHaveAttribute("href", `/templates/${MockTemplate.name}/settings`);
+		await expect(
+			menu.getByRole("menuitem", { name: "Edit files" }),
+		).toHaveAttribute(
+			"href",
+			`/templates/${MockTemplate.name}/versions/${MockTemplateVersion.name}/edit`,
+		);
+		await expect(
+			menu.getByRole("menuitem", { name: "Duplicate…" }),
+		).toHaveAttribute("href", `/templates/new?fromTemplate=${MockTemplate.id}`);
+	},
+};
 
 export const CanNotUpdate: Story = {
 	args: {

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -106,29 +106,25 @@ const TemplateMenu: FC<TemplateMenuProps> = ({
 					</ShadcnButton>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
-					<DropdownMenuItem
-						onClick={() => navigate(`${templateLink}/settings`)}
-					>
-						<SettingsIcon className="size-icon-sm" />
-						Settings
+					<DropdownMenuItem asChild>
+						<RouterLink to={`${templateLink}/settings`}>
+							<SettingsIcon className="size-icon-sm" />
+							Settings
+						</RouterLink>
 					</DropdownMenuItem>
 
-					<DropdownMenuItem
-						onClick={() =>
-							navigate(`${templateLink}/versions/${templateVersion}/edit`)
-						}
-					>
-						<EditIcon />
-						Edit files
+					<DropdownMenuItem asChild>
+						<RouterLink to={`${templateLink}/versions/${templateVersion}/edit`}>
+							<EditIcon />
+							Edit files
+						</RouterLink>
 					</DropdownMenuItem>
 
-					<DropdownMenuItem
-						onClick={() =>
-							navigate(`/templates/new?fromTemplate=${templateId}`)
-						}
-					>
-						<CopyIcon className="size-icon-sm" />
-						Duplicate&hellip;
+					<DropdownMenuItem asChild>
+						<RouterLink to={`/templates/new?fromTemplate=${templateId}`}>
+							<CopyIcon className="size-icon-sm" />
+							Duplicate&hellip;
+						</RouterLink>
 					</DropdownMenuItem>
 
 					<DropdownMenuItem onClick={() => handleExport()}>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

The Settings, Edit files, and Duplicate actions on template pages used click handlers, preventing users from opening their destinations in new tabs.

Render these actions as links and cover their destinations in the existing Storybook interaction test.

Closes https://linear.app/codercom/issue/DEVEX-703/template-page-action-buttons-are-onclick-handlers-not-real-links
