### PR TITLE
chore(site): bump @pierre/diffs from 1.3.6 to 1.4.0

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -54,7 +54,7 @@
 		"@lexical/utils": "0.49.0",
 		"@monaco-editor/react": "4.7.0",
 		"@novnc/novnc": "^1.5.0",
-		"@pierre/diffs": "1.3.6",
+		"@pierre/diffs": "1.4.0",
 		"@pierre/trees": "1.0.0-beta.6",
 		"@shadcn/react": "0.3.0",
 		"@tanstack/react-query-devtools": "5.82.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@pierre/diffs':
-        specifier: 1.3.6
-        version: 1.3.6(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 1.4.0
+        version: 1.4.0(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pierre/trees':
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(@pierre/theme@2.0.0)(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.3)
@@ -1617,11 +1617,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pierre/diffs@1.3.6':
-    resolution: {integrity: sha512-a3woaW2QHy78JDxPJK0OJzwZUN4xoQLLIS/pceO8X6+L8gA5D682mP7/w3YxxEVRPXOaoe/p/RJ5Oj/3nrEzew==, tarball: https://registry.npmjs.org/@pierre/diffs/-/diffs-1.3.6.tgz}
+  '@pierre/diffs@1.4.0':
+    resolution: {integrity: sha512-eSYnNDjRdgx01O16t8yxVW5M96ppgUMKbMyRE7/cyeJa+dMQrS/s0ed3n0KK9a2Or7SXon6cYbBLhAiAggD6ZQ==, tarball: https://registry.npmjs.org/@pierre/diffs/-/diffs-1.4.0.tgz}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@pierre/theme@2.0.0':
     resolution: {integrity: sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==, tarball: https://registry.npmjs.org/@pierre/theme/-/theme-2.0.0.tgz}
@@ -7538,7 +7543,7 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
 
-  '@pierre/diffs@1.3.6(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@pierre/diffs@1.4.0(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@pierre/theme': 2.0.0
       '@pierre/theming': 1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.3)
@@ -7546,9 +7551,10 @@ snapshots:
       diff: 9.0.0
       hast-util-to-html: 9.0.5
       lru_map: 0.4.1
+      shiki: 4.4.3
+    optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      shiki: 4.4.3
     transitivePeerDependencies:
       - '@shikijs/themes'
 

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -420,7 +420,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	onScrollToFileComplete,
 }) => {
 	const theme = useTheme();
-	const codeViewRef = useRef<CodeViewHandle<string>>(null);
+	const codeViewRef = useRef<CodeViewHandle<string, undefined>>(null);
 	const isDark = theme.palette.mode === "dark";
 	const [activeFile, setActiveFile] = useState<string | null>(null);
 


### PR DESCRIPTION
Upgrades `@pierre/diffs` from 1.3.6 to 1.4.0.

<details>
<summary>LLM Description</summary>

## What changed in the library

Version 1.4.0 has a new editing subsystem. The old editor types are removed from the public API. There is a new generic `Editor<EType, LAnnotation, Caret>` type. The edit-complete callback now uses an accept/reject model. Editable drafts can stay in memory with the new `editStateKey` option.

These changes are additive for read-only use. Our diff surfaces are read-only, so the risk is low.

## Changes in this PR

- `site/package.json` and `site/pnpm-lock.yaml`: version 1.3.6 to 1.4.0.
- `DiffViewer.tsx`: one line. `CodeViewHandle` now needs the new `Caret` type argument. We pass `undefined`.

## Behavior changes that apply to us

- `parsePatchFiles` now repairs malformed hunks when it can. Before, it dropped parts of the file.
- The worker now changes lone carriage returns to line feeds before highlighting.
- `WorkerPoolManager` has a new `workerInitializationTimeout` option (default 10 seconds).
- Target equality now compares `cacheKey` first when a key is set. This matches how we stamp keys.

## Cache keys

No change. Version 1.4.0 still keys cached ASTs by `cacheKey` only. It does not make keys from content. Our content-hash keys in `parseDiff.ts` stay necessary.

## Verification

- `tsc -p .` is clean.
- 527 unit tests pass.
- Biome is clean.
- Vite development build completes.
</details>

<details>
<summary>Analysis notes (Coder Agents generated)</summary>

Source-level comparison of the published 1.3.6 and 1.4.0 tarballs:

- Removed exports are all editor-related (`DiffsEditor`, `DiffsTextDocument`, `EditorChange`, `EditorState`, `TextEdit`, `Position`, `Range`, `CreateEditor`, and related types). We do not import any of them.
- All types we consume (`FileDiffMetadata`, `FileContents`, `ChangeTypes`, `SelectedLineRange`, `DiffLineAnnotation`, `Hunk`, `HunkData`, `VirtualFileMetrics`, `CodeViewLineSelection`, `CodeViewScrollTarget`, interaction callbacks) are identical or changed only in type-parameter names.
- The new `Caret` type parameter defaults to `undefined` on the React components, but not on `CodeViewHandle`, which caused the single compile error.
- CSS output is almost identical: one selector broadened for edit predictions. No CSS variables or data attributes removed. Our `--diffs-*` overrides and `unsafeCSS` are not affected.
- Runtime dependencies are unchanged (`shiki`, `diff@9.0.0`, `lru_map`, and others). React and React DOM peer dependencies are now optional.
- `areDiffTargetsEqual` and the new `areFileTargetsEqual` compare `cacheKey` before object identity. This is more correct for our content-hash keys: a mutated and restamped diff is detected as changed, and an unchanged diff skips re-render even when we pass a new object.

</details>
