### PR TITLE
refactor: modernize the edit user page

### DIFF
--- a/docs/admin/users/index.md
+++ b/docs/admin/users/index.md
@@ -229,11 +229,10 @@ The following filters are supported:
 To edit a user's display name or username with the web UI:
 
 1. Log in as a user admin.
-2. Go to **Users**
-3. Find the user whose details you would like to edit
-4. Select **Edit** from the actions menu
-5. Make any desired changes
-6. Select **Save**
+2. Go to **Users**.
+3. Open the actions menu for the user and select **Edit**.
+4. Make any desired changes.
+5. Select **Save**.
 
 ## Retrieve your list of Coder users
 

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -34,7 +34,7 @@ import { getAuthorizationKey } from "./authCheck";
 import { invalidateGroupMembersAISpend } from "./groups";
 import { cachedQuery } from "./util";
 
-const usersQueryKey = ["users"] as const;
+export const usersQueryKey = ["users"] as const;
 
 export function usersKey(req: UsersRequest) {
 	return [...usersQueryKey, req] as const;

--- a/site/src/modules/users/UserActionDialogs.tsx
+++ b/site/src/modules/users/UserActionDialogs.tsx
@@ -28,11 +28,13 @@ export type UserAdminAction =
 type UserActionDialogsProps = {
 	action: UserAdminAction | undefined;
 	onClose: () => void;
+	onDeleted?: (user: User) => void;
 };
 
 export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 	action,
 	onClose,
+	onDeleted,
 }) => {
 	const queryClient = useQueryClient();
 	const user = action?.user;
@@ -99,6 +101,7 @@ export const UserActionDialogs: FC<UserActionDialogsProps> = ({
 							await deleteUserMutation.mutateAsync(user.id);
 							onClose();
 							toast.success(`User "${user.username}" deleted successfully.`);
+							onDeleted?.(user);
 						} catch (error) {
 							toast.error(
 								getErrorMessage(

--- a/site/src/modules/users/UserMoreActions.stories.tsx
+++ b/site/src/modules/users/UserMoreActions.stories.tsx
@@ -59,6 +59,22 @@ export const OpenMenu: Story = {
 	},
 };
 
+export const OnEditPage: Story = {
+	args: {
+		showEdit: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: /open menu/i }));
+		const menu = within(document.body);
+		await menu.findByRole("menuitem", { name: "View workspaces" });
+		await expect(
+			menu.queryByRole("menuitem", { name: "Edit" }),
+		).not.toBeInTheDocument();
+		await menu.findByRole("menuitem", { name: "Edit roles" });
+	},
+};
+
 export const OidcRoleSyncDisablesEditRoles: Story = {
 	args: {
 		user: { ...MockUserMember, login_type: "oidc" },

--- a/site/src/modules/users/UserMoreActions.tsx
+++ b/site/src/modules/users/UserMoreActions.tsx
@@ -18,6 +18,8 @@ type UserMoreActionsProps = {
 	onAction: (action: UserAdminAction) => void;
 	canViewActivity?: boolean;
 	oidcRoleSyncEnabled?: boolean;
+	/** Hide the Edit item when the menu is already on the edit page. */
+	showEdit?: boolean;
 };
 
 export const UserMoreActions: FC<UserMoreActionsProps> = ({
@@ -26,6 +28,7 @@ export const UserMoreActions: FC<UserMoreActionsProps> = ({
 	onAction,
 	canViewActivity,
 	oidcRoleSyncEnabled,
+	showEdit = true,
 }) => {
 	return (
 		<DropdownMenu>
@@ -58,9 +61,11 @@ export const UserMoreActions: FC<UserMoreActionsProps> = ({
 					</DropdownMenuItem>
 				)}
 
-				<DropdownMenuItem asChild>
-					<Link to={user.username}>Edit</Link>
-				</DropdownMenuItem>
+				{showEdit && (
+					<DropdownMenuItem asChild>
+						<Link to={user.username}>Edit</Link>
+					</DropdownMenuItem>
+				)}
 
 				<DropdownMenuItem
 					disabled={user.login_type === "oidc" && oidcRoleSyncEnabled}

--- a/site/src/modules/users/UserMoreActions.tsx
+++ b/site/src/modules/users/UserMoreActions.tsx
@@ -18,7 +18,6 @@ type UserMoreActionsProps = {
 	onAction: (action: UserAdminAction) => void;
 	canViewActivity?: boolean;
 	oidcRoleSyncEnabled?: boolean;
-	/** Hide the Edit item when the menu is already on the edit page. */
 	showEdit?: boolean;
 };
 

--- a/site/src/pages/EditUserPage/EditUserForm.stories.tsx
+++ b/site/src/pages/EditUserPage/EditUserForm.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
 import { expect, userEvent, within } from "storybook/test";
-import { mockApiError } from "#/testHelpers/entities";
+import { UserMoreActions } from "#/modules/users/UserMoreActions";
+import {
+	MockUserMember,
+	MockUserOwner,
+	mockApiError,
+} from "#/testHelpers/entities";
+import { docs } from "#/utils/docs";
 import { EditUserForm } from "./EditUserForm";
 
 const meta: Meta<typeof EditUserForm> = {
@@ -23,7 +29,24 @@ const meta: Meta<typeof EditUserForm> = {
 export default meta;
 type Story = StoryObj<typeof EditUserForm>;
 
-export const Ready: Story = {};
+export const Ready: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: "Edit John Doe" }),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: /back to users/i }),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: /view docs/i }),
+		).toHaveAttribute("href", docs("/admin/users#edit-a-users-profile"));
+		await expect(canvas.getByText("Unique identifier.")).toBeVisible();
+		await expect(
+			canvas.getByText("Friendly name. Defaults to the username if blank."),
+		).toBeVisible();
+	},
+};
 
 export const NoDisplayName: Story = {
 	args: {
@@ -32,6 +55,27 @@ export const NoDisplayName: Story = {
 			name: "",
 			avatar_url: "",
 		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: "Edit jane-doe" }),
+		).toBeVisible();
+	},
+};
+
+// The heading names the saved user, so editing the name field must not rename
+// the page while the admin is still typing.
+export const HeadingKeepsSavedName: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const field = canvas.getByLabelText("Name");
+		await userEvent.clear(field);
+		await userEvent.type(field, "Jonathan Doe");
+		await expect(field).toHaveValue("Jonathan Doe");
+		await expect(
+			canvas.getByRole("heading", { name: "Edit John Doe" }),
+		).toBeVisible();
 	},
 };
 
