### PR TITLE
fix(coderd/x/chatd): avoid closing poller hint channels (#28746)

### DIFF
--- a/coderd/x/chatd/stream_sync_poller.go
+++ b/coderd/x/chatd/stream_sync_poller.go
@@ -101,7 +101,6 @@ func (p *streamSyncPoller) unregister(subscriber *streamSyncPollerSubscriber) {
 	if len(chatSubscribers) == 0 {
 		delete(p.subscribers, subscriber.chatID)
 	}
-	close(subscriber.hints)
 }
 
 func (p *streamSyncPoller) loop() {


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/28746

Original PR: #28746 — fix(coderd/x/chatd): avoid closing poller hint channels
Merge commit: ced03dc30baecc9a08cef57996374dc358fcb824
Requested by: @ethanndickson