### PR TITLE
feat(coderd): add aggregate agent time report queries

### DIFF
--- a/coderd/agenttime/backfill_test.go
+++ b/coderd/agenttime/backfill_test.go
@@ -484,10 +484,10 @@ func insertAgentTimeMessage(ctx context.Context, t testing.TB, db *sql.DB, chatI
 func insertManyUnaccountedAgentTimeMessages(ctx context.Context, t testing.TB, db *sql.DB, chatID uuid.UUID, createdAt time.Time, count int) {
 	t.Helper()
 
-	_, err := db.ExecContext(ctx, `ALTER TABLE chat_messages DISABLE TRIGGER trigger_agent_time_account_chat_messages_after_insert`)
+	_, err := db.ExecContext(ctx, `ALTER TABLE chat_messages DISABLE TRIGGER trigger_zz_agent_time_account_chat_messages_after_insert`)
 	require.NoError(t, err)
 	defer func() {
-		_, enableErr := db.ExecContext(ctx, `ALTER TABLE chat_messages ENABLE TRIGGER trigger_agent_time_account_chat_messages_after_insert`)
+		_, enableErr := db.ExecContext(ctx, `ALTER TABLE chat_messages ENABLE TRIGGER trigger_zz_agent_time_account_chat_messages_after_insert`)
 		require.NoError(t, enableErr)
 	}()
 

--- a/coderd/agenttime/backfill_test.go
+++ b/coderd/agenttime/backfill_test.go
@@ -344,10 +344,109 @@ func TestAgentTimeBackfillUsesAdvisoryLock(t *testing.T) {
 	require.False(t, event.Locked)
 }
 
-type chatState struct {
-	SnapshotVersion   int64
-	HistoryVersion    int64
-	GenerationAttempt int64
+func TestAgentTimeChatDeletionPreservesUnaccountedMessages(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
+	fixture := setupAgentTimeFixture(t, db)
+	ids := []int64{
+		insertAgentTimeMessage(ctx, t, sqlDB, fixture.chat.ID, database.ChatMessageRoleAssistant, database.ChatMessageVisibilityBoth, time.Date(2025, 4, 1, 12, 0, 0, 0, time.UTC), int64Ptr(150), false),
+		insertAgentTimeMessage(ctx, t, sqlDB, fixture.chat.ID, database.ChatMessageRoleTool, database.ChatMessageVisibilityUser, time.Date(2025, 4, 2, 12, 0, 0, 0, time.UTC), int64Ptr(250), false),
+	}
+	clearAgentTimeAccounting(ctx, t, sqlDB, ids)
+
+	_, err := sqlDB.ExecContext(ctx, `DELETE FROM chats WHERE id = $1`, fixture.chat.ID)
+	require.NoError(t, err)
+
+	requireDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 4, 1), 150)
+	requireDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 4, 2), 250)
+	requireAgentTimeMarkerCount(ctx, t, sqlDB, ids, 0)
+}
+
+func TestAgentTimePhysicalIdentityCascadesPreserveTotals(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
+
+	userCascade := setupAgentTimeFixture(t, db)
+	userMessageID := insertAgentTimeMessage(ctx, t, sqlDB, userCascade.chat.ID, database.ChatMessageRoleAssistant, database.ChatMessageVisibilityBoth, time.Date(2025, 5, 1, 12, 0, 0, 0, time.UTC), int64Ptr(500), false)
+	clearAgentTimeAccounting(ctx, t, sqlDB, []int64{userMessageID})
+	_, err := sqlDB.ExecContext(ctx, `DELETE FROM user_status_changes WHERE user_id = $1`, userCascade.user.ID)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userCascade.user.ID)
+	require.NoError(t, err)
+	requireDailyAgentTime(ctx, t, sqlDB, userCascade.org.ID, userCascade.user.ID, date(2025, 5, 1), 500)
+
+	orgCascade := setupAgentTimeFixture(t, db)
+	orgMessageID := insertAgentTimeMessage(ctx, t, sqlDB, orgCascade.chat.ID, database.ChatMessageRoleAssistant, database.ChatMessageVisibilityBoth, time.Date(2025, 5, 2, 12, 0, 0, 0, time.UTC), int64Ptr(600), false)
+	clearAgentTimeAccounting(ctx, t, sqlDB, []int64{orgMessageID})
+	_, err = sqlDB.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgCascade.org.ID)
+	require.NoError(t, err)
+	requireDailyAgentTime(ctx, t, sqlDB, orgCascade.org.ID, orgCascade.user.ID, date(2025, 5, 2), 600)
+}
+
+func TestAgentTimeRetentionSkipsBusyChats(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
+	fixture := setupAgentTimeFixture(t, db)
+	_, err := db.ArchiveChatByID(ctx, fixture.chat.ID)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, `UPDATE chats SET updated_at = $1 WHERE id = $2`, time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC), fixture.chat.ID)
+	require.NoError(t, err)
+
+	lockTx, err := sqlDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = lockTx.Rollback() }()
+	_, err = lockTx.ExecContext(ctx, `SELECT id FROM chats WHERE id = $1 FOR UPDATE`, fixture.chat.ID)
+	require.NoError(t, err)
+
+	deleted, err := db.DeleteOldChats(ctx, database.DeleteOldChatsParams{
+		BeforeTime: time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC),
+		LimitCount: 1,
+	})
+	require.NoError(t, err)
+	require.Zero(t, deleted)
+
+	require.NoError(t, lockTx.Rollback())
+	deleted, err = db.DeleteOldChats(ctx, database.DeleteOldChatsParams{
+		BeforeTime: time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC),
+		LimitCount: 1,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
+}
+
+func TestAgentTimeRetentionDefersOversizedUnaccountedChats(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
+	fixture := setupAgentTimeFixture(t, db)
+	_, err := db.ArchiveChatByID(ctx, fixture.chat.ID)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, `UPDATE chats SET updated_at = $1 WHERE id = $2`, time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC), fixture.chat.ID)
+	require.NoError(t, err)
+	insertManyUnaccountedAgentTimeMessages(ctx, t, sqlDB, fixture.chat.ID, time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC), 10001)
+
+	deleted, err := db.DeleteOldChats(ctx, database.DeleteOldChatsParams{
+		BeforeTime: time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC),
+		LimitCount: 1,
+	})
+	require.NoError(t, err)
+	require.Zero(t, deleted)
+	_, err = db.GetChatByID(ctx, fixture.chat.ID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `DELETE FROM chats WHERE id = $1`, fixture.chat.ID)
+	require.ErrorContains(t, err, "exceeding fallback limit")
+	_, err = db.GetChatByID(ctx, fixture.chat.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 10001, countChatMessages(ctx, t, sqlDB, fixture.chat.ID))
+	requireNoDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 6, 1))
 }
 
 func setupAgentTimeFixture(t testing.TB, db database.Store) agentTimeFixture {
@@ -382,6 +481,24 @@ func insertAgentTimeMessage(ctx context.Context, t testing.TB, db *sql.DB, chatI
 	return id
 }
 
+func insertManyUnaccountedAgentTimeMessages(ctx context.Context, t testing.TB, db *sql.DB, chatID uuid.UUID, createdAt time.Time, count int) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, `ALTER TABLE chat_messages DISABLE TRIGGER trigger_agent_time_account_chat_messages_after_insert`)
+	require.NoError(t, err)
+	defer func() {
+		_, enableErr := db.ExecContext(ctx, `ALTER TABLE chat_messages ENABLE TRIGGER trigger_agent_time_account_chat_messages_after_insert`)
+		require.NoError(t, enableErr)
+	}()
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO chat_messages (chat_id, role, content, content_version, visibility, runtime_ms, created_at)
+		SELECT $1, 'assistant'::chat_message_role, '[]'::jsonb, 1, 'both'::chat_message_visibility, 1, $2::timestamptz + (gs || ' milliseconds')::interval
+		FROM generate_series(1, $3::int) AS gs
+	`, chatID, createdAt, count)
+	require.NoError(t, err)
+}
+
 func clearAgentTimeAccounting(ctx context.Context, t testing.TB, db *sql.DB, messageIDs []int64) {
 	t.Helper()
 
@@ -389,6 +506,43 @@ func clearAgentTimeAccounting(ctx context.Context, t testing.TB, db *sql.DB, mes
 	require.NoError(t, err)
 	_, err = db.ExecContext(ctx, `DELETE FROM agent_time_daily; DELETE FROM agent_time_organization_daily`)
 	require.NoError(t, err)
+}
+
+func isolateBackfillOrg(ctx context.Context, t testing.TB, db *sql.DB, orgID uuid.UUID, cursorMessageID int64) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO agent_time_backfill_status (organization_id, cursor_message_id, completed_at)
+		SELECT id, CASE WHEN id = $1 THEN $2::bigint ELSE 0 END, CASE WHEN id = $1 THEN NULL ELSE now() END
+		FROM organizations
+		ON CONFLICT (organization_id) DO UPDATE SET
+			cursor_message_id = EXCLUDED.cursor_message_id,
+			completed_at = EXCLUDED.completed_at,
+			processed_messages = 0,
+			last_error = '',
+			last_error_at = NULL,
+			updated_at = now()
+	`, orgID, cursorMessageID)
+	require.NoError(t, err)
+}
+
+func readBackfillStatus(ctx context.Context, t testing.TB, db *sql.DB, orgID uuid.UUID) database.AgentTimeBackfillStatus {
+	t.Helper()
+
+	var status database.AgentTimeBackfillStatus
+	err := db.QueryRowContext(ctx, `
+		SELECT organization_id, cursor_message_id, processed_messages, completed_at, last_error, last_error_at, updated_at
+		FROM agent_time_backfill_status
+		WHERE organization_id = $1
+	`, orgID).Scan(&status.OrganizationID, &status.CursorMessageID, &status.ProcessedMessages, &status.CompletedAt, &status.LastError, &status.LastErrorAt, &status.UpdatedAt)
+	require.NoError(t, err)
+	return status
+}
+
+type chatState struct {
+	SnapshotVersion   int64
+	HistoryVersion    int64
+	GenerationAttempt int64
 }
 
 func readChatState(ctx context.Context, t testing.TB, db *sql.DB, chatID uuid.UUID) chatState {
@@ -470,35 +624,4 @@ func requireAgentTimeSummaryInvariant(ctx context.Context, t testing.TB, db *sql
  )`).Scan(&mismatch)
 	require.NoError(t, err)
 	require.False(t, mismatch, "organization summaries must equal canonical user/day sums")
-}
-
-func isolateBackfillOrg(ctx context.Context, t testing.TB, db *sql.DB, orgID uuid.UUID, cursorMessageID int64) {
-	t.Helper()
-
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO agent_time_backfill_status (organization_id, cursor_message_id, completed_at)
-		SELECT id, CASE WHEN id = $1 THEN $2::bigint ELSE 0 END, CASE WHEN id = $1 THEN NULL ELSE now() END
-		FROM organizations
-		ON CONFLICT (organization_id) DO UPDATE SET
-			cursor_message_id = EXCLUDED.cursor_message_id,
-			completed_at = EXCLUDED.completed_at,
-			processed_messages = 0,
-			last_error = '',
-			last_error_at = NULL,
-			updated_at = now()
-	`, orgID, cursorMessageID)
-	require.NoError(t, err)
-}
-
-func readBackfillStatus(ctx context.Context, t testing.TB, db *sql.DB, orgID uuid.UUID) database.AgentTimeBackfillStatus {
-	t.Helper()
-
-	var status database.AgentTimeBackfillStatus
-	err := db.QueryRowContext(ctx, `
-		SELECT organization_id, cursor_message_id, processed_messages, completed_at, last_error, last_error_at, updated_at
-		FROM agent_time_backfill_status
-		WHERE organization_id = $1
-	`, orgID).Scan(&status.OrganizationID, &status.CursorMessageID, &status.ProcessedMessages, &status.CompletedAt, &status.LastError, &status.LastErrorAt, &status.UpdatedAt)
-	require.NoError(t, err)
-	return status
 }

