### PR TITLE
fix: show estimated context usage after compaction

### DIFF
--- a/coderd/x/chatd/attempt.go
+++ b/coderd/x/chatd/attempt.go
@@ -48,14 +48,15 @@ type pendingDynamicToolCall struct {
 // field-compatible with chatloop.CompactionResult; generateCompaction
 // converts between the two directly.
 type compactionOutcome struct {
-	SystemSummary    string
-	SummaryReport    string
-	Source           chatloop.CompactionSource
-	ThresholdPercent int32
-	UsagePercent     float64
-	ContextTokens    int64
-	ContextLimit     int64
-	Runtime          time.Duration
+	SystemSummary          string
+	SummaryReport          string
+	Source                 chatloop.CompactionSource
+	ThresholdPercent       int32
+	UsagePercent           float64
+	ContextTokens          int64
+	ContextLimit           int64
+	EstimatedContextTokens int64
+	Runtime                time.Duration
 }
 
 type compactionStatus int

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5471,7 +5471,11 @@ func TestActiveServer_Compaction(t *testing.T) {
 		resultPart := singlePartOfType(t, compressed.results[0], codersdk.ChatMessagePartTypeToolResult)
 		require.Equal(t, callPart.ToolCallID, resultPart.ToolCallID)
 		require.Equal(t, "chat_summarized", resultPart.ToolName)
-		require.JSONEq(t, `{"summary":"summary text for compaction","source":"automatic","threshold_percent":70,"usage_percent":80,"context_tokens":80,"context_limit_tokens":100}`, string(resultPart.Result))
+		require.JSONEq(t, fmt.Sprintf(`{"summary":"summary text for compaction","source":"automatic","threshold_percent":70,"usage_percent":80,"context_tokens":80,"context_limit_tokens":100,"estimated_context_tokens":%d}`, (len(summaryText)+2)/3), string(resultPart.Result))
+		for _, msg := range []database.ChatMessage{compressed.summaries[0], compressed.calls[0], compressed.results[0]} {
+			require.False(t, msg.InputTokens.Valid)
+			require.False(t, msg.OutputTokens.Valid)
+		}
 		requireTextPart(t, messages[len(messages)-1], "continued after compaction")
 	})
 

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -124,6 +124,8 @@ type CompactionResult struct {
 	UsagePercent     float64
 	ContextTokens    int64
 	ContextLimit     int64
+	// EstimatedContextTokens covers only SystemSummary, not the full prompt.
+	EstimatedContextTokens int64
 	// Runtime is the wall-clock duration of the summarization model
 	// call, the compaction step's billable runtime (see
 	// PersistedStep.Runtime). Zero when the run was gated off before
@@ -200,14 +202,16 @@ func GenerateCompaction(ctx context.Context, opts GenerateCompactionOptions) (Co
 		ContextLimit:     contextLimit,
 		Runtime:          summaryRuntime,
 	}
+	result.EstimatedContextTokens = int64((len(result.SystemSummary) + bytesPerTokenEstimate - 1) / bytesPerTokenEstimate)
 	if config.PublishMessagePart != nil && config.ToolCallID != "" {
 		resultJSON, _ := json.Marshal(map[string]any{
-			"summary":              summary,
-			"source":               config.Source,
-			"threshold_percent":    config.ThresholdPercent,
-			"usage_percent":        usagePercent,
-			"context_tokens":       contextTokens,
-			"context_limit_tokens": contextLimit,
+			"summary":                  summary,
+			"source":                   config.Source,
+			"threshold_percent":        config.ThresholdPercent,
+			"usage_percent":            usagePercent,
+			"context_tokens":           contextTokens,
+			"context_limit_tokens":     contextLimit,
+			"estimated_context_tokens": result.EstimatedContextTokens,
 		})
 		config.PublishMessagePart(
 			codersdk.ChatMessageRoleTool,

--- a/coderd/x/chatd/chatloop/compaction_internal_test.go
+++ b/coderd/x/chatd/chatloop/compaction_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -352,6 +353,48 @@ func TestGenerateCompaction_DefaultSourceAutomatic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "auto summary", result.SummaryReport)
 	require.Equal(t, CompactionSourceAutomatic, result.Source)
+}
+
+func TestGenerateCompaction_SummaryEstimate(t *testing.T) {
+	t.Parallel()
+	for _, prefix := range []string{"P", "Pr", "Pre"} {
+		t.Run(prefix, func(t *testing.T) {
+			t.Parallel()
+			var parts []codersdk.ChatMessagePart
+			result, err := GenerateCompaction(t.Context(), GenerateCompactionOptions{
+				Model: &chattest.FakeModel{
+					GenerateFn: func(context.Context, fantasy.Call) (*fantasy.Response, error) {
+						return &fantasy.Response{
+							Content: []fantasy.Content{fantasy.TextContent{Text: "界x"}},
+							Usage:   fantasy.Usage{InputTokens: 900, OutputTokens: 400},
+						}, nil
+					},
+				},
+				Messages:            []fantasy.Message{textMessage(fantasy.MessageRoleUser, "hello")},
+				SystemSummaryPrefix: prefix,
+				Force:               true,
+				ContextLimit:        1000,
+				StepUsage:           fantasy.Usage{InputTokens: 800},
+				ToolCallID:          "summary",
+				ToolName:            "chat_summarized",
+				PublishMessagePart: func(_ codersdk.ChatMessageRole, part codersdk.ChatMessagePart) {
+					parts = append(parts, part)
+				},
+				Clock: quartz.NewMock(t),
+			})
+			require.NoError(t, err)
+			require.Equal(t, prefix+"\n\n界x", result.SystemSummary)
+			require.Equal(t, int64(3), result.EstimatedContextTokens)
+			require.Equal(t, int64(800), result.ContextTokens)
+			require.Len(t, parts, 2)
+			require.Equal(t, codersdk.ChatMessagePartTypeToolResult, parts[1].Type)
+			require.False(t, parts[1].IsError)
+			var metadata map[string]any
+			require.NoError(t, json.Unmarshal(parts[1].Result, &metadata))
+			require.Equal(t, float64(3), metadata["estimated_context_tokens"])
+			require.Equal(t, float64(1000), metadata["context_limit_tokens"])
+		})
+	}
 }
 
 // TestGenerateCompaction_RequiresClock verifies a nil clock is

--- a/coderd/x/chatd/message_conversion.go
+++ b/coderd/x/chatd/message_conversion.go
@@ -349,12 +349,13 @@ func buildCompactionMessages(input buildCompactionMessagesInput) (compactionMess
 		return compactionMessagesForCommit{}, xerrors.Errorf("marshal compaction tool call: %w", err)
 	}
 	summaryResult, err := json.Marshal(map[string]any{
-		"summary":              input.compaction.SummaryReport,
-		"source":               source,
-		"threshold_percent":    input.compaction.ThresholdPercent,
-		"usage_percent":        input.compaction.UsagePercent,
-		"context_tokens":       input.compaction.ContextTokens,
-		"context_limit_tokens": input.compaction.ContextLimit,
+		"summary":                  input.compaction.SummaryReport,
+		"source":                   source,
+		"threshold_percent":        input.compaction.ThresholdPercent,
+		"usage_percent":            input.compaction.UsagePercent,
+		"context_tokens":           input.compaction.ContextTokens,
+		"context_limit_tokens":     input.compaction.ContextLimit,
+		"estimated_context_tokens": input.compaction.EstimatedContextTokens,
 	})
 	if err != nil {
 		return compactionMessagesForCommit{}, xerrors.Errorf("marshal compaction result: %w", err)

--- a/coderd/x/chatd/message_conversion_test.go
+++ b/coderd/x/chatd/message_conversion_test.go
@@ -304,13 +304,14 @@ func TestBuildCompactionMessages_CompressedSummaryToolCallAndResult(t *testing.T
 		toolCallID:     "summary-1",
 		toolName:       "chat_summarized",
 		compaction: compactionOutcome{
-			SystemSummary:    "system summary",
-			SummaryReport:    "user report",
-			ThresholdPercent: 70,
-			UsagePercent:     81.5,
-			ContextTokens:    815,
-			ContextLimit:     1000,
-			Runtime:          1500 * time.Millisecond,
+			SystemSummary:          "system summary",
+			SummaryReport:          "user report",
+			ThresholdPercent:       70,
+			UsagePercent:           81.5,
+			ContextTokens:          815,
+			ContextLimit:           1000,
+			Runtime:                1500 * time.Millisecond,
+			EstimatedContextTokens: 5,
 		},
 	})
 	require.NoError(t, err)
@@ -340,7 +341,7 @@ func TestBuildCompactionMessages_CompressedSummaryToolCallAndResult(t *testing.T
 	resultPart := parseMessageParts(t, got.Messages[2].Role, got.Messages[2].Content)[0]
 	require.Equal(t, codersdk.ChatMessagePartTypeToolResult, resultPart.Type)
 	require.Equal(t, "summary-1", resultPart.ToolCallID)
-	require.JSONEq(t, `{"summary":"user report","source":"automatic","threshold_percent":70,"usage_percent":81.5,"context_tokens":815,"context_limit_tokens":1000}`, string(resultPart.Result))
+	require.JSONEq(t, `{"summary":"user report","source":"automatic","threshold_percent":70,"usage_percent":81.5,"context_tokens":815,"context_limit_tokens":1000,"estimated_context_tokens":5}`, string(resultPart.Result))
 }
 
 // A compaction that never reached the summary model call carries no
@@ -449,13 +450,14 @@ func TestBuildCompactionMessages_ManualSource(t *testing.T) {
 		toolCallID:     "summary-1",
 		toolName:       "chat_summarized",
 		compaction: compactionOutcome{
-			SystemSummary:    "system summary",
-			SummaryReport:    "user report",
-			Source:           chatloop.CompactionSourceManual,
-			ThresholdPercent: 70,
-			UsagePercent:     10,
-			ContextTokens:    100,
-			ContextLimit:     1000,
+			SystemSummary:          "system summary",
+			SummaryReport:          "user report",
+			Source:                 chatloop.CompactionSourceManual,
+			ThresholdPercent:       70,
+			UsagePercent:           10,
+			EstimatedContextTokens: 5,
+			ContextTokens:          100,
+			ContextLimit:           1000,
 		},
 	})
 	require.NoError(t, err)
