### PR TITLE
feat(site/src/pages/TemplateBuilder): add per-module agent selector UI

### DIFF
--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import type { TemplateBuilderModule } from "#/api/typesGenerated";
+import { ModuleSettingsStep } from "./ModuleSettingsStep";
+import type { SelectedBaseAgent } from "./wizardState";
+
+const baseId = "docker";
+
+function makeModule(
+	overrides: Partial<TemplateBuilderModule> &
+		Pick<TemplateBuilderModule, "id" | "display_name">,
+): TemplateBuilderModule {
+	return {
+		description: "",
+		icon: "",
+		category: "IDE",
+		version: "1.0.0",
+		compatible_os: ["linux"],
+		conflicts_with: [],
+		variables: [],
+		...overrides,
+	};
+}
+
+const modules = [
+	makeModule({ id: "code-server", display_name: "code-server" }),
+];
+
+const twoAgents: SelectedBaseAgent[] = [
+	{ name: "main", displayName: "Main", default: true },
+	{ name: "gpu", displayName: "GPU", default: false },
+];
+
+const oneAgent: SelectedBaseAgent[] = [
+	{ name: "main", displayName: "Main", default: true },
+];
+
+const meta: Meta<typeof ModuleSettingsStep> = {
+	title: "pages/TemplateBuilder/ModuleSettingsStep",
+	component: ModuleSettingsStep,
+	args: {
+		baseId,
+		selectedModuleIds: ["code-server"],
+		moduleVariables: {},
+		moduleAgents: {},
+		agents: oneAgent,
+		onChangeModuleVariables: fn(),
+		onChangeModuleAgent: fn(),
+		onRemoveModule: fn(),
+		registerModuleRef: fn(),
+	},
+	parameters: {
+		queries: [
+			{
+				key: ["templateBuilder", "modules", baseId],
+				data: { modules },
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ModuleSettingsStep>;
+
+// A single-agent base shows no agent picker: there is nothing to choose.
+export const SingleAgent: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("code-server");
+		await expect(canvas.queryByText("Agent")).not.toBeInTheDocument();
+	},
+};
+
+// A multi-agent base shows the picker with the base default preselected.
+export const MultipleAgents: Story = {
+	args: { agents: twoAgents },
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Agent");
+		await expect(canvas.getByRole("radio", { name: /Main/ })).toBeChecked();
+	},
+};
+
+// Picking a different agent reports the choice to the caller.
+export const ChangeAgent: Story = {
+	args: { agents: twoAgents },
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Agent");
+		await userEvent.click(canvas.getByRole("radio", { name: /GPU/ }));
+		await expect(args.onChangeModuleAgent).toHaveBeenCalledWith(
+			"code-server",
+			"gpu",
+		);
+	},
+};

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.stories.tsx
@@ -6,25 +6,17 @@ import type { SelectedBaseAgent } from "./wizardState";
 
 const baseId = "docker";
 
-function makeModule(
-	overrides: Partial<TemplateBuilderModule> &
-		Pick<TemplateBuilderModule, "id" | "display_name">,
-): TemplateBuilderModule {
-	return {
-		description: "",
-		icon: "",
-		category: "IDE",
-		version: "1.0.0",
-		compatible_os: ["linux"],
-		conflicts_with: [],
-		variables: [],
-		...overrides,
-	};
-}
-
-const modules = [
-	makeModule({ id: "code-server", display_name: "code-server" }),
-];
+const codeServer: TemplateBuilderModule = {
+	id: "code-server",
+	display_name: "code-server",
+	description: "",
+	icon: "",
+	category: "IDE",
+	version: "1.0.0",
+	compatible_os: ["linux"],
+	conflicts_with: [],
+	variables: [],
+};
 
 const twoAgents: SelectedBaseAgent[] = [
 	{ name: "main", displayName: "Main", default: true },
@@ -53,7 +45,7 @@ const meta: Meta<typeof ModuleSettingsStep> = {
 		queries: [
 			{
 				key: ["templateBuilder", "modules", baseId],
-				data: { modules },
+				data: { modules: [codeServer] },
 			},
 		],
 	},

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -17,15 +17,21 @@ import {
 } from "./ConfigurationField";
 import { defaultPlaceholder } from "./defaultPlaceholder";
 import { ModuleConfiguration } from "./ModuleConfiguration";
+import type { SelectedBaseAgent } from "./wizardState";
 
 interface ModuleSettingsStepProps {
 	baseId: string;
 	selectedModuleIds: string[];
 	moduleVariables: Record<string, Record<string, string>>;
+	/** Base agents modules can target. Empty or single-agent hides the selector. */
+	agents: SelectedBaseAgent[];
+	/** Selected agent name per module id; unset uses the base default. */
+	moduleAgents: Record<string, string | undefined>;
 	onChangeModuleVariables: (
 		moduleId: string,
 		variables: Record<string, string>,
 	) => void;
+	onChangeModuleAgent: (moduleId: string, agentName: string) => void;
 	onRemoveModule: (moduleId: string) => void;
 	registerModuleRef: (moduleId: string, node: HTMLDivElement | null) => void;
 }
@@ -72,6 +78,31 @@ function variableToField(
 	};
 }
 
