### PR TITLE
feat(site/src/pages/TemplateBuilder): plumb per-module agent selection state

### DIFF
--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.stories.tsx
@@ -29,6 +29,7 @@ const baseState: TemplateBuilderWizardState = {
 		iconUrl: "/icon/docker.svg",
 		hasParameters: false,
 		hasPrerequisites: false,
+		agents: [],
 	},
 	name: "docker",
 	displayName: "Docker Containers",

--- a/site/src/pages/TemplateBuilder/steps.test.ts
+++ b/site/src/pages/TemplateBuilder/steps.test.ts
@@ -37,6 +37,7 @@ describe("shouldSkip", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		});
 		expect(stepById("base-parameters").shouldSkip(noParams)).toBe(true);
@@ -49,6 +50,7 @@ describe("shouldSkip", () => {
 				name: "AWS Linux",
 				hasParameters: true,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		});
 		expect(stepById("base-parameters").shouldSkip(withParams)).toBe(false);
@@ -131,6 +133,46 @@ describe("stepModuleSettingsRequired", () => {
 		});
 		expect(stepModuleSettingsRequired(state)).toBe(true);
 	});
+
+	it("returns true for a multi-agent base with a selected module and no vars", () => {
+		const state = stateWith({
+			selectedBase: {
+				id: "gpu-base",
+				name: "GPU Base",
+				hasParameters: false,
+				hasPrerequisites: false,
+				agents: [
+					{ name: "main", displayName: "Main", default: true },
+					{ name: "gpu", displayName: "GPU", default: false },
+				],
+			},
+			selectedModules: [
+				{
+					id: "a",
+					name: "A",
+					iconUrl: "/a.svg",
+					hasConfigurableVars: false,
+				},
+			],
+		});
+		expect(stepModuleSettingsRequired(state)).toBe(true);
+	});
+
+	it("returns false for a multi-agent base with no modules selected", () => {
+		const state = stateWith({
+			selectedBase: {
+				id: "gpu-base",
+				name: "GPU Base",
+				hasParameters: false,
+				hasPrerequisites: false,
+				agents: [
+					{ name: "main", displayName: "Main", default: true },
+					{ name: "gpu", displayName: "GPU", default: false },
+				],
+			},
+		});
+		expect(stepModuleSettingsRequired(state)).toBe(false);
+	});
 });
 
 describe("findNextVisibleIndex", () => {
@@ -141,6 +183,7 @@ describe("findNextVisibleIndex", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		});
 		// From base-infra (index 0), next visible should be module-select (index 2).
@@ -165,6 +208,7 @@ describe("findNextVisibleIndex", () => {
 				name: "AWS Linux",
 				hasParameters: true,
 				hasPrerequisites: false,
+				agents: [],
 			},
 			selectedModules: [
 				{
@@ -192,6 +236,7 @@ describe("findPrevVisibleIndex", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		});
 		// From module-select (index 2), prev visible should be base-infra (index 0).
@@ -227,6 +272,7 @@ describe("nearestVisible", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		};
 		// Index 1 (base-parameters) is skipped, nearest backward is 0 (base-infra).
@@ -246,6 +292,7 @@ describe("furthestAllowedIndex", () => {
 				name: "Docker",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		});
 		expect(furthestAllowedIndex(withBase)).toBe(WIZARD_STEPS.length - 1);

--- a/site/src/pages/TemplateBuilder/steps.ts
+++ b/site/src/pages/TemplateBuilder/steps.ts
@@ -16,13 +16,20 @@ type WizardStep = {
 };
 
 /**
- * Returns true when at least one selected module exposes variables that
- * need user configuration (non-sensitive).
+ * Returns true when the module-settings step has something to configure:
+ * a selected module with user-facing variables, or a multi-agent base with
+ * at least one module (each module then needs an agent target).
  */
 export const stepModuleSettingsRequired = (
 	state: TemplateBuilderWizardState,
 ): boolean => {
-	return state.selectedModules.some((m) => m.hasConfigurableVars);
+	if (state.selectedModules.some((m) => m.hasConfigurableVars)) {
+		return true;
+	}
+	const base = state.selectedBase;
+	return Boolean(
+		base && base.agents.length > 1 && state.selectedModules.length > 0,
+	);
 };
 
 /**

--- a/site/src/pages/TemplateBuilder/wizardState.test.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.test.ts
@@ -6,6 +6,7 @@ import {
 	initWizardState,
 	moduleHasConfigurableVars,
 	type SelectedBaseMeta,
+	type SelectedModuleMeta,
 	type TemplateBuilderWizardState,
 	toComposeRequest,
 	toCreateTemplateRequest,
@@ -21,6 +22,33 @@ function reduce(
 	return actions.reduce(wizardReducer, state);
 }
 
+const multiAgentBase: SelectedBaseMeta = {
+	id: "gpu-base",
+	name: "GPU Base",
+	hasParameters: false,
+	hasPrerequisites: false,
+	agents: [
+		{ name: "main", displayName: "Main", default: true },
+		{ name: "gpu", displayName: "GPU", default: false },
+	],
+};
+
+const singleAgentBase: SelectedBaseMeta = {
+	id: "docker",
+	name: "Docker",
+	hasParameters: false,
+	hasPrerequisites: false,
+	agents: [{ name: "main", displayName: "Main", default: true }],
+};
+
+function stateWithBase(base: SelectedBaseMeta): TemplateBuilderWizardState {
+	return { ...initialWizardState, baseTemplateId: base.id, selectedBase: base };
+}
+
+function moduleMeta(id: string): SelectedModuleMeta {
+	return { id, name: id, iconUrl: "/icon.svg", hasConfigurableVars: false };
+}
+
 describe("wizardReducer", () => {
 	describe("SET_BASE", () => {
 		it("sets the selected base", () => {
@@ -32,6 +60,7 @@ describe("wizardReducer", () => {
 						name: "Docker",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 			]);
@@ -50,6 +79,7 @@ describe("wizardReducer", () => {
 						iconUrl: "/icon/docker.png",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 			]);
@@ -70,6 +100,7 @@ describe("wizardReducer", () => {
 						iconUrl: "/icon/docker.png",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 				{
@@ -81,6 +112,7 @@ describe("wizardReducer", () => {
 						iconUrl: "/icon/aws.svg",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 			]);
@@ -101,6 +133,7 @@ describe("wizardReducer", () => {
 						iconUrl: "/icon/docker.png",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 				{
@@ -117,6 +150,7 @@ describe("wizardReducer", () => {
 						iconUrl: "/icon/docker.png",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 			]);
@@ -132,6 +166,7 @@ describe("wizardReducer", () => {
 						name: "Docker",
 						hasParameters: true,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 				{
@@ -145,6 +180,7 @@ describe("wizardReducer", () => {
 						name: "AWS Linux",
 						hasParameters: true,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 			]);
@@ -161,6 +197,7 @@ describe("wizardReducer", () => {
 						name: "Docker",
 						hasParameters: true,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 				{
@@ -174,6 +211,7 @@ describe("wizardReducer", () => {
 						name: "Docker",
 						hasParameters: true,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 			]);
@@ -295,6 +333,87 @@ describe("wizardReducer", () => {
 			const codeServer = state.modules.find((m) => m.id === "code-server");
 			expect(codeServer?.variables).toEqual({ port: "8080" });
 		});
+
+		it("seeds the base default agent for modules on a multi-agent base", () => {
+			const state = reduce(
+				[
+					{
+						type: "SET_MODULES",
+						modules: [{ id: "code-server" }],
+						meta: [moduleMeta("code-server")],
+					},
+				],
+				stateWithBase(multiAgentBase),
+			);
+			expect(state.modules[0].agent_name).toBe("main");
+		});
+
+		it("preserves an existing agent choice across re-selection", () => {
+			const state = reduce(
+				[
+					{
+						type: "SET_MODULES",
+						modules: [{ id: "code-server" }],
+						meta: [moduleMeta("code-server")],
+					},
+					{
+						type: "SET_MODULE_AGENT",
+						moduleId: "code-server",
+						agentName: "gpu",
+					},
+					{
+						type: "SET_MODULES",
+						modules: [{ id: "code-server" }, { id: "npm-config" }],
+						meta: [moduleMeta("code-server"), moduleMeta("npm-config")],
+					},
+				],
+				stateWithBase(multiAgentBase),
+			);
+			const codeServer = state.modules.find((m) => m.id === "code-server");
+			const npmConfig = state.modules.find((m) => m.id === "npm-config");
+			expect(codeServer?.agent_name).toBe("gpu");
+			expect(npmConfig?.agent_name).toBe("main");
+		});
+
+		it("leaves agent_name unset on a single-agent base", () => {
+			const state = reduce(
+				[
+					{
+						type: "SET_MODULES",
+						modules: [{ id: "code-server" }],
+						meta: [moduleMeta("code-server")],
+					},
+				],
+				stateWithBase(singleAgentBase),
+			);
+			expect(state.modules[0].agent_name).toBeUndefined();
+		});
+	});
+
+	describe("SET_MODULE_AGENT", () => {
+		it("sets the agent target for the named module only", () => {
+			const state = reduce(
+				[
+					{
+						type: "SET_MODULES",
+						modules: [{ id: "code-server" }, { id: "npm-config" }],
+						meta: [moduleMeta("code-server"), moduleMeta("npm-config")],
+					},
+					{
+						type: "SET_MODULE_AGENT",
+						moduleId: "code-server",
+						agentName: "gpu",
+					},
+				],
+				stateWithBase(multiAgentBase),
+			);
+			expect(
+				state.modules.find((m) => m.id === "code-server")?.agent_name,
+			).toBe("gpu");
+			expect(state.modules.find((m) => m.id === "npm-config")?.agent_name).toBe(
+				"main",
+			);
+		});
 	});
 
 	describe("SET_MODULE_VARIABLES", () => {
@@ -365,6 +484,7 @@ describe("wizardReducer", () => {
 						iconUrl: "/icon/docker.png",
 						hasParameters: false,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 				{ type: "SET_HAS_PROVISIONERS", value: true },
@@ -389,6 +509,7 @@ describe("wizardReducer", () => {
 						name: "Docker",
 						hasParameters: true,
 						hasPrerequisites: false,
+						agents: [],
 					},
 				},
 				{
@@ -575,6 +696,21 @@ describe("toSelectedBaseMeta", () => {
 		expect(meta.name).toBe("Docker Containers");
 		expect(meta.id).toBe("docker");
 	});
+
+	it("maps agents and falls back displayName to name", () => {
+		const meta = toSelectedBaseMeta(
+			makeBase({
+				agents: [
+					{ name: "main", display_name: "Main", default: true },
+					{ name: "gpu", display_name: "", default: false },
+				],
+			}),
+		);
+		expect(meta.agents).toEqual([
+			{ name: "main", displayName: "Main", default: true },
+			{ name: "gpu", displayName: "gpu", default: false },
+		]);
+	});
 });
 
 describe("baseCustomizationDefaults", () => {
@@ -586,6 +722,7 @@ describe("baseCustomizationDefaults", () => {
 			iconUrl: "/icon/aws.svg",
 			hasParameters: false,
 			hasPrerequisites: false,
+			agents: [],
 		};
 		expect(baseCustomizationDefaults(base)).toEqual({
 			name: "aws-linux",
@@ -601,6 +738,7 @@ describe("baseCustomizationDefaults", () => {
 			name: "Scratch",
 			hasParameters: false,
 			hasPrerequisites: false,
+			agents: [],
 		};
 		expect(baseCustomizationDefaults(base)).toEqual({
 			name: "scratch",
@@ -632,6 +770,7 @@ describe("initWizardState", () => {
 				iconUrl: "/icon/docker.png",
 				hasParameters: false,
 				hasPrerequisites: false,
+				agents: [],
 			},
 		});
 		expect(state.baseTemplateId).toBe("docker");

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -11,7 +11,7 @@ import type {
  * UI-only view of a base coder_agent. displayName is guaranteed non-empty:
  * it falls back to name when the API omits display_name.
  */
-export type SelectedBaseAgent = {
+type SelectedBaseAgent = {
 	name: string;
 	displayName: string;
 	default: boolean;

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -1,10 +1,21 @@
 import type {
 	TemplateBuilderBase,
+	TemplateBuilderBaseAgent,
 	TemplateBuilderComposeModule,
 	TemplateBuilderComposeRequest,
 	TemplateBuilderCreateTemplateRequest,
 	TemplateBuilderModule,
 } from "#/api/typesGenerated";
+
+/**
+ * UI-only view of a base coder_agent. displayName is guaranteed non-empty:
+ * it falls back to name when the API omits display_name.
+ */
+export type SelectedBaseAgent = {
+	name: string;
+	displayName: string;
+	default: boolean;
+};
 
 /**
  * UI-only metadata for the selected base template.
@@ -18,6 +29,7 @@ export type SelectedBaseMeta = {
 	os?: string;
 	hasParameters: boolean;
 	hasPrerequisites: boolean;
+	agents: SelectedBaseAgent[];
 };
 
 /**
@@ -26,6 +38,7 @@ export type SelectedBaseMeta = {
 export function toSelectedBaseMeta(
 	base: TemplateBuilderBase,
 ): SelectedBaseMeta {
+	const agents = base.agents.map(toSelectedBaseAgent);
 	return {
 		id: base.id,
 		name: base.name,
@@ -35,7 +48,23 @@ export function toSelectedBaseMeta(
 		hasParameters:
 			base.variables?.length > 0 && base.variables?.some((v) => !v.sensitive),
 		hasPrerequisites: Boolean(base.prerequisites?.length),
+		agents,
 	};
+}
+
+function toSelectedBaseAgent(
+	agent: TemplateBuilderBaseAgent,
+): SelectedBaseAgent {
+	return {
+		name: agent.name,
+		displayName: agent.display_name || agent.name,
+		default: agent.default,
+	};
+}
+
+/** Name of the base agent modules attach to when they do not name one. */
+function defaultBaseAgentName(base: SelectedBaseMeta): string | undefined {
+	return base.agents.find((a) => a.default)?.name;
 }
 
 /**
@@ -142,6 +171,11 @@ export type WizardAction =
 			variables: Record<string, string>;
 	  }
 	| {
+			type: "SET_MODULE_AGENT";
+			moduleId: string;
+			agentName: string;
+	  }
+	| {
 			type: "SET_CUSTOMIZATION";
 			field: "name" | "displayName" | "description" | "icon";
 			value: string;
@@ -178,17 +212,37 @@ export function wizardReducer(
 		case "SET_MODULES": {
 			// Preserve existing variable values for modules that remain selected.
 			const existingById = new Map(state.modules.map((m) => [m.id, m]));
+			const base = state.selectedBase;
+			const defaultAgent = base ? defaultBaseAgentName(base) : undefined;
 			const merged = action.modules.map((incoming) => {
 				const existing = existingById.get(incoming.id);
+				let next = incoming;
 				if (existing?.variables && !incoming.variables) {
-					return { ...incoming, variables: existing.variables };
+					next = { ...next, variables: existing.variables };
 				}
-				return incoming;
+				// Only multi-agent bases carry a per-module agent choice; single-agent
+				// bases leave agent_name unset so the backend uses the sole agent.
+				if (base && base.agents.length > 1) {
+					next = {
+						...next,
+						agent_name:
+							incoming.agent_name ?? existing?.agent_name ?? defaultAgent,
+					};
+				}
+				return next;
 			});
 			return {
 				...state,
 				modules: merged,
 				selectedModules: action.meta,
+			};
+		}
+		case "SET_MODULE_AGENT": {
+			return {
+				...state,
+				modules: state.modules.map((m) =>
+					m.id === action.moduleId ? { ...m, agent_name: action.agentName } : m,
+				),
 			};
 		}
 		case "SET_MODULE_VARIABLES": {

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -184,6 +184,25 @@ export type WizardAction =
 	| { type: "RESET_CUSTOMIZATIONS" }
 	| { type: "RESET" };
 
+/**
+ * Merges an incoming SET_MODULES entry with its previously selected state,
+ * preserving prior variable values and agent choice. agentDefault is set only
+ * for multi-agent bases; when undefined, agent_name is left as-is.
+ */
+function mergeSelectedModule(
+	incoming: TemplateBuilderComposeModule,
+	existing: TemplateBuilderComposeModule | undefined,
+	agentDefault: string | undefined,
+): TemplateBuilderComposeModule {
+	return {
+		...incoming,
+		variables: incoming.variables ?? existing?.variables,
+		...(agentDefault !== undefined && {
+			agent_name: incoming.agent_name ?? existing?.agent_name ?? agentDefault,
+		}),
+	};
+}
+
 export function wizardReducer(
 	state: TemplateBuilderWizardState,
 	action: WizardAction,
@@ -210,30 +229,22 @@ export function wizardReducer(
 				baseVariableValues: action.values,
 			};
 		case "SET_MODULES": {
-			// Preserve existing variable values for modules that remain selected.
 			const existingById = new Map(state.modules.map((m) => [m.id, m]));
 			const base = state.selectedBase;
-			const defaultAgent = base ? defaultBaseAgentName(base) : undefined;
-			const merged = action.modules.map((incoming) => {
-				const existing = existingById.get(incoming.id);
-				let next = incoming;
-				if (existing?.variables && !incoming.variables) {
-					next = { ...next, variables: existing.variables };
-				}
-				// Only multi-agent bases carry a per-module agent choice; single-agent
-				// bases leave agent_name unset so the backend uses the sole agent.
-				if (base && base.agents.length > 1) {
-					next = {
-						...next,
-						agent_name:
-							incoming.agent_name ?? existing?.agent_name ?? defaultAgent,
-					};
-				}
-				return next;
-			});
+			// Only multi-agent bases carry a per-module agent choice; agentDefault
+			// stays undefined otherwise so agent_name is left unset and the backend
+			// uses the sole agent.
+			const agentDefault =
+				base && base.agents.length > 1 ? defaultBaseAgentName(base) : undefined;
 			return {
 				...state,
-				modules: merged,
+				modules: action.modules.map((incoming) =>
+					mergeSelectedModule(
+						incoming,
+						existingById.get(incoming.id),
+						agentDefault,
+					),
+				),
 				selectedModules: action.meta,
 			};
 		}


### PR DESCRIPTION
Part of DEVEX-556. Stacked on #28905 (Task B). Frontend state and step-flow plumbing only, no visible selector UI yet (that lands in the Task D follow-up).

## Changes

- `SelectedBaseMeta` now carries the base's `agents` (`displayName` falls back to `name` when the API omits `display_name`).
- New `SET_MODULE_AGENT` reducer action sets a module's agent target.
- `SET_MODULES` seeds the base default agent for newly selected modules on multi-agent bases and preserves existing choices; single-agent bases leave `agent_name` unset so the backend uses the sole agent.
- `stepModuleSettingsRequired` now also requires the module-settings step when a multi-agent base has at least one selected module.

`hasMultipleAgents` is computed inline (`agents.length > 1`) rather than stored, to avoid a second source of truth.

## Tests

Unit tests for agent mapping/fallback, default seeding, choice preservation across re-selection, single-agent no-op, `SET_MODULE_AGENT`, and the multi-agent module-settings step gating. `lint:types` and `biome check` clean.

---
🤖 Generated with Coder Agents.