### PR TITLE
feat(site): enable oxlint rules-of-hooks

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -102,6 +102,7 @@
 		"for-direction": "error",
 		"valid-typeof": "error",
 		"require-yield": "error",
+		"rules-of-hooks": "error",
 
 		// --- security ---
 		"jsx-no-target-blank": "error",
@@ -216,7 +217,6 @@
 		"iframe-has-title": "off", // a11y/useIframeTitle (small)
 		"prefer-template": "off", // style/useTemplate (small)
 		"no-console": "off", // suspicious/noConsole (small, coder error rule: Biome suppression to migrate)
-		"rules-of-hooks": "off", // correctness/useHookAtTopLevel (large: flags Storybook render callbacks Biome allows)
 		"exhaustive-deps": "off", // correctness/useExhaustiveDependencies (large: reimplementation; Biome suppressions to migrate)
 		"no-restricted-imports": [
 			"error",

--- a/site/.storybook/preview.tsx
+++ b/site/.storybook/preview.tsx
@@ -118,7 +118,7 @@ const withQuery: Decorator = (Story, { parameters }) => {
 	);
 };
 
-const withTheme: Decorator = (Story, context) => {
+const withTheme: Decorator = function WithTheme(Story, context) {
 	const selectedTheme = DecoratorHelpers.pluckThemeFromContext(context);
 	const { themeOverride } = DecoratorHelpers.useThemeParameters() ?? {};
 	const selected = themeOverride || selectedTheme || "dark";

--- a/site/src/components/Checkbox/Checkbox.stories.tsx
+++ b/site/src/components/Checkbox/Checkbox.stories.tsx
@@ -77,7 +77,7 @@ export const WithLabel: Story = {
 };
 
 export const Indeterminate: Story = {
-	render: () => {
+	render: function IndeterminateRender() {
 		const [checked, setChecked] = React.useState<boolean | "indeterminate">(
 			"indeterminate",
 		);

--- a/site/src/components/Filter/SelectFilter.stories.tsx
+++ b/site/src/components/Filter/SelectFilter.stories.tsx
@@ -64,7 +64,7 @@ export const WithSearch: Story = {
 	args: {
 		selectedOption: options[25],
 	},
-	render: (args) => {
+	render: function WithSearchRender(args) {
 		const [selectedOption, setSelectedOption] = useState<
 			SelectFilterOption | undefined
 		>(args.selectedOption);

--- a/site/src/components/Slider/Slider.stories.tsx
+++ b/site/src/components/Slider/Slider.stories.tsx
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof Slider>;
 export const Default: Story = {};
 
 export const Controlled: Story = {
-	render: (args) => {
+	render: function ControlledRender(args) {
 		const [value, setValue] = React.useState(50);
 		return (
 			<Slider {...args} value={[value]} onValueChange={([v]) => setValue(v)} />

--- a/site/src/modules/terminal/WorkspaceTerminal.tsx
+++ b/site/src/modules/terminal/WorkspaceTerminal.tsx
@@ -152,6 +152,7 @@ export const WorkspaceTerminal = ({
 	const getTerminalDimensions = useCallback(
 		(terminal: Terminal): { height: number; width: number } | null => {
 			if (terminal.rows <= 0 || terminal.cols <= 0) {
+				// oxlint-disable-next-line react-hooks/rules-of-hooks -- reportTerminalError is a useEffectEvent used only to read the latest onError without making this callback reactive; intentionally invoked outside an effect.
 				reportTerminalError(
 					new Error(
 						`Terminal has non-positive dimensions: ${terminal.rows}x${terminal.cols}`,

--- a/site/src/pages/AISettingsPage/GatewayKeysPage/CreateGatewayKeyDialog.stories.tsx
+++ b/site/src/pages/AISettingsPage/GatewayKeysPage/CreateGatewayKeyDialog.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof CreateGatewayKeyDialog>;
 export const Form: Story = {};
 
 export const CreateAndReveal: Story = {
-	render: (args) => {
+	render: function CreateAndRevealRender(args) {
 		const [createdKey, setCreatedKey] = useState<
 			CreateAIGatewayKeyResponse | undefined
 		>(undefined);
@@ -72,7 +72,7 @@ export const InvalidName: Story = {
 };
 
 export const CreateError: Story = {
-	render: (args) => {
+	render: function CreateErrorRender(args) {
 		const [submitError, setSubmitError] = useState<unknown>(undefined);
 		const error = mockApiError({
 			message: "Key name must be unique.",
@@ -109,7 +109,7 @@ export const CreateError: Story = {
 };
 
 export const GeneralCreateError: Story = {
-	render: (args) => {
+	render: function GeneralCreateErrorRender(args) {
 		const [submitError, setSubmitError] = useState<unknown>(undefined);
 		const error = mockApiError({ message: "Failed to create key." });
 		return (
@@ -138,7 +138,7 @@ export const GeneralCreateError: Story = {
 };
 
 export const EscapeDoesNotDismissCreatedKey: Story = {
-	render: (args) => {
+	render: function EscapeDoesNotDismissCreatedKeyRender(args) {
 		const [createdKey, setCreatedKey] = useState<
 			CreateAIGatewayKeyResponse | undefined
 		>(undefined);
@@ -173,7 +173,7 @@ export const EscapeDoesNotDismissCreatedKey: Story = {
 };
 
 export const ReopenAfterCreate: Story = {
-	render: (args) => {
+	render: function ReopenAfterCreateRender(args) {
 		const [open, setOpen] = useState(args.open);
 		const [createdKey, setCreatedKey] = useState<
 			CreateAIGatewayKeyResponse | undefined

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -510,7 +510,7 @@ export const WithAttachmentError: Story = {
 
 /** File reference chip rendered inline with text in the editor. */
 export const WithFileReference: Story = {
-	render: (args) => {
+	render: function WithFileReferenceRender(args) {
 		const ref = useRef<ChatMessageInputRef>(null);
 
 		useEffect(() => {
@@ -539,7 +539,7 @@ export const WithFileReference: Story = {
 
 /** Multiple file reference chips rendered inline with text. */
 export const WithMultipleFileReferences: Story = {
-	render: (args) => {
+	render: function WithMultipleFileReferencesRender(args) {
 		const ref = useRef<ChatMessageInputRef>(null);
 
 		useEffect(() => {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -1874,7 +1874,9 @@ export const SelectedOrganizationSurvivesRemount: Story = {
 const revocablePermissions: Record<string, boolean> = {};
 let revocableQueryClient: QueryClient | undefined;
 
-const withRevocableQueryClient: Decorator = (Story) => {
+const withRevocableQueryClient: Decorator = function WithRevocableQueryClient(
+	Story,
+) {
 	const [queryClient] = useState(
 		() =>
 			new QueryClient({

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -317,7 +317,7 @@ export const StaleTurnSummaryAfterStreamingIsSuppressed: Story = {
 		}),
 		pixel: { exclude: true },
 	},
-	render: (args) => {
+	render: function StaleTurnSummaryAfterStreamingIsSuppressedRender(args) {
 		const initialSummary = "Added Docker and Terraform validation";
 		const freshSummary = "Validated provider configs and exited cleanly";
 		const [phase, setPhase] = useState<

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/filters/FilterPopover.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/filters/FilterPopover.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof FilterPopover> = {
 		filters: DEFAULT_AGENT_SIDEBAR_FILTERS,
 		onFiltersChange: fn(),
 	},
-	render: (args) => {
+	render: function FilterPopoverRender(args) {
 		const [filters, setFilters] = useState(args.filters);
 		return (
 			<FilterPopover

--- a/site/src/pages/AgentsPage/components/TerminalPanel.tsx
+++ b/site/src/pages/AgentsPage/components/TerminalPanel.tsx
@@ -95,6 +95,7 @@ export const TerminalPanel: FC<TerminalPanelProps> = ({
 		// A dropped connection produces no output, so signal readiness to surface
 		// the terminal alerts instead of waiting on the fallback timer.
 		if (status === "disconnected") {
+			// oxlint-disable-next-line react-hooks/rules-of-hooks -- signalReady is a useEffectEvent used to read the latest onReady without re-running effects; intentionally invoked from this handler.
 			signalReady();
 		}
 	};
@@ -169,6 +170,7 @@ export const TerminalPanel: FC<TerminalPanelProps> = ({
 						isVisible={shouldMountTerminal}
 						autoFocus={Boolean(isHot) && autoFocus}
 						onStatusChange={handleStatusChange}
+						// oxlint-disable-next-line react-hooks/rules-of-hooks -- signalReady is a useEffectEvent passed as a ready callback so it always reads the latest onReady without re-subscribing.
 						onContentReady={signalReady}
 						onError={handleTerminalError}
 						reconnectionToken={reconnectionToken}

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -48,7 +48,9 @@ const withWorkspaceCount = (count: number) => (Story: FC) => {
 	return <Story />;
 };
 
-const withUnavailableWorkspaceCount = (Story: FC) => {
+const withUnavailableWorkspaceCount = function WithUnavailableWorkspaceCount(
+	Story: FC,
+) {
 	const queryClient = useQueryClient();
 	queryClient.setQueryData(workspacesKey(userWorkspacesRequest), {
 		workspaces: [],

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -258,6 +258,7 @@ export function useFileAttachments(
 		void (async () => {
 			try {
 				const result = await API.experimental.uploadChatFile(file, uploadOrgId);
+				// oxlint-disable-next-line react-hooks/rules-of-hooks -- commitUploadOutcome is a useEffectEvent so this async upload flow always reads the latest persist/epoch state; intentionally invoked outside an effect.
 				commitUploadOutcome(file, uploadOrgId, uploadEpoch, {
 					status: "uploaded",
 					fileId: result.id,
@@ -269,6 +270,7 @@ export function useFileAttachments(
 					void fetch(getChatFileURL(result.id));
 				}
 			} catch (err: unknown) {
+				// oxlint-disable-next-line react-hooks/rules-of-hooks -- commitUploadOutcome is a useEffectEvent so this async upload flow always reads the latest persist/epoch state; intentionally invoked outside an effect.
 				commitUploadOutcome(file, uploadOrgId, uploadEpoch, {
 					status: "error",
 					error: formatAgentAttachmentUploadError(err),

--- a/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/BuildLogsDrawer.stories.tsx
@@ -47,7 +47,7 @@ export const CloseWithEscape: Story = {
 // button on close instead of falling back to the document body. The parent
 // owns this via `onCloseAutoFocus`.
 export const RestoresFocusToOpener: Story = {
-	render: () => {
+	render: function RestoresFocusToOpenerRender() {
 		const [open, setOpen] = useState(false);
 		const openerRef = useRef<HTMLButtonElement>(null);
 		return (

--- a/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.stories.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.stories.tsx
@@ -34,7 +34,7 @@ export const OnTagsChange: Story = {
 	args: {
 		tags: {},
 	},
-	render: (args) => {
+	render: function OnTagsChangeRender(args) {
 		const [tags, setTags] = useState(args.tags);
 		return <ProvisionerTagsPopover tags={tags} onTagsChange={fn(setTags)} />;
 	},

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -160,7 +160,10 @@ export const withDesktopViewport = (Story: FC) => (
 	</div>
 );
 
-export const withAuthProvider = (Story: FC, { parameters }: StoryContext) => {
+export const withAuthProvider = function WithAuthProvider(
+	Story: FC,
+	{ parameters }: StoryContext,
+) {
 	if (!parameters.user) {
 		throw new Error("You forgot to add `parameters.user` to your story");
 	}


### PR DESCRIPTION
## What

Enables the oxlint `rules-of-hooks` rule (`correctness/useHookAtTopLevel`), previously disabled in the migration backlog, and resolves the violations it surfaced.

## Why it was off

The config comment said it "flags Storybook render callbacks Biome allows." Investigating empirically confirmed why the two linters diverge:

- oxlint's `rules-of-hooks` ports eslint-plugin-react-hooks, which enforces **both** that hooks are called at the top level **and** that the enclosing function is named like a component (uppercase) or hook (`use*`). Storybook `render: (args) => {...}` arrows and `withX` decorators are anonymous, so they fail the second check.
- Biome's `useHookAtTopLevel` only checks the conditional/nested part, never the enclosing function's identity — so it silently permits these. (It also has no `useEffectEvent` checks at all.)

## Approach

- **Storybook render callbacks** → named `function <StoryName>Render(...)`. Matches a pattern already used in the repo (e.g. `SelectFilter.stories.tsx`).
- **Hook-using decorators** → named function expressions on the existing const, e.g. `const withTheme: Decorator = function WithTheme(Story, context) {...}`. Keeps every decorator signature and call site unchanged.
- **Real-code `useEffectEvent` calls outside effects** (5 sites in `WorkspaceTerminal.tsx`, `TerminalPanel.tsx`, `useFileAttachments.ts`) → suppressed with `// oxlint-disable-next-line react-hooks/rules-of-hooks -- <rationale>`. These are genuine (but intentional) deviations from React's Effect Event rules that Biome never checked; suppressing avoids risky behavioral refactors of concurrency-sensitive code. Worth a follow-up for the owning teams to evaluate.

No per-file disabling of the rule; it is enabled globally.

## Verification

- `pnpm --dir site lint:oxlint` (oxlint `--deny-warnings`): 0 errors
- Biome lint + format: clean
- `tsc --noEmit`: clean

<details>
<summary>Investigation notes</summary>

- Proved Biome's rule, when force-enabled, still ignores anonymous render callbacks while catching conditional hooks — so the divergence is the "must be a component/hook" check, not the top-level check.
- In coder/coder's actual Biome config the rule isn't even active (react domain not enabled), so Biome enforced none of it.
- oxlint suppression gotchas found while wiring this up:
  - The rationale separator must be ` -- `, not `:` (the `:` form silently fails to suppress).
  - Between JSX attributes you must use a plain `//` comment; the `{/* */}` form is invalid there and does not suppress.

</details>

---
*Opened by Coder Agents on behalf of @jeremyruppel.*
