### PR TITLE
refactor(site/src/pages/TemplateBuilder): readability clean-up for the template wizard

### DIFF
--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -49,10 +49,10 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 				Select your infrastructure foundation.
 			</TemplateBuilderSubtitle>
 
-			{/* Show two rows of cards (sized to the common 214px card height plus
-			    the row gap) and let any extra rows scroll, so the Continue button
+			{/* Show three rows of cards (sized to the common 214px card height plus
+			    the row gaps) and let any extra rows scroll, so the Continue button
 			    stays high and is easy to discover. */}
-			<div className="max-h-[452px] overflow-y-auto p-1 -m-1">
+			<div className="max-h-[682px] overflow-y-auto p-1 -m-1">
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
 					{bases.map((base) => (
 						<TemplateCard

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -49,9 +49,10 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 				Select your infrastructure foundation.
 			</TemplateBuilderSubtitle>
 
-			{/* Cap the visible cards at two rows and let the rest scroll, so the
-			    Continue button stays above the fold and is easy to discover. */}
-			<div className="max-h-[23.5rem] overflow-y-auto p-1 -m-1">
+			{/* Show two full rows of cards and let any extra rows scroll, so the
+			    Continue button stays high and is easy to discover. The height fits
+			    two of the tallest stretched cards plus the row gap. */}
+			<div className="max-h-[33rem] overflow-y-auto p-1 -m-1">
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
 					{bases.map((base) => (
 						<TemplateCard

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -49,10 +49,10 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 				Select your infrastructure foundation.
 			</TemplateBuilderSubtitle>
 
-			{/* Show two full rows of cards and let any extra rows scroll, so the
-			    Continue button stays high and is easy to discover. The height fits
-			    two of the tallest stretched cards plus the row gap. */}
-			<div className="max-h-[33rem] overflow-y-auto p-1 -m-1">
+			{/* Show two rows of cards (sized to the common 214px card height plus
+			    the row gap) and let any extra rows scroll, so the Continue button
+			    stays high and is easy to discover. */}
+			<div className="max-h-[452px] overflow-y-auto p-1 -m-1">
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
 					{bases.map((base) => (
 						<TemplateCard

--- a/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/BaseInfraSelectStep.tsx
@@ -49,18 +49,22 @@ export const BaseInfraSelectStep: FC<BaseInfraSelectStepProps> = ({
 				Select your infrastructure foundation.
 			</TemplateBuilderSubtitle>
 
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-				{bases.map((base) => (
-					<TemplateCard
-						key={base.id}
-						name={base.name}
-						description={base.description}
-						iconUrl={base.icon}
-						detailsUrl={detailsUrl(base.id)}
-						selected={base.id === selectedBaseId}
-						onSelect={() => onSelectBase(toSelectedBaseMeta(base))}
-					/>
-				))}
+			{/* Cap the visible cards at two rows and let the rest scroll, so the
+			    Continue button stays above the fold and is easy to discover. */}
+			<div className="max-h-[23.5rem] overflow-y-auto p-1 -m-1">
+				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+					{bases.map((base) => (
+						<TemplateCard
+							key={base.id}
+							name={base.name}
+							description={base.description}
+							iconUrl={base.icon}
+							detailsUrl={detailsUrl(base.id)}
+							selected={base.id === selectedBaseId}
+							onSelect={() => onSelectBase(toSelectedBaseMeta(base))}
+						/>
+					))}
+				</div>
 			</div>
 		</div>
 	);

--- a/site/src/pages/TemplateBuilder/ModuleCard.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleCard.tsx
@@ -62,7 +62,7 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
 			</div>
 
 			<div>
-				<h3 id={nameId} className="text-sm font-bold text-content-primary">
+				<h3 id={nameId} className="mt-0 text-sm font-bold text-content-primary">
 					{name}
 					{official && (
 						<>

--- a/site/src/pages/TemplateBuilder/ModuleCard.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleCard.tsx
@@ -61,8 +61,8 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
 				</div>
 			</div>
 
-			<div>
-				<h3 id={nameId} className="mt-0 text-sm font-bold text-content-primary">
+			<div className="flex flex-col gap-2">
+				<h3 id={nameId} className="my-0 text-sm font-bold text-content-primary">
 					{name}
 					{official && (
 						<>
@@ -71,19 +71,13 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
 						</>
 					)}
 				</h3>
-				<p className="text-xs font-normal text-content-secondary">
+				<p className="my-0 text-xs font-normal text-content-secondary">
 					{description}
 				</p>
 
-				<div>
-					<Link
-						href={detailsUrl}
-						target="_blank"
-						className="text-xs font-normal"
-					>
-						View details
-					</Link>
-				</div>
+				<Link href={detailsUrl} target="_blank" className="text-xs font-normal">
+					View details
+				</Link>
 			</div>
 		</div>
 	);

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -232,29 +232,33 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				</TabsList>
 			</Tabs>
 
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-				{visibleModules.length ? (
-					visibleModules.map((m) => (
-						<ModuleCard
-							key={m.id}
-							name={m.display_name}
-							description={m.description}
-							iconUrl={m.icon}
-							detailsUrl={moduleDetailsUrl(m.id)}
-							selected={selectedSet.has(m.id)}
-							onSelect={() => handleToggle(m)}
-						/>
-					))
-				) : (
-					<div className="col-span-full my-12 flex flex-col items-center gap-1 text-content-secondary">
-						<SearchIcon />
-						<p className="m-0 text-xs font-normal">
-							{doesBaseTemplateHaveModules
-								? "No module matched your search"
-								: "No modules available for this base template"}
-						</p>
-					</div>
-				)}
+			{/* Cap the visible cards at two rows and let the rest scroll, so the
+			    Continue button stays above the fold and is easy to discover. */}
+			<div className="max-h-[23.5rem] overflow-y-auto p-1 -m-1">
+				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+					{visibleModules.length ? (
+						visibleModules.map((m) => (
+							<ModuleCard
+								key={m.id}
+								name={m.display_name}
+								description={m.description}
+								iconUrl={m.icon}
+								detailsUrl={moduleDetailsUrl(m.id)}
+								selected={selectedSet.has(m.id)}
+								onSelect={() => handleToggle(m)}
+							/>
+						))
+					) : (
+						<div className="col-span-full my-12 flex flex-col items-center gap-1 text-content-secondary">
+							<SearchIcon />
+							<p className="m-0 text-xs font-normal">
+								{doesBaseTemplateHaveModules
+									? "No module matched your search"
+									: "No modules available for this base template"}
+							</p>
+						</div>
+					)}
+				</div>
 			</div>
 
 			{conflicts.length > 0 && (

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -232,9 +232,10 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				</TabsList>
 			</Tabs>
 
-			{/* Cap the visible cards at two rows and let the rest scroll, so the
-			    Continue button stays above the fold and is easy to discover. */}
-			<div className="max-h-[23.5rem] overflow-y-auto p-1 -m-1">
+			{/* Show two full rows of cards and let any extra rows scroll, so the
+			    Continue button stays high and is easy to discover. The height fits
+			    two of the tallest stretched cards plus the row gap. */}
+			<div className="max-h-[33rem] overflow-y-auto p-1 -m-1">
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
 					{visibleModules.length ? (
 						visibleModules.map((m) => (

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -232,10 +232,10 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				</TabsList>
 			</Tabs>
 
-			{/* Show two full rows of cards and let any extra rows scroll, so the
-			    Continue button stays high and is easy to discover. The height fits
-			    two of the tallest stretched cards plus the row gap. */}
-			<div className="max-h-[33rem] overflow-y-auto p-1 -m-1">
+			{/* Show two rows of cards (sized to the common 214px card height plus
+			    the row gap) and let any extra rows scroll, so the Continue button
+			    stays high and is easy to discover. */}
+			<div className="max-h-[452px] overflow-y-auto p-1 -m-1">
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
 					{visibleModules.length ? (
 						visibleModules.map((m) => (

--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -232,10 +232,10 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				</TabsList>
 			</Tabs>
 
-			{/* Show two rows of cards (sized to the common 214px card height plus
-			    the row gap) and let any extra rows scroll, so the Continue button
+			{/* Show three rows of cards (sized to the common 214px card height plus
+			    the row gaps) and let any extra rows scroll, so the Continue button
 			    stays high and is easy to discover. */}
-			<div className="max-h-[452px] overflow-y-auto p-1 -m-1">
+			<div className="max-h-[682px] overflow-y-auto p-1 -m-1">
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
 					{visibleModules.length ? (
 						visibleModules.map((m) => (

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -128,7 +128,7 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 		<>
 			<TemplateBuilderTitle>Configure modules</TemplateBuilderTitle>
 			<TemplateBuilderSubtitle>
-				Set values for module variables.
+				Customise your modules.
 			</TemplateBuilderSubtitle>
 
 			<div className="flex flex-col gap-6">

--- a/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSettingsStep.tsx
@@ -127,9 +127,7 @@ export const ModuleSettingsStep: FC<ModuleSettingsStepProps> = ({
 	return (
 		<>
 			<TemplateBuilderTitle>Configure modules</TemplateBuilderTitle>
-			<TemplateBuilderSubtitle>
-				Customise your modules.
-			</TemplateBuilderSubtitle>
+			<TemplateBuilderSubtitle>Customise your modules.</TemplateBuilderSubtitle>
 
 			<div className="flex flex-col gap-6">
 				{selectedModules.map((mod) => {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderAvatarData.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderAvatarData.tsx
@@ -19,7 +19,7 @@ export const TemplateBuilderAvatarData: FC<TemplateBuilderAvatarDataProps> = ({
 	return (
 		<AvatarData
 			avatar={<Avatar src={iconUrl} size="lg" variant="icon" />}
-			title={<h3 className="m-0 text-xl font-semibold">{name}</h3>}
+			title={<h3 className="m-0 text-sm font-semibold">{name}</h3>}
 			subtitle={
 				<>
 					<p className="text-xs font-normal text-content-secondary inline">

--- a/site/src/pages/TemplateBuilder/TemplateBuilderHeader.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderHeader.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from "react";
 
 export const TemplateBuilderTitle: FC<PropsWithChildren> = ({ children }) => {
-	return <h2 className="mt-0 text-2xl font-semibold mb-1">{children}</h2>;
+	return <h2 className="mt-0 text-xl font-semibold mb-1">{children}</h2>;
 };
 
 export const TemplateBuilderSubtitle: FC<PropsWithChildren> = ({

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -281,7 +281,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 
 	return (
 		<Margins className="pb-12">
-			<PageHeader className="pb-6">
+			<PageHeader>
 				<PageHeaderTitle>Create new template</PageHeaderTitle>
 				<PageHeaderSubtitle>
 					A Terraform blueprint for reproducible workspaces.

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -281,7 +281,7 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 
 	return (
 		<Margins className="pb-12">
-			<PageHeader>
+			<PageHeader className="pb-6">
 				<PageHeaderTitle>Create new template</PageHeaderTitle>
 				<PageHeaderSubtitle>
 					A Terraform blueprint for reproducible workspaces.

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -61,7 +61,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 			</div>
 
 			<div>
-				<h3 id={nameId} className="text-sm font-bold text-content-primary">
+				<h3 id={nameId} className="mt-0 text-sm font-bold text-content-primary">
 					{name}
 					{official && (
 						<>

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -60,8 +60,8 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 				</div>
 			</div>
 
-			<div>
-				<h3 id={nameId} className="mt-0 text-sm font-bold text-content-primary">
+			<div className="flex flex-col gap-2">
+				<h3 id={nameId} className="my-0 text-sm font-bold text-content-primary">
 					{name}
 					{official && (
 						<>
@@ -70,8 +70,8 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 						</>
 					)}
 				</h3>
-				<div>
-					<p className="text-xs font-normal text-content-secondary">
+				<div className="flex flex-col gap-2">
+					<p className="my-0 text-xs font-normal text-content-secondary">
 						{description}
 					</p>
 


### PR DESCRIPTION
## What

General clean-up of the template builder wizard for readability: the base-template and module selection lists now show a fixed number of card rows with the rest scrollable, and spacing, font sizes, and card internals are aligned so the steps read consistently.

## Changes

**Scrollable card lists**
- `BaseInfraSelectStep` and `ModuleSelectStep` cap the card grid at three rows (sized to the common 214px card height plus row gaps) inside a vertically scrolling container. Extra cards remain reachable via the scrollbar instead of growing the page unbounded. Padding keeps card focus rings and selected borders from clipping at the scroll edges.

**Spacing alignment**
- Card body laid out as a flex column with a consistent 8px gap between headline, description, and "View details", replacing inconsistent browser-default margins.
- Logo-to-headline gap set to 12px in both `ModuleCard` and `TemplateCard`.
- Removed a redundant wrapper around the module card's "View details" link so both card types render identically.

**Font sizes**
- Step titles ("Pick a base template", "Select modules", ...) reduced from 24px to 20px.
- Selected base/module headline (`TemplateBuilderAvatarData`) reduced from 20px to 14px.

**Copy**
- Configure modules subtitle reworded from "Set values for module variables." to "Customise your modules."

No behavioral, data, or API changes; selection, search, and category filtering are untouched.

## Changes

Current state at 1440px width:

| Before |After|
| --- | --- |
|  <img width="1508" height="999" alt="Screenshot 2026-09-03 at 14 25 32" src="https://github.com/user-attachments/assets/24720fc8-cd6b-4035-aeb0-da5925f0aae3" />|  <img width="1495" height="975" alt="Screenshot 2026-09-03 at 14 25 12" src="https://github.com/user-attachments/assets/d053097d-c4a0-4c34-ab07-eafa72c6515f" />|

## Testing

- `pnpm check` (Biome), `pnpm lint:types` (tsc), and all 41 `src/pages/TemplateBuilder` Storybook tests pass.
- Verified live against `./scripts/develop.sh` (port 8080): row counts, gaps (12px / 8px), and font sizes (20px / 14px) measured in-browser.

---

_Generated by Coder Agents on behalf of @chrifro._
