### PR TITLE
feat: highlight missed required Template Builder fields

### DIFF
--- a/site/src/components/FormField/FormField.stories.tsx
+++ b/site/src/components/FormField/FormField.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useFormik } from "formik";
 import type { FC } from "react";
-import { expect, within } from "storybook/test";
+import { expect, waitFor, within } from "storybook/test";
 import { FormField } from "./FormField";
+import { HasReachedBottomProvider } from "./HasReachedBottomContext";
 
 interface ExampleFormFieldProps {
 	id?: string;
@@ -12,6 +13,7 @@ interface ExampleFormFieldProps {
 	required?: boolean;
 	error?: string;
 	value?: string;
+	markInvalidWhenScrolledPastEmpty?: boolean;
 }
 
 const ExampleFormField: FC<ExampleFormFieldProps> = ({
@@ -22,6 +24,7 @@ const ExampleFormField: FC<ExampleFormFieldProps> = ({
 	required,
 	error,
 	value = "",
+	markInvalidWhenScrolledPastEmpty,
 }) => {
 	const form = useFormik({
 		initialValues: { value },
@@ -43,6 +46,7 @@ const ExampleFormField: FC<ExampleFormFieldProps> = ({
 			label={label}
 			description={description}
 			required={required}
+			markInvalidWhenScrolledPastEmpty={markInvalidWhenScrolledPastEmpty}
 		/>
 	);
 };
@@ -156,5 +160,48 @@ export const RequiredWithDescription: Story = {
 			"aria-describedby",
 			"story-field-description",
 		);
+	},
+};
+
+// The short story content means the HasReachedBottomProvider marks the page as
+// scrolled to the bottom on mount, so an empty required field opted into
+// markInvalidWhenScrolledPastEmpty flips to aria-invalid.
+export const RequiredMissHighlightedAtBottom: Story = {
+	args: {
+		required: true,
+		markInvalidWhenScrolledPastEmpty: true,
+	},
+	decorators: [
+		(Story) => (
+			<HasReachedBottomProvider>
+				<Story />
+			</HasReachedBottomProvider>
+		),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const input = canvas.getByRole("textbox", { name: /Provider name/ });
+		await waitFor(() => expect(input).toHaveAttribute("aria-invalid", "true"));
+	},
+};
+
+// A filled required field stays valid even at the bottom of the page.
+export const RequiredMissClearedWhenFilled: Story = {
+	args: {
+		required: true,
+		markInvalidWhenScrolledPastEmpty: true,
+		value: "my-template",
+	},
+	decorators: [
+		(Story) => (
+			<HasReachedBottomProvider>
+				<Story />
+			</HasReachedBottomProvider>
+		),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const input = canvas.getByRole("textbox", { name: /Provider name/ });
+		await expect(input).not.toHaveAttribute("aria-invalid", "true");
 	},
 };

--- a/site/src/components/FormField/FormField.tsx
+++ b/site/src/components/FormField/FormField.tsx
@@ -1,4 +1,14 @@
-import { type FC, type HTMLAttributes, type ReactNode, useId } from "react";
+import {
+	type FC,
+	type HTMLAttributes,
+	type ReactNode,
+	useContext,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from "react";
+import { HasReachedBottomContext } from "#/components/FormField/HasReachedBottomContext";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { cn } from "#/utils/cn";
@@ -17,6 +27,13 @@ type FormFieldProps = React.ComponentPropsWithRef<"input"> & {
 	 * Renders in place of the default `Input` element
 	 */
 	control?: (props: ControlProps) => ReactNode;
+	/**
+	 * When true and the field is `required` with an empty value, the input
+	 * flips to `aria-invalid` (destructive red border) once the user scrolls
+	 * past it or reaches the bottom of the page. The cue clears as soon as
+	 * they type a value.
+	 */
+	markInvalidWhenScrolledPastEmpty?: boolean;
 };
 
 export const FormField: FC<FormFieldProps> = ({
@@ -25,6 +42,7 @@ export const FormField: FC<FormFieldProps> = ({
 	description,
 	className,
 	control,
+	markInvalidWhenScrolledPastEmpty,
 	...inputProps
 }) => {
 	const generatedId = useId();
@@ -39,14 +57,57 @@ export const FormField: FC<FormFieldProps> = ({
 		.filter(Boolean)
 		.join(" ");
 	const required = inputProps.required ?? false;
+
+	// Flip empty required fields to the destructive outline once the user has
+	// either scrolled past the field or reached the bottom of the page, so
+	// easy-to-miss required fields stand out. The cue clears as soon as the
+	// field has a value. Implemented inline (no custom hook) with a sticky
+	// IntersectionObserver plus the window-level HasReachedBottomContext.
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	const [scrolledPast, setScrolledPast] = useState(false);
+	const { hasReachedBottom } = useContext(HasReachedBottomContext);
+
+	useEffect(() => {
+		if (!markInvalidWhenScrolledPastEmpty) {
+			return;
+		}
+		const el = wrapperRef.current;
+		if (!el || typeof IntersectionObserver === "undefined") {
+			return;
+		}
+		let hasBeenSeen = false;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						hasBeenSeen = true;
+					} else if (hasBeenSeen && entry.boundingClientRect.top < 0) {
+						setScrolledPast(true);
+					}
+				}
+			},
+			{ threshold: 0 },
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [markInvalidWhenScrolledPastEmpty]);
+
+	const isEmpty = field.value == null || field.value === "";
+	const showRequiredMiss = Boolean(
+		markInvalidWhenScrolledPastEmpty &&
+			required &&
+			isEmpty &&
+			(scrolledPast || hasReachedBottom),
+	);
+	const isInvalid = Boolean(field.error) || showRequiredMiss;
 	const controlProps: ControlProps = {
 		id,
-		"aria-invalid": field.error,
+		"aria-invalid": isInvalid,
 		"aria-describedby": describedBy || undefined,
 	};
 
 	return (
-		<div className="flex flex-col gap-2">
+		<div ref={wrapperRef} className="flex flex-col gap-2">
 			<Label htmlFor={id}>
 				{label}
 				{required && (
@@ -73,7 +134,7 @@ export const FormField: FC<FormFieldProps> = ({
 					onBlur={field.onBlur}
 					{...inputProps}
 					{...controlProps}
-					className={cn(field.error && "border-border-destructive", className)}
+					className={cn(isInvalid && "border-border-destructive", className)}
 				/>
 			)}
 			{field.error ? (

--- a/site/src/components/FormField/HasReachedBottomContext.tsx
+++ b/site/src/components/FormField/HasReachedBottomContext.tsx
@@ -1,0 +1,55 @@
+import {
+	createContext,
+	type FC,
+	type PropsWithChildren,
+	useEffect,
+	useState,
+} from "react";
+
+/**
+ * Tracks whether the user has scrolled to the bottom of the window at least
+ * once. Consumed by required-field wrappers (via `useContext`) so they can flip
+ * empty required fields to the destructive red outline once the user reaches
+ * the end of the page, catching required fields that were visible but never
+ * scrolled past. Sticky: stays true once triggered.
+ *
+ * This is a context + provider component, not a custom hook: consumers read it
+ * with `useContext(HasReachedBottomContext)` directly.
+ */
+export const HasReachedBottomContext = createContext<{
+	hasReachedBottom: boolean;
+}>({ hasReachedBottom: false });
+
+const BOTTOM_TOLERANCE_PX = 4;
+
+export const HasReachedBottomProvider: FC<PropsWithChildren> = ({
+	children,
+}) => {
+	const [hasReachedBottom, setHasReachedBottom] = useState(false);
+
+	useEffect(() => {
+		if (hasReachedBottom) {
+			return;
+		}
+		const check = () => {
+			const scrolled = window.scrollY + window.innerHeight;
+			const total = document.documentElement.scrollHeight;
+			if (scrolled >= total - BOTTOM_TOLERANCE_PX) {
+				setHasReachedBottom(true);
+			}
+		};
+		check();
+		window.addEventListener("scroll", check, { passive: true });
+		window.addEventListener("resize", check);
+		return () => {
+			window.removeEventListener("scroll", check);
+			window.removeEventListener("resize", check);
+		};
+	}, [hasReachedBottom]);
+
+	return (
+		<HasReachedBottomContext.Provider value={{ hasReachedBottom }}>
+			{children}
+		</HasReachedBottomContext.Provider>
+	);
+};

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -31,6 +31,7 @@ type OrganizationAutocompleteProps = {
 	id?: string;
 	ariaLabel?: string;
 	required?: boolean;
+	"aria-invalid"?: boolean;
 	disabled?: boolean;
 	/**
 	 * Overrides the trigger button's width/layout classes when the default
@@ -65,6 +66,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	id,
 	ariaLabel,
 	required,
+	"aria-invalid": ariaInvalid,
 	disabled,
 	triggerClassName,
 	optionsTabbable = false,
@@ -91,9 +93,11 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					disabled={disabled}
 					aria-expanded={open}
 					aria-required={required}
+					aria-invalid={ariaInvalid}
 					data-testid="organization-autocomplete"
 					className={cn(
 						"group w-full justify-start gap-2 font-normal",
+						ariaInvalid && "border-border-destructive",
 						triggerClassName,
 					)}
 				>

--- a/site/src/pages/TemplateBuilder/ConfigurationField.tsx
+++ b/site/src/pages/TemplateBuilder/ConfigurationField.tsx
@@ -104,6 +104,10 @@ const TextField: FC<TextFieldDefinition> = ({
 		description={description}
 		required={required}
 		placeholder={placeholder}
+		// Once the user scrolls past a required field (or reaches the bottom of
+		// the page), flag it if still empty so easy-to-miss required fields
+		// stand out. Clears as soon as the field has a value.
+		markInvalidWhenScrolledPastEmpty
 	/>
 );
 

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -17,6 +17,7 @@ import type {
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
+import { HasReachedBottomProvider } from "#/components/FormField/HasReachedBottomContext";
 import { Link } from "#/components/Link/Link";
 import { Margins } from "#/components/Margins/Margins";
 import {
@@ -301,17 +302,23 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 				{/* Main content area */}
 				<div className="flex-1 min-w-0">
 					<div className="p-6 border border-solid rounded-lg overflow-x-auto">
-						{renderStepContent(
-							currentStep.id,
-							state,
-							dispatch,
-							moduleVarMap,
-							createError,
-							handleProvisionerStatusChange,
-							handleDeselectModule,
-							registerModuleRef,
-							handleCreate,
-						)}
+						{/*
+						 * Reset the "has reached bottom" signal on every step change so
+						 * required fields on a fresh step do not start out flagged.
+						 */}
+						<HasReachedBottomProvider key={currentStep.id}>
+							{renderStepContent(
+								currentStep.id,
+								state,
+								dispatch,
+								moduleVarMap,
+								createError,
+								handleProvisionerStatusChange,
+								handleDeselectModule,
+								registerModuleRef,
+								handleCreate,
+							)}
+						</HasReachedBottomProvider>
 					</div>
 
 					{/* Navigation controls */}

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -1,5 +1,5 @@
 import { useFormik } from "formik";
-import { type FC, useEffect, useState } from "react";
+import { type FC, useContext, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import * as Yup from "yup";
 import {
@@ -10,6 +10,7 @@ import type { Organization } from "#/api/typesGenerated";
 import { Alert } from "#/components/Alert/Alert";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { FormField } from "#/components/FormField/FormField";
+import { HasReachedBottomContext } from "#/components/FormField/HasReachedBottomContext";
 import { IconField } from "#/components/IconField/IconField";
 import { Label } from "#/components/Label/Label";
 import { Link } from "#/components/Link/Link";
@@ -113,6 +114,13 @@ export const TemplateCustomizationsStep: FC<
 		void form.setFieldValue("organization_id", org?.id ?? "");
 	};
 
+	// Flag the required organization once the user reaches the bottom of the
+	// page with nothing selected. Unlike the text fields (which also flag on
+	// scroll-past via FormField), the autocomplete only uses the page-bottom
+	// signal, which is sufficient for a single control near the top.
+	const { hasReachedBottom } = useContext(HasReachedBottomContext);
+	const organizationMissed = hasReachedBottom && !selectedOrg;
+
 	return (
 		<form
 			id={TEMPLATE_CUSTOMIZATIONS_FORM_ID}
@@ -153,6 +161,9 @@ export const TemplateCustomizationsStep: FC<
 							<OrganizationAutocomplete
 								id="organization"
 								required
+								aria-invalid={
+									Boolean(organizationField.error) || organizationMissed
+								}
 								value={selectedOrg}
 								onChange={handleOrgChange}
 								options={orgOptions}
@@ -208,6 +219,7 @@ export const TemplateCustomizationsStep: FC<
 						})}
 						label="ID"
 						required
+						markInvalidWhenScrolledPastEmpty
 						id="template-name"
 						placeholder="my-template"
 					/>


### PR DESCRIPTION
## What

Highlights missed required fields in the template builder. An empty required field flips to the destructive red outline (`aria-invalid` + `border-border-destructive`) once the user either scrolls past it or reaches the bottom of the page, and the cue clears the moment the field has a value.

Resolves [DEVEX-832](https://linear.app/codercom/issue/DEVEX-832/highlight-missed-required-template-builder-fields). This is an isolated slice of #27077 (its item 7), rebased onto current `main`.

## Implementation note: no new custom hooks

#27077 introduced two custom hooks (`useHasBeenScrolledPast`, `useHasReachedBottom`). Per the request, this PR delivers the same behavior **without adding any new custom React hooks**:

- The per-field "scrolled past" detection is inlined directly in `FormField` using built-in hooks (`useRef` + `useState` + `useEffect` with a sticky `IntersectionObserver`).
- The window-level "reached bottom" signal is a **context + provider component** (`HasReachedBottomContext` / `HasReachedBottomProvider`), consumed via `useContext(HasReachedBottomContext)` — no `useX` wrapper hook.

## Changes

- **`FormField`**: new opt-in `markInvalidWhenScrolledPastEmpty` prop. When set, an empty `required` field becomes `aria-invalid` once `scrolledPast || hasReachedBottom`. Default behavior (error-driven `aria-invalid`) is unchanged.
- **`HasReachedBottomContext.tsx`** (new): context + provider component tracking whether the window has been scrolled to the bottom at least once (sticky). Not a hook.
- **`ConfigurationField`**: enables the prop on the module/base text fields, so every module and base-template required text param gets the cue for free.
- **`TemplateBuilderPageView`**: wraps step content in `HasReachedBottomProvider`, keyed by `currentStep.id` so the signal resets on each step.
- **`OrganizationAutocomplete`**: adds `aria-invalid` support (destructive border on the trigger).
- **`TemplateCustomizationsStep`**: enables the cue on the `ID` field and flags the required `Organization` autocomplete once the page bottom is reached with nothing selected.

## Testing

- `pnpm check` (biome) clean
- `pnpm lint:types` (tsc) clean
- `pnpm vitest run --project=storybook src/components/FormField` — 9 pass, incl. new `RequiredMissHighlightedAtBottom` / `RequiredMissClearedWhenFilled` interaction stories
- `pnpm vitest run --project=storybook src/pages/TemplateBuilder src/components/OrganizationAutocomplete` — pass
- `pnpm vitest run --project=unit src/pages/TemplateBuilder` — 61 pass

<details>
<summary>Behavior / scope notes</summary>

- The `Organization` autocomplete uses only the page-bottom signal (not a per-field observer). It is a single control near the top of the Customizations step, so the bottom-of-page catch is sufficient and avoids duplicating observer logic outside `FormField`.
- `IntersectionObserver`/scroll behavior is not exercisable in a plain unit test; the new Storybook stories assert the reached-bottom path (short story content triggers the provider on mount).
- Per Tracy's summary, #27077 items 5 (scroll fix) and 6 (customizations layout) are already handled on `main` by #27437/#27797; item 4 is a separate PR (DEVEX-830). This PR is item 7.

</details>

---

Coder Agents generated, on behalf of @aqandrew.
