### PR TITLE
docs: normalize control plane, coderd, and coder server terminology

### DIFF
--- a/docs/.style/style-guide/word-choice.md
+++ b/docs/.style/style-guide/word-choice.md
@@ -28,7 +28,7 @@ It reads as a misspelling of the product name.
 
 **Do**:
 
-> Run `coder login` to authenticate against the Coder server.
+> Run `coder login` to authenticate against your Coder deployment.
 >
 > Open the AI Gateway integration page to configure model providers.
 
@@ -109,6 +109,49 @@ It isn't itself the concept, so it stays in backticks as a tool name.
 > The category is lowercase.)
 
 *Enforced by `Coder.DevContainer` (planned).*
+
+## Naming Coder's components
+
+Three terms name the thing that serves the Coder API and dashboard, and each has one job.
+
+Use *control plane* for the component that serves the Coder API and dashboard, brokers connections to workspaces, and coordinates provisioners.
+It is the default in prose, diagrams, and any planning, sizing, architecture, or security discussion.
+
+Use `coderd` only for the process itself, such as in metric names, log output, configuration flags, or troubleshooting steps.
+Introduce it on first use in a page as "`coderd`, the process that runs the control plane".
+
+Use `coder server` only for the command a reader runs.
+
+Don't use "the Coder server" as a name for the control plane, and don't describe the control plane generically as "a service".
+"Server" is ambiguous in a Coder deployment: it can read as the machine, the process, or the whole installation.
+Control plane is also the only one of the three that scales to a list of components, as in "the control plane, the workspaces, and the workspace proxies".
+
+| Do                                                 | Don't                                       |
+|----------------------------------------------------|---------------------------------------------|
+| the control plane serves the dashboard             | the Coder server serves the dashboard       |
+| `coderd` writes the build log                      | the server writes the build log             |
+| run `coder server` to start the control plane      | run the Coder server                        |
+| the control plane, the workspaces, and the proxies | the server, the workspaces, and the proxies |
+
+Use *workspace agent*, or `coder agent` for the process, for the agent that runs inside a workspace.
+Don't shorten it to "the agent" on a page that also discusses AI agents or Coder Agents.
+
+**Do**:
+
+> The control plane brokers the connection, and the workspace agent dials out to it.
+> Workspaces need no inbound ports.
+>
+> Set `CODER_ACCESS_URL` before you run `coder server`.
+> `coderd` logs the resolved access URL at startup.
+
+**Don't**:
+
+> The Coder server brokers the connection, and the agent dials out to it.
+>
+> The service logs the resolved access URL at startup.
+
+*Documentation-only.
+No Vale rule.*
 
 ## One term per concept
 

--- a/docs/about/contributing/frontend.md
+++ b/docs/about/contributing/frontend.md
@@ -14,11 +14,11 @@ you.
 
 You can run the UI and access the Coder dashboard in two ways:
 
-1. Build the UI pointing to an external Coder server:
+1. Build the UI pointing to an external Coder deployment:
    `CODER_HOST=https://mycoder.com pnpm dev` inside of the `site` folder. This
    is helpful when you are building something in the UI and already have the
-   data on your deployed server.
-2. Build the entire Coder server + UI locally: `./scripts/develop.sh` in the
+   data on your deployment.
+2. Build the entire control plane + UI locally: `./scripts/develop.sh` in the
    root folder. This is useful for contributing to features that are not
    deployed yet or that involve both the frontend and backend.
 

--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -24,7 +24,7 @@ If you have experience with a provider that is not listed here, please
 
 ### Set environment variables
 
-After you create an OAuth application, set environment variables to configure the Coder server to use it:
+After you create an OAuth application, set environment variables to configure the control plane to use it:
 
 ```dotenv
 CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>"

--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -22,9 +22,10 @@ page describes possible deployments, challenges, and risks associated with them.
 
 ### coderd
 
-_coderd_ is the service created by running `coder server`. It is a thin API that
-connects workspaces, provisioners and users. _coderd_ stores its state in
-Postgres and is the only service that communicates with Postgres.
+`coderd` is the process that runs the control plane, started with
+`coder server`. It is a thin API that connects workspaces, provisioners and
+users. `coderd` stores its state in Postgres and is the only component that
+communicates with Postgres.
 
 It offers:
 
@@ -39,7 +40,7 @@ It offers:
 _provisionerd_ is the execution context for infrastructure modifying providers.
 At the moment, the only provider is Terraform (running `terraform`).
 
-By default, the Coder server runs multiple provisioner daemons.
+By default, the control plane runs multiple provisioner daemons.
 [External provisioners](../provisioners/index.md) can be added for security or
 scalability purposes.
 
@@ -49,17 +50,18 @@ At the highest level, a workspace is a set of cloud resources. These resources
 can be VMs, Kubernetes clusters, storage buckets, or whatever else Terraform
 lets you dream up.
 
-The resources that run the agent are described as _computational resources_,
-while those that don't are called _peripheral resources_.
+The resources that run the workspace agent are described as _computational
+resources_, while those that don't are called _peripheral resources_.
 
 Each resource may also be _persistent_ or _ephemeral_ depending on whether
 they're destroyed on workspace stop.
 
 ### Agents
 
-An agent is the Coder service that runs within a user's remote workspace. It
-provides a consistent interface for coderd and clients to communicate with
-workspaces regardless of operating system, architecture, or cloud.
+A workspace agent is the Coder process that runs within a user's remote
+workspace. It provides a consistent interface for `coderd` and clients to
+communicate with workspaces regardless of operating system, architecture, or
+cloud.
 
 It offers the following services along with much more:
 
@@ -74,12 +76,12 @@ within workspaces.
 
 ## Service Bundling
 
-While _coderd_ and Postgres can be orchestrated independently, our default
+While `coderd` and Postgres can be orchestrated independently, our default
 installation paths bundle them all together into one system service. It's
 perfectly fine to run a production deployment this way, but there are certain
 situations that necessitate decomposition:
 
-- Reducing global client latency (distribute coderd and centralize database)
+- Reducing global client latency (distribute `coderd` and centralize database)
 - Achieving greater availability and efficiency (horizontally scale individual
   services)
 

--- a/docs/admin/infrastructure/scale-testing.md
+++ b/docs/admin/infrastructure/scale-testing.md
@@ -77,7 +77,7 @@ seconds. Here are the resulting metrics:
 
 Coder:
 
-- Median CPU usage for _coderd_: 3 vCPU, peaking at 3.7 vCPU while all tests are
+- Median CPU usage for `coderd`: 3 vCPU, peaking at 3.7 vCPU while all tests are
   running concurrently.
 - Median API request rate: 350 RPS during dashboard tests, 250 RPS during Web
   Terminal and workspace apps tests.
@@ -181,7 +181,7 @@ Each external provisioner can run a single concurrent workspace build. For
 example, running 10 provisioner containers will allow 10 users to start
 workspaces at the same time.
 
-By default, the Coder server runs 3 built-in provisioner daemons, but the
+By default, the control plane runs 3 built-in provisioner daemons, but the
 _Premium_ Coder release allows for running external provisioners to separate the
 load caused by workspace provisioning on the `coderd` nodes.
 

--- a/docs/admin/infrastructure/scale-utility.md
+++ b/docs/admin/infrastructure/scale-utility.md
@@ -196,7 +196,7 @@ your setup.
 
 The greedy agent variant is a template modification that makes the Coder agent
 transmit large metadata (size: 4K) while reporting stats. The transmission of
-large chunks puts extra overhead on coderd instances and agents when handling
+large chunks puts extra overhead on `coderd` instances and agents when handling
 and storing the data.
 
 Use this template variant to verify limits of the cluster performance.
@@ -212,7 +212,7 @@ This dashboard provides insights into various aspects, including:
 
 - Utilization of resources within the Coder control plane (CPU, memory, pods)
 - Database performance metrics (CPU, memory, I/O, connections, queries)
-- Coderd API performance (requests, latency, error rate)
+- `coderd` API performance (requests, latency, error rate)
 - Resource consumption within Coder workspaces (CPU, memory, network usage)
 - Internal metrics related to provisioner jobs
 
@@ -226,25 +226,25 @@ of Coder, necessitating action from operators.
 ## Autoscaling
 
 We generally do not recommend using an autoscaler that modifies the number of
-coderd replicas. In particular, scale down events can cause interruptions for a
-large number of users.
+`coderd` replicas. In particular, scale down events can cause interruptions for
+a large number of users.
 
-Coderd is different from a simple request-response HTTP service in that it
+`coderd` is different from a simple request-response HTTP service in that it
 services long-lived connections whenever it proxies HTTP applications like IDEs
 or terminals that rely on websockets, or when it relays tunneled connections to
-workspaces. Loss of a coderd replica will drop these long-lived connections and
-interrupt users. For example, if you have 4 coderd replicas behind a load
+workspaces. Loss of a `coderd` replica will drop these long-lived connections
+and interrupt users. For example, if you have 4 `coderd` replicas behind a load
 balancer, and an autoscaler decides to reduce it to 3, roughly 25% of the
 connections will drop. An even larger proportion of users could be affected if
 they use applications that use more than one websocket.
 
 The severity of the interruption varies by application. Coder's web terminal,
 for example, will reconnect to the same session and continue. So, this should
-not be interpreted as saying coderd replicas should never be taken down for any
-reason.
+not be interpreted as saying `coderd` replicas should never be taken down for
+any reason.
 
-We recommend you plan to run enough coderd replicas to comfortably meet your
-weekly high-water-mark load, and monitor coderd peak CPU & memory utilization
+We recommend you plan to run enough `coderd` replicas to comfortably meet your
+weekly high-water-mark load, and monitor `coderd` peak CPU & memory utilization
 over the long term, reevaluating periodically. When scaling down (or performing
 upgrades), schedule these outside normal working hours to minimize user
 interruptions.
@@ -255,11 +255,11 @@ When running on Kubernetes on cloud infrastructure (i.e. not bare metal), many
 operators choose to employ a _cluster_ autoscaler that adds and removes
 Kubernetes _nodes_ according to load. Coder can coexist with such cluster
 autoscalers, but we recommend you take steps to prevent the autoscaler from
-evicting coderd pods, as an eviction will cause the same interruptions as
+evicting `coderd` pods, as an eviction will cause the same interruptions as
 described above. For example, if you are using the
 [Kubernetes cluster autoscaler](https://kubernetes.io/docs/reference/labels-annotations-taints/#cluster-autoscaler-kubernetes-io-safe-to-evict),
 you may wish to set `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` as
-an annotation on the coderd deployment.
+an annotation on the `coderd` deployment.
 
 ## Troubleshooting
 

--- a/docs/admin/infrastructure/validated-architectures/10k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/10k-users.md
@@ -29,8 +29,8 @@ continuously improve the reliability and performance of the platform.
 - If deploying on Kubernetes:
   - Set CPU request and limit to `4000m`
   - Set Memory request and limit to `12Gi`
-- Coderd does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
-- Coderd instances should be deployed in the same region as the database.
+- `coderd` does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
+- `coderd` instances should be deployed in the same region as the database.
 
 ### Workspace Proxies
 
@@ -63,7 +63,7 @@ If you choose to deploy workspaces in multiple geographic regions, provision
   - Set Memory request and limit to `1Gi`
 - If deploying on virtual machines, stack up to 30 provisioners per machine with a commensurate amount of memory and CPU.
 - Provisioners benefit from high performance disks like SSDs.
-- [Do not run provisioners on Coderd nodes](../../provisioners/index.md#disable-built-in-provisioners) at this scale.
+- [Do not run provisioners on `coderd` nodes](../../provisioners/index.md#disable-built-in-provisioners) at this scale.
 - If deploying workspaces to multiple clouds or multiple Kubernetes clusters, divide the provisioner replicas among the
   clouds or clusters according to expected usage.
 

--- a/docs/admin/infrastructure/validated-architectures/1k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/1k-users.md
@@ -26,10 +26,10 @@ architectural tier](./2k-users.md).
 - If deploying on Kubernetes:
   - Set CPU request and limit to `2000m`
   - Set Memory request and limit to `8Gi`
-- Coderd does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
+- `coderd` does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
 - For small deployments (ca. 100 users, 10 concurrent workspace builds), it is
   acceptable to deploy provisioners on `coderd` replicas.
-- Coderd instances should be deployed in the same region as the database.
+- `coderd` instances should be deployed in the same region as the database.
 
 ### Provisioners
 

--- a/docs/admin/infrastructure/validated-architectures/2k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/2k-users.md
@@ -32,8 +32,8 @@ continuously improve the reliability and performance of the platform.
 - If deploying on Kubernetes:
   - Set CPU request and limit to `4000m`
   - Set Memory request and limit to `12Gi`
-- Coderd does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
-- Coderd instances should be deployed in the same region as the database.
+- `coderd` does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
+- `coderd` instances should be deployed in the same region as the database.
 
 ### Workspace Proxies
 
@@ -66,7 +66,7 @@ If you choose to deploy workspaces in multiple geographic regions, provision
   - Set Memory request and limit to `1Gi`
 - If deploying on virtual machines, stack up to 30 provisioners per machine with a commensurate amount of memory and CPU.
 - Provisioners benefit from high performance disks like SSDs.
-- [Do not run provisioners on Coderd nodes](../../provisioners/index.md#disable-built-in-provisioners) at this scale.
+- [Do not run provisioners on `coderd` nodes](../../provisioners/index.md#disable-built-in-provisioners) at this scale.
 - If deploying workspaces to multiple clouds or multiple Kubernetes clusters, divide the provisioner replicas among the
   clouds or clusters according to expected usage.
 

--- a/docs/admin/infrastructure/validated-architectures/3k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/3k-users.md
@@ -30,8 +30,8 @@ continuously improve the reliability and performance of the platform.
 - If deploying on Kubernetes:
   - Set CPU request and limit to `4000m`
   - Set Memory request and limit to `12Gi`
-- Coderd does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
-- Coderd instances should be deployed in the same region as the database.
+- `coderd` does not typically benefit from high performance disks like SSDs (unless you are co-locating provisioners).
+- `coderd` instances should be deployed in the same region as the database.
 
 ### Workspace Proxies
 
@@ -64,7 +64,7 @@ If you choose to deploy workspaces in multiple geographic regions, provision
   - Set Memory request and limit to `1Gi`
 - If deploying on virtual machines, stack up to 30 provisioners per machine with a commensurate amount of memory and CPU.
 - Provisioners benefit from high performance disks like SSDs.
-- [Do not run provisioners on Coderd nodes](../../provisioners/index.md#disable-built-in-provisioners) at this scale.
+- [Do not run provisioners on `coderd` nodes](../../provisioners/index.md#disable-built-in-provisioners) at this scale.
 - If deploying workspaces to multiple clouds or multiple Kubernetes clusters, divide the provisioner replicas among the
   clouds or clusters according to expected usage.
 

--- a/docs/admin/infrastructure/validated-architectures/index.md
+++ b/docs/admin/infrastructure/validated-architectures/index.md
@@ -52,11 +52,11 @@ management, template definitions, insights, and deployment configuration.
 
 ### Coder control plane
 
-Coder's control plane, also known as _coderd_, is the main service recommended
-for deployment with multiple replicas to ensure high availability. It provides
-an API for managing workspaces and templates, and serves the dashboard UI. In
-addition, each _coderd_ replica hosts 3 Terraform [provisioners](#provisioner)
-by default.
+Coder's control plane, run by the `coderd` process, is the main component
+recommended for deployment with multiple replicas to ensure high availability.
+It provides an API for managing workspaces and templates, and serves the
+dashboard UI. In addition, each `coderd` replica hosts 3 Terraform
+[provisioners](#provisioner) by default.
 
 ### User
 
@@ -305,9 +305,9 @@ database to the prior version.
 ### Performance efficiency
 
 We highly recommend deploying the PostgreSQL instance in the same region (and if
-possible, same availability zone) as the Coder server to optimize for low
-latency connections. We recommend keeping latency under 10ms between the Coder
-server and database.
+possible, same availability zone) as the control plane to optimize for low
+latency connections. We recommend keeping latency under 10ms between the control
+plane and database.
 
 When determining scaling requirements, take into account the following
 considerations:

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -20,7 +20,7 @@ Coder can act as an OAuth2 authorization server, allowing third-party applicatio
 
 ## Enable OAuth2 Provider
 
-Add the `oauth2` experiment flag to your Coder server:
+Add the `oauth2` experiment flag to your control plane:
 
 ```sh
 coder server --experiments oauth2
