### PR TITLE
fix(coderd/templatebuilder): strip prerequisite markers from delivered README

### DIFF
--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -78,7 +78,7 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 	if len(req.Modules) == 0 {
 		return &ComposeResult{
 			MainTF:     formatHCL(mainTF),
-			Readme:     []byte(BaseReadme(req.BaseTemplateID)),
+			Readme:     composedReadme(req.BaseTemplateID),
 			ExtraFiles: extraFiles,
 		}, nil
 	}
@@ -119,10 +119,22 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 	result := &ComposeResult{
 		MainTF:     formatHCL(mainTF),
 		ModulesTF:  formatHCL(modulesTF),
-		Readme:     []byte(BaseReadme(req.BaseTemplateID)),
+		Readme:     composedReadme(req.BaseTemplateID),
 		ExtraFiles: extraFiles,
 	}
 	return result, nil
+}
+
+// composedReadme returns the base README prepared for delivery in the
+// output archive. The prerequisites markers are stripped so they do not
+// render as literal text when the README is viewed. Returns nil when the
+// base has no README.
+func composedReadme(baseTemplateID string) []byte {
+	readme := StripPrerequisiteMarkers(BaseReadme(baseTemplateID))
+	if readme == "" {
+		return nil
+	}
+	return []byte(readme)
 }
 
 // formatHCL applies canonical HCL formatting to src. If src is not valid

