### PR TITLE
docs(docs/install): add template builder registry URL to Artifactory mirror guide

### DIFF
--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -264,6 +264,9 @@ rather than `registry.coder.com`.
 The value is a bare host, optionally with a port (for example, `mirror.internal:8443`).
 A leading `http(s)://` scheme and trailing slash are stripped, and a path, query, fragment, or credentials is rejected at server start.
 
+For a complete walkthrough of setting up the mirror, see
+[Mirror the Coder Registry with JFrog Artifactory](./registry-mirror-artifactory.md).
+
 ## Coder Modules
 
 To use Coder modules in offline installations, you can either:

--- a/docs/install/registry-mirror-artifactory.md
+++ b/docs/install/registry-mirror-artifactory.md
@@ -146,6 +146,27 @@ services:
 
 </div>
 
+## Step 6: Point the template builder at your mirror
+
+The [template builder](../admin/templates/creating-templates.md) resolves module
+sources against `registry.coder.com` by default. To make it generate module
+source paths that point at your Artifactory mirror instead, set the
+`CODER_TEMPLATE_BUILDER_REGISTRY_URL` environment variable on your Coder server:
+
+```sh
+CODER_TEMPLATE_BUILDER_REGISTRY_URL=<your-artifactory-host>
+```
+
+The value is a bare host, optionally with a port (for example,
+`artifactory.example.com` or `mycompany.jfrog.io:8443`). A leading `http(s)://`
+scheme and trailing slash are stripped, and a path, query, fragment, or
+credentials is rejected at server start.
+
+Without this variable, the template builder still requires outbound access to
+`registry.coder.com`. For fully air-gapped deployments that cannot set a mirror,
+disable the builder instead with `CODER_DISABLE_TEMPLATE_BUILDER=true`. See
+[Air-gapped Deployments](./airgap.md#template-builder) for details.
+
 ## Caching Behavior
 
 Artifactory uses **lazy caching**, meaning modules are cached on first request.


### PR DESCRIPTION
## Summary

Documents the Coder server environment variable needed to point the in-product **template builder** at a JFrog Artifactory registry mirror, and cross-links the two relevant install guides.

The Artifactory guide already covered mirroring the Coder Registry and configuring the Terraform CLI on Coder, but it never mentioned `CODER_TEMPLATE_BUILDER_REGISTRY_URL`, which the template builder needs so it generates module source paths against the mirror instead of `registry.coder.com`. This env var was only documented in the [air-gapped deployments](https://coder.com/docs/install/airgap) guide.

## Changes

- `docs/install/registry-mirror-artifactory.md`: new **Step 6: Point the template builder at your mirror**
  - Documents `CODER_TEMPLATE_BUILDER_REGISTRY_URL=<your-artifactory-host>` and the accepted value format (bare host, optional port; scheme/trailing slash stripped; path/query/fragment/credentials rejected at startup).
  - Notes the `CODER_DISABLE_TEMPLATE_BUILDER=true` fallback for fully air-gapped deployments.
  - Links to the air-gapped deployments doc's Template builder section.
- `docs/install/airgap.md`: the Template builder section now cross-links to the Artifactory mirror guide.

## Validation

- `pnpm run format-docs` — no changes
- `pnpm run lint-docs` — 0 errors

---

This PR was generated by Coder Agents on behalf of @jeremyruppel.