--- a/coderd/agenttime/concurrency_test.go
+++ b/coderd/agenttime/concurrency_test.go
@@ -1,0 +1,166 @@
+package agenttime_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/coder/coder/v2/coderd/agenttime"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestAgentTimeSummaryFailureIsAtomic(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+	fixture := setupAgentTimeFixture(t, db)
+	id := insertAgentTimeMessage(ctx, t, sqlDB, fixture.chat.ID, database.ChatMessageRoleAssistant, database.ChatMessageVisibilityBoth, date(2025, 1, 1), new(int64(100)), false)
+	clearAgentTimeAccounting(ctx, t, sqlDB, []int64{id})
+	isolateBackfillOrg(ctx, t, sqlDB, fixture.org.ID, 0)
+	_, err := sqlDB.ExecContext(ctx, "DELETE FROM agent_time_backfill_status WHERE organization_id=$1", fixture.org.ID)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, `
+ CREATE FUNCTION fail_agent_time_summary() RETURNS trigger LANGUAGE plpgsql AS $$
+ BEGIN RAISE EXCEPTION 'summary unavailable'; END; $$;
+ CREATE TRIGGER fail_agent_time_summary BEFORE INSERT OR UPDATE ON agent_time_organization_daily
+ FOR EACH ROW EXECUTE FUNCTION fail_agent_time_summary();`)
+	require.NoError(t, err)
+	_, err = agenttime.RunOnce(ctx, db, 100)
+	require.ErrorContains(t, err, "summary unavailable")
+	status := readBackfillStatus(ctx, t, sqlDB, fixture.org.ID)
+	require.Contains(t, status.LastError, "summary unavailable", "first-batch failures must survive status-discovery rollback")
+	require.Zero(t, status.ProcessedMessages)
+	requireNoDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 1, 1))
+	requireAgentTimeMarkerCount(ctx, t, sqlDB, []int64{id}, 0)
+	_, err = sqlDB.ExecContext(ctx, "DELETE FROM chats WHERE id=$1", fixture.chat.ID)
+	require.ErrorContains(t, err, "summary unavailable")
+	require.EqualValues(t, 1, countChatMessages(ctx, t, sqlDB, fixture.chat.ID))
+	requireNoDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 1, 1))
+	_, err = sqlDB.ExecContext(ctx, "DROP TRIGGER fail_agent_time_summary ON agent_time_organization_daily")
+	require.NoError(t, err)
+	_, err = agenttime.RunOnce(ctx, db, 100)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, "DELETE FROM chats WHERE id=$1", fixture.chat.ID)
+	require.NoError(t, err)
+	requireDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 1, 1), 100)
+}
+
+func TestAgentTimeSubchatConcurrentSummaries(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+	fixture := setupAgentTimeFixture(t, db)
+	secondUser := dbgen.User(t, db, database.User{})
+	subchat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID: fixture.org.ID, OwnerID: secondUser.ID,
+		LastModelConfigID: fixture.chat.LastModelConfigID, ParentChatID: uuid.NullUUID{UUID: fixture.chat.ID, Valid: true}, RootChatID: uuid.NullUUID{UUID: fixture.chat.ID, Valid: true},
+	})
+	var group errgroup.Group
+	for i := range 20 {
+		chatID := fixture.chat.ID
+		if i%2 == 1 {
+			chatID = subchat.ID
+		}
+		first, second := date(2025, 1, 1), date(2025, 1, 2)
+		if i%2 == 1 {
+			first, second = second, first
+		}
+		group.Go(func() error {
+			_, err := sqlDB.ExecContext(ctx, `
+   INSERT INTO chat_messages (chat_id,role,content,content_version,visibility,runtime_ms,created_at)
+   VALUES ($1,'assistant','[]',1,'model',5,$2),($1,'tool','[]',1,'model',5,$3)`, chatID, first, second)
+			return err
+		})
+	}
+	require.NoError(t, group.Wait())
+	for _, userID := range []uuid.UUID{fixture.user.ID, secondUser.ID} {
+		requireDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, userID, date(2025, 1, 1), 50)
+		requireDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, userID, date(2025, 1, 2), 50)
+	}
+}
+
+func TestAgentTimeOutOfOrderCommits(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+	first, second := setupAgentTimeFixture(t, db), setupAgentTimeFixture(t, db)
+	early, err := sqlDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer early.Rollback()
+	late, err := sqlDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer late.Rollback()
+	for _, row := range []struct {
+		tx   *sql.Tx
+		chat uuid.UUID
+		day  time.Time
+	}{{early, first.chat.ID, date(2025, 1, 1)}, {late, second.chat.ID, date(2025, 1, 2)}} {
+		_, err = row.tx.ExecContext(ctx, `INSERT INTO chat_messages (chat_id,role,content,content_version,visibility,runtime_ms,created_at)
+  VALUES ($1,'assistant','[]',1,'both',100,$2)`, row.chat, row.day)
+		require.NoError(t, err)
+	}
+	require.NoError(t, late.Commit())
+	requireDailyAgentTime(ctx, t, sqlDB, second.org.ID, second.user.ID, date(2025, 1, 2), 100)
+	requireNoDailyAgentTime(ctx, t, sqlDB, first.org.ID, first.user.ID, date(2025, 1, 1))
+	_, err = agenttime.RunOnce(ctx, db, 100)
+	require.NoError(t, err)
+	require.NoError(t, early.Commit())
+	requireDailyAgentTime(ctx, t, sqlDB, first.org.ID, first.user.ID, date(2025, 1, 1), 100)
+}
+
+func TestAgentTimeConcurrentInsertBackfillAndLegacyPurge(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+	fixture := setupAgentTimeFixture(t, db)
+	id := insertAgentTimeMessage(ctx, t, sqlDB, fixture.chat.ID, database.ChatMessageRoleAssistant, database.ChatMessageVisibilityBoth, date(2025, 1, 1), new(int64(100)), false)
+	clearAgentTimeAccounting(ctx, t, sqlDB, []int64{id})
+	isolateBackfillOrg(ctx, t, sqlDB, fixture.org.ID, 0)
+	_, err := sqlDB.ExecContext(ctx, "UPDATE chats SET archived=true,updated_at='2025-01-01' WHERE id=$1", fixture.chat.ID)
+	require.NoError(t, err)
+	live, err := sqlDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer live.Rollback()
+	_, err = live.ExecContext(ctx, "SELECT id FROM chats WHERE id=$1 FOR UPDATE", fixture.chat.ID)
+	require.NoError(t, err)
+	_, err = live.ExecContext(ctx, `INSERT INTO chat_messages (chat_id,role,content,content_version,visibility,runtime_ms,created_at)
+ VALUES ($1,'assistant','[]',1,'both',200,'2025-01-01')`, fixture.chat.ID)
+	require.NoError(t, err)
+	legacy, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	defer legacy.Close()
+	var pid int
+	require.NoError(t, legacy.QueryRowContext(ctx, "SELECT pg_backend_pid()").Scan(&pid))
+	deleted := make(chan error, 1)
+	go func() {
+		_, err := legacy.ExecContext(ctx, "DELETE FROM chats WHERE id=$1", fixture.chat.ID)
+		deleted <- err
+	}()
+	require.Eventually(t, func() bool {
+		var blocked bool
+		err := sqlDB.QueryRowContext(ctx, "SELECT cardinality(pg_blocking_pids($1)) > 0", pid).Scan(&blocked)
+		return err == nil && blocked
+	}, testutil.WaitLong, testutil.IntervalFast, "legacy deletion must be waiting on the live chat lock")
+	event, err := agenttime.RunOnce(ctx, db, 100)
+	require.NoError(t, err)
+	require.True(t, event.ResetCursor)
+	count, err := db.DeleteOldChats(ctx, database.DeleteOldChatsParams{BeforeTime: date(2026, 1, 1), LimitCount: 100})
+	require.NoError(t, err)
+	require.Zero(t, count)
+	require.NoError(t, live.Commit())
+	select {
+	case err := <-deleted:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	require.Zero(t, countChatMessages(ctx, t, sqlDB, fixture.chat.ID))
+	requireDailyAgentTime(ctx, t, sqlDB, fixture.org.ID, fixture.user.ID, date(2025, 1, 1), 300)
+}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3115,11 +3115,39 @@ func (q *querier) GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, temp
 	return q.db.GetActiveWorkspaceBuildsByTemplateID(ctx, templateID)
 }
 
