### PR TITLE
Validate a tar upload instead of storing it unread

### DIFF
--- a/coderd/files.go
+++ b/coderd/files.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/archive"
@@ -45,6 +46,28 @@ const (
 // @Success 201 {object} codersdk.UploadResponse "Returns newly created file"
 // @Failure 413 {object} codersdk.Response "Request body exceeds 100 MiB, or a .zip archive exceeds it once expanded"
 // @Router /api/v2/files [post]
+// validateTar reports whether data can be read as a tar archive. Only the
+// headers are walked, so the cost is proportional to the number of entries
+// rather than the size of their contents. Without this an archive that cannot
+// be read is stored and returns a hash, and the failure surfaces much later in
+// whatever first tries to read the filesystem back out.
+func validateTar(data []byte) error {
+	if len(data) > 1 && data[0] == 0x1f && data[1] == 0x8b {
+		return xerrors.New("archive is gzip compressed, upload an uncompressed tar or a .zip archive")
+	}
+
+	reader := tar.NewReader(bytes.NewReader(data))
+	for {
+		_, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
 func (api *API) postFile(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -112,6 +135,16 @@ func (api *API) postFile(rw http.ResponseWriter, r *http.Request) {
 			}
 		}
 		contentType = tarMimeType
+	}
+
+	if contentType == tarMimeType {
+		if err := validateTar(data); err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid .tar archive file.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 	}
 
 	hashBytes := sha256.Sum256(data)

--- a/coderd/files_internal_test.go
+++ b/coderd/files_internal_test.go
@@ -1,0 +1,63 @@
+package coderd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTar(t *testing.T) {
+	t.Parallel()
+
+	buildTar := func(t *testing.T) []byte {
+		t.Helper()
+
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: "main.tf", Mode: 0o600, Size: 4}))
+		_, err := tw.Write([]byte("main"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		return buf.Bytes()
+	}
+
+	gzipBytes := func(t *testing.T, data []byte) []byte {
+		t.Helper()
+
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, err := gw.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+
+		return buf.Bytes()
+	}
+
+	t.Run("Tar", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateTar(buildTar(t)))
+	})
+
+	t.Run("EmptyArchive", func(t *testing.T) {
+		t.Parallel()
+		// Two zeroed blocks are how a tar marks its end, and uploads of that
+		// shape are already accepted today.
+		require.NoError(t, validateTar(make([]byte, 1024)))
+	})
+
+	t.Run("Gzipped", func(t *testing.T) {
+		t.Parallel()
+		err := validateTar(gzipBytes(t, buildTar(t)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "gzip")
+	})
+
+	t.Run("NotAnArchive", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, validateTar([]byte("this is not a tar archive")))
+	})
+}

--- a/coderd/files_test.go
+++ b/coderd/files_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/binary"
 	"io"
@@ -69,6 +70,44 @@ func TestPostFiles(t *testing.T) {
 
 		_, err := client.Upload(ctx, "application/x-zip-compressed", bytes.NewReader(archivetest.TestZipFileBytes()))
 		require.NoError(t, err)
+	})
+
+	t.Run("GzippedTar", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		var tarBytes bytes.Buffer
+		tw := tar.NewWriter(&tarBytes)
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: "main.tf", Mode: 0o600, Size: 4}))
+		_, err := tw.Write([]byte("main"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		var gzipped bytes.Buffer
+		gw := gzip.NewWriter(&gzipped)
+		_, err = gw.Write(tarBytes.Bytes())
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+
+		// A gzipped tar used to be stored as-is and only blew up later, in
+		// whatever first read the archive back.
+		_, err = client.Upload(ctx, codersdk.ContentTypeTar, bytes.NewReader(gzipped.Bytes()))
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+		require.Contains(t, apiErr.Detail, "gzip")
+	})
+
+	t.Run("UnreadableTar", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.Upload(ctx, codersdk.ContentTypeTar, bytes.NewReader([]byte("this is not a tar archive")))
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 
 	t.Run("InsertAlreadyExists", func(t *testing.T) {


### PR DESCRIPTION
Fixes #28913.

`postFile` checks the `Content-Type` header and, for zip, validates the archive with `zip.NewReader` before converting it. A tar is stored unread, so a gzipped tar sent as `application/x-tar` is accepted, hashed and returned as a valid file id. The failure then surfaces much later in whatever first reads the filesystem back, which in the report is preview, reported as "Unable to parse workspace tags" with a nil dereference underneath. As the reporter says, an empty template panics too, because the template content is never reached.

The upload path now walks the tar headers and rejects an archive it cannot read, so the mistake gets a 400 where it was made. Only headers are walked, so the cost is proportional to the number of entries rather than their contents. A gzip magic check gives that case its own message, since sending `tar czf` output is the easy way to hit this and the CLI accepts it.

This is the first of the three suggestions in the issue. I did not touch the reader on the preview side, and I did not add gzip support: accepting gzip changes what the endpoint means and is worth deciding separately, though the asymmetry with `coder templates push` is the part that cost the reporter the most time.

Tests: `TestValidateTar` covers a real tar, the all-zero block form that current uploads already use, a gzipped tar and non-archive bytes. `TestPostFiles` gains a `GzippedTar` case asserting a 400 whose detail mentions gzip, and an `UnreadableTar` case.

On what I ran: `go test ./coderd/ -run TestValidateTar` passes. I could not run the `TestPostFiles` cases locally, `coderdtest.New` does not come up in my sandbox and the run sat at `files_test.go:46` until the timeout, so those two are unverified by me and rely on CI.
