### PR TITLE
chore: add Gemini 3.8 Flash to the known models catalog and price book

### DIFF
--- a/coderd/aibridge/prices/data/prices.json
+++ b/coderd/aibridge/prices/data/prices.json
@@ -2257,6 +2257,14 @@
   },
   {
     "provider": "google",
+    "model": "gemini-3.8-flash",
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "google",
     "model": "gemini-embedding-001",
     "input_price": 150000,
     "output_price": 0,
@@ -2994,9 +3002,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat-v3.1",
-    "input_price": 550000,
-    "output_price": 1650000,
-    "cache_read_price": 550000,
+    "input_price": 250000,
+    "output_price": 950000,
+    "cache_read_price": 130000,
     "cache_write_price": null
   },
   {
@@ -3050,9 +3058,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash",
-    "input_price": 71680,
-    "output_price": 143360,
-    "cache_read_price": 14336,
+    "input_price": 85540,
+    "output_price": 171080,
+    "cache_read_price": 17108,
     "cache_write_price": null
   },
   {
@@ -3074,9 +3082,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro",
-    "input_price": 1024164,
-    "output_price": 2048328,
-    "cache_read_price": 85347,
+    "input_price": 1030776,
+    "output_price": 2061552,
+    "cache_read_price": 85898,
     "cache_write_price": null
   },
   {
@@ -3250,6 +3258,14 @@
   {
     "provider": "openrouter",
     "model": "google/gemini-3.7-flash",
+    "input_price": 750000,
+    "output_price": 3750000,
+    "cache_read_price": 75000,
+    "cache_write_price": 41667
+  },
+  {
+    "provider": "openrouter",
+    "model": "google/gemini-3.8-flash",
     "input_price": 750000,
     "output_price": 3750000,
     "cache_read_price": 75000,
@@ -3938,9 +3954,9 @@
   {
     "provider": "openrouter",
     "model": "nvidia/nemotron-3-ultra-550b-a55b",
-    "input_price": 500000,
-    "output_price": 2200000,
-    "cache_read_price": 100000,
+    "input_price": 625000,
+    "output_price": 3125000,
+    "cache_read_price": 187500,
     "cache_write_price": null
   },
   {
@@ -4908,7 +4924,7 @@
     "model": "qwen/qwen3.8-2.4t-a95b",
     "input_price": 2000000,
     "output_price": 6000000,
-    "cache_read_price": 250000,
+    "cache_read_price": 200000,
     "cache_write_price": null
   },
   {
@@ -5314,9 +5330,9 @@
   {
     "provider": "openrouter",
     "model": "z-ai/glm-5.2",
-    "input_price": 1190000,
-    "output_price": 3740000,
-    "cache_read_price": 221000,
+    "input_price": 966000,
+    "output_price": 3036000,
+    "cache_read_price": 193200,
     "cache_write_price": null
   },
   {
@@ -5386,9 +5402,9 @@
   {
     "provider": "openrouter",
     "model": "~deepseek/deepseek-v4-flash-latest",
-    "input_price": 49980,
-    "output_price": 99960,
-    "cache_read_price": 9996,
+    "input_price": 50000,
+    "output_price": 160000,
+    "cache_read_price": 13000,
     "cache_write_price": null
   },
   {
@@ -5441,10 +5457,18 @@
   },
   {
     "provider": "openrouter",
+    "model": "~z-ai/glm-flash-latest",
+    "input_price": 75000,
+    "output_price": 250000,
+    "cache_read_price": 15000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
     "model": "~z-ai/glm-latest",
-    "input_price": 1170000,
-    "output_price": 3960000,
-    "cache_read_price": 234000,
+    "input_price": 1150000,
+    "output_price": 3500000,
+    "cache_read_price": 100000,
     "cache_write_price": null
   },
   {

--- a/scripts/aibridgepricesgen/curation.json
+++ b/scripts/aibridgepricesgen/curation.json
@@ -122,6 +122,9 @@
 			"modelIdentifier": "gemini-flash-latest"
 		},
 		{
+			"modelIdentifier": "gemini-3.8-flash"
+		},
+		{
 			"modelIdentifier": "gemini-3.7-flash"
 		},
 		{

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
@@ -387,6 +387,17 @@
 		},
 		{
 			"provider": "google",
+			"modelIdentifier": "gemini-3.8-flash",
+			"displayName": "Gemini 3.8 Flash",
+			"aliases": [],
+			"contextLimit": 1048576,
+			"maxOutputTokens": 65536,
+			"inputCost": 0.75,
+			"outputCost": 3.75,
+			"cacheReadCost": 0.075
+		},
+		{
+			"provider": "google",
 			"modelIdentifier": "gemini-3.7-flash",
 			"displayName": "Gemini 3.7 Flash",
 			"aliases": [],
@@ -593,10 +604,10 @@
 			"displayName": "GLM-5.2",
 			"aliases": [],
 			"contextLimit": 1048576,
-			"maxOutputTokens": 262144,
-			"inputCost": 1.19,
-			"outputCost": 3.74,
-			"cacheReadCost": 0.221
+			"maxOutputTokens": 131072,
+			"inputCost": 0.966,
+			"outputCost": 3.036,
+			"cacheReadCost": 0.1932
 		},
 		{
 			"provider": "openrouter",
@@ -689,9 +700,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 0.07168,
-			"outputCost": 0.14336,
-			"cacheReadCost": 0.014336
+			"inputCost": 0.08554,
+			"outputCost": 0.17108,
+			"cacheReadCost": 0.017108
 		},
 		{
 			"provider": "openrouter",
@@ -700,9 +711,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 1.024164,
-			"outputCost": 2.048328,
-			"cacheReadCost": 0.085347
+			"inputCost": 1.030776,
+			"outputCost": 2.061552,
+			"cacheReadCost": 0.085898
 		},
 		{
 			"provider": "openrouter",


### PR DESCRIPTION
Add Gemini 3.8 Flash to the Agents-page known models list so it appears as a suggestion when an admin adds a chat model in `/agents` settings, and pick up its pricing in the AI Bridge price book.

Google released `gemini-3.8-flash` today (2026-09-02). models.dev already lists it, so this is a curation entry under `google` (sorted ahead of 3.7 Flash, which it supersedes) plus a regeneration with `make gen/aibridge-prices`. No override is needed, and no Go change is needed: `googleSupportedThinkingLevels` already treats Flash >= 3.7 as LOW/MEDIUM/HIGH, so 3.8 gets the same reasoning-effort mapping as 3.7.

| File | Change |
|---|---|
| `scripts/aibridgepricesgen/curation.json` | `gemini-3.8-flash` under `google` |
| `knownModelsGenerated.json` | new `gemini-3.8-flash` entry (1,048,576 context, 65,536 max output, $0.75 / $3.75 / $0.075 cache read per 1M tokens); the GLM 5.2 and two DeepSeek openrouter rows are upstream drift |
| `coderd/aibridge/prices/data/prices.json` | added `google/gemini-3.8-flash`, `openrouter/google/gemini-3.8-flash`, `openrouter/~z-ai/glm-flash-latest`; 8 openrouter rows repriced upstream since the last refresh (deepseek-chat-v3.1, deepseek-v4-flash, deepseek-v4-pro, nemotron-3-ultra-550b-a55b, qwen3.8-2.4t-a95b, z-ai/glm-5.2, ~deepseek/deepseek-v4-flash-latest, ~z-ai/glm-latest) |

Vercel does not list Gemini 3.8 Flash upstream yet, and openrouter/vercel have no Gemini curation entries today, so the catalog change is google-only, matching how 3.6 and 3.7 Flash were added.

Validation: `go test ./scripts/aibridgepricesgen/... ./coderd/aibridge/prices/...` and `vitest run` on `knownModels/` (52 tests) pass.

Companion dogfood PR enabling the model on dev.coder.com: https://github.com/coder/dogfood/pull/464

> Xum opened this PR on behalf of @ibetitsmike.