--- a/coderd/templatebuilder/compose.go
+++ b/coderd/templatebuilder/compose.go
@@ -130,7 +130,7 @@ func Compose(req ComposeRequest) (*ComposeResult, error) {
 // render as literal text when the README is viewed. Returns nil when the
 // base has no README.
 func composedReadme(baseTemplateID string) []byte {
-	readme := StripPrerequisiteMarkers(BaseReadme(baseTemplateID))
+	readme := StripPrerequisitesMarkers(BaseReadme(baseTemplateID))
 	if readme == "" {
 		return nil
 	}

--- a/coderd/templatebuilder/compose_test.go
+++ b/coderd/templatebuilder/compose_test.go
@@ -28,6 +28,10 @@ func TestCompose(t *testing.T) {
 		require.Contains(t, string(result.MainTF), `resource "coder_agent" "main"`)
 		require.Empty(t, result.ModulesTF)
 		require.NotEmpty(t, result.Readme, "compose should include base README")
+		require.NotContains(t, string(result.Readme), "prerequisites:start",
+			"delivered README should not contain prerequisites markers")
+		require.NotContains(t, string(result.Readme), "prerequisites:end",
+			"delivered README should not contain prerequisites markers")
 	})
 
 	t.Run("BaseWithModuleAndVariableOverride", func(t *testing.T) {

--- a/coderd/templatebuilder/prerequisites.go
+++ b/coderd/templatebuilder/prerequisites.go
@@ -32,19 +32,14 @@ func ExtractPrerequisites(readme string) string {
 // prerequisiteMarkerLine matches either prerequisites marker on its own
 // line, including the trailing newline and an optional following blank
 // line, so removing it does not leave an extra gap in the rendered README.
-// The marker text is derived from the constants above so there is a single
-// source of truth.
 var prerequisiteMarkerLine = regexp.MustCompile(
 	`(?m)^[ \t]*(?:` +
 		regexp.QuoteMeta(prerequisitesStartMarker) + `|` +
 		regexp.QuoteMeta(prerequisitesEndMarker) +
 		`)[ \t]*\n?\n?`)
 
-// StripPrerequisiteMarkers removes the prerequisites comment markers from a
-// README body. The content between the markers is preserved. The markers
-// exist only to delimit the prerequisites section for ExtractPrerequisites;
-// leaving them in the delivered README causes them to render as literal text
-// in the Markdown viewer.
+// Remove the prerequisites comment markers from a README body,
+// preserving the content between the markers.
 func StripPrerequisiteMarkers(readme string) string {
 	return prerequisiteMarkerLine.ReplaceAllString(readme, "")
 }

--- a/coderd/templatebuilder/prerequisites.go
+++ b/coderd/templatebuilder/prerequisites.go
@@ -1,6 +1,9 @@
 package templatebuilder
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 const (
 	// prerequisitesStartMarker delimits the beginning of the prerequisites
@@ -24,4 +27,18 @@ func ExtractPrerequisites(readme string) string {
 		return ""
 	}
 	return strings.TrimSpace(after[:endIdx])
+}
+
+// prerequisiteMarkerLine matches a prerequisites marker on its own line,
+// including the trailing newline and an optional following blank line, so
+// removing it does not leave an extra gap in the rendered README.
+var prerequisiteMarkerLine = regexp.MustCompile(`(?m)^[ \t]*<!-- prerequisites:(?:start|end) -->[ \t]*\n?\n?`)
+
+// StripPrerequisiteMarkers removes the prerequisites comment markers from a
+// README body. The content between the markers is preserved. The markers
+// exist only to delimit the prerequisites section for ExtractPrerequisites;
+// leaving them in the delivered README causes them to render as literal text
+// in the Markdown viewer.
+func StripPrerequisiteMarkers(readme string) string {
+	return prerequisiteMarkerLine.ReplaceAllString(readme, "")
 }

--- a/coderd/templatebuilder/prerequisites.go
+++ b/coderd/templatebuilder/prerequisites.go
@@ -29,10 +29,16 @@ func ExtractPrerequisites(readme string) string {
 	return strings.TrimSpace(after[:endIdx])
 }
 
-// prerequisiteMarkerLine matches a prerequisites marker on its own line,
-// including the trailing newline and an optional following blank line, so
-// removing it does not leave an extra gap in the rendered README.
-var prerequisiteMarkerLine = regexp.MustCompile(`(?m)^[ \t]*<!-- prerequisites:(?:start|end) -->[ \t]*\n?\n?`)
+// prerequisiteMarkerLine matches either prerequisites marker on its own
+// line, including the trailing newline and an optional following blank
+// line, so removing it does not leave an extra gap in the rendered README.
+// The marker text is derived from the constants above so there is a single
+// source of truth.
+var prerequisiteMarkerLine = regexp.MustCompile(
+	`(?m)^[ \t]*(?:` +
+		regexp.QuoteMeta(prerequisitesStartMarker) + `|` +
+		regexp.QuoteMeta(prerequisitesEndMarker) +
+		`)[ \t]*\n?\n?`)
 
 // StripPrerequisiteMarkers removes the prerequisites comment markers from a
 // README body. The content between the markers is preserved. The markers

--- a/coderd/templatebuilder/prerequisites.go
+++ b/coderd/templatebuilder/prerequisites.go
@@ -29,10 +29,10 @@ func ExtractPrerequisites(readme string) string {
 	return strings.TrimSpace(after[:endIdx])
 }
 
-// prerequisiteMarkerLine matches either prerequisites marker on its own
+// prerequisitesMarkerLine matches either prerequisites marker on its own
 // line, including the trailing newline and an optional following blank
 // line, so removing it does not leave an extra gap in the rendered README.
-var prerequisiteMarkerLine = regexp.MustCompile(
+var prerequisitesMarkerLine = regexp.MustCompile(
 	`(?m)^[ \t]*(?:` +
 		regexp.QuoteMeta(prerequisitesStartMarker) + `|` +
 		regexp.QuoteMeta(prerequisitesEndMarker) +
@@ -40,6 +40,6 @@ var prerequisiteMarkerLine = regexp.MustCompile(
 
 // Remove the prerequisites comment markers from a README body,
 // preserving the content between the markers.
-func StripPrerequisiteMarkers(readme string) string {
-	return prerequisiteMarkerLine.ReplaceAllString(readme, "")
+func StripPrerequisitesMarkers(readme string) string {
+	return prerequisitesMarkerLine.ReplaceAllString(readme, "")
 }

--- a/coderd/templatebuilder/prerequisites_test.go
+++ b/coderd/templatebuilder/prerequisites_test.go
@@ -84,3 +84,59 @@ func TestExtractPrerequisites(t *testing.T) {
 		})
 	}
 }
+
+func TestStripPrerequisiteMarkers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		readme   string
+		expected string
+	}{
+		{
+			name: "BothMarkers",
+			readme: "# Title\n\n" +
+				"<!-- prerequisites:start -->\n\n" +
+				"## Prerequisites\n\n" +
+				"Install Docker.\n\n" +
+				"<!-- prerequisites:end -->\n\n" +
+				"## Architecture\n",
+			expected: "# Title\n\n## Prerequisites\n\nInstall Docker.\n\n## Architecture\n",
+		},
+		{
+			name:     "NoMarkers",
+			readme:   "# Title\n\n## Prerequisites\n\nSome content.\n",
+			expected: "# Title\n\n## Prerequisites\n\nSome content.\n",
+		},
+		{
+			name: "StartMarkerOnly",
+			readme: "# Title\n\n" +
+				"<!-- prerequisites:start -->\n\n" +
+				"## Prerequisites\n",
+			expected: "# Title\n\n## Prerequisites\n",
+		},
+		{
+			name: "MarkerWithoutTrailingBlankLine",
+			readme: "# Title\n" +
+				"<!-- prerequisites:start -->\n" +
+				"## Prerequisites\n",
+			expected: "# Title\n## Prerequisites\n",
+		},
+		{
+			name: "EndMarkerAtEOF",
+			readme: "Content.\n\n" +
+				"<!-- prerequisites:end -->\n",
+			expected: "Content.\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := templatebuilder.StripPrerequisiteMarkers(tt.readme)
+			require.Equal(t, tt.expected, result)
+			require.NotContains(t, result, "prerequisites:start")
+			require.NotContains(t, result, "prerequisites:end")
+		})
+	}
+}

--- a/coderd/templatebuilder/prerequisites_test.go
+++ b/coderd/templatebuilder/prerequisites_test.go
@@ -85,7 +85,7 @@ func TestExtractPrerequisites(t *testing.T) {
 	}
 }
 
-func TestStripPrerequisiteMarkers(t *testing.T) {
+func TestStripPrerequisitesMarkers(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -133,7 +133,7 @@ func TestStripPrerequisiteMarkers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := templatebuilder.StripPrerequisiteMarkers(tt.readme)
+			result := templatebuilder.StripPrerequisitesMarkers(tt.readme)
 			require.Equal(t, tt.expected, result)
 			require.NotContains(t, result, "prerequisites:start")
 			require.NotContains(t, result, "prerequisites:end")


### PR DESCRIPTION
## Problem

Template builder base READMEs delimit their prerequisites section with HTML comment markers (`<!-- prerequisites:start -->` / `<!-- prerequisites:end -->`). `ExtractPrerequisites` uses these to populate the builder's Prerequisites step, which works correctly.

However, `Compose` embeds the **full** base README verbatim into the generated template's tarball. Because `react-markdown` renders raw HTML comments as literal text, the markers were visible when the delivered README is viewed via `MemoizedMarkdown`.

<img width="876" height="586" alt="Screenshot 2026-09-03 at 3 28 08 PM" src="https://github.com/user-attachments/assets/70353ee2-1ff6-4e70-9b5d-7ac0521b945f" />

## Fix

Strip the prerequisite markers from the README before writing it into the tarball (Option 2), keeping the change contained to the template builder and leaving global markdown rendering untouched.

- `prerequisites.go`: new `StripPrerequisiteMarkers` removes each marker line (plus an optional trailing blank line so no gap is left) while preserving the content between them.
- `compose.go`: new `composedReadme` helper applies the strip in both `Compose` return paths; returns `nil` for an empty README, preserving the existing "omit README.md when empty" behavior.
- `ExtractPrerequisites` still reads the markers from the source `BaseReadme`, so the builder's Prerequisites step is unaffected.

## Testing

- `TestStripPrerequisiteMarkers` covers both markers, no markers, single markers, missing trailing blank line, and end-of-file cases.
- Extended the compose test to assert the delivered README contains no marker text.
- `go test ./coderd/templatebuilder/`, `go vet`, and `golangci-lint run ./coderd/templatebuilder/...` all pass.

<details>
<summary>Approach considered</summary>

Two options were on the table:

1. Skip HTML comments in the shared `MemoizedMarkdown` component (fixes any stray comment globally, but changes shared rendering behavior app-wide).
2. Strip the markers from the README before inserting it into the template zipball (targeted; markers have no purpose in the delivered README since prerequisites are already extracted separately).

Option 2 was chosen for being contained and easily unit-tested.
</details>

---
_This PR was created by Coder Agents on behalf of @jeremyruppel._
