### PR TITLE
fix(site/src): show 403 detail as ErrorAlert title

### DIFF
--- a/site/src/components/Alert/ErrorAlert.stories.tsx
+++ b/site/src/components/Alert/ErrorAlert.stories.tsx
@@ -43,6 +43,17 @@ export const APIErrorWithDetail: Story = {
 	},
 };
 
+export const ForbiddenError: Story = {
+	args: {
+		error: mockApiError({
+			message: "Forbidden.",
+			detail:
+				"You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials.",
+			status: 403,
+		}),
+	},
+};
+
 export const WithDismiss: Story = {
 	args: {
 		dismissible: true,

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -19,20 +19,25 @@ export const ErrorAlert: FC<ErrorAlertProps> = ({
 	const message = getErrorMessage(error, "Something went wrong.");
 	const detail = getErrorDetail(error);
 	const status = getErrorStatus(error);
+	const isForbidden = status === 403;
+
+	// Forbidden responses carry a generic status word as the message ("Forbidden.")
+	// and the actionable explanation in the detail, so the detail becomes the title.
+	const title = isForbidden && detail ? detail : message;
 
 	// For some reason, the message and detail can be the same on the BE, but does
-	// not make sense in the FE to showing them duplicated. However, we should always
-	// display the detail if its a 403 Forbidden response.
-	const shouldDisplayDetail = status === 403 || message !== detail;
+	// not make sense in the FE to showing them duplicated.
+	const shouldDisplayDetail =
+		detail !== undefined && detail !== title && message !== detail;
 	const shouldDisplayResponseData = isAxiosError(error) && error.response?.data;
 	const shouldDisplayStackTrace = error instanceof Error;
 
 	return (
 		<Alert severity="error" prominent {...alertProps}>
-			<AlertTitle>{message}</AlertTitle>
+			<AlertTitle>{title}</AlertTitle>
 			<AlertDescription>
 				{shouldDisplayDetail && detail}
-				{status === 403 && (
+				{isForbidden && (
 					// When the error is a Forbidden response we include a link for the user to
 					// go back to a known viewable page.
 					<Link href="/workspaces" className="w-fit">

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -11,6 +11,15 @@ type ErrorAlertProps = Readonly<
 	}
 >;
 
+// Some responses use a raw HTTP status word as the message and put the
+// actionable explanation in the detail. Those status words are meaningless to
+// users, so they are replaced with a human title and the detail carries the
+// explanation.
+const genericStatusTitles: Record<number, { pattern: RegExp; title: string }> =
+	{
+		403: { pattern: /^forbidden\.?$/i, title: "Permission required" },
+	};
+
 export const ErrorAlert: FC<ErrorAlertProps> = ({
 	error,
 	showDebugDetail = true,
@@ -21,29 +30,31 @@ export const ErrorAlert: FC<ErrorAlertProps> = ({
 	const status = getErrorStatus(error);
 	const isForbidden = status === 403;
 
-	// Forbidden responses carry a generic status word as the message ("Forbidden.")
-	// and the actionable explanation in the detail, so the detail becomes the title.
-	const title = isForbidden && detail ? detail : message;
+	const genericStatus = status ? genericStatusTitles[status] : undefined;
+	const title = genericStatus?.pattern.test(message.trim())
+		? genericStatus.title
+		: message;
 
 	// For some reason, the message and detail can be the same on the BE, but does
 	// not make sense in the FE to showing them duplicated.
-	const shouldDisplayDetail =
-		detail !== undefined && detail !== title && message !== detail;
+	const shouldDisplayDetail = detail !== undefined && detail !== title;
 	const shouldDisplayResponseData = isAxiosError(error) && error.response?.data;
 	const shouldDisplayStackTrace = error instanceof Error;
 
 	return (
 		<Alert severity="error" prominent {...alertProps}>
-			<AlertTitle>{title}</AlertTitle>
+			<AlertTitle className="font-semibold">{title}</AlertTitle>
 			<AlertDescription>
-				{shouldDisplayDetail && detail}
-				{isForbidden && (
-					// When the error is a Forbidden response we include a link for the user to
-					// go back to a known viewable page.
-					<Link href="/workspaces" className="w-fit">
-						Go to workspaces
-					</Link>
-				)}
+				<span className="flex flex-col items-start gap-1">
+					{shouldDisplayDetail && <span>{detail}</span>}
+					{isForbidden && (
+						// When the error is a Forbidden response we include a link for the user to
+						// go back to a known viewable page.
+						<Link href="/workspaces" className="w-fit">
+							Go to workspaces
+						</Link>
+					)}
+				</span>
 			</AlertDescription>
 			{(shouldDisplayResponseData || shouldDisplayStackTrace) &&
 				showDebugDetail && (

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2662,10 +2662,12 @@ type MockAPIInput = {
 	message?: string;
 	detail?: string;
 	validations?: FieldError[];
+	status?: number;
 };
 
 type MockAPIOutput = {
 	isAxiosError: true;
+	status: number | undefined;
 	response: {
 		data: {
 			message: string;
@@ -2679,9 +2681,11 @@ export const mockApiError = ({
 	message = "Something went wrong.",
 	detail,
 	validations,
+	status,
 }: MockAPIInput): MockAPIOutput => ({
 	// This is how axios can check if it is an axios error when calling isAxiosError
 	isAxiosError: true,
+	status,
 	response: {
 		data: {
 			message,


### PR DESCRIPTION
`ErrorAlert` showed the raw HTTP status word `Forbidden.` as the title for 403s, while the actionable copy already exists in the API response `Detail` field. The status word is meaningless to users.

Frontend only: `httpapi.ResourceForbiddenResponse` is unchanged, so API and CLI output stay the same.

![ErrorAlert 403 before and after](https://raw.githubusercontent.com/coder/coder/assets/pr-28954-error-alert/error-alert-403-before-after.png)

## Changes

- Generic 403s get a human title, `Permission required`, matching `ChatAccessDeniedAlert` and the `EmptyState` message/description convention. The detail stays in the description where the existing copy belongs.
- The substitution is guarded by a message pattern (`/^forbidden\.?$/i`), so endpoints returning a specific 403 message keep it. `genericStatusTitles` maps status to pattern and title, so other raw-status-word responses can be added later.
- The title is now `font-semibold`. Title and description were both plain `text-sm`, so the title did not read as a title.
- Description content is stacked in a column, so the detail and the "Go to workspaces" link no longer run together inline.
- `mockApiError` accepts `status` so stories can exercise the 403 path (`getErrorStatus` reads the top-level `status`).

Added an `ErrorAlert/ForbiddenError` story with the real API copy.

Note: `AgentCreateForm.stories.tsx`'s 403 mock only sets `response.status`, not the top-level `status`, so it does not hit this branch and its assertions are unaffected.

---
Generated by Coder Agents on behalf of @designertyler.
