### PR TITLE
fix(cli): preserve immutable parameters in update dry-runs

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -654,10 +654,15 @@ func prepWorkspaceBuild(inv *serpent.Invocation, client *codersdk.Client, args p
 	// Only perform dry-run for workspace creation and updates
 	// Skip for start and restart to avoid unnecessary delays
 	if args.Action == WorkspaceCreate || args.Action == WorkspaceUpdate {
+		dryRunParameters := buildParameters
+		if args.Action == WorkspaceUpdate {
+			dryRunParameters = workspaceBuildParametersForDryRun(buildParameters, args.LastBuildParameters, templateVersionParameters)
+		}
+
 		// Run a dry-run with the given parameters to check correctness
 		dryRun, err := client.CreateTemplateVersionDryRun(inv.Context(), templateVersion.ID, codersdk.CreateTemplateVersionDryRunRequest{
 			WorkspaceName:       args.NewWorkspaceName,
-			RichParameterValues: buildParameters,
+			RichParameterValues: dryRunParameters,
 		})
 		if err != nil {
 			return nil, xerrors.Errorf("begin workspace dry-run: %w", err)
@@ -705,4 +710,30 @@ func prepWorkspaceBuild(inv *serpent.Invocation, client *codersdk.Client, args p
 	}
 
 	return buildParameters, nil
+}
+
+// workspaceBuildParametersForDryRun adds unchanged immutable parameters from
+// the previous build to an update dry-run. Unlike a workspace build, a template
+// version dry-run has no workspace context from which the server can recover
+// previous values.
+func workspaceBuildParametersForDryRun(
+	buildParameters []codersdk.WorkspaceBuildParameter,
+	lastBuildParameters []codersdk.WorkspaceBuildParameter,
+	templateVersionParameters []codersdk.TemplateVersionParameter,
+) []codersdk.WorkspaceBuildParameter {
+	dryRunParameters := append([]codersdk.WorkspaceBuildParameter(nil), buildParameters...)
+	for _, buildParameter := range lastBuildParameters {
+		tvp := findTemplateVersionParameter(buildParameter, templateVersionParameters)
+		if tvp == nil || tvp.Mutable || tvp.Ephemeral {
+			continue
+		}
+
+		if findWorkspaceBuildParameter(buildParameter.Name, dryRunParameters) != nil {
+			continue
+		}
+
+		dryRunParameters = append(dryRunParameters, buildParameter)
+	}
+
+	return dryRunParameters
 }

--- a/cli/parameterresolver_internal_test.go
+++ b/cli/parameterresolver_internal_test.go
@@ -89,16 +89,19 @@ func TestWorkspaceBuildParametersForDryRun(t *testing.T) {
 
 	buildParameters := []codersdk.WorkspaceBuildParameter{
 		{Name: "mutable", Value: "new"},
+		{Name: "immutable_present", Value: "resolved"},
 	}
 	lastBuildParameters := []codersdk.WorkspaceBuildParameter{
 		{Name: "mutable", Value: "old"},
 		{Name: "immutable", Value: "repository"},
+		{Name: "immutable_present", Value: "previous"},
 		{Name: "ephemeral", Value: "old"},
 		{Name: "removed", Value: "old"},
 	}
 	templateVersionParameters := []codersdk.TemplateVersionParameter{
 		{Name: "mutable", Mutable: true},
-		{Name: "immutable", Mutable: false},
+		{Name: "immutable", Mutable: false, Options: []codersdk.TemplateVersionParameterOption{{Value: "different"}}},
+		{Name: "immutable_present", Mutable: false},
 		{Name: "ephemeral", Mutable: true, Ephemeral: true},
 	}
 
@@ -110,9 +113,11 @@ func TestWorkspaceBuildParametersForDryRun(t *testing.T) {
 
 	assert.Equal(t, []codersdk.WorkspaceBuildParameter{
 		{Name: "mutable", Value: "new"},
+		{Name: "immutable_present", Value: "resolved"},
 		{Name: "immutable", Value: "repository"},
 	}, dryRunParameters)
 	assert.Equal(t, []codersdk.WorkspaceBuildParameter{
 		{Name: "mutable", Value: "new"},
+		{Name: "immutable_present", Value: "resolved"},
 	}, buildParameters, "must not mutate the workspace build parameters")
 }

--- a/cli/parameterresolver_internal_test.go
+++ b/cli/parameterresolver_internal_test.go
@@ -83,3 +83,36 @@ func TestIsValidTemplateParameterOption(t *testing.T) {
 		assert.False(t, isValidTemplateParameterOption(bp, tvp))
 	})
 }
+
+func TestWorkspaceBuildParametersForDryRun(t *testing.T) {
+	t.Parallel()
+
+	buildParameters := []codersdk.WorkspaceBuildParameter{
+		{Name: "mutable", Value: "new"},
+	}
+	lastBuildParameters := []codersdk.WorkspaceBuildParameter{
+		{Name: "mutable", Value: "old"},
+		{Name: "immutable", Value: "repository"},
+		{Name: "ephemeral", Value: "old"},
+		{Name: "removed", Value: "old"},
+	}
+	templateVersionParameters := []codersdk.TemplateVersionParameter{
+		{Name: "mutable", Mutable: true},
+		{Name: "immutable", Mutable: false},
+		{Name: "ephemeral", Mutable: true, Ephemeral: true},
+	}
+
+	dryRunParameters := workspaceBuildParametersForDryRun(
+		buildParameters,
+		lastBuildParameters,
+		templateVersionParameters,
+	)
+
+	assert.Equal(t, []codersdk.WorkspaceBuildParameter{
+		{Name: "mutable", Value: "new"},
+		{Name: "immutable", Value: "repository"},
+	}, dryRunParameters)
+	assert.Equal(t, []codersdk.WorkspaceBuildParameter{
+		{Name: "mutable", Value: "new"},
+	}, buildParameters, "must not mutate the workspace build parameters")
+}


### PR DESCRIPTION
Template version dry-runs have no workspace context, so they cannot recover the previous values of immutable parameters. The CLI omits unchanged immutable parameters from consecutive workspace builds, so `coder update` on a template that validates other resources against an immutable parameter rejected the dry-run plan even though the real build reuses the stored value.

Adds `workspaceBuildParametersForDryRun` in `cli/create.go`: for update dry-runs, unchanged immutable parameters from the last build are appended to the dry-run request. Mutable, ephemeral, and removed parameters are skipped, and the actual workspace build request stays unchanged so the server continues to recover previous values as before.