@@ -406,7 +406,7 @@ scheme (`javascript:`, `data:`, `file:`, or `ftp:`). The same cause answers
 `server_error` on `POST /oauth2/authorize`. Update the application's callback
 URL (see [Callback URL schemes](#callback-url-schemes)).
 
-The server log records the application ID and the stored value. The response
+The `coderd` log records the application ID and the stored value. The response
 does not, so a bad URL is never echoed back to a browser.
 
 ### "invalid_scope" returned to your callback
@@ -527,9 +527,9 @@ Public clients (`token_endpoint_auth_method: none`) additionally cannot register
 - **Implement PKCE**: PKCE is mandatory for all authorization code clients
   (public and confidential)
 - **Validate redirect URLs**: Only register trusted redirect URIs. Dangerous
-  schemes (`javascript:`, `data:`, `file:`, `ftp:`) are blocked by the server,
-  custom URI schemes for native apps (`myapp://`) are permitted, and public
-  clients additionally cannot use `mailto:`, `tel:`, or `sms:`
+  schemes (`javascript:`, `data:`, `file:`, `ftp:`) are blocked by the control
+  plane, custom URI schemes for native apps (`myapp://`) are permitted, and
+  public clients additionally cannot use `mailto:`, `tel:`, or `sms:`
 - **Rotate secrets**: Periodically rotate client secrets using the management API
 
 ## Limitations

--- a/docs/admin/monitoring/connection-logs.md
+++ b/docs/admin/monitoring/connection-logs.md
@@ -21,8 +21,8 @@ performed via the dashboard.
 ## SSH and IDE Sessions
 
 The connection log aims to capture a record of all workspace SSH and IDE sessions.
-These events are reported by workspace agents, and their receipt by the server
-is not guaranteed.
+These events are reported by workspace agents, and their receipt by the control
+plane is not guaranteed.
 
 Agent-reported events do not identify the Coder user who connected. To
 attribute SSH and IDE activity to a user, correlate them with tunnel

--- a/docs/admin/monitoring/index.md
+++ b/docs/admin/monitoring/index.md
@@ -16,7 +16,7 @@ Learn how to install & read the docs on the
 
 ## Table of Contents
 
-- [Logs](./logs.md): Learn how to access to Coder server logs, agent logs, and
+- [Logs](./logs.md): Learn how to access to `coderd` logs, agent logs, and
   even how to expose Kubernetes pod scheduling logs.
 - [Metrics](./metrics.md): Learn about the valuable metrics to measure on a
   Coder deployment, regardless of your monitoring stack.

--- a/docs/admin/monitoring/logs.md
+++ b/docs/admin/monitoring/logs.md
@@ -8,8 +8,9 @@ captured via Splunk, Datadog, Grafana Loki, or other ingestion tools.
 
 ## `coderd` Logs
 
-By default, the Coder server exports human-readable logs to standard output. You
-can access these logs via `kubectl logs deployment/coder -n <coder-namespace>`
+By default, `coderd`, the process that runs the control plane, exports
+human-readable logs to standard output. You can access these logs via
+`kubectl logs deployment/coder -n <coder-namespace>`
 on Kubernetes or `journalctl -u coder` if you deployed Coder on a host
 machine/VM.
 

--- a/docs/admin/networking/high-availability.md
+++ b/docs/admin/networking/high-availability.md
@@ -10,17 +10,18 @@ Postgres endpoint.
 and other cloud vendors offer fully-managed HA Postgres services that pair
 nicely with Coder.
 
-For Coder to operate correctly, Coderd instances should have low-latency
+For Coder to operate correctly, `coderd` instances should have low-latency
 connections to each other so that they can effectively relay traffic between
-users and workspaces no matter which Coderd instance users or workspaces connect
-to. We make a best-effort attempt to warn the user when inter-Coderd latency is
-too high, but if requests start dropping, this is one metric to investigate.
+users and workspaces no matter which `coderd` instance users or workspaces
+connect to. We make a best-effort attempt to warn the user when inter-`coderd`
+latency is too high, but if requests start dropping, this is one metric to
+investigate.
 
-We also recommend that you deploy all Coderd instances such that they have
-low-latency connections to Postgres. Coderd often makes several database
+We also recommend that you deploy all `coderd` instances such that they have
+low-latency connections to Postgres. `coderd` often makes several database
 round-trips while processing a single API request, so prioritizing low-latency
-between Coderd and Postgres is more important than low-latency between users and
-Coderd.
+between `coderd` and Postgres is more important than low-latency between users
+and `coderd`.
 
 Note that this latency requirement applies _only_ to Coder services. Coder will
 operate correctly even with few seconds of latency on workspace <-> Coder and
@@ -37,7 +38,7 @@ connect to the same Postgres endpoint.
 > [Upgrading Best Practices](../../install/upgrade-best-practices.md) for
 > recommended procedures.
 
-HA brings one configuration variable to set in each Coderd node:
+HA brings one configuration variable to set in each `coderd` node:
 `CODER_DERP_SERVER_RELAY_URL`. The HA nodes use these URLs to communicate with
 each other. Inter-node communication is only required while using the embedded
 relay (default). If you're using [custom relays](./index.md#custom-relays),

--- a/docs/admin/networking/index.md
+++ b/docs/admin/networking/index.md
@@ -2,15 +2,15 @@
 title: Networking
 ---
 
-Coder's network topology has three types of nodes: workspaces, coder servers,
-and users.
+Coder's network topology has three types of nodes: workspaces, the control
+plane, and users.
 
-The coder server must have an inbound address reachable by users and workspaces,
-but otherwise, all topologies _just work_ with Coder.
+The control plane must have an inbound address reachable by users and
+workspaces, but otherwise, all topologies _just work_ with Coder.
 
 When possible, we establish direct connections between users and workspaces.
 Direct connections are as fast as connecting to the workspace outside of Coder.
-When NAT traversal fails, connections are relayed through the coder server. All
+When NAT traversal fails, connections are relayed through the control plane. All
 user-workspace connections are end-to-end encrypted.
 
 [Tailscale's open source](https://tailscale.com) backs our websocket/HTTPS
@@ -25,12 +25,12 @@ In order for clients and workspaces to be able to connect:
 > workspaces over a good quality, broadband network connection. The following
 > are minimum requirements:
 >
-> - better than 400ms round-trip latency to the Coder server and to their
+> - better than 400ms round-trip latency to the control plane and to their
 >   workspace
 > - better than 0.5% random packet loss
 
-- All clients and agents must be able to establish a connection to the Coder
-  server (`CODER_ACCESS_URL`) over HTTP/HTTPS.
+- All clients and agents must be able to establish a connection to the control
+  plane (`CODER_ACCESS_URL`) over HTTP/HTTPS.
 - Any reverse proxy or ingress between the Coder control plane and
   clients/agents must support WebSockets.
 
@@ -69,14 +69,14 @@ In order for clients to be able to establish direct connections:
     ephemeral (high) ports. If a firewall between the client and the agent
     blocks this UDP traffic, direct connections will not be possible.
 
-## coder server
+## Control plane
 
-Workspaces connect to the coder server via the server's external address, set
+Workspaces connect to the control plane via its external address, set
 via [`ACCESS_URL`](../../admin/setup/index.md#access-url). There must not be a
-NAT between workspaces and coder server.
+NAT between workspaces and the control plane.
 
-Users connect to the coder server's dashboard and API through its `ACCESS_URL`
-as well. There must not be a NAT between users and the coder server.
+Users connect to the control plane's dashboard and API through its `ACCESS_URL`
+as well. There must not be a NAT between users and the control plane.
 
 Template admins can overwrite the site-wide access URL at the template level by
 leveraging the `url` argument when
@@ -89,11 +89,11 @@ provider "coder" {
 ```
 
 This is useful when debugging connectivity issues between the workspace agent
-and the Coder server.
+and the control plane.
 
 ## Web Apps
 
-The coder servers relays dashboard-initiated connections between the user and
+The control plane relays dashboard-initiated connections between the user and
 the workspace. Web terminal <-> workspace connections are an exception and may
 be direct.
 
@@ -122,7 +122,7 @@ but this can be disabled or changed for
 
 ### Relayed connections
 
-By default, your Coder server also runs a built-in DERP relay which can be used
+By default, your control plane also runs a built-in DERP relay which can be used
 for both public and [Air-gapped deployments](../../install/airgap.md).
 
 However, Tailscale maintains a global fleet of [DERP relays](https://tailscale.com/kb/1118/custom-derp-servers/#what-are-derp-servers) intended for their product, and has allowed Coder to access and use them.
@@ -168,8 +168,8 @@ coder server --derp-config-path derpmap.json
 ### Dashboard connections
 
 The dashboard (and web apps opened through the dashboard) are served from the
-coder server, so they can only be geo-distributed with High Availability mode in
-our Premium Edition. [Reach out to Sales](https://coder.com/contact) to learn
+control plane, so they can only be geo-distributed with High Availability mode
+in our Premium Edition. [Reach out to Sales](https://coder.com/contact) to learn
 more.
 
 ## Browser-only connections
@@ -205,7 +205,7 @@ There are three main types of latency metrics for your Coder deployment:
 
 - Dashboard-to-server latency:
 
-  The Coder UI measures round-trip time to the Coder server or workspace proxy using built-in browser timing capabilities.
+  The Coder UI measures round-trip time to the control plane or workspace proxy using built-in browser timing capabilities.
 
   This appears in the user interface next to your username, showing how responsive the dashboard is.
 
@@ -238,7 +238,7 @@ Latency measurements are color-coded in the dashboard:
 
 ### Factors that affect latency
 
-- **Geographic distance**: Physical distance between users, Coder server, and workspaces.
+- **Geographic distance**: Physical distance between users, the control plane, and workspaces.
 - **Network connectivity**: Quality of internet connections and routing.
 - **Infrastructure**: Cloud provider regions and network optimization.
 - **P2P connectivity**: Whether direct connections can be established or relays are needed.
@@ -247,9 +247,9 @@ Latency measurements are color-coded in the dashboard:
 
 To improve latency and user experience:
 
-- **Deploy workspace proxies**: Place [proxies](./workspace-proxies.md) in regions closer to users, connecting back to your single Coder server deployment.
+- **Deploy workspace proxies**: Place [proxies](./workspace-proxies.md) in regions closer to users, connecting back to your single control plane deployment.
 - **Use P2P connections**: Ensure network configurations permit direct connections.
-- **Strategic placement**: Deploy your Coder server in a region where most users work.
+- **Strategic placement**: Deploy your control plane in a region where most users work.
 - **Network configuration**: Optimize routing between users and workspaces.
 - **Check firewall rules**: Ensure they don't block necessary Coder connections.
 

--- a/docs/admin/networking/stun.md
+++ b/docs/admin/networking/stun.md
@@ -47,7 +47,7 @@ At a high level, STUN works like this:
   public internet, and respond with the public IP address and port from which
   the request came.
 - **Coordination:** The client and agent then exchange this information through
-  the Coder server. They will then construct packets that should be able to
+  the control plane. They will then construct packets that should be able to
   successfully traverse their counterpart's NATs successfully.
 - **NAT Traversal:** The client and agent then send these crafted packets to
   their counterpart's public addresses. If all goes well, the NATs on the other
@@ -80,7 +80,7 @@ address and port on which they can be reached.
 
 ![Diagram of a workspace agent and client in separate networks](../../images/networking/stun2.1.png)
 
-They then exchange this information through Coder server, and can then
+They then exchange this information through the control plane, and can then
 communicate directly with each other through their respective NATs.
 
 ![Diagram of a workspace agent and client in separate networks](../../images/networking/stun2.2.png)

--- a/docs/admin/networking/troubleshooting.md
+++ b/docs/admin/networking/troubleshooting.md
@@ -37,7 +37,7 @@ Possible agent-side issues with direct connection:
 
 Direct connections can be disabled at the deployment level by setting the
 `CODER_BLOCK_DIRECT` environment variable or the `--block-direct-connections`
-flag on the server. When set, this will be reflected in the output of
+flag on the control plane. When set, this will be reflected in the output of
 `coder ping`.
 
 ### UDP Blocked
@@ -116,7 +116,7 @@ will not be affected by the low MTU.
 
 To disable direct connections, set the
 [`--block-direct-connections`](../../reference/cli/server.md#--block-direct-connections)
-flag or `CODER_BLOCK_DIRECT` environment variable on the Coder server.
+flag or `CODER_BLOCK_DIRECT` environment variable on the control plane.
 
 ## Throughput
 

--- a/docs/admin/networking/wildcard-access-url.md
+++ b/docs/admin/networking/wildcard-access-url.md
@@ -80,7 +80,7 @@ for subdomain app routing.
 
 ### DNS Setup
 
-You'll need to configure DNS to point wildcard subdomains to your Coder server:
+You'll need to configure DNS to point wildcard subdomains to your control plane:
 
 > [!NOTE]
 > We do not recommend using a top-level-domain for Coder wildcard access
@@ -154,7 +154,7 @@ If workspace applications are not working:
 1. Verify the `CODER_WILDCARD_ACCESS_URL` environment variable is configured correctly:
    - Check the deployment settings in the Coder dashboard (Settings > Deployment)
    - Ensure it matches your wildcard domain (e.g., `*.coder.example.com`)
-   - Restart the Coder server if you made changes to the environment variable
+   - Restart the control plane if you made changes to the environment variable
 2. Check DNS resolution for wildcard subdomains:
 
    ```sh

--- a/docs/admin/networking/workspace-proxies.md
+++ b/docs/admin/networking/workspace-proxies.md
@@ -23,8 +23,8 @@ over workspace proxies.
 
 Each workspace proxy should be a unique instance. At no point should two
 workspace proxy instances share the same authentication token. They only require
-port 443 to be open and are expected to have network connectivity to the coderd
-dashboard. Workspace proxies **do not** make any database connections.
+port 443 to be open and are expected to have network connectivity to the control
+plane dashboard. Workspace proxies **do not** make any database connections.
 
 Workspace proxies can be used in the browser by navigating to the user
 `Account -> Workspace Proxy`
@@ -56,9 +56,9 @@ newyork                             unregistered
 
 ## Step 2: Deploy the proxy
 
-Deploying the workspace proxy will also register the proxy with coderd and make
-the workspace proxy usable. If the proxy deployment is successful,
-`coder wsproxy ls` will show an `ok` status code:
+Deploying the workspace proxy will also register the proxy with the control
+plane and make the workspace proxy usable. If the proxy deployment is
+successful, `coder wsproxy ls` will show an `ok` status code:
 
 ```sh
 $ coder wsproxy ls
@@ -81,7 +81,7 @@ Other Status codes:
 
 ### Configuration
 
-Workspace proxy configuration overlaps with a subset of the coderd
+Workspace proxy configuration overlaps with a subset of the `coderd`
 configuration. To see the full list of configuration options:
 `coder wsproxy server --help`
 
@@ -178,7 +178,7 @@ sudo systemctl restart coder-workspace-proxy
 ### Running in Docker
 
 Modify the default entrypoint to run a workspace proxy server instead of a
-regular Coder server.
+regular control plane.
 
 #### Docker Compose
 

--- a/docs/admin/provisioners/index.md
+++ b/docs/admin/provisioners/index.md
@@ -1,6 +1,6 @@
 # External provisioners
 
-By default, the Coder server runs
+By default, the control plane runs
 [built-in provisioner daemons](../../reference/cli/server.md#--provisioner-daemons),
 which execute `terraform` during workspace and template builds. However, there
 are often benefits to running external provisioner daemons:
@@ -9,16 +9,16 @@ are often benefits to running external provisioner daemons:
   preventing malicious templates from gaining sh access to the Coder host.
 
 - **Isolate APIs:** Deploy provisioners in isolated environments (on-prem, AWS,
-  Azure) instead of exposing APIs (Docker, Kubernetes, VMware) to the Coder
-  server. See
+  Azure) instead of exposing APIs (Docker, Kubernetes, VMware) to the control
+  plane. See
   [Provider Authentication](../../admin/templates/extending-templates/provider-authentication.md)
   for more details.
 
 - **Isolate secrets**: Keep Coder unaware of cloud secrets, manage/rotate
   secrets on provisioner servers.
 
-- **Reduce server load**: External provisioners reduce load and build queue
-  times from the Coder server. See
+- **Reduce control plane load**: External provisioners reduce load and build
+  queue times from the control plane. See
   [Scaling Coder](../../admin/infrastructure/index.md#scale-tests) for more
   details.
 
@@ -113,7 +113,7 @@ Global pre-shared keys (PSK) make it difficult to rotate keys or isolate provisi
 A deployment-wide PSK can be used to authenticate any provisioner. To use a
 global PSK, set a
 [provisioner daemon pre-shared key (PSK)](../../reference/cli/server.md#--provisioner-daemon-psk)
-on the Coder server.
+on the control plane.
 
 Next, start the provisioner:
 
@@ -288,7 +288,7 @@ coder templates push on-prem \
 ## Example: Running an external provisioner with Helm
 
 Coder provides a Helm chart for running external provisioner daemons, which you
-will use in concert with the Helm chart for deploying the Coder server.
+will use in concert with the Helm chart for deploying the control plane.
 
 1. Create a provisioner key:
 
@@ -346,7 +346,7 @@ will use in concert with the Helm chart for deploying the Coder server.
    ```
 
    You can verify that your provisioner daemons have successfully connected to
-   Coderd by looking for a debug log message that says
+   `coderd` by looking for a debug log message that says
    `provisioner: successfully connected to coderd` from each Pod.
 
 ## Example: Running an external provisioner on a VM
@@ -371,7 +371,7 @@ docker run --rm -it \
 
 ## Disable built-in provisioners
 
-As mentioned above, the Coder server will run built-in provisioners by default.
+As mentioned above, the control plane will run built-in provisioners by default.
 This can be disabled with a server-wide
 [flag or environment variable](../../reference/cli/server.md#--provisioner-daemons).
 

--- a/docs/admin/security/database-encryption.md
+++ b/docs/admin/security/database-encryption.md
@@ -86,8 +86,8 @@ coder:
           key: keys
 ```
 
-- Restart the Coder server. The server will now encrypt all new data with the
-  provided key.
+- Restart the control plane. It will now encrypt all new data with the provided
+  key.
 
 ## Rotating keys
 
@@ -114,8 +114,8 @@ data:
   keys: <new-key>,<old-key1>,<old-key2>,...
 ```
 
-- After updating the configuration, restart the Coder server. The server will
-  now encrypt all new data with the new key, but will be able to decrypt tokens
+- After updating the configuration, restart the control plane. It will now
+  encrypt all new data with the new key, but will be able to decrypt tokens
   encrypted with the old key(s).
 
 - To re-encrypt all encrypted database fields with the new key, run
@@ -138,7 +138,7 @@ To disable encryption, perform the following actions:
 
 - Ensure you have a valid backup of your database. **Do not skip this step.**
 
-- Stop all active coderd instances. This will prevent new encrypted data from
+- Stop all active `coderd` instances. This will prevent new encrypted data from
   being written, which may cause the next step to fail.
 
 - Run
@@ -156,7 +156,7 @@ To disable encryption, perform the following actions:
   [external token encryption keys](../../reference/cli/server.md#--external-token-encryption-keys)
   from Coder's configuration.
 
-- Start coderd. You can now safely delete the encryption keys from your secret
+- Start `coderd`. You can now safely delete the encryption keys from your secret
   store.
 
 ## Deleting Encrypted Data
@@ -168,7 +168,7 @@ To delete all encrypted data from your database, perform the following actions:
 
 - Ensure you have a valid backup of your database. **Do not skip this step.**
 
-- Stop all active coderd instances. This will prevent new encrypted data from
+- Stop all active `coderd` instances. This will prevent new encrypted data from
   being written.
 
 - Run
@@ -180,7 +180,7 @@ To delete all encrypted data from your database, perform the following actions:
   [external token encryption keys](../../reference/cli/server.md#--external-token-encryption-keys)
   from Coder's configuration.
 
-- Start coderd. You can now safely delete the encryption keys from your secret
+- Start `coderd`. You can now safely delete the encryption keys from your secret
   store.
 
 ## Troubleshooting

--- a/docs/admin/setup/chat-lifecycle-hooks.md
+++ b/docs/admin/setup/chat-lifecycle-hooks.md
@@ -75,7 +75,7 @@ Provider-executed tools don't produce `pre_tool_use` or `post_tool_use` events b
 For `pre_tool_use`, `tool_input` carries the model's JSON bytes with key spelling and order preserved, so a policy can read them exactly as the model wrote them.
 Coder's built-in tools decode that JSON with Go, which matches property names case-insensitively and keeps the last match, so `{"path":"/allowed","PATH":"/secret"}` could make a policy approve `/allowed` while the tool opens `/secret`.
 Coder rejects a built-in tool call whose input repeats a key or spells a schema property with different capitalization, before dispatching `pre_tool_use`.
-This check doesn't cover dynamic and MCP tools, because the client and the workspace agent execute those calls rather than coderd.
+This check doesn't cover dynamic and MCP tools, because the client and the workspace agent execute those calls rather than `coderd`.
 A policy that gates them must validate their input itself.
 The chat `edit_files` tool reads `old_text` and `new_text` and, for rollout compatibility, also accepts the deprecated `search` and `replace` keys when the new fields are empty. A policy that gates edit content should inspect `old_text` and `new_text`, and `search`/`replace` while the compatibility window lasts.
 

--- a/docs/admin/setup/index.md
+++ b/docs/admin/setup/index.md
@@ -1,7 +1,7 @@
 # Configure Control Plane Access
 
-Coder server's primary configuration is done via environment variables. For a
-full list of the options, run `coder server --help` or see our
+The control plane's primary configuration is done via environment variables. For
+a full list of the options, run `coder server --help` or see our
 [CLI documentation](../../reference/cli/server.md).
 
 > [!TIP]
@@ -57,7 +57,7 @@ It requires a DNS record and TLS certificate for `*.example.com`.
 > browsers consider these "public" domains and will refuse Coder's cookies,
 > which are vital to the proper operation of this feature.
 
-If you are providing TLS certificates directly to the Coder server, either
+If you are providing TLS certificates directly to the control plane, either
 
 1. Use a single certificate and key for both the root and wildcard domains.
 1. Configure multiple certificates and keys via
@@ -72,7 +72,7 @@ After you enable the wildcard access URL, you should [disable path-based apps](.
 
 ## TLS & Reverse Proxy
 
-The Coder server can directly use TLS certificates with `CODER_TLS_ENABLE` and
+The control plane can directly use TLS certificates with `CODER_TLS_ENABLE` and
 accompanying configuration flags. However, Coder can also run behind a
 reverse-proxy to terminate TLS certificates from LetsEncrypt.
 
@@ -149,8 +149,8 @@ steps:
 ## Configuring Coder behind a proxy
 
 To configure Coder behind a corporate proxy, set the environment variables
-`HTTP_PROXY` and `HTTPS_PROXY`. Be sure to restart the server. Lowercase values
-(e.g. `http_proxy`) are also respected in this case.
+`HTTP_PROXY` and `HTTPS_PROXY`. Be sure to restart the control plane. Lowercase
+values (e.g. `http_proxy`) are also respected in this case.
 
 ## Continue your setup with external authentication
 

--- a/docs/admin/templates/extending-templates/index.md
+++ b/docs/admin/templates/extending-templates/index.md
@@ -60,7 +60,7 @@ A common configuration is a template whose only persistent resource is the home
 directory. This allows the developer to retain their work while ensuring the
 rest of their environment is consistently up-to-date on each workspace restart.
 
-When a workspace is deleted, the Coder server essentially runs a
+When a workspace is deleted, the control plane essentially runs a
 [terraform destroy](https://www.terraform.io/cli/commands/destroy) to remove all
 resources associated with the workspace.
 

--- a/docs/admin/templates/extending-templates/modules.md
+++ b/docs/admin/templates/extending-templates/modules.md
@@ -161,7 +161,7 @@ template as the underlying module.
 
 ### Private git repository
 
-If you are importing a module from a private git repository, the Coder server or
+If you are importing a module from a private git repository, the control plane or
 [provisioner](../../provisioners/index.md) needs git credentials. Since this token
 will only be used for cloning your repositories with modules, it is best to
 create a token with access limited to the repository and no extra permissions.

--- a/docs/admin/templates/extending-templates/provider-authentication.md
+++ b/docs/admin/templates/extending-templates/provider-authentication.md
@@ -5,13 +5,13 @@ title: Provider Authentication
 > [!CAUTION]
 > Do not store secrets in templates. Assume every user has cleartext access to every template.
 
-The Coder server's
+The control plane's
 [provisioner](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/provisioner)
 process needs to authenticate with other provider APIs to provision workspaces.
 There are two approaches to do this:
 
 - Pass credentials to the provisioner as parameters.
-- Preferred: Execute the Coder server in an environment that is authenticated
+- Preferred: Run the control plane in an environment that is authenticated
   with the provider.
 
 We encourage the latter approach where supported:

--- a/docs/admin/templates/extending-templates/workspace-tags.md
+++ b/docs/admin/templates/extending-templates/workspace-tags.md
@@ -109,7 +109,7 @@ Passing template tags in from other data sources or resources is not permitted.
 ### HCL syntax
 
 When importing the template version with `coder_workspace_tags`, the Coder provisioner server extracts raw partial queries for each workspace tag and stores them in the database.
-During workspace build time, the Coder server uses the [HashiCorp HCL library](https://github.com/hashicorp/hcl) to evaluate these raw queries on-the-fly without processing the entire Terraform template.
+During workspace build time, the control plane uses the [HashiCorp HCL library](https://github.com/hashicorp/hcl) to evaluate these raw queries on-the-fly without processing the entire Terraform template.
 This evaluation is simpler but also limited in terms of available functions, variables, and references to other resources.
 
 #### Supported syntax

--- a/docs/admin/templates/managing-templates/change-management.md
+++ b/docs/admin/templates/managing-templates/change-management.md
@@ -5,7 +5,7 @@ automating the creation of new versions in CI/CD pipelines.
 
 These pipelines will require tokens for your deployment. To cap token lifetime
 on creation,
-[configure Coder server to set a shorter max token lifetime](../../../reference/cli/server.md#--max-token-lifetime).
+[configure the control plane to set a shorter max token lifetime](../../../reference/cli/server.md#--max-token-lifetime).
 
 ## coderd Terraform Provider
 

--- a/docs/admin/templates/managing-templates/image-management.md
+++ b/docs/admin/templates/managing-templates/image-management.md
@@ -30,7 +30,7 @@ to consider:
 - `curl`, `wget`, or `busybox` is required to download and run
   [the agent](../../../../provisionersdk/scripts/bootstrap_linux.sh)
 - `git` is recommended so developers can clone repositories
-- If the Coder server is using a certificate from an internal certificate
+- If the control plane is using a certificate from an internal certificate
   authority (CA), you'll need to add or mount these into your image
 - Other generic utilities that will be required by all users, such as `ssh`,
   `docker`, `bash`, `jq`, and/or internal tooling

--- a/docs/admin/users/github-auth.md
+++ b/docs/admin/users/github-auth.md
@@ -5,10 +5,10 @@ users.
 We provide it for convenience, allowing you to experiment with Coder
 without setting up your own GitHub OAuth app.
 
-If you authenticate with it, you grant Coder server read access to your GitHub
-user email and other metadata listed during the authentication flow.
+If you authenticate with it, you grant the control plane read access to your
+GitHub user email and other metadata listed during the authentication flow.
 
-This access is necessary for the Coder server to complete the authentication
+This access is necessary for the control plane to complete the authentication
 process.
 To the best of our knowledge, Coder, the company, does not gain access
 to this data by administering the GitHub app.
@@ -47,7 +47,7 @@ To use the default configuration:
 ## Disable the Default GitHub App
 
 You can disable the default GitHub app by [configuring your own app](#step-1-configure-the-oauth-application-in-github)
-or by adding the following environment variable to your [Coder server configuration](../../reference/cli/server.md#options):
+or by adding the following environment variable to your [control plane configuration](../../reference/cli/server.md#options):
 
 ```sh
 CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE=false
@@ -85,7 +85,7 @@ CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE=false
 
 ## Step 2: Configure Coder with the OAuth credentials
 
-Coder server reads these settings from environment variables. Set them
+The control plane reads these settings from environment variables. Set them
 wherever your deployment manages environment variables. For example, use
 Helm `values.yaml` for Kubernetes or `/etc/coder.d/coder.env` for a system
 service.

--- a/docs/admin/users/groups-roles.md
+++ b/docs/admin/users/groups-roles.md
@@ -88,7 +88,7 @@ Note that these permissions only apply to the scope of an
 
 A malicious Template Admin could write a template that executes commands on the
 host (or `coder server` container), which potentially escalates their privileges
-or shuts down the Coder server. To avoid this, run
+or shuts down the control plane. To avoid this, run
 [external provisioners](../provisioners/index.md).
 
 In low-trust environments, we do not recommend giving users direct access to

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -150,7 +150,7 @@ Visit the Coder UI to confirm these changes:
 > Use server flags only with Coder deployments with a single organization.
 > You can use the dashboard to configure group sync instead.
 
-1. Configure the Coder server to read groups from the claim name with the
+1. Configure the control plane to read groups from the claim name with the
    [OIDC group field](../../reference/cli/server.md#--oidc-group-field) server
    flag:
 
@@ -297,11 +297,11 @@ Visit the Coder UI to confirm these changes:
 > Use server flags only with Coder deployments with a single organization.
 > You can use the dashboard to configure role sync instead.
 
-1. Configure the Coder server to read groups from the claim name with the
+1. Configure the control plane to read groups from the claim name with the
    [OIDC role field](../../reference/cli/server.md#--oidc-user-role-field)
    server flag:
 
-1. Set the following in your Coder server [configuration](../setup/index.md).
+1. Set the following in your control plane [configuration](../setup/index.md).
 
    ```dotenv
     # Depending on your identity provider configuration, you may need to explicitly request a "roles" scope
@@ -415,7 +415,7 @@ Some common issues when enabling group, role, or organization sync.
 
 If you are running into issues with a sync:
 
-1. View your Coder server logs and enable
+1. View your `coderd` logs and enable
    [verbose mode](../../reference/cli/index.md#-v---verbose).
 
 1. To reduce noise, you can filter for only logs related to group/role sync:
@@ -424,7 +424,7 @@ If you are running into issues with a sync:
    CODER_LOG_FILTER=".*userauth.*|.*groups returned.*"
    ```
 
-1. Restart the server after changing these configuration values.
+1. Restart the control plane after changing these configuration values.
 
 1. Attempt to log in, preferably with a user who has the `Owner` role.
 

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -155,7 +155,7 @@ Coder supports user provisioning and deprovisioning via SCIM 2.0 with header
 authentication. Upon deactivation, users are
 [suspended](../index.md#suspend-a-user) and are not deleted.
 [Configure](../../setup/index.md) your SCIM application with an auth key and supply
-it the Coder server.
+it to the control plane.
 
 ```dotenv
 CODER_SCIM_AUTH_HEADER="your-api-key"
@@ -176,7 +176,7 @@ CODER_SCIM_USE_LEGACY=false
 ```
 
 This is also available as the `--scim-use-legacy` server flag and the `scimUseLegacy` YAML option.
-Changing it requires a restart of the Coder server.
+Changing it requires a restart of the control plane.
 
 Behavior notes:
 

--- a/docs/admin/users/password-auth.md
+++ b/docs/admin/users/password-auth.md
@@ -9,7 +9,7 @@ setup is a username/password account.
 
 To disable password authentication, use the
 [`CODER_DISABLE_PASSWORD_AUTH`](../../reference/cli/server.md#--disable-password-auth)
-flag on the Coder server.
+flag on the control plane.
 
 ## Restore the `Owner` user
 
@@ -18,7 +18,7 @@ If you remove the admin user account (or forget the password), you can run the
 on your server.
 
 > [!IMPORTANT]
-> You must run this command on the same machine running the Coder server.
+> You must run this command on the same machine running the control plane.
 > If you are running Coder on Kubernetes, this means using
 > [kubectl exec](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/)
 > to exec into the pod.

--- a/docs/ai-coder/agents/licensing-usage.md
+++ b/docs/ai-coder/agents/licensing-usage.md
@@ -36,7 +36,7 @@ Agent Time excludes:
 - Time a parent agent spends waiting for a subagent, because the subagent records its own model invocations.
 - Model calls that don't produce chat messages, such as title generation.
 - Failed or retried model calls, which persist no content and record no runtime.
-- Client-executed tools and chats handed off to external coding agents, since that work happens outside the server.
+- Client-executed tools and chats handed off to external coding agents, since that work happens outside the control plane.
 
 Coder records Agent Time in milliseconds and sums it across all Coder Agents chats in the deployment.
 

--- a/docs/ai-coder/agents/tasks-to-chats-migration.md
+++ b/docs/ai-coder/agents/tasks-to-chats-migration.md
@@ -184,7 +184,7 @@ The WebSocket sends JSON envelopes with a `type` field (`"ping"`,
 | `message`      | A complete message has been persisted                   |
 | `status`       | The chat status changed (e.g. `running` → `waiting`)    |
 | `error`        | An error occurred during processing                     |
-| `retry`        | The server is retrying a failed LLM call                |
+| `retry`        | The control plane is retrying a failed LLM call         |
 | `queue_update` | The queued message list changed                         |
 
 Use `after_id` as a query parameter when reconnecting to skip messages the

--- a/docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md
+++ b/docs/ai-coder/ai-gateway/ai-gateway-proxy/setup.md
@@ -8,7 +8,7 @@ Once enabled, `coderd` runs the AI Gateway Proxy in-process and intercepts traff
 **Required:**
 
 1. AI Gateway must be enabled and configured (requires a Premium license, which includes [AI Governance](../../ai-governance.md)). See [AI Gateway Setup](../setup.md) for further information.
-1. AI Gateway Proxy must be [enabled](#proxy-configuration) using the server flag.
+1. AI Gateway Proxy must be [enabled](#proxy-configuration) using the `coder server` flag.
 1. A [CA certificate](#ca-certificate) must be configured for MITM interception.
 1. [Clients](#client-configuration) must be configured to use the proxy and trust the CA certificate.
 
@@ -56,7 +56,7 @@ All other traffic is tunneled through without decryption.
 Intercepted requests are forwarded to the AI Gateway, configured via [`CODER_AI_GATEWAY_PROXY_TARGET`](../../../reference/cli/server.md#--ai-gateway-proxy-target).
 By default, this is the embedded AI Gateway at `<coderd-access-url>/api/v2/ai-gateway`, and no configuration is needed.
 
-AI Gateway Proxy remains part of the `coder server` process when you [deploy AI Gateway as a standalone service](../standalone.md).
+AI Gateway Proxy remains part of the `coderd` process when you [deploy AI Gateway as a standalone service](../standalone.md).
 To forward intercepted requests to the standalone gateway, set the following:
 
 ```sh
@@ -67,7 +67,7 @@ CODER_AI_GATEWAY_PROXY_TARGET=https://ai-gateway.example.com/
 
 The target is used as-is: the proxy appends only the provider and request path to it, and the URL must not include query parameters.
 
-For additional configuration options, see the [Coder server configuration](../../../reference/cli/server.md#options).
+For additional configuration options, see the [`coder server` configuration](../../../reference/cli/server.md#options).
 
 ## Security Considerations
 
@@ -259,7 +259,7 @@ If your organization requires all outbound traffic to pass through a corporate p
 Tunneled requests (non-allowlisted domains) are forwarded to the upstream proxy configured via [`CODER_AI_GATEWAY_PROXY_UPSTREAM`](../../../reference/cli/server.md#--ai-gateway-proxy-upstream).
 
 MITM'd requests (AI provider domains) are forwarded to AI Gateway, which then communicates with AI providers.
-To ensure AI Gateway also routes requests through the upstream proxy, make sure to configure the proxy settings for the Coder server process.
+To ensure AI Gateway also routes requests through the upstream proxy, make sure to configure the proxy settings for the `coderd` process.
 
 ![AI Gateway Proxy with an upstream corporate proxy](../../../images/aibridge/ai-gateway-proxy-upstream.png)
 
@@ -401,7 +401,7 @@ When the AI Gateway [proxy target](#proxy-target) URL (the Coder access URL by d
 own certificate or a load balancer's, if TLS is terminated there) to forward intercepted requests to AI Gateway.
 This primarily affects deployments using a self-signed or internal CA, since publicly trusted CAs are typically already
 in the system trust store.
-If the certificate is signed by a CA not in the system trust store, the connection fails and the Coder server logs:
+If the certificate is signed by a CA not in the system trust store, the connection fails and `coderd` logs:
 
 ```sh
 WARN: Cannot read TLS response from mitm'd server tls: failed to verify certificate: x509: certificate signed by unknown authority
@@ -427,7 +427,7 @@ MITM CA certificate. Visit [Trust the CA certificate](#trust-the-ca-certificate)
 
 The proxy intercepts HTTPS traffic only for hostnames matching the base URL of an enabled AI [Provider](../providers.md) configured in AI
 Gateway. Check that the provider is enabled and its base URL matches the hostname the tool is connecting to. Verify that
-`HTTPS_PROXY` points at the proxy. When interception is working, coderd logs:
+`HTTPS_PROXY` points at the proxy. When interception is working, `coderd` logs:
 
 ```sh
 routing MITM request to AI Gateway
@@ -460,7 +460,7 @@ See [Client Configuration](#client-configuration) for how to configure the proxy
 
 ### Connections to internal services are blocked
 
-Tunneled requests to private or reserved IP ranges are blocked by default. When a request is blocked, coderd logs:
+Tunneled requests to private or reserved IP ranges are blocked by default. When a request is blocked, `coderd` logs:
 
 ```sh
 WARN  blocking connection to private/reserved IP  hostname=... port=... resolved_ip=...

--- a/docs/ai-coder/ai-gateway/clients/xum.md
+++ b/docs/ai-coder/ai-gateway/clients/xum.md
@@ -58,7 +58,7 @@ export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/ai-gateway/anthropic
 
 ## Run Xum in a Coder workspace
 
-To run Xum inside a Coder workspace (for example, as a Coder app), you can install it with the [`mux` module](https://registry.coder.com/modules/coder/mux) (still published under its pre-rename name) and pre-configure AI Gateway via environment variables on the agent:
+To run Xum inside a Coder workspace (for example, as a Coder app), you can install it with the [`mux` module](https://registry.coder.com/modules/coder/mux) (still published under its pre-rename name) and pre-configure AI Gateway via environment variables on the workspace agent:
 
 ```tf
 data "coder_workspace" "me" {}

--- a/docs/ai-coder/ai-gateway/monitoring.md
+++ b/docs/ai-coder/ai-gateway/monitoring.md
@@ -189,7 +189,7 @@ Refer to the [`coder ai-gateway start` logging options](../../reference/cli/ai-g
 
 AI Gateway can emit a structured log for every interception record to an external SIEM or observability platform.
 The `CODER_AI_GATEWAY_STRUCTURED_LOGGING` setting belongs to `coderd`, and the standalone gateway does not consume it.
-Standalone replicas send interception records to `coderd`, which writes the structured logs to the Coder server log output.
+Standalone replicas send interception records to `coderd`, which writes the structured logs to the `coderd` log output.
 Refer to [structured logging](./setup.md#structured-logging) for configuration and record types.
 
 ## Export data
@@ -252,7 +252,7 @@ in the AI Gateway setup guide.
 ## Tracing
 
 AI Gateway supports tracing through [OpenTelemetry](https://opentelemetry.io/) for request processing, upstream API calls, and MCP server interactions.
-Embedded gateway spans are emitted by the `coder server` process.
+Embedded gateway spans are emitted by the `coderd` process.
 Standalone spans are emitted independently by every replica with the service name `coder-ai-gateway`.
 
 ### Enable tracing

--- a/docs/ai-coder/ai-gateway/providers.md
+++ b/docs/ai-coder/ai-gateway/providers.md
@@ -29,7 +29,7 @@ handling, and how to monitor providers.
 > once seeding has completed.
 >
 > **Any changes to the provider environment variables after seeding will
-> cause the server to fail to start, to prevent operators from updating a
+> cause `coderd` to fail to start, to prevent operators from updating a
 > configuration that is ineffectual.**
 >
 > The environment variables can be safely removed once seeding has
@@ -356,5 +356,5 @@ and how to enable or disable it.
 | Symptom                                        | Likely cause                                               | Corrective action                        |
 |------------------------------------------------|------------------------------------------------------------|------------------------------------------|
 | Startup fails referencing an existing provider | Env config drifted from a provider already in the database | Remove the provider env vars and restart |
-| Provider returns errors with no upstream call  | The provider is `disabled` or in `error` status            | Consult the server logs for details      |
-| Configuration changes not taking effect        | Reloads are firing but failing to apply                    | Consult the server logs for details      |
+| Provider returns errors with no upstream call  | The provider is `disabled` or in `error` status            | Consult the `coderd` logs for details    |
+| Configuration changes not taking effect        | Reloads are firing but failing to apply                    | Consult the `coderd` logs for details    |

--- a/docs/ai-coder/ai-gateway/reference.md
+++ b/docs/ai-coder/ai-gateway/reference.md
@@ -42,7 +42,7 @@ When API dumps are enabled, each replica writes its own [API dumps](./setup.md#a
 
 `coderd` remains required for standalone operation.
 A replica becomes unready when its control connection is unavailable, even if its HTTP listener remains healthy.
-AI Gateway Proxy remains part of `coder server` and can forward its intercepted traffic to either the embedded gateway or a standalone endpoint.
+AI Gateway Proxy remains part of `coderd` and can forward its intercepted traffic to either the embedded gateway or a standalone endpoint.
 
 ## Version compatibility
 

--- a/docs/ai-coder/ai-gateway/standalone.md
+++ b/docs/ai-coder/ai-gateway/standalone.md
@@ -184,7 +184,7 @@ Configure AI Gateway Proxy and direct AI clients to send requests to the standal
 
 ### AI Gateway Proxy
 
-[AI Gateway Proxy](./ai-gateway-proxy/index.md) remains part of the `coder server` process.
+[AI Gateway Proxy](./ai-gateway-proxy/index.md) remains part of the `coderd` process.
 Configure its target to use the standalone Service, Ingress, `HTTPRoute`, or load balancer.
 
 If you installed the Helm chart, get the exact in-cluster Service URL from the chart notes:

--- a/docs/ai-coder/mcp-server.md
+++ b/docs/ai-coder/mcp-server.md
@@ -230,8 +230,8 @@ them for you to invoke, for example as slash commands:
 ### Connection timeouts
 
 - Verify your Coder deployment URL is correct and accessible
-- Check network connectivity between your MCP client and the Coder server
-- Review Coder server logs for any errors
+- Check network connectivity between your MCP client and the control plane
+- Review the logs from `coderd`, the process that runs the control plane, for any errors
 
 ### OAuth2 authentication not working
 

--- a/docs/get-started/customize-your-template/authenticate-to-github.md
+++ b/docs/get-started/customize-your-template/authenticate-to-github.md
@@ -26,7 +26,7 @@ You already met one [data source](https://developer.hashicorp.com/terraform/lang
 
 `coder_external_auth` is a data source you add for its side effect rather than its value.
 Its presence tells Coder that a workspace requires an authenticated session with a provider before it starts.
-The `id` points at a provider configured on the Coder deployment, and the local Coder server you started in Part 1 already has a `github` provider available.
+The `id` points at a provider configured on the Coder deployment, and the local control plane you started in Part 1 already has a `github` provider available.
 
 > [!NOTE]
 > External authentication lets a workspace sign in to an outside service, such as a Git provider, before it starts.
@@ -70,7 +70,7 @@ coder templates push -d ~/coder-quickstart -y quickstart
 ## Step 2: Connect your workspace to GitHub
 
 Update the workspace you built in [Launch your first workspace](../index.md) to the version you just published.
-Because the local Coder server is already connected to GitHub, you don't configure an OAuth app; you only authorize the workspace.
+Because the local control plane is already connected to GitHub, you don't configure an OAuth app; you only authorize the workspace.
 
 <div class="tabs">
 

--- a/docs/get-started/customize-your-template/index.md
+++ b/docs/get-started/customize-your-template/index.md
@@ -2,7 +2,7 @@
 title: Customize your template
 ---
 
-In [Launch your first workspace](../index.md), you installed the `coder` CLI, started the Coder server, and built a workspace from the Quickstart template.
+In [Launch your first workspace](../index.md), you installed the `coder` CLI, started the control plane, and built a workspace from the Quickstart template.
 That template is a good starting point, but it has gaps:
 
 - It may not include every language in which you write code.
@@ -74,7 +74,7 @@ The template web editor opens:
 ### CLI
 
 Pull the template to your local filesystem so you can edit it in your own editor.
-With the server running in your existing terminal, open a second terminal and log in:
+With the control plane running in your existing terminal, open a second terminal and log in:
 
 ```sh
 coder login

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -9,7 +9,7 @@ This workspace includes a basic set of tools to edit most code bases.
 
 In this quickstart, you'll:
 
-- ✅ Install Coder server.
+- ✅ Install the Coder control plane.
 - ✅ Create a **template** (blueprint for dev environments).
 - ✅ Launch a **workspace** (your actual dev environment).
 - ✅ Connect from your favorite IDE.
@@ -38,9 +38,9 @@ explained through a cooking analogy:
 <summary>Why a separate machine?</summary>
 
 Coder's value comes from remote development.
-Hosting the Coder server on a separate machine, such as a cloud VM, a spare desktop, or on-premises hardware, gives you and your team infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
+Hosting the control plane on a separate machine, such as a cloud VM, a spare desktop, or on-premises hardware, gives you and your team infrastructure that's more powerful, always-on, and reachable from anywhere, instead of tying your dev environment to your own laptop.
 
-When you're ready to move past this tutorial, install the Coder server on a separate machine and connect to it remotely.
+When you're ready to move past this tutorial, install the control plane on a separate machine and connect to it remotely.
 Refer to the [Install guide](../install/index.md) for supported platforms and installation methods.
 
 </details>
@@ -205,7 +205,7 @@ automatically, go to <http://localhost:3000>.
 - If you get a browser warning similar to `Secure Site Not Available`, you can
   ignore the warning and continue to the setup page.
 
-If your Coder server is on a network or cloud device, or you are having trouble
+If your control plane is on a network or cloud device, or you are having trouble
 viewing the page, locate the web UI URL in Coder logs in your terminal. It looks
 like `https://<CUSTOM-STRING>.<TUNNEL>.try.coder.app`. It's one of the first
 lines of output, so you might have to scroll up to find it.
@@ -330,7 +330,7 @@ workspace, you can clone it manually if you want:
 
 You now have:
 
-- A Coder server running locally.
+- A control plane running locally.
 - A template defining your environment.
 - A workspace running that environment.
 - IDE access to code remotely.
@@ -362,7 +362,7 @@ A runtime must be running before you create a workspace from a Docker-based temp
 
 If the runtime is running but Coder still cannot connect, the daemon may expose its socket at a path other than `/var/run/docker.sock`.
 This is common with Colima on macOS and with rootless Docker on Linux.
-In that case, point Coder at the socket with the `DOCKER_HOST` environment variable, then restart the Coder server.
+In that case, point Coder at the socket with the `DOCKER_HOST` environment variable, then restart the control plane.
 
 <div class="tabs">
 
@@ -415,7 +415,7 @@ In that case, point Coder at the socket with the `DOCKER_HOST` environment varia
    docker ps
    ```
 
-1. If `docker ps` works but Coder still cannot connect, point `DOCKER_HOST` at the Colima socket, then restart the Coder server:
+1. If `docker ps` works but Coder still cannot connect, point `DOCKER_HOST` at the Colima socket, then restart the control plane:
 
    ```sh
    export DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock"
@@ -432,7 +432,7 @@ In that case, point Coder at the socket with the `DOCKER_HOST` environment varia
 
 </div>
 
-### Can't start Coder server: Address already in use
+### Can't start `coder server`: Address already in use
 
 ```txt
 Encountered an error running "coder server", see "coder server --help" for more information
@@ -440,7 +440,7 @@ error: configure http(s): listen tcp 127.0.0.1:3000: bind: address already in us
 ```
 
 Another process is already listening on port 3000. Identify and stop it,
-then start the server again.
+then start the control plane again.
 
 <div class="tabs">
 

--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -20,7 +20,7 @@ air-gapped with Kubernetes or Docker.
 
 ## Air-gapped container images
 
-The following instructions walk you through how to build a custom Coder server
+The following instructions walk you through how to build a custom control plane
 image for Docker or Kubernetes
 
 First, build and push a container image extending our official image with the

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -1,6 +1,6 @@
 # Installing Coder
 
-A single CLI (`coder`) is used for both the Coder server and the client.
+A single CLI (`coder`) is used for both the control plane and the client.
 
 We support two release channels: mainline and stable - read the
 [Releases](./releases/index.md) page to learn more about which best suits your team.
@@ -41,7 +41,7 @@ winget install Coder.Coder
 
 </div>
 
-To start the Coder server:
+To start the control plane:
 
 ```sh
 coder server
@@ -60,14 +60,14 @@ coder login https://coder.example.com
 > [!NOTE]
 > Available in Coder 2.19 and newer on macOS and Linux clients only.
 
-Every Coder server hosts CLI binaries for all supported platforms. You can run a
+Every control plane hosts CLI binaries for all supported platforms. You can run a
 script to download the appropriate CLI for your machine from your Coder
 deployment.
 
 ![Install Coder binary from your deployment](../images/install/install_from_deployment.png)
 
 This script works within air-gapped deployments and ensures that the version of
-the CLI you have installed on your machine matches the version of the server.
+the CLI you have installed on your machine matches the version of the control plane.
 
 This script can be useful when authoring a template for installing the CLI.
 

--- a/docs/install/cloud/aws-marketplace.md
+++ b/docs/install/cloud/aws-marketplace.md
@@ -48,5 +48,5 @@ That's all! Use the UI to create your first user, template, and workspace. We re
 
 - [IDEs with Coder](../../user-guides/workspace-access/index.md)
 - [Writing custom templates for Coder](../../admin/templates/index.md)
-- [Configure the Coder server](../../admin/setup/index.md)
+- [Configure the control plane](../../admin/setup/index.md)
 - [Use your own domain + TLS](../../admin/setup/index.md#tls--reverse-proxy)

--- a/docs/install/cloud/azure-vm.md
+++ b/docs/install/cloud/azure-vm.md
@@ -1,6 +1,6 @@
 # Microsoft Azure
 
-This guide shows you how to set up the Coder server on Azure which will
+This guide shows you how to set up the Coder control plane on Azure which will
 provision Azure-hosted Linux workspaces.
 
 ## Requirements

--- a/docs/install/cloud/compute-engine.md
+++ b/docs/install/cloud/compute-engine.md
@@ -47,7 +47,7 @@ pre-installed.
 
 ![Coder Workspace and IDE in GCP VM](../../images/platforms/aws/workspace.png)
 
-## Configuring Coder server
+## Configuring the control plane
 
 Coder is primarily configured by server-side flags and environment variables.
 Given you created or added key-pairs when launching the instance, you can
@@ -77,5 +77,5 @@ to set up authentication.
 
 - [Use your IDE with Coder](../../user-guides/workspace-access/index.md)
 - [Writing custom templates for Coder](../../admin/templates/index.md)
-- [Configure the Coder server](../../admin/setup/index.md)
+- [Configure the control plane](../../admin/setup/index.md)
 - [Use your own domain + TLS](../../admin/setup/index.md#tls--reverse-proxy)

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -131,7 +131,7 @@ export DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock"
 ```
 
 To persist the setting, add the `export` line to your shell's startup file, such as `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`.
-Then restart the Coder server.
+Then restart the control plane.
 
 ### Docker-based workspace is stuck in "Connecting..."
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,6 +1,6 @@
 # Installing Coder
 
-A single CLI (`coder`) is used for both the Coder server and the client.
+A single CLI (`coder`) is used for both the control plane and the client.
 
 We support two release channels: mainline and stable - read the
 [Releases](./releases/index.md) page to learn more about which best suits your team.
@@ -61,9 +61,9 @@ This install guide is meant for **IT Administrators, DevOps, and Platform Teams*
 
 </div>
 
-## Starting the Coder Server
+## Starting the control plane
 
-To start the Coder server:
+To start the control plane:
 
 ```sh
 coder server

--- a/docs/install/registry-mirror-artifactory.md
+++ b/docs/install/registry-mirror-artifactory.md
@@ -95,10 +95,10 @@ module "code-server" {
 }
 ```
 
-## Step 5: Configure Coder Server or Provisioners
+## Step 5: Configure the control plane or provisioners
 
 For Coder to use the Artifactory mirror, configure the Terraform CLI on your
-Coder server or external provisioners.
+control plane or external provisioners.
 
 <div class="tabs">
 
@@ -151,7 +151,7 @@ services:
 The [template builder](../admin/templates/creating-templates.md) resolves module
 sources against `registry.coder.com` by default. To make it generate module
 source paths that point at your Artifactory mirror instead, set the
-`CODER_TEMPLATE_BUILDER_REGISTRY_URL` environment variable on your Coder server:
+`CODER_TEMPLATE_BUILDER_REGISTRY_URL` environment variable on your control plane:
 
 ```sh
 CODER_TEMPLATE_BUILDER_REGISTRY_URL=<your-artifactory-host>

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -3,11 +3,11 @@ title: Uninstall
 ---
 
 <!-- markdownlint-disable MD024 -->
-This article walks you through how to uninstall your Coder server.
+This article walks you through how to uninstall Coder.
 
-To uninstall your Coder server, delete the following directories.
+To uninstall Coder, delete the following directories.
 
-## The Coder server binary and CLI
+## The Coder binary and CLI
 
 <div class="tabs">
 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -1,6 +1,6 @@
 # Upgrade
 
-This article describes how to upgrade your Coder server.
+This article describes how to upgrade your Coder deployment.
 
 > [!CAUTION]
 > Prior to upgrading a production Coder deployment, take a database snapshot since
@@ -11,7 +11,7 @@ For upgrade recommendations and troubleshooting, see
 
 ## Reinstall Coder to upgrade
 
-To upgrade your Coder server, reinstall Coder using your original method
+To upgrade your Coder deployment, reinstall Coder using your original method
 of [install](../install/index.md).
 
 ### Coder install script

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -125,6 +125,12 @@ Refer to [Coder Desktop](../user-guides/desktop/index.md).
 The editor extension that connects VS Code, and forks such as Cursor and Devin Desktop (formerly Windsurf), to Coder workspaces.
 Refer to [VS Code](../user-guides/workspace-access/vscode.md).
 
+### `coder server`
+
+The CLI command that starts [`coderd`](#coderd).
+Use this name only for the command a reader runs, not as a name for the [control plane](#control-plane) itself.
+Refer to the [`coder server` reference](./cli/server.md).
+
 ### `coder_agent`
 
 The Terraform resource that declares a [workspace agent](#workspace-agent) inside a template.
@@ -147,8 +153,9 @@ Refer to the [`coder_script` resource](https://registry.terraform.io/providers/c
 
 ### `coderd`
 
-The Coder control plane server, started with `coder server`.
-It serves the dashboard and API, brokers connections to workspaces, and stores state in PostgreSQL.
+The process that runs the [control plane](#control-plane), started with [`coder server`](#coder-server).
+Use `coderd` for the process itself, such as in metric names, log output, configuration flags, and troubleshooting steps.
+Introduce it on first use in a page as "`coderd`, the process that runs the control plane".
 Refer to [Architecture](../admin/infrastructure/architecture.md).
 
 ### codersdk
@@ -177,8 +184,10 @@ Refer to [Connection logs](../admin/monitoring/connection-logs.md).
 
 ### Control plane
 
-The collective term for `coderd`, its provisioners, and its database.
-The control plane also runs the agent loop for [Coder Agents](#coder-agents).
+The component that serves the Coder API and dashboard, brokers connections to workspaces, and coordinates provisioners.
+It is implemented by the [`coderd`](#coderd) process and also runs the agent loop for [Coder Agents](#coder-agents).
+Use *control plane* in prose, diagrams, and any planning, sizing, architecture, or security discussion.
+Do not call it "the Coder server", and do not describe it generically as "a service".
 
 ### Custom roles
 

--- a/docs/tutorials/best-practices/scale-coder.md
+++ b/docs/tutorials/best-practices/scale-coder.md
@@ -16,16 +16,16 @@ end-user experience and measure the effects of modifications you make to your
 deployment.
 
 - Log output
-  - Capture log output from from Coder Server instances and external provisioner daemons
+  - Capture log output from from control plane instances and external provisioner daemons
   and store them in a searchable log store like Loki, CloudWatch logs, or other tools.
   - Retain logs for a minimum of thirty days, ideally ninety days.
   This allows you investigate when anomalous behaviors began.
 
 - Metrics
   - Capture infrastructure metrics like CPU, memory, open files, and network I/O for all
-  Coder Server, external provisioner daemon, workspace proxy, and PostgreSQL instances.
-  - Capture Coder Server and External Provisioner daemons metrics
-  [via Prometheus](#how-to-capture-coder-server-metrics-with-prometheus).
+  control plane, external provisioner daemon, workspace proxy, and PostgreSQL instances.
+  - Capture control plane and external provisioner daemon metrics
+  [via Prometheus](#how-to-capture-control-plane-metrics-with-prometheus).
 
 Retain metric time series for at least six months. This allows you to see
 performance trends relative to user growth.
@@ -45,8 +45,8 @@ they affect the end-user experience.
      Monitor trends and pay special attention to the daily and weekly peak utilization.
      Use long-term trends to plan infrastructure upgrades.
 
-- Tail latency of Coder Server API requests
-  - High tail latency can indicate Coder Server or the PostgreSQL database is underprovisioned
+- Tail latency of Coder API requests
+  - High tail latency can indicate the control plane or the PostgreSQL database is underprovisioned
   for the load.
   - Use the `coderd_api_request_latencies_seconds` metric.
 
@@ -54,9 +54,9 @@ they affect the end-user experience.
   - High tail latency can indicate the PostgreSQL database is low in resources.
   - Use the `coderd_db_query_latencies_seconds` metric.
 
-### How to capture Coder server metrics with Prometheus
+### How to capture control plane metrics with Prometheus
 
-Edit your Helm `values.yaml` to capture metrics from Coder Server and external provisioner daemons with
+Edit your Helm `values.yaml` to capture metrics from the control plane and external provisioner daemons with
 [Prometheus](../../admin/integrations/prometheus.md):
 
 1. Enable Prometheus metrics:
@@ -85,31 +85,31 @@ Edit your Helm `values.yaml` to capture metrics from Coder Server and external p
      CODER_PROMETHEUS_COLLECT_AGENT_STATS=false
      ```
 
-## Coder Server
+## Control plane
 
 ### Locality
 
 If increased availability of the Coder API is a concern, deploy at least three
-instances of Coder Server. Spread the instances across nodes with anti-affinity rules in
+control plane instances. Spread the instances across nodes with anti-affinity rules in
 Kubernetes or in different availability zones of the same geographic region.
 
 Do not deploy in different geographic regions.
 
-Coder Servers need to be able to communicate with one another directly with low
+Control plane instances need to be able to communicate with one another directly with low
 latency, under 10ms. Note that this is for the availability of the Coder API.
 Workspaces are not fault tolerant unless they are explicitly built that way at
 the template level.
 
-Deploy Coder Server instances as geographically close to PostgreSQL as possible.
-Low-latency communication (under 10ms) with Postgres is essential for Coder
-Server's performance.
+Deploy control plane instances as geographically close to PostgreSQL as possible.
+Low-latency communication (under 10ms) with Postgres is essential for control
+plane performance.
 
 ### Scaling
 
-Coder Server can be scaled both vertically for bigger instances and horizontally
+The control plane can be scaled both vertically for bigger instances and horizontally
 for more instances.
 
-Aim to keep the number of Coder Server instances relatively small, preferably
+Aim to keep the number of control plane instances relatively small, preferably
 under ten instances, and opt for vertical scale over horizontal scale after
 meeting availability requirements.
 
@@ -119,10 +119,10 @@ give specific sizing recommendations for various user scales. These are a useful
 starting point, but very few deployments will remain stable at a predetermined
 user level over the long term. We recommend monitoring and adjusting resources as needed.
 
-We don't recommend that you autoscale the Coder Servers. Instead, scale the
+We don't recommend that you autoscale the control plane instances. Instead, scale the
 deployment for peak weekly usage.
 
-Although Coder Server persists no internal state, it operates as a proxy for end
+Although the control plane persists no internal state, it operates as a proxy for end
 users to their workspaces in two capacities:
 
 1. As an HTTP proxy when they access workspace applications in their browser via
@@ -131,7 +131,7 @@ users to their workspaces in two capacities:
 1. As a DERP proxy when establishing tunneled connections with CLI tools like
    `coder ssh`, `coder port-forward`, and others, and with desktop IDEs.
 
-Stopping a Coder Server instance will (momentarily) disconnect any users
+Stopping a control plane instance will (momentarily) disconnect any users
 currently connecting through that instance. Adding a new instance is not
 disruptive, but you should remove instances and perform upgrades during a
 maintenance window to minimize disruption.
@@ -141,9 +141,9 @@ maintenance window to minimize disruption.
 ### Locality
 
 We recommend that you run one or more
-[provisioner daemon deployments external to Coder Server](../../admin/provisioners/index.md)
-and disable provisioner daemons within your Coder Server.
-This allows you to scale them independently of the Coder Server:
+[provisioner daemon deployments external to the control plane](../../admin/provisioners/index.md)
+and disable provisioner daemons within your control plane.
+This allows you to scale them independently of the control plane:
 
 ```yaml
 CODER_PROVISIONER_DAEMONS=0
@@ -163,7 +163,7 @@ workspaces they will provision or are hosted in.
   deployments and use template tags to select the correct set of provisioner
   daemons.
 
-- Provisioner daemons need to be able to connect to Coder Server, but this does not need
+- Provisioner daemons need to be able to connect to the control plane, but this does not need
   to be a low-latency connection.
 
 Provisioner daemons make no direct connections to the PostgreSQL database, so
@@ -203,11 +203,11 @@ the number and size of your provisioner daemon instances.
 
 PostgreSQL is the primary persistence layer for all of Coder's deployment data.
 We also use `LISTEN` and `NOTIFY` to coordinate between different instances of
-Coder Server.
+the control plane.
 
 ### Locality
 
-Coder Server instances must have low-latency connections (under 10ms) to
+Control plane instances must have low-latency connections (under 10ms) to
 PostgreSQL. If you use multiple PostgreSQL replicas in a clustered config, these
 must also be low-latency with respect to one another.
 
@@ -220,12 +220,12 @@ give specific sizing recommendations for various user scales.
 
 ### Connection pool tuning
 
-Coder Server maintains a pool of connections to PostgreSQL. You can tune the
+The control plane maintains a pool of connections to PostgreSQL. You can tune the
 pool size with the following settings:
 
 > [!NOTE]
 > When adjusting these settings, please ensure that your PostgreSQL Server has `max_connections`
-> set appropriately to accommodate all Coder Server replicas multiplied by the
+> set appropriately to accommodate all control plane replicas multiplied by the
 > maximum number of open connections. We recommend configuring an additional 20%
 > of connections to account for churn and other clients.
 >
@@ -243,8 +243,8 @@ overhead (churn) when load fluctuates. Monitor these metrics to understand your
 connection pool behavior:
 
 - **Capacity**: `go_sql_max_open_connections - go_sql_in_use_connections` shows
-  how many connections are available for new requests. If this is 0, Coder
-  Server performance will start to degrade. This just provides a point-in-time view
+  how many connections are available for new requests. If this is 0, control
+  plane performance will start to degrade. This just provides a point-in-time view
   of the connections, however.
 
   For a more systematic view, consider running
@@ -334,8 +334,8 @@ be susceptible to a user or process consuming shared resources.
     using autostop policies to stop more workspaces during off-peak hours.
 
 - If you do overprovision workspaces onto nodes, keep them in a separate node
-  pool and schedule Coder control plane (Coder Server, PostgreSQL, workspace
-  proxies) components on a different node pool to avoid resource spikes
+  pool and schedule the control plane, PostgreSQL, and workspace proxy
+  components on a different node pool to avoid resource spikes
   affecting them.
 
 Coder customers have had success with both:
@@ -356,7 +356,7 @@ Coder customers have had success with both:
 ## Networking
 
 Set up your network so that most users can get direct, peer-to-peer connections
-to their workspaces. This drastically reduces the load on Coder Server and
+to their workspaces. This drastically reduces the load on the control plane and
 workspace proxy instances.
 
 ## Next steps

--- a/docs/tutorials/best-practices/security-best-practices.md
+++ b/docs/tutorials/best-practices/security-best-practices.md
@@ -16,13 +16,13 @@ encryption.
 As with any security guide, the steps and suggestions outlined in this document
 are not meant to be exhaustive and do not offer any guarantee.
 
-## Coder Server
+## Control plane
 
-Coder Server is the main control core of a Coder deployment.
+The control plane is the core of a Coder deployment.
 
-If the Coder Server is compromised in a security incident, it can affect every
+If the control plane is compromised in a security incident, it can affect every
 other part of your deployment. Even a successful read-only attack against the
-Coder Server could result in a complete compromise of the Coder deployment if
+control plane could result in a complete compromise of the Coder deployment if
 credentials are stolen.
 
 ### User authentication
@@ -48,18 +48,18 @@ Place Coder behind a TLS-capable reverse-proxy/load balancer and enable
 [Strict Transport Security](../../reference/cli/server.md#--strict-transport-security)
 so that connections from end users are always encrypted.
 
-Enable [TLS](../../reference/cli/server.md#--tls-address) on Coder Server and
-encrypt traffic from the reverse-proxy/load balancer to Coder Server, so that
+Enable [TLS](../../reference/cli/server.md#--tls-address) on the control plane and
+encrypt traffic from the reverse-proxy/load balancer to the control plane, so that
 even if an attacker gains access to your network, they will not be able to snoop
-on Coder Server traffic.
+on control plane traffic.
 
 ### Encryption at rest
 
-Coder Server persists no state locally. No action is required.
+The control plane persists no state locally. No action is required.
 
-### Server logs and audit logs
+### Control plane logs and audit logs
 
-Capture the logging output of all Coder Server instances and persist them.
+Capture the logging output of all control plane instances and persist them.
 
 Retain all logs for a minimum of thirty days, ideally ninety days. Filter audit
 logs (which have `msg: audit_log`) and retain them for a minimum of two years
@@ -81,7 +81,7 @@ A malicious workspace could reuse Coder cookies to call the API or interact with
 1. Disable path-based apps:
 
    ```sh
-   coderd server --disable-path-apps
+   coder server --disable-path-apps
    # or
    export CODER_DISABLE_PATH_APPS=true
    ```
@@ -91,9 +91,9 @@ malicious workspaces accessing other workspaces owned by the same user or perfor
 
 If you do keep path-based apps enabled:
 
-- Path-based apps cannot be shared with other users unless you start the Coder server with `--dangerous-allow-path-app-sharing`.
-- Users with the site `owner` role cannot use their admin privileges to access path-based apps for workspaces unless the
-  server is started with `--dangerous-allow-path-app-site-owner-access`.
+- Path-based apps cannot be shared with other users unless you start `coder server` with `--dangerous-allow-path-app-sharing`.
+- Users with the site `owner` role cannot use their admin privileges to access path-based apps for workspaces unless
+  `coder server` is started with `--dangerous-allow-path-app-site-owner-access`.
 
 ## PostgreSQL
 
@@ -123,8 +123,8 @@ of the Coder deployment.
 ### Encryption in transit
 
 Enable TLS on PostgreSQL and set `sslmode=verify-full` in your
-[postgres URL](../../reference/cli/server.md#--postgres-url) on Coder Server.
-This configures Coder Server to only establish TLS connections to PostgreSQL and
+[postgres URL](../../reference/cli/server.md#--postgres-url) on the control plane.
+This configures the control plane to only establish TLS connections to PostgreSQL and
 check that the PostgreSQL server’s certificate is valid and matches the expected
 hostname.
 
@@ -171,7 +171,7 @@ systems.
 ### External provisioner daemons
 
 When Coder workspaces are deployed into multiple clusters/clouds, or workspaces
-are in a different cluster/cloud than the Coder Server, use external provisioner
+are in a different cluster/cloud than the control plane, use external provisioner
 daemons.
 
 Running provisioner daemons within the same cluster/cloud as the workspaces they
@@ -182,7 +182,7 @@ provision:
   credentials issued outside the cloud/cluster.
 - Means that you don’t have to open any ingress ports on the clusters/clouds
   that host workspaces.
-  - The external provisioner daemons dial out to Coder Server.
+  - The external provisioner daemons dial out to the control plane.
   - Provisioner daemons run in the cluster, so you don’t need to expose
     cluster/cloud APIs externally.
 - Each cloud/cluster is isolated, so a compromise of a provisioner daemon is
@@ -192,7 +192,7 @@ provision:
 
 1. Use a [scoped key](../../admin/provisioners/index.md#scoped-key-recommended) to
    authenticate the provisioner daemons with Coder. These keys can only be used
-   to authenticate provisioner daemons (not other APIs on the Coder Server).
+   to authenticate provisioner daemons (not other APIs on the control plane).
 
 1. Store the keys securely and use environment variables to pass them to the
    provisioner daemon.
@@ -224,8 +224,8 @@ credentials, if available:
 
 ### Encryption in transit
 
-Enable TLS on Coder Server and ensure you use an `https://` URL to access the
-Coder Server.
+Enable TLS on the control plane and ensure you use an `https://` URL to access the
+control plane.
 
 See the **Encryption in transit** subheading of the
 [Templates](#workspace-templates) section for more about encrypting
@@ -273,8 +273,8 @@ workspaces and can access any port on any running workspace.
 
 ### Encryption in transit
 
-Enable TLS on Coder Server and ensure you use an `https://` URL to access the
-Coder Server.
+Enable TLS on the control plane and ensure you use an `https://` URL to access the
+control plane.
 
 Communication to the proxied workspace applications is always encrypted with
 Wireguard. No action is required.
@@ -291,7 +291,7 @@ code via the
 
 Furthermore, Coder templates are designed to provision compute resources in one
 or more clusters/clouds, and template authors are generally in full control over
-code and scripts executed by the Coder agent in those compute resources.
+code and scripts executed by the workspace agent in those compute resources.
 
 This means that template admins have remote code execution privileges for any
 provisioner daemons in their organization and within any cluster/cloud those
@@ -457,7 +457,7 @@ inbound connections are handled exclusively by the encrypted tunnels.
 [DERP](https://tailscale.com/kb/1232/derp-servers) is a relay protocol developed
 by Tailscale.
 
-Coder Server and Workspace Proxies include a DERP service by default. Tailcale
+The control plane and Workspace Proxies include a DERP service by default. Tailcale
 also runs a set of public DERP servers, globally distributed.
 
 All DERP messages are end-to-end encrypted, so the DERP service only learns the
@@ -500,7 +500,7 @@ using the default set of STUN servers operated by Google.
 #### Workspace apps
 
 Coder workspace apps are a way to allow users to access web applications running
-in the workspace via the Coder Server or Workspace Proxy.
+in the workspace via the control plane or Workspace Proxy.
 
 1. [Disable workspace apps on sub-paths](../../reference/cli/server.md#--disable-path-apps)
    of the main Coder domain name.
@@ -511,14 +511,14 @@ in the workspace via the Coder Server or Workspace Proxy.
    Because of the default
    [same-origin policy](https://en.wikipedia.org/wiki/Same-origin_policy) in
    browsers, serving web apps on the main Coder domain would allow those apps to
-   send API requests to the Coder Server, authenticated as the logged-in user
+   send API requests to the control plane, authenticated as the logged-in user
    without their explicit consent.
 
 #### Port sharing
 
 Coder supports the option to allow users to designate specific network ports on
 their workspace as shared, which allows others to access those ports via the
-Coder Server.
+control plane.
 
 Consider restricting the maximum sharing level for workspaces, located in the
 template settings for the corresponding template.

--- a/docs/tutorials/best-practices/speed-up-templates.md
+++ b/docs/tutorials/best-practices/speed-up-templates.md
@@ -74,7 +74,7 @@ becomes available.
 
 ### Increase provisioner daemons
 
-Provisioners are queue-based to reduce unpredictable load to the Coder server.
+Provisioners are queue-based to reduce unpredictable load to the control plane.
 If you require a higher bandwidth of provisioner jobs, you can do so by
 increasing the
 [`CODER_PROVISIONER_DAEMONS`](../../reference/cli/server.md#--provisioner-daemons)

--- a/docs/tutorials/external-database.md
+++ b/docs/tutorials/external-database.md
@@ -7,7 +7,7 @@ For production deployments, we recommend using an external
 
 ## Basic configuration
 
-Before starting the Coder server, prepare the database server by creating a role
+Before starting the control plane, prepare the database server by creating a role
 and a database. Remember that the role must have access to the created database.
 
 With `psql`:
@@ -81,7 +81,7 @@ ALTER ROLE coder SET search_path = myschema;
 
 ## Troubleshooting
 
-### Coder server fails startup with "current_schema: converting NULL to string is unsupported"
+### `coder server` fails startup with "current_schema: converting NULL to string is unsupported"
 
 Please make sure that the schema selected in the connection string
 `...&search_path=myschema` exists and the role has granted permissions to access

--- a/docs/tutorials/faqs.md
+++ b/docs/tutorials/faqs.md
@@ -156,18 +156,18 @@ resource "coder_app" "code-server" {
 ## I installed Coder and created a workspace but the icons do not load
 
 An important concept to understand is that Coder creates workspaces which have
-an agent that must be able to reach the `coder server`.
+an agent that must be able to reach the control plane.
 
 If the [`CODER_ACCESS_URL`](../admin/setup/index.md#access-url) is not
 accessible from a workspace, the workspace may build, but the agent cannot reach
 Coder, and thus the missing icons. e.g., Terminal, IDEs, Apps.
 
 By default, `coder server` automatically creates an Internet-accessible
-reverse proxy so that workspaces you create can reach the server.
+reverse proxy so that workspaces you create can reach the control plane.
 
 If you are doing a standalone install, e.g., on a MacBook and want to build
 workspaces in Docker Desktop, everything is self-contained and workspaces
-(containers in Docker Desktop) can reach the Coder server.
+(containers in Docker Desktop) can reach the control plane.
 
 ```sh
 coder server --access-url http://localhost:3000 --address 0.0.0.0:3000
@@ -216,7 +216,7 @@ sudo systemctl restart coder.service
 1. Run the `coder server` command below to retrieve the `psql` connection URL
    which includes the database user and password.
 2. `psql` into Postgres, and do a select query on the `users` table.
-3. Restart the `coder server`, pull up the Coder UI and log in (you will still
+3. Restart the control plane, pull up the Coder UI and log in (you will still
    need your password)
 
 ```sh
@@ -562,17 +562,17 @@ confidential resources to their local machines.
 For more advanced security needs, consider adopting an endpoint security
 solution.
 
-## How do I change the access URL for my Coder server?
+## How do I change the access URL for my control plane?
 
 You may want to change the default domain that's used to access coder, i.e. `yourcompany.coder.com` and find yourself unfamiliar with the process.
 
-To change the access URL associated with your server, you can edit any of the following variables:
+To change the access URL associated with your control plane, you can edit any of the following variables:
 
 - CLI using the `--access-url` flag
 - YAML using the `accessURL` option
 - or ENV using the `CODER_ACCESS_URL` environmental variable.
 
-For example, if you're using an environment file to configure your server, you'll want to edit the file located at `/etc/coder.d/coder.env` and edit the following:
+For example, if you're using an environment file to configure your control plane, you'll want to edit the file located at `/etc/coder.d/coder.env` and edit the following:
 
 `CODER_ACCESS_URL=https://yourcompany.coder.com` to your new desired URL.
 

--- a/docs/tutorials/persistent-shared-workspaces.md
+++ b/docs/tutorials/persistent-shared-workspaces.md
@@ -242,7 +242,7 @@ Access removal requires a workspace restart. Run
 
 Group membership changes in your IdP are not reflected until the user logs out
 and back in. Group sync runs at login time, not on a polling schedule. Check the
-Coder server logs with
+logs from `coderd`, the process that runs the control plane, with
 `CODER_LOG_FILTER=".*userauth.*|.*groups returned.*"` for details. See
 [Troubleshooting group sync](../admin/users/idp-sync.md#troubleshooting-grouproleorganization-sync)
 for more information.

--- a/docs/tutorials/template-from-scratch.md
+++ b/docs/tutorials/template-from-scratch.md
@@ -133,7 +133,7 @@ runs inside the compute aspect of your workspace, typically a VM or container.
 In our case, it will run in Docker.
 
 You do not need to have any open ports on the compute aspect, but the agent
-needs `curl` access to the Coder server.
+needs `curl` access to the control plane.
 
 Add this snippet after the last closing `}` in `main.tf` to create the agent:
 
@@ -174,7 +174,7 @@ resource "coder_agent" "main" {
 }
 ```
 
-Because Docker is running locally in the Coder server, there is no need to
+Because Docker is running on the same machine as the control plane, there is no need to
 authenticate `coder_agent`. But if your `coder_agent` is running on a remote
 host, your template will need
 [authentication credentials](../admin/external-auth/index.md).

--- a/docs/user-guides/workspace-access/web-terminal.md
+++ b/docs/user-guides/workspace-access/web-terminal.md
@@ -63,11 +63,11 @@ workspace:
 
 1. **Browser**: Renders the terminal using xterm.js
 2. **WebSocket**: Maintains a persistent, low-latency connection
-3. **Coder Server**: Routes traffic between browser and workspace
+3. **Control plane**: Routes traffic between browser and workspace
 4. **Workspace Agent**: Manages the pseudo-terminal (PTY) session
 5. **Shell Process**: Your actual bash/zsh/fish shell
 
-The connection flow is: Browser ↔ WebSocket ↔ Coder Server ↔ Workspace Agent ↔ Shell Process
+The connection flow is: Browser ↔ WebSocket ↔ Control plane ↔ Workspace Agent ↔ Shell Process
 
 ### Reconnection & Persistence
 
@@ -117,7 +117,7 @@ CODER_WEB_TERMINAL_RENDERER=canvas
   complex rendering
 - **`dom`**: Fallback option, useful for accessibility tools or older browsers
 
-> **Note:** The renderer setting is deployment-wide and requires a Coder server
+> **Note:** The renderer setting is deployment-wide and requires a control plane
 > restart to take effect.
 
 ## Keyboard Shortcuts


### PR DESCRIPTION
Normalizes the three overlapping names for the thing that serves the Coder API and dashboard. This is step 1 of the Install/Deploy and Administration refactor ([DOCS-685](https://linear.app/codercom/issue/DOCS-685), [DOCS-738](https://linear.app/codercom/issue/DOCS-738)) and lands first because every later page depends on settled terminology.

Resolves [DOCS-871](https://linear.app/codercom/issue/DOCS-871).

## The rule

| Term | Means | Use when |
|---|---|---|
| control plane | The component that serves the Coder API and dashboard, brokers connections, and coordinates provisioners | Default in prose, diagrams, planning, sizing, security |
| `coderd` | The process that implements it | Architecture internals, metrics, logs, flags, troubleshooting |
| `coder server` | The literal CLI command | Only when the reader will type it |

Retired: "the Coder server" as a name for the component, and "a service" as a standalone description of it.

## What changed

- **`docs/.style/style-guide/word-choice.md`**: new "Naming Coder's components" rule, with do/don't examples. Also fixes a "Do" example on that page that itself used "the Coder server".
- **`docs/reference/glossary.md`**: rewrote `coderd` and Control plane, added a `coder server` entry. The existing Control plane entry defined it as "the collective term for `coderd`, its provisioners, and its database", which made it indistinguishable from the Deployment entry two sections later. Control plane is now the component; Deployment remains the whole installation.
- **65 pages** across `docs/admin`, `docs/install`, `docs/get-started`, `docs/tutorials`, `docs/user-guides`, `docs/ai-coder`, and `docs/about`: roughly 154 component-sense "Coder server" usages, 21 bare "the server" usages meaning the control plane, 3 "a service" descriptions, and 43 unbackticked `coderd` mentions in prose.
- One real bug caught in passing: `docs/tutorials/best-practices/security-best-practices.md` documented `coderd server --disable-path-apps`, which is not a command. Now `coder server`.

Generated files were not touched: `configuration-reference.md`, `prometheus.md`, `audit-logs.md`, `reference/cli/*`, `reference/api/*`, and the generated blocks inside `feature-stages.md`. Those still contain the retired term and need generator-side changes; see the deferred list below.

## Reviewer attention, please

**Anchor changes.** 11 headings were renamed, so their fragments change. No in-repo link targets any of them (the one internal link that did was updated), but external deep links from tickets or blog posts would break, and fragments cannot be fixed with a redirect. Happy to revert any of these if you would rather they ride along with the page moves in [DOCS-869](https://linear.app/codercom/issue/DOCS-869), which changes those URLs anyway.

<details>
<summary>Renamed headings and their old fragments</summary>

| File | Old fragment | New heading |
|---|---|---|
| `admin/networking/index.md` | `#coder-server` | `## Control plane` |
| `install/index.md` | `#starting-the-coder-server` | `## Starting the control plane` |
| `install/uninstall.md` | `#the-coder-server-binary-and-cli` | `## The Coder binary and CLI` |
| `install/registry-mirror-artifactory.md` | `#step-5-configure-coder-server-or-provisioners` | `## Step 5: Configure the control plane or provisioners` |
| `install/cloud/compute-engine.md` | `#configuring-coder-server` | `## Configuring the control plane` |
| `get-started/index.md` | `#cant-start-coder-server-address-already-in-use` | ``### Can't start `coder server`: Address already in use`` |
| `tutorials/external-database.md` | `#coder-server-fails-startup-with-...` | ``### `coder server` fails startup with ...`` |
| `tutorials/faqs.md` | `#how-do-i-change-the-access-url-for-my-coder-server` | `## How do I change the access URL for my control plane?` |
| `tutorials/best-practices/security-best-practices.md` | `#coder-server` | `## Control plane` |
| `tutorials/best-practices/security-best-practices.md` | `#server-logs-and-audit-logs` | `### Control plane logs and audit logs` |
| `tutorials/best-practices/scale-coder.md` | `#coder-server`, `#how-to-capture-coder-server-metrics-with-prometheus` | `## Control plane`, `### How to capture control plane metrics with Prometheus` |

</details>

**One deliberate deviation from the issue.** DOCS-871 proposed reserving "sub-agent" for the Coder Agents sense and using "devcontainer agent" for the workspace sense. I did not make that change. The glossary already disambiguates with "Sub-agent (Coder Agents)" and "Sub-agent (dev containers)", and "devcontainer agent" would violate the existing dev container spelling rule in the same style guide, which requires "dev container" as two lowercase words. The current split reads correctly and costs no churn. Happy to revisit if you disagree.

<details>
<summary>Deferred, with reasons</summary>

- **Generated content still says "Coder server".** `reference/cli/*` comes from Go command help text, `configuration-reference.md` from `configdocgen`, and `reference/api/*` from Swagger annotations. Fixing those means changing Go source, which belongs in its own PR so a docs review does not turn into a backend review.
- **`validated-architectures/index.md` "also known as `coderd`"** is fixed here, but the page's larger problem is that it holds four documents in one file. That split is [DOCS-868](https://linear.app/codercom/issue/DOCS-868).
- **"server flag" phrasing** in `admin/users/idp-sync.md` and `admin/users/oidc-auth/index.md` means `coder server` flags. Left alone; rewording those sentences is a copy edit, not a substitution.
- **Metric and UI labels** such as "Dashboard-to-server latency" in `admin/networking/index.md`. Renaming risks diverging from what the dashboard shows.
- **Pre-existing `Coder.GerundHeading` warnings** on headings this PR touches, and a "from from" typo in `scale-coder.md`. Out of scope for a terminology pass.
- **Peer-sense "server"** in NAT traversal prose, where "client or server" describes the connection roles rather than the control plane. Needs restructuring, not substitution.

</details>

## Verification

| Check | Result |
|---|---|
| `make lint/emdash` | pass |
| `make lint/markdown` | pass, 504 files, 0 errors |
| `make lint/docs-html` | pass |
| `make lint/prose` | pass, findings identical to the `main` baseline (1 intentional demo error, 145 warnings, 1 suggestion; only Vale's file ordering and one line-number shift in `glossary.md` differ) |
| `make gen` | clean, no drift |
| `make fmt/markdown` | applied |

No redirects needed: no page moved or was renamed in this PR.

<details>
<summary>Merged main, 2026-09-14</summary>

One conflict, in `docs/ai-coder/ai-gateway/providers.md`. Both hunks were text this PR had edited and `main` had since deleted in #29053, which removed env-based AI provider configuration:

- The deprecated provider seeding note, which held a `coderd` backtick fix, is gone. Took `main`.
- The failure-mode table lost its env-drift row. Took `main`'s two rows and reapplied the `coderd` logs wording.

`main` also landed new prose carrying the retired terms, so the pass was extended to cover it:

- `docs/admin/integrations/oauth2-provider.md`: two "the server log(s)" in the scope-enforcement sections added by #29144 are now "the `coderd` log(s)"; "a `scope` the server will not grant" is now "the control plane".
- `docs/reference/cli/index.md` gained "the server" from #29104, and stays deferred as generated content.

The new `docs/ai-coder/agent-relay/claude-code.md` needed no change, and no page `main` added links to a heading this PR renamed.

</details>

<details>
<summary>Decision log for the wider refactor</summary>

Agreed with @nickvigilante before implementation, recorded on DOCS-685 and in the Notion outline:

1. Feature stages and release channels move to Reference; ESR upgrade guides move under Operate. No new top-level Releases section.
2. `data-retention.md` moves to Administration > Security; `chat-lifecycle-hooks.md` moves into the Coder Agents docs. `admin/setup/` therefore survives as "Deployment configuration" and `configdocgen` is not touched.
3. Prepare is advisory, not a gate, framed as "don't know where to start? Start here", with lead times and owners per item.
4. One actor table, on the Install overview, spanning all five phases, noting that one person can be several actors and several people can be one actor.
5. The quickstart stays independent and is mentioned once, on the Install overview. The proposed `server/single-machine` page is dropped.
6. Coder Validated Architecture keeps its name in nav, defined in-page, with a glossary entry.
7. PR 3 is split: moves only, then prose, so the riskiest change reads as a pure rename diff.
8. For every PR that moves a page, the coder.com `redirects.json` change merges first.
9. There is no Download section and no CLI page in docs. Per-OS CLI steps live on coder.com/download and the Install overview links to it.

</details>

Generated with Coder Agents on behalf of @nickvigilante.

