### PR TITLE
chore: enable oxlint no-this-alias rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -84,7 +84,7 @@
 			},
 			"complexity": {
 				"noImportantStyles": "off", // TODO: check and fix !important styles
-				"noUselessThisAlias": "off", // oxlint owns no-this-alias
+				"noUselessThisAlias": "off",
 				"useLiteralKeys": "off"
 			}
 		}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -84,6 +84,7 @@
 			},
 			"complexity": {
 				"noImportantStyles": "off", // TODO: check and fix !important styles
+				"noUselessThisAlias": "off", // oxlint owns no-this-alias
 				"useLiteralKeys": "off"
 			}
 		}

--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -50,6 +50,7 @@
 		"no-useless-switch-case": "error",
 		"no-unneeded-ternary": "error",
 		"no-unnecessary-type-constraint": "error",
+		"no-this-alias": "error",
 		"prefer-arrow-callback": "error",
 		"prefer-date-now": "error",
 		"prefer-array-flat-map": "error",
@@ -185,7 +186,6 @@
 		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
 		"no-unused-vars": "off", // correctness/noUnusedVariables + noUnusedImports (small: dead-store "used" semantics differ)
-		"no-this-alias": "off", // complexity/noUselessThisAlias (medium)
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)

--- a/site/src/components/Tabs/utils/useKebabMenu.test.tsx
+++ b/site/src/components/Tabs/utils/useKebabMenu.test.tsx
@@ -1,11 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
-import {
-	type ResizeObserverMock,
-	setupResizeObserverMock,
-} from "#/testHelpers/resizeObserver";
+import { MockResizeObserver } from "#/testHelpers/resizeObserver";
 import { useKebabMenu } from "./useKebabMenu";
