### PR TITLE
test(cli): bind GitHub OAuth tests to loopback

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -397,18 +397,6 @@ func TestServer(t *testing.T) {
 			createUserPostRestart                 bool
 		}
 
-		waitAuthMethods := func(t *testing.T, ctx context.Context, client *codersdk.Client, expected codersdk.GithubAuthMethod) codersdk.AuthMethods {
-			t.Helper()
-
-			var authMethods codersdk.AuthMethods
-			testutil.Eventually(ctx, t, func(ctx context.Context) bool {
-				var err error
-				authMethods, err = client.AuthMethods(ctx)
-				return err == nil && authMethods.Github == expected
-			}, testutil.IntervalFast, "github auth method did not reach expected state: %+v", expected)
-			return authMethods
-		}
-
 		runGitHubProviderTest := func(t *testing.T, tc testCase) {
 			t.Parallel()
 
@@ -464,12 +452,11 @@ func TestServer(t *testing.T) {
 			}
 
 			client := codersdk.New(accessURL)
-			expectedGithubAuthMethod := codersdk.GithubAuthMethod{
-				Enabled:                   tc.expectGithubEnabled,
-				DefaultProviderConfigured: tc.expectGithubDefaultProviderConfigured,
-			}
-			authMethods := waitAuthMethods(t, ctx, client, expectedGithubAuthMethod)
-			require.Equal(t, expectedGithubAuthMethod, authMethods.Github)
+
+			authMethods, err := client.AuthMethods(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
+			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
 
 			cancelFunc()
 			select {
@@ -490,8 +477,10 @@ func TestServer(t *testing.T) {
 			client = codersdk.New(accessURL)
 
 			ctx = testutil.Context(t, testutil.WaitLong)
-			authMethods = waitAuthMethods(t, ctx, client, expectedGithubAuthMethod)
-			require.Equal(t, expectedGithubAuthMethod, authMethods.Github)
+			authMethods, err = client.AuthMethods(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectGithubEnabled, authMethods.Github.Enabled)
+			require.Equal(t, tc.expectGithubDefaultProviderConfigured, authMethods.Github.DefaultProviderConfigured)
 		}
 
 		for _, tc := range []testCase{

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -426,7 +426,8 @@ func TestServer(t *testing.T) {
 			args := []string{
 				"server",
 				"--postgres-url", dbURL,
-				"--http-address", ":0",
+				// Match the client's loopback address to avoid overlapping wildcard listeners on macOS.
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "https://example.com",
 			}
 			if tc.githubClientID != "" {


### PR DESCRIPTION
On macOS, the Coder test server listening on all addresses could share a port with another test’s loopback listener. Go enables `SO_REUSEADDR` by default, allowing overlapping addresses such as `[::]:61025` and `127.0.0.1:61025`. The OAuth test’s SDK connects to `127.0.0.1:61025`, so its requests could reach the other server and report GitHub authentication as disabled despite the intended server being correctly configured.

Bind the GitHub OAuth default-provider tests to `127.0.0.1:0`, matching the SDK’s address and preventing this overlap. Remove the retries introduced in #28358 and #28622: they were unnecessary to fix the flake.

To test this fix, I had an agent connect to a live GitHub macOS runner with [wush](https://github.com/coder/wush), reproduce the flake, and verify the new changes actually resolve it.

Refs https://linear.app/codercom/issue/ENG-3285/flake-testserveroauth2githubdefaultprovidernewdeployment

<sub>Generated by Coder Agents on behalf of @hugodutka.</sub>
