### PR TITLE
chore: make pre-commit hook checks opt-in

### DIFF
--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -148,22 +148,26 @@ no matter how long they take.
 git config core.hooksPath scripts/githooks
 ```
 
-Two hooks run automatically:
+Two hooks run automatically. Both skip their checks unless the
+developer opts in via git config or is allowlisted in the hook:
 
 - **pre-commit**: Classifies staged files by type and runs either
   the full `make pre-commit` or the lightweight `make pre-commit-light`
   depending on whether Go, TypeScript, SQL, proto, or Makefile
-  changes are present. Falls back to the full target when
-  `CODER_HOOK_RUN_ALL=1` is set. A markdown-only commit takes
+  changes are present. Allowlisted in `scripts/githooks/pre-commit`.
+  Runs only for developers who opt in with
+  `git config coder.pre-commit true`. Falls back to the full target
+  when `CODER_HOOK_RUN_ALL=1` is set. A markdown-only commit takes
   seconds; a Go change takes several minutes.
 - **pre-push**: Classifies changed files (vs remote branch or
   merge-base) and runs `make pre-push` when Go, TypeScript, SQL,
   proto, or Makefile changes are detected. Skips tests entirely
   for lightweight changes. Allowlisted in
   `scripts/githooks/pre-push`. Runs only for developers who opt
-  in. Falls back to `make pre-push` when the diff range can't
-  be determined or `CODER_HOOK_RUN_ALL=1` is set. Allow at least
-  15 minutes for a full run.
+  in with `git config coder.pre-push true`. Falls back to
+  `make pre-push` when the diff range can't be determined or
+  `CODER_HOOK_RUN_ALL=1` is set. Allow at least 15 minutes for a
+  full run.
 
 `git commit` and `git push` will appear to hang while hooks run.
 This is normal. Do not interrupt, retry, or reduce the timeout.

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -87,6 +87,10 @@ Install the git hooks to run these automatically:
 git config core.hooksPath scripts/githooks
 ```
 
+Hook checks are opt-in. Enable them with `git config coder.pre-commit true`
+and `git config coder.pre-push true`; developers allowlisted in the hook
+scripts run them by default.
+
 The hooks classify staged/changed files and select the appropriate target.
 Commits that only touch docs, shell, terraform, or other lightweight files
 run `make pre-commit-light` instead of the full `make pre-commit`, and

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -5,6 +5,12 @@
 # targets. Falls back to the full `make pre-commit` when the
 # Makefile changed or CODER_HOOK_RUN_ALL=1 is set.
 #
+# Opt in/out without modifying this file:
+#
+#   git config coder.pre-commit true    # opt in
+#   git config coder.pre-commit false   # opt out (overrides allowlist)
+#   git config --unset coder.pre-commit # default (allowlist decides)
+#
 # Installation (worktree-compatible):
 #
 #   git config core.hooksPath scripts/githooks
@@ -12,6 +18,13 @@
 # Bypass: git commit --no-verify
 
 set -euo pipefail
+
+# Allowlist of developers who opt in to pre-commit checks by default.
+# Matched against CODER_WORKSPACE_OWNER_NAME.
+ALLOWLIST=(
+	mafredri
+	johnstcn
+)
 
 cd "$(git rev-parse --show-toplevel)"
 
@@ -27,6 +40,32 @@ done < <(git rev-parse --local-env-vars)
 # In linked worktrees, set worktree-scoped hooksPath to override shared config.
 if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; then
 	git config --worktree core.hooksPath scripts/githooks
+fi
+
+# Explicit opt-in/opt-out via git config (overrides allowlist).
+run=false
+opt_in=$(git config --type=bool coder.pre-commit 2>/dev/null || true)
+if [[ $opt_in == true ]]; then
+	run=true
+elif [[ $opt_in == false ]]; then
+	# Explicit opt-out, skip everything including hint.
+	exit 0
+fi
+
+# Check allowlist.
+if ! $run; then
+	owner=${CODER_WORKSPACE_OWNER_NAME:-}
+	for allowed in "${ALLOWLIST[@]}"; do
+		if [[ $owner == "$allowed" ]]; then
+			run=true
+			break
+		fi
+	done
+fi
+
+if ! $run; then
+	echo "pre-commit: checks disabled, opt in with: git config coder.pre-commit true"
+	exit 0
 fi
 
 if [[ ${CODER_HOOK_RUN_ALL:-} == 1 ]]; then


### PR DESCRIPTION
The pre-commit hook currently runs `make pre-commit` or `make pre-commit-light` on every commit for everyone who has the repository hooks installed. This makes it opt-in, mirroring how `scripts/githooks/pre-push` already works: checks run only when `git config coder.pre-commit true` is set or the workspace owner is on the hook's allowlist, and `git config coder.pre-commit false` opts out explicitly. By default the hook prints a one-line skip message and exits 0.

Hook installation (`core.hooksPath`) and the linked-worktree hooksPath shield are unchanged, so `post-checkout` and `pre-push` keep working as before. `.claude/docs/WORKFLOWS.md` and `docs/about/contributing/CONTRIBUTING.md` describe the new opt-in.

> Xum (an AI coding agent) authored this PR on behalf of @ibetitsmike.
