### PR TITLE
chore(site): enable oxlint no-unused-vars rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -185,7 +185,19 @@
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
-		"no-unused-vars": "off", // correctness/noUnusedVariables + noUnusedImports (small: dead-store "used" semantics differ)
+		"no-unused-vars": [
+			"error",
+			{
+				// Match Biome's noUnusedVariables/noUnusedImports behavior.
+				// oxlint only applies its built-in "^_" var/arg defaults when the
+				// rule is configured with no options object; supplying options
+				// (needed for ignoreRestSiblings) resets them, so re-specify.
+				"ignoreRestSiblings": true,
+				"argsIgnorePattern": "^_",
+				"varsIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern": "^_"
+			}
+		],
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)

--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -82,6 +82,19 @@
 		"no-unsafe-optional-chaining": "error",
 		"no-unused-labels": "error",
 		"no-unused-private-class-members": "error",
+		"no-unused-vars": [
+			"error",
+			{
+				// Match Biome's noUnusedVariables/noUnusedImports behavior.
+				// oxlint only applies its built-in "^_" var/arg defaults when the
+				// rule is configured with no options object; supplying options
+				// (needed for ignoreRestSiblings) resets them, so re-specify.
+				"ignoreRestSiblings": true,
+				"argsIgnorePattern": "^_",
+				"varsIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern": "^_"
+			}
+		],
 		"void-dom-elements-no-children": "error",
 		"use-isnan": "error",
 		"jsx-key": "error",
@@ -185,19 +198,6 @@
 		"no-redeclare": "off", // suspicious/noRedeclare (medium: TS declaration merging)
 		"role-has-required-aria-props": "off", // a11y/useAriaPropsForRole (medium)
 		"no-irregular-whitespace": "off", // suspicious/noIrregularWhitespace (medium)
-		"no-unused-vars": [
-			"error",
-			{
-				// Match Biome's noUnusedVariables/noUnusedImports behavior.
-				// oxlint only applies its built-in "^_" var/arg defaults when the
-				// rule is configured with no options object; supplying options
-				// (needed for ignoreRestSiblings) resets them, so re-specify.
-				"ignoreRestSiblings": true,
-				"argsIgnorePattern": "^_",
-				"varsIgnorePattern": "^_",
-				"caughtErrorsIgnorePattern": "^_"
-			}
-		],
 		"no-inferrable-types": "off", // style/noInferrableTypes (medium, coder error rule)
 		"consistent-type-imports": "off", // style/useImportType (medium)
 		"jsx-curly-brace-presence": "off", // style/useConsistentCurlyBraces (medium, coder error rule)


### PR DESCRIPTION
## What

Enables the `no-unused-vars` rule in oxlint (`site/.oxlintrc.jsonc`), moving it off the migration backlog.

## Why / how

Biome's `noUnusedVariables` (with `ignoreRestSiblings: true`) + `noUnusedImports` remain the authoritative check, so oxlint is configured to match their behavior exactly and stay "nothing more" than Biome.

`ignoreRestSiblings` defaults to `false` in oxlint, so an options object is required to match Biome. However, per the [oxlint docs](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars), oxlint only applies its built-in `^_` default for `varsIgnorePattern`/`argsIgnorePattern` when the rule is configured **without** an options object; supplying options resets those to none. So the `^_` patterns are re-specified explicitly (plus `caughtErrorsIgnorePattern`, which has no `^_` default at all) to preserve parity.

Behavior verified against the current tree:

| Config | oxlint errors |
|--------|--------------|
| `"error"` (string) | 18 |
| `["error", { ignoreRestSiblings: true }]` | 50 (every `_`-prefixed var/arg) |
| `+ vars/argsIgnorePattern: "^_"` | 1 (`_error` catch param) |
| `+ caughtErrorsIgnorePattern: "^_"` | 0 |

`pnpm run lint:oxlint` is clean with the final config.

## Scope

Biome's `noUnusedImports`/`noUnusedVariables` are intentionally **left enabled** for now. The root Biome config also covers JS/TS outside `site/` (e.g. `offlinedocs/`, `scripts/`) that oxlint does not lint, so removing them there is not a clean 1:1 swap and is deferred.

---

Generated by Coder Agents on behalf of @jeremyruppel.