@@ -65,6 +109,7 @@ export const CannotEditAvatar: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		await expect(canvas.getByLabelText(/username/i)).toBeVisible();
 		await expect(canvas.queryByLabelText("Avatar URL")).not.toBeInTheDocument();
 	},
 };
@@ -77,6 +122,14 @@ export const FormError: Story = {
 			],
 		}),
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: /save/i }));
+		await expect(
+			await canvas.findByText("Username is already taken."),
+		).toBeVisible();
+		await expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+	},
 };
 
 export const GeneralError: Story = {
@@ -85,10 +138,49 @@ export const GeneralError: Story = {
 			message: "Failed to update user profile.",
 		}),
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("Failed to update user profile."),
+		).toBeVisible();
+		await expect(canvas.getByLabelText(/username/i)).toBeVisible();
+	},
 };
 
 export const Loading: Story = {
 	args: {
 		isLoading: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("button", { name: /save/i })).toBeDisabled();
+		await expect(canvas.getByRole("button", { name: /cancel/i })).toBeEnabled();
+	},
+};
+
+export const WithActionsMenu: Story = {
+	args: {
+		headerActions: (
+			<UserMoreActions
+				user={MockUserMember}
+				me={MockUserOwner.id}
+				showEdit={false}
+				canViewActivity
+				onAction={action("action")}
+			/>
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("link", { name: /back to users/i }),
+		).toBeVisible();
+		await userEvent.click(canvas.getByRole("button", { name: /open menu/i }));
+		const menu = within(document.body);
+		await menu.findByRole("menuitem", { name: "View workspaces" });
+		await expect(
+			menu.queryByRole("menuitem", { name: "Edit" }),
+		).not.toBeInTheDocument();
+		await menu.findByRole("menuitem", { name: "Suspend…" });
 	},
 };

