### PR TITLE
refactor(site): refresh groups pages

### DIFF
--- a/site/e2e/tests/groups/createGroup.spec.ts
+++ b/site/e2e/tests/groups/createGroup.spec.ts
@@ -18,8 +18,8 @@ test("create group", async ({ page, baseURL }) => {
 	});
 	await expect(page).toHaveTitle("Groups - Coder");
 
-	await page.getByText("Create group").click();
-	await expect(page).toHaveTitle("Create Group - Coder");
+	await page.getByRole("link", { name: "New group" }).click();
+	await expect(page).toHaveTitle("New group - Coder");
 
 	const name = randomName();
 	const groupValues = {
@@ -28,8 +28,8 @@ test("create group", async ({ page, baseURL }) => {
 		avatarURL: "/emojis/1f60d.png",
 	};
 
-	await page.getByLabel("Name", { exact: true }).fill(groupValues.name);
-	await page.getByLabel("Display Name").fill(groupValues.displayName);
+	await page.getByRole("textbox", { name: /^Name/ }).fill(groupValues.name);
+	await page.getByLabel("Display name").fill(groupValues.displayName);
 	await page.getByLabel("Avatar URL").fill(groupValues.avatarURL);
 	await page.getByRole("button", { name: /save/i }).click();
 

--- a/site/e2e/tests/organizationGroups.spec.ts
+++ b/site/e2e/tests/organizationGroups.spec.ts
@@ -47,12 +47,12 @@ test("create group", async ({ page }) => {
 	await expect(page).toHaveTitle("Groups - Coder");
 
 	// Create a new group
-	await page.getByText("Create group").click();
-	await expect(page).toHaveTitle("Create Group - Coder");
+	await page.getByRole("link", { name: "New group" }).click();
+	await expect(page).toHaveTitle("New group - Coder");
 	const name = randomName();
-	await page.getByLabel("Name", { exact: true }).fill(name);
+	await page.getByRole("textbox", { name: /^Name/ }).fill(name);
 	const displayName = `Group ${name}`;
-	await page.getByLabel("Display Name").fill(displayName);
+	await page.getByLabel("Display name").fill(displayName);
 	await page.getByLabel("Avatar URL").fill("/emojis/1f60d.png");
 	await page.getByRole("button", { name: /save/i }).click();
 

--- a/site/src/pages/GroupsPage/CreateGroupPage.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPage.tsx
@@ -4,10 +4,12 @@ import { useNavigate, useParams } from "react-router";
 import { createGroup } from "#/api/queries/groups";
 import { pageTitle } from "#/utils/page";
 import { CreateGroupPageView } from "./CreateGroupPageView";
+import { useGroupsSettings } from "./GroupsPageProvider";
 
 const CreateGroupPage: FC = () => {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
+	const { showOrganizations } = useGroupsSettings();
 	const { organization } = useParams() as { organization: string };
 	const createGroupMutation = useMutation(
 		createGroup(queryClient, organization ?? "default"),
@@ -15,7 +17,7 @@ const CreateGroupPage: FC = () => {
 
 	return (
 		<>
-			<title>{pageTitle("Create Group")}</title>
+			<title>{pageTitle("New group")}</title>
 
 			<CreateGroupPageView
 				onSubmit={async (data) => {
@@ -26,8 +28,12 @@ const CreateGroupPage: FC = () => {
 							: `/deployment/groups/${newGroup.name}`,
 					);
 				}}
+				onCancel={() => {
+					navigate("..");
+				}}
 				error={createGroupMutation.error}
 				isLoading={createGroupMutation.isPending}
+				showOrganizations={showOrganizations}
 			/>
 		</>
 	);

--- a/site/src/pages/GroupsPage/CreateGroupPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPageView.stories.tsx
@@ -1,17 +1,62 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { mockApiError } from "#/testHelpers/entities";
 import { CreateGroupPageView } from "./CreateGroupPageView";
 
 const meta: Meta<typeof CreateGroupPageView> = {
 	title: "pages/OrganizationGroupsPage/CreateGroupPageView",
 	component: CreateGroupPageView,
+	args: {
+		onSubmit: fn(),
+		onCancel: fn(),
+		isLoading: false,
+		showOrganizations: true,
+	},
 };
 
 export default meta;
 type Story = StoryObj<typeof CreateGroupPageView>;
 
-export const Example: Story = {};
+export const Example: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: "New group" }),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: "Back to groups" }),
+		).toBeVisible();
+		await expect(canvas.getByRole("textbox", { name: /^Name/ })).toBeRequired();
+		await expect(canvas.getByText("Unique identifier.")).toBeVisible();
+		await expect(
+			canvas.getByText("Friendly name. Defaults to the name if blank."),
+		).toBeVisible();
+		await expect(canvas.getByRole("button", { name: "Save" })).toBeVisible();
+		await expect(
+			canvas.getByText(/Add a group to this organization/),
+		).toBeVisible();
+	},
+};
+
+export const WithoutOrganizations: Story = {
+	args: {
+		showOrganizations: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText(/Add a group to this deployment/),
+		).toBeVisible();
+	},
+};
+
+export const Cancel: Story = {
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Cancel" }));
+		await expect(args.onCancel).toHaveBeenCalled();
+	},
+};
 
 export const WithError: Story = {
 	args: {
@@ -24,7 +69,7 @@ export const WithError: Story = {
 		const canvas = within(canvasElement);
 
 		await step("Enter name", async () => {
-			const input = canvas.getByLabelText("Name");
+			const input = canvas.getByRole("textbox", { name: /^Name/ });
 			await userEvent.type(input, "new-group");
 			input.blur();
 		});
@@ -35,7 +80,7 @@ export const InvalidName: Story = {
 	play: async ({ canvasElement }) => {
 		const user = userEvent.setup();
 		const body = within(canvasElement.ownerDocument.body);
-		const input = await body.findByLabelText("Name");
+		const input = await body.findByRole("textbox", { name: /^Name/ });
 		await user.type(input, "$om3 !nv@lid Name");
 		input.blur();
 	},

--- a/site/src/pages/GroupsPage/CreateGroupPageView.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPageView.tsx
@@ -1,14 +1,20 @@
 import { useFormik } from "formik";
+import { ArrowLeftIcon } from "lucide-react";
 import type { FC } from "react";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 import * as Yup from "yup";
 import { isApiValidationError } from "#/api/errors";
 import type { CreateGroupRequest } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
+import { FormFields, FormFooter } from "#/components/Form/Form";
+import { FormField } from "#/components/FormField/FormField";
 import { IconField } from "#/components/IconField/IconField";
-import { Input } from "#/components/Input/Input";
-import { Label } from "#/components/Label/Label";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
 import { Spinner } from "#/components/Spinner/Spinner";
 import {
 	getFormHelpers,
@@ -22,16 +28,19 @@ const validationSchema = Yup.object({
 
 type CreateGroupPageViewProps = {
 	onSubmit: (data: CreateGroupRequest) => void;
+	onCancel: () => void;
 	error?: unknown;
 	isLoading: boolean;
+	showOrganizations: boolean;
 };
 
 export const CreateGroupPageView: FC<CreateGroupPageViewProps> = ({
 	onSubmit,
+	onCancel,
 	error,
 	isLoading,
+	showOrganizations,
 }) => {
-	const navigate = useNavigate();
 	const form = useFormik<CreateGroupRequest>({
 		initialValues: {
 			name: "",
@@ -43,85 +52,51 @@ export const CreateGroupPageView: FC<CreateGroupPageViewProps> = ({
 		onSubmit,
 	});
 	const getFieldHelpers = getFormHelpers<CreateGroupRequest>(form, error);
-	const onCancel = () => navigate(-1);
-	const nameField = getFieldHelpers("name");
-	const displayNameField = getFieldHelpers("display_name", {
-		helperText: "Keep empty to default to the name.",
-	});
 
 	return (
-		<div className="flex flex-col items-start w-full max-w-xl">
-			<div className="flex flex-row items-start pb-6">
-				<h1 className="m-0 flex items-center gap-2 text-3xl font-semibold leading-tight">
-					New Group
-				</h1>
-			</div>
+		<>
+			<Button variant="subtle" asChild className="-ml-3">
+				<Link to="..">
+					<ArrowLeftIcon />
+					<span>Back to groups</span>
+				</Link>
+			</Button>
 
-			<form
-				className="flex flex-col w-full max-w-xl  gap-10 rounded-lg border border-solid border-border-default p-6"
-				onSubmit={form.handleSubmit}
-			>
-				<section className="flex flex-col gap-4">
-					<div className="flex flex-col gap-2">
-						<h2 className="text-xl font-medium text-content-primary m-0">
-							Group settings
-						</h2>
-						<p className="text-sm leading-relaxed text-content-secondary m-0">
-							Set a name and avatar for this group.
-						</p>
-					</div>
-					<div className="flex flex-col gap-6">
-						{Boolean(error) && !isApiValidationError(error) && (
-							<ErrorAlert error={error} />
-						)}
+			<div className="pt-6">
+				<SettingsHeader>
+					<SettingsHeaderTitle>New group</SettingsHeaderTitle>
+					<SettingsHeaderDescription>
+						Add a group to this{" "}
+						{showOrganizations ? "organization" : "deployment"}.
+					</SettingsHeaderDescription>
+				</SettingsHeader>
 
-						<div className="flex flex-col items-start gap-2">
-							<Label htmlFor={nameField.id}>Name</Label>
-							<Input
-								id={nameField.id}
-								name={nameField.name}
-								value={nameField.value}
-								onChange={onChangeTrimmed(form)}
-								onBlur={nameField.onBlur}
-								autoFocus
-								autoComplete="name"
-								aria-invalid={nameField.error}
-							/>
-							{nameField.helperText && (
-								<span
-									className={`text-xs text-left ${
-										nameField.error
-											? "text-content-destructive"
-											: "text-content-secondary"
-									}`}
-								>
-									{nameField.helperText}
-								</span>
-							)}
-						</div>
-						<div className="flex flex-col items-start gap-2">
-							<Label htmlFor={displayNameField.id}>Display Name</Label>
-							<Input
-								id={displayNameField.id}
-								name={displayNameField.name}
-								value={displayNameField.value}
-								onChange={displayNameField.onChange}
-								onBlur={displayNameField.onBlur}
-								autoComplete="display_name"
-								aria-invalid={displayNameField.error}
-							/>
-							{displayNameField.helperText && (
-								<span
-									className={`text-xs text-left ${
-										displayNameField.error
-											? "text-content-destructive"
-											: "text-content-secondary"
-									}`}
-								>
-									{displayNameField.helperText}
-								</span>
-							)}
-						</div>
+				<form
+					className="flex flex-col gap-6 border border-solid p-6 rounded-lg"
+					onSubmit={form.handleSubmit}
+				>
+					{Boolean(error) && !isApiValidationError(error) && (
+						<ErrorAlert error={error} />
+					)}
+
+					<FormFields>
+						<FormField
+							field={getFieldHelpers("name", {
+								helperText: "Unique identifier.",
+							})}
+							label="Name"
+							onChange={onChangeTrimmed(form)}
+							autoFocus
+							autoComplete="name"
+							required
+						/>
+						<FormField
+							field={getFieldHelpers("display_name", {
+								helperText: "Friendly name. Defaults to the name if blank.",
+							})}
+							label="Display name"
+							autoComplete="display_name"
+						/>
 						<IconField
 							{...getFieldHelpers("avatar_url")}
 							onChange={onChangeTrimmed(form)}
@@ -129,19 +104,19 @@ export const CreateGroupPageView: FC<CreateGroupPageViewProps> = ({
 							label="Avatar URL"
 							onPickEmoji={(value) => form.setFieldValue("avatar_url", value)}
 						/>
-					</div>
-				</section>
+					</FormFields>
 
-				<footer className="flex items-center justify-end space-x-2">
-					<Button onClick={onCancel} variant="outline">
-						Cancel
-					</Button>
-					<Button type="submit" disabled={isLoading}>
-						<Spinner loading={isLoading} />
-						Create group
-					</Button>
-				</footer>
-			</form>
-		</div>
+					<FormFooter className="mt-0">
+						<Button type="button" onClick={onCancel} variant="outline">
+							Cancel
+						</Button>
+						<Button type="submit" disabled={isLoading}>
+							<Spinner loading={isLoading} />
+							Save
+						</Button>
+					</FormFooter>
+				</form>
+			</div>
+		</>
 	);
 };

--- a/site/src/pages/GroupsPage/GroupPage.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.stories.tsx
@@ -211,7 +211,10 @@ export const NoUpdatePermission: Story = {
 		const canvas = within(canvasElement);
 		await expect(
 			await canvas.findByRole("link", { name: "Back to groups" }),
-		).toBeVisible();
+		).toHaveAttribute(
+			"href",
+			`/organizations/${MockDefaultOrganization.name}/groups`,
+		);
 		expect(
 			canvas.queryByRole("button", { name: "Add users" }),
 		).not.toBeInTheDocument();
@@ -253,6 +256,15 @@ export const SettingsWithoutUpdatePermission: Story = {
 		).toBeInTheDocument();
 		// The editable budget/name form is never rendered.
 		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("link", {
+				name: "Back to groups",
+				hidden: true,
+			}),
+		).toHaveAttribute(
+			"href",
+			`/organizations/${MockDefaultOrganization.name}/groups`,
+		);
 		expect(
 			canvas.queryByRole("button", { name: "Save" }),
 		).not.toBeInTheDocument();

--- a/site/src/pages/GroupsPage/GroupPage.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.stories.tsx
@@ -207,6 +207,15 @@ export const NoUpdatePermission: Story = {
 			permissionsQuery({ canUpdateGroup: false }),
 		],
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("link", { name: "Back to groups" }),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("button", { name: "Add users" }),
+		).not.toBeInTheDocument();
+	},
 };
 
 /**

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -126,10 +126,7 @@ const GroupPage: FC = () => {
 
 			<div className="flex justify-between items-center">
 				<Button variant="subtle" asChild className="-ml-3">
-					<Link
-						to={activeTab === "settings" ? "../.." : ".."}
-						relative="path"
-					>
+					<Link to={activeTab === "settings" ? "../.." : ".."} relative="path">
 						<ArrowLeftIcon />
 						<span>Back to groups</span>
 					</Link>

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -126,7 +126,10 @@ const GroupPage: FC = () => {
 
 			<div className="flex justify-between items-center">
 				<Button variant="subtle" asChild className="-ml-3">
-					<Link to={activeTab === "settings" ? "../.." : ".."}>
+					<Link
+						to={activeTab === "settings" ? "../.." : ".."}
+						relative="path"
+					>
 						<ArrowLeftIcon />
 						<span>Back to groups</span>
 					</Link>
@@ -152,7 +155,7 @@ const GroupPage: FC = () => {
 							}}
 						>
 							<TrashIcon />
-							Delete&hellip;
+							Delete
 						</Button>
 					</div>
 				)}

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -1,7 +1,8 @@
-import { TrashIcon, UserPlusIcon } from "lucide-react";
+import { ArrowLeftIcon, TrashIcon, UserPlusIcon } from "lucide-react";
 import { type ComponentProps, type FC, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
+	Link,
 	Outlet,
 	useLocation,
 	useNavigate,
@@ -24,7 +25,6 @@ import type {
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Button } from "#/components/Button/Button";
 import { DeleteDialog } from "#/components/Dialog/DeleteDialog/DeleteDialog";
 import {
@@ -38,11 +38,7 @@ import type { UsersFilter } from "#/components/Filter/UsersFilter";
 import { Loader } from "#/components/Loader/Loader";
 import { MultiMemberSelect } from "#/components/MultiUserSelect/MultiUserSelect";
 import type { PaginationResult } from "#/components/PaginationWidget/PaginationContainer";
-import {
-	SettingsHeader,
-	SettingsHeaderDescription,
-	SettingsHeaderTitle,
-} from "#/components/SettingsHeader/SettingsHeader";
+import { SettingsHeaderTitle } from "#/components/SettingsHeader/SettingsHeader";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { LinkTabs, LinkTabsList, TabLink } from "#/components/Tabs/Tabs";
 import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
@@ -128,54 +124,57 @@ const GroupPage: FC = () => {
 		<>
 			{title}
 
-			<SettingsHeader
-				actions={
-					canUpdateGroup && (
-						<div className="flex items-center gap-2">
-							{!isEveryoneGroup(groupData) && (
-								<AddUsersDialog
-									organizationId={groupData.organization_id}
-									onSubmit={async (users) => {
-										await addMembersMutation.mutateAsync({
-											groupId: groupData.id,
-											userIds: users.map((u) => u.user_id),
-										});
-									}}
-								/>
-							)}
-							<Button
-								variant="destructive"
-								disabled={groupData.id === groupData.organization_id}
-								onClick={() => {
-									setIsDeletingGroup(true);
+			<div className="flex justify-between items-center">
+				<Button variant="subtle" asChild className="-ml-3">
+					<Link to={activeTab === "settings" ? "../.." : ".."}>
+						<ArrowLeftIcon />
+						<span>Back to groups</span>
+					</Link>
+				</Button>
+				{canUpdateGroup && (
+					<div className="flex items-center gap-2">
+						{!isEveryoneGroup(groupData) && (
+							<AddUsersDialog
+								organizationId={groupData.organization_id}
+								onSubmit={async (users) => {
+									await addMembersMutation.mutateAsync({
+										groupId: groupData.id,
+										userIds: users.map((u) => u.user_id),
+									});
 								}}
-							>
-								<TrashIcon />
-								Delete&hellip;
-							</Button>
-						</div>
-					)
-				}
-			>
-				<AvatarData
-					avatar={
-						<Avatar
-							src={groupData.avatar_url}
-							fallback={groupData.display_name || groupData.name}
-							size="lg"
-						/>
-					}
-					title={
-						<SettingsHeaderTitle>
+							/>
+						)}
+						<Button
+							variant="destructive"
+							disabled={groupData.id === groupData.organization_id}
+							onClick={() => {
+								setIsDeletingGroup(true);
+							}}
+						>
+							<TrashIcon />
+							Delete&hellip;
+						</Button>
+					</div>
+				)}
+			</div>
+
+			<div className="flex flex-col gap-6 pt-6">
+				<div className="flex items-center gap-4 min-w-0">
+					<Avatar
+						src={groupData.avatar_url}
+						fallback={groupData.display_name || groupData.name}
+						size="lg"
+					/>
+					<SettingsHeaderTitle>
+						<span className="block min-w-0 truncate">
 							{groupData.display_name || groupData.name || "Unknown Group"}
-						</SettingsHeaderTitle>
-					}
-				/>
-				<SettingsHeaderDescription>
+						</span>
+					</SettingsHeaderTitle>
+				</div>
+				<p className="text-sm text-content-secondary m-0">
 					Manage members for this group.
-				</SettingsHeaderDescription>
-			</SettingsHeader>
-			<div className="flex flex-col gap-10 w-full">
+				</p>
+
 				{canUpdateGroup && (
 					<LinkTabs
 						active={activeTab}

--- a/site/src/pages/GroupsPage/GroupSettingsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPage.tsx
@@ -63,7 +63,6 @@ const GroupSettingsPage: FC = () => {
 
 	return (
 		<GroupSettingsPageView
-			onCancel={() => navigate("..")}
 			onSubmit={async (data) => {
 				const { monthly_budget_per_member, ...groupFields } = data;
 				try {

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
@@ -26,6 +26,12 @@ export const Default: Story = {
 		const canvas = within(canvasElement);
 		// Without the aibridge feature, the AI budget section is hidden.
 		await expect(canvas.queryByText("AI budget")).not.toBeInTheDocument();
+		await expect(canvas.getByRole("textbox", { name: /^Name/ })).toBeVisible();
+		await expect(canvas.getByText("*")).toBeVisible();
+		await expect(canvas.getByText("Unique identifier.")).toBeVisible();
+		await expect(
+			canvas.getByText("Friendly name. Defaults to the name if blank."),
+		).toBeVisible();
 	},
 };
 
@@ -47,7 +53,7 @@ export const WithAIBudget: Story = {
 		);
 		await expect(
 			canvas.getByRole("link", {
-				name: /learn how budgets apply across groups/i,
+				name: /view docs/i,
 			}),
 		).toBeInTheDocument();
 	},
@@ -71,7 +77,7 @@ export const AIBudgetUncapped: Story = {
 		).toBeInTheDocument();
 		await expect(
 			canvas.getByRole("link", {
-				name: /learn how budgets apply across groups/i,
+				name: /view docs/i,
 			}),
 		).toHaveAttribute(
 			"href",

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof GroupSettingsPageView> = {
 	title: "pages/OrganizationGroupsPage/GroupSettingsPageView",
 	component: GroupSettingsPageView,
 	args: {
-		onCancel: fn(),
 		onSubmit: fn(),
 		group: MockGroup,
 		showAISettings: false,

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -55,7 +55,7 @@ const BudgetDocsLink: FC = () => (
 		// wraps to its own line under the helper text.
 		className="pl-0"
 	>
-		Learn how budgets apply across groups
+		View docs
 	</Link>
 );
 
@@ -166,9 +166,11 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 		onSubmit,
 	});
 	const getFieldHelpers = getFormHelpers<FormData>(form, errors);
-	const nameField = getFieldHelpers("name");
+	const nameField = getFieldHelpers("name", {
+		helperText: "Unique identifier.",
+	});
 	const displayNameField = getFieldHelpers("display_name", {
-		helperText: "Keep empty to default to the name.",
+		helperText: "Friendly name. Defaults to the name if blank.",
 	});
 	const quotaField = getFieldHelpers("quota_allowance", {
 		helperText: `This group gives ${form.values.quota_allowance} quota credits to each
@@ -177,8 +179,8 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 	const budgetField = getFieldHelpers("monthly_budget_per_member");
 
 	return (
-		<form className="flex flex-col gap-10 pb-8" onSubmit={form.handleSubmit}>
-			<section className="flex flex-col gap-4 max-w-md">
+		<form className="flex flex-col gap-6" onSubmit={form.handleSubmit}>
+			<section className="flex flex-col gap-4">
 				<div className="flex flex-col gap-2">
 					<h2 className="text-xl font-semibold text-content-primary m-0">
 						General
@@ -186,7 +188,12 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 				</div>
 				<div className="flex flex-col gap-6">
 					<div className="flex flex-col items-start gap-2">
-						<Label htmlFor={nameField.id}>Name</Label>
+						<Label htmlFor={nameField.id}>
+							Name{" "}
+							<span className="text-xs font-bold text-content-destructive">
+								*
+							</span>
+						</Label>
 						<Input
 							id={nameField.id}
 							name={nameField.name}
@@ -249,7 +256,7 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 			</section>
 
 			{showAISettings && (
-				<section className="flex flex-col gap-8 max-w-md">
+				<section className="flex flex-col gap-4">
 					<h2 className="m-0 text-xl font-semibold text-content-primary">
 						AI budget
 					</h2>
@@ -287,7 +294,7 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 				</section>
 			)}
 
-			<section className="flex flex-col gap-8">
+			<section className="flex flex-col gap-4">
 				<div className="flex flex-col gap-2">
 					<h2 className="text-xl font-semibold text-content-primary m-0">
 						Quotas
@@ -324,11 +331,7 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 				</div>
 			</section>
 
-			<footer className="flex items-center justify-start space-x-2">
-				<Button onClick={onCancel} variant="outline">
-					Cancel
-				</Button>
-
+			<footer className="flex items-center justify-end space-x-2">
 				<Button type="submit" disabled={isLoading}>
 					<Spinner loading={isLoading} />
 					Save

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.tsx
@@ -140,7 +140,6 @@ interface UpdateGroupFormProps {
 	initialBudgetDollars: number | null;
 	errors: unknown;
 	onSubmit: (data: FormData) => void;
-	onCancel: () => void;
 	isLoading: boolean;
 }
 
@@ -150,7 +149,6 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 	initialBudgetDollars,
 	errors,
 	onSubmit,
-	onCancel,
 	isLoading,
 }) => {
 	const form = useFormik<FormData>({
@@ -342,7 +340,6 @@ const UpdateGroupForm: FC<UpdateGroupFormProps> = ({
 };
 
 type SettingsGroupPageViewProps = {
-	onCancel: () => void;
 	onSubmit: (data: FormData) => void;
 	group: Group;
 	showAISettings: boolean;
@@ -352,7 +349,6 @@ type SettingsGroupPageViewProps = {
 };
 
 const GroupSettingsPageView: FC<SettingsGroupPageViewProps> = ({
-	onCancel,
 	onSubmit,
 	group,
 	showAISettings,
@@ -365,7 +361,6 @@ const GroupSettingsPageView: FC<SettingsGroupPageViewProps> = ({
 			group={group}
 			showAISettings={showAISettings}
 			initialBudgetDollars={initialBudgetDollars}
-			onCancel={onCancel}
 			errors={formErrors}
 			isLoading={isUpdating}
 			onSubmit={onSubmit}

--- a/site/src/pages/GroupsPage/GroupsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.tsx
@@ -11,17 +11,10 @@ import { organizationsPermissions } from "#/api/queries/organizations";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { useFilter } from "#/components/Filter/Filter";
 import { Loader } from "#/components/Loader/Loader";
-import {
-	SettingsHeader,
-	SettingsHeaderDescription,
-	SettingsHeaderDocsLink,
-	SettingsHeaderTitle,
-} from "#/components/SettingsHeader/SettingsHeader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
-import { docs } from "#/utils/docs";
 import { pageTitle } from "#/utils/page";
 import { useGroupsSettings } from "./GroupsPageProvider";
 import { GroupsPageView, joinGroupsSpend } from "./GroupsPageView";
@@ -113,20 +106,12 @@ const GroupsPage: FC = () => {
 		<div className="w-full max-w-(--breakpoint-2xl) pb-10">
 			{title}
 
-			<SettingsHeader>
-				<SettingsHeaderTitle>Groups</SettingsHeaderTitle>
-				<SettingsHeaderDescription>
-					Manage groups for this{" "}
-					{showOrganizations ? "organization" : "deployment"}.{" "}
-					<SettingsHeaderDocsLink href={docs("/admin/users/groups-roles")} />
-				</SettingsHeaderDescription>
-			</SettingsHeader>
-
 			<GroupsPageView
 				groups={groupsWithSpend}
 				spendError={groupsSpendQuery.isError}
 				canCreateGroup={permissions.createGroup}
 				groupsEnabled={groupsEnabled}
+				showOrganizations={showOrganizations}
 				showAIBudget={aibridgeVisible}
 				filterProps={{ filter }}
 				groupsQuery={groupsQuery}

--- a/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
@@ -29,6 +29,8 @@ const meta: Meta<typeof GroupsPageView> = {
 	args: {
 		canCreateGroup: true,
 		groupsEnabled: true,
+		showOrganizations: true,
+		spendError: false,
 		filterProps: getDefaultFilterProps<FilterProps>({
 			values: {},
 			menus: {},
@@ -112,6 +114,14 @@ export const WithGroups: Story = {
 	},
 	parameters: {
 		queries: [seedAvatars(MockGroup.name, [MockUserOwner, MockUserMember], 2)],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("heading", { name: "Groups" })).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: /view docs/i }),
+		).toBeVisible();
+		expect(canvas.getAllByRole("link", { name: "New group" })).toHaveLength(1);
 	},
 };
 
@@ -366,11 +376,28 @@ export const EmptyGroup: Story = {
 		groups: [],
 		canCreateGroup: false,
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("heading", { name: "Groups" })).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: /view docs/i }),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("link", { name: "New group" }),
+		).not.toBeInTheDocument();
+	},
 };
 
 export const EmptyGroupWithPermission: Story = {
 	args: {
 		groups: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("heading", { name: "Groups" })).toBeVisible();
+		expect(
+			canvas.getAllByRole("link", { name: "New group" }).length,
+		).toBeGreaterThanOrEqual(2);
 	},
 };
 

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -19,6 +19,12 @@ import { EmptyState } from "#/components/EmptyState/EmptyState";
 import type { useFilter } from "#/components/Filter/Filter";
 import { GroupsFilter } from "#/components/Filter/GroupsFilter";
 import { PaginationContainer } from "#/components/PaginationWidget/PaginationContainer";
+import {
+	SettingsHeader,
+	SettingsHeaderDescription,
+	SettingsHeaderDocsLink,
+	SettingsHeaderTitle,
+} from "#/components/SettingsHeader/SettingsHeader";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
 import {
 	Table,
@@ -38,6 +44,7 @@ import type { PaginationResultInfo } from "#/hooks/usePaginatedQuery";
 import { AIBudgetUsage } from "#/modules/groups/AIBudgetUsage";
 import { PremiumPaywall } from "#/modules/paywall/PremiumPaywall";
 import type { Permissions } from "#/modules/permissions";
+import { docs } from "#/utils/docs";
 import { SpendEstimateDocsLink } from "./AICostControl";
 import { StatusIconTooltip } from "./StatusIconTooltip";
 
@@ -73,6 +80,7 @@ type GroupsPageViewProps = {
 	spendError: boolean;
 	canCreateGroup: boolean;
 	groupsEnabled: boolean;
+	showOrganizations: boolean;
 	showAIBudget: boolean;
 	filterProps: { filter: ReturnType<typeof useFilter> };
 	groupsQuery: PaginationResultInfo & {
@@ -86,86 +94,98 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 	spendError,
 	canCreateGroup,
 	groupsEnabled,
+	showOrganizations,
 	showAIBudget,
 	filterProps,
 	groupsQuery,
 	permissions,
 }) => {
-	if (!groupsEnabled) {
-		return (
-			<PremiumPaywall
-				source="groups"
-				message="Groups"
-				description="Run isolated business units on one deployment, each with its own users, templates, provisioners, and infrastructure."
-				features={[
-					"Isolate provisioners & infrastructure",
-					"Sync org membership from your IdP",
-					"Manage orgs at scale via Terraform",
-				]}
-				canViewPremium={permissions.viewAllLicenses}
-			/>
-		);
-	}
-
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="flex flex-row justify-between">
-				<GroupsFilter {...filterProps} />
-				{canCreateGroup && (
-					<Button asChild>
-						<RouterLink to="create">
-							<PlusIcon className="size-icon-sm" />
-							Create group
-						</RouterLink>
-					</Button>
-				)}
-			</div>
+		<>
+			<SettingsHeader
+				actions={
+					groupsEnabled &&
+					canCreateGroup && (
+						<Button asChild>
+							<RouterLink to="create">
+								<PlusIcon />
+								New group
+							</RouterLink>
+						</Button>
+					)
+				}
+			>
+				<SettingsHeaderTitle>Groups</SettingsHeaderTitle>
+				<SettingsHeaderDescription>
+					Manage groups for this{" "}
+					{showOrganizations ? "organization" : "deployment"}.{" "}
+					<SettingsHeaderDocsLink href={docs("/admin/users/groups-roles")} />
+				</SettingsHeaderDescription>
+			</SettingsHeader>
 
-			<PaginationContainer query={groupsQuery} paginationUnitLabel="groups">
-				<Table aria-label="Groups">
-					<TableHeader>
-						<TableRow>
-							<TableHead className="w-2/5">Name</TableHead>
-							<TableHead className={showAIBudget ? "w-1/5" : "w-3/5"}>
-								Users
-							</TableHead>
-							{showAIBudget && (
-								<TableHead className="w-2/5">
-									<div className="flex items-center gap-1">
-										AI spend
-										{spendError ? (
-											<StatusIconTooltip
-												kind="warning"
-												message="AI spend couldn't be loaded, so budgets aren't shown."
-											/>
-										) : (
-											<StatusIconTooltip
-												message={
-													<>
-														Approximate AI spend compared to the group's AI
-														budget for the active period.{" "}
-														<SpendEstimateDocsLink />
-													</>
-												}
-											/>
-										)}
-									</div>
-								</TableHead>
-							)}
-							<TableHead className="w-auto" />
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						<GroupsTableBody
-							groups={groups}
-							canCreateGroup={canCreateGroup}
-							showAIBudget={showAIBudget}
-							filterUsed={filterProps.filter.used}
-						/>
-					</TableBody>
-				</Table>
-			</PaginationContainer>
-		</div>
+			{!groupsEnabled ? (
+				<PremiumPaywall
+					source="groups"
+					message="Groups"
+					description="Run isolated business units on one deployment, each with its own users, templates, provisioners, and infrastructure."
+					features={[
+						"Isolate provisioners & infrastructure",
+						"Sync org membership from your IdP",
+						"Manage orgs at scale via Terraform",
+					]}
+					canViewPremium={permissions.viewAllLicenses}
+				/>
+			) : (
+				<div className="flex flex-col gap-4">
+					<GroupsFilter {...filterProps} />
+
+					<PaginationContainer query={groupsQuery} paginationUnitLabel="groups">
+						<Table aria-label="Groups">
+							<TableHeader>
+								<TableRow>
+									<TableHead className="w-2/5">Name</TableHead>
+									<TableHead className={showAIBudget ? "w-1/5" : "w-3/5"}>
+										Users
+									</TableHead>
+									{showAIBudget && (
+										<TableHead className="w-2/5">
+											<div className="flex items-center gap-1">
+												AI spend
+												{spendError ? (
+													<StatusIconTooltip
+														kind="warning"
+														message="AI spend couldn't be loaded, so budgets aren't shown."
+													/>
+												) : (
+													<StatusIconTooltip
+														message={
+															<>
+																Approximate AI spend compared to the group's AI
+																budget for the active period.{" "}
+																<SpendEstimateDocsLink />
+															</>
+														}
+													/>
+												)}
+											</div>
+										</TableHead>
+									)}
+									<TableHead className="w-auto" />
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								<GroupsTableBody
+									groups={groups}
+									canCreateGroup={canCreateGroup}
+									showAIBudget={showAIBudget}
+									filterUsed={filterProps.filter.used}
+								/>
+							</TableBody>
+						</Table>
+					</PaginationContainer>
+				</div>
+			)}
+		</>
 	);
 };
 
@@ -212,8 +232,8 @@ const GroupsTableBody: FC<GroupsTableBodyProps> = ({
 					canCreateGroup && (
 						<Button asChild>
 							<RouterLink to="create">
-								<PlusIcon className="size-icon-sm" />
-								Create group
+								<PlusIcon />
+								New group
 							</RouterLink>
 						</Button>
 					)


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Refreshes the groups experience so the list, creation flow, group detail, and settings pages share a cleaner and more consistent settings-page layout.

- Moves the primary `New group` action into the groups page header.
- Reworks group creation around the shared form and settings-header components.
- Adds clearer field guidance, required-state treatment, and organization/deployment-aware copy.
- Adds consistent `Back to groups` navigation across creation and detail views.
- Simplifies the group header and aligns member/settings actions with the surrounding UI.
- Tightens settings form spacing and standardizes action placement and labels.

| Old | New |
| --- | --- |
| <img width="1440" height="900" alt="groups-list-old" src="https://github.com/user-attachments/assets/08d0b08c-fd50-4c39-9f4f-e3449977eded" /> | <img width="1440" height="900" alt="groups-list-new" src="https://github.com/user-attachments/assets/20e80312-e95a-4518-94b8-59f31069c05d" /> |
| <img width="1440" height="900" alt="group-create-empty-old" src="https://github.com/user-attachments/assets/e1663f88-649d-4cf8-829b-ce1baf4db644" /> | <img width="1440" height="900" alt="group-create-empty-new" src="https://github.com/user-attachments/assets/a4eefb54-0374-4ba2-b7e8-9ed47f67cac2" /> |
| <img width="1440" height="900" alt="group-create-filled-old" src="https://github.com/user-attachments/assets/e4eccfe9-ec33-4d18-887d-3db4e92e42b3" /> | <img width="1440" height="900" alt="group-create-filled-new" src="https://github.com/user-attachments/assets/efecbd1e-0a7b-4882-a0dc-a60145037ea7" /> |
| <img width="1440" height="900" alt="group-detail-old" src="https://github.com/user-attachments/assets/27942e92-bc1e-44dc-adc6-49767e7145e7" /> | <img width="1440" height="900" alt="group-detail-new" src="https://github.com/user-attachments/assets/8256b101-b2f3-411a-8284-f936a44855ff" /> |
| <img width="1440" height="900" alt="group-settings-old" src="https://github.com/user-attachments/assets/4e2bc716-448e-4664-8a5c-95c81ab6e292" /> | <img width="1440" height="900" alt="group-settings-new" src="https://github.com/user-attachments/assets/b347853a-d797-4840-96f6-05afafe04685" /> |

