### PR TITLE
refactor(site): refactor `<CreateEditRolePage />`

### DIFF
--- a/site/e2e/tests/organizations/customRoles/customRoles.spec.ts
+++ b/site/e2e/tests/organizations/customRoles/customRoles.spec.ts
@@ -45,7 +45,7 @@ test.describe("CustomRolesPage", () => {
 			`/organizations/${org.name}/roles/${customRole.name}`,
 		);
 
-		const cancelButton = page.getByRole("button", { name: "Cancel" }).first();
+		const cancelButton = page.getByRole("link", { name: "Cancel" });
 		await expect(cancelButton).toBeVisible();
 		await cancelButton.click();
 
@@ -73,7 +73,7 @@ test.describe("CustomRolesPage", () => {
 		await page.goto(`/organizations/${org.name}/roles/${customRole.name}`);
 
 		const displayNameInput = page.getByRole("textbox", {
-			name: "Display name",
+			name: /^Display name/,
 		});
 		await displayNameInput.fill("Custom Role Test 2 Edited");
 
@@ -87,7 +87,7 @@ test.describe("CustomRolesPage", () => {
 		await expect(organizationMemberCheckbox).toBeVisible();
 		await organizationMemberCheckbox.click();
 
-		const saveButton = page.getByRole("button", { name: /save/i }).first();
+		const saveButton = page.getByRole("button", { name: "Save" });
 		await expect(saveButton).toBeVisible();
 		await saveButton.click();
 
@@ -140,19 +140,17 @@ test.describe("CustomRolesPage", () => {
 
 		const customRoleName = "custom-role-test";
 		const roleNameInput = page.getByRole("textbox", {
-			exact: true,
-			name: "Name",
+			name: /^Name/,
 		});
 		await roleNameInput.fill(customRoleName);
 
 		const customRoleDisplayName = "Custom Role Test";
 		const displayNameInput = page.getByRole("textbox", {
-			exact: true,
-			name: "Display Name",
+			name: /^Display name/,
 		});
 		await displayNameInput.fill(customRoleDisplayName);
 
-		await page.getByRole("button", { name: "Create Role" }).first().click();
+		await page.getByRole("button", { name: "Create custom role" }).click();
 
 		await expect(page).toHaveURL(`/organizations/${org.name}/roles`);
 

--- a/site/src/api/queries/roles.ts
+++ b/site/src/api/queries/roles.ts
@@ -11,6 +11,9 @@ const getRoleQueryKey = (organizationId: string, roleName: string) => [
 
 export const rolesQueryKey = ["roles"];
 
+export const organizationRolesQueryKey = (organization: string) =>
+	["organization", organization, "roles"] as const;
+
 export const roles = () => {
 	return {
 		queryKey: rolesQueryKey,
@@ -20,9 +23,22 @@ export const roles = () => {
 
 export const organizationRoles = (organization: string) => {
 	return {
-		queryKey: ["organization", organization, "roles"],
+		queryKey: organizationRolesQueryKey(organization),
 		queryFn: () => API.getOrganizationRoles(organization),
 	};
+};
+
+const invalidateOrganizationRoles = async (
+	queryClient: QueryClient,
+	organization: string,
+	roleName: string,
+) => {
+	await queryClient.invalidateQueries({
+		queryKey: organizationRolesQueryKey(organization),
+	});
+	await queryClient.invalidateQueries({
+		queryKey: getRoleQueryKey(organization, roleName),
+	});
 };
 
 export const createOrganizationRole = (
@@ -33,9 +49,11 @@ export const createOrganizationRole = (
 		mutationFn: (request: Role) =>
 			API.createOrganizationRole(organization, request),
 		onSuccess: async (updatedRole: Role) =>
-			await queryClient.invalidateQueries({
-				queryKey: getRoleQueryKey(organization, updatedRole.name),
-			}),
+			await invalidateOrganizationRoles(
+				queryClient,
+				organization,
+				updatedRole.name,
+			),
 	};
 };
 
@@ -47,9 +65,11 @@ export const updateOrganizationRole = (
 		mutationFn: (request: Role) =>
 			API.updateOrganizationRole(organization, request),
 		onSuccess: async (updatedRole: Role) =>
-			await queryClient.invalidateQueries({
-				queryKey: getRoleQueryKey(organization, updatedRole.name),
-			}),
+			await invalidateOrganizationRoles(
+				queryClient,
+				organization,
+				updatedRole.name,
+			),
 	};
 };
 
@@ -61,8 +81,6 @@ export const deleteOrganizationRole = (
 		mutationFn: (roleName: string) =>
 			API.deleteOrganizationRole(organization, roleName),
 		onSuccess: async (_: unknown, roleName: string) =>
-			await queryClient.invalidateQueries({
-				queryKey: getRoleQueryKey(organization, roleName),
-			}),
+			await invalidateOrganizationRoles(queryClient, organization, roleName),
 	};
 };

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePage.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePage.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import { organizationRolesQueryKey } from "#/api/queries/roles";
+import {
+	assignableRole,
+	MockDefaultOrganization,
+	MockRoleWithOrgPermissions,
+	mockApiError,
+} from "#/testHelpers/entities";
+import {
+	withOrganizationSettingsProvider,
+	withToaster,
+} from "#/testHelpers/storybook";
+import CreateEditRolePage from "./CreateEditRolePage";
+
+const organizationName = MockDefaultOrganization.name;
+const rolesPath = `/organizations/${organizationName}/roles`;
+
+const meta = {
+	title: "pages/OrganizationCreateEditRolePage/CreateEditRolePage",
+	component: CreateEditRolePage,
+	decorators: [withToaster, withOrganizationSettingsProvider],
+	parameters: {
+		queries: [
+			{
+				key: organizationRolesQueryKey(organizationName),
+				data: [assignableRole(MockRoleWithOrgPermissions, true)],
+			},
+		],
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `${rolesPath}/create`,
+				pathParams: { organization: organizationName },
+			},
+			routing: [
+				{
+					path: "/organizations/:organization/roles",
+					element: <div>Roles list</div>,
+				},
+				{
+					path: "/organizations/:organization/roles/create",
+					useStoryElement: true,
+				},
+				{
+					path: "/organizations/:organization/roles/:roleName",
+					useStoryElement: true,
+				},
+			],
+		}),
+	},
+} satisfies Meta<typeof CreateEditRolePage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ShowsSuccessNotificationOnSubmit: Story = {
+	beforeEach: () => {
+		spyOn(API, "createOrganizationRole").mockResolvedValue({
+			...MockRoleWithOrgPermissions,
+			name: "auditor",
+			display_name: "Auditor",
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+
+		await user.type(await canvas.findByLabelText(/^Name/), "auditor");
+		await user.click(
+			canvas.getByRole("button", { name: "Create custom role" }),
+		);
+
+		await waitFor(() => {
+			expect(API.createOrganizationRole).toHaveBeenCalled();
+		});
+		await expect(canvas.findByText("Roles list")).resolves.toBeVisible();
+	},
+};
+
+export const ShowsErrorWhenCreateFails: Story = {
+	beforeEach: () => {
+		spyOn(API, "createOrganizationRole").mockRejectedValue(
+			mockApiError({ message: "A role named auditor already exists." }),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+
+		await user.type(await canvas.findByLabelText(/^Name/), "auditor");
+		await user.click(
+			canvas.getByRole("button", { name: "Create custom role" }),
+		);
+
+		await canvas.findAllByText("A role named auditor already exists.");
+	},
+};
+
+export const RoleNotFound: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `${rolesPath}/missing-role`,
+				pathParams: {
+					organization: organizationName,
+					roleName: "missing-role",
+				},
+			},
+			routing: [
+				{
+					path: "/organizations/:organization/roles",
+					element: <div>Roles list</div>,
+				},
+				{
+					path: "/organizations/:organization/roles/create",
+					useStoryElement: true,
+				},
+				{
+					path: "/organizations/:organization/roles/:roleName",
+					useStoryElement: true,
+				},
+			],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(await canvas.findByText("Role not found")).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: /back to roles/i }),
+		).toHaveAttribute("href", rolesPath);
+	},
+};
+
+export const NavigatesBackToRoles: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+
+		await user.click(
+			await canvas.findByRole("link", { name: /back to roles/i }),
+		);
+		await expect(await canvas.findByText("Roles list")).toBeVisible();
+	},
+};

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
 import {
@@ -10,105 +10,109 @@ import {
 } from "#/api/queries/roles";
 import type { CustomRoleRequest } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Button } from "#/components/Button/Button";
+import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { Loader } from "#/components/Loader/Loader";
 import { useOrganizationSettings } from "#/modules/management/OrganizationSettingsLayout";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { pageTitle } from "#/utils/page";
-import CreateEditRolePageView from "./CreateEditRolePageView";
+import { CreateEditRolePageView } from "./CreateEditRolePageView";
 
 const CreateEditRolePage: FC = () => {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
-
-	const { organization: organizationName, roleName } = useParams() as {
-		organization: string;
-		roleName: string;
-	};
+	const { organization: organizationName, roleName } = useParams();
 	const { organizationPermissions } = useOrganizationSettings();
+	const rolesQuery = useQuery({
+		...organizationRoles(organizationName ?? ""),
+		enabled: Boolean(organizationName),
+	});
 	const createOrganizationRoleMutation = useMutation(
-		createOrganizationRole(queryClient, organizationName),
+		createOrganizationRole(queryClient, organizationName ?? ""),
 	);
 	const updateOrganizationRoleMutation = useMutation(
-		updateOrganizationRole(queryClient, organizationName),
+		updateOrganizationRole(queryClient, organizationName ?? ""),
 	);
-	const { data: roleData, isLoading } = useQuery(
-		organizationRoles(organizationName),
-	);
-	const role = roleData?.find((role) => role.name === roleName);
 
-	if (isLoading) {
+	if (!organizationName) {
+		return <EmptyState message="Organization not found" />;
+	}
+
+	const rolesHref = `/organizations/${organizationName}/roles`;
+
+	if (rolesQuery.isLoading) {
 		return <Loader />;
+	}
+
+	if (rolesQuery.error) {
+		return <ErrorAlert error={rolesQuery.error} />;
 	}
 
 	if (!organizationPermissions) {
 		return <ErrorAlert error="Failed to load organization permissions" />;
 	}
 
+	const role = roleName
+		? rolesQuery.data?.find((candidate) => candidate.name === roleName)
+		: undefined;
+
+	if (roleName && !role) {
+		return (
+			<EmptyState
+				message="Role not found"
+				cta={
+					<Button variant="outline" asChild>
+						<Link to={rolesHref}>Back to roles</Link>
+					</Button>
+				}
+			/>
+		);
+	}
+
+	const isEditing = role !== undefined;
+	const saveRole = isEditing
+		? updateOrganizationRoleMutation
+		: createOrganizationRoleMutation;
+
+	const handleSubmit = (data: CustomRoleRequest) => {
+		const mutation = saveRole.mutateAsync(data, {
+			onSuccess: () => {
+				navigate(rolesHref);
+			},
+		});
+		toast.promise(mutation, {
+			loading: `${isEditing ? "Updating" : "Creating"} custom role "${data.name}"...`,
+			success: `Custom role "${data.name}" ${isEditing ? "updated" : "created"} successfully.`,
+			error: (error) => ({
+				message: getErrorMessage(
+					error,
+					`Failed to ${isEditing ? "update" : "create"} custom role "${data.name}".`,
+				),
+				description: getErrorDetail(error),
+			}),
+		});
+	};
+
 	return (
 		<RequirePermission
 			isFeatureVisible={
-				role
+				isEditing
 					? organizationPermissions.updateOrgRoles
 					: organizationPermissions.createOrgRoles
 			}
 		>
 			<title>
 				{pageTitle(
-					role !== undefined ? "Edit Custom Role" : "Create Custom Role",
+					isEditing ? "Edit Custom Role" : "New Custom Role",
+					isEditing ? role.display_name || role.name : undefined,
 				)}
 			</title>
 
 			<CreateEditRolePageView
 				role={role}
-				onSubmit={async (data: CustomRoleRequest) => {
-					const mutation = role
-						? updateOrganizationRoleMutation.mutateAsync(data, {
-								onSuccess: () => {
-									navigate(`/organizations/${organizationName}/roles`);
-								},
-							})
-						: createOrganizationRoleMutation.mutateAsync(data, {
-								onSuccess: () => {
-									navigate(`/organizations/${organizationName}/roles`);
-								},
-							});
-					toast.promise(
-						mutation,
-						role
-							? {
-									loading: `Updating custom role "${data.name}"...`,
-									success: `Custom role "${data.name}" updated successfully.`,
-									error: (error) => ({
-										message: getErrorMessage(
-											error,
-											`Failed to update custom role "${data.name}".`,
-										),
-										description: getErrorDetail(error),
-									}),
-								}
-							: {
-									loading: `Creating custom role "${data.name}"...`,
-									success: `Custom role "${data.name}" created successfully.`,
-									error: (error) => ({
-										message: getErrorMessage(
-											error,
-											`Failed to create custom role "${data.name}".`,
-										),
-										description: getErrorDetail(error),
-									}),
-								},
-					);
-				}}
-				error={
-					role
-						? updateOrganizationRoleMutation.error
-						: createOrganizationRoleMutation.error
-				}
-				isLoading={
-					role
-						? updateOrganizationRoleMutation.isPending
-						: createOrganizationRoleMutation.isPending
-				}
+				onSubmit={handleSubmit}
+				error={saveRole.error}
+				isLoading={saveRole.isPending}
 				organizationName={organizationName}
 			/>
 		</RequirePermission>

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
@@ -1,50 +1,101 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import {
 	assignableRole,
 	MockRole2WithOrgPermissions,
 	MockRoleWithOrgPermissions,
 	mockApiError,
 } from "#/testHelpers/entities";
-import CreateEditRolePageView from "./CreateEditRolePageView";
+import { CreateEditRolePageView } from "./CreateEditRolePageView";
+
+const organizationName = "my-org";
 
 const meta: Meta<typeof CreateEditRolePageView> = {
 	title: "pages/OrganizationCreateEditRolePage",
 	component: CreateEditRolePageView,
+	args: {
+		onSubmit: fn(),
+		error: undefined,
+		isLoading: false,
+		organizationName,
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: `/organizations/${organizationName}/roles/create` },
+			routing: [
+				{ path: "/organizations/:organization/roles", useStoryElement: true },
+				{
+					path: "/organizations/:organization/roles/create",
+					useStoryElement: true,
+				},
+				{
+					path: "/organizations/:organization/roles/:roleName",
+					useStoryElement: true,
+				},
+			],
+		}),
+	},
 };
 
 export default meta;
 type Story = StoryObj<typeof CreateEditRolePageView>;
 
-export const Default: Story = {
+export const Create: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: "New Custom Role" }),
+		).toBeVisible();
+		await expect(
+			canvas.getByRole("link", { name: /back to roles/i }),
+		).toHaveAttribute("href", `/organizations/${organizationName}/roles`);
+		await expect(canvas.getByRole("link", { name: "Cancel" })).toHaveAttribute(
+			"href",
+			`/organizations/${organizationName}/roles`,
+		);
+		await expect(
+			canvas.getByRole("button", { name: "Create custom role" }),
+		).toBeEnabled();
+	},
+};
+
+export const Edit: Story = {
 	args: {
 		role: assignableRole(MockRoleWithOrgPermissions, true),
-		onSubmit: () => null,
-		error: undefined,
-		isLoading: false,
-		organizationName: "my-org",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByRole("heading", { name: "Edit Custom Role" }),
+		).toBeVisible();
+		await expect(canvas.getByLabelText(/^Name/)).toBeDisabled();
+		await expect(canvas.getByRole("button", { name: "Save" })).toBeEnabled();
 	},
 };
 
 export const CheckboxIndeterminate: Story = {
 	args: {
-		...Default.args,
 		role: assignableRole(MockRole2WithOrgPermissions, true),
 	},
 };
 
 export const WithError: Story = {
 	args: {
-		...Default.args,
-		role: undefined,
-		error: "this is an error",
+		error: mockApiError({
+			message: "Failed to create custom role.",
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("alert")).toHaveTextContent(
+			"Failed to create custom role.",
+		);
 	},
 };
 
 export const WithValidationError: Story = {
 	args: {
-		...Default.args,
-		role: undefined,
 		error: mockApiError({
 			message: "A role named new-role already exists.",
 			validations: [{ field: "name", detail: "Role names must be unique" }],
@@ -54,7 +105,7 @@ export const WithValidationError: Story = {
 		const canvas = within(canvasElement);
 
 		await step("Enter name", async () => {
-			const input = canvas.getByLabelText("Name");
+			const input = canvas.getByLabelText(/^Name/);
 			await userEvent.type(input, "new-role");
 			input.blur();
 		});
@@ -62,46 +113,36 @@ export const WithValidationError: Story = {
 };
 
 export const InvalidCharsError: Story = {
-	args: {
-		...Default.args,
-		role: undefined,
-	},
 	play: async ({ canvasElement, step }) => {
 		const canvas = within(canvasElement);
 
 		await step("Enter name", async () => {
-			const input = canvas.getByLabelText("Name");
+			const input = canvas.getByLabelText(/^Name/);
 			await userEvent.type(input, "!~@#@!");
 			input.blur();
 		});
 	},
 };
 
-export const CannotEditRoleName: Story = {
-	args: {
-		...Default.args,
-	},
-};
-
 export const ShowAllResources: Story = {
 	args: {
-		...Default.args,
+		role: assignableRole(MockRoleWithOrgPermissions, true),
 		allResources: true,
 	},
 };
 
 export const Loading: Story = {
 	args: {
-		...Default.args,
+		role: assignableRole(MockRoleWithOrgPermissions, true),
 		isLoading: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("button", { name: /save/i })).toBeDisabled();
 	},
 };
 
 export const ToggleParentCheckbox: Story = {
-	args: {
-		...Default.args,
-		role: undefined,
-	},
 	play: async ({ canvasElement }) => {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
@@ -114,42 +155,54 @@ export const ToggleParentCheckbox: Story = {
 };
 
 export const ToggleAdvancedPermissions: Story = {
-	args: {
-		...Default.args,
-		role: undefined,
-	},
 	play: async ({ canvasElement }) => {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 
-		// Advanced-only resources are hidden until the switch is enabled.
 		expect(
 			canvas.queryByRole("checkbox", { name: "api_key" }),
 		).not.toBeInTheDocument();
 
-		const [toggle] = canvas.getAllByRole("switch", {
+		const toggle = canvas.getByRole("switch", {
 			name: "Show advanced permissions",
 		});
 		await user.click(toggle);
 
-		// Enabling the switch reveals advanced resources and flips the label.
 		await expect(
 			canvas.getByRole("checkbox", { name: "api_key" }),
 		).toBeInTheDocument();
-		const [enabledToggle] = canvas.getAllByRole("switch", {
+		const enabledToggle = canvas.getByRole("switch", {
 			name: "Hide advanced permissions",
 		});
 		await expect(enabledToggle).toBeChecked();
 
 		await user.click(enabledToggle);
 
-		// Disabling the switch hides advanced resources again.
 		await expect(
 			canvas.queryByRole("checkbox", { name: "api_key" }),
 		).not.toBeInTheDocument();
-		const [disabledToggle] = canvas.getAllByRole("switch", {
+		const disabledToggle = canvas.getByRole("switch", {
 			name: "Show advanced permissions",
 		});
 		await expect(disabledToggle).not.toBeChecked();
+	},
+};
+
+export const SubmitsNewRole: Story = {
+	play: async ({ canvasElement, args }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+
+		await user.type(canvas.getByLabelText(/^Name/), "auditor");
+		const memberCheckbox = canvas.getByRole("checkbox", {
+			name: "organization_member",
+		});
+		await user.click(memberCheckbox);
+		await expect(memberCheckbox).toBeChecked();
+		await user.click(
+			canvas.getByRole("button", { name: "Create custom role" }),
+		);
+
+		await expect(args.onSubmit).toHaveBeenCalled();
 	},
 };

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -1,21 +1,28 @@
-import { useFormik } from "formik";
-import { type FC, useId, useState } from "react";
-import { useNavigate } from "react-router";
+import { type FormikContextType, useFormik } from "formik";
+import { ArrowLeftIcon } from "lucide-react";
+import {
+	type Dispatch,
+	type FC,
+	type SetStateAction,
+	useId,
+	useState,
+} from "react";
+import { Link } from "react-router";
 import * as Yup from "yup";
 import { isApiValidationError } from "#/api/errors";
 import { RBACResourceActions } from "#/api/rbacresourcesGenerated";
-import type {
-	AssignableRoles,
-	CustomRoleRequest,
-	Permission,
-	RBACAction,
-	RBACResource,
-	Role,
+import {
+	type AssignableRoles,
+	type CustomRoleRequest,
+	type Permission,
+	type RBACAction,
+	RBACActions,
+	type RBACResource,
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import { Checkbox } from "#/components/Checkbox/Checkbox";
-import { FormFields, FormFooter, VerticalForm } from "#/components/Form/Form";
+import { FormFooter } from "#/components/Form/Form";
 import { FormField } from "#/components/FormField/FormField";
 import { Label } from "#/components/Label/Label";
 import {
@@ -33,10 +40,16 @@ import {
 	TableHeader,
 	TableRow,
 } from "#/components/Table/Table";
-import { getFormHelpers, nameValidator } from "#/utils/formUtils";
+import {
+	displayNameValidator,
+	getFormHelpers,
+	nameValidator,
+	onChangeTrimmed,
+} from "#/utils/formUtils";
 
 const validationSchema = Yup.object({
 	name: nameValidator("Name"),
+	display_name: displayNameValidator("Display name"),
 });
 
 type CreateEditRolePageViewProps = {
@@ -48,7 +61,7 @@ type CreateEditRolePageViewProps = {
 	allResources?: boolean;
 };
 
-const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
+export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 	role,
 	onSubmit,
 	error,
@@ -56,13 +69,12 @@ const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 	organizationName,
 	allResources = false,
 }) => {
-	const navigate = useNavigate();
-	const onCancel = () => navigate(-1);
-
+	const isEditing = role !== undefined;
+	const rolesHref = `/organizations/${organizationName}/roles`;
 	const form = useFormik<CustomRoleRequest>({
 		initialValues: {
-			name: role?.name || "",
-			display_name: role?.display_name || "",
+			name: role?.name ?? "",
+			display_name: role?.display_name ?? "",
 			site_permissions: role?.site_permissions ?? [],
 			user_permissions: role?.user_permissions ?? [],
 			organization_permissions: role?.organization_permissions ?? [],
@@ -73,81 +85,81 @@ const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 		onSubmit,
 	});
 
-	const getFieldHelpers = getFormHelpers<Role>(form, error);
+	const getFieldHelpers = getFormHelpers<CustomRoleRequest>(form, error);
 
 	return (
-		<>
-			<div className="flex flex-row gap-4 items-baseline justify-between">
+		<div>
+			<Button variant="subtle" asChild className="-ml-3">
+				<Link to={rolesHref}>
+					<ArrowLeftIcon />
+					<span>Back to roles</span>
+				</Link>
+			</Button>
+
+			<div className="pt-6">
 				<SettingsHeader>
 					<SettingsHeaderTitle>
-						{role ? "Edit" : "Create"} Custom Role
+						{isEditing ? "Edit Custom Role" : "New Custom Role"}
 					</SettingsHeaderTitle>
 					<SettingsHeaderDescription>
 						Set a name and permissions for this role.
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<div className="flex space-x-2 items-center">
-					<Button
-						variant="outline"
-						onClick={() => {
-							navigate(`/organizations/${organizationName}/roles`);
-						}}
+				<div className="border border-solid p-6 rounded-lg">
+					<form
+						onSubmit={form.handleSubmit}
+						noValidate
+						autoComplete="off"
+						aria-label="Custom role settings form"
+						className="flex flex-col gap-6"
 					>
-						Cancel
-					</Button>
-					<Button
-						onClick={() => {
-							form.handleSubmit();
-						}}
-					>
-						<Spinner loading={isLoading} />
-						{role !== undefined ? "Save" : "Create Role"}
-					</Button>
+						<fieldset
+							disabled={isLoading}
+							className="flex flex-col gap-6 m-0 border-none p-0 min-w-0"
+						>
+							{Boolean(error) && !isApiValidationError(error) && (
+								<ErrorAlert error={error} />
+							)}
+
+							<FormField
+								field={getFieldHelpers("name", {
+									helperText: "Cannot be changed after the role is created.",
+								})}
+								label="Name"
+								required
+								autoFocus
+								disabled={isEditing}
+								onChange={onChangeTrimmed(form)}
+								className="w-full"
+							/>
+							<FormField
+								field={getFieldHelpers("display_name", {
+									helperText: "Keep empty to default to the name.",
+								})}
+								label="Display name"
+								className="w-full"
+							/>
+							<ActionCheckboxes
+								permissions={role?.organization_permissions ?? []}
+								form={form}
+								allResources={allResources}
+							/>
+						</fieldset>
+
+						<FormFooter>
+							<Button asChild variant="outline">
+								<Link to={rolesHref}>Cancel</Link>
+							</Button>
+							<Button type="submit" disabled={isLoading}>
+								<Spinner loading={isLoading} aria-hidden />
+								{isEditing ? "Save" : "Create custom role"}
+							</Button>
+						</FormFooter>
+					</form>
 				</div>
 			</div>
-
-			<VerticalForm onSubmit={form.handleSubmit}>
-				<FormFields>
-					{Boolean(error) && !isApiValidationError(error) && (
-						<ErrorAlert error={error} />
-					)}
-
-					<FormField
-						field={getFieldHelpers("name", {
-							helperText:
-								"The role name cannot be modified after the role is created.",
-						})}
-						label="Name"
-						autoFocus
-						disabled={role !== undefined}
-						className="w-full"
-					/>
-					<FormField
-						field={getFieldHelpers("display_name", {
-							helperText: "Optional: keep empty to default to the name.",
-						})}
-						label="Display Name"
-						className="w-full"
-					/>
-					<ActionCheckboxes
-						permissions={role?.organization_permissions || []}
-						form={form}
-						allResources={allResources}
-					/>
-				</FormFields>
-				<FormFooter>
-					<Button onClick={onCancel} variant="outline">
-						Cancel
-					</Button>
-
-					<Button type="submit" disabled={isLoading}>
-						<Spinner loading={isLoading} />
-						{role ? "Save role" : "Create Role"}
-					</Button>
-				</FormFooter>
-			</VerticalForm>
-		</>
+		</div>
 	);
 };
 
@@ -159,7 +171,6 @@ const ResourceActionComparator = (
 	p.resource_type === resource &&
 	(p.action.toString() === "*" || p.action === action);
 
-// the subset of resources that are useful for most users
 const DEFAULT_RESOURCES = [
 	"audit_log",
 	"group",
@@ -178,15 +189,17 @@ const filteredRBACResourceActions = Object.fromEntries(
 	),
 );
 
-// Object.entries widens keys to `string`; this narrows them back to the
-// RBACResource union without an assertion.
 function isRBACResource(resource: string): resource is RBACResource {
 	return resource in RBACResourceActions;
 }
 
+function isRBACAction(action: string): action is RBACAction {
+	return RBACActions.some((rbacAction) => rbacAction === action);
+}
+
 interface ActionCheckboxesProps {
 	permissions: readonly Permission[];
-	form: ReturnType<typeof useFormik<Role>> & { values: Role };
+	form: FormikContextType<CustomRoleRequest>;
 	allResources: boolean;
 }
 
@@ -203,19 +216,22 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 		: filteredRBACResourceActions;
 
 	const handleActionCheckChange = async (name: string, checked: boolean) => {
-		const [resource_type, action] = name.split(":");
+		const [resourceType, action] = name.split(":");
+		if (!isRBACResource(resourceType) || !isRBACAction(action)) {
+			return;
+		}
 
 		const newPermissions = checked
 			? [
 					...checkedActions,
 					{
 						negate: false,
-						resource_type: resource_type as RBACResource,
-						action: action as RBACAction,
+						resource_type: resourceType,
+						action,
 					},
 				]
-			: checkedActions?.filter(
-					(p) => p.resource_type !== resource_type || p.action !== action,
+			: checkedActions.filter(
+					(p) => p.resource_type !== resourceType || p.action !== action,
 				);
 
 		setCheckActions(newPermissions);
@@ -231,64 +247,62 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 
 		const newCheckedActions =
 			!checked || indeterminate
-				? checkedActions?.filter((p) => p.resource_type !== resource)
+				? checkedActions.filter((p) => p.resource_type !== resource)
 				: checkedActions;
 
-		const newPermissions =
-			checked || indeterminate
-				? [
-						...newCheckedActions,
-						...Object.keys(resourceActionsForResource).map((resourceKey) => ({
-							negate: false,
-							resource_type: resource as RBACResource,
-							action: resourceKey as RBACAction,
-						})),
-					]
-				: [...newCheckedActions];
+		const resourcePermissions: Permission[] = [];
+		if (checked || indeterminate) {
+			for (const resourceKey of Object.keys(resourceActionsForResource)) {
+				if (!isRBACAction(resourceKey)) {
+					continue;
+				}
+				resourcePermissions.push({
+					negate: false,
+					resource_type: resource,
+					action: resourceKey,
+				});
+			}
+		}
+
+		const newPermissions = [...newCheckedActions, ...resourcePermissions];
 
 		setCheckActions(newPermissions);
 		await form.setFieldValue("organization_permissions", newPermissions);
 	};
 
 	return (
-		<>
-			<Table>
-				<TableHeader>
-					<TableRow>
-						<TableHead>Permission</TableHead>
-						<TableHead className="py-1 text-right">
-							<ShowAllResourcesSwitch
-								showAllResources={showAllResources}
-								setShowAllResources={setShowAllResources}
-							/>
-						</TableHead>
-					</TableRow>
-				</TableHeader>
-				<TableBody>
-					{Object.entries(resourceActions).map(([resourceKey, value]) => {
-						if (!isRBACResource(resourceKey)) {
-							return null;
-						}
-						return (
-							<PermissionCheckboxGroup
-								key={resourceKey}
-								checkedActions={checkedActions?.filter(
-									(a) => a.resource_type === resourceKey,
-								)}
-								resourceKey={resourceKey}
-								value={value}
-								handleActionCheckChange={handleActionCheckChange}
-								handleResourceCheckChange={handleResourceCheckChange}
-							/>
-						);
-					})}
-				</TableBody>
-			</Table>
-			<ShowAllResourcesSwitch
-				showAllResources={showAllResources}
-				setShowAllResources={setShowAllResources}
-			/>
-		</>
+		<Table aria-label="Role permissions">
+			<TableHeader>
+				<TableRow>
+					<TableHead>Permission</TableHead>
+					<TableHead className="py-1 text-right">
+						<ShowAllResourcesSwitch
+							showAllResources={showAllResources}
+							setShowAllResources={setShowAllResources}
+						/>
+					</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{Object.entries(resourceActions).map(([resourceKey, value]) => {
+					if (!isRBACResource(resourceKey)) {
+						return null;
+					}
+					return (
+						<PermissionCheckboxGroup
+							key={resourceKey}
+							checkedActions={checkedActions.filter(
+								(a) => a.resource_type === resourceKey,
+							)}
+							resourceKey={resourceKey}
+							value={value}
+							handleActionCheckChange={handleActionCheckChange}
+							handleResourceCheckChange={handleResourceCheckChange}
+						/>
+					);
+				})}
+			</TableBody>
+		</Table>
 	);
 };
 
@@ -317,9 +331,9 @@ const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
 		checkedActions.length > 0 && checkedActions.length < actionCount;
 
 	return (
-		<TableRow key={resourceKey}>
+		<TableRow>
 			<TableCell className="px-4" colSpan={2}>
-				<li key={resourceKey} className="m-0 list-none">
+				<div>
 					<div className="inline-flex items-center gap-2">
 						<Checkbox
 							name={resourceKey}
@@ -365,7 +379,7 @@ const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
 							);
 						})}
 					</ul>
-				</li>
+				</div>
 			</TableCell>
 		</TableRow>
 	);
@@ -373,7 +387,7 @@ const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
 
 interface ShowAllResourcesSwitchProps {
 	showAllResources: boolean;
-	setShowAllResources: React.Dispatch<React.SetStateAction<boolean>>;
+	setShowAllResources: Dispatch<SetStateAction<boolean>>;
 }
 
 const ShowAllResourcesSwitch: FC<ShowAllResourcesSwitchProps> = ({
@@ -399,5 +413,3 @@ const ShowAllResourcesSwitch: FC<ShowAllResourcesSwitchProps> = ({
 		</div>
 	);
 };
-
-export default CreateEditRolePageView;


### PR DESCRIPTION
> 🤖 This PR was modified by Coder Agents on behalf of Jake Howell.

Similar in vein to the other page upgrades I've been working through, this refactors the custom role create/edit experience to use the latest settings page patterns.

- Refreshes the create/edit custom role layout with consistent navigation, form styling, copy, and loading states.
- Adds validation for display names and trims role names as they are entered.
- Improves handling for missing organizations, missing roles, permissions failures, and role query errors.
- Adds success/error notifications for create and update mutations.
- Invalidates both the organization roles list and individual role queries after role mutations.
- Improves permission selection typing, semantics, and accessibility.
- Updates the custom roles end-to-end tests for the refreshed UI and accessible labels.

| Create | Edit |
| --- | --- |
| <img width="2902" height="4260" alt="preview-custom-role-new" src="https://github.com/user-attachments/assets/4d454063-68a9-42e8-8534-1c827734f001"/> | <img width="2902" height="4260" alt="preview-custom-role-edit" src="https://github.com/user-attachments/assets/e38c516e-dc45-4232-bad9-8f43b542e92e"/> |