### PR TITLE
fix(site/src/pages/TemplateBuilder): center official badge in template card title

### DIFF
--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -61,10 +61,10 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 			</div>
 
 			<div>
-				<h3 className="flex items-center gap-2 text-sm font-bold text-content-primary">
-					<span id={nameId}>{name}</span>
+				<h3 id={nameId} className="text-sm font-bold text-content-primary">
+					{name}
 					{official && (
-						<BadgeCheckIcon className="size-4 shrink-0 text-highlight-sky" />
+						<BadgeCheckIcon className="inline size-4 ml-1 align-middle text-highlight-sky" />
 					)}
 				</h3>
 				<div>

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -64,7 +64,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 				<h3 id={nameId} className="text-sm font-bold text-content-primary">
 					{name}
 					{official && (
-						<BadgeCheckIcon className="inline size-4 ml-1 align-middle text-highlight-sky" />
+						<BadgeCheckIcon className="relative bottom-[2px] inline size-4 ml-1 align-middle text-highlight-sky" />
 					)}
 				</h3>
 				<div>

--- a/site/src/pages/TemplateBuilder/TemplateCard.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateCard.tsx
@@ -61,13 +61,10 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
 			</div>
 
 			<div>
-				<h3 id={nameId} className="text-sm font-bold text-content-primary">
-					{name}
+				<h3 className="flex items-center gap-2 text-sm font-bold text-content-primary">
+					<span id={nameId}>{name}</span>
 					{official && (
-						<>
-							{" "}
-							<BadgeCheckIcon className="size-4 text-highlight-sky align-middle inline-block" />
-						</>
+						<BadgeCheckIcon className="size-4 shrink-0 text-highlight-sky" />
 					)}
 				</h3>
 				<div>


### PR DESCRIPTION
## Summary

Vertically centers the "official" verified badge next to a base template's title in the template builder flow (`/templates/new/builder`) and standardizes its spacing.

- The badge previously sat below the optical middle of the title; it is now nudged to the cap-height center.
- Spacing between the name and the badge is an explicit 4px (`ml-1`).
- The badge stays inline after the last word, so when the title wraps to two lines it trails the last word (centered on that line) instead of detaching from the text.

Scope: `site/src/pages/TemplateBuilder/TemplateCard.tsx`.

## Before / after

Base infra step, "AWS EC2 (Windows)" card. The dashed line marks the cap-height center of the title.

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/coder/coder/39b0ef54cc6b5c4abe693b68cc0f167275665554/pr-assets/before.png) | ![After](https://raw.githubusercontent.com/coder/coder/39b0ef54cc6b5c4abe693b68cc0f167275665554/pr-assets/after.png) |

---

Generated by Coder Agents.