+func (q *querier) GetAgentTimeBreakdown(ctx context.Context, arg database.GetAgentTimeBreakdownParams) ([]database.GetAgentTimeBreakdownRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return nil, err
+	}
+	return q.db.GetAgentTimeBreakdown(ctx, arg)
+}
+
+func (q *querier) GetAgentTimeBuckets(ctx context.Context, arg database.GetAgentTimeBucketsParams) ([]database.GetAgentTimeBucketsRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return nil, err
+	}
+	return q.db.GetAgentTimeBuckets(ctx, arg)
+}
+
+func (q *querier) GetAgentTimeEarliestDate(ctx context.Context, arg database.GetAgentTimeEarliestDateParams) (string, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return "", err
+	}
+	return q.db.GetAgentTimeEarliestDate(ctx, arg)
+}
+
 func (q *querier) GetAgentTimeStatus(ctx context.Context, organizationID uuid.UUID) (database.GetAgentTimeStatusRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
 		return database.GetAgentTimeStatusRow{}, err
 	}
 	return q.db.GetAgentTimeStatus(ctx, organizationID)
+}
+
+func (q *querier) GetAgentTimeSummary(ctx context.Context, arg database.GetAgentTimeSummaryParams) (database.GetAgentTimeSummaryRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return database.GetAgentTimeSummaryRow{}, err
+	}
+	return q.db.GetAgentTimeSummary(ctx, arg)
 }
 
 func (q *querier) GetAllTailnetCoordinators(ctx context.Context) ([]database.TailnetCoordinator, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -5816,6 +5816,30 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		dbm.EXPECT().GetAgentTimeStatus(gomock.Any(), organizationID).Return(row, nil).AnyTimes()
 		check.Args(organizationID).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(row)
 	}))
