### PR TITLE
fix(site): show new branch names on the chat page when they change

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -3141,6 +3141,87 @@ describe("mergeWatchedChatSummary", () => {
 		});
 	});
 
+	it("adopts diff status when only base_branch, head_branch, or reviewer_count change", () => {
+		const cachedDiffStatus = {
+			chat_id: "chat-1",
+			url: "https://example.com/pr/1",
+			pull_request_state: "open",
+			pull_request_title: "Title",
+			pull_request_draft: false,
+			changes_requested: false,
+			additions: 1,
+			deletions: 2,
+			changed_files: 3,
+			base_branch: "main",
+			head_branch: "feature",
+			reviewer_count: 1,
+			refreshed_at: "2025-01-01T00:00:00.000Z",
+			stale_at: "2025-01-01T01:00:00.000Z",
+		};
+		const watchedDiffStatus = {
+			...cachedDiffStatus,
+			base_branch: "release",
+			head_branch: "feature-renamed",
+			reviewer_count: 2,
+			refreshed_at: "2025-01-01T00:05:00.000Z",
+			stale_at: "2025-01-01T01:05:00.000Z",
+		};
+		const cachedChat = makeChat("chat-1", {
+			diff_status: cachedDiffStatus,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			diff_status: watchedDiffStatus,
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "diff_status_change",
+			}),
+		).toMatchObject({
+			diff_status: watchedDiffStatus,
+		});
+	});
+
+	it("returns the cached chat when only refreshed_at/stale_at differ", () => {
+		const cachedDiffStatus = {
+			chat_id: "chat-1",
+			url: "https://example.com/pr/1",
+			pull_request_state: "open",
+			pull_request_title: "Title",
+			pull_request_draft: false,
+			changes_requested: false,
+			additions: 1,
+			deletions: 2,
+			changed_files: 3,
+			base_branch: "main",
+			head_branch: "feature",
+			reviewer_count: 1,
+			refreshed_at: "2025-01-01T00:00:00.000Z",
+			stale_at: "2025-01-01T01:00:00.000Z",
+		};
+		const watchedDiffStatus = {
+			...cachedDiffStatus,
+			refreshed_at: "2025-01-01T00:05:00.000Z",
+			stale_at: "2025-01-01T01:05:00.000Z",
+		};
+		const cachedChat = makeChat("chat-1", {
+			diff_status: cachedDiffStatus,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			diff_status: watchedDiffStatus,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "diff_status_change",
+			}),
+		).toBe(cachedChat);
+	});
+
 	it("marks other chats unread on fresh status updates", () => {
 		const cachedChat = makeChat("chat-1", {
 			has_unread: false,

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -3141,7 +3141,11 @@ describe("mergeWatchedChatSummary", () => {
 		});
 	});
 
-	it("adopts diff status when only base_branch, head_branch, or reviewer_count change", () => {
+	it.each([
+		{ field: "base_branch", to: "release" },
+		{ field: "head_branch", to: "feature-renamed" },
+		{ field: "reviewer_count", to: 2 },
+	])("adopts diff status when only $field changes", ({ field, to }) => {
 		const cachedDiffStatus = {
 			chat_id: "chat-1",
 			url: "https://example.com/pr/1",
@@ -3160,28 +3164,20 @@ describe("mergeWatchedChatSummary", () => {
 		};
 		const watchedDiffStatus = {
 			...cachedDiffStatus,
-			base_branch: "release",
-			head_branch: "feature-renamed",
-			reviewer_count: 2,
-			refreshed_at: "2025-01-01T00:05:00.000Z",
-			stale_at: "2025-01-01T01:05:00.000Z",
+			[field]: to,
 		};
 		const cachedChat = makeChat("chat-1", {
 			diff_status: cachedDiffStatus,
-			updated_at: "2025-01-01T00:00:00.000Z",
 		});
 		const watchedChat = makeChat("chat-1", {
 			diff_status: watchedDiffStatus,
-			updated_at: "2025-01-01T00:05:00.000Z",
 		});
 
-		expect(
-			mergeWatchedChatSummary(cachedChat, watchedChat, {
-				eventKind: "diff_status_change",
-			}),
-		).toMatchObject({
-			diff_status: watchedDiffStatus,
+		const merged = mergeWatchedChatSummary(cachedChat, watchedChat, {
+			eventKind: "diff_status_change",
 		});
+
+		expect(merged.diff_status).toBe(watchedDiffStatus);
 	});
 
 	it("returns the cached chat when only refreshed_at/stale_at differ", () => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -484,6 +484,8 @@ type MergeWatchedChatOptions = {
 	readonly activeChatId?: string;
 };
 
+// Do not compare refreshed_at and stale_at: they change on every
+// poll. If they were compared, the cache would update every time.
 const diffStatusEqual = (
 	a: TypesGen.ChatDiffStatus | undefined,
 	b: TypesGen.ChatDiffStatus | undefined,

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -486,6 +486,8 @@ type MergeWatchedChatOptions = {
 
 // Shallow-compare two ChatDiffStatus objects by their meaningful
 // fields, ignoring refreshed_at/stale_at which change on every poll.
+// This covers all fields the UI renders, including the branch pill's
+// base_branch/head_branch, so retargeted PRs still trigger an update.
 const diffStatusEqual = (
 	a: TypesGen.ChatDiffStatus | undefined,
 	b: TypesGen.ChatDiffStatus | undefined,
@@ -505,9 +507,12 @@ const diffStatusEqual = (
 		a.additions === b.additions &&
 		a.deletions === b.deletions &&
 		a.changed_files === b.changed_files &&
+		a.base_branch === b.base_branch &&
+		a.head_branch === b.head_branch &&
 		a.pr_number === b.pr_number &&
 		a.approved === b.approved &&
-		a.commits === b.commits
+		a.commits === b.commits &&
+		a.reviewer_count === b.reviewer_count
 	);
 };
 

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -484,10 +484,6 @@ type MergeWatchedChatOptions = {
 	readonly activeChatId?: string;
 };
 
-// Shallow-compare two ChatDiffStatus objects by their meaningful
-// fields, ignoring refreshed_at/stale_at which change on every poll.
-// This covers all fields the UI renders, including the branch pill's
-// base_branch/head_branch, so retargeted PRs still trigger an update.
 const diffStatusEqual = (
 	a: TypesGen.ChatDiffStatus | undefined,
 	b: TypesGen.ChatDiffStatus | undefined,


### PR DESCRIPTION
## Problem

The chat page shows the branch names of a pull request. These names can be wrong.

The cause: when the branch names change on GitHub, the server tells the page about the change. But the page ignores the message if only the branch names changed. The page shows the old names until the user reloads it.

## Fix

The page now checks the branch names when it gets the message. If the names changed, the page shows the new names.

> [!NOTE]
> This PR was generated by Coder Agents.
