### PR TITLE
docs(docs/ai-coder/agent-relay): update Cursor BYOM reference to Self-Hosted Machines

### DIFF
--- a/docs/ai-coder/agent-relay/cursor.md
+++ b/docs/ai-coder/agent-relay/cursor.md
@@ -6,7 +6,7 @@ title: Agent Relay for Cursor
 > Agent Relay for Cursor is in [early access](../../install/releases/feature-stages.md#early-access-features) and is currently in closed preview with select customers.
 
 [Agent Relay](./index.md) connects [Cursor Cloud Agents](https://cursor.com/cloud) to self-hosted Coder workspaces.
-Cursor also refers to this self-hosted worker model as [bring-your-own-machine (BYOM)](https://cursor.com/docs/cloud-agent/bring-your-own-machine).
+Cursor also refers to this self-hosted worker model as [self-hosted machines](https://cursor.com/docs/cloud-agent/self-hosted).
 Developers keep using the Cursor client and cloud agent workflow they already know.
 The agent's tool calls run inside a Coder workspace on infrastructure you control instead of a Cursor-managed environment.
 


### PR DESCRIPTION
Updates the Agent Relay for Cursor docs page to reflect Cursor's renamed terminology: "bring-your-own-machine (BYOM)" is now "Self-Hosted Machines" per Cursor's current docs (https://cursor.com/docs/cloud-agent/self-hosted).

- Replaced the BYOM term and outdated link with "Self-Hosted Machines" and the current Cursor docs URL.

_This PR was created by a Coder Agent on behalf of @mattvollmer._