+/**
+ * Builds the synthetic radio field that lets the user pick which base agent a
+ * module attaches to. Only shown for bases with more than one agent.
+ */
+function agentField(
+	moduleId: string,
+	agents: SelectedBaseAgent[],
+	value: string | undefined,
+	onChange: (agentName: string) => void,
+): ConfigurationFieldDefinition {
+	return {
+		type: "radio",
+		id: `mod-${moduleId}-agent`,
+		label: "Agent",
+		description: "Choose which agent this module attaches to.",
+		required: true,
+		value: value ?? agents.find((a) => a.default)?.name,
+		onChange,
+		options: agents.map((a) => ({
+			value: a.name,
+			label: a.default ? `${a.displayName} (default)` : a.displayName,
+		})),
+	};
+}
+
 function moduleDetailsUrl(moduleId: string): string {
 	return `https://registry.coder.com/modules/${moduleId}`;
 }
@@ -108,12 +139,16 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 	baseId,
 	selectedModuleIds,
 	moduleVariables,
+	agents,
+	moduleAgents,
 	onChangeModuleVariables,
+	onChangeModuleAgent,
 	onRemoveModule,
 	registerModuleRef,
 }) => {
 	const { data } = useQuery(templateBuilderModules(baseId));
 	const modules = data?.modules ?? [];
+	const showAgentSelector = agents.length > 1;
 
 	const selectedModules = selectedModuleIds
 		.map((id) => modules.find((m) => m.id === id))
@@ -149,6 +184,13 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 					const optionalVars = configurableVars.filter((v) => !v.required);
 
 					const requiredFields = requiredVars.map(toField);
+					if (showAgentSelector) {
+						requiredFields.unshift(
+							agentField(mod.id, agents, moduleAgents[mod.id], (agentName) =>
+								onChangeModuleAgent(mod.id, agentName),
+							),
+						);
+					}
 					const optionalFields = optionalVars.map(toField);
 
 					return (

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -17,7 +17,7 @@ import {
 } from "./ConfigurationField";
 import { defaultPlaceholder } from "./defaultPlaceholder";
 import { ModuleConfiguration } from "./ModuleConfiguration";
-import type { SelectedBaseAgent } from "./wizardState";
+import { defaultAgentName, type SelectedBaseAgent } from "./wizardState";
 
 interface ModuleSettingsStepProps {
 	baseId: string;
@@ -75,31 +75,6 @@ function variableToField(
 			onBlur: () => {},
 			error: false,
 		},
-	};
-}
-
-/**
- * Builds the synthetic radio field that lets the user pick which base agent a
- * module attaches to. Only shown for bases with more than one agent.
- */
-function agentField(
-	moduleId: string,
-	agents: SelectedBaseAgent[],
-	value: string | undefined,
-	onChange: (agentName: string) => void,
-): ConfigurationFieldDefinition {
-	return {
-		type: "radio",
-		id: `mod-${moduleId}-agent`,
-		label: "Agent",
-		description: "Choose which agent this module attaches to.",
-		required: true,
-		value: value ?? agents.find((a) => a.default)?.name,
-		onChange,
-		options: agents.map((a) => ({
-			value: a.name,
-			label: a.default ? `${a.displayName} (default)` : a.displayName,
-		})),
 	};
 }
 
@@ -185,11 +160,19 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 
 					const requiredFields = requiredVars.map(toField);
 					if (showAgentSelector) {
-						requiredFields.unshift(
-							agentField(mod.id, agents, moduleAgents[mod.id], (agentName) =>
-								onChangeModuleAgent(mod.id, agentName),
-							),
-						);
+						requiredFields.unshift({
+							type: "radio",
+							id: `mod-${mod.id}-agent`,
+							label: "Agent",
+							description: "Choose which agent this module attaches to.",
+							required: true,
+							value: moduleAgents[mod.id] ?? defaultAgentName(agents),
+							onChange: (agentName) => onChangeModuleAgent(mod.id, agentName),
+							options: agents.map((a) => ({
+								value: a.name,
+								label: a.default ? `${a.displayName} (default)` : a.displayName,
+							})),
+						});
 					}
 					const optionalFields = optionalVars.map(toField);
 

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -416,11 +416,22 @@ function renderStepContent(
 					baseId={state.selectedBase.id}
 					selectedModuleIds={state.modules.map((m) => m.id)}
 					moduleVariables={moduleVarMap}
+					agents={state.selectedBase.agents}
+					moduleAgents={Object.fromEntries(
+						state.modules.map((m) => [m.id, m.agent_name]),
+					)}
 					onChangeModuleVariables={(moduleId, variables) =>
 						dispatch({
 							type: "SET_MODULE_VARIABLES",
 							moduleId,
 							variables,
+						})
+					}
+					onChangeModuleAgent={(moduleId, agentName) =>
+						dispatch({
+							type: "SET_MODULE_AGENT",
+							moduleId,
+							agentName,
 						})
 					}
 					onRemoveModule={onRemoveModule}

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -11,7 +11,7 @@ import type {
  * UI-only view of a base coder_agent. displayName is guaranteed non-empty:
  * it falls back to name when the API omits display_name.
  */
-type SelectedBaseAgent = {
+export type SelectedBaseAgent = {
 	name: string;
 	displayName: string;
 	default: boolean;

--- a/site/src/pages/TemplateBuilder/wizardState.ts
+++ b/site/src/pages/TemplateBuilder/wizardState.ts
@@ -62,9 +62,11 @@ function toSelectedBaseAgent(
 	};
 }
 
-/** Name of the base agent modules attach to when they do not name one. */
-function defaultBaseAgentName(base: SelectedBaseMeta): string | undefined {
-	return base.agents.find((a) => a.default)?.name;
+/** Name of the default agent modules attach to when they do not name one. */
+export function defaultAgentName(
+	agents: SelectedBaseAgent[],
+): string | undefined {
+	return agents.find((a) => a.default)?.name;
 }
 
 /**
@@ -235,7 +237,9 @@ export function wizardReducer(
 			// stays undefined otherwise so agent_name is left unset and the backend
 			// uses the sole agent.
 			const agentDefault =
-				base && base.agents.length > 1 ? defaultBaseAgentName(base) : undefined;
+				base && base.agents.length > 1
+					? defaultAgentName(base.agents)
+					: undefined;
 			return {
 				...state,
 				modules: action.modules.map((incoming) =>


### PR DESCRIPTION
Part of DEVEX-556. Stacked on #28912 (agent backend), which is stacked on #28906 (Task C).

Adds the visible per-module agent selector.

- A radio **Agent** picker renders per module in the module-settings step, only when the selected base declares more than one agent. The choice drives compose targeting (`agent_id`) via `SET_MODULE_AGENT`.
- Built as a synthetic `radio` `ConfigurationField`, reusing the existing field-render path rather than a bespoke component.
- Storybook `play` tests: single-agent hides the picker, multi-agent preselects the base default, and changing reports `(moduleId, agentName)`.

Because the paired `agent_name` binding is handled server-side (#28912), the client never sees or special-cases that variable — the selector is purely compose targeting.

---
🤖 Generated with Coder Agents.