### PR TITLE
feat: expose template builder agents and per-module agent

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -28015,6 +28015,12 @@ const docTemplate = `{
         "codersdk.TemplateBuilderBase": {
             "type": "object",
             "properties": {
+                "agents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.TemplateBuilderBaseAgent"
+                    }
+                },
                 "description": {
                     "type": "string"
                 },
@@ -28041,6 +28047,21 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.TemplateBuilderBaseAgent": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "description": "Default reports whether modules attach to this agent when they do not\nname one.",
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.TemplateBuilderBasesResponse": {
             "type": "object",
             "properties": {
@@ -28055,6 +28076,10 @@ const docTemplate = `{
         "codersdk.TemplateBuilderComposeModule": {
             "type": "object",
             "properties": {
+                "agent_name": {
+                    "description": "AgentName targets a base coder_agent by name. Empty uses the base default.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -25745,6 +25745,12 @@
 		"codersdk.TemplateBuilderBase": {
 			"type": "object",
 			"properties": {
+				"agents": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.TemplateBuilderBaseAgent"
+					}
+				},
 				"description": {
 					"type": "string"
 				},
@@ -25771,6 +25777,21 @@
 				}
 			}
 		},
+		"codersdk.TemplateBuilderBaseAgent": {
+			"type": "object",
+			"properties": {
+				"default": {
+					"description": "Default reports whether modules attach to this agent when they do not\nname one.",
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.TemplateBuilderBasesResponse": {
 			"type": "object",
 			"properties": {
@@ -25785,6 +25806,10 @@
 		"codersdk.TemplateBuilderComposeModule": {
 			"type": "object",
 			"properties": {
+				"agent_name": {
+					"description": "AgentName targets a base coder_agent by name. Empty uses the base default.",
+					"type": "string"
+				},
 				"id": {
 					"type": "string"
 				},

--- a/coderd/templatebuilder_compose_test.go
+++ b/coderd/templatebuilder_compose_test.go
@@ -69,6 +69,46 @@ func TestTemplateBuilderCompose(t *testing.T) {
 		require.Contains(t, files["modules.tf"], `coder_agent.main.id`)
 	})
 
+	t.Run("PerModuleAgentName", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		tarData, err := client.TemplateBuilderCompose(ctx, codersdk.TemplateBuilderComposeRequest{
+			BaseTemplateID: "docker",
+			Modules: []codersdk.TemplateBuilderComposeModule{
+				{ID: "code-server", AgentName: "main"},
+			},
+		})
+		require.NoError(t, err)
+
+		files := extractTarFiles(t, tarData)
+		require.Contains(t, files["modules.tf"], `coder_agent.main.id`)
+	})
+
+	t.Run("UnknownAgentName", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.TemplateBuilderCompose(ctx, codersdk.TemplateBuilderComposeRequest{
+			BaseTemplateID: "docker",
+			Modules: []codersdk.TemplateBuilderComposeModule{
+				{ID: "code-server", AgentName: "nonexistent"},
+			},
+		})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
 	t.Run("UnknownBase", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)

--- a/coderd/templatebuilder_handler.go
+++ b/coderd/templatebuilder_handler.go
@@ -83,6 +83,7 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 			OS:            string(templatebuilder.BaseTemplateOS(id)),
 			Variables:     vars,
 			Prerequisites: templatebuilder.BasePrerequisites(id),
+			Agents:        baseAgentsToSDK(templatebuilder.BaseAgents(id)),
 		})
 	}
 
@@ -98,6 +99,19 @@ func (api *API) templateBuilderBases(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.TemplateBuilderBasesResponse{
 		Bases: bases,
 	})
+}
+
+// baseAgentsToSDK converts base template agents to the SDK type.
+func baseAgentsToSDK(agents []templatebuilder.BaseAgent) []codersdk.TemplateBuilderBaseAgent {
+	out := make([]codersdk.TemplateBuilderBaseAgent, 0, len(agents))
+	for _, a := range agents {
+		out = append(out, codersdk.TemplateBuilderBaseAgent{
+			Name:        a.Name,
+			DisplayName: a.DisplayName,
+			Default:     a.Default,
+		})
+	}
+	return out
 }
 
 // baseVariablesToSDK converts base template variables to the SDK type,
@@ -220,6 +234,7 @@ func (api *API) templateBuilderCompose(rw http.ResponseWriter, r *http.Request) 
 	for _, m := range req.Modules {
 		composeReq.Modules = append(composeReq.Modules, templatebuilder.ComposeModule{
 			ID:        m.ID,
+			AgentName: m.AgentName,
 			Variables: m.Variables,
 		})
 	}
@@ -330,6 +345,7 @@ func (api *API) templateBuilderCreateTemplate(rw http.ResponseWriter, r *http.Re
 	for _, m := range req.Modules {
 		composeReq.Modules = append(composeReq.Modules, templatebuilder.ComposeModule{
 			ID:        m.ID,
+			AgentName: m.AgentName,
 			Variables: m.Variables,
 		})
 	}

--- a/coderd/templatebuilder_handler_test.go
+++ b/coderd/templatebuilder_handler_test.go
@@ -102,7 +102,25 @@ func TestTemplateBuilderBases(t *testing.T) {
 			} else {
 				require.Empty(t, b.Variables, "base %q should have no variables", spec.id)
 			}
+
+			// Every base declares at least one agent, exactly one default.
+			require.NotEmpty(t, b.Agents, "base %q should declare agents", spec.id)
+			defaults := 0
+			for _, a := range b.Agents {
+				if a.Default {
+					defaults++
+				}
+			}
+			require.Equal(t, 1, defaults, "base %q should mark exactly one default agent", spec.id)
 		}
+
+		// aws-linux names its agent "dev"; the rest use "main".
+		require.Equal(t,
+			[]codersdk.TemplateBuilderBaseAgent{{Name: "dev", Default: true}},
+			basesByID["aws-linux"].Agents)
+		require.Equal(t,
+			[]codersdk.TemplateBuilderBaseAgent{{Name: "main", Default: true}},
+			basesByID["docker"].Agents)
 	})
 
 	t.Run("Sorted", func(t *testing.T) {

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -59,6 +59,17 @@ type TemplateBuilderBase struct {
 	OS            string                          `json:"os"`
 	Variables     []TemplateBuilderModuleVariable `json:"variables"`
 	Prerequisites string                          `json:"prerequisites"`
+	Agents        []TemplateBuilderBaseAgent      `json:"agents"`
+}
+
+// TemplateBuilderBaseAgent is a coder_agent a base template declares. Modules
+// composed onto the base target one of these by Name.
+type TemplateBuilderBaseAgent struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	// Default reports whether modules attach to this agent when they do not
+	// name one.
+	Default bool `json:"default"`
 }
 
 // TemplateBuilderBasesResponse is the response body for listing template builder bases.
@@ -112,7 +123,9 @@ type TemplateBuilderComposeRequest struct {
 // TemplateBuilderComposeModule identifies a module and its variable
 // values for the compose request.
 type TemplateBuilderComposeModule struct {
-	ID        string            `json:"id"`
+	ID string `json:"id"`
+	// AgentName targets a base coder_agent by name. Empty uses the base default.
+	AgentName string            `json:"agent_name,omitempty"`
 	Variables map[string]string `json:"variables,omitempty"`
 }
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -13994,6 +13994,13 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ```json
 {
+  "agents": [
+    {
+      "default": true,
+      "display_name": "string",
+      "name": "string"
+    }
+  ],
   "description": "string",
   "icon": "string",
   "id": "string",
@@ -14019,6 +14026,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 | Name            | Type                                                                                      | Required | Restrictions | Description |
 |-----------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `agents`        | array of [codersdk.TemplateBuilderBaseAgent](#codersdktemplatebuilderbaseagent)           | false    |              |             |
 | `description`   | string                                                                                    | false    |              |             |
 | `icon`          | string                                                                                    | false    |              |             |
 | `id`            | string                                                                                    | false    |              |             |
@@ -14027,12 +14035,37 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `prerequisites` | string                                                                                    | false    |              |             |
 | `variables`     | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              |             |
 
+## codersdk.TemplateBuilderBaseAgent
+
+```json
+{
+  "default": true,
+  "display_name": "string",
+  "name": "string"
+}
+```
+
+### Properties
+
+| Name           | Type    | Required | Restrictions | Description                                                                     |
+|----------------|---------|----------|--------------|---------------------------------------------------------------------------------|
+| `default`      | boolean | false    |              | Default reports whether modules attach to this agent when they do not name one. |
+| `display_name` | string  | false    |              |                                                                                 |
+| `name`         | string  | false    |              |                                                                                 |
+
 ## codersdk.TemplateBuilderBasesResponse
 
 ```json
 {
   "bases": [
     {
+      "agents": [
+        {
+          "default": true,
+          "display_name": "string",
+          "name": "string"
+        }
+      ],
       "description": "string",
       "icon": "string",
       "id": "string",
@@ -14066,6 +14099,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ```json
 {
+  "agent_name": "string",
   "id": "string",
   "variables": {
     "property1": "string",
@@ -14076,11 +14110,12 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name               | Type   | Required | Restrictions | Description |
-|--------------------|--------|----------|--------------|-------------|
-| `id`               | string | false    |              |             |
-| `variables`        | object | false    |              |             |
-| » `[any property]` | string | false    |              |             |
+| Name               | Type   | Required | Restrictions | Description                                                                 |
+|--------------------|--------|----------|--------------|-----------------------------------------------------------------------------|
+| `agent_name`       | string | false    |              | Agent name targets a base coder_agent by name. Empty uses the base default. |
+| `id`               | string | false    |              |                                                                             |
+| `variables`        | object | false    |              |                                                                             |
+| » `[any property]` | string | false    |              |                                                                             |
 
 ## codersdk.TemplateBuilderComposeRequest
 
@@ -14093,6 +14128,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   },
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",
@@ -14142,6 +14178,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
   "icon": "string",
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",

--- a/docs/reference/api/templatebuilder.md
+++ b/docs/reference/api/templatebuilder.md
@@ -26,6 +26,13 @@ curl -X GET http://coder-server:8080/api/v2/templatebuilder/bases \
 {
   "bases": [
     {
+      "agents": [
+        {
+          "default": true,
+          "display_name": "string",
+          "name": "string"
+        }
+      ],
       "description": "string",
       "icon": "string",
       "id": "string",
@@ -81,6 +88,7 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose \
   },
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",
@@ -133,6 +141,7 @@ curl -X POST http://coder-server:8080/api/v2/templatebuilder/compose/template \
   "icon": "string",
   "modules": [
     {
+      "agent_name": "string",
       "id": "string",
       "variables": {
         "property1": "string",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -9259,6 +9259,22 @@ export interface TemplateBuilderBase {
 	readonly os: string;
 	readonly variables: readonly TemplateBuilderModuleVariable[];
 	readonly prerequisites: string;
+	readonly agents: readonly TemplateBuilderBaseAgent[];
+}
+
+// From codersdk/templatebuilder.go
+/**
+ * TemplateBuilderBaseAgent is a coder_agent a base template declares. Modules
+ * composed onto the base target one of these by Name.
+ */
+export interface TemplateBuilderBaseAgent {
+	readonly name: string;
+	readonly display_name: string;
+	/**
+	 * Default reports whether modules attach to this agent when they do not
+	 * name one.
+	 */
+	readonly default: boolean;
 }
 
 // From codersdk/templatebuilder.go
@@ -9276,6 +9292,10 @@ export interface TemplateBuilderBasesResponse {
  */
 export interface TemplateBuilderComposeModule {
 	readonly id: string;
+	/**
+	 * AgentName targets a base coder_agent by name. Empty uses the base default.
+	 */
+	readonly agent_name?: string;
 	readonly variables?: Record<string, string>;
 }
 

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -564,6 +564,7 @@ describe("toSelectedBaseMeta", () => {
 		os: "linux",
 		variables: [],
 		prerequisites: "",
+		agents: [],
 		...overrides,
 	});
 


### PR DESCRIPTION
Part of [DEVEX-556](https://linear.app/codercom/issue/DEVEX-556). Builds on the base agent metadata added in #28794.

## Summary

Surfaces the backend multi-agent support through the SDK and HTTP API: the bases endpoint returns each base's agents, and compose/create-template accept a per-module `agent_name`.

## What changed

- `codersdk/templatebuilder.go`: added `TemplateBuilderBaseAgent`, `TemplateBuilderBase.Agents`, and `TemplateBuilderComposeModule.AgentName` (`agent_name,omitempty`).
- `coderd/templatebuilder_handler.go`: added `baseAgentsToSDK`; the bases endpoint returns agents, and the compose and create-template endpoints forward `AgentName`.
- `make gen` regenerated `site/src/api/typesGenerated.ts`, `coderd/apidoc/docs.go`, `coderd/apidoc/swagger.json`, `docs/reference/api/schemas.md`, and `docs/reference/api/templatebuilder.md`.
- `wizardState.test.ts`: added `agents: []` to the base fixture now that the field is required on the generated type.

## Scope

SDK/API plumbing only. `ComposeModule.AgentName` now has a producer (the handlers) but no caller sets it yet — the wizard UI (follow-up) is what will populate it. No DB change, so `enterprise/audit/table.go` is unaffected.

## Testing

- Bases endpoint asserts each base returns agents with exactly one default (and the `dev`/`main` names).
- Per-module `agent_name` round-trip and unknown-agent (400) compose tests.
- `make gen` (idempotent), `make fmt` (no changes), `golangci-lint ./coderd/... ./codersdk/...`, the Go template-builder tests, frontend `tsc` + `biome check`, and docs markdownlint all pass.

<details>
<summary>Design note</summary>

`display_name` is intentionally returned as `""` for now: every base is single-agent, so no base authors a per-agent label. The field exists for multi-agent bases where the wizard radio needs a human-readable name; consumers fall back to the agent `name` when it is empty.

</details>

---
🤖 Generated by Coder Agents on behalf of @jeremyruppel.