+	s.Run("GetAgentTimeEarliestDate", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.GetAgentTimeEarliestDateParams{}
+		result := ""
+		dbm.EXPECT().GetAgentTimeEarliestDate(gomock.Any(), arg).Return(result, nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(result)
+	}))
+	s.Run("GetAgentTimeSummary", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.GetAgentTimeSummaryParams{}
+		result := database.GetAgentTimeSummaryRow{}
+		dbm.EXPECT().GetAgentTimeSummary(gomock.Any(), arg).Return(result, nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(result)
+	}))
+	s.Run("GetAgentTimeBuckets", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.GetAgentTimeBucketsParams{}
+		result := []database.GetAgentTimeBucketsRow{}
+		dbm.EXPECT().GetAgentTimeBuckets(gomock.Any(), arg).Return(result, nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(result)
+	}))
+	s.Run("GetAgentTimeBreakdown", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.GetAgentTimeBreakdownParams{}
+		result := []database.GetAgentTimeBreakdownRow{}
+		dbm.EXPECT().GetAgentTimeBreakdown(gomock.Any(), arg).Return(result, nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(result)
+	}))
 	s.Run("GetWebpushVAPIDKeys", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetWebpushVAPIDKeys(gomock.Any()).Return(database.GetWebpushVAPIDKeysRow{VapidPublicKey: "test", VapidPrivateKey: "test"}, nil).AnyTimes()
 		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(database.GetWebpushVAPIDKeysRow{VapidPublicKey: "test", VapidPrivateKey: "test"})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1384,11 +1384,43 @@ func (m queryMetricsStore) GetActiveWorkspaceBuildsByTemplateID(ctx context.Cont
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetAgentTimeBreakdown(ctx context.Context, arg database.GetAgentTimeBreakdownParams) ([]database.GetAgentTimeBreakdownRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAgentTimeBreakdown(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetAgentTimeBreakdown").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAgentTimeBreakdown").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetAgentTimeBuckets(ctx context.Context, arg database.GetAgentTimeBucketsParams) ([]database.GetAgentTimeBucketsRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAgentTimeBuckets(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetAgentTimeBuckets").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAgentTimeBuckets").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetAgentTimeEarliestDate(ctx context.Context, arg database.GetAgentTimeEarliestDateParams) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAgentTimeEarliestDate(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetAgentTimeEarliestDate").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAgentTimeEarliestDate").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetAgentTimeStatus(ctx context.Context, organizationID uuid.UUID) (database.GetAgentTimeStatusRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetAgentTimeStatus(ctx, organizationID)
 	m.queryLatencies.WithLabelValues("GetAgentTimeStatus").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAgentTimeStatus").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetAgentTimeSummary(ctx context.Context, arg database.GetAgentTimeSummaryParams) (database.GetAgentTimeSummaryRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAgentTimeSummary(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetAgentTimeSummary").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAgentTimeSummary").Inc()
 	return r0, r1
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2442,6 +2442,51 @@ func (mr *MockStoreMockRecorder) GetActiveWorkspaceBuildsByTemplateID(ctx, templ
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveWorkspaceBuildsByTemplateID", reflect.TypeOf((*MockStore)(nil).GetActiveWorkspaceBuildsByTemplateID), ctx, templateID)
 }
 
+// GetAgentTimeBreakdown mocks base method.
+func (m *MockStore) GetAgentTimeBreakdown(ctx context.Context, arg database.GetAgentTimeBreakdownParams) ([]database.GetAgentTimeBreakdownRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentTimeBreakdown", ctx, arg)
+	ret0, _ := ret[0].([]database.GetAgentTimeBreakdownRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAgentTimeBreakdown indicates an expected call of GetAgentTimeBreakdown.
+func (mr *MockStoreMockRecorder) GetAgentTimeBreakdown(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentTimeBreakdown", reflect.TypeOf((*MockStore)(nil).GetAgentTimeBreakdown), ctx, arg)
+}
+
+// GetAgentTimeBuckets mocks base method.
+func (m *MockStore) GetAgentTimeBuckets(ctx context.Context, arg database.GetAgentTimeBucketsParams) ([]database.GetAgentTimeBucketsRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentTimeBuckets", ctx, arg)
+	ret0, _ := ret[0].([]database.GetAgentTimeBucketsRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAgentTimeBuckets indicates an expected call of GetAgentTimeBuckets.
+func (mr *MockStoreMockRecorder) GetAgentTimeBuckets(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentTimeBuckets", reflect.TypeOf((*MockStore)(nil).GetAgentTimeBuckets), ctx, arg)
+}
+
+// GetAgentTimeEarliestDate mocks base method.
+func (m *MockStore) GetAgentTimeEarliestDate(ctx context.Context, arg database.GetAgentTimeEarliestDateParams) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentTimeEarliestDate", ctx, arg)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAgentTimeEarliestDate indicates an expected call of GetAgentTimeEarliestDate.
+func (mr *MockStoreMockRecorder) GetAgentTimeEarliestDate(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentTimeEarliestDate", reflect.TypeOf((*MockStore)(nil).GetAgentTimeEarliestDate), ctx, arg)
+}
+
 // GetAgentTimeStatus mocks base method.
 func (m *MockStore) GetAgentTimeStatus(ctx context.Context, organizationID uuid.UUID) (database.GetAgentTimeStatusRow, error) {
 	m.ctrl.T.Helper()
@@ -2455,6 +2500,21 @@ func (m *MockStore) GetAgentTimeStatus(ctx context.Context, organizationID uuid.
 func (mr *MockStoreMockRecorder) GetAgentTimeStatus(ctx, organizationID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentTimeStatus", reflect.TypeOf((*MockStore)(nil).GetAgentTimeStatus), ctx, organizationID)
+}
+
+// GetAgentTimeSummary mocks base method.
+func (m *MockStore) GetAgentTimeSummary(ctx context.Context, arg database.GetAgentTimeSummaryParams) (database.GetAgentTimeSummaryRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentTimeSummary", ctx, arg)
+	ret0, _ := ret[0].(database.GetAgentTimeSummaryRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAgentTimeSummary indicates an expected call of GetAgentTimeSummary.
+func (mr *MockStoreMockRecorder) GetAgentTimeSummary(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentTimeSummary", reflect.TypeOf((*MockStore)(nil).GetAgentTimeSummary), ctx, arg)
 }
 
 // GetAllTailnetCoordinators mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -389,7 +389,11 @@ type sqlcQuerier interface {
 	// TestGetActiveUsersAuthorizationRolesParity enforces this.
 	GetActiveUsersAuthorizationRoles(ctx context.Context) ([]GetActiveUsersAuthorizationRolesRow, error)
 	GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, templateID uuid.UUID) ([]WorkspaceBuild, error)
+	GetAgentTimeBreakdown(ctx context.Context, arg GetAgentTimeBreakdownParams) ([]GetAgentTimeBreakdownRow, error)
+	GetAgentTimeBuckets(ctx context.Context, arg GetAgentTimeBucketsParams) ([]GetAgentTimeBucketsRow, error)
+	GetAgentTimeEarliestDate(ctx context.Context, arg GetAgentTimeEarliestDateParams) (string, error)
 	GetAgentTimeStatus(ctx context.Context, organizationID uuid.UUID) (GetAgentTimeStatusRow, error)
+	GetAgentTimeSummary(ctx context.Context, arg GetAgentTimeSummaryParams) (GetAgentTimeSummaryRow, error)
 	// For PG Coordinator HTMLDebug
 	GetAllTailnetCoordinators(ctx context.Context) ([]TailnetCoordinator, error)
 	GetAllTailnetPeers(ctx context.Context) ([]TailnetPeer, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -111,6 +111,245 @@ func (q *sqlQuerier) ActivityBumpWorkspace(ctx context.Context, arg ActivityBump
 	return err
 }
 
+const getAgentTimeBreakdown = `-- name: GetAgentTimeBreakdown :many
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE $5::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT $5::boolean
+), totals AS (
+    SELECT CASE WHEN $6::text = 'user' THEN user_id ELSE organization_id END AS id,
+        SUM(agent_time_ms) AS agent_time_ms
+    FROM daily
+    WHERE day >= $7::date AND day < $8::date
+    AND ($9::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = $9)
+    AND ($10::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = $10)
+    GROUP BY 1
+), named AS (
+    SELECT totals.id, totals.agent_time_ms,
+        CASE WHEN $6::text = 'user' THEN
+            CASE WHEN u.id IS NULL OR u.deleted THEN 'Deleted user' ELSE u.username END
+        ELSE
+            CASE WHEN o.id IS NULL OR o.deleted THEN 'Deleted organization'
+                ELSE COALESCE(NULLIF(o.display_name, ''), o.name) END
+        END::text AS name,
+        CASE WHEN $6::text = 'user' THEN u.id IS NULL OR u.deleted
+            ELSE o.id IS NULL OR o.deleted END::boolean AS deleted
+    FROM totals
+    LEFT JOIN users u ON $6::text = 'user' AND u.id = totals.id
+    LEFT JOIN organizations o ON $6::text = 'organization' AND o.id = totals.id
+)
+SELECT id::uuid AS id, name, deleted, agent_time_ms::text AS agent_time_ms FROM named
+ORDER BY
+    CASE WHEN $1::text = 'agent_time' AND $2::text = 'desc' THEN agent_time_ms END DESC,
+    CASE WHEN $1::text = 'agent_time' AND $2::text = 'asc' THEN agent_time_ms END ASC,
+    CASE WHEN $1::text = 'name' AND $2::text = 'desc' THEN name END DESC,
+    CASE WHEN $1::text = 'name' AND $2::text = 'asc' THEN name END ASC,
+    id ASC
+LIMIT $4::int OFFSET $3::int
+`
+
+type GetAgentTimeBreakdownParams struct {
+	SortBy                 string    `db:"sort_by" json:"sort_by"`
+	SortOrder              string    `db:"sort_order" json:"sort_order"`
+	PageOffset             int32     `db:"page_offset" json:"page_offset"`
+	PageLimit              int32     `db:"page_limit" json:"page_limit"`
+	UseOrganizationSummary bool      `db:"use_organization_summary" json:"use_organization_summary"`
+	GroupBy                string    `db:"group_by" json:"group_by"`
+	StartDate              time.Time `db:"start_date" json:"start_date"`
+	EndDate                time.Time `db:"end_date" json:"end_date"`
+	OrganizationID         uuid.UUID `db:"organization_id" json:"organization_id"`
+	UserID                 uuid.UUID `db:"user_id" json:"user_id"`
+}
+
+type GetAgentTimeBreakdownRow struct {
+	ID          uuid.UUID `db:"id" json:"id"`
+	Name        string    `db:"name" json:"name"`
+	Deleted     bool      `db:"deleted" json:"deleted"`
+	AgentTimeMs string    `db:"agent_time_ms" json:"agent_time_ms"`
+}
+
+func (q *sqlQuerier) GetAgentTimeBreakdown(ctx context.Context, arg GetAgentTimeBreakdownParams) ([]GetAgentTimeBreakdownRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAgentTimeBreakdown,
+		arg.SortBy,
+		arg.SortOrder,
+		arg.PageOffset,
+		arg.PageLimit,
+		arg.UseOrganizationSummary,
+		arg.GroupBy,
+		arg.StartDate,
+		arg.EndDate,
+		arg.OrganizationID,
+		arg.UserID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetAgentTimeBreakdownRow
+	for rows.Next() {
+		var i GetAgentTimeBreakdownRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Deleted,
+			&i.AgentTimeMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getAgentTimeBuckets = `-- name: GetAgentTimeBuckets :many
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE $6::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT $6::boolean
+)
+SELECT date_trunc($1::text, day::timestamp)::date::text AS bucket_date,
+    SUM(agent_time_ms)::text AS agent_time_ms
+FROM daily
+WHERE day >= $2::date AND day < $3::date
+    AND ($4::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = $4)
+    AND ($5::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = $5)
+GROUP BY 1
+ORDER BY 1
+`
+
+type GetAgentTimeBucketsParams struct {
+	Interval               string    `db:"interval" json:"interval"`
+	StartDate              time.Time `db:"start_date" json:"start_date"`
+	EndDate                time.Time `db:"end_date" json:"end_date"`
+	OrganizationID         uuid.UUID `db:"organization_id" json:"organization_id"`
+	UserID                 uuid.UUID `db:"user_id" json:"user_id"`
+	UseOrganizationSummary bool      `db:"use_organization_summary" json:"use_organization_summary"`
+}
+
+type GetAgentTimeBucketsRow struct {
+	BucketDate  string `db:"bucket_date" json:"bucket_date"`
+	AgentTimeMs string `db:"agent_time_ms" json:"agent_time_ms"`
+}
+
+func (q *sqlQuerier) GetAgentTimeBuckets(ctx context.Context, arg GetAgentTimeBucketsParams) ([]GetAgentTimeBucketsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAgentTimeBuckets,
+		arg.Interval,
+		arg.StartDate,
+		arg.EndDate,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.UseOrganizationSummary,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetAgentTimeBucketsRow
+	for rows.Next() {
+		var i GetAgentTimeBucketsRow
+		if err := rows.Scan(&i.BucketDate, &i.AgentTimeMs); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getAgentTimeEarliestDate = `-- name: GetAgentTimeEarliestDate :one
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE $3::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT $3::boolean
+)
+SELECT COALESCE(MIN(day)::text, '')::text AS earliest_date
+FROM daily
+WHERE ($1::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = $1)
+    AND ($2::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = $2)
+`
+
+type GetAgentTimeEarliestDateParams struct {
+	OrganizationID         uuid.UUID `db:"organization_id" json:"organization_id"`
+	UserID                 uuid.UUID `db:"user_id" json:"user_id"`
+	UseOrganizationSummary bool      `db:"use_organization_summary" json:"use_organization_summary"`
+}
+
+func (q *sqlQuerier) GetAgentTimeEarliestDate(ctx context.Context, arg GetAgentTimeEarliestDateParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, getAgentTimeEarliestDate, arg.OrganizationID, arg.UserID, arg.UseOrganizationSummary)
+	var earliest_date string
+	err := row.Scan(&earliest_date)
+	return earliest_date, err
+}
+
+const getAgentTimeSummary = `-- name: GetAgentTimeSummary :one
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE $6::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT $6::boolean
+)
+SELECT COALESCE(SUM(agent_time_ms), 0)::text AS agent_time_ms,
+    COUNT(DISTINCT CASE WHEN $1::text = 'user' THEN user_id ELSE organization_id END)::bigint AS count
+FROM daily
+WHERE day >= $2::date AND day < $3::date
+    AND ($4::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = $4)
+    AND ($5::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = $5)
+`
+
+type GetAgentTimeSummaryParams struct {
+	GroupBy                string    `db:"group_by" json:"group_by"`
+	StartDate              time.Time `db:"start_date" json:"start_date"`
+	EndDate                time.Time `db:"end_date" json:"end_date"`
+	OrganizationID         uuid.UUID `db:"organization_id" json:"organization_id"`
+	UserID                 uuid.UUID `db:"user_id" json:"user_id"`
+	UseOrganizationSummary bool      `db:"use_organization_summary" json:"use_organization_summary"`
+}
+
+type GetAgentTimeSummaryRow struct {
+	AgentTimeMs string `db:"agent_time_ms" json:"agent_time_ms"`
+	Count       int64  `db:"count" json:"count"`
+}
+
+func (q *sqlQuerier) GetAgentTimeSummary(ctx context.Context, arg GetAgentTimeSummaryParams) (GetAgentTimeSummaryRow, error) {
+	row := q.db.QueryRowContext(ctx, getAgentTimeSummary,
+		arg.GroupBy,
+		arg.StartDate,
+		arg.EndDate,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.UseOrganizationSummary,
+	)
+	var i GetAgentTimeSummaryRow
+	err := row.Scan(&i.AgentTimeMs, &i.Count)
+	return i, err
+}
+
 const accountAgentTimeMessages = `-- name: AccountAgentTimeMessages :one
 SELECT account_agent_time_messages($1::bigint[])::bigint
 `

--- a/coderd/database/queries/agenttime.sql
+++ b/coderd/database/queries/agenttime.sql
@@ -1,0 +1,90 @@
+-- name: GetAgentTimeEarliestDate :one
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE @use_organization_summary::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT @use_organization_summary::boolean
+)
+SELECT COALESCE(MIN(day)::text, '')::text AS earliest_date
+FROM daily
+WHERE (@organization_id::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = @organization_id)
+    AND (@user_id::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = @user_id);
+
+-- name: GetAgentTimeSummary :one
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE @use_organization_summary::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT @use_organization_summary::boolean
+)
+SELECT COALESCE(SUM(agent_time_ms), 0)::text AS agent_time_ms,
+    COUNT(DISTINCT CASE WHEN @group_by::text = 'user' THEN user_id ELSE organization_id END)::bigint AS count
+FROM daily
+WHERE day >= @start_date::date AND day < @end_date::date
+    AND (@organization_id::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = @organization_id)
+    AND (@user_id::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = @user_id);
+
+-- name: GetAgentTimeBuckets :many
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE @use_organization_summary::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT @use_organization_summary::boolean
+)
+SELECT date_trunc(@interval::text, day::timestamp)::date::text AS bucket_date,
+    SUM(agent_time_ms)::text AS agent_time_ms
+FROM daily
+WHERE day >= @start_date::date AND day < @end_date::date
+    AND (@organization_id::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = @organization_id)
+    AND (@user_id::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = @user_id)
+GROUP BY 1
+ORDER BY 1;
+
+-- name: GetAgentTimeBreakdown :many
+WITH daily AS (
+    SELECT organization_id, '00000000-0000-0000-0000-000000000000'::uuid AS user_id, day, agent_time_ms
+    FROM agent_time_organization_daily
+    WHERE @use_organization_summary::boolean
+    UNION ALL
+    SELECT organization_id, user_id, day, agent_time_ms::numeric
+    FROM agent_time_daily
+    WHERE NOT @use_organization_summary::boolean
+), totals AS (
+    SELECT CASE WHEN @group_by::text = 'user' THEN user_id ELSE organization_id END AS id,
+        SUM(agent_time_ms) AS agent_time_ms
+    FROM daily
+    WHERE day >= @start_date::date AND day < @end_date::date
+    AND (@organization_id::uuid = '00000000-0000-0000-0000-000000000000' OR organization_id = @organization_id)
+    AND (@user_id::uuid = '00000000-0000-0000-0000-000000000000' OR user_id = @user_id)
+    GROUP BY 1
+), named AS (
+    SELECT totals.id, totals.agent_time_ms,
+        CASE WHEN @group_by::text = 'user' THEN
+            CASE WHEN u.id IS NULL OR u.deleted THEN 'Deleted user' ELSE u.username END
+        ELSE
+            CASE WHEN o.id IS NULL OR o.deleted THEN 'Deleted organization'
+                ELSE COALESCE(NULLIF(o.display_name, ''), o.name) END
+        END::text AS name,
+        CASE WHEN @group_by::text = 'user' THEN u.id IS NULL OR u.deleted
+            ELSE o.id IS NULL OR o.deleted END::boolean AS deleted
+    FROM totals
+    LEFT JOIN users u ON @group_by::text = 'user' AND u.id = totals.id
+    LEFT JOIN organizations o ON @group_by::text = 'organization' AND o.id = totals.id
+)
+SELECT id::uuid AS id, name, deleted, agent_time_ms::text AS agent_time_ms FROM named
+ORDER BY
+    CASE WHEN @sort_by::text = 'agent_time' AND @sort_order::text = 'desc' THEN agent_time_ms END DESC,
+    CASE WHEN @sort_by::text = 'agent_time' AND @sort_order::text = 'asc' THEN agent_time_ms END ASC,
+    CASE WHEN @sort_by::text = 'name' AND @sort_order::text = 'desc' THEN name END DESC,
+    CASE WHEN @sort_by::text = 'name' AND @sort_order::text = 'asc' THEN name END ASC,
+    id ASC
+LIMIT @page_limit::int OFFSET @page_offset::int;


### PR DESCRIPTION
Add aggregate-only report queries and complete the PostgreSQL coverage for accounting retries, rollback, retention, and concurrent inserts. Organization/day summaries keep the measured ten-year deployment overview within the 500 ms query budget, without scanning raw messages.

Part 3 of the Agent time reporting stack.

Depends on #28988.

<details>
<summary>Agent time stack (merge in order)</summary>

| Part | PR | Changed lines |
| --- | --- | ---: |
| 1 | #28987 Capture and retention protection | 1,062 |
| 2 | #28988 Bounded historical backfill | 1,147 |
| 3 | #28989 Aggregate queries and concurrency coverage | 836 |
| 4 | #28990 SDK and report assembly | 731 |
| 5 | #28991 Administrator HTTP API | 1,160 |
| 6 | #28993 UI helpers, chart, and table | 993 |
| 7 | #28994 Report view and data states | 862 |
| 8 | #28995 Page, URL state, and navigation | 649 |

Counts include additions, deletions, and generated files. Each PR is based on the preceding branch; retarget/rebase successors after their base is merged.

</details>
