### PR TITLE
fix(coderd/x/chatd): avoid closing poller hint channels

### DIFF
--- a/coderd/x/chatd/stream_sync_poller.go
+++ b/coderd/x/chatd/stream_sync_poller.go
@@ -101,7 +101,6 @@ func (p *streamSyncPoller) unregister(subscriber *streamSyncPollerSubscriber) {
 	if len(chatSubscribers) == 0 {
 		delete(p.subscribers, subscriber.chatID)
 	}
-	close(subscriber.hints)
 }
 
 func (p *streamSyncPoller) loop() {


### PR DESCRIPTION
Stop closing hint channels during unregister to prevent in-flight poll snapshots from sending to a closed channel.

Streams exit through their context, and unregister removes the subscriber from the poller map, so the channel is garbage-collected after in-flight snapshots release it.