@@ -464,7 +466,7 @@ func TestBuildCompactionMessages_ManualSource(t *testing.T) {
 	callPart := parseMessageParts(t, got.Messages[1].Role, got.Messages[1].Content)[0]
 	require.JSONEq(t, `{"source":"manual","threshold_percent":70}`, string(callPart.Args))
 	resultPart := parseMessageParts(t, got.Messages[2].Role, got.Messages[2].Content)[0]
-	require.JSONEq(t, `{"summary":"user report","source":"manual","threshold_percent":70,"usage_percent":10,"context_tokens":100,"context_limit_tokens":1000}`, string(resultPart.Result))
+	require.JSONEq(t, `{"summary":"user report","source":"manual","threshold_percent":70,"usage_percent":10,"context_tokens":100,"context_limit_tokens":1000,"estimated_context_tokens":5}`, string(resultPart.Result))
 }
 
 // TestDecisionForcedCompaction verifies the manual compaction request

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -207,6 +207,10 @@ func DiscriminatedChatMessagePart(ts *guts.Typescript) {
 	// we can copy type information from the original interface.
 	fieldMap := make(map[string]*bindings.PropertySignature, len(iface.Fields))
 	for _, f := range iface.Fields {
+		if f.Name == "result" {
+			unknown := bindings.KeywordUnknown
+			f.Type = &unknown
+		}
 		fieldMap[f.Name] = f
 	}
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3507,7 +3507,7 @@ export interface ChatToolResultPart {
 	readonly tool_call_id?: string;
 	readonly tool_name?: string;
 	readonly mcp_server_config_id?: string;
-	readonly result?: Record<string, string>;
+	readonly result?: unknown;
 	readonly result_delta?: string;
 	readonly result_reset?: boolean;
 	readonly is_error?: boolean;

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
-import { MockChatMessage } from "#/testHelpers/chatEntities";
+import {
+	MockChatCompactionMessage,
+	MockChatMessage,
+} from "#/testHelpers/chatEntities";
 import {
 	extractContextUsageFromMessage,
 	getLatestContextUsage,
@@ -98,6 +101,97 @@ describe("getLatestContextUsage", () => {
 		role: "tool",
 		content: [{ type: "tool-result", tool_name: "chat_summarized" }],
 	};
+
+	it("uses the compacted estimate after reloading persisted messages", () => {
+		const messages: TypesGen.ChatMessage[] = JSON.parse(
+			JSON.stringify([
+				{ ...MockChatMessage, id: 1, usage: { input_tokens: 90000 } },
+				MockChatCompactionMessage,
+			]),
+		);
+		expect(getLatestContextUsage(messages)).toEqual({
+			usedTokens: 12000,
+			contextLimitTokens: 100000,
+			estimated: true,
+		});
+		expect(getLatestContextUsage(messages, 200000)).toEqual({
+			usedTokens: 12000,
+			contextLimitTokens: 200000,
+			estimated: true,
+		});
+	});
+
+	it("replaces the estimate with newer measured usage", () => {
+		const result = getLatestContextUsage(
+			[
+				MockChatCompactionMessage,
+				{
+					...MockChatMessage,
+					id: 4,
+					usage: { input_tokens: 15000, context_limit: 200000 },
+				},
+			],
+			100000,
+		);
+		expect(result?.usedTokens).toBe(15000);
+		expect(result?.contextLimitTokens).toBe(200000);
+		expect(result?.estimated).toBeUndefined();
+	});
+
+	it.each([
+		undefined,
+		null,
+		[],
+		{},
+		{ estimated_context_tokens: 0, context_limit_tokens: 100000 },
+		{ estimated_context_tokens: -1, context_limit_tokens: 100000 },
+		{ estimated_context_tokens: 1.5, context_limit_tokens: 100000 },
+		{ estimated_context_tokens: "12000", context_limit_tokens: 100000 },
+		{ estimated_context_tokens: 12000, context_limit_tokens: 0 },
+		{ estimated_context_tokens: 12000 },
+	])(
+		"does not reuse pre-compaction usage for invalid metadata %j",
+		(result) => {
+			const message: TypesGen.ChatMessage = JSON.parse(
+				JSON.stringify({
+					...MockChatCompactionMessage,
+					content: [
+						{ type: "tool-result", tool_name: "chat_summarized", result },
+					],
+				}),
+			);
+			expect(
+				getLatestContextUsage([
+					{ ...MockChatMessage, usage: { input_tokens: 90000 } },
+					message,
+				]),
+			).toBeNull();
+		},
+	);
+
+	it.each<TypesGen.ChatMessagePart>([
+		{ type: "tool-call", tool_name: "chat_summarized" },
+		{
+			type: "tool-result",
+			tool_name: "chat_summarized",
+			is_error: true,
+			result: MockChatCompactionMessage.content?.find(
+				(part) => part.type === "tool-result",
+			)?.result,
+		},
+		{ type: "tool-call", tool_name: "chat_cleared" },
+	])("stops at a boundary without successful summary metadata: %j", (part) => {
+		expect(
+			getLatestContextUsage([
+				MockChatCompactionMessage,
+				{ ...MockChatMessage, content: [part] },
+			]),
+		).toBeNull();
+	});
+
+	it("has no usage for an empty chat", () => {
+		expect(getLatestContextUsage([], 200000)).toBeNull();
+	});
 
 	it("returns usage from the newest usage-bearing message", () => {
 		const messages = [

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
@@ -102,13 +102,11 @@ describe("getLatestContextUsage", () => {
 		content: [{ type: "tool-result", tool_name: "chat_summarized" }],
 	};
 
-	it("uses the compacted estimate after reloading persisted messages", () => {
-		const messages: TypesGen.ChatMessage[] = JSON.parse(
-			JSON.stringify([
-				{ ...MockChatMessage, id: 1, usage: { input_tokens: 90000 } },
-				MockChatCompactionMessage,
-			]),
-		);
+	it("uses the compacted estimate from persisted messages", () => {
+		const messages: TypesGen.ChatMessage[] = [
+			{ ...MockChatMessage, id: 1, usage: { input_tokens: 90000 } },
+			MockChatCompactionMessage,
+		];
 		expect(getLatestContextUsage(messages)).toEqual({
 			usedTokens: 12000,
 			contextLimitTokens: 100000,
@@ -152,14 +150,12 @@ describe("getLatestContextUsage", () => {
 	])(
 		"does not reuse pre-compaction usage for invalid metadata %j",
 		(result) => {
-			const message: TypesGen.ChatMessage = JSON.parse(
-				JSON.stringify({
-					...MockChatCompactionMessage,
-					content: [
-						{ type: "tool-result", tool_name: "chat_summarized", result },
-					],
-				}),
-			);
+			const message: TypesGen.ChatMessage = {
+				...MockChatCompactionMessage,
+				content: [
+					{ type: "tool-result", tool_name: "chat_summarized", result },
+				],
+			};
 			expect(
 				getLatestContextUsage([
 					{ ...MockChatMessage, usage: { input_tokens: 90000 } },

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
@@ -2,7 +2,8 @@ import type * as TypesGen from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import { findWorkspaceAgent } from "#/utils/workspace";
 import type { AgentContextUsage } from "../AgentChatInput";
-import { asString } from "../ChatElements/runtimeTypeUtils";
+import { asNumber, asString } from "../ChatElements/runtimeTypeUtils";
+import { parseArgs } from "../ChatElements/tools/utils";
 import { asNonEmptyString } from "./blockUtils";
 
 export const extractContextUsageFromMessage = (
@@ -45,16 +46,38 @@ export const extractContextUsageFromMessage = (
 
 export const getLatestContextUsage = (
 	messages: readonly TypesGen.ChatMessage[],
+	activeContextLimit?: number,
 ): AgentContextUsage | null => {
 	for (const message of messages.toReversed()) {
-		const isContextBoundary = message.content?.some(
+		const contextBoundary = message.content?.find(
 			(part) =>
 				(part.type === "tool-call" || part.type === "tool-result") &&
 				(part.tool_name === "chat_summarized" ||
 					part.tool_name === "chat_cleared"),
 		);
-		if (isContextBoundary) {
-			return null;
+		if (contextBoundary) {
+			if (
+				contextBoundary.type !== "tool-result" ||
+				contextBoundary.tool_name !== "chat_summarized" ||
+				contextBoundary.is_error
+			) {
+				return null;
+			}
+			const result = parseArgs(contextBoundary.result);
+			const usedTokens = asNumber(result?.estimated_context_tokens);
+			const contextLimitTokens = asNumber(
+				activeContextLimit ?? result?.context_limit_tokens,
+			);
+			if (
+				usedTokens === undefined ||
+				!Number.isSafeInteger(usedTokens) ||
+				usedTokens <= 0 ||
+				contextLimitTokens === undefined ||
+				contextLimitTokens <= 0
+			) {
+				return null;
+			}
+			return { usedTokens, contextLimitTokens, estimated: true };
 		}
 
 		const usage = extractContextUsageFromMessage(message);

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -1,4 +1,5 @@
 import type * as TypesGen from "#/api/typesGenerated";
+import { asRecord } from "../ChatElements/runtimeTypeUtils";
 import { shouldRenderTool } from "../ChatElements/tools/toolVisibility";
 import type {
 	ParsedMessageContent,
@@ -275,11 +276,13 @@ const partFileIds = (part: TypesGen.ChatMessagePart): string[] => {
 	switch (part.type) {
 		case "file":
 			return part.file_id ? [part.file_id] : [];
-		case "tool-result":
-			return [
-				part.result?.recording_file_id,
-				part.result?.thumbnail_file_id,
-			].filter((fileId): fileId is string => Boolean(fileId));
+		case "tool-result": {
+			const result = asRecord(part.result);
+			return [result?.recording_file_id, result?.thumbnail_file_id].filter(
+				(fileId): fileId is string =>
+					typeof fileId === "string" && fileId.length > 0,
+			);
+		}
 		default:
 			return [];
 	}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -1,7 +1,7 @@
 import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import {
 	chatPromptsKey,
 	userCompactionThresholdsKey,
@@ -135,126 +135,35 @@ const StoryChatPageInput: FC<{
 	</div>
 );
 
-const compactionStore = createChatStore();
 export const ContextUsageAfterCompaction: Story = {
 	render: () => {
-		compactionStore.resetTransientState();
-		compactionStore.replaceMessages([]);
-		compactionStore.setChatStatus("waiting");
-		return <StoryChatPageInput store={compactionStore} contextLimit={200000} />;
+		const store = createChatStore();
+		store.replaceMessages([MockChatCompactionMessage]);
+		store.setChatStatus("waiting");
+		return <StoryChatPageInput store={store} contextLimit={200000} />;
 	},
 	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const body = within(document.body);
-		const gauge = canvas.getByRole("button", { name: "Context usage" });
-		await userEvent.hover(gauge);
-		await waitFor(() =>
-			expect(
-				body.getByText("Context usage will appear after sending a message."),
-			).toBeVisible(),
-		);
-		await userEvent.unhover(gauge);
-
-		const previous: TypesGen.ChatMessage = {
-			...MockChatMessage,
-			id: 1,
-			usage: { input_tokens: 90000, context_limit: 200000 },
-		};
-		const call: TypesGen.ChatMessagePart = {
-			type: "tool-call",
-			tool_call_id: "summary-1",
-			tool_name: "chat_summarized",
-		};
-		compactionStore.replaceMessages([previous]);
-		compactionStore.setChatStatus("running");
-		compactionStore.applyMessagePart(call);
-		compactionStore.applyMessageParts(MockChatCompactionMessage.content ?? []);
-		const persisted: TypesGen.ChatMessage[] = [
-			previous,
-			{ ...MockChatMessage, id: 2, role: "assistant", content: [call] },
-			MockChatCompactionMessage,
-		];
-		compactionStore.replaceMessages(persisted);
-		compactionStore.clearStreamState();
-		compactionStore.setChatStatus("waiting");
-
-		await waitFor(() =>
-			expect(gauge).toHaveAccessibleName(
-				"Estimated context usage 6%. 12,000 of 200,000 tokens used.",
-			),
-		);
-		await userEvent.hover(gauge);
-		await waitFor(() =>
-			expect(
-				body.getByText("Estimated: 6% - 12K / 200K context used"),
-			).toBeVisible(),
-		);
-		await expect(
-			body.getByText(/Based on the compacted summary only/),
-		).toBeVisible();
-		await expect(
-			body.queryByText("Context usage will appear after sending a message."),
-		).toBeNull();
-		await expect(
-			canvas.getByRole("textbox", { name: "Chat message" }),
-		).toHaveTextContent(/^$/);
-
-		const reloaded: TypesGen.ChatMessage[] = JSON.parse(
-			JSON.stringify(persisted),
-		);
-		compactionStore.replaceMessages(reloaded);
-		await expect(gauge).toHaveAccessibleName(
-			"Estimated context usage 6%. 12,000 of 200,000 tokens used.",
+		await userEvent.hover(
+			within(canvasElement).getByRole("button", { name: /context usage/i }),
 		);
 	},
 };
 
-const failedCompactionStore = createChatStore();
 export const UncommittedCompactionKeepsContextUsage: Story = {
 	render: () => {
-		failedCompactionStore.resetTransientState();
-		failedCompactionStore.replaceMessages([
-			{
-				...MockChatMessage,
-				usage: { input_tokens: 90000, context_limit: 200000 },
-			},
-		]);
-		failedCompactionStore.setChatStatus("waiting");
-		return (
-			<StoryChatPageInput store={failedCompactionStore} contextLimit={200000} />
-		);
+		const store = createChatStore();
+		const previousMessage: TypesGen.ChatMessage = {
+			...MockChatMessage,
+			usage: { input_tokens: 90000, context_limit: 200000 },
+		};
+		store.replaceMessages([previousMessage]);
+		store.setChatStatus("waiting");
+		return <StoryChatPageInput store={store} contextLimit={200000} />;
 	},
 	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		for (const status of ["error", "waiting"] satisfies TypesGen.ChatStatus[]) {
-			failedCompactionStore.setChatStatus("running");
-			failedCompactionStore.applyMessagePart({
-				type: "tool-call",
-				tool_call_id: "summary-1",
-				tool_name: "chat_summarized",
-			});
-			if (status === "error") {
-				failedCompactionStore.applyMessagePart({
-					type: "tool-result",
-					tool_call_id: "summary-1",
-					tool_name: "chat_summarized",
-					is_error: true,
-					result: { error: "Summary failed" },
-				});
-			}
-			failedCompactionStore.clearStreamState();
-			failedCompactionStore.setChatStatus(status);
-			const gauge = canvas.getByRole("button", {
-				name: "Context usage 45%. 90,000 of 200,000 tokens used.",
-			});
-			await userEvent.hover(gauge);
-			await waitFor(() =>
-				expect(
-					within(document.body).getByText("45% - 90K / 200K context used"),
-				).toBeVisible(),
-			);
-			await userEvent.unhover(gauge);
-		}
+		await userEvent.hover(
+			within(canvasElement).getByRole("button", { name: /context usage/i }),
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -1,7 +1,7 @@
 import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
 	chatPromptsKey,
 	userCompactionThresholdsKey,
@@ -9,7 +9,12 @@ import {
 import { preferenceSettingsKey } from "#/api/queries/users";
 import { workspacesKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
-import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
+import {
+	MockChat,
+	MockChatCompactionMessage,
+	MockChatMessage,
+	MockChatQueuedMessage,
+} from "#/testHelpers/chatEntities";
 import { MockChatModel } from "#/testHelpers/chatModels";
 import {
 	MockUserChatCompactionThresholds,
@@ -96,7 +101,8 @@ const mockCompactionModels: readonly TypesGen.ChatModel[] = [
 const StoryChatPageInput: FC<{
 	store: ReturnType<typeof createChatStore>;
 	onInterrupt?: () => void;
-}> = ({ store, onInterrupt }) => (
+	contextLimit?: number;
+}> = ({ store, onInterrupt, contextLimit }) => (
 	<div className="mx-auto w-full max-w-3xl p-4">
 		<ChatPageInput
 			chat={{ ...MockChat, id: "", organization_id: "" }}
@@ -118,6 +124,7 @@ const StoryChatPageInput: FC<{
 					provider: "openai",
 					model: "gpt-4o",
 					displayName: "GPT-4o",
+					contextLimit,
 				},
 			]}
 			modelSelectorPlaceholder="Select model"
@@ -127,6 +134,129 @@ const StoryChatPageInput: FC<{
 		/>
 	</div>
 );
+
+const compactionStore = createChatStore();
+export const ContextUsageAfterCompaction: Story = {
+	render: () => {
+		compactionStore.resetTransientState();
+		compactionStore.replaceMessages([]);
+		compactionStore.setChatStatus("waiting");
+		return <StoryChatPageInput store={compactionStore} contextLimit={200000} />;
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+		const gauge = canvas.getByRole("button", { name: "Context usage" });
+		await userEvent.hover(gauge);
+		await waitFor(() =>
+			expect(
+				body.getByText("Context usage will appear after sending a message."),
+			).toBeVisible(),
+		);
+		await userEvent.unhover(gauge);
+
+		const previous: TypesGen.ChatMessage = {
+			...MockChatMessage,
+			id: 1,
+			usage: { input_tokens: 90000, context_limit: 200000 },
+		};
+		const call: TypesGen.ChatMessagePart = {
+			type: "tool-call",
+			tool_call_id: "summary-1",
+			tool_name: "chat_summarized",
+		};
+		compactionStore.replaceMessages([previous]);
+		compactionStore.setChatStatus("running");
+		compactionStore.applyMessagePart(call);
+		compactionStore.applyMessageParts(MockChatCompactionMessage.content ?? []);
+		const persisted: TypesGen.ChatMessage[] = [
+			previous,
+			{ ...MockChatMessage, id: 2, role: "assistant", content: [call] },
+			MockChatCompactionMessage,
+		];
+		compactionStore.replaceMessages(persisted);
+		compactionStore.clearStreamState();
+		compactionStore.setChatStatus("waiting");
+
+		await waitFor(() =>
+			expect(gauge).toHaveAccessibleName(
+				"Estimated context usage 6%. 12,000 of 200,000 tokens used.",
+			),
+		);
+		await userEvent.hover(gauge);
+		await waitFor(() =>
+			expect(
+				body.getByText("Estimated: 6% - 12K / 200K context used"),
+			).toBeVisible(),
+		);
+		await expect(
+			body.getByText(/Based on the compacted summary only/),
+		).toBeVisible();
+		await expect(
+			body.queryByText("Context usage will appear after sending a message."),
+		).toBeNull();
+		await expect(
+			canvas.getByRole("textbox", { name: "Chat message" }),
+		).toHaveTextContent(/^$/);
+
+		const reloaded: TypesGen.ChatMessage[] = JSON.parse(
+			JSON.stringify(persisted),
+		);
+		compactionStore.replaceMessages(reloaded);
+		await expect(gauge).toHaveAccessibleName(
+			"Estimated context usage 6%. 12,000 of 200,000 tokens used.",
+		);
+	},
+};
+
+const failedCompactionStore = createChatStore();
+export const UncommittedCompactionKeepsContextUsage: Story = {
+	render: () => {
+		failedCompactionStore.resetTransientState();
+		failedCompactionStore.replaceMessages([
+			{
+				...MockChatMessage,
+				usage: { input_tokens: 90000, context_limit: 200000 },
+			},
+		]);
+		failedCompactionStore.setChatStatus("waiting");
+		return (
+			<StoryChatPageInput store={failedCompactionStore} contextLimit={200000} />
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		for (const status of ["error", "waiting"] satisfies TypesGen.ChatStatus[]) {
+			failedCompactionStore.setChatStatus("running");
+			failedCompactionStore.applyMessagePart({
+				type: "tool-call",
+				tool_call_id: "summary-1",
+				tool_name: "chat_summarized",
+			});
+			if (status === "error") {
+				failedCompactionStore.applyMessagePart({
+					type: "tool-result",
+					tool_call_id: "summary-1",
+					tool_name: "chat_summarized",
+					is_error: true,
+					result: { error: "Summary failed" },
+				});
+			}
+			failedCompactionStore.clearStreamState();
+			failedCompactionStore.setChatStatus(status);
+			const gauge = canvas.getByRole("button", {
+				name: "Context usage 45%. 90,000 of 200,000 tokens used.",
+			});
+			await userEvent.hover(gauge);
+			await waitFor(() =>
+				expect(
+					within(document.body).getByText("45% - 90K / 200K context used"),
+				).toBeVisible(),
+			);
+			await userEvent.unhover(gauge);
+		}
+	},
+};
 
 const buildMessage = (
 	id: number,

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -399,7 +399,10 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const userPromptHistory: readonly string[] =
 		promptsData?.prompts.map((prompt) => prompt.text) ?? [];
 
-	const rawUsage = getLatestContextUsage(messages);
+	const rawUsage = getLatestContextUsage(
+		messages,
+		modelOptions.find((option) => option.id === selectedModel)?.contextLimit,
+	);
 	const latestContextUsage =
 		rawUsage || chatContext
 			? {

--- a/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/ContextUsageIndicator.tsx
@@ -35,6 +35,7 @@ import { SvgRingProgress } from "./SvgRingProgress";
 
 export interface AgentContextUsage {
 	readonly usedTokens?: number;
+	readonly estimated?: boolean;
 	readonly contextLimitTokens?: number;
 	readonly inputTokens?: number;
 	readonly outputTokens?: number;
@@ -384,7 +385,7 @@ export const ContextUsageIndicator: FC<{
 	].filter((note) => note !== "");
 	const statusNote = statusNotes.length > 0 ? ` ${statusNotes.join(" ")}` : "";
 	const ariaLabel = hasPercent
-		? `Context usage ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${statusNote}`
+		? `${usage?.estimated ? "Estimated context usage" : "Context usage"} ${percentLabel}. ${formatTokenCount(usedTokens)} of ${formatTokenCount(contextLimitTokens)} tokens used.${statusNote}`
 		: statusNote !== ""
 			? `Context usage.${statusNote}`
 			: "Context usage";
@@ -392,10 +393,16 @@ export const ContextUsageIndicator: FC<{
 	const panelContent = (
 		<div className="text-xs text-content-primary">
 			{hasPercent
-				? `${percentLabel} - ${formatTokenCountCompact(usedTokens)} / ${formatTokenCountCompact(contextLimitTokens)} context used`
+				? `${usage?.estimated ? "Estimated: " : ""}${percentLabel} - ${formatTokenCountCompact(usedTokens)} / ${formatTokenCountCompact(contextLimitTokens)} context used`
 				: hasReportedUsage
 					? "Context usage unavailable"
 					: "Context usage will appear after sending a message."}
+			{hasPercent && usage?.estimated && (
+				<div className="mt-1 max-w-64 text-content-secondary">
+					Based on the compacted summary only, excluding other prompt content
+					and tools. Replaced by measured usage after the next response.
+				</div>
+			)}
 			{hasPercent &&
 				usage?.compressionThreshold !== undefined &&
 				usage.compressionThreshold > 0 && (

--- a/site/src/testHelpers/chatEntities.ts
+++ b/site/src/testHelpers/chatEntities.ts
@@ -143,9 +143,13 @@ export const MockChatCompactionMessage: ChatMessage = {
 			type: "tool-result",
 			tool_call_id: "summary-1",
 			tool_name: "chat_summarized",
-			result: JSON.parse(
-				'{"summary":"Compacted conversation","source":"manual","context_tokens":90000,"context_limit_tokens":100000,"estimated_context_tokens":12000}',
-			),
+			result: {
+				summary: "Compacted conversation",
+				source: "manual",
+				context_tokens: 90000,
+				context_limit_tokens: 100000,
+				estimated_context_tokens: 12000,
+			},
 		},
 	],
 };

--- a/site/src/testHelpers/chatEntities.ts
+++ b/site/src/testHelpers/chatEntities.ts
@@ -134,6 +134,22 @@ export const MockChatFileMetadata: ChatFileMetadata = {
 	created_at: MOCK_TIMESTAMP,
 };
 
+export const MockChatCompactionMessage: ChatMessage = {
+	...MockChatMessage,
+	id: 3,
+	role: "tool",
+	content: [
+		{
+			type: "tool-result",
+			tool_call_id: "summary-1",
+			tool_name: "chat_summarized",
+			result: JSON.parse(
+				'{"summary":"Compacted conversation","source":"manual","context_tokens":90000,"context_limit_tokens":100000,"estimated_context_tokens":12000}',
+			),
+		},
+	],
+};
+
 export const MockChatQueuedMessage: ChatQueuedMessage = {
 	id: 1,
 	chat_id: "chat-1",

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import type {
 	CreateUserSecretRequest,
 	CreateWorkspaceBuildRequest,
+	ListInboxNotificationsResponse,
 	UpdateUserSecretRequest,
 	UserSecret,
 } from "#/api/typesGenerated";
@@ -12,6 +13,13 @@ import * as M from "./entities";
 import { MockGroup, MockWorkspaceQuota } from "./entities";
 
 export const handlers = [
+	http.get("/api/v2/notifications/inbox", () => {
+		return HttpResponse.json<ListInboxNotificationsResponse>({
+			notifications: [],
+			unread_count: 0,
+		});
+	}),
+
 	http.get("/api/v2/templates/:templateId/daus", () => {
 		return HttpResponse.json(M.MockTemplateDAUResponse);
 	}),

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -5,6 +5,7 @@ import type {
 	CreateUserSecretRequest,
 	CreateWorkspaceBuildRequest,
 	ListInboxNotificationsResponse,
+	Preset,
 	UpdateUserSecretRequest,
 	UserSecret,
 } from "#/api/typesGenerated";
@@ -137,6 +138,9 @@ export const handlers = [
 	}),
 	http.get("/api/v2/templateversions/:templateVersionId", () => {
 		return HttpResponse.json(M.MockTemplateVersion);
+	}),
+	http.get("/api/v2/templateversions/:templateVersionId/presets", () => {
+		return HttpResponse.json<Preset[]>([]);
 	}),
 	http.get("/api/v2/templateversions/:templateVersionId/resources", () => {
 		return HttpResponse.json([


### PR DESCRIPTION
After compaction, the context gauge showed the unused-chat placeholder until the next response. It now shows a clearly labeled estimate based on the compacted summary, keeps that estimate after reload, and uses the selected chat model’s context limit. The next response replaces it with measured usage.

The estimate stays separate from provider-reported token accounting. Remote dogfood UAT passed the core workflow on cb18cbdac596231acf821cd612c5a8c5d1db1c7b. It has not been repeated on the current head, 8cfc3da83c07179aa5ea0e0ba627c83971c8fdcd.

> Xum acted on behalf of @ibetitsmike.

<details>
<summary>Review follow-up and validation</summary>

- DanielleMaywood's review of df01d8b5369: simplified both nested label ternaries and removed the unrelated mock handlers in 8cfc3da83c0. Replies: [accessible label](https://github.com/coder/coder/pull/28984#discussion_r4003806647), [panel label](https://github.com/coder/coder/pull/28984#discussion_r4003807264), [mock scope](https://github.com/coder/coder/pull/28984#discussion_r4003807845). All three threads resolved.
- Local visual review, task ecb1c01d70: six states of the label refactor inspected with no regressions found. Frontend self-review: FE1 through FE10 passed.
- Passed frontend format, check, and lint; 50 targeted unit tests; 19 stories; 64 label parity comparisons; and the full pre-commit and pre-push hooks, including Go tests, frontend tests, and the production frontend build.
- The pre-push run used a process-local LD_PRELOAD shim to refuse loopback port 3000, preventing unmocked test requests from reaching the unrelated host service. No hooks were disabled and the host service was not changed.
- [Documentation analysis is blocked](https://github.com/coder/coder/actions/runs/34827361213/job/103922480177): its Coder workspace is dormant, so the review did not run. The workspace needs reactivation before retrying that check.

</details>
