### PR TITLE
feat: add opt-in vim-style chat navigation shortcuts

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -23336,13 +23336,15 @@ const docTemplate = `{
                 "ai-gateway-seat-exclusion",
                 "chat-advisor",
                 "chat-virtual-desktop",
-                "agent-lifecycle-hooks"
+                "agent-lifecycle-hooks",
+                "chat-vim-navigation"
             ],
             "x-enum-comments": {
                 "ExperimentAIGatewaySeatExclusion": "Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
                 "ExperimentAgentLifecycleHooks": "Enables chat lifecycle hook webhooks for agent chats.",
                 "ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
                 "ExperimentChatAdvisor": "Enables the advisor tool for root agent chats.",
+                "ExperimentChatVimNavigation": "Enables the opt-in vim-style keyboard navigation setting for agent chats.",
                 "ExperimentChatVirtualDesktop": "Enables virtual desktop and computer use provider for agents.",
                 "ExperimentExample": "This isn't used for anything.",
                 "ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -23368,7 +23370,8 @@ const docTemplate = `{
                 "Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
                 "Enables the advisor tool for root agent chats.",
                 "Enables virtual desktop and computer use provider for agents.",
-                "Enables chat lifecycle hook webhooks for agent chats."
+                "Enables chat lifecycle hook webhooks for agent chats.",
+                "Enables the opt-in vim-style keyboard navigation setting for agent chats."
             ],
             "x-enum-varnames": [
                 "ExperimentExample",
@@ -23384,7 +23387,8 @@ const docTemplate = `{
                 "ExperimentAIGatewaySeatExclusion",
                 "ExperimentChatAdvisor",
                 "ExperimentChatVirtualDesktop",
-                "ExperimentAgentLifecycleHooks"
+                "ExperimentAgentLifecycleHooks",
+                "ExperimentChatVimNavigation"
             ]
         },
         "codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -21236,13 +21236,15 @@
 				"ai-gateway-seat-exclusion",
 				"chat-advisor",
 				"chat-virtual-desktop",
-				"agent-lifecycle-hooks"
+				"agent-lifecycle-hooks",
+				"chat-vim-navigation"
 			],
 			"x-enum-comments": {
 				"ExperimentAIGatewaySeatExclusion": "Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
 				"ExperimentAgentLifecycleHooks": "Enables chat lifecycle hook webhooks for agent chats.",
 				"ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
 				"ExperimentChatAdvisor": "Enables the advisor tool for root agent chats.",
+				"ExperimentChatVimNavigation": "Enables the opt-in vim-style keyboard navigation setting for agent chats.",
 				"ExperimentChatVirtualDesktop": "Enables virtual desktop and computer use provider for agents.",
 				"ExperimentExample": "This isn't used for anything.",
 				"ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -21268,7 +21270,8 @@
 				"Excludes AI Gateway (AI Bridge) usage from AI Governance seat consumption.",
 				"Enables the advisor tool for root agent chats.",
 				"Enables virtual desktop and computer use provider for agents.",
-				"Enables chat lifecycle hook webhooks for agent chats."
+				"Enables chat lifecycle hook webhooks for agent chats.",
+				"Enables the opt-in vim-style keyboard navigation setting for agent chats."
 			],
 			"x-enum-varnames": [
 				"ExperimentExample",
@@ -21284,7 +21287,8 @@
 				"ExperimentAIGatewaySeatExclusion",
 				"ExperimentChatAdvisor",
 				"ExperimentChatVirtualDesktop",
-				"ExperimentAgentLifecycleHooks"
+				"ExperimentAgentLifecycleHooks",
+				"ExperimentChatVimNavigation"
 			]
 		},
 		"codersdk.ExternalAPIKeyScopes": {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -5174,6 +5174,7 @@ const (
 	ExperimentChatAdvisor               Experiment = "chat-advisor"                // Enables the advisor tool for root agent chats.
 	ExperimentChatVirtualDesktop        Experiment = "chat-virtual-desktop"        // Enables virtual desktop and computer use provider for agents.
 	ExperimentAgentLifecycleHooks       Experiment = "agent-lifecycle-hooks"       // Enables chat lifecycle hook webhooks for agent chats.
+	ExperimentChatVimNavigation         Experiment = "chat-vim-navigation"         // Enables the opt-in vim-style keyboard navigation setting for agent chats.
 )
 
 func (e Experiment) DisplayName() string {
@@ -5204,6 +5205,8 @@ func (e Experiment) DisplayName() string {
 		return "Chat Virtual Desktop"
 	case ExperimentAgentLifecycleHooks:
 		return "Agent Lifecycle Hooks"
+	case ExperimentChatVimNavigation:
+		return "Chat Vim Navigation"
 	default:
 		// Split on hyphen and convert to title case
 		// e.g. "mcp-server-http" -> "Mcp Server Http"
@@ -5228,6 +5231,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentChatAdvisor,
 	ExperimentChatVirtualDesktop,
 	ExperimentAgentLifecycleHooks,
+	ExperimentChatVimNavigation,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -8856,9 +8856,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                                                                                                                                                                     |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent-lifecycle-hooks`, `ai-gateway-seat-exclusion`, `auto-fill-parameters`, `chat-advisor`, `chat-virtual-desktop`, `example`, `mcp-server-http`, `mcp-tool-search`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-capable-licensing`, `workspace-usage` |
+| Value(s)                                                                                                                                                                                                                                                                                                            |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent-lifecycle-hooks`, `ai-gateway-seat-exclusion`, `auto-fill-parameters`, `chat-advisor`, `chat-vim-navigation`, `chat-virtual-desktop`, `example`, `mcp-server-http`, `mcp-tool-search`, `nats_pubsub`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-capable-licensing`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5010,6 +5010,7 @@ export type Experiment =
 	| "agent-lifecycle-hooks"
 	| "auto-fill-parameters"
 	| "chat-advisor"
+	| "chat-vim-navigation"
 	| "chat-virtual-desktop"
 	| "example"
 	| "mcp-server-http"
@@ -5026,6 +5027,7 @@ export const Experiments: Experiment[] = [
 	"agent-lifecycle-hooks",
 	"auto-fill-parameters",
 	"chat-advisor",
+	"chat-vim-navigation",
 	"chat-virtual-desktop",
 	"example",
 	"mcp-server-http",

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPage.tsx
@@ -6,10 +6,16 @@ import {
 	updateUserChatDebugLogging,
 	userChatDebugLogging,
 } from "#/api/queries/chats";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { AgentSettingsGeneralPageView } from "./AgentSettingsGeneralPageView";
+import { VIM_NAVIGATION_EXPERIMENT } from "./hooks/useVimNavigation";
 
 const AgentSettingsGeneralPage: FC = () => {
 	const queryClient = useQueryClient();
+	const { experiments } = useDashboard();
+	const showVimNavigationSettings = experiments.includes(
+		VIM_NAVIGATION_EXPERIMENT,
+	);
 	const userPromptQuery = useQuery(chatUserCustomPrompt());
 	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
 	const saveUserPromptMutation = useMutation(
@@ -29,6 +35,7 @@ const AgentSettingsGeneralPage: FC = () => {
 			onSaveUserDebugLogging={saveUserDebugLoggingMutation.mutate}
 			isSavingUserDebugLogging={saveUserDebugLoggingMutation.isPending}
 			isSaveUserDebugLoggingError={saveUserDebugLoggingMutation.isError}
+			showVimNavigationSettings={showVimNavigationSettings}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
@@ -30,6 +30,7 @@ const baseArgs: AgentSettingsGeneralPageViewProps = {
 	onSaveUserDebugLogging: fn(),
 	isSavingUserDebugLogging: false,
 	isSaveUserDebugLoggingError: false,
+	showVimNavigationSettings: false,
 };
 
 const meta = {
@@ -153,14 +154,17 @@ export const TogglesSendShortcut: Story = {
 };
 
 export const VimNavigationCtrlModifier: Story = {
+	args: { showVimNavigationSettings: true },
 	beforeEach: withVimNavigationPreference("ctrl"),
 };
 
 export const VimNavigationAltModifier: Story = {
+	args: { showVimNavigationSettings: true },
 	beforeEach: withVimNavigationPreference("alt"),
 };
 
 export const VimNavigationMetaModifier: Story = {
+	args: { showVimNavigationSettings: true },
 	beforeEach: withVimNavigationPreference("meta"),
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
@@ -2,11 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
 import type { AgentChatSendShortcut } from "#/api/typesGenerated";
+import { withVimNavigationPreference } from "#/testHelpers/vimNavigation";
 import {
 	AgentSettingsGeneralPageView,
 	type AgentSettingsGeneralPageViewProps,
 } from "./AgentSettingsGeneralPageView";
-import { VIM_NAVIGATION_STORAGE_KEY } from "./hooks/useVimNavigation";
 
 const preferencesData = {
 	thinking_display_mode: "auto" as const,
@@ -152,24 +152,16 @@ export const TogglesSendShortcut: Story = {
 	},
 };
 
-export const TogglesVimNavigation: Story = {
-	beforeEach: () => {
-		localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
-		return () => localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const toggle = await canvas.findByRole("switch", {
-			name: "Vim-style chat navigation",
-		});
+export const VimNavigationCtrlModifier: Story = {
+	beforeEach: withVimNavigationPreference("ctrl"),
+};
 
-		expect(toggle).not.toBeChecked();
-		await userEvent.click(toggle);
-		await waitFor(() => {
-			expect(toggle).toBeChecked();
-			expect(localStorage.getItem(VIM_NAVIGATION_STORAGE_KEY)).toBe("true");
-		});
-	},
+export const VimNavigationAltModifier: Story = {
+	beforeEach: withVimNavigationPreference("alt"),
+};
+
+export const VimNavigationMetaModifier: Story = {
+	beforeEach: withVimNavigationPreference("meta"),
 };
 
 export const ShowsChatDebugLoggingToggle: Story = {

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
@@ -6,6 +6,7 @@ import {
 	AgentSettingsGeneralPageView,
 	type AgentSettingsGeneralPageViewProps,
 } from "./AgentSettingsGeneralPageView";
+import { VIM_NAVIGATION_STORAGE_KEY } from "./hooks/useVimNavigation";
 
 const preferencesData = {
 	thinking_display_mode: "auto" as const,
@@ -147,6 +148,26 @@ export const TogglesSendShortcut: Story = {
 				agent_chat_send_shortcut: "modifier_enter",
 			});
 			expect(toggle).toBeChecked();
+		});
+	},
+};
+
+export const TogglesVimNavigation: Story = {
+	beforeEach: () => {
+		localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
+		return () => localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = await canvas.findByRole("switch", {
+			name: "Vim-style chat navigation",
+		});
+
+		expect(toggle).not.toBeChecked();
+		await userEvent.click(toggle);
+		await waitFor(() => {
+			expect(toggle).toBeChecked();
+			expect(localStorage.getItem(VIM_NAVIGATION_STORAGE_KEY)).toBe("true");
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.tsx
@@ -3,6 +3,7 @@ import type { UseMutateFunction } from "react-query";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ChatFullWidthSettings } from "./components/ChatFullWidthSettings";
 import { ChatSendShortcutSettings } from "./components/ChatSendShortcutSettings";
+import { ChatVimNavigationSettings } from "./components/ChatVimNavigationSettings";
 import {
 	CodeDiffDisplaySettings,
 	ShellToolDisplaySettings,
@@ -59,7 +60,13 @@ export const AgentSettingsGeneralPageView: FC<
 				isAnyPromptSaving={isSavingUserPrompt}
 			/>
 			<ChatFullWidthSettings />
-			<ChatSendShortcutSettings />
+			<div className="flex flex-col gap-4">
+				<h3 className="m-0 text-sm font-semibold text-content-primary">
+					Keyboard shortcuts
+				</h3>
+				<ChatSendShortcutSettings />
+				<ChatVimNavigationSettings />
+			</div>
 			<ThinkingDisplaySettings />
 			<ShellToolDisplaySettings />
 			<CodeDiffDisplaySettings />

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.tsx
@@ -32,6 +32,7 @@ export interface AgentSettingsGeneralPageViewProps {
 	>;
 	isSavingUserDebugLogging: boolean;
 	isSaveUserDebugLoggingError: boolean;
+	showVimNavigationSettings: boolean;
 }
 
 export const AgentSettingsGeneralPageView: FC<
@@ -45,6 +46,7 @@ export const AgentSettingsGeneralPageView: FC<
 	onSaveUserDebugLogging,
 	isSavingUserDebugLogging,
 	isSaveUserDebugLoggingError,
+	showVimNavigationSettings,
 }) => {
 	return (
 		<div className="flex flex-col gap-8">
@@ -65,7 +67,7 @@ export const AgentSettingsGeneralPageView: FC<
 					Keyboard shortcuts
 				</h3>
 				<ChatSendShortcutSettings />
-				<ChatVimNavigationSettings />
+				{showVimNavigationSettings && <ChatVimNavigationSettings />}
 			</div>
 			<ThinkingDisplaySettings />
 			<ShellToolDisplaySettings />

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -25,6 +25,7 @@ import {
 	cancelChatListRefetches,
 	cancelLoadedChatEntityRefetch,
 	chatEntityKey,
+	chat as chatQueryOptions,
 	infiniteChats,
 	invalidateChatCostTree,
 	invalidateChatDiffContents,
@@ -79,6 +80,7 @@ import { ResizableChatsSidebarFrame } from "./components/ChatsSidebar/ResizableC
 import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
+import { useVimNavigation } from "./hooks/useVimNavigation";
 import { getAgentSidebarFilters } from "./utils/agentSidebarFilters";
 import {
 	archiveChatAndDeleteWorkspace,
@@ -680,9 +682,36 @@ const AgentsPageLayout: FC = () => {
 		});
 	}, [queryClient]);
 
+	// State for the shared rename-chat dialog. Lifted here so both the
+	// sidebar menu and the chat top bar open the same dialog instance.
+	const [chatPendingRename, setChatPendingRename] =
+		useState<TypesGen.Chat | null>(null);
+
+	const [vimNavigationEnabled] = useVimNavigation();
 	useAgentsPageKeybindings({
 		onNewAgent: handleNewAgent,
 		onToggleSearch: () => setIsSearchDialogOpen((open) => !open),
+		onRenameActiveChat: () => {
+			if (!agentId) {
+				return;
+			}
+			// The active chat may be a child embedded in its root's
+			// `children`, or absent from the paginated list entirely
+			// (filtered out or not yet loaded), in which case the
+			// per-chat query cache populated by the open chat page is
+			// used.
+			const activeChat =
+				chatList
+					.flatMap((chat) => [chat, ...(chat.children ?? [])])
+					.find((chat) => chat.id === agentId) ??
+				queryClient.getQueryData<TypesGen.Chat>(
+					chatQueryOptions(agentId).queryKey,
+				);
+			if (activeChat) {
+				setChatPendingRename(activeChat);
+			}
+		},
+		vimNavigationEnabled,
 	});
 
 	// Fetch workspace name for the confirmation dialog. Only
@@ -714,11 +743,6 @@ const AgentsPageLayout: FC = () => {
 			error.message,
 		]),
 	);
-
-	// State for the shared rename-chat dialog. Lifted here so both the
-	// sidebar menu and the chat top bar open the same dialog instance.
-	const [chatPendingRename, setChatPendingRename] =
-		useState<TypesGen.Chat | null>(null);
 
 	const outletContextValue: AgentsPageOutletContext = {
 		chatErrorReasons,

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -80,7 +80,10 @@ import { ResizableChatsSidebarFrame } from "./components/ChatsSidebar/ResizableC
 import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
-import { useVimNavigation } from "./hooks/useVimNavigation";
+import {
+	useVimNavigationModifier,
+	useVimNavigationSetting,
+} from "./hooks/useVimNavigation";
 import { getAgentSidebarFilters } from "./utils/agentSidebarFilters";
 import {
 	archiveChatAndDeleteWorkspace,
@@ -687,7 +690,8 @@ const AgentsPageLayout: FC = () => {
 	const [chatPendingRename, setChatPendingRename] =
 		useState<TypesGen.Chat | null>(null);
 
-	const [vimNavigationEnabled] = useVimNavigation();
+	const [vimNavigationEnabled] = useVimNavigationSetting();
+	const [vimModifier] = useVimNavigationModifier();
 	useAgentsPageKeybindings({
 		onNewAgent: handleNewAgent,
 		onToggleSearch: () => setIsSearchDialogOpen((open) => !open),
@@ -712,6 +716,7 @@ const AgentsPageLayout: FC = () => {
 			}
 		},
 		vimNavigationEnabled,
+		vimModifier,
 	});
 
 	// Fetch workspace name for the confirmation dialog. Only

--- a/site/src/pages/AgentsPage/AgentsPageLayout.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.tsx
@@ -81,8 +81,8 @@ import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import { useOrganizationChatModels } from "./hooks/useOrganizationChatModels";
 import {
+	useVimNavigationActive,
 	useVimNavigationModifier,
-	useVimNavigationSetting,
 } from "./hooks/useVimNavigation";
 import { getAgentSidebarFilters } from "./utils/agentSidebarFilters";
 import {
@@ -690,7 +690,7 @@ const AgentsPageLayout: FC = () => {
 	const [chatPendingRename, setChatPendingRename] =
 		useState<TypesGen.Chat | null>(null);
 
-	const [vimNavigationEnabled] = useVimNavigationSetting();
+	const vimNavigationEnabled = useVimNavigationActive();
 	const [vimModifier] = useVimNavigationModifier();
 	useAgentsPageKeybindings({
 		onNewAgent: handleNewAgent,

--- a/site/src/pages/AgentsPage/components/ChatSendShortcutSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSendShortcutSettings.tsx
@@ -21,9 +21,6 @@ export const ChatSendShortcutSettings: FC = () => {
 
 	return (
 		<div className="flex flex-col gap-2">
-			<h3 className="m-0 text-sm font-semibold text-content-primary">
-				Keyboard shortcuts
-			</h3>
 			<div className="flex items-center justify-between gap-4">
 				<p
 					id={descriptionId}

--- a/site/src/pages/AgentsPage/components/ChatVimNavigationSettings.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVimNavigationSettings.test.tsx
@@ -1,0 +1,49 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderComponent } from "#/testHelpers/renderHelpers";
+import { isMac } from "#/utils/platform";
+import {
+	VIM_NAVIGATION_MODIFIER_STORAGE_KEY,
+	VIM_NAVIGATION_STORAGE_KEY,
+} from "../hooks/useVimNavigation";
+import { ChatVimNavigationSettings } from "./ChatVimNavigationSettings";
+
+vi.mock("#/utils/platform", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/utils/platform")>()),
+	isMac: vi.fn(),
+}));
+
+const isMacMock = vi.mocked(isMac);
+
+describe("ChatVimNavigationSettings", () => {
+	afterEach(() => {
+		localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
+		localStorage.removeItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY);
+	});
+
+	it("stores the toggle state", async () => {
+		isMacMock.mockReturnValue(false);
+		renderComponent(<ChatVimNavigationSettings />);
+
+		await userEvent.click(
+			screen.getByRole("switch", { name: "Vim-style chat navigation" }),
+		);
+
+		expect(localStorage.getItem(VIM_NAVIGATION_STORAGE_KEY)).toBe("true");
+	});
+
+	it("stores the selected modifier", async () => {
+		isMacMock.mockReturnValue(false);
+		renderComponent(<ChatVimNavigationSettings />);
+
+		await userEvent.click(
+			screen.getByRole("combobox", { name: "Vim navigation modifier" }),
+		);
+		await userEvent.click(await screen.findByRole("option", { name: "Alt" }));
+
+		expect(localStorage.getItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY)).toBe(
+			"alt",
+		);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatVimNavigationSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVimNavigationSettings.tsx
@@ -1,0 +1,30 @@
+import { type FC, useId } from "react";
+import { Switch } from "#/components/Switch/Switch";
+import { useVimNavigation } from "../hooks/useVimNavigation";
+
+export const ChatVimNavigationSettings: FC = () => {
+	const [enabled, setEnabled] = useVimNavigation();
+	const descriptionId = useId();
+
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<p
+				id={descriptionId}
+				className="m-0 flex-1 text-xs text-content-secondary"
+			>
+				Vim-style navigation. Cmd/Ctrl+J and Cmd/Ctrl+K select the next and
+				previous chat, Cmd/Ctrl+Shift+J and Cmd/Ctrl+Shift+K jump to the last
+				and first chat, Cmd/Ctrl+Shift+O starts a new chat, Cmd/Ctrl+Shift+E
+				renames the current chat, and Escape on a sidebar chat returns focus to
+				the message input. Search moves from Cmd/Ctrl+K to Cmd/Ctrl+/. These
+				override browser shortcuts on the same keys.
+			</p>
+			<Switch
+				checked={enabled}
+				onCheckedChange={(checked) => setEnabled(Boolean(checked))}
+				aria-label="Vim-style chat navigation"
+				aria-describedby={descriptionId}
+			/>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatVimNavigationSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ChatVimNavigationSettings.tsx
@@ -1,30 +1,86 @@
 import { type FC, useId } from "react";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "#/components/Select/Select";
 import { Switch } from "#/components/Switch/Switch";
-import { useVimNavigation } from "../hooks/useVimNavigation";
+import {
+	useVimNavigationModifier,
+	useVimNavigationSetting,
+} from "../hooks/useVimNavigation";
+import {
+	getDefaultVimModifier,
+	getModifierLabel,
+	isVimModifier,
+	VIM_MODIFIERS,
+} from "../utils/keyboardShortcuts";
 
 export const ChatVimNavigationSettings: FC = () => {
-	const [enabled, setEnabled] = useVimNavigation();
+	const [enabled, setEnabled] = useVimNavigationSetting();
+	const [modifier, setModifier] = useVimNavigationModifier();
 	const descriptionId = useId();
+	const modifierDescriptionId = useId();
+	const mod = getModifierLabel(modifier);
+	const platformMod = getDefaultVimModifier();
+	const searchSentence =
+		modifier === platformMod
+			? `Search moves from ${mod}+K to ${mod}+/.`
+			: `Search is also available on ${mod}+/.`;
 
 	return (
-		<div className="flex items-center justify-between gap-4">
-			<p
-				id={descriptionId}
-				className="m-0 flex-1 text-xs text-content-secondary"
-			>
-				Vim-style navigation. Cmd/Ctrl+J and Cmd/Ctrl+K select the next and
-				previous chat, Cmd/Ctrl+Shift+J and Cmd/Ctrl+Shift+K jump to the last
-				and first chat, Cmd/Ctrl+Shift+O starts a new chat, Cmd/Ctrl+Shift+E
-				renames the current chat, and Escape on a sidebar chat returns focus to
-				the message input. Search moves from Cmd/Ctrl+K to Cmd/Ctrl+/. These
-				override browser shortcuts on the same keys.
-			</p>
-			<Switch
-				checked={enabled}
-				onCheckedChange={(checked) => setEnabled(Boolean(checked))}
-				aria-label="Vim-style chat navigation"
-				aria-describedby={descriptionId}
-			/>
+		<div className="flex flex-col gap-4">
+			<div className="flex items-center justify-between gap-4">
+				<p
+					id={descriptionId}
+					className="m-0 flex-1 text-xs text-content-secondary"
+				>
+					Vim-style navigation. {mod}+J and {mod}+K select the next and previous
+					chat, {mod}+Shift+J and {mod}+Shift+K jump to the last and first chat,{" "}
+					{mod}+Shift+O starts a new chat, {mod}+Shift+E renames the current
+					chat, and Escape on a sidebar chat returns focus to the message input.{" "}
+					{searchSentence} These override browser shortcuts on the same keys.
+				</p>
+				<Switch
+					checked={enabled}
+					onCheckedChange={(checked) => setEnabled(Boolean(checked))}
+					aria-label="Vim-style chat navigation"
+					aria-describedby={descriptionId}
+				/>
+			</div>
+			<div className="flex items-center justify-between gap-4">
+				<p
+					id={modifierDescriptionId}
+					className="m-0 flex-1 text-xs text-content-secondary"
+				>
+					Modifier key held for the vim-style navigation shortcuts.
+				</p>
+				<Select
+					value={modifier}
+					onValueChange={(value: string) => {
+						if (isVimModifier(value)) {
+							setModifier(value);
+						}
+					}}
+				>
+					<SelectTrigger
+						className="w-44 shrink-0"
+						aria-label="Vim navigation modifier"
+						aria-describedby={modifierDescriptionId}
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{VIM_MODIFIERS.map((value) => (
+							<SelectItem key={value} value={value}>
+								{getModifierLabel(value)}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -20,6 +20,7 @@ import {
 	withAuthProvider,
 	withDashboardProvider,
 } from "#/testHelpers/storybook";
+import { withVimNavigationPreference } from "#/testHelpers/vimNavigation";
 import { useAgentsPageKeybindings } from "../../hooks/useAgentsPageKeybindings";
 import { DEFAULT_AGENT_SIDEBAR_FILTERS as defaultSidebarFilters } from "../../utils/agentSidebarFilters";
 import { ChatsSidebar } from "./ChatsSidebar";
@@ -133,6 +134,8 @@ const ChatsSidebarWithKeybindings = (
 	useAgentsPageKeybindings({
 		onNewAgent: args.onBeforeNewAgent ?? (() => {}),
 		onToggleSearch: () => handleSearchDialogOpenChange(!isSearchDialogOpen),
+		vimNavigationEnabled: false,
+		vimModifier: "ctrl",
 	});
 
 	return (
@@ -2285,4 +2288,36 @@ export const PreservesArchivedFilterOnSettingsNavigation: Story = {
 			expect(fromValue).toContain("archived=archived");
 		});
 	},
+};
+
+// The search shortcut hint is only shown while the button is hovered or
+// focused, so the play function focuses it for the screenshot.
+const focusSearchButton = async ({
+	canvasElement,
+}: {
+	canvasElement: HTMLElement;
+}) => {
+	const canvas = within(canvasElement);
+	const searchButton = await canvas.findByRole("button", {
+		name: "Search chats",
+	});
+	searchButton.focus();
+};
+
+export const VimSearchHintCtrlModifier: Story = {
+	args: { chats: sectionHeaderChats },
+	beforeEach: withVimNavigationPreference("ctrl"),
+	play: focusSearchButton,
+};
+
+export const VimSearchHintAltModifier: Story = {
+	args: { chats: sectionHeaderChats },
+	beforeEach: withVimNavigationPreference("alt"),
+	play: focusSearchButton,
+};
+
+export const VimSearchHintMetaModifier: Story = {
+	args: { chats: sectionHeaderChats },
+	beforeEach: withVimNavigationPreference("meta"),
+	play: focusSearchButton,
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -22,6 +22,7 @@ import {
 } from "#/testHelpers/storybook";
 import { withVimNavigationPreference } from "#/testHelpers/vimNavigation";
 import { useAgentsPageKeybindings } from "../../hooks/useAgentsPageKeybindings";
+import { VIM_NAVIGATION_EXPERIMENT } from "../../hooks/useVimNavigation";
 import { DEFAULT_AGENT_SIDEBAR_FILTERS as defaultSidebarFilters } from "../../utils/agentSidebarFilters";
 import { ChatsSidebar } from "./ChatsSidebar";
 
@@ -2306,18 +2307,21 @@ const focusSearchButton = async ({
 
 export const VimSearchHintCtrlModifier: Story = {
 	args: { chats: sectionHeaderChats },
+	parameters: { experiments: [VIM_NAVIGATION_EXPERIMENT] },
 	beforeEach: withVimNavigationPreference("ctrl"),
 	play: focusSearchButton,
 };
 
 export const VimSearchHintAltModifier: Story = {
 	args: { chats: sectionHeaderChats },
+	parameters: { experiments: [VIM_NAVIGATION_EXPERIMENT] },
 	beforeEach: withVimNavigationPreference("alt"),
 	play: focusSearchButton,
 };
 
 export const VimSearchHintMetaModifier: Story = {
 	args: { chats: sectionHeaderChats },
+	parameters: { experiments: [VIM_NAVIGATION_EXPERIMENT] },
 	beforeEach: withVimNavigationPreference("meta"),
 	play: focusSearchButton,
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.test.tsx
@@ -2,7 +2,7 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { FC, PropsWithChildren } from "react";
 import { QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { Chat } from "#/api/typesGenerated";
@@ -20,6 +20,11 @@ import {
 } from "#/testHelpers/entities";
 import { createTestQueryClient } from "#/testHelpers/renderHelpers";
 import themes, { DEFAULT_THEME } from "#/theme";
+import {
+	VIM_NAVIGATION_EXPERIMENT,
+	VIM_NAVIGATION_MODIFIER_STORAGE_KEY,
+	VIM_NAVIGATION_STORAGE_KEY,
+} from "../../hooks/useVimNavigation";
 import type { AgentSidebarFilters } from "../../utils/agentSidebarFilters";
 import { ChatsSidebar } from "./ChatsSidebar";
 
@@ -76,14 +81,18 @@ const dashboardValue = {
 	canViewOrganizationSettings: false,
 };
 
-const Wrapper: FC<PropsWithChildren> = ({ children }) => {
+const Wrapper: FC<
+	PropsWithChildren<{ experiments?: TypesGen.Experiment[] }>
+> = ({ children, experiments = [] }) => {
 	const queryClient = createTestQueryClient();
 	return (
 		<QueryClientProvider client={queryClient}>
 			<ThemeOverride theme={themes[DEFAULT_THEME]}>
 				<TooltipProvider>
 					<MemoryRouter initialEntries={["/agents"]}>
-						<DashboardContext.Provider value={dashboardValue}>
+						<DashboardContext.Provider
+							value={{ ...dashboardValue, experiments }}
+						>
 							{children}
 						</DashboardContext.Provider>
 					</MemoryRouter>
@@ -664,5 +673,53 @@ describe("ChatsSidebar subtitles", () => {
 		);
 
 		expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+	});
+});
+
+describe("ChatsSidebar vim navigation experiment", () => {
+	const chats = [
+		buildChat({ id: "chat-1", title: "Chat One" }),
+		buildChat({ id: "chat-2", title: "Chat Two" }),
+	];
+
+	const LocationProbe: FC = () => {
+		const location = useLocation();
+		return <div data-testid="location">{location.pathname}</div>;
+	};
+
+	const renderSidebar = (experiments: TypesGen.Experiment[]) =>
+		render(
+			<Wrapper experiments={experiments}>
+				<ChatsSidebar {...defaultProps} chats={chats} />
+				<Routes>
+					<Route path="*" element={<LocationProbe />} />
+				</Routes>
+			</Wrapper>,
+		);
+
+	beforeEach(() => {
+		localStorage.setItem(VIM_NAVIGATION_STORAGE_KEY, "true");
+		localStorage.setItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY, "ctrl");
+	});
+
+	afterEach(() => {
+		localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
+		localStorage.removeItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY);
+	});
+
+	it("ignores the stored setting while the experiment is off", async () => {
+		renderSidebar([]);
+
+		await userEvent.keyboard("{Control>}j{/Control}");
+
+		expect(screen.getByTestId("location")).toHaveTextContent("/agents");
+	});
+
+	it("navigates to the next chat while the experiment is on", async () => {
+		renderSidebar([VIM_NAVIGATION_EXPERIMENT]);
+
+		await userEvent.keyboard("{Control>}j{/Control}");
+
+		expect(screen.getByTestId("location")).toHaveTextContent("/agents/chat-1");
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -22,7 +22,7 @@ import {
 	SquarePenIcon,
 } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
-import { Link, type Location, NavLink } from "react-router";
+import { Link, type Location, NavLink, useNavigate } from "react-router";
 import type { Chat, ChatModel } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
@@ -31,6 +31,8 @@ import { Kbd, KbdGroup } from "#/components/Kbd/Kbd";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { getOSKey } from "#/utils/platform";
+import { useChatVimNavigation } from "../../../hooks/useChatVimNavigation";
+import { useVimNavigation } from "../../../hooks/useVimNavigation";
 import {
 	AGENT_CHAT_STATUS_ORDER,
 	type AgentSidebarFilters,
@@ -51,6 +53,7 @@ import {
 	collectVisibleChatIDs,
 } from "../tree/chatTree";
 import { SortableChatTreeNode } from "../tree/SortableChatTreeNode";
+import { getVisibleChatOrder } from "../tree/visibleChatOrder";
 import {
 	ChatSectionHeader,
 	getSectionToggleTestId,
@@ -131,6 +134,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 	location,
 	currentUserId,
 }) => {
+	const navigate = useNavigate();
 	const locationSearch = normalizeLocationSearch(location.search);
 	const [expandedById, setExpandedById] = useState<Record<string, boolean>>({});
 	const [collapsedSections, setCollapsedSections] = useState<
@@ -332,6 +336,35 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 					),
 				}))
 	).filter((section) => section.chats.length > 0);
+
+	const [vimNavigationEnabled] = useVimNavigation();
+	const chatOrder = getVisibleChatOrder({
+		sections: [
+			{ key: PINNED_SECTION_KEY, chats: sortedPinnedChats },
+			{ key: SHARED_WITH_YOU_SECTION_KEY, chats: sharedWithYouChats },
+			...chatSections,
+		],
+		collapsedSections,
+		expandedById,
+		tree: chatTree,
+	});
+	useChatVimNavigation({
+		// The list is not rendered while loading, on error, or on
+		// settings routes, so navigation would target rows that are
+		// not on screen.
+		enabled:
+			vimNavigationEnabled && !isSettingsPanel && !isLoading && !loadError,
+		visibleChatIds: chatOrder.visible,
+		allChatIds: chatOrder.all,
+		activeChatId,
+		onSelectChat: (chatId) => {
+			navigate({ pathname: `/agents/${chatId}`, search: locationSearch });
+			document
+				.querySelector(`[data-testid="agents-tree-node-${chatId}"]`)
+				?.scrollIntoView({ block: "nearest" });
+		},
+	});
+	const searchShortcutKey = vimNavigationEnabled ? "/" : "K";
 	const isShowingEmptyState = visibleRootIDs.length === 0;
 	const isViewingArchived = sidebarFilters.archiveStatus === "archived";
 	const chatsHeadingLabel = isViewingArchived ? "Archived chats" : "Chats";
@@ -418,7 +451,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 						trailing={
 							<KbdGroup className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
 								<Kbd>{getOSKey()}</Kbd>
-								<Kbd>K</Kbd>
+								<Kbd>{searchShortcutKey}</Kbd>
 							</KbdGroup>
 						}
 					/>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -32,12 +32,16 @@ import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { getOSKey } from "#/utils/platform";
 import { useChatVimNavigation } from "../../../hooks/useChatVimNavigation";
-import { useVimNavigation } from "../../../hooks/useVimNavigation";
+import {
+	useVimNavigationModifier,
+	useVimNavigationSetting,
+} from "../../../hooks/useVimNavigation";
 import {
 	AGENT_CHAT_STATUS_ORDER,
 	type AgentSidebarFilters,
 	DEFAULT_AGENT_SIDEBAR_FILTERS,
 } from "../../../utils/agentSidebarFilters";
+import { getModifierKeycap } from "../../../utils/keyboardShortcuts";
 import { getTimeGroup, TIME_GROUPS } from "../../../utils/timeGroups";
 import { FilterPopover } from "../filters/FilterPopover";
 import { normalizeLocationSearch } from "../locationSearch";
@@ -337,7 +341,8 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 				}))
 	).filter((section) => section.chats.length > 0);
 
-	const [vimNavigationEnabled] = useVimNavigation();
+	const [vimNavigationEnabled] = useVimNavigationSetting();
+	const [vimModifier] = useVimNavigationModifier();
 	const chatOrder = getVisibleChatOrder({
 		sections: [
 			{ key: PINNED_SECTION_KEY, chats: sortedPinnedChats },
@@ -354,6 +359,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 		// not on screen.
 		enabled:
 			vimNavigationEnabled && !isSettingsPanel && !isLoading && !loadError,
+		modifier: vimModifier,
 		visibleChatIds: chatOrder.visible,
 		allChatIds: chatOrder.all,
 		activeChatId,
@@ -364,7 +370,9 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 				?.scrollIntoView({ block: "nearest" });
 		},
 	});
-	const searchShortcutKey = vimNavigationEnabled ? "/" : "K";
+	const searchShortcut = vimNavigationEnabled
+		? { modifier: getModifierKeycap(vimModifier), key: "/" }
+		: { modifier: getOSKey(), key: "K" };
 	const isShowingEmptyState = visibleRootIDs.length === 0;
 	const isViewingArchived = sidebarFilters.archiveStatus === "archived";
 	const chatsHeadingLabel = isViewingArchived ? "Archived chats" : "Chats";
@@ -450,8 +458,8 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 						className="group focus-visible:bg-surface-tertiary/50 focus-visible:text-content-primary"
 						trailing={
 							<KbdGroup className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
-								<Kbd>{getOSKey()}</Kbd>
-								<Kbd>{searchShortcutKey}</Kbd>
+								<Kbd>{searchShortcut.modifier}</Kbd>
+								<Kbd>{searchShortcut.key}</Kbd>
 							</KbdGroup>
 						}
 					/>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -33,8 +33,8 @@ import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { getOSKey } from "#/utils/platform";
 import { useChatVimNavigation } from "../../../hooks/useChatVimNavigation";
 import {
+	useVimNavigationActive,
 	useVimNavigationModifier,
-	useVimNavigationSetting,
 } from "../../../hooks/useVimNavigation";
 import {
 	AGENT_CHAT_STATUS_ORDER,
@@ -341,7 +341,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 				}))
 	).filter((section) => section.chats.length > 0);
 
-	const [vimNavigationEnabled] = useVimNavigationSetting();
+	const vimNavigationEnabled = useVimNavigationActive();
 	const [vimModifier] = useVimNavigationModifier();
 	const chatOrder = getVisibleChatOrder({
 		sections: [

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/visibleChatOrder.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/visibleChatOrder.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Chat } from "#/api/typesGenerated";
+import { buildChatTree } from "./chatTree";
+import { getVisibleChatOrder } from "./visibleChatOrder";
+
+const chat = (id: string, children: Chat[] = []): Chat =>
+	({ id, title: id, children }) as unknown as Chat;
+
+describe("getVisibleChatOrder", () => {
+	const child = chat("a1");
+	const a = chat("a", [child]);
+	const b = chat("b");
+	const c = chat("c");
+	const tree = buildChatTree([a, b, c]);
+	const sections = [
+		{ key: "Pinned", chats: [c] },
+		{ key: "Today", chats: [a, b] },
+	];
+
+	it("lists sections in order and skips collapsed children", () => {
+		expect(
+			getVisibleChatOrder({
+				sections,
+				collapsedSections: {},
+				expandedById: {},
+				tree,
+			}),
+		).toEqual({ visible: ["c", "a", "b"], all: ["c", "a", "a1", "b"] });
+	});
+
+	it("includes children of expanded roots after the root", () => {
+		expect(
+			getVisibleChatOrder({
+				sections,
+				collapsedSections: {},
+				expandedById: { a: true },
+				tree,
+			}).visible,
+		).toEqual(["c", "a", "a1", "b"]);
+	});
+
+	it("omits chats in collapsed sections", () => {
+		expect(
+			getVisibleChatOrder({
+				sections,
+				collapsedSections: { Pinned: true },
+				expandedById: {},
+				tree,
+			}),
+		).toEqual({ visible: ["a", "b"], all: ["c", "a", "a1", "b"] });
+	});
+
+	it("omits children of an expanded root inside a collapsed section", () => {
+		expect(
+			getVisibleChatOrder({
+				sections,
+				collapsedSections: { Today: true },
+				expandedById: { a: true },
+				tree,
+			}).visible,
+		).toEqual(["c"]);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/visibleChatOrder.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/visibleChatOrder.ts
@@ -1,0 +1,46 @@
+import type { Chat } from "#/api/typesGenerated";
+import type { ChatTree } from "./chatTree";
+
+interface VisibleChatSection {
+	readonly key: string;
+	readonly chats: readonly Chat[];
+}
+
+/**
+ * Returns chat IDs in the order they appear in the sidebar.
+ *
+ * `visible` omits chats in collapsed sections and children of roots
+ * that are not expanded. `all` keeps every chat in the same order,
+ * regardless of collapse state.
+ */
+export const getVisibleChatOrder = ({
+	sections,
+	collapsedSections,
+	expandedById,
+	tree,
+}: {
+	readonly sections: readonly VisibleChatSection[];
+	readonly collapsedSections: Record<string, boolean>;
+	readonly expandedById: Record<string, boolean>;
+	readonly tree: ChatTree;
+}): { visible: string[]; all: string[] } => {
+	const visible: string[] = [];
+	const all: string[] = [];
+	for (const section of sections) {
+		const sectionVisible = !collapsedSections[section.key];
+		for (const chat of section.chats) {
+			all.push(chat.id);
+			if (sectionVisible) {
+				visible.push(chat.id);
+			}
+			const childrenVisible = sectionVisible && Boolean(expandedById[chat.id]);
+			for (const childID of tree.childrenById.get(chat.id) ?? []) {
+				all.push(childID);
+				if (childrenVisible) {
+					visible.push(childID);
+				}
+			}
+		}
+	}
+	return { visible, all };
+};

--- a/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.test.ts
@@ -113,4 +113,92 @@ describe("useAgentsPageKeybindings", () => {
 
 		input.remove();
 	});
+
+	it("ignores Ctrl+/, Ctrl+Shift+O, and Ctrl+Shift+E when vim navigation is off", () => {
+		isMacMock.mockReturnValue(false);
+		const onNewAgent = vi.fn();
+		const onToggleSearch = vi.fn();
+		const onRenameActiveChat = vi.fn();
+
+		renderHook(() =>
+			useAgentsPageKeybindings({
+				onNewAgent,
+				onToggleSearch,
+				onRenameActiveChat,
+			}),
+		);
+
+		const slashEvent = dispatchKeyDown("/", { ctrlKey: true });
+		const newEvent = dispatchKeyDown("O", { ctrlKey: true, shiftKey: true });
+		const renameEvent = dispatchKeyDown("E", { ctrlKey: true, shiftKey: true });
+
+		expect(slashEvent.defaultPrevented).toBe(false);
+		expect(newEvent.defaultPrevented).toBe(false);
+		expect(renameEvent.defaultPrevented).toBe(false);
+		expect(onNewAgent).not.toHaveBeenCalled();
+		expect(onToggleSearch).not.toHaveBeenCalled();
+		expect(onRenameActiveChat).not.toHaveBeenCalled();
+	});
+
+	it("moves search from Ctrl+K to Ctrl+/ when vim navigation is on", () => {
+		isMacMock.mockReturnValue(false);
+		const onToggleSearch = vi.fn();
+
+		renderHook(() =>
+			useAgentsPageKeybindings({
+				onNewAgent: vi.fn(),
+				onToggleSearch,
+				vimNavigationEnabled: true,
+			}),
+		);
+
+		const kEvent = dispatchKeyDown("k", { ctrlKey: true });
+		const slashEvent = dispatchKeyDown("/", { ctrlKey: true });
+		// Layouts where "/" is a shifted key report shiftKey alongside it.
+		const shiftedSlashEvent = dispatchKeyDown("/", {
+			ctrlKey: true,
+			shiftKey: true,
+		});
+
+		expect(kEvent.defaultPrevented).toBe(false);
+		expect(slashEvent.defaultPrevented).toBe(true);
+		expect(shiftedSlashEvent.defaultPrevented).toBe(true);
+		expect(onToggleSearch).toHaveBeenCalledTimes(2);
+	});
+
+	it("renames the active chat with Ctrl+Shift+E when vim navigation is on", () => {
+		isMacMock.mockReturnValue(false);
+		const onNewAgent = vi.fn();
+		const onRenameActiveChat = vi.fn();
+
+		renderHook(() =>
+			useAgentsPageKeybindings({
+				onNewAgent,
+				onRenameActiveChat,
+				vimNavigationEnabled: true,
+			}),
+		);
+
+		const renameEvent = dispatchKeyDown("E", { ctrlKey: true, shiftKey: true });
+		const shiftNEvent = dispatchKeyDown("N", { ctrlKey: true, shiftKey: true });
+
+		expect(renameEvent.defaultPrevented).toBe(true);
+		expect(onRenameActiveChat).toHaveBeenCalledTimes(1);
+		expect(shiftNEvent.defaultPrevented).toBe(false);
+		expect(onNewAgent).not.toHaveBeenCalled();
+	});
+
+	it("creates a new agent with Ctrl+Shift+O when vim navigation is on", () => {
+		isMacMock.mockReturnValue(false);
+		const onNewAgent = vi.fn();
+
+		renderHook(() =>
+			useAgentsPageKeybindings({ onNewAgent, vimNavigationEnabled: true }),
+		);
+
+		const event = dispatchKeyDown("O", { ctrlKey: true, shiftKey: true });
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(onNewAgent).toHaveBeenCalledTimes(1);
+	});
 });

--- a/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.test.ts
@@ -3,11 +3,26 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { isMac } from "#/utils/platform";
 import { useAgentsPageKeybindings } from "./useAgentsPageKeybindings";
 
-vi.mock("#/utils/platform", () => ({
+vi.mock("#/utils/platform", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/utils/platform")>()),
 	isMac: vi.fn(),
 }));
 
 const isMacMock = vi.mocked(isMac);
+
+type Options = Parameters<typeof useAgentsPageKeybindings>[0];
+
+const renderKeybindings = (
+	options: Omit<Options, "vimNavigationEnabled" | "vimModifier"> &
+		Partial<Pick<Options, "vimNavigationEnabled" | "vimModifier">>,
+) =>
+	renderHook(() =>
+		useAgentsPageKeybindings({
+			vimNavigationEnabled: false,
+			vimModifier: "ctrl",
+			...options,
+		}),
+	);
 
 const dispatchKeyDown = (
 	key: string,
@@ -34,12 +49,10 @@ describe("useAgentsPageKeybindings", () => {
 		const onNewAgent = vi.fn();
 		const onToggleSearch = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent,
-				onToggleSearch,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+		});
 
 		const firstEvent = dispatchKeyDown("k", { ctrlKey: true });
 		const secondEvent = dispatchKeyDown("k", { ctrlKey: true });
@@ -55,12 +68,10 @@ describe("useAgentsPageKeybindings", () => {
 		const onNewAgent = vi.fn();
 		const onToggleSearch = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent,
-				onToggleSearch,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+		});
 
 		const ctrlEvent = dispatchKeyDown("k", { ctrlKey: true });
 		const metaEvent = dispatchKeyDown("k", { metaKey: true });
@@ -75,12 +86,10 @@ describe("useAgentsPageKeybindings", () => {
 		const onNewAgent = vi.fn();
 		const onToggleSearch = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent,
-				onToggleSearch,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+		});
 
 		const event = dispatchKeyDown("n", { ctrlKey: true });
 
@@ -96,12 +105,10 @@ describe("useAgentsPageKeybindings", () => {
 		const input = document.createElement("input");
 		document.body.appendChild(input);
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent,
-				onToggleSearch,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+		});
 
 		const searchEvent = dispatchKeyDown("k", { ctrlKey: true }, input);
 		const newAgentEvent = dispatchKeyDown("n", { ctrlKey: true }, input);
@@ -120,13 +127,11 @@ describe("useAgentsPageKeybindings", () => {
 		const onToggleSearch = vi.fn();
 		const onRenameActiveChat = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent,
-				onToggleSearch,
-				onRenameActiveChat,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+			onRenameActiveChat,
+		});
 
 		const slashEvent = dispatchKeyDown("/", { ctrlKey: true });
 		const newEvent = dispatchKeyDown("O", { ctrlKey: true, shiftKey: true });
@@ -144,13 +149,11 @@ describe("useAgentsPageKeybindings", () => {
 		isMacMock.mockReturnValue(false);
 		const onToggleSearch = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent: vi.fn(),
-				onToggleSearch,
-				vimNavigationEnabled: true,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent: vi.fn(),
+			onToggleSearch,
+			vimNavigationEnabled: true,
+		});
 
 		const kEvent = dispatchKeyDown("k", { ctrlKey: true });
 		const slashEvent = dispatchKeyDown("/", { ctrlKey: true });
@@ -171,13 +174,11 @@ describe("useAgentsPageKeybindings", () => {
 		const onNewAgent = vi.fn();
 		const onRenameActiveChat = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({
-				onNewAgent,
-				onRenameActiveChat,
-				vimNavigationEnabled: true,
-			}),
-		);
+		renderKeybindings({
+			onNewAgent,
+			onRenameActiveChat,
+			vimNavigationEnabled: true,
+		});
 
 		const renameEvent = dispatchKeyDown("E", { ctrlKey: true, shiftKey: true });
 		const shiftNEvent = dispatchKeyDown("N", { ctrlKey: true, shiftKey: true });
@@ -192,13 +193,78 @@ describe("useAgentsPageKeybindings", () => {
 		isMacMock.mockReturnValue(false);
 		const onNewAgent = vi.fn();
 
-		renderHook(() =>
-			useAgentsPageKeybindings({ onNewAgent, vimNavigationEnabled: true }),
-		);
+		renderKeybindings({ onNewAgent, vimNavigationEnabled: true });
 
 		const event = dispatchKeyDown("O", { ctrlKey: true, shiftKey: true });
 
 		expect(event.defaultPrevented).toBe(true);
+		expect(onNewAgent).toHaveBeenCalledTimes(1);
+	});
+
+	it("binds vim shortcuts to the Alt modifier, including Option chords on macOS", () => {
+		isMacMock.mockReturnValue(true);
+		const onNewAgent = vi.fn();
+		const onToggleSearch = vi.fn();
+		const onRenameActiveChat = vi.fn();
+
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+			onRenameActiveChat,
+			vimNavigationEnabled: true,
+			vimModifier: "alt",
+		});
+
+		// Option+/ and Option+Shift+O on a macOS US layout report "÷" and "Ø".
+		const slashEvent = dispatchKeyDown("÷", { altKey: true, code: "Slash" });
+		const newEvent = dispatchKeyDown("Ø", {
+			altKey: true,
+			shiftKey: true,
+			code: "KeyO",
+		});
+		const renameEvent = dispatchKeyDown("E", {
+			altKey: true,
+			shiftKey: true,
+			code: "KeyE",
+		});
+		const metaSlashEvent = dispatchKeyDown("/", { metaKey: true });
+		const metaNEvent = dispatchKeyDown("n", { metaKey: true });
+
+		expect(slashEvent.defaultPrevented).toBe(true);
+		expect(newEvent.defaultPrevented).toBe(true);
+		expect(renameEvent.defaultPrevented).toBe(true);
+		expect(metaSlashEvent.defaultPrevented).toBe(false);
+		expect(metaNEvent.defaultPrevented).toBe(true);
+		expect(onToggleSearch).toHaveBeenCalledTimes(1);
+		expect(onRenameActiveChat).toHaveBeenCalledTimes(1);
+		expect(onNewAgent).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps Ctrl+K search when the vim modifier is not the platform modifier", () => {
+		isMacMock.mockReturnValue(false);
+		const onNewAgent = vi.fn();
+		const onToggleSearch = vi.fn();
+
+		renderKeybindings({
+			onNewAgent,
+			onToggleSearch,
+			vimNavigationEnabled: true,
+			vimModifier: "meta",
+		});
+
+		const metaSlashEvent = dispatchKeyDown("/", { metaKey: true });
+		const ctrlSlashEvent = dispatchKeyDown("/", { ctrlKey: true });
+		const metaShiftOEvent = dispatchKeyDown("O", {
+			metaKey: true,
+			shiftKey: true,
+		});
+		const ctrlKEvent = dispatchKeyDown("k", { ctrlKey: true });
+
+		expect(metaSlashEvent.defaultPrevented).toBe(true);
+		expect(ctrlSlashEvent.defaultPrevented).toBe(false);
+		expect(metaShiftOEvent.defaultPrevented).toBe(true);
+		expect(ctrlKEvent.defaultPrevented).toBe(true);
+		expect(onToggleSearch).toHaveBeenCalledTimes(2);
 		expect(onNewAgent).toHaveBeenCalledTimes(1);
 	});
 });

--- a/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts
+++ b/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts
@@ -6,29 +6,64 @@ import { isMac } from "#/utils/platform";
  *
  * - Ctrl+N / Cmd+N: Create a new agent.
  * - Ctrl+K / Cmd+K: Toggle agent search.
+ *
+ * With vim navigation enabled, Ctrl+K / Cmd+K is left to chat navigation
+ * and these bindings apply instead:
+ *
+ * - Ctrl+/ / Cmd+/: Toggle agent search.
+ * - Ctrl+Shift+O / Cmd+Shift+O: Create a new agent.
+ * - Ctrl+Shift+E / Cmd+Shift+E: Rename the active chat.
  */
 export function useAgentsPageKeybindings({
 	onNewAgent,
 	onToggleSearch,
+	onRenameActiveChat,
+	vimNavigationEnabled = false,
 }: {
 	onNewAgent: () => void;
 	onToggleSearch?: () => void;
+	onRenameActiveChat?: () => void;
+	vimNavigationEnabled?: boolean;
 }) {
 	useEffect(() => {
 		const handler = (event: KeyboardEvent) => {
 			const isModifierPressed = isMac() ? event.metaKey : event.ctrlKey;
-			if (!isModifierPressed || event.altKey || event.shiftKey) {
+			if (!isModifierPressed || event.altKey) {
 				return;
 			}
 
+			// "/" is a shifted key on many layouts, so it is matched before
+			// the Shift branch.
 			const key = event.key.toLowerCase();
+			if (key === "/") {
+				if (vimNavigationEnabled && onToggleSearch) {
+					event.preventDefault();
+					onToggleSearch();
+				}
+				return;
+			}
+
+			if (event.shiftKey) {
+				if (!vimNavigationEnabled) {
+					return;
+				}
+				if (key === "o") {
+					event.preventDefault();
+					onNewAgent();
+				} else if (key === "e" && onRenameActiveChat) {
+					event.preventDefault();
+					onRenameActiveChat();
+				}
+				return;
+			}
+
 			if (key === "n") {
 				event.preventDefault();
 				onNewAgent();
 				return;
 			}
 
-			if (key === "k" && onToggleSearch) {
+			if (key === "k" && !vimNavigationEnabled && onToggleSearch) {
 				event.preventDefault();
 				onToggleSearch();
 			}
@@ -36,5 +71,5 @@ export function useAgentsPageKeybindings({
 
 		document.addEventListener("keydown", handler);
 		return () => document.removeEventListener("keydown", handler);
-	}, [onNewAgent, onToggleSearch]);
+	}, [onNewAgent, onToggleSearch, onRenameActiveChat, vimNavigationEnabled]);
 }

--- a/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts
+++ b/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { isMac } from "#/utils/platform";
+import { isLetterKey } from "../utils/keyboardShortcuts";
 
 /**
  * Global keyboard shortcuts for the Agents page.
@@ -34,8 +35,7 @@ export function useAgentsPageKeybindings({
 
 			// "/" is a shifted key on many layouts, so it is matched before
 			// the Shift branch.
-			const key = event.key.toLowerCase();
-			if (key === "/") {
+			if (event.key === "/") {
 				if (vimNavigationEnabled && onToggleSearch) {
 					event.preventDefault();
 					onToggleSearch();
@@ -47,23 +47,23 @@ export function useAgentsPageKeybindings({
 				if (!vimNavigationEnabled) {
 					return;
 				}
-				if (key === "o") {
+				if (isLetterKey(event, "o")) {
 					event.preventDefault();
 					onNewAgent();
-				} else if (key === "e" && onRenameActiveChat) {
+				} else if (isLetterKey(event, "e") && onRenameActiveChat) {
 					event.preventDefault();
 					onRenameActiveChat();
 				}
 				return;
 			}
 
-			if (key === "n") {
+			if (isLetterKey(event, "n")) {
 				event.preventDefault();
 				onNewAgent();
 				return;
 			}
 
-			if (key === "k" && !vimNavigationEnabled && onToggleSearch) {
+			if (isLetterKey(event, "k") && !vimNavigationEnabled && onToggleSearch) {
 				event.preventDefault();
 				onToggleSearch();
 			}

--- a/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts
+++ b/site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts
@@ -1,6 +1,11 @@
 import { useEffect } from "react";
-import { isMac } from "#/utils/platform";
-import { isLetterKey } from "../utils/keyboardShortcuts";
+import {
+	getDefaultVimModifier,
+	isLetterKey,
+	isModifierPressed,
+	isSlashKey,
+	type VimModifier,
+} from "../utils/keyboardShortcuts";
 
 /**
  * Global keyboard shortcuts for the Agents page.
@@ -8,35 +13,44 @@ import { isLetterKey } from "../utils/keyboardShortcuts";
  * - Ctrl+N / Cmd+N: Create a new agent.
  * - Ctrl+K / Cmd+K: Toggle agent search.
  *
- * With vim navigation enabled, Ctrl+K / Cmd+K is left to chat navigation
- * and these bindings apply instead:
+ * With vim navigation enabled, these bindings apply using the configured
+ * vim modifier:
  *
- * - Ctrl+/ / Cmd+/: Toggle agent search.
- * - Ctrl+Shift+O / Cmd+Shift+O: Create a new agent.
- * - Ctrl+Shift+E / Cmd+Shift+E: Rename the active chat.
+ * - Modifier+/: Toggle agent search.
+ * - Modifier+Shift+O: Create a new agent.
+ * - Modifier+Shift+E: Rename the active chat.
+ *
+ * The two default bindings keep the platform modifier (Cmd on macOS,
+ * Ctrl elsewhere). When the vim modifier is the platform modifier,
+ * Ctrl+K / Cmd+K is left to chat navigation and search is only
+ * reachable through Modifier+/.
  */
 export function useAgentsPageKeybindings({
 	onNewAgent,
 	onToggleSearch,
 	onRenameActiveChat,
-	vimNavigationEnabled = false,
+	vimNavigationEnabled,
+	vimModifier,
 }: {
 	onNewAgent: () => void;
 	onToggleSearch?: () => void;
 	onRenameActiveChat?: () => void;
-	vimNavigationEnabled?: boolean;
+	vimNavigationEnabled: boolean;
+	vimModifier: VimModifier;
 }) {
 	useEffect(() => {
 		const handler = (event: KeyboardEvent) => {
-			const isModifierPressed = isMac() ? event.metaKey : event.ctrlKey;
-			if (!isModifierPressed || event.altKey) {
-				return;
-			}
+			const platformModifier = getDefaultVimModifier();
+			const isPlatformChord = isModifierPressed(event, platformModifier);
+			const isVimChord =
+				vimNavigationEnabled && isModifierPressed(event, vimModifier);
+			const searchKeyTakenByNavigation =
+				vimNavigationEnabled && vimModifier === platformModifier;
 
 			// "/" is a shifted key on many layouts, so it is matched before
 			// the Shift branch.
-			if (event.key === "/") {
-				if (vimNavigationEnabled && onToggleSearch) {
+			if (isVimChord && isSlashKey(event)) {
+				if (onToggleSearch) {
 					event.preventDefault();
 					onToggleSearch();
 				}
@@ -44,7 +58,7 @@ export function useAgentsPageKeybindings({
 			}
 
 			if (event.shiftKey) {
-				if (!vimNavigationEnabled) {
+				if (!isVimChord) {
 					return;
 				}
 				if (isLetterKey(event, "o")) {
@@ -57,13 +71,21 @@ export function useAgentsPageKeybindings({
 				return;
 			}
 
+			if (!isPlatformChord) {
+				return;
+			}
+
 			if (isLetterKey(event, "n")) {
 				event.preventDefault();
 				onNewAgent();
 				return;
 			}
 
-			if (isLetterKey(event, "k") && !vimNavigationEnabled && onToggleSearch) {
+			if (
+				isLetterKey(event, "k") &&
+				!searchKeyTakenByNavigation &&
+				onToggleSearch
+			) {
 				event.preventDefault();
 				onToggleSearch();
 			}
@@ -71,5 +93,11 @@ export function useAgentsPageKeybindings({
 
 		document.addEventListener("keydown", handler);
 		return () => document.removeEventListener("keydown", handler);
-	}, [onNewAgent, onToggleSearch, onRenameActiveChat, vimNavigationEnabled]);
+	}, [
+		onNewAgent,
+		onToggleSearch,
+		onRenameActiveChat,
+		vimNavigationEnabled,
+		vimModifier,
+	]);
 }

--- a/site/src/pages/AgentsPage/hooks/useChatVimNavigation.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatVimNavigation.test.ts
@@ -1,0 +1,208 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isMac } from "#/utils/platform";
+import { useChatVimNavigation } from "./useChatVimNavigation";
+
+vi.mock("#/utils/platform", () => ({
+	isMac: vi.fn(),
+}));
+
+const isMacMock = vi.mocked(isMac);
+
+const dispatchKeyDown = (
+	key: string,
+	options: KeyboardEventInit = {},
+	target: EventTarget = document,
+) => {
+	const event = new KeyboardEvent("keydown", {
+		key,
+		cancelable: true,
+		bubbles: true,
+		...options,
+	});
+	target.dispatchEvent(event);
+	return event;
+};
+
+const chatIds = ["a", "b", "c"];
+
+const render = (
+	overrides: Partial<Parameters<typeof useChatVimNavigation>[0]> = {},
+) => {
+	const onSelectChat = vi.fn();
+	renderHook(() =>
+		useChatVimNavigation({
+			enabled: true,
+			visibleChatIds: chatIds,
+			allChatIds: chatIds,
+			activeChatId: "b",
+			onSelectChat,
+			...overrides,
+		}),
+	);
+	return onSelectChat;
+};
+
+describe("useChatVimNavigation", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		document.body.innerHTML = "";
+	});
+
+	it("does nothing when disabled", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render({ enabled: false });
+
+		const event = dispatchKeyDown("j", { ctrlKey: true });
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(onSelectChat).not.toHaveBeenCalled();
+	});
+
+	it("moves to the next and previous chat with Ctrl+J and Ctrl+K", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render();
+
+		const nextEvent = dispatchKeyDown("j", { ctrlKey: true });
+		const prevEvent = dispatchKeyDown("k", { ctrlKey: true });
+
+		expect(nextEvent.defaultPrevented).toBe(true);
+		expect(prevEvent.defaultPrevented).toBe(true);
+		expect(onSelectChat).toHaveBeenNthCalledWith(1, "c");
+		expect(onSelectChat).toHaveBeenNthCalledWith(2, "a");
+	});
+
+	it("uses Cmd instead of Ctrl on macOS", () => {
+		isMacMock.mockReturnValue(true);
+		const onSelectChat = render();
+
+		const ctrlEvent = dispatchKeyDown("j", { ctrlKey: true });
+		const metaEvent = dispatchKeyDown("j", { metaKey: true });
+
+		expect(ctrlEvent.defaultPrevented).toBe(false);
+		expect(metaEvent.defaultPrevented).toBe(true);
+		expect(onSelectChat).toHaveBeenCalledExactlyOnceWith("c");
+	});
+
+	it("jumps to the last and first chat with Shift", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render({ activeChatId: "b" });
+
+		dispatchKeyDown("J", { ctrlKey: true, shiftKey: true });
+		dispatchKeyDown("K", { ctrlKey: true, shiftKey: true });
+
+		expect(onSelectChat).toHaveBeenNthCalledWith(1, "c");
+		expect(onSelectChat).toHaveBeenNthCalledWith(2, "a");
+	});
+
+	it("anchors a hidden active chat to its nearest visible neighbors", () => {
+		isMacMock.mockReturnValue(false);
+		// "b1" is a collapsed child of "b", so it is in the full order
+		// but not the visible one.
+		const onSelectChat = render({
+			visibleChatIds: ["a", "b", "c"],
+			allChatIds: ["a", "b", "b1", "c"],
+			activeChatId: "b1",
+		});
+
+		dispatchKeyDown("j", { ctrlKey: true });
+		dispatchKeyDown("k", { ctrlKey: true });
+
+		expect(onSelectChat).toHaveBeenNthCalledWith(1, "c");
+		expect(onSelectChat).toHaveBeenNthCalledWith(2, "b");
+	});
+
+	it("clamps a hidden active chat at the list edges", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render({
+			visibleChatIds: ["a", "b"],
+			allChatIds: ["a", "b", "c"],
+			activeChatId: "c",
+		});
+
+		dispatchKeyDown("j", { ctrlKey: true });
+
+		expect(onSelectChat).toHaveBeenCalledExactlyOnceWith("b");
+	});
+
+	it("ignores keys while focus is inside a dialog", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render();
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		const input = document.createElement("input");
+		dialog.appendChild(input);
+		document.body.appendChild(dialog);
+		input.focus();
+
+		const event = dispatchKeyDown("j", { ctrlKey: true }, input);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(onSelectChat).not.toHaveBeenCalled();
+	});
+
+	it("stops at the list boundaries", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render({ activeChatId: "c" });
+
+		const event = dispatchKeyDown("j", { ctrlKey: true });
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(onSelectChat).not.toHaveBeenCalled();
+	});
+
+	it("enters the list from either end when no chat is active", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render({ activeChatId: undefined });
+
+		dispatchKeyDown("j", { ctrlKey: true });
+		dispatchKeyDown("k", { ctrlKey: true });
+
+		expect(onSelectChat).toHaveBeenNthCalledWith(1, "a");
+		expect(onSelectChat).toHaveBeenNthCalledWith(2, "c");
+	});
+
+	it("handles shortcuts from editable elements", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render();
+		const input = document.createElement("input");
+		document.body.appendChild(input);
+
+		const event = dispatchKeyDown("j", { ctrlKey: true }, input);
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(onSelectChat).toHaveBeenCalledExactlyOnceWith("c");
+	});
+
+	it("focuses the composer on Escape from a sidebar row", () => {
+		isMacMock.mockReturnValue(false);
+		render();
+		const row = document.createElement("div");
+		row.dataset.testid = "agents-tree-node-b";
+		const link = document.createElement("a");
+		link.href = "#";
+		row.appendChild(link);
+		const composer = document.createElement("div");
+		composer.dataset.testid = "chat-message-input";
+		composer.tabIndex = 0;
+		document.body.append(row, composer);
+		link.focus();
+
+		const event = dispatchKeyDown("Escape", {}, link);
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(document.activeElement).toBe(composer);
+	});
+
+	it("ignores Escape outside the sidebar", () => {
+		isMacMock.mockReturnValue(false);
+		render();
+		const composer = document.createElement("div");
+		composer.dataset.testid = "chat-message-input";
+		document.body.append(composer);
+
+		const event = dispatchKeyDown("Escape");
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+});

--- a/site/src/pages/AgentsPage/hooks/useChatVimNavigation.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatVimNavigation.test.ts
@@ -141,6 +141,17 @@ describe("useChatVimNavigation", () => {
 		expect(onSelectChat).not.toHaveBeenCalled();
 	});
 
+	it("matches the physical key on non-Latin layouts", () => {
+		isMacMock.mockReturnValue(false);
+		const onSelectChat = render();
+
+		// Russian layout: the key at the "J" position reports "о".
+		const event = dispatchKeyDown("о", { ctrlKey: true, code: "KeyJ" });
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(onSelectChat).toHaveBeenCalledExactlyOnceWith("c");
+	});
+
 	it("stops at the list boundaries", () => {
 		isMacMock.mockReturnValue(false);
 		const onSelectChat = render({ activeChatId: "c" });

--- a/site/src/pages/AgentsPage/hooks/useChatVimNavigation.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatVimNavigation.test.ts
@@ -1,13 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isMac } from "#/utils/platform";
 import { useChatVimNavigation } from "./useChatVimNavigation";
-
-vi.mock("#/utils/platform", () => ({
-	isMac: vi.fn(),
-}));
-
-const isMacMock = vi.mocked(isMac);
 
 const dispatchKeyDown = (
 	key: string,
@@ -33,6 +26,7 @@ const render = (
 	renderHook(() =>
 		useChatVimNavigation({
 			enabled: true,
+			modifier: "ctrl",
 			visibleChatIds: chatIds,
 			allChatIds: chatIds,
 			activeChatId: "b",
@@ -45,12 +39,10 @@ const render = (
 
 describe("useChatVimNavigation", () => {
 	afterEach(() => {
-		vi.clearAllMocks();
 		document.body.innerHTML = "";
 	});
 
 	it("does nothing when disabled", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render({ enabled: false });
 
 		const event = dispatchKeyDown("j", { ctrlKey: true });
@@ -60,7 +52,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("moves to the next and previous chat with Ctrl+J and Ctrl+K", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render();
 
 		const nextEvent = dispatchKeyDown("j", { ctrlKey: true });
@@ -72,20 +63,42 @@ describe("useChatVimNavigation", () => {
 		expect(onSelectChat).toHaveBeenNthCalledWith(2, "a");
 	});
 
-	it("uses Cmd instead of Ctrl on macOS", () => {
-		isMacMock.mockReturnValue(true);
-		const onSelectChat = render();
+	it("matches only the configured modifier", () => {
+		const onSelectChat = render({ modifier: "meta" });
 
 		const ctrlEvent = dispatchKeyDown("j", { ctrlKey: true });
+		const altEvent = dispatchKeyDown("j", { altKey: true });
 		const metaEvent = dispatchKeyDown("j", { metaKey: true });
 
 		expect(ctrlEvent.defaultPrevented).toBe(false);
+		expect(altEvent.defaultPrevented).toBe(false);
 		expect(metaEvent.defaultPrevented).toBe(true);
 		expect(onSelectChat).toHaveBeenCalledExactlyOnceWith("c");
 	});
 
+	it("navigates with the Alt modifier, including Option+J on macOS", () => {
+		const onSelectChat = render({ modifier: "alt" });
+
+		// Option+J on a macOS US layout reports the character "∆".
+		const nextEvent = dispatchKeyDown("∆", { altKey: true, code: "KeyJ" });
+		const prevEvent = dispatchKeyDown("k", { altKey: true, code: "KeyK" });
+
+		expect(nextEvent.defaultPrevented).toBe(true);
+		expect(prevEvent.defaultPrevented).toBe(true);
+		expect(onSelectChat).toHaveBeenNthCalledWith(1, "c");
+		expect(onSelectChat).toHaveBeenNthCalledWith(2, "a");
+	});
+
+	it("ignores chords with an extra modifier held", () => {
+		const onSelectChat = render();
+
+		const event = dispatchKeyDown("j", { ctrlKey: true, altKey: true });
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(onSelectChat).not.toHaveBeenCalled();
+	});
+
 	it("jumps to the last and first chat with Shift", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render({ activeChatId: "b" });
 
 		dispatchKeyDown("J", { ctrlKey: true, shiftKey: true });
@@ -96,7 +109,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("anchors a hidden active chat to its nearest visible neighbors", () => {
-		isMacMock.mockReturnValue(false);
 		// "b1" is a collapsed child of "b", so it is in the full order
 		// but not the visible one.
 		const onSelectChat = render({
@@ -113,7 +125,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("clamps a hidden active chat at the list edges", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render({
 			visibleChatIds: ["a", "b"],
 			allChatIds: ["a", "b", "c"],
@@ -126,7 +137,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("ignores keys while focus is inside a dialog", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render();
 		const dialog = document.createElement("div");
 		dialog.setAttribute("role", "dialog");
@@ -142,7 +152,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("matches the physical key on non-Latin layouts", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render();
 
 		// Russian layout: the key at the "J" position reports "о".
@@ -153,7 +162,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("stops at the list boundaries", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render({ activeChatId: "c" });
 
 		const event = dispatchKeyDown("j", { ctrlKey: true });
@@ -163,7 +171,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("enters the list from either end when no chat is active", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render({ activeChatId: undefined });
 
 		dispatchKeyDown("j", { ctrlKey: true });
@@ -174,7 +181,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("handles shortcuts from editable elements", () => {
-		isMacMock.mockReturnValue(false);
 		const onSelectChat = render();
 		const input = document.createElement("input");
 		document.body.appendChild(input);
@@ -186,7 +192,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("focuses the composer on Escape from a sidebar row", () => {
-		isMacMock.mockReturnValue(false);
 		render();
 		const row = document.createElement("div");
 		row.dataset.testid = "agents-tree-node-b";
@@ -206,7 +211,6 @@ describe("useChatVimNavigation", () => {
 	});
 
 	it("ignores Escape outside the sidebar", () => {
-		isMacMock.mockReturnValue(false);
 		render();
 		const composer = document.createElement("div");
 		composer.dataset.testid = "chat-message-input";

--- a/site/src/pages/AgentsPage/hooks/useChatVimNavigation.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatVimNavigation.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { isMac } from "#/utils/platform";
+import { isLetterKey } from "../utils/keyboardShortcuts";
 
 const CHAT_ROW_SELECTOR = '[data-testid^="agents-tree-node-"]';
 const COMPOSER_SELECTOR = '[data-testid="chat-message-input"]';
@@ -66,8 +67,9 @@ export function useChatVimNavigation({
 				return;
 			}
 
-			const key = event.key.toLowerCase();
-			if (key !== "j" && key !== "k") {
+			const isNext = isLetterKey(event, "j");
+			const isPrevious = isLetterKey(event, "k");
+			if (!isNext && !isPrevious) {
 				return;
 			}
 			if (visibleChatIds.length === 0) {
@@ -75,7 +77,7 @@ export function useChatVimNavigation({
 			}
 			event.preventDefault();
 
-			const forward = key === "j";
+			const forward = isNext;
 			const targetId = event.shiftKey
 				? visibleChatIds[forward ? visibleChatIds.length - 1 : 0]
 				: findNeighbor({ visibleChatIds, allChatIds, activeChatId, forward });

--- a/site/src/pages/AgentsPage/hooks/useChatVimNavigation.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatVimNavigation.ts
@@ -1,0 +1,133 @@
+import { useEffect } from "react";
+import { isMac } from "#/utils/platform";
+
+const CHAT_ROW_SELECTOR = '[data-testid^="agents-tree-node-"]';
+const COMPOSER_SELECTOR = '[data-testid="chat-message-input"]';
+const DIALOG_SELECTOR = '[role="dialog"]';
+
+/**
+ * Vim-style keyboard navigation between sidebar chats.
+ *
+ * - Ctrl+J / Cmd+J: Select the next chat.
+ * - Ctrl+K / Cmd+K: Select the previous chat.
+ * - Ctrl+Shift+J / Cmd+Shift+J: Select the last chat.
+ * - Ctrl+Shift+K / Cmd+Shift+K: Select the first chat.
+ * - Escape while a sidebar chat row has focus: Focus the composer.
+ *
+ * `visibleChatIds` must match the sidebar's visual order. `allChatIds`
+ * is the same order including chats hidden by collapsed sections or
+ * parents; it anchors the cursor when the active chat is hidden so
+ * next/previous resolve to the nearest visible neighbor. When the
+ * active chat is in neither list, next selects the first chat and
+ * previous selects the last chat. Keys are ignored while focus is
+ * inside a dialog.
+ */
+export function useChatVimNavigation({
+	enabled,
+	visibleChatIds,
+	allChatIds,
+	activeChatId,
+	onSelectChat,
+}: {
+	enabled: boolean;
+	visibleChatIds: readonly string[];
+	allChatIds: readonly string[];
+	activeChatId: string | undefined;
+	onSelectChat: (chatId: string) => void;
+}) {
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+
+		const handler = (event: KeyboardEvent) => {
+			const active = document.activeElement;
+			if (active instanceof HTMLElement && active.closest(DIALOG_SELECTOR)) {
+				return;
+			}
+
+			if (event.key === "Escape") {
+				if (
+					!(active instanceof HTMLElement) ||
+					!active.closest(CHAT_ROW_SELECTOR)
+				) {
+					return;
+				}
+				const composer = document.querySelector(COMPOSER_SELECTOR);
+				if (composer instanceof HTMLElement) {
+					event.preventDefault();
+					composer.focus();
+				}
+				return;
+			}
+
+			const isModifierPressed = isMac() ? event.metaKey : event.ctrlKey;
+			if (!isModifierPressed || event.altKey) {
+				return;
+			}
+
+			const key = event.key.toLowerCase();
+			if (key !== "j" && key !== "k") {
+				return;
+			}
+			if (visibleChatIds.length === 0) {
+				return;
+			}
+			event.preventDefault();
+
+			const forward = key === "j";
+			const targetId = event.shiftKey
+				? visibleChatIds[forward ? visibleChatIds.length - 1 : 0]
+				: findNeighbor({ visibleChatIds, allChatIds, activeChatId, forward });
+			if (targetId === undefined || targetId === activeChatId) {
+				return;
+			}
+			onSelectChat(targetId);
+		};
+
+		document.addEventListener("keydown", handler);
+		return () => document.removeEventListener("keydown", handler);
+	}, [enabled, visibleChatIds, allChatIds, activeChatId, onSelectChat]);
+}
+
+function findNeighbor({
+	visibleChatIds,
+	allChatIds,
+	activeChatId,
+	forward,
+}: {
+	visibleChatIds: readonly string[];
+	allChatIds: readonly string[];
+	activeChatId: string | undefined;
+	forward: boolean;
+}): string | undefined {
+	const lastIndex = visibleChatIds.length - 1;
+	if (activeChatId === undefined) {
+		return visibleChatIds[forward ? 0 : lastIndex];
+	}
+
+	const visibleIndex = visibleChatIds.indexOf(activeChatId);
+	if (visibleIndex >= 0) {
+		const next = forward
+			? Math.min(visibleIndex + 1, lastIndex)
+			: Math.max(visibleIndex - 1, 0);
+		return visibleChatIds[next];
+	}
+
+	// The active chat is hidden. Walk outward from its position in
+	// the full order to the nearest visible chat in the requested
+	// direction, then clamp at the list edge.
+	const hiddenIndex = allChatIds.indexOf(activeChatId);
+	if (hiddenIndex < 0) {
+		return visibleChatIds[forward ? 0 : lastIndex];
+	}
+	const visible = new Set(visibleChatIds);
+	const step = forward ? 1 : -1;
+	for (let i = hiddenIndex + step; i >= 0 && i < allChatIds.length; i += step) {
+		const id = allChatIds[i];
+		if (id !== undefined && visible.has(id)) {
+			return id;
+		}
+	}
+	return visibleChatIds[forward ? lastIndex : 0];
+}

--- a/site/src/pages/AgentsPage/hooks/useChatVimNavigation.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatVimNavigation.ts
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
-import { isMac } from "#/utils/platform";
-import { isLetterKey } from "../utils/keyboardShortcuts";
+import {
+	isLetterKey,
+	isModifierPressed,
+	type VimModifier,
+} from "../utils/keyboardShortcuts";
 
 const CHAT_ROW_SELECTOR = '[data-testid^="agents-tree-node-"]';
 const COMPOSER_SELECTOR = '[data-testid="chat-message-input"]';
@@ -9,11 +12,13 @@ const DIALOG_SELECTOR = '[role="dialog"]';
 /**
  * Vim-style keyboard navigation between sidebar chats.
  *
- * - Ctrl+J / Cmd+J: Select the next chat.
- * - Ctrl+K / Cmd+K: Select the previous chat.
- * - Ctrl+Shift+J / Cmd+Shift+J: Select the last chat.
- * - Ctrl+Shift+K / Cmd+Shift+K: Select the first chat.
+ * - Modifier+J: Select the next chat.
+ * - Modifier+K: Select the previous chat.
+ * - Modifier+Shift+J: Select the last chat.
+ * - Modifier+Shift+K: Select the first chat.
  * - Escape while a sidebar chat row has focus: Focus the composer.
+ *
+ * `modifier` is the key held for every chord above.
  *
  * `visibleChatIds` must match the sidebar's visual order. `allChatIds`
  * is the same order including chats hidden by collapsed sections or
@@ -25,12 +30,14 @@ const DIALOG_SELECTOR = '[role="dialog"]';
  */
 export function useChatVimNavigation({
 	enabled,
+	modifier,
 	visibleChatIds,
 	allChatIds,
 	activeChatId,
 	onSelectChat,
 }: {
 	enabled: boolean;
+	modifier: VimModifier;
 	visibleChatIds: readonly string[];
 	allChatIds: readonly string[];
 	activeChatId: string | undefined;
@@ -62,8 +69,7 @@ export function useChatVimNavigation({
 				return;
 			}
 
-			const isModifierPressed = isMac() ? event.metaKey : event.ctrlKey;
-			if (!isModifierPressed || event.altKey) {
+			if (!isModifierPressed(event, modifier)) {
 				return;
 			}
 
@@ -89,7 +95,14 @@ export function useChatVimNavigation({
 
 		document.addEventListener("keydown", handler);
 		return () => document.removeEventListener("keydown", handler);
-	}, [enabled, visibleChatIds, allChatIds, activeChatId, onSelectChat]);
+	}, [
+		enabled,
+		modifier,
+		visibleChatIds,
+		allChatIds,
+		activeChatId,
+		onSelectChat,
+	]);
 }
 
 function findNeighbor({

--- a/site/src/pages/AgentsPage/hooks/useVimNavigation.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useVimNavigation.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isMac } from "#/utils/platform";
+import {
+	useVimNavigationModifier,
+	VIM_NAVIGATION_MODIFIER_STORAGE_KEY,
+} from "./useVimNavigation";
+
+vi.mock("#/utils/platform", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/utils/platform")>()),
+	isMac: vi.fn(),
+}));
+
+const isMacMock = vi.mocked(isMac);
+
+describe("useVimNavigationModifier", () => {
+	afterEach(() => {
+		localStorage.removeItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY);
+	});
+
+	it("defaults to Ctrl when nothing is stored", () => {
+		isMacMock.mockReturnValue(false);
+		const { result } = renderHook(() => useVimNavigationModifier());
+		expect(result.current[0]).toBe("ctrl");
+	});
+
+	it("defaults to Cmd on macOS", () => {
+		isMacMock.mockReturnValue(true);
+		const { result } = renderHook(() => useVimNavigationModifier());
+		expect(result.current[0]).toBe("meta");
+	});
+
+	it("falls back to the default for an unrecognized stored value", () => {
+		isMacMock.mockReturnValue(false);
+		localStorage.setItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY, "hyper");
+		const { result } = renderHook(() => useVimNavigationModifier());
+		expect(result.current[0]).toBe("ctrl");
+	});
+
+	it("persists and publishes a new modifier", () => {
+		isMacMock.mockReturnValue(false);
+		const { result } = renderHook(() => useVimNavigationModifier());
+
+		act(() => {
+			result.current[1]("alt");
+		});
+
+		expect(result.current[0]).toBe("alt");
+		expect(localStorage.getItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY)).toBe(
+			"alt",
+		);
+	});
+});

--- a/site/src/pages/AgentsPage/hooks/useVimNavigation.ts
+++ b/site/src/pages/AgentsPage/hooks/useVimNavigation.ts
@@ -1,0 +1,48 @@
+import { useSyncExternalStore } from "react";
+
+export const VIM_NAVIGATION_STORAGE_KEY = "agents.vim-navigation";
+const KEY = VIM_NAVIGATION_STORAGE_KEY;
+
+// In-tab subscribers. The native "storage" event only fires
+// cross-tab, so we maintain our own listener set for same-tab
+// reactivity when the toggle is flipped in settings.
+const listeners = new Set<() => void>();
+
+function subscribe(callback: () => void): () => void {
+	listeners.add(callback);
+
+	const onStorage = (e: StorageEvent) => {
+		if (e.key === KEY) {
+			callback();
+		}
+	};
+	window.addEventListener("storage", onStorage);
+
+	return () => {
+		listeners.delete(callback);
+		window.removeEventListener("storage", onStorage);
+	};
+}
+
+function getSnapshot(): boolean {
+	return localStorage.getItem(KEY) === "true";
+}
+
+/**
+ * Reactive hook for the vim-style chat navigation preference.
+ * When enabled, Cmd/Ctrl+J and Cmd/Ctrl+K move between chats in
+ * the sidebar, Cmd/Ctrl+Shift+O starts a new chat, Cmd/Ctrl+Shift+E
+ * renames the active chat, and search moves to Cmd/Ctrl+/.
+ */
+export function useVimNavigation(): [boolean, (v: boolean) => void] {
+	const enabled = useSyncExternalStore(subscribe, getSnapshot);
+
+	const setEnabled = (value: boolean) => {
+		localStorage.setItem(KEY, String(value));
+		for (const fn of listeners) {
+			fn();
+		}
+	};
+
+	return [enabled, setEnabled];
+}

--- a/site/src/pages/AgentsPage/hooks/useVimNavigation.ts
+++ b/site/src/pages/AgentsPage/hooks/useVimNavigation.ts
@@ -1,4 +1,6 @@
 import { useSyncExternalStore } from "react";
+import type { Experiment } from "#/api/typesGenerated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import {
 	getDefaultVimModifier,
 	isVimModifier,
@@ -8,6 +10,23 @@ import {
 export const VIM_NAVIGATION_STORAGE_KEY = "agents.vim-navigation";
 export const VIM_NAVIGATION_MODIFIER_STORAGE_KEY =
 	"agents.vim-navigation-modifier";
+
+/**
+ * Experiment flag gating vim-style chat navigation.
+ */
+export const VIM_NAVIGATION_EXPERIMENT: Experiment = "chat-vim-navigation";
+
+/**
+ * Reports whether vim-style navigation shortcuts should be active:
+ * the deployment experiment is enabled and the user has turned the
+ * setting on. A stored setting has no effect while the experiment is
+ * off.
+ */
+export function useVimNavigationActive(): boolean {
+	const { experiments } = useDashboard();
+	const [enabled] = useVimNavigationSetting();
+	return experiments.includes(VIM_NAVIGATION_EXPERIMENT) && enabled;
+}
 
 // In-tab subscribers keyed by storage key. The native "storage" event
 // only fires cross-tab, so `writeKey` notifies same-tab subscribers

--- a/site/src/pages/AgentsPage/hooks/useVimNavigation.ts
+++ b/site/src/pages/AgentsPage/hooks/useVimNavigation.ts
@@ -1,18 +1,29 @@
 import { useSyncExternalStore } from "react";
+import {
+	getDefaultVimModifier,
+	isVimModifier,
+	type VimModifier,
+} from "../utils/keyboardShortcuts";
 
 export const VIM_NAVIGATION_STORAGE_KEY = "agents.vim-navigation";
-const KEY = VIM_NAVIGATION_STORAGE_KEY;
+export const VIM_NAVIGATION_MODIFIER_STORAGE_KEY =
+	"agents.vim-navigation-modifier";
 
-// In-tab subscribers. The native "storage" event only fires
-// cross-tab, so we maintain our own listener set for same-tab
-// reactivity when the toggle is flipped in settings.
-const listeners = new Set<() => void>();
+// In-tab subscribers keyed by storage key. The native "storage" event
+// only fires cross-tab, so `writeKey` notifies same-tab subscribers
+// directly.
+const listenersByKey = new Map<string, Set<() => void>>();
 
-function subscribe(callback: () => void): () => void {
+function subscribeToKey(key: string, callback: () => void): () => void {
+	let listeners = listenersByKey.get(key);
+	if (!listeners) {
+		listeners = new Set();
+		listenersByKey.set(key, listeners);
+	}
 	listeners.add(callback);
 
 	const onStorage = (e: StorageEvent) => {
-		if (e.key === KEY) {
+		if (e.key === key) {
 			callback();
 		}
 	};
@@ -24,25 +35,56 @@ function subscribe(callback: () => void): () => void {
 	};
 }
 
-function getSnapshot(): boolean {
-	return localStorage.getItem(KEY) === "true";
+function writeKey(key: string, value: string) {
+	localStorage.setItem(key, value);
+	for (const fn of listenersByKey.get(key) ?? []) {
+		fn();
+	}
 }
 
+const subscribeEnabled = (callback: () => void) =>
+	subscribeToKey(VIM_NAVIGATION_STORAGE_KEY, callback);
+
+const getEnabledSnapshot = (): boolean =>
+	localStorage.getItem(VIM_NAVIGATION_STORAGE_KEY) === "true";
+
 /**
- * Reactive hook for the vim-style chat navigation preference.
- * When enabled, Cmd/Ctrl+J and Cmd/Ctrl+K move between chats in
- * the sidebar, Cmd/Ctrl+Shift+O starts a new chat, Cmd/Ctrl+Shift+E
- * renames the active chat, and search moves to Cmd/Ctrl+/.
+ * Reactive hook for the stored vim-style chat navigation preference.
+ * This is the raw user setting; it does not account for the
+ * deployment experiment.
  */
-export function useVimNavigation(): [boolean, (v: boolean) => void] {
-	const enabled = useSyncExternalStore(subscribe, getSnapshot);
+export function useVimNavigationSetting(): [boolean, (v: boolean) => void] {
+	const enabled = useSyncExternalStore(subscribeEnabled, getEnabledSnapshot);
 
 	const setEnabled = (value: boolean) => {
-		localStorage.setItem(KEY, String(value));
-		for (const fn of listeners) {
-			fn();
-		}
+		writeKey(VIM_NAVIGATION_STORAGE_KEY, String(value));
 	};
 
 	return [enabled, setEnabled];
+}
+
+const subscribeModifier = (callback: () => void) =>
+	subscribeToKey(VIM_NAVIGATION_MODIFIER_STORAGE_KEY, callback);
+
+const getModifierSnapshot = (): VimModifier => {
+	const stored = localStorage.getItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY);
+	return isVimModifier(stored) ? stored : getDefaultVimModifier();
+};
+
+/**
+ * Reactive hook for the modifier key used by vim-style chat
+ * navigation. An unset or unrecognized stored value resolves to
+ * the platform default.
+ */
+export function useVimNavigationModifier(): [
+	VimModifier,
+	(v: VimModifier) => void,
+] {
+	const modifier = useSyncExternalStore(subscribeModifier, getModifierSnapshot);
+
+	const setModifier = (value: VimModifier) => {
+		writeKey(VIM_NAVIGATION_MODIFIER_STORAGE_KEY, value);
+	};
+
+	return [modifier, setModifier];
 }

--- a/site/src/pages/AgentsPage/utils/keyboardShortcuts.test.ts
+++ b/site/src/pages/AgentsPage/utils/keyboardShortcuts.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isLetterKey } from "./keyboardShortcuts";
+
+const keydown = (init: KeyboardEventInit) => new KeyboardEvent("keydown", init);
+
+describe("isLetterKey", () => {
+	it("matches by key on Latin layouts, including shifted letters", () => {
+		expect(isLetterKey(keydown({ key: "j", code: "KeyJ" }), "j")).toBe(true);
+		expect(isLetterKey(keydown({ key: "J", code: "KeyJ" }), "j")).toBe(true);
+		expect(isLetterKey(keydown({ key: "k", code: "KeyK" }), "j")).toBe(false);
+	});
+
+	it("prefers the printed letter on remapped Latin layouts", () => {
+		// Dvorak: the key at the QWERTY "J" position prints "h".
+		expect(isLetterKey(keydown({ key: "h", code: "KeyJ" }), "j")).toBe(false);
+		expect(isLetterKey(keydown({ key: "j", code: "KeyC" }), "j")).toBe(true);
+	});
+
+	it("falls back to the physical key on non-Latin layouts", () => {
+		expect(isLetterKey(keydown({ key: "о", code: "KeyJ" }), "j")).toBe(true);
+		expect(isLetterKey(keydown({ key: "ξ", code: "KeyJ" }), "j")).toBe(true);
+		expect(isLetterKey(keydown({ key: "о", code: "KeyK" }), "j")).toBe(false);
+	});
+});

--- a/site/src/pages/AgentsPage/utils/keyboardShortcuts.test.ts
+++ b/site/src/pages/AgentsPage/utils/keyboardShortcuts.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from "vitest";
-import { isLetterKey } from "./keyboardShortcuts";
+import { describe, expect, it, vi } from "vitest";
+import { isMac, isWindows } from "#/utils/platform";
+import {
+	getDefaultVimModifier,
+	getModifierKeycap,
+	getModifierLabel,
+	isLetterKey,
+	isModifierPressed,
+	isSlashKey,
+} from "./keyboardShortcuts";
+
+vi.mock("#/utils/platform", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/utils/platform")>()),
+	isMac: vi.fn(),
+	isWindows: vi.fn(),
+	getOSKey: () => "OSKEY",
+}));
+
+const isMacMock = vi.mocked(isMac);
+const isWindowsMock = vi.mocked(isWindows);
 
 const keydown = (init: KeyboardEventInit) => new KeyboardEvent("keydown", init);
 
@@ -20,5 +38,100 @@ describe("isLetterKey", () => {
 		expect(isLetterKey(keydown({ key: "о", code: "KeyJ" }), "j")).toBe(true);
 		expect(isLetterKey(keydown({ key: "ξ", code: "KeyJ" }), "j")).toBe(true);
 		expect(isLetterKey(keydown({ key: "о", code: "KeyK" }), "j")).toBe(false);
+	});
+});
+
+describe("isSlashKey", () => {
+	it("matches by key on Latin layouts, including shifted slashes", () => {
+		expect(isSlashKey(keydown({ key: "/", code: "Slash" }))).toBe(true);
+		expect(
+			isSlashKey(keydown({ key: "/", code: "Digit7", shiftKey: true })),
+		).toBe(true);
+		expect(
+			isSlashKey(keydown({ key: "?", code: "Slash", shiftKey: true })),
+		).toBe(false);
+	});
+
+	it("falls back to the physical key for non-ASCII characters", () => {
+		// Option+/ on a macOS US layout reports "÷".
+		expect(isSlashKey(keydown({ key: "÷", code: "Slash" }))).toBe(true);
+		expect(isSlashKey(keydown({ key: ".", code: "Slash" }))).toBe(false);
+	});
+});
+
+describe("isModifierPressed", () => {
+	it.each([
+		["ctrl", { ctrlKey: true }],
+		["alt", { altKey: true }],
+		["meta", { metaKey: true }],
+	] as const)("matches %s alone or with Shift", (modifier, init) => {
+		expect(isModifierPressed(keydown(init), modifier)).toBe(true);
+		expect(
+			isModifierPressed(keydown({ ...init, shiftKey: true }), modifier),
+		).toBe(true);
+		expect(isModifierPressed(keydown({}), modifier)).toBe(false);
+	});
+
+	it("rejects chords with a different or additional modifier", () => {
+		expect(isModifierPressed(keydown({ metaKey: true }), "ctrl")).toBe(false);
+		expect(isModifierPressed(keydown({ ctrlKey: true }), "alt")).toBe(false);
+		expect(isModifierPressed(keydown({ altKey: true }), "meta")).toBe(false);
+		// AltGr on Windows reports Ctrl+Alt.
+		expect(
+			isModifierPressed(keydown({ ctrlKey: true, altKey: true }), "ctrl"),
+		).toBe(false);
+		expect(
+			isModifierPressed(keydown({ ctrlKey: true, altKey: true }), "alt"),
+		).toBe(false);
+		expect(
+			isModifierPressed(keydown({ metaKey: true, ctrlKey: true }), "meta"),
+		).toBe(false);
+	});
+});
+
+describe("getModifierLabel", () => {
+	it("uses Cmd and Option on macOS", () => {
+		isMacMock.mockReturnValue(true);
+		isWindowsMock.mockReturnValue(false);
+		expect(getModifierLabel("ctrl")).toBe("Ctrl");
+		expect(getModifierLabel("alt")).toBe("Option");
+		expect(getModifierLabel("meta")).toBe("Cmd");
+	});
+
+	it("uses Win on Windows", () => {
+		isMacMock.mockReturnValue(false);
+		isWindowsMock.mockReturnValue(true);
+		expect(getModifierLabel("alt")).toBe("Alt");
+		expect(getModifierLabel("meta")).toBe("Win");
+	});
+
+	it("uses Alt and Super elsewhere", () => {
+		isMacMock.mockReturnValue(false);
+		isWindowsMock.mockReturnValue(false);
+		expect(getModifierLabel("ctrl")).toBe("Ctrl");
+		expect(getModifierLabel("alt")).toBe("Alt");
+		expect(getModifierLabel("meta")).toBe("Super");
+	});
+});
+
+describe("getModifierKeycap", () => {
+	it("uses the OS key glyph for Cmd on macOS and labels otherwise", () => {
+		isMacMock.mockReturnValue(true);
+		isWindowsMock.mockReturnValue(false);
+		expect(getModifierKeycap("meta")).toBe("OSKEY");
+		expect(getModifierKeycap("alt")).toBe("Option");
+		expect(getModifierKeycap("ctrl")).toBe("Ctrl");
+
+		isMacMock.mockReturnValue(false);
+		expect(getModifierKeycap("meta")).toBe("Super");
+	});
+});
+
+describe("getDefaultVimModifier", () => {
+	it("is Cmd on macOS and Ctrl elsewhere", () => {
+		isMacMock.mockReturnValue(true);
+		expect(getDefaultVimModifier()).toBe("meta");
+		isMacMock.mockReturnValue(false);
+		expect(getDefaultVimModifier()).toBe("ctrl");
 	});
 });

--- a/site/src/pages/AgentsPage/utils/keyboardShortcuts.ts
+++ b/site/src/pages/AgentsPage/utils/keyboardShortcuts.ts
@@ -1,0 +1,18 @@
+/**
+ * Reports whether a keydown event is for the given Latin letter,
+ * regardless of keyboard layout.
+ *
+ * `event.key` reflects the active layout and is used when it is an
+ * ASCII letter, which also covers remapped Latin layouts such as
+ * Dvorak. On Cyrillic, Greek, Hebrew, and similar layouts it reports
+ * the native character instead, so the physical `event.code`
+ * ("KeyJ") is used for those.
+ */
+export const isLetterKey = (event: KeyboardEvent, letter: string): boolean => {
+	const lower = letter.toLowerCase();
+	const key = event.key.toLowerCase();
+	if (/^[a-z]$/.test(key)) {
+		return key === lower;
+	}
+	return event.code === `Key${lower.toUpperCase()}`;
+};

--- a/site/src/pages/AgentsPage/utils/keyboardShortcuts.ts
+++ b/site/src/pages/AgentsPage/utils/keyboardShortcuts.ts
@@ -1,12 +1,34 @@
+import { getOSKey, isMac, isWindows } from "#/utils/platform";
+
+/**
+ * Modifier key held for every vim navigation shortcut. `meta` is
+ * Cmd on macOS, Win on Windows, and Super elsewhere.
+ */
+export type VimModifier = "ctrl" | "alt" | "meta";
+
+export const VIM_MODIFIERS: readonly VimModifier[] = ["ctrl", "alt", "meta"];
+
+export const isVimModifier = (value: string | null): value is VimModifier =>
+	value !== null && (VIM_MODIFIERS as readonly string[]).includes(value);
+
+/**
+ * Modifier used when none has been stored: Cmd on macOS, Ctrl elsewhere.
+ */
+export function getDefaultVimModifier(): VimModifier {
+	return isMac() ? "meta" : "ctrl";
+}
+
 /**
  * Reports whether a keydown event is for the given Latin letter,
  * regardless of keyboard layout.
  *
  * `event.key` reflects the active layout and is used when it is an
  * ASCII letter, which also covers remapped Latin layouts such as
- * Dvorak. On Cyrillic, Greek, Hebrew, and similar layouts it reports
- * the native character instead, so the physical `event.code`
- * ("KeyJ") is used for those.
+ * Dvorak. When it is not (Cyrillic, Greek, Hebrew, and similar
+ * layouts report the native character; Option+letter on macOS
+ * reports a symbol such as "∆" or "Dead"), the physical `event.code`
+ * ("KeyJ") is used instead. `event.code` names the QWERTY position,
+ * so on those layouts the chord is matched by physical position.
  */
 export const isLetterKey = (event: KeyboardEvent, letter: string): boolean => {
 	const lower = letter.toLowerCase();
@@ -15,4 +37,72 @@ export const isLetterKey = (event: KeyboardEvent, letter: string): boolean => {
 		return key === lower;
 	}
 	return event.code === `Key${lower.toUpperCase()}`;
+};
+
+/**
+ * Reports whether a keydown event is for the slash key. `event.key`
+ * is used when it is a printable ASCII character so that layouts
+ * where "/" is a shifted key still match; otherwise the physical
+ * `event.code` ("Slash") is used, which covers Option+/ on macOS
+ * ("÷") and layouts whose slash position emits a non-ASCII character.
+ */
+export const isSlashKey = (event: KeyboardEvent): boolean => {
+	if (/^[\x20-\x7e]$/.test(event.key)) {
+		return event.key === "/";
+	}
+	return event.code === "Slash";
+};
+
+/**
+ * Reports whether exactly the given modifier is held. The other two
+ * modifiers must be released so that chords such as AltGr (Ctrl+Alt
+ * on Windows) or Ctrl+Cmd do not match. Shift is not checked.
+ *
+ * Known conflicts that `preventDefault` cannot suppress: with `meta`,
+ * Windows reserves Win+J, Win+K, Win+E, and Win+/ for the OS, and
+ * most Linux desktops bind Super+letter to window management; with
+ * `alt`, Alt+Shift switches the input language on Windows and on
+ * Linux desktops configured with `grp:alt_shift_toggle`, and Firefox
+ * on Windows and Linux may open a menu for Alt+Shift+letter chords.
+ */
+export const isModifierPressed = (
+	event: KeyboardEvent,
+	modifier: VimModifier,
+): boolean => {
+	switch (modifier) {
+		case "ctrl":
+			return event.ctrlKey && !event.altKey && !event.metaKey;
+		case "alt":
+			return event.altKey && !event.ctrlKey && !event.metaKey;
+		case "meta":
+			return event.metaKey && !event.ctrlKey && !event.altKey;
+	}
+};
+
+/**
+ * Human-readable name for a modifier on the current platform.
+ */
+export const getModifierLabel = (modifier: VimModifier): string => {
+	switch (modifier) {
+		case "ctrl":
+			return "Ctrl";
+		case "alt":
+			return isMac() ? "Option" : "Alt";
+		case "meta":
+			if (isMac()) {
+				return "Cmd";
+			}
+			return isWindows() ? "Win" : "Super";
+	}
+};
+
+/**
+ * Keycap text for a modifier in a `Kbd` hint. Cmd on macOS uses the
+ * same glyph as `getOSKey`; every other modifier uses its text label.
+ */
+export const getModifierKeycap = (modifier: VimModifier): string => {
+	if (modifier === "meta" && isMac()) {
+		return getOSKey();
+	}
+	return getModifierLabel(modifier);
 };

--- a/site/src/testHelpers/vimNavigation.ts
+++ b/site/src/testHelpers/vimNavigation.ts
@@ -1,0 +1,18 @@
+import {
+	VIM_NAVIGATION_MODIFIER_STORAGE_KEY,
+	VIM_NAVIGATION_STORAGE_KEY,
+} from "#/pages/AgentsPage/hooks/useVimNavigation";
+import type { VimModifier } from "#/pages/AgentsPage/utils/keyboardShortcuts";
+
+/**
+ * Story `beforeEach` that turns the vim navigation preference on with
+ * the given modifier and clears both keys on cleanup.
+ */
+export const withVimNavigationPreference = (modifier: VimModifier) => () => {
+	localStorage.setItem(VIM_NAVIGATION_STORAGE_KEY, "true");
+	localStorage.setItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY, modifier);
+	return () => {
+		localStorage.removeItem(VIM_NAVIGATION_STORAGE_KEY);
+		localStorage.removeItem(VIM_NAVIGATION_MODIFIER_STORAGE_KEY);
+	};
+};


### PR DESCRIPTION
Adds an opt-in "Vim-style chat navigation" toggle to the Agents settings page (Keyboard shortcuts section), with a configurable modifier key, gated behind the `chat-vim-navigation` deployment experiment. The setting is stored in localStorage and is off by default; with it off, or with the experiment disabled, keybindings are unchanged.

When enabled, with `Mod` being the selected modifier (Ctrl, Alt/Option, or Super/Win/Cmd; default Cmd on macOS and Ctrl elsewhere):

| Shortcut | Action |
|---|---|
| Mod+J / Mod+K | Next / previous chat in the sidebar's visual order |
| Mod+Shift+J / Mod+Shift+K | Last / first loaded chat |
| Mod+Shift+O | New chat |
| Mod+Shift+E | Rename the active chat |
| Mod+/ | Search. When `Mod` is the platform modifier this replaces Cmd/Ctrl+K; otherwise Cmd/Ctrl+K keeps working too |
| Escape (on a focused sidebar row) | Return focus to the composer |

Navigation is immediate and works while typing in the composer. The visible order is derived by a pure helper (`getVisibleChatOrder`) that mirrors the sidebar render: pinned, shared with you, then time/status sections, skipping collapsed sections and including children of expanded roots. When the active chat is hidden inside a collapsed section or parent, J/K anchor to its nearest visible neighbor. Keys are ignored while focus is inside a dialog, and navigation is disabled on settings routes and while the list is loading or errored.

Chords match exactly one modifier (so AltGr, which reports Ctrl+Alt, never matches). Letters and `/` match by `event.key` when it is ASCII and fall back to the physical `event.code` otherwise, which keeps non-Latin layouts and macOS Option chords (Option+J reports "∆") working. Every hint and the settings description derive from the selected modifier; on macOS Super is labelled Cmd and Alt is labelled Option, and the sidebar `Kbd` hint uses the same `⌘` glyph as the existing search hint.

### Experiment

`codersdk.ExperimentChatVimNavigation` (`chat-vim-navigation`). The settings block, both key handlers, and the hint are gated on `useDashboard().experiments`; when off, no `keydown` listener is registered for navigation and a stored setting is inert.

### Known limitations

- "Last chat" means the last loaded page.
- Some OS chords cannot be intercepted by the page: Win+J/K/E/`/` on Windows and Super+letter on most Linux desktops (with `meta`), Alt+Shift input-language switching (with `alt`). These are documented on `isModifierPressed`.
- With `alt` on macOS, Option always produces a non-ASCII glyph, so letters resolve by QWERTY physical position on remapped layouts such as Dvorak.
- The Rename menu item does not yet show a shortcut hint.

<details>
<summary>Implementation plan</summary>

## Findings

- Shortcut hook: `site/src/pages/AgentsPage/hooks/useAgentsPageKeybindings.ts`. Listens on `document` keydown, modifier was `isMac() ? metaKey : ctrlKey`. Bindings before this change: Cmd/Ctrl+N (new agent), Cmd/Ctrl+K (toggle search). Already fires while an input is focused.
- Cmd/Ctrl+J is unused. Ctrl+J opens Downloads in Chrome/Edge on Windows/Linux; `preventDefault` on the document listener suppresses that.
- Sidebar display order is computed inline in `ChatsPanel.tsx`: pinned -> shared with you -> time/status sections, with collapsible sections and expandable children. No exported "visible order" helper existed.
- Active chat comes from the route `/agents/:agentId`; rows are `NavLink`s that preserve `location.search`.
- Settings: `/agents/settings/general` already has a "Keyboard shortcuts" heading. Two storage patterns exist: server-side user preferences and localStorage via `useSyncExternalStore` (`useChatFullWidth.ts`).
- The Lexical composer consumes Enter and Escape, so unmodified `g`/`G`/Enter cannot be global.
- Experiments are read in `site/src` via `useDashboard().experiments.includes(...)`; stories pass `parameters.experiments` through `withDashboardProvider`.

## Decisions

1. Cmd+K conflict: vim mode moves search to Mod+/; Cmd/Ctrl+K stays available when the vim modifier is not the platform modifier.
2. Selection model: immediate navigation on J/K (no separate cursor + Enter).
3. Storage: localStorage for both the toggle and the modifier.
4. Pagination: "last chat" means last loaded chat.
5. Rename chord: Mod+Shift+E. New chat chord: Mod+Shift+O (Cmd/Ctrl+N is reserved by browsers outside the PWA).
6. All new keys are gated behind the toggle and the experiment; nothing is always on.
7. Modifier choices are Ctrl, Alt, Meta; exact-modifier matching replaces the previous `altKey` rejection. Meta stays selectable on Windows (labelled Win) with the OS conflicts documented.
8. Kbd hint uses the existing `getOSKey` glyph for Cmd on macOS and text labels otherwise; prose and the Select use text labels (Cmd, Option).

## Changes

1. `hooks/useVimNavigation.ts`: localStorage toggle `agents.vim-navigation` (`useVimNavigationSetting`), modifier `agents.vim-navigation-modifier` (`useVimNavigationModifier`), and `useVimNavigationActive` = experiment && toggle.
2. `utils/keyboardShortcuts.ts`: `isLetterKey`, `isSlashKey`, `isModifierPressed`, `getDefaultVimModifier`, `getModifierLabel`, `getModifierKeycap`.
3. `tree/visibleChatOrder.ts`: pure helper returning `{ visible, all }` chat ID orders.
4. `hooks/useChatVimNavigation.ts`: J/K, Shift+J/K, Escape handling; dialog guard; hidden-row anchoring; takes the modifier.
5. `useAgentsPageKeybindings.ts`: Mod+/ search, Mod+Shift+O new, Mod+Shift+E rename; Cmd/Ctrl+K search unless the vim modifier takes it.
6. `ChatsPanel.tsx`: computes order, mounts the nav hook, navigates preserving `location.search`, swaps the Search `Kbd` hint.
7. `AgentsPageLayout.tsx`: wires rename to the shared `RenameChatDialog`, falling back to the per-chat query cache when the active chat is not in the paginated list.
8. `ChatVimNavigationSettings.tsx` (toggle + modifier `Select`) under a hoisted "Keyboard shortcuts" heading; rendered by `AgentSettingsGeneralPageView` only when the experiment is on.
9. `codersdk/deployment.go`: `ExperimentChatVimNavigation`; `make gen` output for swagger, docs, and `typesGenerated.ts`.
10. Tests: matcher and label unit tests per modifier, hook tests for each modifier, settings component test (stored values), sidebar test for experiment off vs on (route assertion), `visibleChatOrder` tests. Stories: one per modifier for the settings block and for the sidebar search hint.

</details>

---

Generated by Coder Agents on behalf of @jscottmiller.
