### PR TITLE
feat(coderd/templatebuilder): bind module agent_name to the attached agent

### DIFF
--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -310,6 +310,7 @@ func renderModules(
 			RegistryBase:      registryURL,
 			PinnedVersion:     manifest.PinnedVersion,
 			AgentResourceName: agentRef,
+			AgentName:         agentName,
 			Variables:         vars,
 		}
 

--- a/coderd/templatebuilder/compose_internal_test.go
+++ b/coderd/templatebuilder/compose_internal_test.go
@@ -169,6 +169,7 @@ func TestRenderModulesAgentTargeting(t *testing.T) {
 		[]ComposeModule{
 			{ID: "code-server", AgentName: "gpu"},
 			{ID: "git-commit-signing"},
+			{ID: "zed", AgentName: "gpu"},
 		},
 		catalog, "registry.coder.com", agentRefByName, "main",
 	)
@@ -177,4 +178,7 @@ func TestRenderModulesAgentTargeting(t *testing.T) {
 	out := string(modulesTF)
 	require.Contains(t, out, "coder_agent.gpu[0].id")
 	require.Contains(t, out, "coder_agent.main.id")
+	// zed declares an agent_name input; the builder binds it to the attached
+	// agent's name rather than leaving the manifest default.
+	require.Contains(t, out, `agent_name = "gpu"`)
 }

--- a/coderd/templatebuilder/modules/filebrowser/filebrowser.tf.tmpl
+++ b/coderd/templatebuilder/modules/filebrowser/filebrowser.tf.tmpl
@@ -3,7 +3,7 @@ module "filebrowser" {
   source   = "{{ .RegistryBase }}/coder/filebrowser/coder"
   version  = "{{ .PinnedVersion }}"
   agent_id = coder_agent.{{ .AgentResourceName }}.id
-  agent_name = {{ .Variables.agent_name }}
+  agent_name = "{{ .AgentName }}"
   database_path = {{ .Variables.database_path }}
   folder = {{ .Variables.folder }}
   port = {{ .Variables.port }}

--- a/coderd/templatebuilder/modules/filebrowser/module.json
+++ b/coderd/templatebuilder/modules/filebrowser/module.json
@@ -28,7 +28,7 @@
       "description": "The name of the coder_agent resource.",
       "required": false,
       "sensitive": false,
-      "computed": false
+      "computed": true
     },
     {
       "name": "database_path",

--- a/coderd/templatebuilder/modules/jetbrains/jetbrains.tf.tmpl
+++ b/coderd/templatebuilder/modules/jetbrains/jetbrains.tf.tmpl
@@ -3,7 +3,7 @@ module "jetbrains" {
   source   = "{{ .RegistryBase }}/coder/jetbrains/coder"
   version  = "{{ .PinnedVersion }}"
   agent_id = coder_agent.{{ .AgentResourceName }}.id
-  agent_name = {{ .Variables.agent_name }}
+  agent_name = "{{ .AgentName }}"
   channel = {{ .Variables.channel }}
   download_base_link = {{ .Variables.download_base_link }}
   folder = {{ .Variables.folder }}

--- a/coderd/templatebuilder/modules/jetbrains/module.json
+++ b/coderd/templatebuilder/modules/jetbrains/module.json
@@ -29,7 +29,7 @@
       "description": "The name of a Coder agent. Needed for workspaces with multiple agents.",
       "required": false,
       "sensitive": false,
-      "computed": false
+      "computed": true
     },
     {
       "name": "channel",

--- a/coderd/templatebuilder/modules/zed/module.json
+++ b/coderd/templatebuilder/modules/zed/module.json
@@ -30,7 +30,7 @@
       "default": "",
       "required": false,
       "sensitive": false,
-      "computed": false
+      "computed": true
     },
     {
       "name": "folder",

--- a/coderd/templatebuilder/modules/zed/zed.tf.tmpl
+++ b/coderd/templatebuilder/modules/zed/zed.tf.tmpl
@@ -3,7 +3,7 @@ module "zed" {
   source   = "{{ .RegistryBase }}/coder/zed/coder"
   version  = "{{ .PinnedVersion }}"
   agent_id = coder_agent.{{ .AgentResourceName }}.id
-  agent_name = {{ .Variables.agent_name }}
+  agent_name = "{{ .AgentName }}"
   folder = {{ .Variables.folder }}
   settings = {{ .Variables.settings }}
 }

--- a/coderd/templatebuilder/render.go
+++ b/coderd/templatebuilder/render.go
@@ -43,6 +43,10 @@ type ModuleRenderContext struct {
 	// AgentResourceName is the Terraform resource name of the coder_agent
 	// declared in the base template (e.g. "main" or "dev").
 	AgentResourceName string
+	// AgentName is the attached agent's name, for modules that take an
+	// agent_name input. Builder-owned like AgentResourceName; the two name the
+	// same agent (id vs. label).
+	AgentName string
 	// Variables maps variable names to their HCL expressions.
 	Variables map[string]string
 }


### PR DESCRIPTION
Part of DEVEX-556. Stacked on #28906 (Task C). Backend half of the per-module agent work; the selector UI follows in #28911.

Modules that take an `agent_name` input (`zed`, `jetbrains`, `filebrowser`) now treat it as builder-owned, matching the computed `agent_id`:

- `agent_name` marked `computed: true` in those manifests, so the API strips it (no free-text field to reconcile on the client).
- The builder renders it from the attached agent via a new `ModuleRenderContext.AgentName`; templates use `agent_name = "{{ .AgentName }}"`.
- Agent names are coder_agent resource labels: unique within the template and validated unique per base manifest, so they are a safe key. `agent_id` (association) and `agent_name` (label) stay distinct.

`TestRenderModulesAgentTargeting` now also renders `zed` against a second agent and asserts `agent_name = "gpu"`.

---
🤖 Generated with Coder Agents.