### PR TITLE
refactor(site): import `cn` directly

### DIFF
--- a/site/src/components/Abbr/Abbr.tsx
+++ b/site/src/components/Abbr/Abbr.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes } from "react";
-import { cn } from "#/utils/cn";
 
 type Pronunciation = "shorthand" | "acronym" | "initialism";
 

--- a/site/src/components/Alert/Alert.tsx
+++ b/site/src/components/Alert/Alert.tsx
@@ -1,4 +1,5 @@
 import { cva } from "class-variance-authority";
+import { cn } from "cn";
 import {
 	CircleAlertIcon,
 	CircleCheckIcon,
@@ -8,7 +9,6 @@ import {
 } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
 import { Button } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 
 const alertVariants = cva(
 	"relative w-full rounded-lg border border-solid p-4 text-left",

--- a/site/src/components/AnimatedIcons/Check.tsx
+++ b/site/src/components/AnimatedIcons/Check.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import { CheckIcon as LucideCheckIcon } from "lucide-react";
-import { cn } from "#/utils/cn";
 
 type CheckIconProps = React.ComponentProps<typeof LucideCheckIcon>;
 

--- a/site/src/components/AnimatedIcons/ChevronDown.tsx
+++ b/site/src/components/AnimatedIcons/ChevronDown.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import { ChevronDownIcon as LucideChevronDown } from "lucide-react";
-import { cn } from "#/utils/cn";
 
 interface ChevronDownIconProps
 	extends React.ComponentProps<typeof LucideChevronDown> {

--- a/site/src/components/Autocomplete/Autocomplete.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CheckIcon, XIcon } from "lucide-react";
 import {
 	type KeyboardEvent,
@@ -24,7 +25,6 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 
 interface AutocompleteProps<TOption> {
 	value: TOption | null;

--- a/site/src/components/Autocomplete/WorkspaceUserAutocomplete.tsx
+++ b/site/src/components/Autocomplete/WorkspaceUserAutocomplete.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, useId, useState } from "react";
 import { keepPreviousData, useQuery } from "react-query";
 import { getErrorMessage } from "#/api/errors";
@@ -19,7 +20,6 @@ import {
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useDebouncedFunction, useDebouncedValue } from "#/hooks/debounce";
-import { cn } from "#/utils/cn";
 import { prepareQuery } from "#/utils/filters";
 
 // The common properties between users and org members that we need.

--- a/site/src/components/Avatar/Avatar.tsx
+++ b/site/src/components/Avatar/Avatar.tsx
@@ -10,10 +10,10 @@
  * @see {@link https://github.com/coder/coder/pull/15930#issuecomment-2552292440}
  */
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Avatar as AvatarPrimitive } from "radix-ui";
 import { useAppearance } from "#/theme/appearance";
 import { getExternalImageStylesFromUrl } from "#/theme/externalImages";
-import { cn } from "#/utils/cn";
 
 const avatarVariants = cva(
 	"relative flex shrink-0 overflow-hidden rounded border border-solid bg-surface-secondary text-content-secondary",

--- a/site/src/components/Avatar/AvatarCard.tsx
+++ b/site/src/components/Avatar/AvatarCard.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { cn } from "#/utils/cn";
 
 type AvatarCardProps = {
 	header: string;

--- a/site/src/components/Avatar/AvatarData.tsx
+++ b/site/src/components/Avatar/AvatarData.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { cn } from "#/utils/cn";
 
 interface AvatarDataProps {
 	title: ReactNode;

--- a/site/src/components/Badge/Badge.tsx
+++ b/site/src/components/Badge/Badge.tsx
@@ -3,8 +3,8 @@
  * @see {@link https://ui.shadcn.com/docs/components/badge}
  */
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Slot } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 const badgeVariants = cva(
 	`

--- a/site/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/site/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,9 +2,10 @@
  * Copied from shadc/ui on 12/13/2024
  * @see {@link https://ui.shadcn.com/docs/components/breadcrumb}
  */
+
+import { cn } from "cn";
 import { MoreHorizontalIcon } from "lucide-react";
 import { NavLink } from "react-router";
-import { cn } from "#/utils/cn";
 
 type BreadcrumbProps = React.ComponentPropsWithRef<"nav"> & {
 	separator?: React.ReactNode;

--- a/site/src/components/Button/Button.tsx
+++ b/site/src/components/Button/Button.tsx
@@ -3,8 +3,8 @@
  * @see {@link https://ui.shadcn.com/docs/components/button}
  */
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Slot } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 // Be careful when changing the child styles from the button such as images
 // because they can override the styles from other components like Avatar.

--- a/site/src/components/Calendar/Calendar.tsx
+++ b/site/src/components/Calendar/Calendar.tsx
@@ -7,6 +7,7 @@
  * in the component library.
  */
 
+import { cn } from "cn";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import {
@@ -15,7 +16,6 @@ import {
 	getDefaultClassNames,
 } from "react-day-picker";
 import { Button, type ButtonProps } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 
 function Calendar({
 	className,

--- a/site/src/components/Chart/Chart.tsx
+++ b/site/src/components/Chart/Chart.tsx
@@ -2,9 +2,10 @@
  * Copied from shadc/ui on 01/13/2025
  * @see {@link https://ui.shadcn.com/docs/components/chart}
  */
+
+import { cn } from "cn";
 import { createContext, type Ref, useContext, useId, useMemo } from "react";
 import * as RechartsPrimitive from "recharts";
-import { cn } from "#/utils/cn";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;

--- a/site/src/components/Checkbox/Checkbox.tsx
+++ b/site/src/components/Checkbox/Checkbox.tsx
@@ -2,9 +2,10 @@
  * Copied from shadc/ui on 04/03/2025
  * @see {@link https://ui.shadcn.com/docs/components/checkbox}
  */
+
+import { cn } from "cn";
 import { CheckIcon, MinusIcon } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 /**
  * To allow for an indeterminate state the checkbox must be controlled, otherwise the checked prop would remain undefined

--- a/site/src/components/CodeExample/CodeExample.tsx
+++ b/site/src/components/CodeExample/CodeExample.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Button } from "#/components/Button/Button";
@@ -6,7 +7,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { CopyButton } from "../CopyButton/CopyButton";
 
 interface CodeExampleProps {

--- a/site/src/components/CollapsibleSummary/CollapsibleSummary.tsx
+++ b/site/src/components/CollapsibleSummary/CollapsibleSummary.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
-import { cn } from "#/utils/cn";
 
 const collapsibleSummaryVariants = cva(
 	`flex items-center gap-1 p-0 bg-transparent border-0 text-inherit cursor-pointer

--- a/site/src/components/Combobox/Combobox.tsx
+++ b/site/src/components/Combobox/Combobox.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CheckIcon } from "lucide-react";
 import type React from "react";
 import { createContext, useContext, useState } from "react";
@@ -16,7 +17,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 type ComboboxContextProps = {
 	open: boolean;

--- a/site/src/components/Command/Command.tsx
+++ b/site/src/components/Command/Command.tsx
@@ -1,6 +1,6 @@
 import { Command as CommandPrimitive } from "cmdk";
+import { cn } from "cn";
 import { SearchIcon } from "lucide-react";
-import { cn } from "#/utils/cn";
 
 export const Command: React.FC<
 	React.ComponentPropsWithRef<typeof CommandPrimitive>

--- a/site/src/components/ContextMenu/ContextMenu.tsx
+++ b/site/src/components/ContextMenu/ContextMenu.tsx
@@ -5,8 +5,9 @@
  * by construction.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/context-menu}
  */
+
+import { cn } from "cn";
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 import {
 	menuContentClass,
 	menuItemClass,

--- a/site/src/components/CopyableValue/CopyableValue.tsx
+++ b/site/src/components/CopyableValue/CopyableValue.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, type HTMLAttributes, useState } from "react";
 import {
 	Tooltip,
@@ -6,7 +7,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { useClickable } from "#/hooks/useClickable";
 import { useClipboard } from "#/hooks/useClipboard";
-import { cn } from "#/utils/cn";
 
 type TooltipSide = "top" | "right" | "bottom" | "left";
 

--- a/site/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/site/src/components/DateRangePicker/DateRangePicker.tsx
@@ -4,6 +4,7 @@
  * component with one that matches the native design language.
  */
 
+import { cn } from "cn";
 import dayjs from "dayjs";
 import { CalendarIcon, MoveRightIcon } from "lucide-react";
 import { type FC, useState } from "react";
@@ -15,7 +16,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 export type DateRangeValue = {
 	startDate: Date;

--- a/site/src/components/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/site/src/components/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -3,6 +3,7 @@
  * hidden until "Custom range" is chosen.
  */
 
+import { cn } from "cn";
 import { CalendarIcon, CheckIcon } from "lucide-react";
 import { type FC, type KeyboardEvent, useEffect, useId, useState } from "react";
 import type { DateRange as DayPickerDateRange } from "react-day-picker";
@@ -23,7 +24,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "#/components/Select/Select";
-import { cn } from "#/utils/cn";
 import {
 	combineDateTime,
 	type DateTimeRangeValue,

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -3,10 +3,10 @@
  * @see {@link https://ui.shadcn.com/docs/components/dialog}
  */
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { Button } from "#/components/Button/Button";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 
 export const Dialog = DialogPrimitive.Root;
 

--- a/site/src/components/Drawer/Drawer.tsx
+++ b/site/src/components/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
+import { cn } from "cn";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { createContext, useContext } from "react";
-import { cn } from "#/utils/cn";
 
 type DrawerDirection = "top" | "bottom" | "left" | "right";
 

--- a/site/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/site/src/components/DropdownMenu/DropdownMenu.tsx
@@ -5,9 +5,10 @@
  * This component was updated to match the styles from the Figma design:
  * @see {@link https://www.figma.com/design/WfqIgsTFXN2BscBSSyXWF8/Coder-kit?node-id=656-2354&t=CiGt5le3yJEwMH4M-0}
  */
+
+import { cn } from "cn";
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 import {
 	menuContentClass,
 	menuItemClass,

--- a/site/src/components/DurationField/DurationField.tsx
+++ b/site/src/components/DurationField/DurationField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type ComponentProps,
 	type FC,
@@ -14,7 +15,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "#/components/Select/Select";
-import { cn } from "#/utils/cn";
 import {
 	durationInDays,
 	durationInHours,

--- a/site/src/components/EmptyState/EmptyState.tsx
+++ b/site/src/components/EmptyState/EmptyState.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes, ReactNode } from "react";
-import { cn } from "#/utils/cn";
 
 export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
 	/** Text Message to display, placed inside Typography component */

--- a/site/src/components/FileUpload/FileUpload.tsx
+++ b/site/src/components/FileUpload/FileUpload.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import { CloudUploadIcon, FolderIcon, TrashIcon } from "lucide-react";
 import { type DragEvent, type FC, type ReactNode, useRef } from "react";
 import { Button } from "#/components/Button/Button";
 import { useClickable } from "#/hooks/useClickable";
-import { cn } from "#/utils/cn";
 import { Spinner } from "../Spinner/Spinner";
 
 interface FileUploadProps {

--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ExternalLinkIcon, SlidersHorizontalIcon } from "lucide-react";
 import {
 	type ComponentProps,
@@ -25,7 +26,6 @@ import {
 import { SearchField } from "#/components/SearchField/SearchField";
 import { Skeleton, type SkeletonProps } from "#/components/Skeleton/Skeleton";
 import { useDebouncedFunction } from "#/hooks/debounce";
-import { cn } from "#/utils/cn";
 import {
 	type FilterValues,
 	parseFilterQuery,

--- a/site/src/components/Filter/SelectFilter.tsx
+++ b/site/src/components/Filter/SelectFilter.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import {
 	Combobox,
@@ -9,7 +10,6 @@ import {
 	ComboboxTrigger,
 } from "#/components/Combobox/Combobox";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 
 const BASE_WIDTH = 200;
 

--- a/site/src/components/Form/Form.tsx
+++ b/site/src/components/Form/Form.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type ComponentProps,
 	createContext,
@@ -7,7 +8,6 @@ import {
 	useContext,
 } from "react";
 import { AlphaBadge, DeprecatedBadge } from "#/components/Badge/PresetBadges";
-import { cn } from "#/utils/cn";
 
 type FormContextValue = { direction?: "horizontal" | "vertical" };
 

--- a/site/src/components/FormField/FormField.tsx
+++ b/site/src/components/FormField/FormField.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { type FC, type HTMLAttributes, type ReactNode, useId } from "react";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
-import { cn } from "#/utils/cn";
 import type { FormHelpers } from "#/utils/formUtils";
 
 type ControlProps = Pick<

--- a/site/src/components/FullPageLayout/Sidebar.tsx
+++ b/site/src/components/FullPageLayout/Sidebar.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { ComponentProps, FC, HTMLAttributes } from "react";
 import { Link, type LinkProps } from "react-router";
-import { cn } from "#/utils/cn";
 import { TopbarIconButton } from "./Topbar";
 
 export const Sidebar: FC<HTMLAttributes<HTMLDivElement>> = (props) => {

--- a/site/src/components/FullPageLayout/Topbar.tsx
+++ b/site/src/components/FullPageLayout/Topbar.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	cloneElement,
 	type FC,
@@ -7,7 +8,6 @@ import {
 } from "react";
 import { Avatar, type AvatarProps } from "#/components/Avatar/Avatar";
 import { Button, type ButtonProps } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 
 export const Topbar: FC<HTMLAttributes<HTMLElement>> = ({
 	className,

--- a/site/src/components/HelpPopover/HelpPopover.tsx
+++ b/site/src/components/HelpPopover/HelpPopover.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CircleHelpIcon, ExternalLinkIcon } from "lucide-react";
 import type { FC, HTMLAttributes, PropsWithChildren, ReactNode } from "react";
 import {
@@ -6,7 +7,6 @@ import {
 	type PopoverContentProps,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 type Icon = typeof CircleHelpIcon;
 

--- a/site/src/components/IconField/IconField.tsx
+++ b/site/src/components/IconField/IconField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type ComponentPropsWithRef,
 	type FC,
@@ -22,7 +23,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 const EmojiPicker = lazy(() => import("./EmojiPicker"));
 

--- a/site/src/components/Icons/ProductLogo.tsx
+++ b/site/src/components/Icons/ProductLogo.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { getApplicationName, getLogoURL } from "#/utils/appearance";
-import { cn } from "#/utils/cn";
 import { ExternalImage } from "../ExternalImage/ExternalImage";
 
 /**

--- a/site/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/site/src/components/InfoTooltip/InfoTooltip.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import {
 	HelpPopover,
@@ -8,7 +9,6 @@ import {
 	HelpPopoverTitle,
 } from "#/components/HelpPopover/HelpPopover";
 import type { ThemeRole } from "#/theme/roles";
-import { cn } from "#/utils/cn";
 
 interface InfoTooltipProps {
 	type?: ThemeRole;

--- a/site/src/components/Input/Input.tsx
+++ b/site/src/components/Input/Input.tsx
@@ -2,8 +2,9 @@
  * Copied from shadc/ui on 11/13/2024
  * @see {@link https://ui.shadcn.com/docs/components/input}
  */
+
+import { cn } from "cn";
 import type { ComponentPropsWithRef, FC } from "react";
-import { cn } from "#/utils/cn";
 
 type InputProps = ComponentPropsWithRef<"input">;
 

--- a/site/src/components/InputGroup/InputGroup.tsx
+++ b/site/src/components/InputGroup/InputGroup.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Button, type ButtonProps } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
-import { cn } from "#/utils/cn";
 
 export const InputGroup: React.FC<React.ComponentProps<"div">> = ({
 	className,

--- a/site/src/components/Kbd/Kbd.tsx
+++ b/site/src/components/Kbd/Kbd.tsx
@@ -1,4 +1,4 @@
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 
 function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
 	return (

--- a/site/src/components/Label/Label.tsx
+++ b/site/src/components/Label/Label.tsx
@@ -3,8 +3,8 @@
  * @see {@link https://ui.shadcn.com/docs/components/label}
  */
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Label as LabelPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 const labelVariants = cva(
 	"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",

--- a/site/src/components/LastSeen/LastSeen.tsx
+++ b/site/src/components/LastSeen/LastSeen.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type dayjs from "dayjs";
 import type { FC, HTMLAttributes } from "react";
-import { cn } from "#/utils/cn";
 import { isAfter, subtractTime, timeFrom } from "#/utils/time";
 
 interface LastSeenProps

--- a/site/src/components/Latency/Latency.tsx
+++ b/site/src/components/Latency/Latency.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CircleHelpIcon } from "lucide-react";
 import type { FC } from "react";
 import { Abbr } from "#/components/Abbr/Abbr";
@@ -7,7 +8,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 
 interface LatencyProps {

--- a/site/src/components/LinearProgress/LinearProgress.tsx
+++ b/site/src/components/LinearProgress/LinearProgress.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type React from "react";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 
 type LinearProgressProps = React.ComponentProps<"div"> & {
 	value: number;

--- a/site/src/components/Link/Link.tsx
+++ b/site/src/components/Link/Link.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { SquareArrowOutUpRightIcon } from "lucide-react";
 import { Slot } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 const linkVariants = cva(
 	`relative inline-flex items-center no-underline font-medium text-content-link hover:cursor-pointer

--- a/site/src/components/Loader/Loader.tsx
+++ b/site/src/components/Loader/Loader.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes } from "react";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 
 interface LoaderProps extends HTMLAttributes<HTMLDivElement> {
 	fullscreen?: boolean;

--- a/site/src/components/Logs/LogLine.tsx
+++ b/site/src/components/Logs/LogLine.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes } from "react";
 import type { LogLevel } from "#/api/typesGenerated";
-import { cn } from "#/utils/cn";
 
 const DEFAULT_LOG_LINE_SIDE_PADDING = 24;
 

--- a/site/src/components/Logs/Logs.tsx
+++ b/site/src/components/Logs/Logs.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 import { type Line, LogLine, LogLinePrefix } from "./LogLine";
 
 export const DEFAULT_LOG_LINE_SIDE_PADDING = 24;

--- a/site/src/components/Margins/Margins.tsx
+++ b/site/src/components/Margins/Margins.tsx
@@ -1,10 +1,10 @@
+import { cn } from "cn";
 import type { FC, JSX } from "react";
 import {
 	containerWidth,
 	containerWidthMedium,
 	sidePadding,
 } from "#/theme/constants";
-import { cn } from "#/utils/cn";
 
 export type Size = "regular" | "medium" | "condensed" | "small";
 

--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import isEqual from "lodash/isEqual";
 import {
 	createElement,
@@ -20,7 +21,6 @@ import {
 	TableHeader,
 	TableRow,
 } from "#/components/Table/Table";
-import { cn } from "#/utils/cn";
 
 interface MarkdownProps {
 	/**

--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -3,6 +3,7 @@
  * @see {@link https://shadcnui-expansions.typeart.cc/docs/multiple-selector}
  */
 import { Command as CommandPrimitive, useCommandState } from "cmdk";
+import { cn } from "cn";
 import { InfoIcon, XIcon } from "lucide-react";
 import {
 	type ComponentPropsWithoutRef,
@@ -31,7 +32,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useDebouncedValue } from "#/hooks/debounce";
-import { cn } from "#/utils/cn";
 
 export interface Option {
 	value: string;

--- a/site/src/components/MultiUserSelect/MultiUserSelect.tsx
+++ b/site/src/components/MultiUserSelect/MultiUserSelect.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, type ReactNode, useState } from "react";
 import { keepPreviousData, useQuery } from "react-query";
 import { organizationMembers } from "#/api/queries/organizations";
@@ -14,7 +15,6 @@ import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { SearchField } from "#/components/SearchField/SearchField";
 import { useDebouncedFunction } from "#/hooks/debounce";
-import { cn } from "#/utils/cn";
 import { prepareQuery } from "#/utils/filters";
 
 const DEBOUNCE_MS = 750;

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CheckIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import type { Organization } from "#/api/typesGenerated";
@@ -18,7 +19,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 type OrganizationAutocompleteProps = {
 	value: Organization | null;

--- a/site/src/components/PageHeader/FullWidthPageHeader.tsx
+++ b/site/src/components/PageHeader/FullWidthPageHeader.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, PropsWithChildren, ReactNode } from "react";
-import { cn } from "#/utils/cn";
 
 interface FullWidthPageHeaderProps {
 	children?: ReactNode;

--- a/site/src/components/PageHeader/PageHeader.tsx
+++ b/site/src/components/PageHeader/PageHeader.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type React from "react";
 import type { FC, ReactNode } from "react";
-import { cn } from "#/utils/cn";
 
 interface PageHeaderProps {
 	actions?: ReactNode;

--- a/site/src/components/PaginationWidget/PaginationAmount.tsx
+++ b/site/src/components/PaginationWidget/PaginationAmount.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
-import { cn } from "#/utils/cn";
 
 type PaginationHeaderProps = {
 	paginationUnitLabel: string;

--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -1,10 +1,10 @@
+import { cn } from "cn";
 import { ArrowRightIcon, CheckIcon } from "lucide-react";
 import type React from "react";
 import type { FC } from "react";
 import { type LinkProps, Link as RouterLink } from "react-router";
 import { Button } from "#/components/Button/Button";
 import { Supergraphic } from "#/components/Supergraphic/Supergraphic";
-import { cn } from "#/utils/cn";
 
 export const PREMIUM_FEATURES = [
 	"High availability & workspace proxies",

--- a/site/src/components/Paywall/PaywallPremium.tsx
+++ b/site/src/components/Paywall/PaywallPremium.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { Supergraphic } from "#/components/Supergraphic/Supergraphic";
-import { cn } from "#/utils/cn";
 import {
 	PaywallCTALink,
 	PaywallFeature,

--- a/site/src/components/Paywall/PaywallSmall.tsx
+++ b/site/src/components/Paywall/PaywallSmall.tsx
@@ -1,4 +1,4 @@
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 import {
 	Paywall,
 	PaywallContent,

--- a/site/src/components/Popover/Popover.tsx
+++ b/site/src/components/Popover/Popover.tsx
@@ -2,8 +2,9 @@
  * Copied from shadcn/ui and modified on 12/13/2024
  * @see {@link https://ui.shadcn.com/docs/components/popover}
  */
+
+import { cn } from "cn";
 import { Popover as PopoverPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 export type PopoverContentProps = React.ComponentPropsWithRef<
 	typeof PopoverPrimitive.Content

--- a/site/src/components/RadioGroup/RadioGroup.tsx
+++ b/site/src/components/RadioGroup/RadioGroup.tsx
@@ -2,9 +2,10 @@
  * Copied from shadc/ui on 04/04/2025
  * @see {@link https://ui.shadcn.com/docs/components/radio-group}
  */
+
+import { cn } from "cn";
 import { CircleIcon } from "lucide-react";
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 export const RadioGroup: React.FC<
 	React.ComponentPropsWithRef<typeof RadioGroupPrimitive.Root>

--- a/site/src/components/ScrollArea/ScrollArea.tsx
+++ b/site/src/components/ScrollArea/ScrollArea.tsx
@@ -2,8 +2,9 @@
  * Copied from shadc/ui on 03/05/2025
  * @see {@link https://ui.shadcn.com/docs/components/scroll-area}
  */
+
+import { cn } from "cn";
 import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 interface ScrollAreaProps
 	extends React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root> {

--- a/site/src/components/Select/Select.tsx
+++ b/site/src/components/Select/Select.tsx
@@ -2,6 +2,8 @@
  * Copied from shadc/ui on 13/01/2025
  * @see {@link https://ui.shadcn.com/docs/components/select}
  */
+
+import { cn } from "cn";
 import {
 	CheckIcon,
 	ChevronUpIcon,
@@ -9,7 +11,6 @@ import {
 } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
-import { cn } from "#/utils/cn";
 
 export const Select = SelectPrimitive.Root;
 

--- a/site/src/components/SelectField/SelectField.tsx
+++ b/site/src/components/SelectField/SelectField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import { FormField } from "#/components/FormField/FormField";
 import {
@@ -6,7 +7,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "#/components/Select/Select";
-import { cn } from "#/utils/cn";
 import type { FormHelpers } from "#/utils/formUtils";
 
 type SelectFieldProps = {

--- a/site/src/components/Separator/Separator.tsx
+++ b/site/src/components/Separator/Separator.tsx
@@ -2,9 +2,10 @@
  * Copied from shadc/ui on 06/20/2025
  * @see {@link https://ui.shadcn.com/docs/components/separator}
  */
+
+import { cn } from "cn";
 import { Separator as SeparatorPrimitive } from "radix-ui";
 import type * as React from "react";
-import { cn } from "#/utils/cn";
 
 function Separator({
 	className,

--- a/site/src/components/SettingsHeader/SettingsHeader.tsx
+++ b/site/src/components/SettingsHeader/SettingsHeader.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import type { FC, PropsWithChildren, ReactNode } from "react";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 
 type SettingsHeaderProps = Readonly<
 	PropsWithChildren<{

--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import { NavLink } from "react-router";
-import { cn } from "#/utils/cn";
 
 interface SidebarProps {
 	children?: ReactNode;

--- a/site/src/components/Skeleton/Skeleton.tsx
+++ b/site/src/components/Skeleton/Skeleton.tsx
@@ -3,7 +3,7 @@
  * @see {@link https://ui.shadcn.com/docs/components/skeleton}
  */
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 
 const skeletonVariants = cva("bg-surface-tertiary animate-pulse", {
 	variants: {

--- a/site/src/components/Slider/Slider.tsx
+++ b/site/src/components/Slider/Slider.tsx
@@ -2,8 +2,9 @@
  * Copied from shadc/ui on 04/16/2025
  * @see {@link https://ui.shadcn.com/docs/components/slider}
  */
+
+import { cn } from "cn";
 import { Slider as SliderPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 export const Slider: React.FC<
 	React.ComponentPropsWithRef<typeof SliderPrimitive.Root>

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -6,8 +6,8 @@
 
 import { isPixel } from "@coder/pixel-storybook/storyapi";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import type { ReactNode } from "react";
-import { cn } from "#/utils/cn";
 
 const leaves = Array.from({ length: 8 }).map((_, i) => i);
 

--- a/site/src/components/StackLabel/StackLabel.tsx
+++ b/site/src/components/StackLabel/StackLabel.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { ComponentProps, FC } from "react";
-import { cn } from "#/utils/cn";
 
 /**
  * Use these components as the label in FormControlLabel when implementing radio

--- a/site/src/components/Stats/Stats.tsx
+++ b/site/src/components/Stats/Stats.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes, ReactNode } from "react";
-import { cn } from "#/utils/cn";
 
 export const Stats: FC<HTMLAttributes<HTMLDivElement>> = ({
 	children,

--- a/site/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/site/src/components/StatusIndicator/StatusIndicator.tsx
@@ -1,11 +1,11 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { createContext, type FC, useContext } from "react";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 const statusIndicatorVariants = cva(
 	"font-medium inline-flex items-center gap-2",

--- a/site/src/components/Supergraphic/Supergraphic.tsx
+++ b/site/src/components/Supergraphic/Supergraphic.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 
 /**
  * A decorative layer that paints the Coder brand supergraphic.

--- a/site/src/components/Switch/Switch.tsx
+++ b/site/src/components/Switch/Switch.tsx
@@ -3,8 +3,8 @@
  * @see {@link https://ui.shadcn.com/docs/components/switch}
  */
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Switch as SwitchPrimitives } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 const switchVariants = cva(
 	`peer inline-flex shrink-0 cursor-pointer items-center rounded-full shadow-xs transition-colors

--- a/site/src/components/Table/Table.tsx
+++ b/site/src/components/Table/Table.tsx
@@ -3,7 +3,7 @@
  * @see {@link https://ui.shadcn.com/docs/components/table}
  */
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 
 type TableProps = React.ComponentPropsWithRef<"table"> & {
 	wrapperClassName?: string;

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Tabs as TabsPrimitive } from "radix-ui";
 import {
 	type ComponentProps,
@@ -11,7 +12,6 @@ import {
 	useRef,
 } from "react";
 import { Link, type LinkProps } from "react-router";
-import { cn } from "#/utils/cn";
 
 // --- Radix tabs (stateful panels) ---
 

--- a/site/src/components/Textarea/Textarea.tsx
+++ b/site/src/components/Textarea/Textarea.tsx
@@ -2,7 +2,7 @@
  * Copied from shadc/ui on 11/13/2024
  * @see {@link https://ui.shadcn.com/docs/components/textarea}
  */
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 
 export const Textarea: React.FC<React.ComponentPropsWithRef<"textarea">> = ({
 	className,

--- a/site/src/components/Timeline/TimelineEntry.tsx
+++ b/site/src/components/Timeline/TimelineEntry.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import { TableRow, type TableRowProps } from "#/components/Table/Table";
-import { cn } from "#/utils/cn";
 
 interface TimelineEntryProps extends TableRowProps {
 	ref?: React.Ref<HTMLTableRowElement>;

--- a/site/src/components/Toaster/Toaster.tsx
+++ b/site/src/components/Toaster/Toaster.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	CheckIcon,
 	InfoIcon,
@@ -7,7 +8,6 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps as SonnerProps } from "sonner";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 
 export const Toaster = ({ ...props }: SonnerProps) => {
 	return (

--- a/site/src/components/Tooltip/Tooltip.tsx
+++ b/site/src/components/Tooltip/Tooltip.tsx
@@ -2,8 +2,9 @@
  * Copied from shadc/ui on 02/05/2025
  * @see {@link https://ui.shadcn.com/docs/components/tooltip}
  */
+
+import { cn } from "cn";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
-import { cn } from "#/utils/cn";
 
 export const TooltipProvider = TooltipPrimitive.Provider;
 

--- a/site/src/components/UsageBar/UsageBar.tsx
+++ b/site/src/components/UsageBar/UsageBar.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { clampPercentage, type UsageSeverity } from "#/utils/budget";
-import { cn } from "#/utils/cn";
 
 const severityProgressClasses = {
 	normal: "bg-content-secondary",

--- a/site/src/hooks/useClickableTableRow.ts
+++ b/site/src/hooks/useClickableTableRow.ts
@@ -13,8 +13,9 @@
  * It might not make sense to test this hook until the underlying design
  * problems are fixed.
  */
+
+import { cn } from "cn";
 import type { HTMLAttributes, MouseEventHandler } from "react";
-import { cn } from "#/utils/cn";
 import {
 	type ClickableAriaRole,
 	type UseClickableResult,

--- a/site/src/modules/apps/AppStatusStateIcon.tsx
+++ b/site/src/modules/apps/AppStatusStateIcon.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	BanIcon,
 	CircleAlertIcon,
@@ -9,7 +10,6 @@ import {
 import type { FC } from "react";
 import type { WorkspaceAppStatusState } from "#/api/typesGenerated";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 
 type AppStatusStateIconProps = {
 	state: WorkspaceAppStatusState;

--- a/site/src/modules/apps/WorkspaceAppFrame.tsx
+++ b/site/src/modules/apps/WorkspaceAppFrame.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	EllipsisVerticalIcon,
 	ExternalLinkIcon,
@@ -15,7 +16,6 @@ import {
 } from "#/components/DropdownMenu/DropdownMenu";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useProxy } from "#/contexts/ProxyContext";
-import { cn } from "#/utils/cn";
 import { isAppBlockedByMissingWildcard } from "./apps";
 import { useAppLink } from "./useAppLink";
 import { WorkspaceWildcardWarning } from "./WorkspaceWildcardWarning";

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -1,10 +1,10 @@
+import { cn } from "cn";
 import { type FC, type HTMLAttributes, Suspense } from "react";
 import { Outlet } from "react-router";
 import { Loader } from "#/components/Loader/Loader";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { AnnouncementBanners } from "#/modules/dashboard/AnnouncementBanners/AnnouncementBanners";
 import { LicenseBanner } from "#/modules/dashboard/LicenseBanner/LicenseBanner";
-import { cn } from "#/utils/cn";
 import { DeploymentBanner } from "./DeploymentBanner/DeploymentBanner";
 import { Navbar } from "./Navbar/Navbar";
 import { UpdateCheckNotice } from "./UpdateCheckNotice/UpdateCheckNotice";

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -1,4 +1,5 @@
 import { cva } from "class-variance-authority";
+import { cn } from "cn";
 import { ChevronRightIcon, TriangleAlertIcon } from "lucide-react";
 import { useState } from "react";
 import { Button } from "#/components/Button/Button";
@@ -8,7 +9,6 @@ import {
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 
 const formatMessage = (message: string) => {
 	// If the message ends with an alphanumeric character, add a period.

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ChevronRightIcon,
 	CircleHelpIcon,
@@ -26,7 +27,6 @@ import {
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Latency } from "#/components/Latency/Latency";
 import type { ProxyContextValue } from "#/contexts/ProxyContext";
-import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 import {
 	AdminSettingsItems,

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { NavLink, useLocation } from "react-router";
 import { API } from "#/api/api";
@@ -8,7 +9,6 @@ import { ProductLogo } from "#/components/Icons/ProductLogo";
 import type { ProxyContextValue } from "#/contexts/ProxyContext";
 import { NotificationsInbox } from "#/modules/notifications/NotificationsInbox/NotificationsInbox";
 import { getPrereleaseFlag } from "#/utils/buildInfo";
-import { cn } from "#/utils/cn";
 import {
 	type AdminSettingsPermissions,
 	canViewAdminSettings,

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdown.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { OctagonAlertIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC, JSX } from "react";
 import { useQuery } from "react-query";
@@ -12,7 +13,6 @@ import {
 } from "#/components/DropdownMenu/DropdownMenu";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
 import { getSeverity, type UsageSeverity } from "#/utils/budget";
-import { cn } from "#/utils/cn";
 import { UserDropdownAISpend } from "./UserDropdownAISpend";
 import { UserDropdownContent } from "./UserDropdownContent";
 import { UserDropdownPremiumTrialCTA } from "./UserDropdownPremiumTrialCTA";

--- a/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.tsx
+++ b/site/src/modules/dashboard/UpdateCheckNotice/UpdateCheckNotice.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { InfoIcon, XIcon } from "lucide-react";
 import type { FC } from "react";
 import { Button } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 
 type UpdateCheckNoticeProps = {

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import { Link, NavLink, useMatch } from "react-router";
 import {
@@ -8,7 +9,6 @@ import {
 	canAccessAnyChatModelConfig,
 	type Permissions,
 } from "#/modules/permissions";
-import { cn } from "#/utils/cn";
 
 interface AISettingsSidebarViewProps {
 	/** Site-wide permissions. */

--- a/site/src/modules/notifications/NotificationsInbox/InboxButton.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxButton.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { BellIcon } from "lucide-react";
 import { Button, type ButtonProps } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 import { UnreadBadge } from "./UnreadBadge";
 
 type InboxButtonProps = ButtonProps & {

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { RefreshCwIcon, SettingsIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Link as RouterLink } from "react-router";
@@ -10,7 +11,6 @@ import {
 } from "#/components/Popover/Popover";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { InboxButton } from "./InboxButton";
 import { InboxItem } from "./InboxItem";
 import { UnreadBadge } from "./UnreadBadge";

--- a/site/src/modules/notifications/NotificationsInbox/UnreadBadge.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/UnreadBadge.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, HTMLProps } from "react";
-import { cn } from "#/utils/cn";
 
 type UnreadBadgeProps = {
 	count: number;

--- a/site/src/modules/provisioners/Provisioner.tsx
+++ b/site/src/modules/provisioners/Provisioner.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { Building2Icon, UserIcon } from "lucide-react";
 import type { FC } from "react";
 import type { HealthMessage, ProvisionerDaemon } from "#/api/typesGenerated";
@@ -7,7 +8,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { createDayString } from "#/utils/createDayString";
 import { ProvisionerTag } from "./ProvisionerTag";
 

--- a/site/src/modules/provisioners/ProvisionerAlert.tsx
+++ b/site/src/modules/provisioners/ProvisionerAlert.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import {
 	Alert,
@@ -6,7 +7,6 @@ import {
 	AlertTitle,
 } from "#/components/Alert/Alert";
 import { ProvisionerTag } from "#/modules/provisioners/ProvisionerTag";
-import { cn } from "#/utils/cn";
 
 export enum AlertVariant {
 	// Alerts are usually styled with a full rounded border and meant to use as a visually distinct element of the page.

--- a/site/src/modules/provisioners/ProvisionerTags.tsx
+++ b/site/src/modules/provisioners/ProvisionerTags.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC, HTMLProps } from "react";
 import { Badge } from "#/components/Badge/Badge";
-import { cn } from "#/utils/cn";
 
 export const ProvisionerTags: FC<HTMLProps<HTMLDivElement>> = ({
 	className,

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ContainerIcon, ExternalLinkIcon } from "lucide-react";
 import type { FC } from "react";
 import { useMutation, useQueryClient } from "react-query";
@@ -35,7 +36,6 @@ import {
 import { useProxy } from "#/contexts/ProxyContext";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
 import { AppStatuses } from "#/pages/WorkspacePage/AppStatuses";
-import { cn } from "#/utils/cn";
 import { portForwardURL } from "#/utils/portForward";
 import { AgentApps, organizeAgentApps } from "./AgentApps/AgentApps";
 import { AgentButton } from "./AgentButton";

--- a/site/src/modules/resources/AgentLatency.tsx
+++ b/site/src/modules/resources/AgentLatency.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import type { DERPRegion, WorkspaceAgent } from "#/api/typesGenerated";
 import {
@@ -7,7 +8,6 @@ import {
 	HelpPopoverTitle,
 	HelpPopoverTrigger,
 } from "#/components/HelpPopover/HelpPopover";
-import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 
 const getDisplayLatency = (agent: WorkspaceAgent) => {

--- a/site/src/modules/resources/AgentLogs/AgentLogs.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogs.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type CSSProperties,
 	type FC,
@@ -18,7 +19,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { AGENT_LOG_LINE_HEIGHT, AgentLogLine } from "./AgentLogLine";
 
 // Fallback log used in places where we must always have a valid log source.

--- a/site/src/modules/resources/AgentMetadata.tsx
+++ b/site/src/modules/resources/AgentMetadata.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import {
 	type FC,
@@ -20,7 +21,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import type { OneWayWebSocket } from "#/utils/OneWayWebSocket";
 
 type ItemStatus = "stale" | "valid" | "loading";

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	CopyIcon,
 	EllipsisIcon,
@@ -66,7 +67,6 @@ import {
 } from "#/modules/workspaces/health";
 import { AgentAlert } from "#/pages/WorkspacePage/AgentAlert";
 import { AppStatuses } from "#/pages/WorkspacePage/AppStatuses";
-import { cn } from "#/utils/cn";
 import { AgentApps, organizeAgentApps } from "./AgentApps/AgentApps";
 import { AgentDevcontainerCard } from "./AgentDevcontainerCard";
 import { AgentExternal } from "./AgentExternal";

--- a/site/src/modules/resources/AgentRowPreview.tsx
+++ b/site/src/modules/resources/AgentRowPreview.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import { SquareTerminalIcon } from "lucide-react";
 import type { FC } from "react";
 import type { WorkspaceAgent } from "#/api/typesGenerated";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { cn } from "#/utils/cn";
 import { DisplayAppNameMap } from "./AppLink/AppLink";
 import { AppPreview } from "./AppLink/AppPreview";
 import { BaseIcon } from "./AppLink/BaseIcon";

--- a/site/src/modules/resources/AgentStatus.tsx
+++ b/site/src/modules/resources/AgentStatus.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { TriangleAlertIcon } from "lucide-react";
 import type { FC } from "react";
 import type {
@@ -17,7 +18,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import {
 	agentConnectionMessages,
 	agentScriptMessages,

--- a/site/src/modules/roles/RoleSelector.tsx
+++ b/site/src/modules/roles/RoleSelector.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { UserIcon } from "lucide-react";
 import { type FC, useId } from "react";
 import { getErrorMessage } from "#/api/errors";
@@ -6,7 +7,6 @@ import { Alert, AlertTitle } from "#/components/Alert/Alert";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { CollapsibleSummary } from "#/components/CollapsibleSummary/CollapsibleSummary";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
-import { cn } from "#/utils/cn";
 import { roleDescriptions } from "./index";
 
 const advancedRoleNames = ["organization-workspace-creation-ban"];

--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes } from "react";
 import { Link as RouterLink } from "react-router";
 import type { TemplateExample } from "#/api/typesGenerated";
@@ -5,7 +6,6 @@ import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 
 type TemplateExampleCardProps = HTMLAttributes<HTMLDivElement> & {
 	example: TemplateExample;

--- a/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	EllipsisIcon,
 	FolderIcon,
@@ -18,7 +19,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
-import { cn } from "#/utils/cn";
 import type { FileTree } from "#/utils/filetree";
 import { getTemplateFileIcon } from "./TemplateFileIcon";
 

--- a/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
@@ -1,10 +1,10 @@
+import { cn } from "cn";
 import set from "lodash/set";
 import { EditIcon } from "lucide-react";
 import { type FC, useCallback, useMemo } from "react";
 import { Link as RouterLink } from "react-router";
 import { SyntaxHighlighter } from "#/components/SyntaxHighlighter/SyntaxHighlighter";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
-import { cn } from "#/utils/cn";
 import type { FileTree } from "#/utils/filetree";
 import type { TemplateVersionFiles } from "#/utils/templateVersion";
 import { getTemplateFileIcon } from "./TemplateFileIcon";

--- a/site/src/modules/templates/TemplateUpdateMessage.tsx
+++ b/site/src/modules/templates/TemplateUpdateMessage.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { MemoizedMarkdown } from "#/components/Markdown/Markdown";
-import { cn } from "#/utils/cn";
 
 interface TemplateUpdateMessageProps {
 	children: string;

--- a/site/src/modules/terminal/WorkspaceTerminal.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.tsx
@@ -5,6 +5,7 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { cn } from "cn";
 import {
 	type Ref,
 	useCallback,
@@ -29,7 +30,6 @@ import {
 	ContextMenuTrigger,
 } from "#/components/ContextMenu/ContextMenu";
 import { useClipboard } from "#/hooks/useClipboard";
-import { cn } from "#/utils/cn";
 import { isMac } from "#/utils/platform";
 import { terminalWebsocketUrl } from "#/utils/terminal";
 import type { ConnectionStatus } from "./types";

--- a/site/src/modules/terminal/WorkspaceTerminalAlerts.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminalAlerts.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { RefreshCwIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
 import type { WorkspaceAgent } from "#/api/typesGenerated";
@@ -8,7 +9,6 @@ import {
 } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import type { ConnectionStatus } from "./types";
 

--- a/site/src/modules/users/UserGroupsCell.tsx
+++ b/site/src/modules/users/UserGroupsCell.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { UsersIcon } from "lucide-react";
 import type { FC } from "react";
 import type { Group } from "#/api/typesGenerated";
@@ -8,7 +9,6 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import { TableCell } from "#/components/Table/Table";
-import { cn } from "#/utils/cn";
 
 type GroupsCellProps = {
 	userGroups: readonly Group[] | undefined;

--- a/site/src/modules/workspaces/BuildIcon/BuildIcon.tsx
+++ b/site/src/modules/workspaces/BuildIcon/BuildIcon.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type LucideProps,
 	PlayIcon,
@@ -9,7 +10,6 @@ import type {
 	WorkspaceTransition,
 } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { cn } from "#/utils/cn";
 
 type BuildIconProps = LucideProps & {
 	transition: WorkspaceTransition;

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	CircleAlertIcon,
 	EyeIcon,
@@ -45,7 +46,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
 
 interface DynamicParameterProps {

--- a/site/src/modules/workspaces/WorkspaceBuildData/WorkspaceBuildData.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildData/WorkspaceBuildData.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { InfoIcon } from "lucide-react";
 import type { WorkspaceBuild } from "#/api/typesGenerated";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
@@ -7,7 +8,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { BuildIcon } from "#/modules/workspaces/BuildIcon/BuildIcon";
-import { cn } from "#/utils/cn";
 import { createDayString } from "#/utils/createDayString";
 import {
 	buildReasonLabels,

--- a/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import {
 	type FC,
@@ -9,7 +10,6 @@ import {
 import type { ProvisionerJobLog, WorkspaceBuild } from "#/api/typesGenerated";
 import type { Line } from "#/components/Logs/LogLine";
 import { DEFAULT_LOG_LINE_SIDE_PADDING, Logs } from "#/components/Logs/Logs";
-import { cn } from "#/utils/cn";
 
 type Stage = ProvisionerJobLog["stage"];
 type LogsGroupedByStage = Record<Stage, ProvisionerJobLog[]>;

--- a/site/src/modules/workspaces/WorkspaceMoreActions/DownloadLogsDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/DownloadLogsDialog.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { saveAs } from "file-saver";
 import JSZip from "jszip";
 import { type FC, useEffect, useMemo, useRef, useState } from "react";
@@ -12,7 +13,6 @@ import {
 	type ConfirmDialogProps,
 } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
-import { cn } from "#/utils/cn";
 import { getWorkspaceAgents } from "#/utils/workspace";
 
 type DownloadLogsDialogProps = Pick<

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/Bar.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/Bar.tsx
@@ -1,4 +1,4 @@
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 export type BarColors = {
 	stroke: string;
 	fill: string;

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/Blocks.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/Blocks.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { EllipsisIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
-import { cn } from "#/utils/cn";
 
 const spaceBetweenBlocks = 4;
 const moreIconSize = 18;

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/Chart.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/Chart.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import type { FC, HTMLProps } from "react";
 import React, { useEffect, useRef } from "react";
@@ -5,7 +6,6 @@ import {
 	SearchField,
 	type SearchFieldProps,
 } from "#/components/SearchField/SearchField";
-import { cn } from "#/utils/cn";
 import type { BarColors } from "./Bar";
 
 export const Chart = (props: HTMLProps<HTMLDivElement>) => {

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/XAxis.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/XAxis.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import { type FC, type HTMLProps, useLayoutEffect, useRef } from "react";
-import { cn } from "#/utils/cn";
 import { formatTime } from "./utils";
 
 const XAxisMinWidth = 130;

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/YAxis.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/YAxis.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, HTMLProps } from "react";
-import { cn } from "#/utils/cn";
 
 export const YAxis: FC<HTMLProps<HTMLDivElement>> = (props) => {
 	return (

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/AgenticLoopTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/AgenticLoopTable.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 import { roundDurationDisplay } from "../../utils";
 
 interface AgenticLoopTableProps {

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/PromptTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/PromptTable.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { Badge } from "#/components/Badge/Badge";
 import {
@@ -7,7 +8,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { AIBridgeModelIcon } from "#/pages/AIBridgePage/icons/AIBridgeModelIcon";
-import { cn } from "#/utils/cn";
 import { formatDate } from "#/utils/time";
 import { TokenBadges } from "../../TokenBadges";
 

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon, InfoIcon, LoaderIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
 import type {
@@ -19,7 +20,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import { JsonPrettyPrinter } from "../../JsonPrettyPrinter";
 import { AgenticLoopTable } from "./AgenticLoopTable";

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/ToolCallTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/ToolCallTable.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
-import { cn } from "#/utils/cn";
 import { formatDate } from "#/utils/time";
 import { TokenBadges } from "../../TokenBadges";
 

--- a/site/src/pages/AIBridgePage/icons/AIBridgeClientIcon.tsx
+++ b/site/src/pages/AIBridgePage/icons/AIBridgeClientIcon.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { CircleQuestionMarkIcon } from "lucide-react";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { cn } from "#/utils/cn";
 
 export const AIBridgeClientIcon = ({
 	client,

--- a/site/src/pages/AIBridgePage/icons/AIBridgeModelIcon.tsx
+++ b/site/src/pages/AIBridgePage/icons/AIBridgeModelIcon.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { CircleQuestionMarkIcon } from "lucide-react";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { cn } from "#/utils/cn";
 
 // Infers the model family from a model name string.
 // See official model naming docs:

--- a/site/src/pages/AIBridgePage/icons/AIBridgeProviderIcon.tsx
+++ b/site/src/pages/AIBridgePage/icons/AIBridgeProviderIcon.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { CircleQuestionMarkIcon } from "lucide-react";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { cn } from "#/utils/cn";
 
 export const AIBridgeProviderIcon = ({
 	provider,

--- a/site/src/pages/AISettingsPage/LifecyclePage/components/DurationField/DurationField.tsx
+++ b/site/src/pages/AISettingsPage/LifecyclePage/components/DurationField/DurationField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import { type FC, type ReactNode, useState } from "react";
 import { Input } from "#/components/Input/Input";
@@ -8,7 +9,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "#/components/Select/Select";
-import { cn } from "#/utils/cn";
 import {
 	durationInDays,
 	durationInHours,

--- a/site/src/pages/AISettingsPage/LifecyclePage/components/LifecycleSettingLayout.tsx
+++ b/site/src/pages/AISettingsPage/LifecyclePage/components/LifecycleSettingLayout.tsx
@@ -1,9 +1,9 @@
+import { cn } from "cn";
 import type { FC, FormEventHandler, ReactNode } from "react";
 import { Button } from "#/components/Button/Button";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Switch } from "#/components/Switch/Switch";
 import { TemporarySavedState } from "#/components/TemporarySavedState/TemporarySavedState";
-import { cn } from "#/utils/cn";
 
 interface LifecycleSettingLayoutProps {
 	title: string;

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormFieldPrimitives.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormFieldPrimitives.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import {
@@ -6,7 +7,6 @@ import {
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
 import { Label } from "#/components/Label/Label";
-import { cn } from "#/utils/cn";
 
 const RequiredMark = () => (
 	<span className="text-xs font-bold text-content-destructive">*</span>

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormFields.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormFields.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FormikContextType } from "formik";
 import { type FC, type ReactNode, useId } from "react";
 import { Button } from "#/components/Button/Button";
@@ -15,7 +16,6 @@ import {
 	SelectValue,
 } from "#/components/Select/Select";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { MCPServerAuthSection } from "./MCPServerAuthSection";
 import { MCPServerBehaviorSection } from "./MCPServerBehaviorSection";
 import { CollapsibleSection, Field } from "./MCPServerFormFieldPrimitives";

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerFormHeader.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ArrowLeftIcon, Share2Icon } from "lucide-react";
 import { type FC, useId } from "react";
 import { Link } from "react-router";
@@ -11,7 +12,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { MCPServerIcon } from "./MCPServerIcon";
 
 const MCPServerFormBackLink: FC<{ to: string }> = ({ to }) => {

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerIcon.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerIcon.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { ServerIcon } from "lucide-react";
 import type { FC } from "react";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { cn } from "#/utils/cn";
 
 export const MCPServerIcon: FC<{
 	iconUrl: string;

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerRow.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerRow.tsx
@@ -1,10 +1,10 @@
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Badge } from "#/components/Badge/Badge";
 import { TableCell, TableRow } from "#/components/Table/Table";
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
-import { cn } from "#/utils/cn";
 import { MCPServerIcon } from "./MCPServerIcon";
 import { AUTH_TYPE_LABELS, AVAILABILITY_LABELS } from "./mcpServerFormLogic";
 

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormFields.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FormikContextType } from "formik";
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
@@ -43,7 +44,6 @@ import type {
 	ModelConfigFormBuildResult,
 	ModelFormValues,
 } from "#/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import type { FormHelpers } from "#/utils/formUtils";
 import {

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelFormHeader.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ArrowLeftIcon,
 	CopyIcon,
@@ -27,7 +28,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import type { ProviderState } from "#/modules/aiModels/providerStates";
 import { getProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
-import { cn } from "#/utils/cn";
 import { useOrganizationModelsPath } from "../organizationModels";
 
 export const ModelFormBackLink: FC = () => {

--- a/site/src/pages/AISettingsPage/ModelsPage/components/ModelRow.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/components/ModelRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import type { FC } from "react";
 import type { ChatModel } from "#/api/typesGenerated";
@@ -11,7 +12,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import { ProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
-import { cn } from "#/utils/cn";
 
 type ModelRowProps = {
 	model: ChatModel;

--- a/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/components/ProviderRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import {
 	AgentsUnsupportedProviderTypes,
@@ -13,7 +14,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
-import { cn } from "#/utils/cn";
 import { ProviderIcon } from "./ProviderIcon";
 import { getProviderDisplayType } from "./providerFormApiMap";
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import { ArchiveIcon, TriangleAlertIcon } from "lucide-react";
-
 import {
 	type FC,
 	type ReactNode,
@@ -26,7 +26,6 @@ import {
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
 import { findWorkspaceAppWithAgent } from "#/modules/apps/workspaceApps";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
-import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import { generateConnectionSessionId, generateUUID } from "#/utils/random";
 import { findWorkspaceAgent } from "#/utils/workspace";

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, useEffect, useRef, useState } from "react";
 import {
 	useInfiniteQuery,
@@ -60,7 +61,6 @@ import {
 	useDashboard,
 } from "#/modules/dashboard/useDashboard";
 import { canAccessCoderAgentsSettings } from "#/modules/permissions";
-import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import { emptyInputStorageKey } from "./components/AgentCreateForm";

--- a/site/src/pages/AgentsPage/components/AdminChatDebugLoggingSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdminChatDebugLoggingSettings.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Switch } from "#/components/Switch/Switch";
-import { cn } from "#/utils/cn";
 
 interface AdminChatDebugLoggingSettingsProps {
 	adminSettings: TypesGen.ChatDebugLoggingAdminSettings | undefined;

--- a/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
+++ b/site/src/pages/AgentsPage/components/AdvisorSettings.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import { type FC, useId } from "react";
 import { getErrorMessage } from "#/api/errors";
@@ -8,7 +9,6 @@ import type {
 import { Button } from "#/components/Button/Button";
 import { useTemporarySavedState } from "#/components/TemporarySavedState/TemporarySavedState";
 import { AgentSettingLayout } from "#/pages/AISettingsPage/CoderAgentsPage/components/AgentSettingLayout";
-import { cn } from "#/utils/cn";
 
 interface MutationCallbacks {
 	onSuccess?: () => void;

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ArrowLeftIcon,
 	ArrowUpIcon,
@@ -57,7 +58,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { countInvisibleCharacters } from "#/utils/invisibleUnicode";
 import { isBelowMdViewport, isMobileViewport } from "#/utils/mobile";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";

--- a/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
+++ b/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { type FC, useState } from "react";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
-import { cn } from "#/utils/cn";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { loadPersistedLeftSidebarWidth } from "./ChatsSidebar/sidebarWidth";
 

--- a/site/src/pages/AgentsPage/components/AttachmentPreview.tsx
+++ b/site/src/pages/AgentsPage/components/AttachmentPreview.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { AlertTriangleIcon, ClipboardPasteIcon, XIcon } from "lucide-react";
 import type { FC, ReactEventHandler } from "react";
 import { toast } from "sonner";
@@ -7,7 +8,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { useLatestAbortController } from "../hooks/useLatestAbortController";
 import { isAbortError } from "../utils/chatAttachments";
 import {

--- a/site/src/pages/AgentsPage/components/ChatConversation/AssistantOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AssistantOutput.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { PauseIcon } from "lucide-react";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 import { Shimmer } from "../ChatElements";
 import { ToolIcon } from "../ChatElements/tools/ToolIcon";
 import { ChatStatusCallout } from "./ChatStatusCallout";

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	AlertTriangleIcon,
 	DownloadIcon,
@@ -11,7 +12,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { useLatestAbortController } from "../../hooks/useLatestAbortController";
 import {
 	type AttachmentFailure,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -2,6 +2,7 @@ import {
 	MessageScroller,
 	useMessageScroller,
 } from "@shadcn/react/message-scroller";
+import { cn } from "cn";
 import {
 	ChevronLeftIcon,
 	ChevronRightIcon,
@@ -9,10 +10,8 @@ import {
 	PencilIcon,
 } from "lucide-react";
 import { type FC, memo, type ReactNode, useState } from "react";
-
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
-
 import { AlertTitle } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
@@ -21,7 +20,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 import {
 	ConversationItem,

--- a/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
@@ -1,10 +1,10 @@
+import { cn } from "cn";
 import { type FC, memo, useLayoutEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import type { UrlTransform } from "streamdown";
 import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ThinkingDisplayMode } from "#/api/typesGenerated";
-import { cn } from "#/utils/cn";
 import { Response, Tool } from "../ChatElements";
 import { WebSearchSources } from "../ChatElements/tools";
 import { ReadFilesTool } from "../ChatElements/tools/ReadFilesTool";

--- a/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import { type FC, Fragment } from "react";
-import { cn } from "#/utils/cn";
 import { Message, MessageContent } from "../ChatElements";
 import { FileReferenceChip } from "../ChatMessageInput/FileReferenceChip";
 import {

--- a/site/src/pages/AgentsPage/components/ChatElements/CompactOrgSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/CompactOrgSelector.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CheckIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import type { Organization } from "#/api/typesGenerated";
@@ -16,7 +17,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 interface CompactOrgSelectorProps {
 	value: Organization | null;

--- a/site/src/pages/AgentsPage/components/ChatElements/Conversation.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Conversation.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { ComponentPropsWithRef } from "react";
-import { cn } from "#/utils/cn";
 
 type ConversationProps = ComponentPropsWithRef<"div">;
 

--- a/site/src/pages/AgentsPage/components/ChatElements/MarkdownImage.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/MarkdownImage.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { ImageIcon } from "lucide-react";
 import { useState } from "react";
-import { cn } from "#/utils/cn";
 import {
 	externalImageHost,
 	isExternalImageSource,

--- a/site/src/pages/AgentsPage/components/ChatElements/Message.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Message.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { ComponentPropsWithRef } from "react";
-import { cn } from "#/utils/cn";
 
 type MessageProps = ComponentPropsWithRef<"div">;
 

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CheckIcon, InfoIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
@@ -23,7 +24,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { ProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
 import { formatProviderLabel as defaultFormatProviderLabel } from "#/utils/aiProviders";
-import { cn } from "#/utils/cn";
 import { formatReasoningEffort } from "../../utils/reasoningEffort";
 
 export interface ModelSelectorOption {

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
@@ -2,6 +2,7 @@ import {
 	File as FileViewer,
 	type SupportedLanguages,
 } from "@pierre/diffs/react";
+import { cn } from "cn";
 import type { ComponentPropsWithRef, ReactNode } from "react";
 import {
 	type Components,
@@ -11,7 +12,6 @@ import {
 } from "streamdown";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { useTheme } from "#/theme/context";
-import { cn } from "#/utils/cn";
 import { MarkdownImage } from "./MarkdownImage";
 
 interface ResponseProps extends Omit<ComponentPropsWithRef<"div">, "children"> {

--- a/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Shimmer.tsx
@@ -1,8 +1,7 @@
+import { cn } from "cn";
 import type { MotionProps } from "motion/react";
 import { MotionConfig, MotionConfigContext, motion } from "motion/react";
 import { type ElementType, type JSX, useContext } from "react";
-
-import { cn } from "#/utils/cn";
 
 type MotionHTMLProps = MotionProps & Record<string, unknown>;
 

--- a/site/src/pages/AgentsPage/components/ChatElements/TranscriptRow.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/TranscriptRow.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { Slot } from "radix-ui";
 import type { ComponentPropsWithRef, FC } from "react";
-import { cn } from "#/utils/cn";
 
 type TranscriptRowProps = ComponentPropsWithRef<"div"> & {
 	asChild?: boolean;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	LoaderIcon,
 	MessageCircleQuestionIcon,
@@ -8,7 +9,6 @@ import { useMutation } from "react-query";
 import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
-import { cn } from "#/utils/cn";
 import { ToolCall } from "./ToolCall";
 import type { ToolStatus } from "./utils";
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/DiffFileHeader.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/DiffFileHeader.tsx
@@ -1,5 +1,5 @@
 import type { FileContents, FileDiffMetadata } from "@pierre/diffs";
-import { cn } from "#/utils/cn";
+import { cn } from "cn";
 import { countChangedLines } from "../../../utils/countChangedLines";
 import { changeColor, changeLabel } from "../../../utils/diffColors";
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { OctagonXIcon } from "lucide-react";
 import type React from "react";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -8,7 +9,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import {
 	type AgentDisplayState,
 	resolveAgentDisplayState,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessOutputTool.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { OctagonXIcon } from "lucide-react";
 import type React from "react";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -8,7 +9,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import {
 	type AgentDisplayState,
 	resolveAgentDisplayState,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -1,9 +1,9 @@
 import { File as FileViewer } from "@pierre/diffs/react";
+import { cn } from "cn";
 import { type ComponentPropsWithRef, type FC, memo } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { useTheme } from "#/theme/context";
-import { cn } from "#/utils/cn";
 import { AdvisorTool, type AdvisorToolResultType } from "./AdvisorTool";
 import {
 	type AskUserQuestion,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ChevronDownIcon,
 	LoaderIcon,
@@ -18,7 +19,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { Shimmer } from "../Shimmer";
 import { TranscriptRow } from "../TranscriptRow";
 import { ToolIcon } from "./ToolIcon";

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ActivityIcon,
 	BadgeQuestionMarkIcon,
@@ -23,7 +24,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 export const toolIcons: Partial<Record<string, LucideIcon>> = {
 	execute: TerminalIcon,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WebSearchSources.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WebSearchSources.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { ExternalLinkIcon, GlobeIcon } from "lucide-react";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 import { ToolCall } from "./ToolCall";
 
 interface WebSearchSourcesProps {

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -6,6 +6,7 @@ import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { mergeRegister } from "@lexical/utils";
+import { cn } from "cn";
 import {
 	$createParagraphNode,
 	$createTextNode,
@@ -35,7 +36,6 @@ import {
 import { useQuery } from "react-query";
 import { userSkills } from "#/api/queries/userSkills";
 import type * as TypesGen from "#/api/typesGenerated";
-import { cn } from "#/utils/cn";
 import { isMobileViewport } from "#/utils/mobile";
 import {
 	DEFAULT_AGENT_CHAT_SEND_SHORTCUT,

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/FileReferenceChip.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/FileReferenceChip.tsx
@@ -1,8 +1,8 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { XIcon } from "lucide-react";
 import type { CSSProperties, FC } from "react";
 import { FileIcon } from "#/components/FileIcon/FileIcon";
-import { cn } from "#/utils/cn";
 import { getFileReferenceDisplay } from "./fileReferenceDisplay";
 
 const fileReferenceChipVariants = cva(

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/FileReferenceNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/FileReferenceNode.tsx
@@ -1,4 +1,5 @@
 import { useLexicalNodeSelection } from "@lexical/react/useLexicalNodeSelection";
+import { cn } from "cn";
 import {
 	$getNodeByKey,
 	DecoratorNode,
@@ -9,7 +10,6 @@ import {
 	type Spread,
 } from "lexical";
 import { type FC, type ReactNode, useSyncExternalStore } from "react";
-import { cn } from "#/utils/cn";
 import { EditableFileReferenceChip } from "./FileReferenceChip";
 import { getFileReferenceSiblingSpacing } from "./fileReferenceDisplay";
 

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/SkillsTriggerMenu.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/SkillsTriggerMenu.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useLayoutEffect, useRef } from "react";
 import {
 	Command,
@@ -11,7 +12,6 @@ import {
 	PopoverAnchor,
 	PopoverContent,
 } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 
 type SkillSource = "personal" | "workspace";
 

--- a/site/src/pages/AgentsPage/components/ChatMessageScroller.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageScroller.tsx
@@ -2,11 +2,11 @@ import {
 	MessageScroller,
 	useMessageScrollerScrollable,
 } from "@shadcn/react/message-scroller";
+import { cn } from "cn";
 import { ArrowDownIcon, RotateCcwIcon } from "lucide-react";
 import { type FC, type ReactNode, useEffect } from "react";
 import { Button } from "#/components/Button/Button";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 
 interface EarlierMessagesProps {

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FormikContextType, getIn } from "formik";
 import { InfoIcon } from "lucide-react";
 import { type FC, Fragment, type ReactNode, useId } from "react";
@@ -35,7 +36,6 @@ import {
 import { useDebouncedValue } from "#/hooks/debounce";
 import { normalizeProvider } from "#/modules/aiModels/helpers";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
-import { cn } from "#/utils/cn";
 import { microsToDollars } from "#/utils/currency";
 import {
 	findKnownModelByCanonicalId,

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelIdentifierField.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelIdentifierField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FormikContextType } from "formik";
 import { CheckIcon } from "lucide-react";
 import {
@@ -11,7 +12,6 @@ import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { normalizeProvider } from "#/modules/aiModels/helpers";
-import { cn } from "#/utils/cn";
 import type { FormHelpers } from "#/utils/formUtils";
 import {
 	findKnownModelByCanonicalId,

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderIcon.tsx
@@ -1,9 +1,9 @@
+import { cn } from "cn";
 import { Building2Icon } from "lucide-react";
 import type { FC } from "react";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { normalizeProvider } from "#/modules/aiModels/helpers";
 import { getProviderIcon } from "#/pages/AISettingsPage/ProvidersPage/components/ProviderIcon";
-import { cn } from "#/utils/cn";
 
 interface ProviderIconProps {
 	provider: string;

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, Profiler, type ReactNode, useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
@@ -5,7 +6,6 @@ import type { UrlTransform } from "streamdown";
 import { chatPromptsQuery, refreshChatContext } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
-import { cn } from "#/utils/cn";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useFileAttachments } from "../hooks/useFileAttachments";

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ArrowLeftIcon,
 	ChevronRightIcon,
@@ -21,7 +22,6 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import { Popover, PopoverTrigger } from "#/components/Popover/Popover";
-import { cn } from "#/utils/cn";
 import { parsePullRequestUrl } from "../utils/pullRequest";
 import {
 	ChatActionsMenuItems,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ResizableChatsSidebarFrame.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ResizableChatsSidebarFrame.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type KeyboardEvent as ReactKeyboardEvent,
 	type ReactNode,
@@ -7,7 +8,6 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { cn } from "#/utils/cn";
 import {
 	clampLeftSidebarWidth,
 	getLeftSidebarMaxWidth,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatSectionHeader.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatSectionHeader.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import { ChevronDownIcon } from "lucide-react";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 
 export const PINNED_SECTION_KEY = "Pinned";
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -14,6 +14,7 @@ import {
 	sortableKeyboardCoordinates,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { cn } from "cn";
 import {
 	PanelLeftCloseIcon,
 	SearchIcon,
@@ -29,7 +30,6 @@ import { ProductLogo } from "#/components/Icons/ProductLogo";
 import { Kbd, KbdGroup } from "#/components/Kbd/Kbd";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
-import { cn } from "#/utils/cn";
 import { getOSKey } from "#/utils/platform";
 import {
 	AGENT_CHAT_STATUS_ORDER,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchInput.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ListFilterIcon, SearchIcon, XIcon } from "lucide-react";
 import type {
 	ChangeEventHandler,
@@ -5,7 +6,6 @@ import type {
 	KeyboardEventHandler,
 	RefObject,
 } from "react";
-import { cn } from "#/utils/cn";
 
 export type SearchFilter = {
 	readonly key: string;

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchResults.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, useEffect, useRef } from "react";
 import { Link, type Location } from "react-router";
 import { CHAT_SEARCH_LIMIT } from "#/api/queries/chats";
@@ -6,7 +7,6 @@ import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { shortRelativeTime } from "#/utils/time";
 import { getChatDisplayConfig } from "../tree/statusConfig";
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/filters/FilterPopover.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/filters/FilterPopover.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { FilterIcon } from "lucide-react";
 import {
 	type ComponentProps,
@@ -16,7 +17,6 @@ import {
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { SearchField } from "#/components/SearchField/SearchField";
-import { cn } from "#/utils/cn";
 import {
 	AGENT_ARCHIVE_STATUS_ORDER,
 	AGENT_CHAT_STATUS_ORDER,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsNavItem.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsNavItem.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ShieldIcon } from "lucide-react";
 import type { ComponentProps, FC, ReactNode } from "react";
 import { Link } from "react-router";
@@ -6,7 +7,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 type SettingsNavItemProps = {
 	icon: FC<{ className?: string }>;

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/settings/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ArrowLeftIcon,
 	ArrowUpRightIcon,
@@ -12,7 +13,6 @@ import {
 import type { FC } from "react";
 import { Link, type Location } from "react-router";
 import { Button } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 import { SettingsNavItem } from "./SettingsNavItem";
 
 interface SettingsPanelProps {

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ArrowLeftIcon,
 	ChevronLeftIcon,
@@ -17,7 +18,6 @@ import {
 	useState,
 } from "react";
 import { Button } from "#/components/Button/Button";
-import { cn } from "#/utils/cn";
 
 /** A single tab definition for the sidebar panel. */
 export interface SidebarTab {

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ChevronDownIcon,
 	ChevronRightIcon,
@@ -23,7 +24,6 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { shortRelativeTime } from "#/utils/time";
 import {
 	ChatActionsMenuItems,

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SortableChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SortableChatTreeNode.tsx
@@ -1,8 +1,8 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { cn } from "cn";
 import type { FC } from "react";
 import type { Chat } from "#/api/typesGenerated";
-import { cn } from "#/utils/cn";
 import { ChatTreeNode } from "./ChatTreeNode";
 
 export const SortableChatTreeNode: FC<{

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	FileIcon,
 	FolderIcon,
@@ -27,7 +28,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { formatKiB } from "#/utils/fileSize";
 import { isMobileViewport } from "#/utils/mobile";
 import { getPathBasename, getPathDirname } from "../utils/path";

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -9,6 +9,7 @@ import type {
 import { CodeView } from "@pierre/diffs/react";
 import type { FileTreeSortComparator, GitStatusEntry } from "@pierre/trees";
 import { FileTree, useFileTree } from "@pierre/trees/react";
+import { cn } from "cn";
 import {
 	type ComponentProps,
 	type CSSProperties,
@@ -22,7 +23,6 @@ import {
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { useTheme } from "#/theme/context";
-import { cn } from "#/utils/cn";
 import { countChangedLines } from "../../utils/countChangedLines";
 import { changeColor, changeLabel } from "../../utils/diffColors";
 import { SEPARATOR_CSS } from "../ChatElements/tools/utils";

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	CheckIcon,
 	ChevronDownIcon,
@@ -30,7 +31,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import type { ChatMessageInputRef } from "../AgentChatInput";
 import { DiffStatBadge } from "../DiffViewer/DiffStats";
 import {

--- a/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerPicker.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronDownIcon, LockIcon, ServerIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
 import { mcpServerOAuth2ConnectPath } from "#/api/api";
@@ -17,7 +18,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 // ── Types ──────────────────────────────────────────────────────
 

--- a/site/src/pages/AgentsPage/components/PersonalInstructionsSettings.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalInstructionsSettings.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import { useState } from "react";
@@ -10,7 +11,6 @@ import {
 	TemporarySavedState,
 	useTemporarySavedState,
 } from "#/components/TemporarySavedState/TemporarySavedState";
-import { cn } from "#/utils/cn";
 import { countInvisibleCharacters } from "#/utils/invisibleUnicode";
 
 interface MutationCallbacks {

--- a/site/src/pages/AgentsPage/components/PersonalSkillEditor.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalSkillEditor.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FormikErrors, useFormik } from "formik";
 import {
 	type ChangeEvent,
@@ -21,7 +22,6 @@ import {
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { formatKiB } from "#/utils/fileSize";
 import {
 	buildPersonalSkillMarkdown,

--- a/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
+++ b/site/src/pages/AgentsPage/components/QueuedMessagesList.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ArrowUpIcon,
 	CornerDownLeftIcon,
@@ -14,7 +15,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 interface QueuedMessagesListProps {
 	messages: readonly ChatQueuedMessage[];

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugAttemptAccordion.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugAttemptAccordion.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronDownIcon } from "lucide-react";
 import type { FC } from "react";
 import { Badge } from "#/components/Badge/Badge";
@@ -6,7 +7,6 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
-import { cn } from "#/utils/cn";
 import { DATE_FORMAT, formatDateTime, humanDuration } from "#/utils/time";
 import {
 	CopyableCodeBlock,

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import type { FC, ReactNode } from "react";
 import { Badge } from "#/components/Badge/Badge";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
-import { cn } from "#/utils/cn";
 import { getRoleBadgeVariant, safeJsonStringify } from "./debugPanelUtils";
 
 interface DebugDataSectionProps {

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugRunCard.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugRunCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { saveAs } from "file-saver";
 import { ChevronDownIcon, DownloadIcon } from "lucide-react";
 import { type FC, useId, useState } from "react";
@@ -15,7 +16,6 @@ import {
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import { DebugStepCard } from "./DebugStepCard";
 import {
 	buildDebugExportBlob,

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugStepCard.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugStepCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronDownIcon, WrenchIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { getErrorMessage } from "#/api/errors";
@@ -8,7 +9,6 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
-import { cn } from "#/utils/cn";
 import { DebugAttemptAccordion } from "./DebugAttemptAccordion";
 import {
 	CopyableCodeBlock,

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugStepCardTooling.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugStepCardTooling.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { WrenchIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Badge } from "#/components/Badge/Badge";
-import { cn } from "#/utils/cn";
 import { CopyableCodeBlock, RoleBadge } from "./DebugPanelPrimitives";
 import {
 	clampContent,

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type ReactNode,
 	type PointerEvent as ReactPointerEvent,
@@ -5,7 +6,6 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { cn } from "#/utils/cn";
 import { AGENTS_MAIN_PANEL_MIN_WIDTH } from "../ChatsSidebar/sidebarWidth";
 
 const STORAGE_KEY = "agents.right-panel-width";

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanelAddTabControl.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ChevronDownIcon,
 	LayoutGridIcon,
@@ -28,7 +29,6 @@ import {
 	canShowPortForwarding,
 	usePortsData,
 } from "#/modules/resources/usePortsData";
-import { cn } from "#/utils/cn";
 import type { PortSelection } from "../../utils/rightPanelTabs";
 import { PortsMenuItem } from "../WorkspacePillPorts";
 

--- a/site/src/pages/AgentsPage/components/SvgRingProgress.tsx
+++ b/site/src/pages/AgentsPage/components/SvgRingProgress.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC } from "react";
-import { cn } from "#/utils/cn";
 
 /**
  * SVG ring (donut) progress indicator.

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CoinsIcon, InfoIcon, ServerIcon } from "lucide-react";
 import { type FC, Fragment, type ReactNode } from "react";
 import { useQuery } from "react-query";
@@ -30,7 +31,6 @@ import {
 	type UsageSeverity,
 	usageProgressPercentage,
 } from "#/utils/budget";
-import { cn } from "#/utils/cn";
 import { formatCostMicros } from "#/utils/currency";
 import { SvgRingProgress } from "./SvgRingProgress";
 

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { RotateCcwIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { getErrorMessage } from "#/api/errors";
@@ -29,7 +30,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { formatProviderLabel } from "#/utils/aiProviders";
-import { cn } from "#/utils/cn";
 import { ProviderIcon } from "./ChatModelAdminPanel/ProviderIcon";
 
 interface UserCompactionThresholdSettingsProps {

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ChevronDownIcon,
 	CopyIcon,
@@ -44,7 +45,6 @@ import {
 	canShowPortForwarding,
 	usePortsData,
 } from "#/modules/resources/usePortsData";
-import { cn } from "#/utils/cn";
 import { belowMdViewportMediaQuery } from "#/utils/mobile";
 import { getWorkspaceStatus, StatusIcon } from "./StatusIcon";
 import { MobilePortsPanel, PortsMenuItem } from "./WorkspacePillPorts";

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { InfoIcon, NetworkIcon } from "lucide-react";
 import { type FC, type KeyboardEvent, useState } from "react";
 import { Link as RouterLink } from "react-router";
@@ -18,7 +19,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { buildReasonLabels } from "#/utils/workspace";
 import { AuditLogDescription } from "./AuditLogDescription/AuditLogDescription";
 import { AuditLogDiff } from "./AuditLogDiff/AuditLogDiff";

--- a/site/src/pages/CliInstallPage/CliInstallPageView.tsx
+++ b/site/src/pages/CliInstallPage/CliInstallPageView.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { Link as RouterLink } from "react-router";
 import { CodeExample } from "#/components/CodeExample/CodeExample";
 import { Welcome } from "#/components/Welcome/Welcome";
-import { cn } from "#/utils/cn";
 
 type CliInstallPageViewProps = {
 	origin: string;

--- a/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { Link, useSearchParams } from "react-router";
 import type { TemplateExample } from "#/api/typesGenerated";
 import { TemplateExampleCard } from "#/modules/templates/TemplateExampleCard/TemplateExampleCard";
-import { cn } from "#/utils/cn";
 import type { StarterTemplatesByTag } from "#/utils/starterTemplates";
 
 const getTagLabel = (tag: string) => {

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import camelCase from "lodash/camelCase";
 import capitalize from "lodash/capitalize";
@@ -36,7 +37,6 @@ import { Spinner } from "#/components/Spinner/Spinner";
 import { Textarea } from "#/components/Textarea/Textarea";
 import { ProvisionerTagsField } from "#/modules/provisioners/ProvisionerTagsField";
 import { SelectedTemplate } from "#/pages/CreateWorkspacePage/SelectedTemplate";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,

--- a/site/src/pages/CreateUserPage/CreateUserForm.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import { CheckIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
@@ -22,7 +23,6 @@ import {
 } from "#/components/Select/Select";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { RoleSelector } from "#/modules/roles/RoleSelector";
-import { cn } from "#/utils/cn";
 import {
 	displayNameValidator,
 	getFormHelpers,

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import { type FC, useState } from "react";
 import { SliderPicker, TwitterPicker } from "react-color";
@@ -15,7 +16,6 @@ import { Label } from "#/components/Label/Label";
 import { Textarea } from "#/components/Textarea/Textarea";
 import { AnnouncementBannerView } from "#/modules/dashboard/AnnouncementBanners/AnnouncementBannerView";
 import { useTheme } from "#/theme/context";
-import { cn } from "#/utils/cn";
 import { getFormHelpers } from "#/utils/formUtils";
 
 interface AnnouncementBannerDialogProps {

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/CoderAgentsProductCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { InfoIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 import { Badge } from "#/components/Badge/Badge";
@@ -9,7 +10,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { CONTACT_SALES_LINK } from "#/modules/licenses/trialLicense";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 
 // Allocation sentinel for unlimited agent runtime hours

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import { ChevronDownIcon, EllipsisVerticalIcon, TrashIcon } from "lucide-react";
 import { type FC, useState } from "react";
@@ -16,7 +17,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
-import { cn } from "#/utils/cn";
 import { AIGovernanceAddOnCard } from "./AIGovernanceAddOnCard";
 import { licenseShowsAiGovernanceAddOn } from "./AIGovernanceLicensing";
 import { CoderAgentsProductCard } from "./CoderAgentsProductCard";

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import { ChevronRightIcon } from "lucide-react";
 import type { FC } from "react";
@@ -10,7 +11,6 @@ import {
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 
 interface ManagedAgentsConsumptionProps {

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/SeatUsageBarCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/SeatUsageBarCard.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
-import { cn } from "#/utils/cn";
 
 type SeatUsageBarCardProps = {
 	title: string;

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentHoursCard.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/TotalAgentHoursCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import { BanIcon, InfoIcon } from "lucide-react";
 import type { FC } from "react";
@@ -9,7 +10,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 
 type TotalAgentHoursCardProps = {
 	feature?: Feature;

--- a/site/src/pages/DeploymentSettingsPage/Option.tsx
+++ b/site/src/pages/DeploymentSettingsPage/Option.tsx
@@ -1,7 +1,7 @@
+import { cn } from "cn";
 import { WrenchIcon } from "lucide-react";
 import type { FC, HTMLAttributes, PropsWithChildren } from "react";
 import { DisabledBadge, EnabledBadge } from "#/components/Badge/PresetBadges";
-import { cn } from "#/utils/cn";
 
 export const OptionName: FC<PropsWithChildren> = ({ children }) => {
 	return (

--- a/site/src/pages/GroupsPage/GroupMembersPage.tsx
+++ b/site/src/pages/GroupsPage/GroupMembersPage.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import { EllipsisVerticalIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
@@ -39,7 +40,6 @@ import {
 import { TableEmpty } from "#/components/TableEmpty/TableEmpty";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
-import { cn } from "#/utils/cn";
 import { formatBudgetUSD } from "#/utils/currency";
 import { SpendEstimateDocsLink } from "./AICostControl";
 import {

--- a/site/src/pages/GroupsPage/UserAIBudgetOverrideDialog.tsx
+++ b/site/src/pages/GroupsPage/UserAIBudgetOverrideDialog.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type FC,
 	type ReactNode,
@@ -53,7 +54,6 @@ import { Label } from "#/components/Label/Label";
 import { Separator } from "#/components/Separator/Separator";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { aiBudgetRangeError, maxAIBudgetDollars } from "#/modules/groups";
-import { cn } from "#/utils/cn";
 import {
 	dollarsToMicros,
 	formatBudgetUSD,

--- a/site/src/pages/HealthPage/Content.tsx
+++ b/site/src/pages/HealthPage/Content.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	CircleAlertIcon,
 	CircleCheckIcon,
@@ -13,7 +14,6 @@ import {
 } from "react";
 import type { HealthCode, HealthSeverity } from "#/api/typesGenerated";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 
 const CONTENT_PADDING = 36;

--- a/site/src/pages/HealthPage/DERPRegionPage.tsx
+++ b/site/src/pages/HealthPage/DERPRegionPage.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronLeftIcon, CodeIcon, HashIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link, useOutletContext, useParams } from "react-router";
@@ -19,7 +20,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 import { pageTitle } from "#/utils/page";
 import {

--- a/site/src/pages/HealthPage/HealthLayout.tsx
+++ b/site/src/pages/HealthPage/HealthLayout.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import kebabCase from "lodash/fp/kebabCase";
 import { BellOffIcon, RotateCcwIcon } from "lucide-react";
 import { type FC, Suspense } from "react";
@@ -15,7 +16,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { DashboardFullPage } from "#/modules/dashboard/DashboardLayout";
-import { cn } from "#/utils/cn";
 import { createDayString } from "#/utils/createDayString";
 import { pageTitle } from "#/utils/page";
 import { HealthIcon } from "./Content";

--- a/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
+++ b/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { GlobeIcon, HashIcon } from "lucide-react";
 import type { FC } from "react";
 import { useOutletContext } from "react-router";
@@ -9,7 +10,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { cn } from "#/utils/cn";
 import { createDayString } from "#/utils/createDayString";
 import { pageTitle } from "#/utils/page";
 import {

--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import { ArrowLeftIcon } from "lucide-react";
 import type { FC } from "react";
@@ -23,7 +24,6 @@ import { Spinner } from "#/components/Spinner/Spinner";
 import { Textarea } from "#/components/Textarea/Textarea";
 import { PremiumPaywall } from "#/modules/paywall/PremiumPaywall";
 import type { Permissions } from "#/modules/permissions";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationInfoForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationInfoForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import * as Yup from "yup";
@@ -19,7 +20,6 @@ import { IconField } from "#/components/IconField/IconField";
 import { Label } from "#/components/Label/Label";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Textarea } from "#/components/Textarea/Textarea";
-import { cn } from "#/utils/cn";
 import {
 	displayNameValidator,
 	getFormHelpers,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon, TriangleAlertIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Link as RouterLink } from "react-router";
@@ -12,7 +13,6 @@ import {
 	ProvisionerTags,
 	ProvisionerTruncateTags,
 } from "#/modules/provisioners/ProvisionerTags";
-import { cn } from "#/utils/cn";
 import { relativeTime } from "#/utils/time";
 import { CancelJobButton } from "./CancelJobButton";
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/ProvisionerKeyRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/ProvisionerKeyRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Link as RouterLink } from "react-router";
@@ -10,7 +11,6 @@ import {
 	ProvisionerTags,
 	ProvisionerTruncateTags,
 } from "#/modules/provisioners/ProvisionerTags";
-import { cn } from "#/utils/cn";
 import { relativeTime } from "#/utils/time";
 
 type ProvisionerKeyRowProps = {

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronRightIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Link as RouterLink } from "react-router";
@@ -19,7 +20,6 @@ import {
 	ProvisionerTruncateTags,
 } from "#/modules/provisioners/ProvisionerTags";
 import { ProvisionerKey } from "#/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerKey";
-import { cn } from "#/utils/cn";
 import { relativeTime } from "#/utils/time";
 import { ProvisionerVersion } from "./ProvisionerVersion";
 

--- a/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseTemplateParametersStep.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import { templateBuilderBases } from "#/api/queries/templateBuilder";
@@ -10,7 +11,6 @@ import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
-import { cn } from "#/utils/cn";
 import {
 	type ConfigurationFieldDefinition,
 	ConfigurationFieldLabel,

--- a/site/src/pages/TemplateBuilder/ModuleCard.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleCard.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import { BadgeCheckIcon, CheckIcon } from "lucide-react";
 import { useId } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 
 type ModuleCardProps = {
 	name: string;

--- a/site/src/pages/TemplateBuilder/SelectionSummary.tsx
+++ b/site/src/pages/TemplateBuilder/SelectionSummary.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
+import { cn } from "cn";
 import { createContext, type PropsWithChildren, useContext } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
-import { cn } from "#/utils/cn";
 import type { StepId } from "./steps";
 
 type Variant = "complete" | "current" | "upcoming" | null | undefined;

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import { BadgeCheckIcon } from "lucide-react";
 import { useId } from "react";
 import { Avatar } from "#/components/Avatar/Avatar";
 import { Link } from "#/components/Link/Link";
-import { cn } from "#/utils/cn";
 
 type TemplateCardProps = {
 	name: string;

--- a/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCustomizationsStep.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import { type FC, useEffect, useState } from "react";
 import { useQuery } from "react-query";
@@ -19,7 +20,6 @@ import {
 	TemplateBuilderSubtitle,
 	TemplateBuilderTitle,
 } from "#/pages/TemplateBuilder/TemplateBuilderHeader";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	CircleCheckIcon,
 	CircleXIcon,
@@ -51,8 +52,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { useTemplateLayoutContext } from "#/pages/TemplatePage/TemplateLayout";
-
-import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 import {
 	addTime,

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FormikTouched, useFormik } from "formik";
 import type { FC } from "react";
 import * as Yup from "yup";
@@ -33,7 +34,6 @@ import {
 	StackLabelHelperText,
 } from "#/components/StackLabel/StackLabel";
 import { Textarea } from "#/components/Textarea/Textarea";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import {
 	displayNameValidator,

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FormikTouched, useFormik } from "formik";
 import { type FC, useEffect, useState } from "react";
 import type { Template, UpdateTemplateMeta } from "#/api/typesGenerated";
@@ -25,7 +26,6 @@ import {
 	StackLabelHelperText,
 } from "#/components/StackLabel/StackLabel";
 import { Switch } from "#/components/Switch/Switch";
-import { cn } from "#/utils/cn";
 import { getFormHelpers } from "#/utils/formUtils";
 import {
 	calculateAutostopRequirementDaysValue,

--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariableField.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariableField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	type FC,
 	type FocusEventHandler,
@@ -9,7 +10,6 @@ import type { TemplateVersionVariable } from "#/api/typesGenerated";
 import { FormField } from "#/components/FormField/FormField";
 import { Label } from "#/components/Label/Label";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
-import { cn } from "#/utils/cn";
 
 export const SensitiveVariableHelperText: FC = () => {
 	return (

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import * as Yup from "yup";
@@ -18,7 +19,6 @@ import {
 import { Label } from "#/components/Label/Label";
 import { Textarea } from "#/components/Textarea/Textarea";
 import type { PublishVersionData } from "#/pages/TemplateVersionEditorPage/types";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import { getFormHelpers } from "#/utils/formUtils";
 

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	ChevronLeftIcon,
 	ExternalLinkIcon,
@@ -51,7 +52,6 @@ import { TemplateFileTree } from "#/modules/templates/TemplateFiles/TemplateFile
 import { TemplateResourcesTable } from "#/modules/templates/TemplateResourcesTable/TemplateResourcesTable";
 import { WorkspaceBuildLogs } from "#/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs";
 import type { PublishVersionData } from "#/pages/TemplateVersionEditorPage/types";
-import { cn } from "#/utils/cn";
 import {
 	createFile,
 	existsFile,

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ArrowRightIcon, PlusIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link as RouterLink, useNavigate } from "react-router";
@@ -40,7 +41,6 @@ import {
 import { useClickableTableRow } from "#/hooks/useClickableTableRow";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
 import type { WorkspacePermissions } from "#/modules/permissions/workspaces";
-import { cn } from "#/utils/cn";
 import { createDayString } from "#/utils/createDayString";
 import { docs } from "#/utils/docs";
 import {

--- a/site/src/pages/UserSettingsPage/AppearancePage/SingleModeSection.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/SingleModeSection.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import type { ConcreteThemeName } from "#/theme";
-import { cn } from "#/utils/cn";
 import { ThemePreview } from "./ThemePreview";
 import { DARK_THEMES, LIGHT_THEMES, THEME_COPY } from "./themeCopy";
 

--- a/site/src/pages/UserSettingsPage/AppearancePage/SyncModeSection.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/SyncModeSection.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import { MoonIcon, SunIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Badge } from "#/components/Badge/Badge";
 import type { ConcreteThemeName } from "#/theme";
-import { cn } from "#/utils/cn";
 import { ThemePreview } from "./ThemePreview";
 import { ThemeSwatch } from "./ThemeSwatch";
 import { SYNC_MODE_THEMES, THEME_COPY } from "./themeCopy";

--- a/site/src/pages/UserSettingsPage/AppearancePage/ThemePreview.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/ThemePreview.tsx
@@ -1,6 +1,6 @@
+import { cn } from "cn";
 import type { CSSProperties, FC } from "react";
 import { baseModeFor, type ConcreteThemeName } from "#/theme";
-import { cn } from "#/utils/cn";
 
 interface ThemePreviewProps {
 	theme: ConcreteThemeName;

--- a/site/src/pages/UserSettingsPage/AppearancePage/ThemeSwatch.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/ThemeSwatch.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import {
 	Tooltip,
@@ -5,7 +6,6 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { baseModeFor, type ConcreteThemeName } from "#/theme";
-import { cn } from "#/utils/cn";
 import { THEME_COPY } from "./themeCopy";
 
 interface ThemeSwatchProps {

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FormikTouched, useFormik } from "formik";
 import { type FC, type ReactNode, useState } from "react";
 import {
@@ -29,7 +30,6 @@ import { Label } from "#/components/Label/Label";
 import { Separator } from "#/components/Separator/Separator";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Textarea } from "#/components/Textarea/Textarea";
-import { cn } from "#/utils/cn";
 import { getFormHelpers } from "#/utils/formUtils";
 import {
 	buildCreateUserSecretRequest,

--- a/site/src/pages/UserSettingsPage/Section.tsx
+++ b/site/src/pages/UserSettingsPage/Section.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { PropsWithChildren, ReactNode } from "react";
-import { cn } from "#/utils/cn";
 
 type SectionProps = PropsWithChildren<{
 	title: ReactNode;

--- a/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { CircleCheckIcon, KeyIcon } from "lucide-react";
 import { type FC, useId, useState } from "react";
 import { useMutation } from "react-query";
@@ -21,7 +22,6 @@ import {
 	SettingsHeaderDescription,
 	SettingsHeaderTitle,
 } from "#/components/SettingsHeader/SettingsHeader";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 
 type LoginTypeConfirmation =

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import type { Region, WorkspaceProxy } from "#/api/typesGenerated";
 import { Avatar } from "#/components/Avatar/Avatar";
@@ -10,7 +11,6 @@ import {
 } from "#/components/StatusIndicator/StatusIndicator";
 import { TableCell, TableRow } from "#/components/Table/Table";
 import type { ProxyLatencyReport } from "#/contexts/useProxyLatency";
-import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 
 interface ProxyRowProps {

--- a/site/src/pages/UsersPage/UsersTable.tsx
+++ b/site/src/pages/UsersPage/UsersTable.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { EllipsisVerticalIcon, TrashIcon } from "lucide-react";
@@ -36,7 +37,6 @@ import {
 	RolesHelpPopover,
 } from "#/modules/users/UserHelpPopovers";
 import { UserRoleCell } from "#/modules/users/UserRoleCell";
-import { cn } from "#/utils/cn";
 
 dayjs.extend(relativeTime);
 

--- a/site/src/pages/WorkspaceBuildPage/Sidebar.tsx
+++ b/site/src/pages/WorkspaceBuildPage/Sidebar.tsx
@@ -1,5 +1,5 @@
+import { cn } from "cn";
 import type { FC, HTMLAttributes } from "react";
-import { cn } from "#/utils/cn";
 
 export const Sidebar: FC<HTMLAttributes<HTMLElement>> = ({
 	children,

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ExternalLinkIcon } from "lucide-react";
 import {
 	type FC,
@@ -39,7 +40,6 @@ import {
 	WorkspaceBuildDataSkeleton,
 } from "#/modules/workspaces/WorkspaceBuildData/WorkspaceBuildData";
 import { WorkspaceBuildLogs } from "#/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs";
-import { cn } from "#/utils/cn";
 import { formatDate } from "#/utils/time";
 import { displayWorkspaceBuildDuration } from "#/utils/workspace";
 import { WorkspaceDeletedBanner } from "../WorkspacePage/WorkspaceDeletedBanner";

--- a/site/src/pages/WorkspacePage/ResourceMetadata.tsx
+++ b/site/src/pages/WorkspacePage/ResourceMetadata.tsx
@@ -1,9 +1,9 @@
+import { cn } from "cn";
 import { Children, type FC, type HTMLAttributes } from "react";
 import type { WorkspaceResource } from "#/api/typesGenerated";
 import { CopyableValue } from "#/components/CopyableValue/CopyableValue";
 import { MemoizedInlineMarkdown } from "#/components/Markdown/InlineMarkdown";
 import { SensitiveValue } from "#/modules/resources/SensitiveValue";
-import { cn } from "#/utils/cn";
 
 type ResourceMetadataProps = Omit<HTMLAttributes<HTMLElement>, "resource"> & {
 	resource: WorkspaceResource;

--- a/site/src/pages/WorkspacePage/WorkspaceBuildLogsSection.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildLogsSection.tsx
@@ -1,8 +1,8 @@
+import { cn } from "cn";
 import type { FC } from "react";
 import type { ProvisionerJobLog } from "#/api/typesGenerated";
 import { Loader } from "#/components/Loader/Loader";
 import { WorkspaceBuildLogs } from "#/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs";
-import { cn } from "#/utils/cn";
 
 interface WorkspaceBuildLogsSectionProps {
 	logs?: ProvisionerJobLog[];

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { type FC, type ReactNode, useState } from "react";
 import type { AlertProps } from "#/components/Alert/Alert";
 import { Badge } from "#/components/Badge/Badge";
@@ -8,7 +9,6 @@ import {
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
 import type { ThemeRole } from "#/theme/roles";
-import { cn } from "#/utils/cn";
 
 export type NotificationItem = {
 	title: string;

--- a/site/src/pages/WorkspacePage/WorkspaceScheduleControls.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceScheduleControls.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import dayjs, { type Dayjs } from "dayjs";
 import { ClockIcon, MinusIcon, PlusIcon } from "lucide-react";
 import { type FC, type ReactNode, useRef, useState } from "react";
@@ -20,7 +21,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { useTime } from "#/hooks/useTime";
 import { getWorkspaceActivityStatus } from "#/modules/workspaces/activity";
-import { cn } from "#/utils/cn";
 import {
 	autostartDisplay,
 	autostopDisplay,

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { ChevronLeftIcon, CircleDollarSignIcon, TrashIcon } from "lucide-react";
 import type { FC } from "react";
 import { useQuery } from "react-query";
@@ -29,7 +30,6 @@ import {
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
 import { WorkspaceStatusIndicator } from "#/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator";
-import { cn } from "#/utils/cn";
 import { displayDormantDeletion } from "#/utils/dormant";
 import { formatDate } from "#/utils/time";
 import type { WorkspacePermissions } from "../../modules/workspaces/permissions";

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageView.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageView.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import type { FC } from "react";
 import type {
@@ -17,7 +18,6 @@ import {
 	getInitialParameterValues,
 	useValidationSchemaForDynamicParameters,
 } from "#/modules/workspaces/DynamicParameter/DynamicParameter";
-import { cn } from "#/utils/cn";
 import { docs } from "#/utils/docs";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { useFormik } from "formik";
 import upperFirst from "lodash/upperFirst";
 import type { FC } from "react";
@@ -24,7 +25,6 @@ import {
 	SelectValue,
 } from "#/components/Select/Select";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { cn } from "#/utils/cn";
 import {
 	getFormHelpers,
 	nameValidator,

--- a/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import { TriangleAlertIcon } from "lucide-react";
 import { Label, Slot } from "radix-ui";
 import {
@@ -24,7 +25,6 @@ import {
 } from "#/components/Dialog/Dialog";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { ACTIVE_BUILD_STATUSES } from "#/modules/workspaces/status";
-import { cn } from "#/utils/cn";
 
 export const BatchUpdateModalForm: FC<BatchUpdateModalFormProps> = ({
 	open,

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -1,3 +1,4 @@
+import { cn } from "cn";
 import {
 	BanIcon,
 	CircleAlertIcon,
@@ -81,7 +82,6 @@ import {
 	useWorkspaceUpdate,
 	WorkspaceUpdateDialogs,
 } from "#/modules/workspaces/WorkspaceUpdateDialogs";
-import { cn } from "#/utils/cn";
 import { getDisplayWorkspaceTemplateName } from "#/utils/workspace";
 import { WorkspaceSharingIndicator } from "./WorkspaceSharingIndicator";
 import { WorkspacesEmpty } from "./WorkspacesEmpty";

--- a/site/src/utils/cn.ts
+++ b/site/src/utils/cn.ts
@@ -1,1 +1,0 @@
-export { cn } from "cn";


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Stacked on #28915.

Imports `cn` directly from the package across the frontend and removes the `utils/cn` barrel module.
