### PR TITLE
fix(site): remove rounded avatars on groups avatar loading

### DIFF
--- a/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
@@ -150,7 +150,6 @@ export const WithMemberAvatars: Story = {
 	},
 };
 
-// Member avatars still loading: the Users column shows avatar placeholders.
 export const WithMemberAvatarsLoading: Story = {
 	args: {
 		groups: [

--- a/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
@@ -167,12 +167,6 @@ export const WithMemberAvatarsLoading: Story = {
 			() => new Promise(() => {}),
 		);
 	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await expect(canvas.getByText("Members loading")).toBeVisible();
-		await expect(canvas.getByText("3 members")).toBeVisible();
-		expect(canvas.queryByText(MockUserOwner.username)).not.toBeInTheDocument();
-	},
 };
 
 const totalRecords = 15;

--- a/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
-import { expect, within } from "storybook/test";
+import { expect, spyOn, within } from "storybook/test";
+import { API } from "#/api/api";
 import {
 	GROUP_MEMBER_AVATAR_LIMIT,
 	getGroupMemberAvatarsQueryKey,
@@ -146,6 +147,32 @@ export const WithMemberAvatars: Story = {
 		const canvas = within(canvasElement);
 		await expect(await canvas.findByText("+3")).toBeInTheDocument();
 		await expect(canvas.getByText("8 members")).toBeInTheDocument();
+	},
+};
+
+// Member avatars still loading: the Users column shows avatar placeholders.
+export const WithMemberAvatarsLoading: Story = {
+	args: {
+		groups: [
+			{
+				...mockGroupWithSpend,
+				id: "members-loading",
+				name: "members-loading",
+				display_name: "Members loading",
+				total_member_count: 3,
+			},
+		],
+	},
+	beforeEach: () => {
+		spyOn(API, "getGroupMembers").mockImplementation(
+			() => new Promise(() => {}),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Members loading")).toBeVisible();
+		await expect(canvas.getByText("3 members")).toBeVisible();
+		expect(canvas.queryByText(MockUserOwner.username)).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -281,11 +281,7 @@ const GroupRow: FC<GroupRowProps> = ({ group, showAIBudget }) => {
 				) : membersQuery.isLoading ? (
 					<div className="flex items-center gap-2">
 						{AVATAR_SKELETON_KEYS.slice(0, skeletonCount).map((key) => (
-							<Skeleton
-								key={key}
-								variant="circular"
-								className="size-(--avatar-default)"
-							/>
+							<Skeleton key={key} className="size-(--avatar-default)" />
 						))}
 					</div>
 				) : (


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

Removes the circular styling from group member avatar skeletons so the loading state matches the final avatar shape.

This appears to be a small leftover from the MUI migration, spotted while refactoring groups.

| Before | After |
| --- | --- |
| <img width="1141" height="131" alt="Circular avatar skeletons before this change" src="https://github.com/user-attachments/assets/4e7fcdbd-5ce2-41f5-b76d-4e2b40c19c82" /> | <img width="1141" height="130" alt="Square avatar skeletons after this change" src="https://github.com/user-attachments/assets/af036bcb-1a1d-40b4-8a0d-4bfea32a5314" /> |