-
-let resizeObserver: ResizeObserverMock;
 
 const setElementOffsetWidth = (element: HTMLElement, width: number): void => {
 	Object.defineProperty(element, "offsetWidth", {
@@ -57,7 +52,8 @@ const TestHarness = ({ tabGap = 0 }: { tabGap?: number }) => {
 
 describe("useKebabMenu", () => {
 	beforeEach(() => {
-		resizeObserver = setupResizeObserverMock();
+		MockResizeObserver.reset();
+		vi.stubGlobal("ResizeObserver", MockResizeObserver);
 	});
 
 	afterEach(() => {
@@ -75,7 +71,7 @@ describe("useKebabMenu", () => {
 		setElementOffsetWidth(startup, 70);
 
 		await act(() => {
-			resizeObserver.getLast().simulateResize(220);
+			MockResizeObserver.getLast().simulateResize(220);
 		});
 
 		expect(screen.getByTestId("visible-values")).toHaveTextContent(
@@ -93,7 +89,7 @@ describe("useKebabMenu", () => {
 		setElementOffsetWidth(startup, 70);
 
 		await act(() => {
-			resizeObserver.getLast().simulateResize(220);
+			MockResizeObserver.getLast().simulateResize(220);
 		});
 
 		expect(screen.getByTestId("visible-values")).toHaveTextContent("all");

--- a/site/src/components/Tabs/utils/useKebabMenu.test.tsx
+++ b/site/src/components/Tabs/utils/useKebabMenu.test.tsx
@@ -1,40 +1,11 @@
 import { act, render, screen } from "@testing-library/react";
+import {
+	type ResizeObserverMock,
+	setupResizeObserverMock,
+} from "#/testHelpers/resizeObserver";
 import { useKebabMenu } from "./useKebabMenu";
 
-type FakeResizeObserverInstance = {
-	simulateResize: (width: number) => void;
-};
-
-let resizeObserverInstances: FakeResizeObserverInstance[] = [];
-
-class MockResizeObserver {
-	private readonly callback: ResizeObserverCallback;
-
-	constructor(callback: ResizeObserverCallback) {
-		this.callback = callback;
-		const self = this;
-		resizeObserverInstances.push({
-			simulateResize(width: number) {
-				self.callback(
-					[{ contentRect: { width, height: 0 } } as ResizeObserverEntry],
-					self as unknown as ResizeObserver,
-				);
-			},
-		});
-	}
-
-	observe(_target: Element) {}
-	unobserve(_target: Element) {}
-	disconnect() {}
-}
-
-const getLastResizeObserver = (): FakeResizeObserverInstance => {
-	const instance = resizeObserverInstances[resizeObserverInstances.length - 1];
-	if (!instance) {
-		throw new Error("No ResizeObserver was constructed");
-	}
-	return instance;
-};
+let resizeObserver: ResizeObserverMock;
 
 const setElementOffsetWidth = (element: HTMLElement, width: number): void => {
 	Object.defineProperty(element, "offsetWidth", {
@@ -86,8 +57,7 @@ const TestHarness = ({ tabGap = 0 }: { tabGap?: number }) => {
 
 describe("useKebabMenu", () => {
 	beforeEach(() => {
-		resizeObserverInstances = [];
-		vi.stubGlobal("ResizeObserver", MockResizeObserver);
+		resizeObserver = setupResizeObserverMock();
 	});
 
 	afterEach(() => {
@@ -105,7 +75,7 @@ describe("useKebabMenu", () => {
 		setElementOffsetWidth(startup, 70);
 
 		await act(() => {
-			getLastResizeObserver().simulateResize(220);
+			resizeObserver.getLast().simulateResize(220);
 		});
 
 		expect(screen.getByTestId("visible-values")).toHaveTextContent(
@@ -123,7 +93,7 @@ describe("useKebabMenu", () => {
 		setElementOffsetWidth(startup, 70);
 
 		await act(() => {
-			getLastResizeObserver().simulateResize(220);
+			resizeObserver.getLast().simulateResize(220);
 		});
 
 		expect(screen.getByTestId("visible-values")).toHaveTextContent("all");

--- a/site/src/pages/AgentsPage/hooks/useDesktopConnection.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useDesktopConnection.test.ts
@@ -1,10 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	type ResizeObserverMock,
-	setupResizeObserverMock,
-} from "#/testHelpers/resizeObserver";
+import { MockResizeObserver } from "#/testHelpers/resizeObserver";
 import { useDesktopConnection } from "./useDesktopConnection";
 
 vi.mock("#/api/api", () => ({
@@ -77,10 +74,6 @@ const mockWatchChatDesktop = vi.mocked(watchChatDesktop);
 const mockClipboardReadText = vi.fn<() => Promise<string>>();
 const mockClipboardWriteText = vi.fn<(text: string) => Promise<void>>();
 
-// ---- Mock ResizeObserver ----------------------------------------------------
-
-let resizeObserver: ResizeObserverMock;
-
 // ---- helpers ---------------------------------------------------------------
 
 function getLastRFBInstance(): MockRFBInstance {
@@ -104,7 +97,8 @@ describe("useDesktopConnection", () => {
 		mockWatchChatDesktop.mockReturnValue(createMockSocket());
 		lastInstance.current = null;
 		FakeRFB.throwOnConstruct = false;
-		resizeObserver = setupResizeObserverMock();
+		MockResizeObserver.reset();
+		vi.stubGlobal("ResizeObserver", MockResizeObserver);
 		mockClipboardReadText.mockReset();
 		mockClipboardReadText.mockResolvedValue("");
 		mockClipboardWriteText.mockReset();
@@ -904,7 +898,7 @@ describe("useDesktopConnection", () => {
 		const rfb = getLastRFBInstance();
 		act(() => rfb.simulateEvent("connect"));
 
-		const observer = resizeObserver.getLast();
+		const observer = MockResizeObserver.getLast();
 
 		// First observation with nonzero size (initial attach).
 		act(() => observer.simulateResize(800, 600));
@@ -928,7 +922,7 @@ describe("useDesktopConnection", () => {
 		const rfb = getLastRFBInstance();
 		act(() => rfb.simulateEvent("connect"));
 
-		const observer = resizeObserver.getLast();
+		const observer = MockResizeObserver.getLast();
 
 		// Initial nonzero observation.
 		act(() => observer.simulateResize(800, 600));
@@ -948,7 +942,7 @@ describe("useDesktopConnection", () => {
 		);
 
 		getLastRFBInstance();
-		const observer = resizeObserver.getLast();
+		const observer = MockResizeObserver.getLast();
 
 		unmount();
 
@@ -965,8 +959,8 @@ describe("useDesktopConnection", () => {
 			const rfb1 = getLastRFBInstance();
 			act(() => rfb1.simulateEvent("connect"));
 
-			expect(resizeObserver.instances).toHaveLength(1);
-			const observer1 = resizeObserver.instances[0];
+			expect(MockResizeObserver.instances).toHaveLength(1);
+			const observer1 = MockResizeObserver.instances[0];
 
 			// Trigger reconnect.
 			act(() => rfb1.simulateEvent("disconnect", { clean: false }));
@@ -976,7 +970,7 @@ describe("useDesktopConnection", () => {
 			expect(observer1.disconnect).toHaveBeenCalled();
 
 			// New observer created for the new connection.
-			expect(resizeObserver.instances).toHaveLength(2);
+			expect(MockResizeObserver.instances).toHaveLength(2);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -992,7 +986,7 @@ describe("useDesktopConnection", () => {
 		const rfb1 = getLastRFBInstance();
 		act(() => rfb1.simulateEvent("connect"));
 
-		const observer1 = resizeObserver.instances[0];
+		const observer1 = MockResizeObserver.instances[0];
 
 		// Set nonzero previous dimensions on old observer.
 		act(() => observer1.simulateResize(800, 600));

--- a/site/src/pages/AgentsPage/hooks/useDesktopConnection.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useDesktopConnection.test.ts
@@ -1,6 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type ResizeObserverMock,
+	setupResizeObserverMock,
+} from "#/testHelpers/resizeObserver";
 import { useDesktopConnection } from "./useDesktopConnection";
 
 vi.mock("#/api/api", () => ({
@@ -75,37 +79,7 @@ const mockClipboardWriteText = vi.fn<(text: string) => Promise<void>>();
 
 // ---- Mock ResizeObserver ----------------------------------------------------
 
-interface FakeResizeObserverInstance {
-	disconnect: ReturnType<typeof vi.fn>;
-	simulateResize: (width: number, height: number) => void;
-}
-
-let resizeObserverInstances: FakeResizeObserverInstance[] = [];
-
-class MockResizeObserver {
-	private _callback: ResizeObserverCallback;
-	private _disconnect = vi.fn();
-
-	constructor(callback: ResizeObserverCallback) {
-		this._callback = callback;
-		const self = this;
-		resizeObserverInstances.push({
-			disconnect: this._disconnect,
-			simulateResize(width: number, height: number) {
-				self._callback(
-					[{ contentRect: { width, height } } as ResizeObserverEntry],
-					self as unknown as ResizeObserver,
-				);
-			},
-		});
-	}
-
-	observe(_target: Element) {}
-	unobserve(_target: Element) {}
-	disconnect() {
-		this._disconnect();
-	}
-}
+let resizeObserver: ResizeObserverMock;
 
 // ---- helpers ---------------------------------------------------------------
 
@@ -114,14 +88,6 @@ function getLastRFBInstance(): MockRFBInstance {
 		throw new Error("No RFB instance was constructed");
 	}
 	return lastInstance.current;
-}
-
-function getLastResizeObserver(): FakeResizeObserverInstance {
-	const instance = resizeObserverInstances[resizeObserverInstances.length - 1];
-	if (!instance) {
-		throw new Error("No ResizeObserver was constructed");
-	}
-	return instance;
 }
 
 function createMockSocket(): WebSocket {
@@ -138,9 +104,7 @@ describe("useDesktopConnection", () => {
 		mockWatchChatDesktop.mockReturnValue(createMockSocket());
 		lastInstance.current = null;
 		FakeRFB.throwOnConstruct = false;
-		resizeObserverInstances = [];
-		globalThis.ResizeObserver =
-			MockResizeObserver as unknown as typeof ResizeObserver;
+		resizeObserver = setupResizeObserverMock();
 		mockClipboardReadText.mockReset();
 		mockClipboardReadText.mockResolvedValue("");
 		mockClipboardWriteText.mockReset();
@@ -156,6 +120,7 @@ describe("useDesktopConnection", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
 	});
 
 	it("does nothing when chatId is undefined", () => {
@@ -939,7 +904,7 @@ describe("useDesktopConnection", () => {
 		const rfb = getLastRFBInstance();
 		act(() => rfb.simulateEvent("connect"));
 
-		const observer = getLastResizeObserver();
+		const observer = resizeObserver.getLast();
 
 		// First observation with nonzero size (initial attach).
 		act(() => observer.simulateResize(800, 600));
@@ -963,7 +928,7 @@ describe("useDesktopConnection", () => {
 		const rfb = getLastRFBInstance();
 		act(() => rfb.simulateEvent("connect"));
 
-		const observer = getLastResizeObserver();
+		const observer = resizeObserver.getLast();
 
 		// Initial nonzero observation.
 		act(() => observer.simulateResize(800, 600));
@@ -983,7 +948,7 @@ describe("useDesktopConnection", () => {
 		);
 
 		getLastRFBInstance();
-		const observer = getLastResizeObserver();
+		const observer = resizeObserver.getLast();
 
 		unmount();
 
@@ -1000,8 +965,8 @@ describe("useDesktopConnection", () => {
 			const rfb1 = getLastRFBInstance();
 			act(() => rfb1.simulateEvent("connect"));
 
-			expect(resizeObserverInstances).toHaveLength(1);
-			const observer1 = resizeObserverInstances[0];
+			expect(resizeObserver.instances).toHaveLength(1);
+			const observer1 = resizeObserver.instances[0];
 
 			// Trigger reconnect.
 			act(() => rfb1.simulateEvent("disconnect", { clean: false }));
@@ -1011,7 +976,7 @@ describe("useDesktopConnection", () => {
 			expect(observer1.disconnect).toHaveBeenCalled();
 
 			// New observer created for the new connection.
-			expect(resizeObserverInstances).toHaveLength(2);
+			expect(resizeObserver.instances).toHaveLength(2);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -1027,7 +992,7 @@ describe("useDesktopConnection", () => {
 		const rfb1 = getLastRFBInstance();
 		act(() => rfb1.simulateEvent("connect"));
 
-		const observer1 = resizeObserverInstances[0];
+		const observer1 = resizeObserver.instances[0];
 
 		// Set nonzero previous dimensions on old observer.
 		act(() => observer1.simulateResize(800, 600));

--- a/site/src/pages/AgentsPage/hooks/useSpeechRecognition.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useSpeechRecognition.test.ts
@@ -46,6 +46,7 @@ function installMock() {
 	class Ctor extends MockSpeechRecognition {
 		constructor() {
 			super();
+			// oxlint-disable-next-line typescript/no-this-alias -- the constructor must record the created instance for the test to access.
 			lastInstance = this;
 		}
 	}

--- a/site/src/testHelpers/resizeObserver.ts
+++ b/site/src/testHelpers/resizeObserver.ts
@@ -1,0 +1,67 @@
+import { type Mock, vi } from "vitest";
+
+interface FakeResizeObserver {
+	observe: Mock;
+	unobserve: Mock;
+	disconnect: Mock;
+	/**
+	 * Invokes the observed callback with a single entry carrying the given
+	 * content-box size, simulating a resize. `height` defaults to 0 for callers
+	 * that only care about width.
+	 */
+	simulateResize: (width: number, height?: number) => void;
+}
+
+export interface ResizeObserverMock {
+	/** Every observer constructed since setup, in creation order. */
+	readonly instances: FakeResizeObserver[];
+	/** Returns the most recently constructed observer, throwing if none exist. */
+	getLast: () => FakeResizeObserver;
+}
+
+/**
+ * Installs a fake `ResizeObserver` on the global object via `vi.stubGlobal`.
+ * jsdom does not implement `ResizeObserver` with real layout, so unit tests
+ * that exercise resize-driven behavior install a controllable stub. The stub is
+ * a `vi.fn` wrapping a class (a plain function is not newable), so each
+ * constructed observer is tracked and tests can drive its callback with
+ * `simulateResize` and assert on `disconnect`.
+ *
+ * Call this inside `beforeEach` (each call starts a fresh instance list) and
+ * `vi.unstubAllGlobals()` in `afterEach` to restore the original global.
+ */
+export function setupResizeObserverMock(): ResizeObserverMock {
+	const instances: FakeResizeObserver[] = [];
+
+	class MockResizeObserver implements ResizeObserver {
+		observe = vi.fn();
+		unobserve = vi.fn();
+		disconnect = vi.fn();
+		private callback: ResizeObserverCallback;
+
+		constructor(callback: ResizeObserverCallback) {
+			this.callback = callback;
+			instances.push(this);
+		}
+
+		simulateResize = (width: number, height = 0): void => {
+			this.callback(
+				[{ contentRect: { width, height } } as ResizeObserverEntry],
+				this,
+			);
+		};
+	}
+
+	vi.stubGlobal("ResizeObserver", vi.fn(MockResizeObserver));
+
+	return {
+		instances,
+		getLast: () => {
+			const instance = instances.at(-1);
+			if (!instance) {
+				throw new Error("No ResizeObserver was constructed");
+			}
+			return instance;
+		},
+	};
+}

--- a/site/src/testHelpers/resizeObserver.ts
+++ b/site/src/testHelpers/resizeObserver.ts
@@ -1,67 +1,54 @@
-import { type Mock, vi } from "vitest";
-
-interface FakeResizeObserver {
-	observe: Mock;
-	unobserve: Mock;
-	disconnect: Mock;
-	/**
-	 * Invokes the observed callback with a single entry carrying the given
-	 * content-box size, simulating a resize. `height` defaults to 0 for callers
-	 * that only care about width.
-	 */
-	simulateResize: (width: number, height?: number) => void;
-}
-
-export interface ResizeObserverMock {
-	/** Every observer constructed since setup, in creation order. */
-	readonly instances: FakeResizeObserver[];
-	/** Returns the most recently constructed observer, throwing if none exist. */
-	getLast: () => FakeResizeObserver;
-}
+import { vi } from "vitest";
 
 /**
- * Installs a fake `ResizeObserver` on the global object via `vi.stubGlobal`.
- * jsdom does not implement `ResizeObserver` with real layout, so unit tests
- * that exercise resize-driven behavior install a controllable stub. The stub is
- * a `vi.fn` wrapping a class (a plain function is not newable), so each
- * constructed observer is tracked and tests can drive its callback with
- * `simulateResize` and assert on `disconnect`.
+ * Controllable fake `ResizeObserver` for unit tests. jsdom does not implement
+ * `ResizeObserver` with real layout, so tests that exercise resize-driven
+ * behavior install this stub and drive it directly.
  *
- * Call this inside `beforeEach` (each call starts a fresh instance list) and
- * `vi.unstubAllGlobals()` in `afterEach` to restore the original global.
+ * Each test wires it up itself: install it with
+ * `vi.stubGlobal("ResizeObserver", MockResizeObserver)` in `beforeEach` (after
+ * calling `MockResizeObserver.reset()`), and restore the real global with
+ * `vi.unstubAllGlobals()` in `afterEach`. Tests reach constructed observers via
+ * `MockResizeObserver.getLast()` / `MockResizeObserver.instances`, drive the
+ * observed callback with `simulateResize`, and assert on `disconnect`.
  */
-export function setupResizeObserverMock(): ResizeObserverMock {
-	const instances: FakeResizeObserver[] = [];
+export class MockResizeObserver implements ResizeObserver {
+	/** Every observer constructed since the last reset, in creation order. */
+	static instances: MockResizeObserver[] = [];
 
-	class MockResizeObserver implements ResizeObserver {
-		observe = vi.fn();
-		unobserve = vi.fn();
-		disconnect = vi.fn();
-		private callback: ResizeObserverCallback;
-
-		constructor(callback: ResizeObserverCallback) {
-			this.callback = callback;
-			instances.push(this);
-		}
-
-		simulateResize = (width: number, height = 0): void => {
-			this.callback(
-				[{ contentRect: { width, height } } as ResizeObserverEntry],
-				this,
-			);
-		};
+	/** Clears tracked instances; call in `beforeEach`. */
+	static reset(): void {
+		MockResizeObserver.instances = [];
 	}
 
-	vi.stubGlobal("ResizeObserver", vi.fn(MockResizeObserver));
+	/** Returns the most recently constructed observer, throwing if none exist. */
+	static getLast(): MockResizeObserver {
+		const last = MockResizeObserver.instances.at(-1);
+		if (!last) {
+			throw new Error("No ResizeObserver was constructed");
+		}
+		return last;
+	}
 
-	return {
-		instances,
-		getLast: () => {
-			const instance = instances.at(-1);
-			if (!instance) {
-				throw new Error("No ResizeObserver was constructed");
-			}
-			return instance;
-		},
+	observe = vi.fn();
+	unobserve = vi.fn();
+	disconnect = vi.fn();
+	private callback: ResizeObserverCallback;
+
+	constructor(callback: ResizeObserverCallback) {
+		this.callback = callback;
+		MockResizeObserver.instances.push(this);
+	}
+
+	/**
+	 * Invokes the observed callback with a single entry carrying the given
+	 * content-box size. `height` defaults to 0 for callers that only care about
+	 * width.
+	 */
+	simulateResize = (width: number, height = 0): void => {
+		this.callback(
+			[{ contentRect: { width, height } } as ResizeObserverEntry],
+			this,
+		);
 	};
 }


### PR DESCRIPTION
## What

Enables the `no-this-alias` oxlint rule and removes the redundant Biome equivalent (`complexity/noUselessThisAlias`), following the migration backlog workflow documented in `site/.oxlintrc.jsonc`.

## Changes

- **`site/.oxlintrc.jsonc`** — enable `no-this-alias` as `"error"` (moved out of the migration backlog into the complexity group).
- **`biome.jsonc`** — disable the now-redundant `complexity/noUselessThisAlias`.
- **`site/src/testHelpers/resizeObserver.ts`** (new) — a shared, controllable fake `ResizeObserver`. Exports a top-level `MockResizeObserver` class that tracks constructed observers via `static instances`/`getLast()`/`reset()`, drives the observed callback with `simulateResize`, and uses a real `vi.fn()` for `disconnect` assertions. The class `implements ResizeObserver`, so there are no `as unknown as` casts.
- **`useKebabMenu.test.tsx`** and **`useDesktopConnection.test.ts`** — deleted their duplicated hand-rolled `MockResizeObserver` and use the shared class. Each test owns the wiring: `MockResizeObserver.reset()` + `vi.stubGlobal("ResizeObserver", MockResizeObserver)` in `beforeEach`, and `vi.unstubAllGlobals()` in `afterEach`. This also fixes a latent issue where the desktop test never restored the global `resize-observer-polyfill`.
- **`useSpeechRecognition.test.ts`** — keeps a targeted `// oxlint-disable-next-line typescript/no-this-alias` for `lastInstance = this`, a legitimate constructor instance-tracking pattern that Biome does not flag (separate SpeechRecognition mock).

## Verification

- `pnpm run lint` (biome, oxlint, tsc, circular-deps, React compiler, knip) — clean
- `pnpm run test` — 217 files, 3448 passed, 2 skipped, 0 failed
- `biome format` on changed files — clean

<details>
<summary>Background / decision log</summary>

The two ResizeObserver test mocks were near-identical (`const self = this` + method-shorthand closures — a pre-ES2015 pattern that oxlint's stricter `no-this-alias` flags). There was no existing shared ResizeObserver test helper (only `testHelpers/matchMedia.ts` as precedent for a shared browser-API mock).

A `resize-observer-polyfill` is installed globally in `test/setup/polyfills.ts`, but it does real (async, layout-based) measurement, so it can't deterministically drive resize callbacks or be spied on. These suites therefore install controllable fakes.

The shared helper exports the mock as a plain top-level class rather than building it inside a setup function, and leaves the `vi.stubGlobal` install / `vi.unstubAllGlobals` restore to each test. Using `this` directly inside the class (rather than aliasing it) keeps `no-this-alias` satisfied without disable comments.

</details>

---
Generated by Coder Agents.
