### PR TITLE
feat(site/src/pages/TemplateBuilder): remove category filter tab icons

### DIFF
--- a/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
+++ b/site/src/pages/TemplateBuilder/ModuleSelectStep.tsx
@@ -1,4 +1,4 @@
-import { PackageIcon, SearchIcon } from "lucide-react";
+import { SearchIcon } from "lucide-react";
 import { type FC, type PropsWithChildren, useMemo, useState } from "react";
 import { useQuery } from "react-query";
 import { templateBuilderModules } from "#/api/queries/templateBuilder";
@@ -225,7 +225,6 @@ export const ModuleSelectStep: FC<ModuleSelectStepProps> = ({
 				<TabsList ref={containerRef}>
 					{visibleFilterTabs.map((tab) => (
 						<TabsTrigger key={tab.value} value={tab.value}>
-							<PackageIcon className="size-icon-sm" />
 							{tab.value} ({tab.count})
 						</TabsTrigger>
 					))}


### PR DESCRIPTION
## Summary

Removes the decorative `PackageIcon` rendered on every module category filter tab in the Template Builder "Select modules" step. The same glyph was repeated across all tabs, adding visual noise without conveying category-specific meaning. Tabs now read as plain text labels with counts.

## Changes

- `site/src/pages/TemplateBuilder/ModuleSelectStep.tsx`: drop the `<PackageIcon>` inside each `TabsTrigger` and remove the now-unused import.

## Visual proof

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/coder/coder/assets/remove-module-tab-icons/pr-assets/tabs_before.png) | ![after](https://raw.githubusercontent.com/coder/coder/assets/remove-module-tab-icons/pr-assets/tabs_after.png) |

## Testing

- `npx vitest run src/pages/TemplateBuilder/ModuleSelectStep.stories.tsx` — 3/3 pass. Tabs are matched by accessible name (label + count), which is unchanged, so the filter/search play test still passes.
- `biome check` clean on the changed file.

---

🤖 This PR was generated by Coder Agents on behalf of @chrifro.
