### PR TITLE
docs: document template builder API request and response fields

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -28068,30 +28068,38 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "agents": {
+                    "description": "Agents are the coder_agents the base declares for modules to target.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderBaseAgent"
                     }
                 },
                 "description": {
+                    "description": "Description summarizes the infrastructure the base provisions.",
                     "type": "string"
                 },
                 "icon": {
+                    "description": "Icon is a URL or built-in icon path.",
                     "type": "string"
                 },
                 "id": {
+                    "description": "ID uniquely identifies the base in compose requests.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Name is the human-facing base template name.",
                     "type": "string"
                 },
                 "os": {
+                    "description": "OS is the operating system the base provisions.",
                     "type": "string"
                 },
                 "prerequisites": {
+                    "description": "Prerequisites describes setup required before using the base, if any.",
                     "type": "string"
                 },
                 "variables": {
+                    "description": "Variables are the base template's configurable inputs.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderModuleVariable"
@@ -28107,9 +28115,11 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "display_name": {
+                    "description": "DisplayName is the human-facing agent name; may be empty.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Name is the coder_agent resource name modules target.",
                     "type": "string"
                 }
             }
@@ -28118,6 +28128,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "bases": {
+                    "description": "Bases are the available base templates.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderBase"
@@ -28133,9 +28144,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
+                    "description": "ID selects a catalog module to compose.",
                     "type": "string"
                 },
                 "variables": {
+                    "description": "Variables sets the module's input variables by name.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -28147,15 +28160,18 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "base_template_id": {
+                    "description": "BaseTemplateID selects the base template to compose onto.",
                     "type": "string"
                 },
                 "base_variable_values": {
+                    "description": "BaseVariableValues sets the base's input variables by name.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "modules": {
+                    "description": "Modules are the modules to compose onto the base.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderComposeModule"
@@ -28182,37 +28198,46 @@ const docTemplate = `{
             ],
             "properties": {
                 "base_template_id": {
+                    "description": "BaseTemplateID selects the base template to compose onto.",
                     "type": "string"
                 },
                 "base_variable_values": {
+                    "description": "BaseVariableValues sets the base's input variables by name.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "description": {
+                    "description": "Description is shown on the template page.",
                     "type": "string"
                 },
                 "display_name": {
+                    "description": "DisplayName is the human-facing template name.",
                     "type": "string"
                 },
                 "icon": {
+                    "description": "Icon is a URL or built-in icon path.",
                     "type": "string"
                 },
                 "modules": {
+                    "description": "Modules are the modules to compose onto the base.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderComposeModule"
                     }
                 },
                 "name": {
+                    "description": "Name is the template's unique slug.",
                     "type": "string"
                 },
                 "organization_id": {
+                    "description": "OrganizationID owns the created template.",
                     "type": "string",
                     "format": "uuid"
                 },
                 "provisioner_tags": {
+                    "description": "ProvisionerTags route the import job to matching provisioners.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -28224,7 +28249,12 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "template": {
-                    "$ref": "#/definitions/codersdk.Template"
+                    "description": "Template is the newly created template.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.Template"
+                        }
+                    ]
                 }
             }
         },
@@ -28232,39 +28262,48 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "category": {
+                    "description": "Category groups related modules in the builder.",
                     "type": "string"
                 },
                 "compatible_os": {
+                    "description": "CompatibleOS lists the base operating systems the module supports.",
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
                 "conflicts_with": {
+                    "description": "ConflictsWith lists module IDs that cannot be selected alongside this one.",
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
                 "description": {
+                    "description": "Description summarizes what the module does.",
                     "type": "string"
                 },
                 "display_name": {
+                    "description": "DisplayName is the human-facing module name.",
                     "type": "string"
                 },
                 "icon": {
+                    "description": "Icon is a URL or built-in icon path.",
                     "type": "string"
                 },
                 "id": {
+                    "description": "ID uniquely identifies the module in the catalog and compose requests.",
                     "type": "string"
                 },
                 "variables": {
+                    "description": "Variables are the module's configurable inputs.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderModuleVariable"
                     }
                 },
                 "version": {
+                    "description": "Version is the pinned module version from the catalog manifest.",
                     "type": "string"
                 }
             }
@@ -28273,25 +28312,35 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "default": {
+                    "description": "Default is applied when no value is supplied; omitted when there is none.",
                     "type": "array",
                     "items": {
                         "type": "integer"
                     }
                 },
                 "description": {
+                    "description": "Description is human-facing help text shown in the builder.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Name is the Terraform variable name values are keyed by.",
                     "type": "string"
                 },
                 "required": {
+                    "description": "Required reports whether a value must be supplied to compose.",
                     "type": "boolean"
                 },
                 "sensitive": {
+                    "description": "Sensitive hides the value in the UI and excludes it from logs.",
                     "type": "boolean"
                 },
                 "type": {
-                    "$ref": "#/definitions/codersdk.TemplateBuilderVariableType"
+                    "description": "Type constrains the accepted value (string, number, or bool).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.TemplateBuilderVariableType"
+                        }
+                    ]
                 }
             }
         },
@@ -28299,6 +28348,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "modules": {
+                    "description": "Modules are the modules available for the requested base.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TemplateBuilderModule"
@@ -28325,12 +28375,15 @@ const docTemplate = `{
             ],
             "properties": {
                 "base_template_id": {
+                    "description": "BaseTemplateID is the selected base, when known.",
                     "type": "string"
                 },
                 "duration_seconds": {
+                    "description": "DurationSeconds is the elapsed wizard time for the event.",
                     "type": "number"
                 },
                 "event_type": {
+                    "description": "EventType is the telemetry event being reported.",
                     "enum": [
                         "wizard_entry",
                         "compose_completion"
@@ -28342,16 +28395,19 @@ const docTemplate = `{
                     ]
                 },
                 "module_ids": {
+                    "description": "ModuleIDs are the selected modules, when known.",
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
                 "session_id": {
+                    "description": "SessionID correlates events within one builder session.",
                     "type": "string",
                     "format": "uuid"
                 },
                 "success": {
+                    "description": "Success reports whether the composition succeeded.",
                     "type": "boolean"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -25794,30 +25794,38 @@
 			"type": "object",
 			"properties": {
 				"agents": {
+					"description": "Agents are the coder_agents the base declares for modules to target.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderBaseAgent"
 					}
 				},
 				"description": {
+					"description": "Description summarizes the infrastructure the base provisions.",
 					"type": "string"
 				},
 				"icon": {
+					"description": "Icon is a URL or built-in icon path.",
 					"type": "string"
 				},
 				"id": {
+					"description": "ID uniquely identifies the base in compose requests.",
 					"type": "string"
 				},
 				"name": {
+					"description": "Name is the human-facing base template name.",
 					"type": "string"
 				},
 				"os": {
+					"description": "OS is the operating system the base provisions.",
 					"type": "string"
 				},
 				"prerequisites": {
+					"description": "Prerequisites describes setup required before using the base, if any.",
 					"type": "string"
 				},
 				"variables": {
+					"description": "Variables are the base template's configurable inputs.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderModuleVariable"
@@ -25833,9 +25841,11 @@
 					"type": "boolean"
 				},
 				"display_name": {
+					"description": "DisplayName is the human-facing agent name; may be empty.",
 					"type": "string"
 				},
 				"name": {
+					"description": "Name is the coder_agent resource name modules target.",
 					"type": "string"
 				}
 			}
@@ -25844,6 +25854,7 @@
 			"type": "object",
 			"properties": {
 				"bases": {
+					"description": "Bases are the available base templates.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderBase"
@@ -25859,9 +25870,11 @@
 					"type": "string"
 				},
 				"id": {
+					"description": "ID selects a catalog module to compose.",
 					"type": "string"
 				},
 				"variables": {
+					"description": "Variables sets the module's input variables by name.",
 					"type": "object",
 					"additionalProperties": {
 						"type": "string"
@@ -25873,15 +25886,18 @@
 			"type": "object",
 			"properties": {
 				"base_template_id": {
+					"description": "BaseTemplateID selects the base template to compose onto.",
 					"type": "string"
 				},
 				"base_variable_values": {
+					"description": "BaseVariableValues sets the base's input variables by name.",
 					"type": "object",
 					"additionalProperties": {
 						"type": "string"
 					}
 				},
 				"modules": {
+					"description": "Modules are the modules to compose onto the base.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderComposeModule"
@@ -25905,37 +25921,46 @@
 			"required": ["name", "organization_id"],
 			"properties": {
 				"base_template_id": {
+					"description": "BaseTemplateID selects the base template to compose onto.",
 					"type": "string"
 				},
 				"base_variable_values": {
+					"description": "BaseVariableValues sets the base's input variables by name.",
 					"type": "object",
 					"additionalProperties": {
 						"type": "string"
 					}
 				},
 				"description": {
+					"description": "Description is shown on the template page.",
 					"type": "string"
 				},
 				"display_name": {
+					"description": "DisplayName is the human-facing template name.",
 					"type": "string"
 				},
 				"icon": {
+					"description": "Icon is a URL or built-in icon path.",
 					"type": "string"
 				},
 				"modules": {
+					"description": "Modules are the modules to compose onto the base.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderComposeModule"
 					}
 				},
 				"name": {
+					"description": "Name is the template's unique slug.",
 					"type": "string"
 				},
 				"organization_id": {
+					"description": "OrganizationID owns the created template.",
 					"type": "string",
 					"format": "uuid"
 				},
 				"provisioner_tags": {
+					"description": "ProvisionerTags route the import job to matching provisioners.",
 					"type": "object",
 					"additionalProperties": {
 						"type": "string"
@@ -25947,7 +25972,12 @@
 			"type": "object",
 			"properties": {
 				"template": {
-					"$ref": "#/definitions/codersdk.Template"
+					"description": "Template is the newly created template.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.Template"
+						}
+					]
 				}
 			}
 		},
@@ -25955,39 +25985,48 @@
 			"type": "object",
 			"properties": {
 				"category": {
+					"description": "Category groups related modules in the builder.",
 					"type": "string"
 				},
 				"compatible_os": {
+					"description": "CompatibleOS lists the base operating systems the module supports.",
 					"type": "array",
 					"items": {
 						"type": "string"
 					}
 				},
 				"conflicts_with": {
+					"description": "ConflictsWith lists module IDs that cannot be selected alongside this one.",
 					"type": "array",
 					"items": {
 						"type": "string"
 					}
 				},
 				"description": {
+					"description": "Description summarizes what the module does.",
 					"type": "string"
 				},
 				"display_name": {
+					"description": "DisplayName is the human-facing module name.",
 					"type": "string"
 				},
 				"icon": {
+					"description": "Icon is a URL or built-in icon path.",
 					"type": "string"
 				},
 				"id": {
+					"description": "ID uniquely identifies the module in the catalog and compose requests.",
 					"type": "string"
 				},
 				"variables": {
+					"description": "Variables are the module's configurable inputs.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderModuleVariable"
 					}
 				},
 				"version": {
+					"description": "Version is the pinned module version from the catalog manifest.",
 					"type": "string"
 				}
 			}
@@ -25996,25 +26035,35 @@
 			"type": "object",
 			"properties": {
 				"default": {
+					"description": "Default is applied when no value is supplied; omitted when there is none.",
 					"type": "array",
 					"items": {
 						"type": "integer"
 					}
 				},
 				"description": {
+					"description": "Description is human-facing help text shown in the builder.",
 					"type": "string"
 				},
 				"name": {
+					"description": "Name is the Terraform variable name values are keyed by.",
 					"type": "string"
 				},
 				"required": {
+					"description": "Required reports whether a value must be supplied to compose.",
 					"type": "boolean"
 				},
 				"sensitive": {
+					"description": "Sensitive hides the value in the UI and excludes it from logs.",
 					"type": "boolean"
 				},
 				"type": {
-					"$ref": "#/definitions/codersdk.TemplateBuilderVariableType"
+					"description": "Type constrains the accepted value (string, number, or bool).",
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.TemplateBuilderVariableType"
+						}
+					]
 				}
 			}
 		},
@@ -26022,6 +26071,7 @@
 			"type": "object",
 			"properties": {
 				"modules": {
+					"description": "Modules are the modules available for the requested base.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TemplateBuilderModule"
@@ -26042,12 +26092,15 @@
 			"required": ["event_type", "session_id"],
 			"properties": {
 				"base_template_id": {
+					"description": "BaseTemplateID is the selected base, when known.",
 					"type": "string"
 				},
 				"duration_seconds": {
+					"description": "DurationSeconds is the elapsed wizard time for the event.",
 					"type": "number"
 				},
 				"event_type": {
+					"description": "EventType is the telemetry event being reported.",
 					"enum": ["wizard_entry", "compose_completion"],
 					"allOf": [
 						{
@@ -26056,16 +26109,19 @@
 					]
 				},
 				"module_ids": {
+					"description": "ModuleIDs are the selected modules, when known.",
 					"type": "array",
 					"items": {
 						"type": "string"
 					}
 				},
 				"session_id": {
+					"description": "SessionID correlates events within one builder session.",
 					"type": "string",
 					"format": "uuid"
 				},
 				"success": {
+					"description": "Success reports whether the composition succeeded.",
 					"type": "boolean"
 				}
 			}

--- a/codersdk/templatebuilder.go
+++ b/codersdk/templatebuilder.go
@@ -20,52 +20,80 @@ const (
 	TemplateBuilderVariableTypeBool   TemplateBuilderVariableType = "bool"
 )
 
+// TemplateBuilderModuleVariable describes a single input variable declared by a
+// base template or module manifest.
 type TemplateBuilderModuleVariable struct {
-	Name        string                      `json:"name"`
-	Type        TemplateBuilderVariableType `json:"type"`
-	Description string                      `json:"description"`
-	Default     json.RawMessage             `json:"default,omitempty"`
-	Required    bool                        `json:"required"`
-	Sensitive   bool                        `json:"sensitive"`
+	// Name is the Terraform variable name values are keyed by.
+	Name string `json:"name"`
+	// Type constrains the accepted value (string, number, or bool).
+	Type TemplateBuilderVariableType `json:"type"`
+	// Description is human-facing help text shown in the builder.
+	Description string `json:"description"`
+	// Default is applied when no value is supplied; omitted when there is none.
+	Default json.RawMessage `json:"default,omitempty"`
+	// Required reports whether a value must be supplied to compose.
+	Required bool `json:"required"`
+	// Sensitive hides the value in the UI and excludes it from logs.
+	Sensitive bool `json:"sensitive"`
 }
 
 // TemplateBuilderModule is the API response type returned by
 // GET /api/v2/templatebuilder/modules. The Version field is
 // populated from the catalog manifest's PinnedVersion at serving time.
 type TemplateBuilderModule struct {
-	ID            string                          `json:"id"`
-	DisplayName   string                          `json:"display_name"`
-	Description   string                          `json:"description"`
-	Icon          string                          `json:"icon"`
-	Category      string                          `json:"category"`
-	Version       string                          `json:"version"`
-	CompatibleOS  []string                        `json:"compatible_os"`
-	ConflictsWith []string                        `json:"conflicts_with"`
-	Variables     []TemplateBuilderModuleVariable `json:"variables"`
+	// ID uniquely identifies the module in the catalog and compose requests.
+	ID string `json:"id"`
+	// DisplayName is the human-facing module name.
+	DisplayName string `json:"display_name"`
+	// Description summarizes what the module does.
+	Description string `json:"description"`
+	// Icon is a URL or built-in icon path.
+	Icon string `json:"icon"`
+	// Category groups related modules in the builder.
+	Category string `json:"category"`
+	// Version is the pinned module version from the catalog manifest.
+	Version string `json:"version"`
+	// CompatibleOS lists the base operating systems the module supports.
+	CompatibleOS []string `json:"compatible_os"`
+	// ConflictsWith lists module IDs that cannot be selected alongside this one.
+	ConflictsWith []string `json:"conflicts_with"`
+	// Variables are the module's configurable inputs.
+	Variables []TemplateBuilderModuleVariable `json:"variables"`
 }
 
 // TemplateBuilderModulesResponse is the response body for listing template builder modules.
 type TemplateBuilderModulesResponse struct {
+	// Modules are the modules available for the requested base.
 	Modules []TemplateBuilderModule `json:"modules"`
 }
 
 // TemplateBuilderBase is the API response type for a base template
 // returned by GET /api/v2/templatebuilder/bases.
 type TemplateBuilderBase struct {
-	ID            string                          `json:"id"`
-	Name          string                          `json:"name"`
-	Description   string                          `json:"description"`
-	Icon          string                          `json:"icon"`
-	OS            string                          `json:"os"`
-	Variables     []TemplateBuilderModuleVariable `json:"variables"`
-	Prerequisites string                          `json:"prerequisites"`
-	Agents        []TemplateBuilderBaseAgent      `json:"agents"`
+	// ID uniquely identifies the base in compose requests.
+	ID string `json:"id"`
+	// Name is the human-facing base template name.
+	Name string `json:"name"`
+	// Description summarizes the infrastructure the base provisions.
+	Description string `json:"description"`
+	// Icon is a URL or built-in icon path.
+	Icon string `json:"icon"`
+	// OS is the operating system the base provisions.
+	OS string `json:"os"`
+	// Variables are the base template's configurable inputs.
+	Variables []TemplateBuilderModuleVariable `json:"variables"`
+	// Prerequisites describes setup required before using the base, if any.
+	Prerequisites string `json:"prerequisites"`
+	// Agents are the coder_agents the base declares for modules to target.
+	Agents []TemplateBuilderBaseAgent `json:"agents"`
 }
 
 // TemplateBuilderBaseAgent is a coder_agent a base template declares. Modules
 // composed onto the base target one of these by Name.
 type TemplateBuilderBaseAgent struct {
-	Name        string `json:"name"`
+	// Name is the coder_agent resource name modules target.
+	Name string `json:"name"`
+	// DisplayName is the human-facing agent name; may be empty.
 	DisplayName string `json:"display_name"`
 	// Default reports whether modules attach to this agent when they do not
 	// name one.
@@ -74,6 +102,7 @@ type TemplateBuilderBaseAgent struct {
 
 // TemplateBuilderBasesResponse is the response body for listing template builder bases.
 type TemplateBuilderBasesResponse struct {
+	// Bases are the available base templates.
 	Bases []TemplateBuilderBase `json:"bases"`
 }
 
@@ -115,17 +144,22 @@ func (c *Client) TemplateBuilderModules(ctx context.Context, base string) (Templ
 // TemplateBuilderComposeRequest is the request body for
 // POST /api/v2/templatebuilder/compose.
 type TemplateBuilderComposeRequest struct {
-	BaseTemplateID     string                         `json:"base_template_id"`
-	BaseVariableValues map[string]string              `json:"base_variable_values,omitempty"`
-	Modules            []TemplateBuilderComposeModule `json:"modules"`
+	// BaseTemplateID selects the base template to compose onto.
+	BaseTemplateID string `json:"base_template_id"`
+	// BaseVariableValues sets the base's input variables by name.
+	BaseVariableValues map[string]string `json:"base_variable_values,omitempty"`
+	// Modules are the modules to compose onto the base.
+	Modules []TemplateBuilderComposeModule `json:"modules"`
 }
 
 // TemplateBuilderComposeModule identifies a module and its variable
 // values for the compose request.
 type TemplateBuilderComposeModule struct {
+	// ID selects a catalog module to compose.
 	ID string `json:"id"`
 	// AgentName targets a base coder_agent by name. Empty uses the base default.
-	AgentName string            `json:"agent_name,omitempty"`
+	AgentName string `json:"agent_name,omitempty"`
+	// Variables sets the module's input variables by name.
 	Variables map[string]string `json:"variables,omitempty"`
 }
 
@@ -146,20 +180,30 @@ func (c *Client) TemplateBuilderCompose(ctx context.Context, req TemplateBuilder
 // TemplateBuilderCreateTemplateRequest is the request body for
 // POST /api/v2/templatebuilder/compose/template.
 type TemplateBuilderCreateTemplateRequest struct {
-	BaseTemplateID     string                         `json:"base_template_id"`
-	BaseVariableValues map[string]string              `json:"base_variable_values,omitempty"`
-	Modules            []TemplateBuilderComposeModule `json:"modules"`
-	OrganizationID     uuid.UUID                      `json:"organization_id" format:"uuid" validate:"required"`
-	Name               string                         `json:"name" validate:"required,template_name"`
-	DisplayName        string                         `json:"display_name,omitempty" validate:"template_display_name"`
-	Description        string                         `json:"description,omitempty" validate:"lt=128"`
-	Icon               string                         `json:"icon,omitempty"`
-	ProvisionerTags    map[string]string              `json:"provisioner_tags,omitempty"`
+	// BaseTemplateID selects the base template to compose onto.
+	BaseTemplateID string `json:"base_template_id"`
+	// BaseVariableValues sets the base's input variables by name.
+	BaseVariableValues map[string]string `json:"base_variable_values,omitempty"`
+	// Modules are the modules to compose onto the base.
+	Modules []TemplateBuilderComposeModule `json:"modules"`
+	// OrganizationID owns the created template.
+	OrganizationID uuid.UUID `json:"organization_id" format:"uuid" validate:"required"`
+	// Name is the template's unique slug.
+	Name string `json:"name" validate:"required,template_name"`
+	// DisplayName is the human-facing template name.
+	DisplayName string `json:"display_name,omitempty" validate:"template_display_name"`
+	// Description is shown on the template page.
+	Description string `json:"description,omitempty" validate:"lt=128"`
+	// Icon is a URL or built-in icon path.
+	Icon string `json:"icon,omitempty"`
+	// ProvisionerTags route the import job to matching provisioners.
+	ProvisionerTags map[string]string `json:"provisioner_tags,omitempty"`
 }
 
 // TemplateBuilderCreateTemplateResponse is the response body for
 // POST /api/v2/templatebuilder/compose/template.
 type TemplateBuilderCreateTemplateResponse struct {
+	// Template is the newly created template.
 	Template Template `json:"template"`
 }
 
@@ -175,12 +219,18 @@ const (
 // TemplateBuilderSessionRequest is the request body for
 // POST /api/v2/templatebuilder/sessions.
 type TemplateBuilderSessionRequest struct {
-	SessionID       uuid.UUID                       `json:"session_id" format:"uuid" validate:"required"`
-	EventType       TemplateBuilderSessionEventType `json:"event_type" validate:"required,oneof=wizard_entry compose_completion"`
-	BaseTemplateID  string                          `json:"base_template_id,omitempty"`
-	ModuleIDs       []string                        `json:"module_ids,omitempty"`
-	DurationSeconds float64                         `json:"duration_seconds,omitempty"`
-	Success         bool                            `json:"success,omitempty"`
+	// SessionID correlates events within one builder session.
+	SessionID uuid.UUID `json:"session_id" format:"uuid" validate:"required"`
+	// EventType is the telemetry event being reported.
+	EventType TemplateBuilderSessionEventType `json:"event_type" validate:"required,oneof=wizard_entry compose_completion"`
+	// BaseTemplateID is the selected base, when known.
+	BaseTemplateID string `json:"base_template_id,omitempty"`
+	// ModuleIDs are the selected modules, when known.
+	ModuleIDs []string `json:"module_ids,omitempty"`
+	// DurationSeconds is the elapsed wizard time for the event.
+	DurationSeconds float64 `json:"duration_seconds,omitempty"`
+	// Success reports whether the composition succeeded.
+	Success bool `json:"success,omitempty"`
 }
 
 // TemplateBuilderSession reports a template builder session event for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -14027,16 +14027,16 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name            | Type                                                                                      | Required | Restrictions | Description |
-|-----------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `agents`        | array of [codersdk.TemplateBuilderBaseAgent](#codersdktemplatebuilderbaseagent)           | false    |              |             |
-| `description`   | string                                                                                    | false    |              |             |
-| `icon`          | string                                                                                    | false    |              |             |
-| `id`            | string                                                                                    | false    |              |             |
-| `name`          | string                                                                                    | false    |              |             |
-| `os`            | string                                                                                    | false    |              |             |
-| `prerequisites` | string                                                                                    | false    |              |             |
-| `variables`     | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              |             |
+| Name            | Type                                                                                      | Required | Restrictions | Description                                                           |
+|-----------------|-------------------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------------|
+| `agents`        | array of [codersdk.TemplateBuilderBaseAgent](#codersdktemplatebuilderbaseagent)           | false    |              | Agents are the coder_agents the base declares for modules to target.  |
+| `description`   | string                                                                                    | false    |              | Description summarizes the infrastructure the base provisions.        |
+| `icon`          | string                                                                                    | false    |              | Icon is a URL or built-in icon path.                                  |
+| `id`            | string                                                                                    | false    |              | ID uniquely identifies the base in compose requests.                  |
+| `name`          | string                                                                                    | false    |              | Name is the human-facing base template name.                          |
+| `os`            | string                                                                                    | false    |              | Os is the operating system the base provisions.                       |
+| `prerequisites` | string                                                                                    | false    |              | Prerequisites describes setup required before using the base, if any. |
+| `variables`     | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              | Variables are the base template's configurable inputs.                |
 
 ## codersdk.TemplateBuilderBaseAgent
 
@@ -14053,8 +14053,8 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Name           | Type    | Required | Restrictions | Description                                                                     |
 |----------------|---------|----------|--------------|---------------------------------------------------------------------------------|
 | `default`      | boolean | false    |              | Default reports whether modules attach to this agent when they do not name one. |
-| `display_name` | string  | false    |              |                                                                                 |
-| `name`         | string  | false    |              |                                                                                 |
+| `display_name` | string  | false    |              | Display name is the human-facing agent name; may be empty.                      |
+| `name`         | string  | false    |              | Name is the coder_agent resource name modules target.                           |
 
 ## codersdk.TemplateBuilderBasesResponse
 
@@ -14094,9 +14094,9 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name    | Type                                                                  | Required | Restrictions | Description |
-|---------|-----------------------------------------------------------------------|----------|--------------|-------------|
-| `bases` | array of [codersdk.TemplateBuilderBase](#codersdktemplatebuilderbase) | false    |              |             |
+| Name    | Type                                                                  | Required | Restrictions | Description                             |
+|---------|-----------------------------------------------------------------------|----------|--------------|-----------------------------------------|
+| `bases` | array of [codersdk.TemplateBuilderBase](#codersdktemplatebuilderbase) | false    |              | Bases are the available base templates. |
 
 ## codersdk.TemplateBuilderComposeModule
 
@@ -14116,8 +14116,8 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Name               | Type   | Required | Restrictions | Description                                                                 |
 |--------------------|--------|----------|--------------|-----------------------------------------------------------------------------|
 | `agent_name`       | string | false    |              | Agent name targets a base coder_agent by name. Empty uses the base default. |
-| `id`               | string | false    |              |                                                                             |
-| `variables`        | object | false    |              |                                                                             |
+| `id`               | string | false    |              | ID selects a catalog module to compose.                                     |
+| `variables`        | object | false    |              | Variables sets the module's input variables by name.                        |
 | » `[any property]` | string | false    |              |                                                                             |
 
 ## codersdk.TemplateBuilderComposeRequest
@@ -14144,12 +14144,12 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name                   | Type                                                                                    | Required | Restrictions | Description |
-|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `base_template_id`     | string                                                                                  | false    |              |             |
-| `base_variable_values` | object                                                                                  | false    |              |             |
-| » `[any property]`     | string                                                                                  | false    |              |             |
-| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
+| Name                   | Type                                                                                    | Required | Restrictions | Description                                                   |
+|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------|
+| `base_template_id`     | string                                                                                  | false    |              | Base template ID selects the base template to compose onto.   |
+| `base_variable_values` | object                                                                                  | false    |              | Base variable values sets the base's input variables by name. |
+| » `[any property]`     | string                                                                                  | false    |              |                                                               |
+| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              | Modules are the modules to compose onto the base.             |
 
 ## codersdk.TemplateBuilderConfig
 
@@ -14200,19 +14200,19 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name                   | Type                                                                                    | Required | Restrictions | Description |
-|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `base_template_id`     | string                                                                                  | false    |              |             |
-| `base_variable_values` | object                                                                                  | false    |              |             |
-| » `[any property]`     | string                                                                                  | false    |              |             |
-| `description`          | string                                                                                  | false    |              |             |
-| `display_name`         | string                                                                                  | false    |              |             |
-| `icon`                 | string                                                                                  | false    |              |             |
-| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              |             |
-| `name`                 | string                                                                                  | true     |              |             |
-| `organization_id`      | string                                                                                  | true     |              |             |
-| `provisioner_tags`     | object                                                                                  | false    |              |             |
-| » `[any property]`     | string                                                                                  | false    |              |             |
+| Name                   | Type                                                                                    | Required | Restrictions | Description                                                     |
+|------------------------|-----------------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------|
+| `base_template_id`     | string                                                                                  | false    |              | Base template ID selects the base template to compose onto.     |
+| `base_variable_values` | object                                                                                  | false    |              | Base variable values sets the base's input variables by name.   |
+| » `[any property]`     | string                                                                                  | false    |              |                                                                 |
+| `description`          | string                                                                                  | false    |              | Description is shown on the template page.                      |
+| `display_name`         | string                                                                                  | false    |              | Display name is the human-facing template name.                 |
+| `icon`                 | string                                                                                  | false    |              | Icon is a URL or built-in icon path.                            |
+| `modules`              | array of [codersdk.TemplateBuilderComposeModule](#codersdktemplatebuildercomposemodule) | false    |              | Modules are the modules to compose onto the base.               |
+| `name`                 | string                                                                                  | true     |              | Name is the template's unique slug.                             |
+| `organization_id`      | string                                                                                  | true     |              | Organization ID owns the created template.                      |
+| `provisioner_tags`     | object                                                                                  | false    |              | Provisioner tags route the import job to matching provisioners. |
+| » `[any property]`     | string                                                                                  | false    |              |                                                                 |
 
 ## codersdk.TemplateBuilderCreateTemplateResponse
 
@@ -14281,9 +14281,9 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name       | Type                                   | Required | Restrictions | Description |
-|------------|----------------------------------------|----------|--------------|-------------|
-| `template` | [codersdk.Template](#codersdktemplate) | false    |              |             |
+| Name       | Type                                   | Required | Restrictions | Description                             |
+|------------|----------------------------------------|----------|--------------|-----------------------------------------|
+| `template` | [codersdk.Template](#codersdktemplate) | false    |              | Template is the newly created template. |
 
 ## codersdk.TemplateBuilderModule
 
@@ -14318,17 +14318,17 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name             | Type                                                                                      | Required | Restrictions | Description |
-|------------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `category`       | string                                                                                    | false    |              |             |
-| `compatible_os`  | array of string                                                                           | false    |              |             |
-| `conflicts_with` | array of string                                                                           | false    |              |             |
-| `description`    | string                                                                                    | false    |              |             |
-| `display_name`   | string                                                                                    | false    |              |             |
-| `icon`           | string                                                                                    | false    |              |             |
-| `id`             | string                                                                                    | false    |              |             |
-| `variables`      | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              |             |
-| `version`        | string                                                                                    | false    |              |             |
+| Name             | Type                                                                                      | Required | Restrictions | Description                                                                 |
+|------------------|-------------------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------------------|
+| `category`       | string                                                                                    | false    |              | Category groups related modules in the builder.                             |
+| `compatible_os`  | array of string                                                                           | false    |              | Compatible os lists the base operating systems the module supports.         |
+| `conflicts_with` | array of string                                                                           | false    |              | Conflicts with lists module IDs that cannot be selected alongside this one. |
+| `description`    | string                                                                                    | false    |              | Description summarizes what the module does.                                |
+| `display_name`   | string                                                                                    | false    |              | Display name is the human-facing module name.                               |
+| `icon`           | string                                                                                    | false    |              | Icon is a URL or built-in icon path.                                        |
+| `id`             | string                                                                                    | false    |              | ID uniquely identifies the module in the catalog and compose requests.      |
+| `variables`      | array of [codersdk.TemplateBuilderModuleVariable](#codersdktemplatebuildermodulevariable) | false    |              | Variables are the module's configurable inputs.                             |
+| `version`        | string                                                                                    | false    |              | Version is the pinned module version from the catalog manifest.             |
 
 ## codersdk.TemplateBuilderModuleVariable
 
@@ -14347,14 +14347,14 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name          | Type                                                                         | Required | Restrictions | Description |
-|---------------|------------------------------------------------------------------------------|----------|--------------|-------------|
-| `default`     | array of integer                                                             | false    |              |             |
-| `description` | string                                                                       | false    |              |             |
-| `name`        | string                                                                       | false    |              |             |
-| `required`    | boolean                                                                      | false    |              |             |
-| `sensitive`   | boolean                                                                      | false    |              |             |
-| `type`        | [codersdk.TemplateBuilderVariableType](#codersdktemplatebuildervariabletype) | false    |              |             |
+| Name          | Type                                                                         | Required | Restrictions | Description                                                               |
+|---------------|------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------|
+| `default`     | array of integer                                                             | false    |              | Default is applied when no value is supplied; omitted when there is none. |
+| `description` | string                                                                       | false    |              | Description is human-facing help text shown in the builder.               |
+| `name`        | string                                                                       | false    |              | Name is the Terraform variable name values are keyed by.                  |
+| `required`    | boolean                                                                      | false    |              | Required reports whether a value must be supplied to compose.             |
+| `sensitive`   | boolean                                                                      | false    |              | Sensitive hides the value in the UI and excludes it from logs.            |
+| `type`        | [codersdk.TemplateBuilderVariableType](#codersdktemplatebuildervariabletype) | false    |              | Type constrains the accepted value (string, number, or bool).             |
 
 ## codersdk.TemplateBuilderModulesResponse
 
@@ -14393,9 +14393,9 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name      | Type                                                                      | Required | Restrictions | Description |
-|-----------|---------------------------------------------------------------------------|----------|--------------|-------------|
-| `modules` | array of [codersdk.TemplateBuilderModule](#codersdktemplatebuildermodule) | false    |              |             |
+| Name      | Type                                                                      | Required | Restrictions | Description                                               |
+|-----------|---------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------|
+| `modules` | array of [codersdk.TemplateBuilderModule](#codersdktemplatebuildermodule) | false    |              | Modules are the modules available for the requested base. |
 
 ## codersdk.TemplateBuilderSessionEventType
 
@@ -14428,14 +14428,14 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 ### Properties
 
-| Name               | Type                                                                                 | Required | Restrictions | Description |
-|--------------------|--------------------------------------------------------------------------------------|----------|--------------|-------------|
-| `base_template_id` | string                                                                               | false    |              |             |
-| `duration_seconds` | number                                                                               | false    |              |             |
-| `event_type`       | [codersdk.TemplateBuilderSessionEventType](#codersdktemplatebuildersessioneventtype) | true     |              |             |
-| `module_ids`       | array of string                                                                      | false    |              |             |
-| `session_id`       | string                                                                               | true     |              |             |
-| `success`          | boolean                                                                              | false    |              |             |
+| Name               | Type                                                                                 | Required | Restrictions | Description                                                |
+|--------------------|--------------------------------------------------------------------------------------|----------|--------------|------------------------------------------------------------|
+| `base_template_id` | string                                                                               | false    |              | Base template ID is the selected base, when known.         |
+| `duration_seconds` | number                                                                               | false    |              | Duration seconds is the elapsed wizard time for the event. |
+| `event_type`       | [codersdk.TemplateBuilderSessionEventType](#codersdktemplatebuildersessioneventtype) | true     |              | Event type is the telemetry event being reported.          |
+| `module_ids`       | array of string                                                                      | false    |              | Module ids are the selected modules, when known.           |
+| `session_id`       | string                                                                               | true     |              | Session ID correlates events within one builder session.   |
+| `success`          | boolean                                                                              | false    |              | Success reports whether the composition succeeded.         |
 
 #### Enumerated Values
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -9254,13 +9254,37 @@ export type TemplateBuildTimeStats = Record<
  * returned by GET /api/v2/templatebuilder/bases.
  */
 export interface TemplateBuilderBase {
+	/**
+	 * ID uniquely identifies the base in compose requests.
+	 */
 	readonly id: string;
+	/**
+	 * Name is the human-facing base template name.
+	 */
 	readonly name: string;
+	/**
+	 * Description summarizes the infrastructure the base provisions.
+	 */
 	readonly description: string;
+	/**
+	 * Icon is a URL or built-in icon path.
+	 */
 	readonly icon: string;
+	/**
+	 * OS is the operating system the base provisions.
+	 */
 	readonly os: string;
+	/**
+	 * Variables are the base template's configurable inputs.
+	 */
 	readonly variables: readonly TemplateBuilderModuleVariable[];
+	/**
+	 * Prerequisites describes setup required before using the base, if any.
+	 */
 	readonly prerequisites: string;
+	/**
+	 * Agents are the coder_agents the base declares for modules to target.
+	 */
 	readonly agents: readonly TemplateBuilderBaseAgent[];
 }
 
@@ -9270,7 +9294,13 @@ export interface TemplateBuilderBase {
  * composed onto the base target one of these by Name.
  */
 export interface TemplateBuilderBaseAgent {
+	/**
+	 * Name is the coder_agent resource name modules target.
+	 */
 	readonly name: string;
+	/**
+	 * DisplayName is the human-facing agent name; may be empty.
+	 */
 	readonly display_name: string;
 	/**
 	 * Default reports whether modules attach to this agent when they do not
@@ -9284,6 +9314,9 @@ export interface TemplateBuilderBaseAgent {
  * TemplateBuilderBasesResponse is the response body for listing template builder bases.
  */
 export interface TemplateBuilderBasesResponse {
+	/**
+	 * Bases are the available base templates.
+	 */
 	readonly bases: readonly TemplateBuilderBase[];
 }
 
@@ -9293,11 +9326,17 @@ export interface TemplateBuilderBasesResponse {
  * values for the compose request.
  */
 export interface TemplateBuilderComposeModule {
+	/**
+	 * ID selects a catalog module to compose.
+	 */
 	readonly id: string;
 	/**
 	 * AgentName targets a base coder_agent by name. Empty uses the base default.
 	 */
 	readonly agent_name?: string;
+	/**
+	 * Variables sets the module's input variables by name.
+	 */
 	readonly variables?: Record<string, string>;
 }
 
@@ -9307,8 +9346,17 @@ export interface TemplateBuilderComposeModule {
  * POST /api/v2/templatebuilder/compose.
  */
 export interface TemplateBuilderComposeRequest {
+	/**
+	 * BaseTemplateID selects the base template to compose onto.
+	 */
 	readonly base_template_id: string;
+	/**
+	 * BaseVariableValues sets the base's input variables by name.
+	 */
 	readonly base_variable_values?: Record<string, string>;
+	/**
+	 * Modules are the modules to compose onto the base.
+	 */
 	readonly modules: readonly TemplateBuilderComposeModule[];
 }
 
@@ -9324,14 +9372,41 @@ export interface TemplateBuilderConfig {
  * POST /api/v2/templatebuilder/compose/template.
  */
 export interface TemplateBuilderCreateTemplateRequest {
+	/**
+	 * BaseTemplateID selects the base template to compose onto.
+	 */
 	readonly base_template_id: string;
+	/**
+	 * BaseVariableValues sets the base's input variables by name.
+	 */
 	readonly base_variable_values?: Record<string, string>;
+	/**
+	 * Modules are the modules to compose onto the base.
+	 */
 	readonly modules: readonly TemplateBuilderComposeModule[];
+	/**
+	 * OrganizationID owns the created template.
+	 */
 	readonly organization_id: string;
+	/**
+	 * Name is the template's unique slug.
+	 */
 	readonly name: string;
+	/**
+	 * DisplayName is the human-facing template name.
+	 */
 	readonly display_name?: string;
+	/**
+	 * Description is shown on the template page.
+	 */
 	readonly description?: string;
+	/**
+	 * Icon is a URL or built-in icon path.
+	 */
 	readonly icon?: string;
+	/**
+	 * ProvisionerTags route the import job to matching provisioners.
+	 */
 	readonly provisioner_tags?: Record<string, string>;
 }
 
@@ -9341,6 +9416,9 @@ export interface TemplateBuilderCreateTemplateRequest {
  * POST /api/v2/templatebuilder/compose/template.
  */
 export interface TemplateBuilderCreateTemplateResponse {
+	/**
+	 * Template is the newly created template.
+	 */
 	readonly template: Template;
 }
 
@@ -9351,24 +9429,73 @@ export interface TemplateBuilderCreateTemplateResponse {
  * populated from the catalog manifest's PinnedVersion at serving time.
  */
 export interface TemplateBuilderModule {
+	/**
+	 * ID uniquely identifies the module in the catalog and compose requests.
+	 */
 	readonly id: string;
+	/**
+	 * DisplayName is the human-facing module name.
+	 */
 	readonly display_name: string;
+	/**
+	 * Description summarizes what the module does.
+	 */
 	readonly description: string;
+	/**
+	 * Icon is a URL or built-in icon path.
+	 */
 	readonly icon: string;
+	/**
+	 * Category groups related modules in the builder.
+	 */
 	readonly category: string;
+	/**
+	 * Version is the pinned module version from the catalog manifest.
+	 */
 	readonly version: string;
+	/**
+	 * CompatibleOS lists the base operating systems the module supports.
+	 */
 	readonly compatible_os: readonly string[];
+	/**
+	 * ConflictsWith lists module IDs that cannot be selected alongside this one.
+	 */
 	readonly conflicts_with: readonly string[];
+	/**
+	 * Variables are the module's configurable inputs.
+	 */
 	readonly variables: readonly TemplateBuilderModuleVariable[];
 }
 
 // From codersdk/templatebuilder.go
+/**
+ * TemplateBuilderModuleVariable describes a single input variable declared by a
+ * base template or module manifest.
+ */
 export interface TemplateBuilderModuleVariable {
+	/**
+	 * Name is the Terraform variable name values are keyed by.
+	 */
 	readonly name: string;
+	/**
+	 * Type constrains the accepted value (string, number, or bool).
+	 */
 	readonly type: TemplateBuilderVariableType;
+	/**
+	 * Description is human-facing help text shown in the builder.
+	 */
 	readonly description: string;
+	/**
+	 * Default is applied when no value is supplied; omitted when there is none.
+	 */
 	readonly default?: Record<string, string>;
+	/**
+	 * Required reports whether a value must be supplied to compose.
+	 */
 	readonly required: boolean;
+	/**
+	 * Sensitive hides the value in the UI and excludes it from logs.
+	 */
 	readonly sensitive: boolean;
 }
 
@@ -9377,6 +9504,9 @@ export interface TemplateBuilderModuleVariable {
  * TemplateBuilderModulesResponse is the response body for listing template builder modules.
  */
 export interface TemplateBuilderModulesResponse {
+	/**
+	 * Modules are the modules available for the requested base.
+	 */
 	readonly modules: readonly TemplateBuilderModule[];
 }
 
@@ -9394,11 +9524,29 @@ export const TemplateBuilderSessionEventTypes: TemplateBuilderSessionEventType[]
  * POST /api/v2/templatebuilder/sessions.
  */
 export interface TemplateBuilderSessionRequest {
+	/**
+	 * SessionID correlates events within one builder session.
+	 */
 	readonly session_id: string;
+	/**
+	 * EventType is the telemetry event being reported.
+	 */
 	readonly event_type: TemplateBuilderSessionEventType;
+	/**
+	 * BaseTemplateID is the selected base, when known.
+	 */
 	readonly base_template_id?: string;
+	/**
+	 * ModuleIDs are the selected modules, when known.
+	 */
 	readonly module_ids?: readonly string[];
+	/**
+	 * DurationSeconds is the elapsed wizard time for the event.
+	 */
 	readonly duration_seconds?: number;
+	/**
+	 * Success reports whether the composition succeeded.
+	 */
 	readonly success?: boolean;
 }
 


### PR DESCRIPTION
Part of DEVEX-556.

Addresses review feedback from @untra on #28905 ([discussion](https://github.com/coder/coder/pull/28905#discussion_r3916476843)): backfill short, tasteful field descriptions on the `codersdk` template builder request/response structs while in the headspace, so they flow into the generated Swagger and API reference docs (and JSDoc on the generated TS types).

## Changes

- Field-level doc comments across the template builder structs in `codersdk/templatebuilder.go`.
- Regenerated derived files via `make gen`: `coderd/apidoc/docs.go`, `coderd/apidoc/swagger.json`, `docs/reference/api/schemas.md`, `site/src/api/typesGenerated.ts`.

No behavior change. `make gen` is idempotent; Go lint/fmt, `lint-docs`, and TS lint all clean.

---
🤖 Generated with Coder Agents.