--- a/site/src/pages/EditUserPage/EditUserForm.stories.tsx
+++ b/site/src/pages/EditUserPage/EditUserForm.stories.tsx
@@ -7,7 +7,6 @@ import {
 	MockUserOwner,
 	mockApiError,
 } from "#/testHelpers/entities";
-import { docs } from "#/utils/docs";
 import { EditUserForm } from "./EditUserForm";
 
 const meta: Meta<typeof EditUserForm> = {
@@ -38,9 +37,6 @@ export const Ready: Story = {
 		await expect(
 			canvas.getByRole("link", { name: /back to users/i }),
 		).toBeVisible();
-		await expect(
-			canvas.getByRole("link", { name: /view docs/i }),
-		).toHaveAttribute("href", docs("/admin/users#edit-a-users-profile"));
 		await expect(canvas.getByText("Unique identifier.")).toBeVisible();
 		await expect(
 			canvas.getByText("Friendly name. Defaults to the username if blank."),

--- a/site/src/pages/EditUserPage/EditUserForm.tsx
+++ b/site/src/pages/EditUserPage/EditUserForm.tsx
@@ -1,15 +1,23 @@
 import { useFormik } from "formik";
-import type { FC } from "react";
+import { ArrowLeftIcon } from "lucide-react";
+import type { FC, ReactNode } from "react";
+import { Link } from "react-router";
 import * as Yup from "yup";
 import { hasApiFieldErrors, isApiError } from "#/api/errors";
 import type { UpdateUserProfileRequest } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
-import { FormFooter } from "#/components/Form/Form";
+import { FormFields, FormFooter } from "#/components/Form/Form";
 import { FormField } from "#/components/FormField/FormField";
-import { FullPageForm } from "#/components/FullPageForm/FullPageForm";
 import { IconField } from "#/components/IconField/IconField";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderDocsLink,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
 import { Spinner } from "#/components/Spinner/Spinner";
+import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,
 	getFormHelpers,
@@ -19,7 +27,7 @@ import {
 
 const validationSchema = Yup.object({
 	username: nameValidator("Username"),
-	name: displayNameValidator("Full name"),
+	name: displayNameValidator("Name"),
 	avatar_url: Yup.string(),
 });
 
@@ -27,8 +35,9 @@ interface EditUserFormProps {
 	error?: unknown;
 	isLoading: boolean;
 	initialValues: UpdateUserProfileRequest;
-	/** Allows hiding the avatar setting when it would be overwritten later by the user's identity provider. */
+	/** Hidden for login types whose avatar is synced from an identity provider. */
 	canEditAvatar: boolean;
+	headerActions?: ReactNode;
 	onSubmit: (values: UpdateUserProfileRequest) => void;
 	onCancel: () => void;
 }
@@ -38,76 +47,103 @@ export const EditUserForm: FC<EditUserFormProps> = ({
 	isLoading,
 	initialValues,
 	canEditAvatar,
+	headerActions,
 	onSubmit,
 	onCancel,
 }) => {
+	// `enableReinitialize` is intentionally omitted: the user query is
+	// invalidated by the actions in the header, and reinitializing would
+	// discard whatever the admin has typed when a refetch lands.
 	const form = useFormik<UpdateUserProfileRequest>({
 		initialValues,
 		validationSchema,
 		onSubmit,
-		enableReinitialize: true,
 	});
-
 	const getFieldHelpers = getFormHelpers(form, error);
+	// Read from the saved user rather than the draft so the heading does not
+	// change on every keystroke.
+	const heading = initialValues.name.trim() || initialValues.username;
 
 	return (
-		<FullPageForm title="Edit user">
-			{isApiError(error) && !hasApiFieldErrors(error) && (
-				<ErrorAlert error={error} className="mb-8" />
-			)}
-			<form onSubmit={form.handleSubmit} autoComplete="off">
-				<div className="flex flex-col gap-6">
-					<FormField
-						field={getFieldHelpers("username")}
-						label="Username"
-						id="username"
-						name="username"
-						value={form.values.username}
-						onChange={onChangeTrimmed(form)}
-						onBlur={form.handleBlur}
-						autoComplete="username"
-						autoFocus
-					/>
+		<div>
+			<div className="flex items-center justify-between">
+				<Button variant="subtle" asChild className="-ml-3">
+					<Link to="/deployment/users">
+						<ArrowLeftIcon />
+						<span>Back to users</span>
+					</Link>
+				</Button>
+				{headerActions}
+			</div>
 
-					<FormField
-						field={getFieldHelpers("name")}
-						label={
-							<>
-								Full name{" "}
-								<span className="font-normal text-content-secondary">
-									(optional)
-								</span>
-							</>
-						}
-						id="name"
-						name="name"
-						value={form.values.name}
-						onChange={form.handleChange}
-						onBlur={form.handleBlur}
-						autoComplete="name"
-					/>
-
-					{canEditAvatar && (
-						<IconField
-							{...getFieldHelpers("avatar_url")}
-							label="Avatar URL"
-							onChange={onChangeTrimmed(form)}
-							onPickEmoji={(value) => form.setFieldValue("avatar_url", value)}
-							fullWidth
+			<div className="pt-6">
+				<SettingsHeader>
+					<SettingsHeaderTitle>Edit {heading}</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Change how this user appears across Coder.{" "}
+						<SettingsHeaderDocsLink
+							href={docs("/admin/users#edit-a-users-profile")}
 						/>
-					)}
-				</div>
+					</SettingsHeaderDescription>
+				</SettingsHeader>
 
-				<FormFooter className="mt-8">
-					<Button onClick={onCancel} variant="outline">
-						Cancel
-					</Button>
-					<Button type="submit" disabled={isLoading}>
-						<Spinner loading={isLoading} />
-						Save
-					</Button>
-				</FormFooter>
-			</form>
-		</FullPageForm>
+				<div className="border border-solid p-6 rounded-lg">
+					<form
+						onSubmit={form.handleSubmit}
+						autoComplete="off"
+						className="flex flex-col gap-6"
+					>
+						{isApiError(error) && !hasApiFieldErrors(error) && (
+							<ErrorAlert error={error} />
+						)}
+
+						<FormFields>
+							<FormField
+								field={getFieldHelpers("username", {
+									helperText: "Unique identifier.",
+								})}
+								label="Username"
+								required
+								onChange={onChangeTrimmed(form)}
+								autoComplete="username"
+								autoFocus
+							/>
+
+							<FormField
+								field={getFieldHelpers("name", {
+									helperText:
+										"Friendly name. Defaults to the username if blank.",
+								})}
+								label="Name"
+								autoComplete="name"
+							/>
+
+							{canEditAvatar && (
+								<IconField
+									{...getFieldHelpers("avatar_url", {
+										helperText: "URL or emoji shown for this user.",
+									})}
+									label="Avatar URL"
+									onChange={onChangeTrimmed(form)}
+									onPickEmoji={(value) =>
+										form.setFieldValue("avatar_url", value)
+									}
+								/>
+							)}
+						</FormFields>
+
+						<FormFooter className="mt-0">
+							<Button onClick={onCancel} variant="outline">
+								Cancel
+							</Button>
+							<Button type="submit" disabled={isLoading}>
+								<Spinner loading={isLoading} />
+								Save
+							</Button>
+						</FormFooter>
+					</form>
+				</div>
+			</div>
+		</div>
 	);
 };

--- a/site/src/pages/EditUserPage/EditUserForm.tsx
+++ b/site/src/pages/EditUserPage/EditUserForm.tsx
@@ -13,11 +13,9 @@ import { IconField } from "#/components/IconField/IconField";
 import {
 	SettingsHeader,
 	SettingsHeaderDescription,
-	SettingsHeaderDocsLink,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,
 	getFormHelpers,
@@ -80,10 +78,7 @@ export const EditUserForm: FC<EditUserFormProps> = ({
 				<SettingsHeader>
 					<SettingsHeaderTitle>Edit {heading}</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
-						Change how this user appears across Coder.{" "}
-						<SettingsHeaderDocsLink
-							href={docs("/admin/users#edit-a-users-profile")}
-						/>
+						Change how this user appears across Coder.
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 

--- a/site/src/pages/EditUserPage/EditUserPage.stories.tsx
+++ b/site/src/pages/EditUserPage/EditUserPage.stories.tsx
@@ -1,0 +1,254 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, userEvent, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import { deploymentConfigQueryKey } from "#/api/queries/deployment";
+import { userKey } from "#/api/queries/users";
+import type { User } from "#/api/typesGenerated";
+import {
+	MockUserMember,
+	MockUserOwner,
+	mockApiError,
+} from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+	withToaster,
+} from "#/testHelpers/storybook";
+import EditUserPage from "./EditUserPage";
+
+const UsersListRoute = () => <div>Users list</div>;
+
+const meta: Meta<typeof EditUserPage> = {
+	title: "pages/EditUserPage/EditUserPage",
+	component: EditUserPage,
+	decorators: [withToaster, withAuthProvider, withDashboardProvider],
+	parameters: {
+		user: MockUserOwner,
+		permissions: {
+			updateUsers: true,
+			viewDeploymentConfig: true,
+		},
+		features: ["audit_log"],
+		queries: [
+			{ key: userKey(MockUserMember.username), data: MockUserMember },
+			{
+				key: deploymentConfigQueryKey,
+				data: {
+					config: { oidc: { user_role_field: "" } },
+					options: [],
+				},
+			},
+		],
+		reactRouter: reactRouterParameters({
+			location: { path: `/deployment/users/${MockUserMember.username}` },
+			routing: [
+				{ path: "/deployment/users", Component: UsersListRoute },
+				{ path: "/deployment/users/:user", useStoryElement: true },
+			],
+		}),
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof EditUserPage>;
+
+export const Ready: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("heading", {
+				name: `Edit ${MockUserMember.name}`,
+			}),
+		).toBeVisible();
+		await userEvent.click(canvas.getByRole("button", { name: /open menu/i }));
+		const menu = within(document.body);
+		await menu.findByRole("menuitem", { name: "View workspaces" });
+		await menu.findByRole("menuitem", { name: "View activity" });
+		await expect(
+			menu.queryByRole("menuitem", { name: "Edit" }),
+		).not.toBeInTheDocument();
+		await menu.findByRole("menuitem", { name: "Delete…" });
+	},
+};
+
+export const WithoutUpdatePermission: Story = {
+	parameters: {
+		permissions: {
+			updateUsers: false,
+			viewDeploymentConfig: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("heading", {
+				name: `Edit ${MockUserMember.name}`,
+			}),
+		).toBeVisible();
+		await expect(
+			canvas.queryByRole("button", { name: /open menu/i }),
+		).not.toBeInTheDocument();
+		await expect(canvas.getByLabelText(/username/i)).toBeVisible();
+	},
+};
+
+const renamedUsername = "renamed-user";
+const renamedName = "Renamed User";
+const renamedUser: User = {
+	...MockUserMember,
+	username: renamedUsername,
+	name: renamedName,
+};
+
+export const SavesAndRenames: Story = {
+	beforeEach: () => {
+		spyOn(API, "updateProfile").mockResolvedValue(renamedUser);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByRole("heading", { name: `Edit ${MockUserMember.name}` });
+
+		const username = canvas.getByLabelText(/username/i);
+		await userEvent.clear(username);
+		await userEvent.type(username, renamedUsername);
+		const name = canvas.getByLabelText("Name");
+		await userEvent.clear(name);
+		await userEvent.type(name, renamedName);
+		await userEvent.click(canvas.getByRole("button", { name: /save/i }));
+
+		// The saved user comes from the mutation response, so the heading updates
+		// without a refetch.
+		await expect(
+			await canvas.findByRole("heading", { name: `Edit ${renamedName}` }),
+		).toBeVisible();
+		await expect(username).toHaveValue(renamedUsername);
+		expect(API.updateProfile).toHaveBeenCalledWith(MockUserMember.id, {
+			username: renamedUsername,
+			name: renamedName,
+			avatar_url: "",
+		});
+	},
+};
+
+const suspendedUser: User = { ...MockUserMember, status: "suspended" };
+// The refetched profile differs from the one the page loaded, as it would if
+// another admin renamed the user in the meantime.
+const refetchedUser: User = { ...suspendedUser, name: "Renamed Elsewhere" };
+
+// Suspending invalidates the user query. The refetched user must not replace
+// what the admin has typed into the form.
+export const KeepsDraftWhenUserRefetches: Story = {
+	beforeEach: () => {
+		spyOn(API, "suspendUser").mockResolvedValue(suspendedUser);
+		spyOn(API, "getUser").mockResolvedValue(refetchedUser);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByRole("heading", { name: `Edit ${MockUserMember.name}` });
+		const name = canvas.getByLabelText("Name");
+		await userEvent.clear(name);
+		await userEvent.type(name, "Draft Name");
+
+		await userEvent.click(canvas.getByRole("button", { name: /open menu/i }));
+		const body = within(document.body);
+		await userEvent.click(
+			await body.findByRole("menuitem", { name: "Suspend…" }),
+		);
+		const dialog = await body.findByRole("dialog");
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Suspend" }),
+		);
+
+		// The success toast is shown after the invalidated user query settles.
+		await body.findByText(
+			`User "${MockUserMember.username}" suspended successfully.`,
+		);
+		expect(API.getUser).toHaveBeenCalledWith(MockUserMember.username);
+		await expect(name).toHaveValue("Draft Name");
+		await expect(
+			await canvas.findByRole("heading", {
+				name: `Edit ${refetchedUser.name}`,
+			}),
+		).toBeVisible();
+	},
+};
+
+export const DeletesAndReturnsToUsers: Story = {
+	beforeEach: () => {
+		spyOn(API, "deleteUser").mockResolvedValue();
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByRole("heading", { name: `Edit ${MockUserMember.name}` });
+		await userEvent.click(canvas.getByRole("button", { name: /open menu/i }));
+		await userEvent.click(
+			await within(document.body).findByRole("menuitem", { name: "Delete…" }),
+		);
+		const dialog = await within(document.body).findByRole("dialog");
+		await userEvent.type(
+			within(dialog).getByLabelText("Name of the user to delete"),
+			MockUserMember.username,
+		);
+		await userEvent.click(
+			within(dialog).getByRole("button", { name: "Delete" }),
+		);
+		await expect(await canvas.findByText("Users list")).toBeVisible();
+		await expect(
+			canvas.queryByRole("heading", { name: `Edit ${MockUserMember.name}` }),
+		).not.toBeInTheDocument();
+		expect(API.deleteUser).toHaveBeenCalledWith(MockUserMember.id);
+	},
+};
+
+export const Loading: Story = {
+	parameters: {
+		queries: [
+			{
+				key: deploymentConfigQueryKey,
+				data: {
+					config: { oidc: { user_role_field: "" } },
+					options: [],
+				},
+			},
+		],
+	},
+	beforeEach: () => {
+		spyOn(API, "getUser").mockReturnValue(new Promise(() => {}));
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("status", { name: /loading/i }),
+		).toBeVisible();
+		await expect(
+			canvas.queryByRole("heading", { name: /edit/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const UserError: Story = {
+	parameters: {
+		queries: [
+			{
+				key: deploymentConfigQueryKey,
+				data: {
+					config: { oidc: { user_role_field: "" } },
+					options: [],
+				},
+			},
+		],
+	},
+	beforeEach: () => {
+		spyOn(API, "getUser").mockRejectedValue(
+			mockApiError({ message: "User not found." }),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(await canvas.findByText("User not found.")).toBeVisible();
+		await expect(
+			canvas.queryByRole("heading", { name: /edit/i }),
+		).not.toBeInTheDocument();
+	},
+};

--- a/site/src/pages/EditUserPage/EditUserPage.tsx
+++ b/site/src/pages/EditUserPage/EditUserPage.tsx
@@ -146,7 +146,15 @@ const EditUserPage: FC = () => {
 			<UserActionDialogs
 				action={action}
 				onClose={() => setAction(undefined)}
-				onDeleted={() => {
+				onDeleted={(deletedUser) => {
+					queryClient.removeQueries({
+						queryKey: userKey(deletedUser.id),
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: userKey(deletedUser.username),
+						exact: true,
+					});
 					navigate("..", { relative: "path" });
 				}}
 			/>

--- a/site/src/pages/EditUserPage/EditUserPage.tsx
+++ b/site/src/pages/EditUserPage/EditUserPage.tsx
@@ -40,11 +40,10 @@ const EditUserPage: FC = () => {
 		enabled: permissions.viewDeploymentConfig,
 	});
 
-	// Indicates if oidc roles are synced from the oidc idp.
-	// Assign 'false' if unknown.
-	const oidcRoleSyncEnabled =
+	const oidcRoleSyncEnabled = Boolean(
 		permissions.viewDeploymentConfig &&
-		deploymentValues?.config.oidc?.user_role_field !== "";
+			deploymentValues?.config.oidc?.user_role_field,
+	);
 
 	const userData = userQuery.data;
 
@@ -89,6 +88,16 @@ const EditUserPage: FC = () => {
 					onSubmit={(values) => {
 						const mutation = updateProfileMutation.mutateAsync(values, {
 							onSuccess: (updatedUser) => {
+								if (
+									!isUUID(usernameOrId) &&
+									updatedUser.username !== usernameOrId
+								) {
+									queryClient.removeQueries({
+										queryKey: userKey(usernameOrId),
+										exact: true,
+									});
+								}
+
 								// The response is the saved user, so write it straight to the
 								// cache: the heading updates immediately instead of waiting on
 								// a refetch, and a rename lands on a warm cache entry.

--- a/site/src/pages/EditUserPage/EditUserPage.tsx
+++ b/site/src/pages/EditUserPage/EditUserPage.tsx
@@ -1,12 +1,24 @@
-import type { FC } from "react";
+import { type FC, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
-import { updateProfile, user } from "#/api/queries/users";
-import type { UpdateUserProfileRequest } from "#/api/typesGenerated";
+import { deploymentConfig } from "#/api/queries/deployment";
+import {
+	updateProfile,
+	user,
+	userKey,
+	usersQueryKey,
+} from "#/api/queries/users";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Loader } from "#/components/Loader/Loader";
-import { Margins } from "#/components/Margins/Margins";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import {
+	UserActionDialogs,
+	type UserAdminAction,
+} from "#/modules/users/UserActionDialogs";
+import { UserMoreActions } from "#/modules/users/UserMoreActions";
 import { pageTitle } from "#/utils/page";
 import { isUUID } from "#/utils/uuid";
 import { EditUserForm } from "./EditUserForm";
@@ -15,72 +27,121 @@ const EditUserPage: FC = () => {
 	const { user: usernameOrId } = useParams() as { user: string };
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const { user: me, permissions } = useAuthenticated();
+	const { entitlements } = useDashboard();
+	const [action, setAction] = useState<UserAdminAction>();
 
 	const userQuery = useQuery(user(usernameOrId));
 	const updateProfileMutation = useMutation(
 		updateProfile(userQuery.data?.id ?? ""),
 	);
+	const { data: deploymentValues } = useQuery({
+		...deploymentConfig(),
+		enabled: permissions.viewDeploymentConfig,
+	});
 
-	if (!userQuery.data) {
-		return <Loader />;
-	}
+	// Indicates if oidc roles are synced from the oidc idp.
+	// Assign 'false' if unknown.
+	const oidcRoleSyncEnabled =
+		permissions.viewDeploymentConfig &&
+		deploymentValues?.config.oidc?.user_role_field !== "";
 
 	const userData = userQuery.data;
 
-	const handleSubmit = async (values: UpdateUserProfileRequest) => {
-		const mutation = updateProfileMutation.mutateAsync(values, {
-			onSuccess: (updatedUser) => {
-				// Invalidate the user cache so other parts of the UI reflect the change.
-				void queryClient.invalidateQueries({
-					queryKey: ["user", usernameOrId],
-				});
-				void queryClient.invalidateQueries({ queryKey: ["users"] });
-
-				// If the URL currently uses the username (not a UUID) and the username
-				// has changed, rewrite the URL so the page doesn't 404 on refresh.
-				if (!isUUID(usernameOrId) && updatedUser.username !== usernameOrId) {
-					navigate(`../${updatedUser.username}`, {
-						relative: "path",
-						replace: true,
-					});
-				}
-			},
-		});
-
-		toast.promise(mutation, {
-			loading: `Saving user "${values.username}"…`,
-			success: `User "${values.username}" updated successfully.`,
-			error: (e) => ({
-				message: getErrorMessage(
-					e,
-					`Failed to update user "${values.username}".`,
-				),
-				description: getErrorDetail(e),
-			}),
-		});
-	};
-
 	return (
-		<Margins>
-			<title>{pageTitle("Edit User", `${userData.username}`)}</title>
+		<>
+			<title>
+				{pageTitle(
+					userData
+						? `Edit ${userData.name?.trim() || userData.username}`
+						: "Edit user",
+				)}
+			</title>
 
-			<EditUserForm
-				error={updateProfileMutation.error}
-				isLoading={updateProfileMutation.isPending}
-				initialValues={{
-					username: userData.username,
-					name: userData.name ?? "",
-					avatar_url: userData.avatar_url ?? "",
-				}}
-				canEditAvatar={
-					userData.login_type === "password" || userData.login_type === "none"
-				}
-				onSubmit={handleSubmit}
-				onCancel={() => {
+			{userQuery.isLoading ? (
+				<Loader />
+			) : !userData ? (
+				<ErrorAlert error={userQuery.error} />
+			) : (
+				<EditUserForm
+					error={updateProfileMutation.error}
+					isLoading={updateProfileMutation.isPending}
+					initialValues={{
+						username: userData.username,
+						name: userData.name ?? "",
+						avatar_url: userData.avatar_url ?? "",
+					}}
+					canEditAvatar={
+						userData.login_type === "password" || userData.login_type === "none"
+					}
+					headerActions={
+						permissions.updateUsers && (
+							<UserMoreActions
+								user={userData}
+								me={me.id}
+								showEdit={false}
+								canViewActivity={entitlements.features.audit_log.enabled}
+								oidcRoleSyncEnabled={oidcRoleSyncEnabled}
+								onAction={setAction}
+							/>
+						)
+					}
+					onSubmit={(values) => {
+						const mutation = updateProfileMutation.mutateAsync(values, {
+							onSuccess: (updatedUser) => {
+								// The response is the saved user, so write it straight to the
+								// cache: the heading updates immediately instead of waiting on
+								// a refetch, and a rename lands on a warm cache entry.
+								queryClient.setQueryData(userKey(updatedUser.id), updatedUser);
+								queryClient.setQueryData(
+									userKey(updatedUser.username),
+									updatedUser,
+								);
+								void queryClient.invalidateQueries({
+									queryKey: usersQueryKey,
+								});
+
+								// If the URL currently uses the username (not a UUID) and the
+								// username has changed, rewrite the URL so the page doesn't
+								// 404 on refresh.
+								if (
+									!isUUID(usernameOrId) &&
+									updatedUser.username !== usernameOrId
+								) {
+									navigate(`../${updatedUser.username}`, {
+										relative: "path",
+										replace: true,
+									});
+								}
+							},
+						});
+
+						toast.promise(mutation, {
+							loading: `Saving user "${values.username}"…`,
+							success: `User "${values.username}" updated successfully.`,
+							error: (error) => ({
+								message: getErrorMessage(
+									error,
+									`Failed to update user "${values.username}".`,
+								),
+								description: getErrorDetail(error),
+							}),
+						});
+					}}
+					onCancel={() => {
+						navigate("..", { relative: "path" });
+					}}
+				/>
+			)}
+
+			<UserActionDialogs
+				action={action}
+				onClose={() => setAction(undefined)}
+				onDeleted={() => {
 					navigate("..", { relative: "path" });
 				}}
 			/>
-		</Margins>
+		</>
 	);
 };
 


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

Redesigns the edit user page using the settings page layout, with clearer field guidance, explicit loading and error states, documentation and back links, and access to the shared user administration menu.

Successful updates refresh the page heading and query cache without resetting an in-progress form during background refetches.

| Old | New |
| --- | --- |
| <img width="2560" height="1800" alt="03-edit-user-member" src="https://github.com/user-attachments/assets/915434fe-9587-49e9-b962-cc1ebeca3ea4" /> | <img width="2560" height="1800" alt="02-edit-user-page" src="https://github.com/user-attachments/assets/2b188c26-4268-4498-96a0-4fd1825a6a49" /> |
| `** didnt exist **` | <img width="2560" height="1800" alt="03-edit-user-page-action-menu" src="https://github.com/user-attachments/assets/1e657626-ab43-4d49-a375-414896728fb9" /> |

<details>
<summary>Stack</summary>

1. #28893 - Edit user page redesign (this PR)
2. #28894 - Create user page redesign

</details>
