### PR TITLE
feat: add GPT-6 Astra to the known models catalog, price book, and chatd

### DIFF
--- a/coderd/aibridge/prices/data/prices.json
+++ b/coderd/aibridge/prices/data/prices.json
@@ -2577,6 +2577,14 @@
   },
   {
     "provider": "openai",
+    "model": "gpt-6-astra",
+    "input_price": 10000000,
+    "output_price": 50000000,
+    "cache_read_price": 1000000,
+    "cache_write_price": 12500000
+  },
+  {
+    "provider": "openai",
     "model": "gpt-image-2",
     "input_price": 5000000,
     "output_price": 30000000,
@@ -2986,8 +2994,8 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat",
-    "input_price": 257400,
-    "output_price": 1028700,
+    "input_price": 320000,
+    "output_price": 890000,
     "cache_read_price": null,
     "cache_write_price": null
   },
@@ -3002,9 +3010,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-chat-v3.1",
-    "input_price": 250000,
-    "output_price": 950000,
-    "cache_read_price": 130000,
+    "input_price": 550000,
+    "output_price": 1650000,
+    "cache_read_price": 550000,
     "cache_write_price": null
   },
   {
@@ -3058,9 +3066,9 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash",
-    "input_price": 88606,
-    "output_price": 177212,
-    "cache_read_price": 17721,
+    "input_price": 79380,
+    "output_price": 158760,
+    "cache_read_price": 15876,
     "cache_write_price": null
   },
   {
@@ -3074,25 +3082,25 @@
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-flash-vision-exp",
-    "input_price": 440000,
-    "output_price": 1320000,
-    "cache_read_price": 14000,
+    "input_price": 220000,
+    "output_price": 660000,
+    "cache_read_price": 7000,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro",
-    "input_price": 1042260,
-    "output_price": 2084520,
-    "cache_read_price": 86855,
+    "input_price": 1030776,
+    "output_price": 2061552,
+    "cache_read_price": 85898,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "deepseek/deepseek-v4-pro-0813",
-    "input_price": 1115400,
-    "output_price": 3346200,
-    "cache_read_price": 37180,
+    "input_price": 660000,
+    "output_price": 1980000,
+    "cache_read_price": 22000,
     "cache_write_price": null
   },
   {
@@ -3405,6 +3413,14 @@
     "input_price": 21000,
     "output_price": 63000,
     "cache_read_price": 4200,
+    "cache_write_price": null
+  },
+  {
+    "provider": "openrouter",
+    "model": "inclusionai/ling-3.0-flash-fin",
+    "input_price": 60000,
+    "output_price": 180000,
+    "cache_read_price": 12000,
     "cache_write_price": null
   },
   {
@@ -4602,9 +4618,9 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen2.5-vl-72b-instruct",
-    "input_price": 250000,
-    "output_price": 750000,
-    "cache_read_price": null,
+    "input_price": 800000,
+    "output_price": 1000000,
+    "cache_read_price": 400000,
     "cache_write_price": null
   },
   {
@@ -4946,10 +4962,10 @@
   {
     "provider": "openrouter",
     "model": "qwen/qwen3.8-27b",
-    "input_price": 425000,
-    "output_price": 2550000,
+    "input_price": 420000,
+    "output_price": 3000000,
     "cache_read_price": 85000,
-    "cache_write_price": 531250
+    "cache_write_price": null
   },
   {
     "provider": "openrouter",
@@ -5090,9 +5106,9 @@
   {
     "provider": "openrouter",
     "model": "tencent/hy3",
-    "input_price": 132000,
-    "output_price": 528000,
-    "cache_read_price": 33000,
+    "input_price": 82500,
+    "output_price": 330000,
+    "cache_read_price": 20625,
     "cache_write_price": null
   },
   {
@@ -5442,9 +5458,9 @@
   {
     "provider": "openrouter",
     "model": "~moonshotai/kimi-latest",
-    "input_price": 2550000,
-    "output_price": 12750000,
-    "cache_read_price": 256000,
+    "input_price": 2500000,
+    "output_price": 14000000,
+    "cache_read_price": 290000,
     "cache_write_price": null
   },
   {
@@ -5474,17 +5490,17 @@
   {
     "provider": "openrouter",
     "model": "~z-ai/glm-flash-latest",
-    "input_price": 75000,
-    "output_price": 250000,
-    "cache_read_price": 15000,
+    "input_price": 71250,
+    "output_price": 237500,
+    "cache_read_price": 14250,
     "cache_write_price": null
   },
   {
     "provider": "openrouter",
     "model": "~z-ai/glm-latest",
-    "input_price": 1106000,
-    "output_price": 3476000,
-    "cache_read_price": 181700,
+    "input_price": 1148000,
+    "output_price": 3608000,
+    "cache_read_price": 188600,
     "cache_write_price": null
   },
   {
@@ -7490,9 +7506,17 @@
   {
     "provider": "vercel",
     "model": "zai/glm-5.3",
-    "input_price": 1400000,
-    "output_price": 4400000,
-    "cache_read_price": 140000,
+    "input_price": 700000,
+    "output_price": 2200000,
+    "cache_read_price": 130000,
+    "cache_write_price": null
+  },
+  {
+    "provider": "vercel",
+    "model": "zai/glm-5.3-fast",
+    "input_price": 2100000,
+    "output_price": 6600000,
+    "cache_read_price": 210000,
     "cache_write_price": null
   },
   {

--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -901,9 +901,13 @@ Subagent model and effort resolution follows this precedence:
 
 During generation preparation, the effective effort is resolved as the chat's `last_reasoning_effort` if set, else the config's `default`; clamped to the config's `max` on the global scale `none < minimal < low < medium < high < xhigh < max`; and passed through to the provider. The provider verifies whether the configured value is valid for that model at runtime. If the model config has no `reasoning_effort`, any user-selected value is ignored. The resolved value is injected into the provider-native options by `chatprovider.ProviderOptionsForCall`, which converts the model config and applies the effort in one step. For Anthropic, the fantasy provider converts effort into enabled budget thinking on models older than Claude 4.6, which reject adaptive thinking.
 
+TODO: document that `applyReasoningEffort` clamps `none` and `minimal` to `low` for GPT-6 Astra (`chatopenai.IsGPT6Astra`), which rejects `none` with HTTP 400 and lists no `minimal` effort.
+
 ##### OpenAI transport selection
 
 OpenAI models speak either the Responses API or Chat Completions. The provider SDK picks per model from a static known-model list, so a newly released model absent from that list falls back to Chat Completions. Model configs may override the choice with `openai_config.use_responses_api` inside `chat_model_configs.options`: unset keeps the known-model list, true forces Responses, false forces Chat Completions. It sits in `openai_config` rather than `provider_options.openai` because it is applied once when the client is built, while `provider_options` holds per-request parameters.
+
+TODO: document that `chatopenai.UsesResponsesAPI` now owns the unset-override decision for both the client (`WithResponsesAPIFunc`) and `TransportFor`, and that GPT-6 Astra defaults to Responses because the pinned SDK predates it and its function calling is Responses-only.
 
 The transport is resolved exactly once, when the client is built, and carried on `chatprovider.Model` as a `chatopenai.Transport`. `Model` wraps the fantasy client with that resolved fact; its fields are unexported and only its constructor sets the transport, deriving it from the client, so no caller can pick a transport that disagrees with the client. `TransportInvalid` is the zero value and panics when read rather than defaulting to a wire format. A nil client yields that invalid zero value, which the construction path reports as an error.
 

--- a/coderd/x/chatd/chatopenai/transport.go
+++ b/coderd/x/chatd/chatopenai/transport.go
@@ -2,6 +2,7 @@ package chatopenai
 
 import (
 	"fmt"
+	"strings"
 
 	fantasyazure "charm.land/fantasy/providers/azure"
 	fantasyopenai "charm.land/fantasy/providers/openai"
@@ -45,10 +46,7 @@ func TransportFor(provider, modelID string, override *bool) Transport {
 	var useResponses bool
 	switch provider {
 	case fantasyopenai.Name:
-		useResponses = fantasyopenai.IsResponsesModel(modelID)
-		if override != nil {
-			useResponses = *override
-		}
+		useResponses = UsesResponsesAPI(modelID, override)
 	case fantasyazure.Name:
 		useResponses = fantasyopenai.IsResponsesModel(modelID)
 	case fantasyopenaicompat.Name:
@@ -61,4 +59,20 @@ func TransportFor(provider, modelID string, override *bool) Transport {
 		return TransportResponses
 	}
 	return TransportChatCompletions
+}
+
+// UsesResponsesAPI decides the wire format for an OpenAI model. override, when
+// non-nil, wins. Otherwise the provider SDK's known-model list decides, except
+// that GPT-6 Astra defaults to Responses: the pinned SDK predates the model and
+// Astra's function calling is Responses-only.
+func UsesResponsesAPI(modelID string, override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	return fantasyopenai.IsResponsesModel(modelID) || IsGPT6Astra(modelID)
+}
+
+// IsGPT6Astra matches gpt-6-astra and its dated snapshots.
+func IsGPT6Astra(modelID string) bool {
+	return strings.HasPrefix(strings.ToLower(modelID), "gpt-6-astra")
 }

--- a/coderd/x/chatd/chatopenai/transport_test.go
+++ b/coderd/x/chatd/chatopenai/transport_test.go
@@ -32,6 +32,10 @@ func TestTransportFor(t *testing.T) {
 		{"OpenAIUnknownModel", fantasyopenai.Name, nonResponsesModel, nil, chatopenai.TransportChatCompletions},
 		{"OpenAIForceResponses", fantasyopenai.Name, nonResponsesModel, &forceResponses, chatopenai.TransportResponses},
 		{"OpenAIForceCompletions", fantasyopenai.Name, responsesModel, &forceCompletions, chatopenai.TransportChatCompletions},
+		// GPT-6 Astra postdates the SDK's known-model list.
+		{"OpenAIGPT6AstraDefaultsToResponses", fantasyopenai.Name, "gpt-6-astra", nil, chatopenai.TransportResponses},
+		{"OpenAIGPT6AstraSnapshotDefaultsToResponses", fantasyopenai.Name, "gpt-6-astra-2026-09-03", nil, chatopenai.TransportResponses},
+		{"OpenAIGPT6AstraForceCompletions", fantasyopenai.Name, "gpt-6-astra", &forceCompletions, chatopenai.TransportChatCompletions},
 		{"AzureIgnoresOverride", fantasyazure.Name, responsesModel, &forceCompletions, chatopenai.TransportResponses},
 		{"AzureKnownModelList", fantasyazure.Name, nonResponsesModel, nil, chatopenai.TransportChatCompletions},
 		{"OpenAICompat", fantasyopenaicompat.Name, responsesModel, &forceResponses, chatopenai.TransportChatCompletions},
@@ -44,6 +48,15 @@ func TestTransportFor(t *testing.T) {
 			require.Equal(t, tt.want, chatopenai.TransportFor(tt.provider, tt.modelID, tt.override))
 		})
 	}
+}
+
+func TestIsGPT6Astra(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, chatopenai.IsGPT6Astra("gpt-6-astra"))
+	require.True(t, chatopenai.IsGPT6Astra("GPT-6-Astra-2026-09-03"))
+	require.False(t, chatopenai.IsGPT6Astra("gpt-5.6-sol"))
+	require.False(t, chatopenai.IsGPT6Astra("gpt-6"))
 }
 
 func TestTransportUsesResponses(t *testing.T) {

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -795,16 +795,14 @@ func ModelFromConfig(
 		}
 		providerClient, err = fantasygoogle.New(options...)
 	case fantasyopenai.Name:
+		override := openAIResponsesAPIOverride(openAIConfig)
 		options := []fantasyopenai.Option{
 			fantasyopenai.WithAPIKey(apiKey),
 			fantasyopenai.WithUseResponsesAPI(),
+			fantasyopenai.WithResponsesAPIFunc(func(modelID string) bool {
+				return chatopenai.UsesResponsesAPI(modelID, override)
+			}),
 			fantasyopenai.WithUserAgent(userAgent),
-		}
-		if override := openAIResponsesAPIOverride(openAIConfig); override != nil {
-			forced := *override
-			options = append(options, fantasyopenai.WithResponsesAPIFunc(func(string) bool {
-				return forced
-			}))
 		}
 		if len(extraHeaders) > 0 {
 			options = append(options, fantasyopenai.WithHeaders(extraHeaders))

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -795,13 +795,13 @@ func ModelFromConfig(
 		}
 		providerClient, err = fantasygoogle.New(options...)
 	case fantasyopenai.Name:
-		override := openAIResponsesAPIOverride(openAIConfig)
+		// Resolved once here so a later mutation of the config cannot move
+		// the client off the transport NewModel records.
+		useResponses := chatopenai.UsesResponsesAPI(modelID, openAIResponsesAPIOverride(openAIConfig))
 		options := []fantasyopenai.Option{
 			fantasyopenai.WithAPIKey(apiKey),
 			fantasyopenai.WithUseResponsesAPI(),
-			fantasyopenai.WithResponsesAPIFunc(func(modelID string) bool {
-				return chatopenai.UsesResponsesAPI(modelID, override)
-			}),
+			fantasyopenai.WithResponsesAPIFunc(func(string) bool { return useResponses }),
 			fantasyopenai.WithUserAgent(userAgent),
 		}
 		if len(extraHeaders) > 0 {

--- a/coderd/x/chatd/chatprovider/reasoningeffort.go
+++ b/coderd/x/chatd/chatprovider/reasoningeffort.go
@@ -15,6 +15,7 @@ import (
 	fantasyopenrouter "charm.land/fantasy/providers/openrouter"
 	fantasyvercel "charm.land/fantasy/providers/vercel"
 
+	"github.com/coder/coder/v2/coderd/x/chatd/chatopenai"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -104,7 +105,7 @@ func applyReasoningEffort(
 
 	switch NormalizeProvider(model.Provider()) {
 	case fantasyopenai.Name, fantasyazure.Name:
-		providerEffort := fantasyopenai.ReasoningEffort(*effort)
+		providerEffort := fantasyopenai.ReasoningEffort(openAIReasoningEffort(model.ModelID(), *effort))
 		switch opts := options[fantasyopenai.Name].(type) {
 		case *fantasyopenai.ResponsesProviderOptions:
 			opts.ReasoningEffort = &providerEffort
@@ -174,6 +175,20 @@ func applyReasoningEffort(
 		providerOptions.Reasoning.Effort = &providerEffort
 	}
 	return options
+}
+
+// openAIReasoningEffort maps the global reasoning effort scale onto what an
+// OpenAI model accepts. GPT-6 Astra rejects none with HTTP 400 and does not
+// list minimal; OpenAI's migration guidance for both is to start at low.
+func openAIReasoningEffort(modelID, effort string) string {
+	if !chatopenai.IsGPT6Astra(modelID) {
+		return effort
+	}
+	switch effort {
+	case codersdk.ChatModelReasoningEffortNone, codersdk.ChatModelReasoningEffortMinimal:
+		return codersdk.ChatModelReasoningEffortLow
+	}
+	return effort
 }
 
 // googleCompatReasoningEffort maps the global reasoning effort scale onto the

--- a/coderd/x/chatd/chatprovider/reasoningeffort_internal_test.go
+++ b/coderd/x/chatd/chatprovider/reasoningeffort_internal_test.go
@@ -66,6 +66,28 @@ func TestApplyReasoningEffort(t *testing.T) {
 		require.Equal(t, fantasyopenai.ReasoningEffortHigh, *providerOptions.ReasoningEffort)
 	})
 
+	t.Run("ClampsUnsupportedGPT6AstraEfforts", func(t *testing.T) {
+		t.Parallel()
+
+		astra := NewModel(&chattest.FakeModel{ProviderName: fantasyopenai.Name, ModelName: "gpt-6-astra"}, nil)
+		for effort, want := range map[string]fantasyopenai.ReasoningEffort{
+			codersdk.ChatModelReasoningEffortNone:    fantasyopenai.ReasoningEffortLow,
+			codersdk.ChatModelReasoningEffortMinimal: fantasyopenai.ReasoningEffortLow,
+			codersdk.ChatModelReasoningEffortLow:     fantasyopenai.ReasoningEffortLow,
+			codersdk.ChatModelReasoningEffortMax:     fantasyopenai.ReasoningEffortMax,
+		} {
+			got := applyReasoningEffort(astra, nil, &effort)
+			providerOptions, ok := got[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions)
+			require.True(t, ok, "%T", got[fantasyopenai.Name])
+			require.Equal(t, want, *providerOptions.ReasoningEffort, "effort %q", effort)
+		}
+
+		// Other OpenAI models keep the caller's value.
+		sol := NewModel(&chattest.FakeModel{ProviderName: fantasyopenai.Name, ModelName: "gpt-5.6-sol"}, nil)
+		got := applyReasoningEffort(sol, nil, new(codersdk.ChatModelReasoningEffortNone))
+		require.Equal(t, fantasyopenai.ReasoningEffortNone, *got[fantasyopenai.Name].(*fantasyopenai.ResponsesProviderOptions).ReasoningEffort)
+	})
+
 	tests := []struct {
 		name      string
 		provider  string

--- a/coderd/x/chatd/chatprovider/responses_api_test.go
+++ b/coderd/x/chatd/chatprovider/responses_api_test.go
@@ -36,6 +36,9 @@ func TestModelFromConfig_OpenAIResponsesAPIOverride(t *testing.T) {
 		{"ForceCompletionsOnKnownModel", responsesModel, &forceCompletions, "/chat/completions"},
 		{"ForceResponsesOnKnownModel", responsesModel, &forceResponses, "/responses"},
 		{"ForceCompletionsOnUnknownModel", nonResponsesModel, &forceCompletions, "/chat/completions"},
+		// GPT-6 Astra postdates the SDK's known-model list.
+		{"DefaultGPT6Astra", "gpt-6-astra", nil, "/responses"},
+		{"ForceCompletionsOnGPT6Astra", "gpt-6-astra", &forceCompletions, "/chat/completions"},
 	}
 
 	for _, tc := range cases {

--- a/scripts/aibridgepricesgen/curation.json
+++ b/scripts/aibridgepricesgen/curation.json
@@ -133,6 +133,10 @@
 	],
 	"openai": [
 		{
+			"modelIdentifier": "gpt-6-astra",
+			"reasoningEffort": "medium"
+		},
+		{
 			"modelIdentifier": "gpt-5.6-sol",
 			"aliases": ["gpt-5.6"],
 			"reasoningEffort": "medium"

--- a/scripts/aibridgepricesgen/overrides.jq
+++ b/scripts/aibridgepricesgen/overrides.jq
@@ -31,6 +31,39 @@ end
     )
   end
 
+# gpt-6-astra: released 2026-09-03 and not listed on models.dev yet. Inject it
+# from OpenAI's published model page and pricing table so the price book and
+# the known-models catalog can carry it; drop this block once upstream lists it.
+# Ref: https://developers.openai.com/api/docs/models/gpt-6-astra
+# Ref: https://developers.openai.com/api/docs/pricing
+| if (.openai.models | has("gpt-6-astra")) then
+    error("overrides.jq: gpt-6-astra now present upstream; drop the injection")
+  else
+    .openai.models."gpt-6-astra" = {
+      id: "gpt-6-astra",
+      name: "GPT-6 Astra",
+      attachment: true,
+      reasoning: true,
+      reasoning_options: [{type: "effort", values: ["low", "medium", "high", "xhigh", "max"]}],
+      tool_call: true,
+      structured_output: true,
+      temperature: false,
+      knowledge: "2026-04-30",
+      release_date: "2026-09-03",
+      last_updated: "2026-09-03",
+      modalities: {input: ["text", "image"], output: ["text"]},
+      open_weights: false,
+      limit: {context: 1050000, input: 922000, output: 128000},
+      cost: {
+        input: 10,
+        output: 50,
+        cache_read: 1,
+        cache_write: 12.5,
+        tiers: [{input: 20, output: 75, cache_read: 2, cache_write: 25, tier: {type: "context", size: 272000}}]
+      }
+    }
+  end
+
 # Mapping of provider names on models.dev to our own names
 # Ref. table definition for ai_provider_type
 # amazon-bedrock -> bedrock

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/knownModels/knownModelsGenerated.json
@@ -422,6 +422,19 @@
 	"openai": [
 		{
 			"provider": "openai",
+			"modelIdentifier": "gpt-6-astra",
+			"displayName": "GPT-6 Astra",
+			"aliases": [],
+			"contextLimit": 1050000,
+			"maxOutputTokens": 128000,
+			"reasoningEffort": "medium",
+			"inputCost": 10,
+			"outputCost": 50,
+			"cacheReadCost": 1,
+			"cacheWriteCost": 12.5
+		},
+		{
+			"provider": "openai",
 			"modelIdentifier": "gpt-5.6-sol",
 			"displayName": "GPT-5.6 Sol",
 			"aliases": ["gpt-5.6"],
@@ -700,9 +713,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 0.088606,
-			"outputCost": 0.177212,
-			"cacheReadCost": 0.017721
+			"inputCost": 0.07938,
+			"outputCost": 0.15876,
+			"cacheReadCost": 0.015876
 		},
 		{
 			"provider": "openrouter",
@@ -711,9 +724,9 @@
 			"aliases": [],
 			"contextLimit": 1048576,
 			"maxOutputTokens": 384000,
-			"inputCost": 1.04226,
-			"outputCost": 2.08452,
-			"cacheReadCost": 0.086855
+			"inputCost": 1.030776,
+			"outputCost": 2.061552,
+			"cacheReadCost": 0.085898
 		},
 		{
 			"provider": "openrouter",
@@ -804,9 +817,9 @@
 			"aliases": [],
 			"contextLimit": 1000000,
 			"maxOutputTokens": 1000000,
-			"inputCost": 1.4,
-			"outputCost": 4.4,
-			"cacheReadCost": 0.14
+			"inputCost": 0.7,
+			"outputCost": 2.2,
+			"cacheReadCost": 0.13
 		},
 		{
 			"provider": "vercel",


### PR DESCRIPTION
Add GPT-6 Astra to the Agents-page known models list so it appears as a suggestion when an admin adds an OpenAI chat model in `/agents` settings, pick up its pricing in the AI Bridge price book, and teach chatd the two Astra facts the pinned provider SDK does not know: it speaks the Responses API and it rejects the `none` reasoning effort.

OpenAI released `gpt-6-astra` today (2026-09-03). models.dev does not list it yet, so `overrides.jq` injects the model from OpenAI's published model page and pricing table, guarded to fail the pipeline once upstream lists it so the injection gets dropped instead of shadowing upstream data. `curation.json` suggests it first under `openai` (ahead of `gpt-5.6-sol`, which it supersedes), and `make gen/aibridge-prices` regenerated both outputs. The chatd change (second and third commits) came out of Codex review. `fantasyopenai.IsResponsesModel` matches a static list plus `gpt-4`/`gpt-5` substrings, so `gpt-6-astra` resolved to Chat Completions, where Astra does not support function calling. `chatopenai.UsesResponsesAPI` now owns the unset-override decision for both the client (`WithResponsesAPIFunc`) and `TransportFor`, defaulting Astra to Responses; `openai_config.use_responses_api` still wins when set. `applyReasoningEffort` clamps `none` and `minimal` to `low` for Astra (OpenAI's migration guidance), since the picker offers every level up to the configured max and the model config has no minimum. Both are red-green tested; `ARCHITECTURE.md` carries TODO markers in the two affected sections per the chatd rule.

## Values

| Field | Value | Source |
|---|---|---|
| model id | `gpt-6-astra` (the only published snapshot/alias; there is no `gpt-6` alias) | https://developers.openai.com/api/docs/models/gpt-6-astra |
| display name | `GPT-6 Astra` | model page title |
| context window | 1,050,000 (`limit.context`); 922,000 max input tokens (`limit.input`) | model page |
| max output tokens | 128,000 | model page |
| input / cached input / cache write / output | $10.00 / $1.00 / $12.50 / $50.00 per 1M tokens (Standard) | https://developers.openai.com/api/docs/pricing (Standard table) and the model page |
| long-context tier (`cost.tiers`, informational; the generator emits flat prices only) | above 272K input tokens: $20.00 / $2.00 / $25.00 / $75.00, i.e. 2x input and cache rates and 1.5x output for the full request | pricing page Standard table and model page notes |
| reasoning efforts | `low`, `medium`, `high`, `xhigh`, `max`; `none` returns HTTP 400 | model page; https://developers.openai.com/api/docs/changelog |
| curated `reasoningEffort` | `medium` | editorial, same as `gpt-5.6-sol`; OpenAI publishes no default effort for Astra |
| knowledge cutoff | 2026-04-30 | model page |
| modalities and features | text + image in, text out; function calling (Responses API only), structured outputs, streaming, prompt caching | model page; changelog |
| unsupported parameters | `temperature`, `top_p`, `logprobs` (`temperature: false` in the injected record) | changelog |

Known gap, unchanged by this PR: the price book is a flat per-model row, so Astra's >272K tier (like Sol's, 5.5's, 5.4's, and Gemini's upstream tiers) is not applied by `aibridgedserver/cost.go`; the tier is recorded in the injected `cost.tiers` for when tier-aware accounting lands, and the dogfood default entry caps context at 272,000.

Not published by OpenAI and therefore not set: a default reasoning effort for Astra, and any Azure, Bedrock, OpenRouter, or Vercel listing. The change is openai-only; the extra provider rows that exist for `gpt-5.6-sol` come from models.dev and will follow for Astra once upstream lists them. Batch/Flex (50%) and Fast mode (2x) pricing is documented on the pricing page but the price book carries Standard rates only, as for every other model.

| File | Change |
|---|---|
| `scripts/aibridgepricesgen/overrides.jq` | guarded `gpt-6-astra` injection under `openai` |
| `scripts/aibridgepricesgen/curation.json` | `gpt-6-astra` first under `openai` with `reasoningEffort: medium` |
| `knownModelsGenerated.json` | new `gpt-6-astra` entry (1,050,000 context, 128,000 max output, $10 / $50 / $1 cache read / $12.5 cache write per 1M tokens); `openrouter/deepseek/deepseek-v4-flash`, `openrouter/deepseek/deepseek-v4-pro`, and `vercel/zai/glm-5.3` repriced upstream |
| `coderd/x/chatd/chatopenai/transport.go`, `chatprovider/chatprovider.go` | `UsesResponsesAPI` + `IsGPT6Astra`; the OpenAI client always gets a `WithResponsesAPIFunc` returning the decision `ModelFromConfig` resolves once through the same helper as `TransportFor` |
| `coderd/x/chatd/chatprovider/reasoningeffort.go` | `openAIReasoningEffort` clamps `none`/`minimal` to `low` for Astra |
| `coderd/x/chatd/ARCHITECTURE.md` | TODO markers in the reasoning-effort and OpenAI transport sections |
| `coderd/aibridge/prices/data/prices.json` | added `openai/gpt-6-astra`; upstream drift since the last refresh: new `openrouter/inclusionai/ling-3.0-flash-fin` and `vercel/zai/glm-5.3-fast`, and 13 repriced rows (openrouter deepseek-chat, deepseek-chat-v3.1, deepseek-v4-flash, deepseek-v4-flash-vision-exp, deepseek-v4-pro, deepseek-v4-pro-0813, qwen2.5-vl-72b-instruct, qwen3.8-27b, tencent/hy3, ~moonshotai/kimi-latest, ~z-ai/glm-flash-latest, ~z-ai/glm-latest; vercel zai/glm-5.3) |

Validation: `go test ./scripts/aibridgepricesgen/... ./coderd/aibridge/prices/... ./coderd/x/chatd/chatopenai/ ./coderd/x/chatd/chatprovider/` plus the transport, Responses, and reasoning-effort tests in `./coderd/x/chatd/`, `vitest run` on `knownModels/` (52 tests), `make lint/ts`, `golangci-lint` on the touched packages, and `biome check` on the changed JSON all pass.

Companion dogfood PR enabling the model on dev.coder.com: https://github.com/coder/dogfood/pull/465

> Xum opened this PR on behalf of @ibetitsmike.
