### PR TITLE
chore(site): remove View suffixes from story titles

### DIFF
--- a/site/src/modules/dashboard/AnnouncementBanners/AnnouncementBannerView.stories.tsx
+++ b/site/src/modules/dashboard/AnnouncementBanners/AnnouncementBannerView.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { AnnouncementBannerView } from "./AnnouncementBannerView";
 
 const meta: Meta<typeof AnnouncementBannerView> = {
-	title: "modules/dashboard/AnnouncementBannerView",
+	title: "modules/dashboard/AnnouncementBanner",
 	component: AnnouncementBannerView,
 };
 

--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.stories.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.stories.tsx
@@ -7,7 +7,7 @@ import {
 import { DeploymentBannerView } from "./DeploymentBannerView";
 
 const meta: Meta<typeof DeploymentBannerView> = {
-	title: "modules/dashboard/DeploymentBannerView",
+	title: "modules/dashboard/DeploymentBanner",
 	component: DeploymentBannerView,
 	args: {
 		stats: MockDeploymentStats,

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.stories.tsx
@@ -23,7 +23,7 @@ import { formatLicenseMessage, LicenseBanner } from "./LicenseBanner";
 import { LicenseBannerView } from "./LicenseBannerView";
 
 const meta: Meta<typeof LicenseBannerView> = {
-	title: "components/LicenseBannerView",
+	title: "components/LicenseBanner",
 	component: LicenseBannerView,
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -39,7 +39,7 @@ const AISettingsIndexRedirectWithProviders = () => (
 );
 
 const meta: Meta<typeof NavbarView> = {
-	title: "modules/dashboard/NavbarView",
+	title: "modules/dashboard/Navbar",
 	parameters: {
 		pixel: { matrix: pixelWithTablet },
 		layout: "fullscreen",

--- a/site/src/modules/management/AISettingsSidebarView.stories.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.stories.tsx
@@ -17,7 +17,7 @@ import { AISettingsSidebar } from "./AISettingsSidebar";
 import AISettingsSidebarView from "./AISettingsSidebarView";
 
 const meta: Meta<typeof AISettingsSidebarView> = {
-	title: "modules/management/AISettingsSidebarView",
+	title: "modules/management/AISettingsSidebar",
 	component: AISettingsSidebarView,
 	args: {
 		permissions: MockPermissions,

--- a/site/src/modules/management/DeploymentSidebarView.stories.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.stories.tsx
@@ -9,7 +9,7 @@ import { withDashboardProvider } from "#/testHelpers/storybook";
 import { DeploymentSidebarView } from "./DeploymentSidebarView";
 
 const meta: Meta<typeof DeploymentSidebarView> = {
-	title: "modules/management/DeploymentSidebarView",
+	title: "modules/management/DeploymentSidebar",
 	component: DeploymentSidebarView,
 	decorators: [withDashboardProvider],
 	parameters: { showOrganizations: true },

--- a/site/src/modules/management/OrganizationSidebarView.stories.tsx
+++ b/site/src/modules/management/OrganizationSidebarView.stories.tsx
@@ -13,7 +13,7 @@ import { withDashboardProvider } from "#/testHelpers/storybook";
 import { OrganizationSidebarView } from "./OrganizationSidebarView";
 
 const meta: Meta<typeof OrganizationSidebarView> = {
-	title: "modules/management/OrganizationSidebarView",
+	title: "modules/management/OrganizationSidebar",
 	component: OrganizationSidebarView,
 	decorators: [withDashboardProvider],
 	parameters: { showOrganizations: true },

--- a/site/src/modules/resources/AgentMetadata.stories.tsx
+++ b/site/src/modules/resources/AgentMetadata.stories.tsx
@@ -6,7 +6,7 @@ import type {
 import { AgentMetadataView } from "./AgentMetadata";
 
 const meta: Meta<typeof AgentMetadataView> = {
-	title: "modules/resources/AgentMetadataView",
+	title: "modules/resources/AgentMetadata",
 	component: AgentMetadataView,
 };
 

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { PortForwardPopoverView } from "./PortForwardButton";
 
 const meta: Meta<typeof PortForwardPopoverView> = {
-	title: "modules/resources/PortForwardPopoverView",
+	title: "modules/resources/PortForwardPopover",
 	component: PortForwardPopoverView,
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
@@ -40,7 +40,7 @@ const defaultFilterProps: FilterProps = {
 };
 
 const meta: Meta<typeof ListSessionsPageView> = {
-	title: "pages/AIBridgePage/ListSessionsPageView",
+	title: "pages/AIBridgePage/ListSessionsPage",
 	component: ListSessionsPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView.stories.tsx
@@ -44,7 +44,7 @@ const defaultArgs: CoderAgentsPageViewProps = {
 };
 
 const meta: Meta<typeof CoderAgentsPageView> = {
-	title: "pages/AISettingsPage/CoderAgentsPage/CoderAgentsPageView",
+	title: "pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage",
 	component: CoderAgentsPageView,
 	args: defaultArgs,
 	parameters: {

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettingsView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettingsView.stories.tsx
@@ -33,7 +33,8 @@ const saveByContext = new Map<
 ]);
 
 const meta: Meta<typeof OrganizationAgentSettingsView> = {
-	title: "pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettings",
+	title:
+		"pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettings/States",
 	component: OrganizationAgentSettingsView,
 	args: {
 		overrides,

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettingsView.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettingsView.stories.tsx
@@ -33,7 +33,7 @@ const saveByContext = new Map<
 ]);
 
 const meta: Meta<typeof OrganizationAgentSettingsView> = {
-	title: "pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettingsView",
+	title: "pages/AISettingsPage/CoderAgentsPage/OrganizationAgentSettings",
 	component: OrganizationAgentSettingsView,
 	args: {
 		overrides,

--- a/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/GatewayKeysPage/GatewayKeysPageView.stories.tsx
@@ -9,7 +9,7 @@ import { docs } from "#/utils/docs";
 import { GatewayKeysPageView } from "./GatewayKeysPageView";
 
 const meta: Meta<typeof GatewayKeysPageView> = {
-	title: "pages/AISettingsPage/GatewayKeysPageView",
+	title: "pages/AISettingsPage/GatewayKeysPage",
 	component: GatewayKeysPageView,
 	// TODO: Stories in this file fail when pixel runs their play functions. Fix them and remove the exclude.
 	parameters: { pixel: { exclude: true } },

--- a/site/src/pages/AISettingsPage/InstructionsPage/InstructionsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/InstructionsPage/InstructionsPageView.stories.tsx
@@ -29,7 +29,7 @@ const baseArgs: InstructionsPageViewProps = {
 };
 
 const meta = {
-	title: "pages/AISettingsPage/InstructionsPage/InstructionsPageView",
+	title: "pages/AISettingsPage/InstructionsPage/InstructionsPage",
 	component: InstructionsPageView,
 	// TODO: Stories in this file fail when pixel runs their play functions. Fix them and remove the exclude.
 	parameters: { pixel: { exclude: true } },

--- a/site/src/pages/AISettingsPage/LifecyclePage/LifecyclePageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/LifecyclePage/LifecyclePageView.stories.tsx
@@ -38,7 +38,7 @@ const baseArgs: LifecyclePageViewProps = {
 };
 
 const meta = {
-	title: "pages/AISettingsPage/LifecyclePage/LifecyclePageView",
+	title: "pages/AISettingsPage/LifecyclePage/LifecyclePage",
 	component: LifecyclePageView,
 	// TODO: Stories in this file fail when pixel runs their play functions. Fix them and remove the exclude.
 	parameters: { pixel: { exclude: true } },

--- a/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/AddMCPServerPage/AddMCPServerPageView.stories.tsx
@@ -6,7 +6,7 @@ import { MockDefaultOrganization } from "#/testHelpers/entities";
 import AddMCPServerPageView from "./AddMCPServerPageView";
 
 const meta: Meta<typeof AddMCPServerPageView> = {
-	title: "pages/AISettingsPage/MCPServersPage/AddMCPServerPageView",
+	title: "pages/AISettingsPage/MCPServersPage/AddMCPServerPage",
 	component: AddMCPServerPageView,
 	args: {
 		isSaving: false,

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from "./testFixtures";
 
 const meta: Meta<typeof MCPServersPageView> = {
-	title: "pages/AISettingsPage/MCPServersPage/MCPServersPage",
+	title: "pages/AISettingsPage/MCPServersPage/MCPServersPage/States",
 	component: MCPServersPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/MCPServersPageView.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from "./testFixtures";
 
 const meta: Meta<typeof MCPServersPageView> = {
-	title: "pages/AISettingsPage/MCPServersPage/MCPServersPageView",
+	title: "pages/AISettingsPage/MCPServersPage/MCPServersPage",
 	component: MCPServersPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage/UpdateMCPServerPageView.stories.tsx
@@ -14,7 +14,7 @@ const onUpdateServer = fn(
 );
 
 const meta: Meta<typeof UpdateMCPServerPageView> = {
-	title: "pages/AISettingsPage/MCPServersPage/UpdateMCPServerPageView",
+	title: "pages/AISettingsPage/MCPServersPage/UpdateMCPServerPage",
 	component: UpdateMCPServerPageView,
 	args: {
 		server: MockCoderMCPServer,

--- a/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/AddModelPage/AddModelPageView.stories.tsx
@@ -18,7 +18,7 @@ import {
 import AddModelPageView from "./AddModelPageView";
 
 const meta: Meta<typeof AddModelPageView> = {
-	title: "pages/AISettingsPage/ModelsPage/AddModelPageView",
+	title: "pages/AISettingsPage/ModelsPage/AddModelPage",
 	component: AddModelPageView,
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/ModelsPageView.stories.tsx
@@ -22,7 +22,7 @@ import {
 } from "./testFixtures";
 
 const meta: Meta<typeof ModelsPageView> = {
-	title: "pages/AISettingsPage/ModelsPage/ModelsPageView",
+	title: "pages/AISettingsPage/ModelsPage/ModelsPage",
 	component: ModelsPageView,
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ModelsPage/UpdateModelPage/UpdateModelPageView.stories.tsx
@@ -28,7 +28,7 @@ const LocationProbe = () => {
 };
 
 const meta: Meta<typeof UpdateModelPageView> = {
-	title: "pages/AISettingsPage/ModelsPage/UpdateModelPageView",
+	title: "pages/AISettingsPage/ModelsPage/UpdateModelPage",
 	component: UpdateModelPageView,
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/ProvidersPageView.stories.tsx
@@ -5,7 +5,7 @@ import { MockAIProviders } from "#/testHelpers/entities";
 import ProvidersPageView from "./ProvidersPageView";
 
 const meta: Meta<typeof ProvidersPageView> = {
-	title: "pages/AISettingsPage/ProvidersPageView",
+	title: "pages/AISettingsPage/ProvidersPage",
 	component: ProvidersPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/ProvidersPage/UpdateProviderPage/UpdateProviderPageView.stories.tsx
@@ -25,7 +25,7 @@ const seed = (provider: AIProvider) => ({
 });
 
 const meta: Meta<typeof UpdateProviderPageView> = {
-	title: "pages/AISettingsPage/UpdateProviderPageView",
+	title: "pages/AISettingsPage/UpdateProviderPage",
 	component: UpdateProviderPageView,
 	decorators: [withToaster],
 };

--- a/site/src/pages/AISettingsPage/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/TemplatesPage/TemplatesPageView.stories.tsx
@@ -53,7 +53,7 @@ const filterState = getDefaultFilterProps<TemplateFilterState>({
 });
 
 const meta = {
-	title: "pages/AISettingsPage/TemplatesPage/TemplatesPage",
+	title: "pages/AISettingsPage/TemplatesPage/TemplatesPage/States",
 	component: TemplatesPageView,
 	decorators: [withDashboardProvider],
 	args: {

--- a/site/src/pages/AISettingsPage/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/AISettingsPage/TemplatesPage/TemplatesPageView.stories.tsx
@@ -53,7 +53,7 @@ const filterState = getDefaultFilterProps<TemplateFilterState>({
 });
 
 const meta = {
-	title: "pages/AISettingsPage/TemplatesPage/TemplatesPageView",
+	title: "pages/AISettingsPage/TemplatesPage/TemplatesPage",
 	component: TemplatesPageView,
 	decorators: [withDashboardProvider],
 	args: {

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -196,7 +196,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 // Meta
 // ---------------------------------------------------------------------------
 const meta: Meta<typeof AgentChatPageView> = {
-	title: "pages/AgentsPage/AgentChatPage",
+	title: "pages/AgentsPage/AgentChatPage/States",
 	component: AgentChatPageView,
 	// Summary is the default tab and reads the chat, so mock it for the sidebar.
 	// Cost needs no mock: these stories leave the aibridge feature off, so the
@@ -269,7 +269,7 @@ export const Archived: Story = {
 	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,
 };
 
-export const OtherUserChatReadOnlyPresentation: Story = {
+export const OtherUserChatReadOnly: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			chatOwner={{ username: "OtherUser", name: "Other User" }}
@@ -328,7 +328,7 @@ export const OtherUserChatOwnerFallback: Story = {
 };
 
 /** Archived chats stay read-only without the owner banner. */
-export const ArchivedOtherUserChatPresentation: Story = {
+export const ArchivedOtherUserChat: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			isArchived
@@ -901,7 +901,7 @@ export const WorkspaceNoAgent: Story = {
 // ---------------------------------------------------------------------------
 
 /** Default loading state with skeleton placeholders. */
-export const LoadingSkeleton: Story = {
+export const Loading: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -196,7 +196,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 // Meta
 // ---------------------------------------------------------------------------
 const meta: Meta<typeof AgentChatPageView> = {
-	title: "pages/AgentsPage/AgentChatPageView",
+	title: "pages/AgentsPage/AgentChatPage",
 	component: AgentChatPageView,
 	// Summary is the default tab and reads the chat, so mock it for the sidebar.
 	// Cost needs no mock: these stories leave the aibridge feature off, so the
@@ -269,7 +269,7 @@ export const Archived: Story = {
 	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,
 };
 
-export const OtherUserChatReadOnly: Story = {
+export const OtherUserChatReadOnlyPresentation: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			chatOwner={{ username: "OtherUser", name: "Other User" }}
@@ -328,7 +328,7 @@ export const OtherUserChatOwnerFallback: Story = {
 };
 
 /** Archived chats stay read-only without the owner banner. */
-export const ArchivedOtherUserChat: Story = {
+export const ArchivedOtherUserChatPresentation: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			isArchived
@@ -901,7 +901,7 @@ export const WorkspaceNoAgent: Story = {
 // ---------------------------------------------------------------------------
 
 /** Default loading state with skeleton placeholders. */
-export const Loading: Story = {
+export const LoadingSkeleton: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPage.stories.tsx
@@ -58,7 +58,7 @@ const createProviderItems = (
 };
 
 const meta = {
-	title: "pages/AgentsPage/AgentSettingsAPIKeysPageView",
+	title: "pages/AgentsPage/AgentSettingsAPIKeysPage",
 	component: AgentSettingsAPIKeysPageView,
 	args: {
 		error: undefined,

--- a/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsCompactionPageView.stories.tsx
@@ -37,7 +37,7 @@ const baseArgs: AgentSettingsCompactionPageViewProps = {
 };
 
 const meta = {
-	title: "pages/AgentsPage/AgentSettingsCompactionPageView",
+	title: "pages/AgentsPage/AgentSettingsCompactionPage",
 	component: AgentSettingsCompactionPageView,
 	args: baseArgs,
 } satisfies Meta<typeof AgentSettingsCompactionPageView>;

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
@@ -33,7 +33,7 @@ const baseArgs: AgentSettingsGeneralPageViewProps = {
 };
 
 const meta = {
-	title: "pages/AgentsPage/AgentSettingsGeneralPageView",
+	title: "pages/AgentsPage/AgentSettingsGeneralPage",
 	component: AgentSettingsGeneralPageView,
 	args: baseArgs,
 	parameters: {

--- a/site/src/pages/AgentsPage/AgentSettingsPersonalSkillsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPersonalSkillsPageView.stories.tsx
@@ -44,7 +44,7 @@ const baseArgs: AgentSettingsPersonalSkillsPageViewProps = {
 };
 
 const meta = {
-	title: "pages/AgentsPage/AgentSettingsPersonalSkillsPageView",
+	title: "pages/AgentsPage/AgentSettingsPersonalSkillsPage",
 	component: AgentSettingsPersonalSkillsPageView,
 	args: baseArgs,
 } satisfies Meta<typeof AgentSettingsPersonalSkillsPageView>;

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -255,7 +255,7 @@ const selectOption = async (
 };
 
 const meta = {
-	title: "pages/AgentsPage/AgentSettingsUserAgentsPageView",
+	title: "pages/AgentsPage/AgentSettingsUserAgentsPage",
 	component: AgentSettingsUserAgentsPageView,
 	args: buildArgs(),
 } satisfies Meta<typeof AgentSettingsUserAgentsPageView>;

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.stories.tsx
@@ -35,7 +35,7 @@ const gitTab: SidebarTab = {
 };
 
 const meta: Meta<typeof SidebarTabView> = {
-	title: "pages/AgentsPage/SidebarTabView",
+	title: "pages/AgentsPage/SidebarTab",
 	component: SidebarTabView,
 	args: {
 		tabs: [gitTab],

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { CreateWorkspacePageView } from "./CreateWorkspacePageView";
 
 const meta: Meta<typeof CreateWorkspacePageView> = {
-	title: "Pages/CreateWorkspacePageView",
+	title: "Pages/CreateWorkspacePage",
 	component: CreateWorkspacePageView,
 	args: {
 		autofillParameters: [],

--- a/site/src/pages/DeploymentSettingsPage/AIGovernanceSettingsPage/AIGovernanceSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AIGovernanceSettingsPage/AIGovernanceSettingsPageView.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { AIGovernanceSettingsPageView } from "./AIGovernanceSettingsPageView";
 
 const meta: Meta<typeof AIGovernanceSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/AIGovernanceSettingsPageView",
+	title: "pages/DeploymentSettingsPage/AIGovernanceSettingsPage",
 	component: AIGovernanceSettingsPageView,
 	args: {
 		options: [

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.stories.tsx
@@ -5,7 +5,7 @@ import { docs } from "#/utils/docs";
 import { AppearanceSettingsPageView } from "./AppearanceSettingsPageView";
 
 const meta: Meta<typeof AppearanceSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/AppearanceSettingsPageView",
+	title: "pages/DeploymentSettingsPage/AppearanceSettingsPage",
 	component: AppearanceSettingsPageView,
 	args: {
 		appearance: {

--- a/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.stories.tsx
@@ -4,7 +4,7 @@ import { docs } from "#/utils/docs";
 import { ExternalAuthSettingsPageView } from "./ExternalAuthSettingsPageView";
 
 const meta: Meta<typeof ExternalAuthSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/ExternalAuthSettingsPageView",
+	title: "pages/DeploymentSettingsPage/ExternalAuthSettingsPage",
 	component: ExternalAuthSettingsPageView,
 	args: {
 		config: {

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { IdpOrgSyncPageView } from "./IdpOrgSyncPageView";
 
 const meta: Meta<typeof IdpOrgSyncPageView> = {
-	title: "pages/IdpOrgSyncPageView",
+	title: "pages/IdpOrgSyncPage",
 	component: IdpOrgSyncPageView,
 	args: {
 		organizationSyncSettings: MockOrganizationSyncSettings2,

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.stories.tsx
@@ -1,7 +1,7 @@
 import { AddNewLicensePageView } from "./AddNewLicensePageView";
 
 export default {
-	title: "pages/DeploymentSettingsPage/AddNewLicensePageView",
+	title: "pages/DeploymentSettingsPage/AddNewLicensePage",
 	component: AddNewLicensePageView,
 };
 

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
@@ -8,7 +8,7 @@ import {
 import LicensesSettingsPageView from "./LicensesSettingsPageView";
 
 const meta: Meta<typeof LicensesSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/LicensesSettingsPage",
+	title: "pages/DeploymentSettingsPage/LicensesSettingsPage/States",
 	component: LicensesSettingsPageView,
 	args: {
 		showConfetti: false,

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.stories.tsx
@@ -8,7 +8,7 @@ import {
 import LicensesSettingsPageView from "./LicensesSettingsPageView";
 
 const meta: Meta<typeof LicensesSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/LicensesSettingsPageView",
+	title: "pages/DeploymentSettingsPage/LicensesSettingsPage",
 	component: LicensesSettingsPageView,
 	args: {
 		showConfetti: false,

--- a/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NetworkSettingsPage/NetworkSettingsPageView.stories.tsx
@@ -10,7 +10,7 @@ const group: SerpentGroup = {
 };
 
 const meta: Meta<typeof NetworkSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/NetworkSettingsPageView",
+	title: "pages/DeploymentSettingsPage/NetworkSettingsPage",
 	component: NetworkSettingsPageView,
 	args: {
 		options: [

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/CreateOAuth2AppPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/CreateOAuth2AppPageView.stories.tsx
@@ -11,7 +11,7 @@ import { withAuthProvider, withToaster } from "#/testHelpers/storybook";
 import { CreateOAuth2AppPageView } from "./CreateOAuth2AppPageView";
 
 const meta = {
-	title: "pages/DeploymentSettingsPage/CreateOAuth2AppPageView",
+	title: "pages/DeploymentSettingsPage/CreateOAuth2AppPage",
 	component: CreateOAuth2AppPageView,
 	parameters: {
 		user: MockUserOwner,

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/EditOAuth2AppPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/EditOAuth2AppPageView.stories.tsx
@@ -32,7 +32,7 @@ const routingFor = (path: string) =>
 	});
 
 const meta = {
-	title: "pages/DeploymentSettingsPage/EditOAuth2AppPageView",
+	title: "pages/DeploymentSettingsPage/EditOAuth2AppPage",
 	component: EditOAuth2AppPageView,
 	parameters: {
 		user: MockUserOwner,

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
@@ -18,7 +18,7 @@ const MockSettingsTab = {
 };
 
 const meta: Meta<typeof OAuth2AppsSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/OAuth2AppsSettingsPage",
+	title: "pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/States",
 	component: OAuth2AppsSettingsPageView,
 	args: {
 		canCreateApp: true,

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.stories.tsx
@@ -18,7 +18,7 @@ const MockSettingsTab = {
 };
 
 const meta: Meta<typeof OAuth2AppsSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/OAuth2AppsSettingsPageView",
+	title: "pages/DeploymentSettingsPage/OAuth2AppsSettingsPage",
 	component: OAuth2AppsSettingsPageView,
 	args: {
 		canCreateApp: true,

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
@@ -16,7 +16,7 @@ const retentionGroup: SerpentGroup = {
 };
 
 const meta: Meta<typeof ObservabilitySettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/ObservabilitySettingsPageView",
+	title: "pages/DeploymentSettingsPage/ObservabilitySettingsPage",
 	component: ObservabilitySettingsPageView,
 	args: {
 		options: [

--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
@@ -5,7 +5,7 @@ import { docs } from "#/utils/docs";
 import { OverviewPageView } from "./OverviewPageView";
 
 const meta: Meta<typeof OverviewPageView> = {
-	title: "pages/DeploymentSettingsPage/OverviewPageView",
+	title: "pages/DeploymentSettingsPage/OverviewPage",
 	component: OverviewPageView,
 	args: {
 		deploymentOptions: [

--- a/site/src/pages/DeploymentSettingsPage/PremiumPage/PremiumPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/PremiumPage/PremiumPageView.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn, within } from "storybook/test";
 import { PremiumPageView } from "./PremiumPageView";
 
 const meta: Meta<typeof PremiumPageView> = {
-	title: "pages/DeploymentSettingsPage/PremiumPageView",
+	title: "pages/DeploymentSettingsPage/PremiumPage",
 	component: PremiumPageView,
 	args: {
 		hasLicense: false,

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
@@ -10,7 +10,7 @@ const group: SerpentGroup = {
 };
 
 const meta: Meta<typeof SecuritySettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/SecuritySettingsPageView",
+	title: "pages/DeploymentSettingsPage/SecuritySettingsPage",
 	component: SecuritySettingsPageView,
 	args: {
 		options: [

--- a/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/UserAuthSettingsPage/UserAuthSettingsPageView.stories.tsx
@@ -15,7 +15,7 @@ const ghGroup: SerpentGroup = {
 };
 
 const meta: Meta<typeof UserAuthSettingsPageView> = {
-	title: "pages/DeploymentSettingsPage/UserAuthSettingsPageView",
+	title: "pages/DeploymentSettingsPage/UserAuthSettingsPage",
 	component: UserAuthSettingsPageView,
 	args: {
 		options: [

--- a/site/src/pages/GroupsPage/CreateGroupPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPageView.stories.tsx
@@ -4,7 +4,7 @@ import { mockApiError } from "#/testHelpers/entities";
 import { CreateGroupPageView } from "./CreateGroupPageView";
 
 const meta: Meta<typeof CreateGroupPageView> = {
-	title: "pages/OrganizationGroupsPage/CreateGroupPageView",
+	title: "pages/OrganizationGroupsPage/CreateGroupPage",
 	component: CreateGroupPageView,
 };
 

--- a/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
+++ b/site/src/pages/GroupsPage/GroupSettingsPageView.stories.tsx
@@ -5,7 +5,7 @@ import { MockGroup } from "#/testHelpers/entities";
 import GroupSettingsPageView from "./GroupSettingsPageView";
 
 const meta: Meta<typeof GroupSettingsPageView> = {
-	title: "pages/OrganizationGroupsPage/GroupSettingsPageView",
+	title: "pages/OrganizationGroupsPage/GroupSettingsPage",
 	component: GroupSettingsPageView,
 	args: {
 		onCancel: fn(),

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { OrganizationMembersPageView } from "./OrganizationMembersPageView";
 
 const meta: Meta<typeof OrganizationMembersPageView> = {
-	title: "pages/OrganizationMembersPageView",
+	title: "pages/OrganizationMembersPage",
 	component: OrganizationMembersPageView,
 	args: {
 		error: undefined,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.stories.tsx
@@ -7,7 +7,7 @@ import {
 import { OrganizationSettingsPageView } from "./OrganizationSettingsPageView";
 
 const meta: Meta<typeof OrganizationSettingsPageView> = {
-	title: "pages/OrganizationSettingsPageView",
+	title: "pages/OrganizationSettingsPage",
 	component: OrganizationSettingsPageView,
 	args: {
 		organization: MockOrganization,

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.stories.tsx
@@ -4,7 +4,7 @@ import { MockPreviewParameter, MockTemplate } from "#/testHelpers/entities";
 import { TemplateEmbedPageView } from "./TemplateEmbedPageView";
 
 const meta: Meta<typeof TemplateEmbedPageView> = {
-	title: "pages/TemplatePage/TemplateEmbedPageView",
+	title: "pages/TemplatePage/TemplateEmbedPage",
 	component: TemplateEmbedPageView,
 	args: {
 		template: MockTemplate,

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
@@ -3,7 +3,7 @@ import { mockApiError } from "#/testHelpers/entities";
 import { TemplateInsightsPageView } from "./TemplateInsightsPage";
 
 const meta: Meta<typeof TemplateInsightsPageView> = {
-	title: "pages/TemplatePage/TemplateInsightsPageView",
+	title: "pages/TemplatePage/TemplateInsightsPage",
 	component: TemplateInsightsPageView,
 };
 

--- a/site/src/pages/TemplatePage/TemplatePrebuildsPage/TemplatePrebuildsPageView.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePrebuildsPage/TemplatePrebuildsPageView.stories.tsx
@@ -6,7 +6,7 @@ import { withToaster } from "#/testHelpers/storybook";
 import { TemplatePrebuildsPageView } from "./TemplatePrebuildsPage";
 
 const meta: Meta<typeof TemplatePrebuildsPageView> = {
-	title: "pages/TemplatePage/TemplatePrebuildsPageView",
+	title: "pages/TemplatePage/TemplatePrebuildsPage",
 	component: TemplatePrebuildsPageView,
 	args: {
 		templateId: MockTemplate.id,

--- a/site/src/pages/TemplatePage/TemplateResourcesPage/TemplateResourcesPageView.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateResourcesPage/TemplateResourcesPageView.stories.tsx
@@ -7,7 +7,7 @@ import {
 import { TemplateResourcesPageView } from "./TemplateResourcesPageView";
 
 const meta: Meta<typeof TemplateResourcesPageView> = {
-	title: "pages/TemplatePage/TemplateResourcesPageView",
+	title: "pages/TemplatePage/TemplateResourcesPage",
 	component: TemplateResourcesPageView,
 };
 

--- a/site/src/pages/TemplateSettingsPage/TemplateParametersPage/TemplateParametersPageView.stories.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateParametersPage/TemplateParametersPageView.stories.tsx
@@ -4,7 +4,7 @@ import { MockTemplateVersion, mockApiError } from "#/testHelpers/entities";
 import { TemplateParametersPageView } from "./TemplateParametersPageView";
 
 const meta: Meta<typeof TemplateParametersPageView> = {
-	title: "pages/TemplateSettingsPage/TemplateParametersPageView",
+	title: "pages/TemplateSettingsPage/TemplateParametersPage",
 	component: TemplateParametersPageView,
 	args: {
 		activeVersion: MockTemplateVersion,

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPageView.stories.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPageView.stories.tsx
@@ -3,7 +3,7 @@ import { MockTemplateACL, MockTemplateACLEmpty } from "#/testHelpers/entities";
 import { TemplatePermissionsPageView } from "./TemplatePermissionsPageView";
 
 const meta: Meta<typeof TemplatePermissionsPageView> = {
-	title: "pages/TemplateSettingsPage/TemplatePermissionsPageView",
+	title: "pages/TemplateSettingsPage/TemplatePermissionsPage",
 	component: TemplatePermissionsPageView,
 };
 

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePageView.stories.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePageView.stories.tsx
@@ -17,7 +17,7 @@ const queryClient = new QueryClient({
 });
 
 const meta: Meta<typeof TemplateSchedulePageView> = {
-	title: "pages/TemplateSettingsPage/TemplateSchedulePageView",
+	title: "pages/TemplateSettingsPage/TemplateSchedulePage",
 	component: TemplateSchedulePageView,
 	decorators: [
 		(Story) => (

--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesPageView.stories.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesPageView.stories.tsx
@@ -12,7 +12,7 @@ import {
 import { TemplateVariablesPageView } from "./TemplateVariablesPageView";
 
 const meta: Meta<typeof TemplateVariablesPageView> = {
-	title: "pages/TemplateSettingsPage/TemplateVariablesPageView",
+	title: "pages/TemplateSettingsPage/TemplateVariablesPage",
 	component: TemplateVariablesPageView,
 	args: {
 		onCancel: action("onCancel"),

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.stories.tsx
@@ -6,7 +6,7 @@ import {
 import { ExternalAuthPageView } from "./ExternalAuthPageView";
 
 const meta: Meta<typeof ExternalAuthPageView> = {
-	title: "pages/UserSettingsPage/ExternalAuthPageView",
+	title: "pages/UserSettingsPage/ExternalAuthPage",
 	component: ExternalAuthPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/UserSettingsPage/OAuth2ProviderPage/OAuth2ProviderPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/OAuth2ProviderPage/OAuth2ProviderPageView.stories.tsx
@@ -3,7 +3,7 @@ import { MockOAuth2ProviderApps } from "#/testHelpers/entities";
 import OAuth2ProviderPageView from "./OAuth2ProviderPageView";
 
 const meta: Meta<typeof OAuth2ProviderPageView> = {
-	title: "pages/UserSettingsPage/OAuth2ProviderPageView",
+	title: "pages/UserSettingsPage/OAuth2ProviderPage",
 	component: OAuth2ProviderPageView,
 };
 

--- a/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPageView.stories.tsx
@@ -3,7 +3,7 @@ import { mockApiError } from "#/testHelpers/entities";
 import { SSHKeysPageView } from "./SSHKeysPageView";
 
 const meta: Meta<typeof SSHKeysPageView> = {
-	title: "pages/UserSettingsPage/SSHKeysPageView",
+	title: "pages/UserSettingsPage/SSHKeysPage",
 	component: SSHKeysPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretsPageView.stories.tsx
@@ -20,7 +20,7 @@ const visibleSecrets = MockUserSecrets.slice(0, 4);
 const PLACEHOLDER_INPUT = "placeholder input";
 
 const meta: Meta<typeof SecretsPageView> = {
-	title: "pages/UserSettingsPage/SecretsPageView",
+	title: "pages/UserSettingsPage/SecretsPage",
 	component: SecretsPageView,
 	// TODO: Stories in this file fail when pixel runs their play functions. Fix them and remove the exclude.
 	parameters: { pixel: { exclude: true } },

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPageView.stories.tsx
@@ -34,7 +34,7 @@ const defaultArgs: ComponentProps<typeof SecurityPageView> = {
 };
 
 const meta: Meta<typeof SecurityPageView> = {
-	title: "pages/UserSettingsPage/SecurityPageView",
+	title: "pages/UserSettingsPage/SecurityPage",
 	component: SecurityPageView,
 	args: defaultArgs,
 };

--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.stories.tsx
@@ -3,7 +3,7 @@ import { MockTokens, mockApiError } from "#/testHelpers/entities";
 import { TokensPageView } from "./TokensPageView";
 
 const meta: Meta<typeof TokensPageView> = {
-	title: "pages/UserSettingsPage/TokensPageView",
+	title: "pages/UserSettingsPage/TokensPage",
 	component: TokensPageView,
 	args: {
 		isLoading: false,

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyView.stories.tsx
@@ -12,7 +12,7 @@ import { docs } from "#/utils/docs";
 import { WorkspaceProxyView } from "./WorkspaceProxyView";
 
 const meta: Meta<typeof WorkspaceProxyView> = {
-	title: "pages/UserSettingsPage/WorkspaceProxyView",
+	title: "pages/UserSettingsPage/WorkspaceProxy",
 	component: WorkspaceProxyView,
 	args: {
 		showPaywall: false,

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -25,7 +25,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 });
 
 const meta: Meta<typeof UsersPageView> = {
-	title: "pages/UsersPageView",
+	title: "pages/UsersPage",
 	component: UsersPageView,
 	args: {
 		canEditUsers: true,

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -25,7 +25,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 });
 
 const meta: Meta<typeof UsersPageView> = {
-	title: "pages/UsersPage",
+	title: "pages/UsersPage/States",
 	component: UsersPageView,
 	args: {
 		canEditUsers: true,

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
@@ -5,7 +5,7 @@ import { MockWorkspace } from "#/testHelpers/entities";
 import { WorkspaceSettingsPageView } from "./WorkspaceSettingsPageView";
 
 const meta: Meta<typeof WorkspaceSettingsPageView> = {
-	title: "pages/WorkspaceSettingsPage/WorkspaceSettingsPageView",
+	title: "pages/WorkspaceSettingsPage/WorkspaceSettingsPage",
 	component: WorkspaceSettingsPageView,
 	args: {
 		error: undefined,

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.stories.tsx
@@ -62,7 +62,7 @@ const aclWithUsersAndGroups: WorkspaceACL = {
 };
 
 const meta: Meta<typeof WorkspaceSharingPageView> = {
-	title: "pages/WorkspaceSharingPageView",
+	title: "pages/WorkspaceSharingPage",
 	component: WorkspaceSharingPageView,
 	parameters: {
 		queries: [


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Removes the trailing `View` suffix from 69 Storybook titles for consistency with newer stories.

Story files whose new titles would collide with an existing group are placed under a `States` subgroup to keep their story IDs isolated.
