### PR TITLE
fix(site): reintroduce default block margins for h1 and h2

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -766,6 +766,16 @@
 		}
 	}
 
+	h1 {
+		margin-block: 0.67em;
+	}
+
+	h2 {
+		margin-block: 0.83em;
+		font-size: 1.5em;
+		font-weight: bold;
+	}
+
 	h2 {
 		font-size: 1.5em;
 		font-weight: bold;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -776,11 +776,6 @@
 		font-weight: bold;
 	}
 
-	h2 {
-		font-size: 1.5em;
-		font-weight: bold;
-	}
-
 	h3,
 	p {
 		margin-block: 1em;


### PR DESCRIPTION
#27821 [enabled Tailwind's preflight styles](https://github.com/coder/coder/pull/27821/changes#diff-7cd927773c2709595b0d405c0b92efae5187e2b96b07fc5cf5bd9eaf0ddc27e4L3-L5), which removes margins for h1 and h2. Previously we'd been developing to match designs without Tailwind's preflight, so we relied on these user agent default block margins (in Chrome/Safari/Firefox) of

- 0.67em for h1 and
- 0.83em for h2.

When that PR merged, an h2 in the template builder (and likely other pages) shifted:

without Tailwind preflight (what this PR restores) | with Tailwind's preflight (current state)
---|---
<img width="199" height="194" alt="image" src="https://github.com/user-attachments/assets/073830ac-d7f1-4f08-b100-9a625b211f45" />|<img width="199" height="167" alt="image" src="https://github.com/user-attachments/assets/02ea955e-49d1-43a8-acc2-0eb2f63e6f38" />

Left screenshot was taken with #27821's parent commit (521c383) checked out.

Since this is just a change to `@layer base` styles, this will not override any headings where margins are set with Tailwind classes, e.g. `h1 className="mt-0"`. The Tailwind classes will take precedence