### PR TITLE
fix: default chat compaction threshold to 30% for large-context models

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -68,13 +68,24 @@ import (
 const (
 	chatStreamBatchSize = 256
 
-	chatContextLimitModelConfigKey                = "context_limit"
-	chatContextCompressionThresholdModelConfigKey = "context_compression_threshold"
-	defaultChatContextCompressionThreshold        = int32(70)
-	minChatContextCompressionThreshold            = int32(0)
-	maxChatContextCompressionThreshold            = int32(100)
-	maxSystemPromptLenBytes                       = 131072 // 128 KiB
+	defaultChatContextCompressionThreshold = int32(70)
+	// Large-context models (1M) compact earlier; 70% of a 1M window
+	// carries too much stale context.
+	largeContextDefaultCompressionThreshold = int32(30)
+	largeContextLimitTokens                 = int64(500_000)
+	minChatContextCompressionThreshold      = int32(0)
+	maxChatContextCompressionThreshold      = int32(100)
+	maxSystemPromptLenBytes                 = 131072 // 128 KiB
 )
+
+// defaultCompressionThresholdForContextLimit returns the compaction
+// threshold used when compression_threshold is omitted at creation.
+func defaultCompressionThresholdForContextLimit(contextLimit int64) int32 {
+	if contextLimit >= largeContextLimitTokens {
+		return largeContextDefaultCompressionThreshold
+	}
+	return defaultChatContextCompressionThreshold
+}
 
 var allowedReasoningEffortValues = strings.Join(codersdk.ChatModelReasoningEffortValues(), ", ")
 
@@ -7301,7 +7312,7 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 
 	compressionThreshold, thresholdErr := normalizeChatCompressionThreshold(
 		req.CompressionThreshold,
-		defaultChatContextCompressionThreshold,
+		defaultCompressionThresholdForContextLimit(contextLimit),
 	)
 	if thresholdErr != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1549,8 +1549,9 @@ func (c *ChatModelCallConfig) UnmarshalStrict(data []byte) error {
 // ChatModel. AIProviderID, Model, and a positive ContextLimit are required.
 // Enabled defaults to true. IsDefault defaults to false when the organization
 // already has a default model. The first model created in an organization is
-// automatically promoted to default. CompressionThreshold defaults to 70. An
-// omitted ModelConfig uses the provider defaults.
+// automatically promoted to default. CompressionThreshold defaults to 70, or
+// 30 when ContextLimit is at least 500k tokens. An omitted ModelConfig uses the
+// provider defaults.
 type CreateChatModelRequest struct {
 	AIProviderID         *uuid.UUID           `json:"ai_provider_id,omitempty" format:"uuid"`
 	Model                string               `json:"model"`

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3900,8 +3900,9 @@ export interface CreateChatMessageResponse {
  * ChatModel. AIProviderID, Model, and a positive ContextLimit are required.
  * Enabled defaults to true. IsDefault defaults to false when the organization
  * already has a default model. The first model created in an organization is
- * automatically promoted to default. CompressionThreshold defaults to 70. An
- * omitted ModelConfig uses the provider defaults.
+ * automatically promoted to default. CompressionThreshold defaults to 70, or
+ * 30 when ContextLimit is at least 500k tokens. An omitted ModelConfig uses the
+ * provider defaults.
  */
 export interface CreateChatModelRequest {
 	readonly ai_provider_id?: string;


### PR DESCRIPTION
Newly created chat model configs with a context limit of 500k+ tokens now default to a 30% compression threshold when `compression_threshold` is omitted. Smaller windows (200k, 272k) keep the existing 70% default. Existing model configs are unchanged; an explicit value still wins.

Also removes two unused `chatContext*ModelConfigKey` constants flagged by the linter and updates the SDK doc comment (regenerated `typesGenerated.ts`).