### PR TITLE
feat: define precision-safe agent time report contracts

### DIFF
--- a/coderd/agenttime.go
+++ b/coderd/agenttime.go
@@ -1,0 +1,266 @@
+package coderd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+const agentTimeHistoricalNotice = "Agent time includes recorded message contributions only, attributed to their UTC creation date. Previously deleted messages and time that was never recorded cannot be recovered. Historical totals may be incomplete even after backfill finishes. Null recorded time does not mean no work occurred."
+
+type agentTimeQuery struct {
+	start, end                 time.Time
+	organizationID, userID     uuid.UUID
+	interval                   codersdk.AgentTimeInterval
+	groupBy, sortBy, sortOrder string
+	limit, offset              int32
+}
+
+func parseAgentTimeQuery(values url.Values, organization string, now time.Time) (agentTimeQuery, []codersdk.ValidationError) {
+	p := httpapi.NewQueryParamParser()
+	date := func(value string) (time.Time, error) {
+		parsed, err := time.Parse(time.DateOnly, value)
+		if err != nil || parsed.Year() < 1 {
+			return time.Time{}, xerrors.New("must be a UTC calendar date in YYYY-MM-DD format")
+		}
+		return parsed, nil
+	}
+	q := agentTimeQuery{
+		start:          httpapi.ParseCustom(p, values, time.Time{}, "start_date", date),
+		end:            httpapi.ParseCustom(p, values, now.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1), "end_date", date),
+		organizationID: p.UUID(values, uuid.Nil, "organization_id"),
+		userID:         p.UUID(values, uuid.Nil, "user_id"),
+		interval:       codersdk.AgentTimeInterval(p.String(values, "day", "interval")),
+		groupBy:        p.String(values, "organization", "group_by"),
+		sortBy:         p.String(values, "agent_time", "sort_by"),
+		sortOrder:      p.String(values, "desc", "sort_order"),
+	}
+	limit, offset := p.Int(values, 25, "limit"), p.Int(values, 0, "offset")
+	addError := func(field, detail string) {
+		p.Errors = append(p.Errors, codersdk.ValidationError{Field: field, Detail: detail})
+	}
+	if limit < 1 || limit > 100 {
+		addError("limit", "must be between 1 and 100")
+	} else {
+		q.limit = int32(limit)
+	}
+	if offset < 0 || offset > math.MaxInt32 {
+		addError("offset", "must be between 0 and 2147483647")
+	} else {
+		q.offset = int32(offset)
+	}
+	if q.interval != codersdk.AgentTimeIntervalDay && q.interval != codersdk.AgentTimeIntervalWeek && q.interval != codersdk.AgentTimeIntervalMonth {
+		addError("interval", "must be day, week, or month")
+	}
+	if q.groupBy != "organization" && q.groupBy != "user" {
+		addError("group_by", "must be organization or user")
+	}
+	if q.sortBy != "agent_time" && q.sortBy != "name" {
+		addError("sort_by", "must be agent_time or name")
+	}
+	if q.sortOrder != "asc" && q.sortOrder != "desc" {
+		addError("sort_order", "must be asc or desc")
+	}
+	if q.end.After(now.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1)) {
+		addError("end_date", "must not be later than tomorrow UTC")
+	}
+	if !q.start.IsZero() && !q.start.Before(q.end) {
+		addError("end_date", "must be after start_date")
+	}
+	for key, id := range map[string]uuid.UUID{"organization_id": q.organizationID, "user_id": q.userID} {
+		if values.Get(key) != "" && id == uuid.Nil {
+			addError(key, "must be a nonzero UUID")
+		}
+	}
+	if organization != "" {
+		id, err := uuid.Parse(organization)
+		switch {
+		case err != nil || id == uuid.Nil:
+			addError("organization", "must be a nonzero organization UUID")
+		case q.organizationID != uuid.Nil && q.organizationID != id:
+			addError("organization_id", "must match the organization in the route")
+		default:
+			q.organizationID = id
+		}
+	}
+	p.ErrorExcessParams(values)
+	return q, p.Errors
+}
+
+type agentTimeRangeError struct{ message string }
+
+func (e *agentTimeRangeError) Error() string { return e.message }
+
+func readAgentTimeReport(ctx context.Context, db database.Store, q agentTimeQuery, now time.Time) (codersdk.AgentTimeReport, error) {
+	report := codersdk.AgentTimeReport{Interval: q.interval, Rows: []codersdk.AgentTimeBreakdown{}, HistoricalNotice: agentTimeHistoricalNotice}
+	earliest, err := db.GetAgentTimeEarliestDate(ctx, database.GetAgentTimeEarliestDateParams{
+		OrganizationID:         q.organizationID,
+		UserID:                 q.userID,
+		UseOrganizationSummary: q.userID == uuid.Nil,
+	})
+	if err != nil {
+		return report, xerrors.Errorf("read earliest agent time date: %w", err)
+	}
+	if earliest != "" {
+		report.Status.EarliestDate = &earliest
+	}
+	if q.start.IsZero() {
+		q.start = q.end.AddDate(0, 0, -1)
+		if earliest != "" {
+			q.start, err = time.Parse(time.DateOnly, earliest)
+			if err != nil {
+				return report, xerrors.Errorf("parse earliest agent time date: %w", err)
+			}
+		}
+	}
+	if !q.start.Before(q.end) {
+		return report, &agentTimeRangeError{message: "end_date must be after the first available date or start_date."}
+	}
+	// Validate the point budget before issuing the chart aggregation query.
+	buckets, err := agentTimeBuckets(q.start, q.end, q.interval, now)
+	if err != nil {
+		return report, err
+	}
+	report.StartDate = q.start.Format(time.DateOnly)
+	report.EndDate = q.end.Format(time.DateOnly)
+	report.Buckets = buckets
+	summary, err := db.GetAgentTimeSummary(ctx, database.GetAgentTimeSummaryParams{
+		StartDate:              q.start,
+		EndDate:                q.end,
+		OrganizationID:         q.organizationID,
+		UserID:                 q.userID,
+		GroupBy:                q.groupBy,
+		UseOrganizationSummary: q.groupBy == "organization" && q.userID == uuid.Nil,
+	})
+	if err != nil {
+		return report, xerrors.Errorf("read agent time summary: %w", err)
+	}
+	report.TotalAgentTimeMS = summary.AgentTimeMs
+	report.Count = summary.Count
+	rows, err := db.GetAgentTimeBreakdown(ctx, database.GetAgentTimeBreakdownParams{
+		StartDate:              q.start,
+		EndDate:                q.end,
+		OrganizationID:         q.organizationID,
+		UserID:                 q.userID,
+		GroupBy:                q.groupBy,
+		PageLimit:              q.limit,
+		PageOffset:             q.offset,
+		SortBy:                 q.sortBy,
+		SortOrder:              q.sortOrder,
+		UseOrganizationSummary: q.groupBy == "organization" && q.userID == uuid.Nil,
+	})
+	if err != nil {
+		return report, xerrors.Errorf("read agent time breakdown: %w", err)
+	}
+	for _, row := range rows {
+		report.Rows = append(report.Rows, agentTimeBreakdownToSDK(row))
+	}
+	points, err := db.GetAgentTimeBuckets(ctx, database.GetAgentTimeBucketsParams{
+		StartDate:              q.start,
+		EndDate:                q.end,
+		OrganizationID:         q.organizationID,
+		UserID:                 q.userID,
+		Interval:               string(q.interval),
+		UseOrganizationSummary: q.userID == uuid.Nil,
+	})
+	if err != nil {
+		return report, xerrors.Errorf("read agent time buckets: %w", err)
+	}
+	status, err := readAgentTimeStatus(ctx, db, q.organizationID)
+	if err != nil {
+		return report, err
+	}
+	status.EarliestDate = report.Status.EarliestDate
+	report.Status = status
+	captured, err := time.Parse(time.RFC3339Nano, status.CaptureStartedAt)
+	if err != nil {
+		return report, xerrors.Errorf("parse agent time capture date: %w", err)
+	}
+	coverageStart := captured.UTC().Truncate(24 * time.Hour)
+	if coverageStart.Before(captured) {
+		coverageStart = coverageStart.AddDate(0, 0, 1)
+	}
+	totals := make(map[string]string, len(points))
+	for _, point := range points {
+		totals[point.BucketDate] = point.AgentTimeMs
+	}
+	for i := range report.Buckets {
+		bucket := &report.Buckets[i]
+		start, _ := time.Parse(time.DateOnly, bucket.StartDate)
+		bucket.Complete = status.BackfillComplete && !start.Before(coverageStart)
+		value, ok := totals[agentTimeBucketStart(start, q.interval).Format(time.DateOnly)]
+		if ok {
+			bucket.AgentTimeMS = &value
+		} else if bucket.Complete {
+			bucket.AgentTimeMS = new("0")
+		}
+	}
+	return report, nil
+}
+
+func readAgentTimeStatus(ctx context.Context, db database.Store, organizationID uuid.UUID) (codersdk.AgentTimeStatus, error) {
+	status, err := db.GetAgentTimeStatus(ctx, organizationID)
+	if err != nil {
+		return codersdk.AgentTimeStatus{}, xerrors.Errorf("read agent time accounting status: %w", err)
+	}
+	return codersdk.AgentTimeStatus{
+		CaptureStartedAt:  status.CaptureStartedAt.UTC().Format(time.RFC3339Nano),
+		BackfillComplete:  status.BackfillComplete,
+		BackfillError:     status.BackfillError,
+		ProcessedMessages: fmt.Sprint(status.ProcessedMessages),
+	}, nil
+}
+
+func agentTimeBreakdownToSDK(row database.GetAgentTimeBreakdownRow) codersdk.AgentTimeBreakdown {
+	return codersdk.AgentTimeBreakdown{ID: row.ID.String(), Name: row.Name, Deleted: row.Deleted, AgentTimeMS: row.AgentTimeMs}
+}
+
+func agentTimeBucketStart(date time.Time, interval codersdk.AgentTimeInterval) time.Time {
+	switch interval {
+	case codersdk.AgentTimeIntervalWeek:
+		return date.AddDate(0, 0, -(int(date.Weekday())+6)%7)
+	case codersdk.AgentTimeIntervalMonth:
+		return time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, time.UTC)
+	default:
+		return date
+	}
+}
+
+func agentTimeBuckets(start, end time.Time, interval codersdk.AgentTimeInterval, now time.Time) ([]codersdk.AgentTimeBucket, error) {
+	buckets := make([]codersdk.AgentTimeBucket, 0)
+	for date := agentTimeBucketStart(start, interval); date.Before(end); {
+		if len(buckets) == 1000 {
+			return nil, &agentTimeRangeError{message: "The range exceeds 1000 chart points. Select a wider interval."}
+		}
+		var next time.Time
+		switch interval {
+		case codersdk.AgentTimeIntervalDay:
+			next = date.AddDate(0, 0, 1)
+		case codersdk.AgentTimeIntervalWeek:
+			next = date.AddDate(0, 0, 7)
+		case codersdk.AgentTimeIntervalMonth:
+			next = date.AddDate(0, 1, 0)
+		default:
+			return nil, &agentTimeRangeError{message: fmt.Sprintf("Invalid agent time interval %q.", interval)}
+		}
+		lower, upper := date, next
+		if lower.Before(start) {
+			lower = start
+		}
+		if upper.After(end) {
+			upper = end
+		}
+		buckets = append(buckets, codersdk.AgentTimeBucket{StartDate: lower.Format(time.DateOnly), EndDate: upper.Format(time.DateOnly), Partial: !lower.Equal(date) || !upper.Equal(next) || upper.After(now)})
+		date = next
+	}
+	return buckets, nil
+}

--- a/coderd/agenttime_internal_test.go
+++ b/coderd/agenttime_internal_test.go
@@ -1,0 +1,160 @@
+package coderd
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestAgentTimeQuery(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 3, 15, 13, 0, 0, 0, time.UTC)
+	org := uuid.New()
+	t.Run("DefaultsAndScope", func(t *testing.T) {
+		t.Parallel()
+		q, errors := parseAgentTimeQuery(url.Values{}, org.String(), now)
+		require.Empty(t, errors)
+		require.True(t, q.start.IsZero())
+		require.Equal(t, "2026-03-16", q.end.Format(time.DateOnly))
+		require.Equal(t, org, q.organizationID)
+		require.Equal(t, int32(25), q.limit)
+	})
+	for _, query := range []string{
+		"start_date=2026-02-30", "start_date=2026-03-10T00:00:00Z", "start_date=0000-01-01",
+		"start_date=2026-03-15&end_date=2026-03-15", "start_date=2026-03-16&end_date=2026-03-15",
+		"end_date=2026-03-17", "interval=hour", "group_by=group", "sort_by=runtime", "sort_order=bad",
+		"limit=0", "limit=101", "limit=bad", "offset=-1", "offset=2147483648", "offset=bad",
+		"organization_id=invalid", "user_id=invalid", "organization_id=" + uuid.Nil.String(), "user_id=" + uuid.Nil.String(),
+		"organization_id=" + uuid.NewString(), "unrecognized=true", "interval=day&interval=week",
+	} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			values, err := url.ParseQuery(query)
+			require.NoError(t, err)
+			_, errors := parseAgentTimeQuery(values, org.String(), now)
+			require.NotEmpty(t, errors)
+		})
+	}
+	for _, path := range []string{"invalid", uuid.Nil.String()} {
+		t.Run("InvalidScope/"+path, func(t *testing.T) {
+			t.Parallel()
+			_, errors := parseAgentTimeQuery(url.Values{}, path, now)
+			require.NotEmpty(t, errors)
+		})
+	}
+}
+
+func TestAgentTimeCalendarBuckets(t *testing.T) {
+	t.Parallel()
+	parse := func(value string) time.Time {
+		date, err := time.Parse(time.DateOnly, value)
+		require.NoError(t, err)
+		return date
+	}
+	for _, tt := range []struct {
+		name, start, end string
+		interval         codersdk.AgentTimeInterval
+		starts, ends     []string
+		partial          []bool
+	}{
+		{"LeapDays", "2024-02-28", "2024-03-02", codersdk.AgentTimeIntervalDay, []string{"2024-02-28", "2024-02-29", "2024-03-01"}, []string{"2024-02-29", "2024-03-01", "2024-03-02"}, []bool{false, false, false}},
+		{"MondayWeeks", "2024-12-29", "2025-01-14", codersdk.AgentTimeIntervalWeek, []string{"2024-12-29", "2024-12-30", "2025-01-06", "2025-01-13"}, []string{"2024-12-30", "2025-01-06", "2025-01-13", "2025-01-14"}, []bool{true, false, false, true}},
+		{"CalendarMonths", "2024-01-31", "2024-04-01", codersdk.AgentTimeIntervalMonth, []string{"2024-01-31", "2024-02-01", "2024-03-01"}, []string{"2024-02-01", "2024-03-01", "2024-04-01"}, []bool{true, false, false}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			buckets, err := agentTimeBuckets(parse(tt.start), parse(tt.end), tt.interval, parse("2026-01-01"))
+			require.NoError(t, err)
+			require.Len(t, buckets, len(tt.starts))
+			for i, bucket := range buckets {
+				require.Equal(t, tt.starts[i], bucket.StartDate)
+				require.Equal(t, tt.ends[i], bucket.EndDate)
+				require.Equal(t, tt.partial[i], bucket.Partial)
+				require.Nil(t, bucket.AgentTimeMS, "coverage must be established before zero filling")
+				require.False(t, bucket.Complete)
+			}
+		})
+	}
+	t.Run("CurrentDay", func(t *testing.T) {
+		t.Parallel()
+		buckets, err := agentTimeBuckets(parse("2026-01-01"), parse("2026-01-02"), codersdk.AgentTimeIntervalDay, parse("2026-01-01").Add(12*time.Hour))
+		require.NoError(t, err)
+		require.True(t, buckets[0].Partial)
+	})
+	t.Run("PointBudgetNotRetentionLimit", func(t *testing.T) {
+		t.Parallel()
+		start, end := parse("2000-01-01"), parse("2026-01-01")
+		_, err := agentTimeBuckets(start, end, codersdk.AgentTimeIntervalDay, end)
+		require.ErrorContains(t, err, "1000 chart points")
+		buckets, err := agentTimeBuckets(start, end, codersdk.AgentTimeIntervalMonth, end)
+		require.NoError(t, err)
+		require.Len(t, buckets, 26*12)
+		buckets, err = agentTimeBuckets(start, start.AddDate(0, 0, 1000), codersdk.AgentTimeIntervalDay, end)
+		require.NoError(t, err)
+		require.Len(t, buckets, 1000)
+	})
+}
+
+func TestAgentTimeCoverage(t *testing.T) {
+	t.Parallel()
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+	org, user := uuid.New(), uuid.New()
+	_, err := sqlDB.ExecContext(t.Context(), `
+ WITH capture AS (UPDATE agent_time_capture SET capture_started_at='2025-01-01 12:00:00+00' RETURNING id)
+ INSERT INTO agent_time_backfill_status (organization_id,completed_at,processed_messages)
+ VALUES ($1,'2025-01-02 00:00:00+00',42);
+ `, org)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(t.Context(), "INSERT INTO agent_time_daily (organization_id,user_id,day,agent_time_ms) VALUES ($1,$2,'2024-12-31',7)", org, user)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(t.Context(), "INSERT INTO agent_time_organization_daily (organization_id,day,agent_time_ms) SELECT organization_id,day,SUM(agent_time_ms) FROM agent_time_daily GROUP BY 1,2 ON CONFLICT (organization_id,day) DO UPDATE SET agent_time_ms=EXCLUDED.agent_time_ms")
+	require.NoError(t, err)
+	q, validations := parseAgentTimeQuery(url.Values{"start_date": {"2024-12-31"}, "end_date": {"2025-01-04"}}, org.String(), time.Date(2025, 1, 3, 12, 0, 0, 0, time.UTC))
+	require.Empty(t, validations)
+	report, err := readAgentTimeReport(t.Context(), db, q, time.Date(2025, 1, 3, 12, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.True(t, report.Status.BackfillComplete)
+	require.Equal(t, "42", report.Status.ProcessedMessages)
+	require.Equal(t, "7", *report.Buckets[0].AgentTimeMS)
+	require.False(t, report.Buckets[0].Complete)
+	require.Nil(t, report.Buckets[1].AgentTimeMS, "capture began mid-day")
+	require.Equal(t, "0", *report.Buckets[2].AgentTimeMS)
+	require.True(t, report.Buckets[2].Complete)
+	require.False(t, report.Buckets[2].Partial)
+	require.True(t, report.Buckets[3].Partial)
+	_, err = sqlDB.ExecContext(t.Context(), "UPDATE agent_time_backfill_status SET completed_at=NULL,last_error='backfill failed' WHERE organization_id=$1", org)
+	require.NoError(t, err)
+	incomplete, err := readAgentTimeReport(t.Context(), db, q, time.Date(2025, 1, 3, 12, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.False(t, incomplete.Status.BackfillComplete)
+	require.Equal(t, "backfill failed", incomplete.Status.BackfillError)
+	require.Nil(t, incomplete.Buckets[2].AgentTimeMS)
+}
+
+func TestAgentTimeReportPrecision(t *testing.T) {
+	t.Parallel()
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+	org := uuid.New()
+	_, err := sqlDB.ExecContext(t.Context(), `
+ INSERT INTO agent_time_daily (organization_id,user_id,day,agent_time_ms)
+ VALUES ($1,$2,'2025-01-01',9223372036854775807),($1,$3,'2025-01-01',9223372036854775807)
+ `, org, uuid.New(), uuid.New())
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(t.Context(), "INSERT INTO agent_time_organization_daily (organization_id,day,agent_time_ms) SELECT organization_id,day,SUM(agent_time_ms) FROM agent_time_daily GROUP BY 1,2 ON CONFLICT (organization_id,day) DO UPDATE SET agent_time_ms=EXCLUDED.agent_time_ms")
+	require.NoError(t, err)
+	now := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	for _, group := range []string{"organization", "user"} {
+		q, validations := parseAgentTimeQuery(url.Values{"start_date": {"2025-01-01"}, "end_date": {"2025-01-02"}, "group_by": {group}}, org.String(), now)
+		require.Empty(t, validations)
+		report, err := readAgentTimeReport(t.Context(), db, q, now)
+		require.NoError(t, err)
+		require.Equal(t, "18446744073709551614", report.TotalAgentTimeMS)
+		require.Equal(t, "18446744073709551614", *report.Buckets[0].AgentTimeMS)
+	}
+}

--- a/coderd/agenttime_test.go
+++ b/coderd/agenttime_test.go
@@ -1,0 +1,53 @@
+package coderd_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+)
+
+// BenchmarkAgentTimeReports uses 3.65 million daily rows: 100 organizations,
+// 10,000 users, and one recorded day per user every ten days over ten years.
+// Message volume does not affect report cost: no report query reads messages.
+// The interactive budget is 500ms per database report (summary, chart, page).
+// PostgreSQL 13.21 EXPLAIN ANALYZE on temporary fixtures, median of three runs:
+// canonical month/year/ten-years: 19.6/399.7/3563.6ms; organization summaries:
+// 0.63/4.93/45.0ms. These measurements exclude network and HTTP overhead.
+func BenchmarkAgentTimeReports(b *testing.B) {
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(b)
+	_, err := sqlDB.ExecContext(b.Context(), `
+ INSERT INTO agent_time_daily (organization_id,user_id,day,agent_time_ms)
+ SELECT md5((u % 100)::text)::uuid, md5(u::text)::uuid,
+   DATE '2016-01-01' + d * 10, 3600000
+ FROM generate_series(1,10000) u CROSS JOIN generate_series(0,364) d;
+ INSERT INTO agent_time_organization_daily (organization_id,day,agent_time_ms) SELECT organization_id,day,SUM(agent_time_ms) FROM agent_time_daily GROUP BY 1,2 ON CONFLICT (organization_id,day) DO UPDATE SET agent_time_ms=EXCLUDED.agent_time_ms;
+ ANALYZE agent_time_daily;
+ ANALYZE agent_time_organization_daily;`)
+	require.NoError(b, err)
+	end := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, summaries := range []bool{false, true} {
+		for _, years := range []int{0, 1, 10} {
+			name, start, interval := "month", end.AddDate(0, -1, 0), "day"
+			if years > 0 {
+				name = fmt.Sprintf("%d-years", years)
+				start = end.AddDate(-years, 0, 0)
+				interval = "month"
+			}
+			b.Run(fmt.Sprintf("summary=%t/%s", summaries, name), func(b *testing.B) {
+				for b.Loop() {
+					_, err := db.GetAgentTimeSummary(b.Context(), database.GetAgentTimeSummaryParams{StartDate: start, EndDate: end, GroupBy: "organization", UseOrganizationSummary: summaries})
+					require.NoError(b, err)
+					_, err = db.GetAgentTimeBuckets(b.Context(), database.GetAgentTimeBucketsParams{StartDate: start, EndDate: end, Interval: interval, UseOrganizationSummary: summaries})
+					require.NoError(b, err)
+					_, err = db.GetAgentTimeBreakdown(b.Context(), database.GetAgentTimeBreakdownParams{StartDate: start, EndDate: end, GroupBy: "organization", PageLimit: 25, SortBy: "agent_time", SortOrder: "desc", UseOrganizationSummary: summaries})
+					require.NoError(b, err)
+				}
+			})
+		}
+	}
+}

--- a/codersdk/agenttime.go
+++ b/codersdk/agenttime.go
@@ -1,0 +1,119 @@
+package codersdk
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"golang.org/x/xerrors"
+)
+
+// AgentTimeInterval groups UTC calendar dates into chart buckets.
+type AgentTimeInterval string
+
+// Agent time chart intervals use Monday-start weeks and calendar months.
+const (
+	AgentTimeIntervalDay   AgentTimeInterval = "day"
+	AgentTimeIntervalWeek  AgentTimeInterval = "week"
+	AgentTimeIntervalMonth AgentTimeInterval = "month"
+)
+
+// AgentTimeRequest selects a half-open UTC date range. Omitting StartDate
+// includes all available recorded history. Omitting EndDate includes today.
+type AgentTimeRequest struct {
+	StartDate      string            `json:"start_date,omitempty" format:"date"`
+	EndDate        string            `json:"end_date,omitempty" format:"date"`
+	Interval       AgentTimeInterval `json:"interval,omitempty"`
+	OrganizationID string            `json:"organization_id,omitempty" format:"uuid"`
+	UserID         string            `json:"user_id,omitempty" format:"uuid"`
+	GroupBy        string            `json:"group_by,omitempty" enums:"organization,user"`
+	Limit          int               `json:"limit,omitempty"`
+	Offset         int               `json:"offset,omitempty"`
+	SortBy         string            `json:"sort_by,omitempty" enums:"agent_time,name"`
+	SortOrder      string            `json:"sort_order,omitempty" enums:"asc,desc"`
+}
+
+// AgentTimeReport contains recorded time, not workspace uptime or elapsed
+// execution intervals. Decimal millisecond strings preserve integer precision
+// for JavaScript clients, including sums larger than a signed 64-bit integer.
+type AgentTimeReport struct {
+	StartDate        string               `json:"start_date" format:"date"`
+	EndDate          string               `json:"end_date" format:"date"`
+	Interval         AgentTimeInterval    `json:"interval"`
+	TotalAgentTimeMS string               `json:"total_agent_time_ms"`
+	Buckets          []AgentTimeBucket    `json:"buckets"`
+	Rows             []AgentTimeBreakdown `json:"rows"`
+	Count            int64                `json:"count"`
+	Status           AgentTimeStatus      `json:"status"`
+	HistoricalNotice string               `json:"historical_notice"`
+}
+
+// AgentTimeBucket describes a UTC calendar bucket clipped to the requested
+// range. A null total means no recorded data and unknown accounting coverage.
+type AgentTimeBucket struct {
+	StartDate   string  `json:"start_date" format:"date"`
+	EndDate     string  `json:"end_date" format:"date"`
+	AgentTimeMS *string `json:"agent_time_ms"`
+	Partial     bool    `json:"partial"`
+	Complete    bool    `json:"complete"`
+}
+
+// AgentTimeBreakdown identifies an organization or user even after deletion.
+type AgentTimeBreakdown struct {
+	ID          string `json:"id" format:"uuid"`
+	Name        string `json:"name"`
+	Deleted     bool   `json:"deleted"`
+	AgentTimeMS string `json:"agent_time_ms"`
+}
+
+// AgentTimeStatus describes capture and recoverable-history backfill. A
+// completed backfill cannot reconstruct previously deleted or unrecorded time.
+type AgentTimeStatus struct {
+	CaptureStartedAt  string  `json:"capture_started_at" format:"date-time"`
+	BackfillComplete  bool    `json:"backfill_complete"`
+	BackfillError     string  `json:"backfill_error"`
+	ProcessedMessages string  `json:"processed_messages"`
+	EarliestDate      *string `json:"earliest_date" format:"date"`
+}
+
+// AgentTime returns a deployment administrator's recorded agent time report.
+func (c *Client) AgentTime(ctx context.Context, req AgentTimeRequest) (AgentTimeReport, error) {
+	return c.requestAgentTime(ctx, "/api/v2/agent-time", req)
+}
+
+// OrganizationAgentTime returns a report restricted to one organization's
+// recorded history. Deployment-config read permission is required.
+func (c *Client) OrganizationAgentTime(ctx context.Context, organization string, req AgentTimeRequest) (AgentTimeReport, error) {
+	return c.requestAgentTime(ctx, "/api/v2/organizations/"+url.PathEscape(organization)+"/agent-time", req)
+}
+
+func (c *Client) requestAgentTime(ctx context.Context, path string, req AgentTimeRequest) (AgentTimeReport, error) {
+	q := url.Values{}
+	for key, value := range map[string]string{
+		"start_date": req.StartDate, "end_date": req.EndDate,
+		"interval": string(req.Interval), "organization_id": req.OrganizationID,
+		"user_id": req.UserID, "group_by": req.GroupBy,
+		"sort_by": req.SortBy, "sort_order": req.SortOrder,
+	} {
+		if value != "" {
+			q.Set(key, value)
+		}
+	}
+	if req.Limit != 0 {
+		q.Set("limit", strconv.Itoa(req.Limit))
+	}
+	if req.Offset != 0 {
+		q.Set("offset", strconv.Itoa(req.Offset))
+	}
+	resp, err := c.Request(ctx, http.MethodGet, path+"?"+q.Encode(), nil)
+	if err != nil {
+		return AgentTimeReport{}, xerrors.Errorf("request agent time: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return AgentTimeReport{}, ReadBodyAsError(resp)
+	}
+	var report AgentTimeReport
+	return report, ReadBodyAsJSON(resp, &report)
+}

--- a/codersdk/agenttime_test.go
+++ b/codersdk/agenttime_test.go
@@ -1,0 +1,55 @@
+package codersdk_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestAgentTimeSDK(t *testing.T) {
+	t.Parallel()
+	for _, organization := range []string{"", uuid.NewString()} {
+		t.Run("Organization/"+organization, func(t *testing.T) {
+			t.Parallel()
+			milliseconds := "18446744073709551614"
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				path := "/api/v2/agent-time"
+				if organization != "" {
+					path = "/api/v2/organizations/" + organization + "/agent-time"
+				}
+				assert.Equal(t, path, r.URL.Path)
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, url.Values{
+					"start_date": {"2025-01-01"}, "end_date": {"2026-01-01"}, "interval": {"month"},
+					"group_by": {"user"}, "limit": {"10"}, "offset": {"20"}, "sort_by": {"name"}, "sort_order": {"asc"},
+				}, r.URL.Query())
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(codersdk.AgentTimeReport{TotalAgentTimeMS: milliseconds, Buckets: []codersdk.AgentTimeBucket{{AgentTimeMS: &milliseconds}, {AgentTimeMS: nil}}})
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+			client := codersdk.New(serverURL)
+			request := codersdk.AgentTimeRequest{StartDate: "2025-01-01", EndDate: "2026-01-01", Interval: codersdk.AgentTimeIntervalMonth, GroupBy: "user", Limit: 10, Offset: 20, SortBy: "name", SortOrder: "asc"}
+			var report codersdk.AgentTimeReport
+			if organization == "" {
+				report, err = client.AgentTime(t.Context(), request)
+			} else {
+				report, err = client.OrganizationAgentTime(t.Context(), organization, request)
+			}
+			require.NoError(t, err)
+			require.Equal(t, milliseconds, report.TotalAgentTimeMS)
+			require.Equal(t, milliseconds, *report.Buckets[0].AgentTimeMS)
+			require.Nil(t, report.Buckets[1].AgentTimeMS)
+		})
+	}
+}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1556,6 +1556,84 @@ export const AgentSubsystems: AgentSubsystem[] = [
 	"exectrace",
 ];
 
+// From codersdk/agenttime.go
+/**
+ * AgentTimeBreakdown identifies an organization or user even after deletion.
+ */
+export interface AgentTimeBreakdown {
+	readonly id: string;
+	readonly name: string;
+	readonly deleted: boolean;
+	readonly agent_time_ms: string;
+}
+
+// From codersdk/agenttime.go
+/**
+ * AgentTimeBucket describes a UTC calendar bucket clipped to the requested
+ * range. A null total means no recorded data and unknown accounting coverage.
+ */
+export interface AgentTimeBucket {
+	readonly start_date: string;
+	readonly end_date: string;
+	readonly agent_time_ms: string | null;
+	readonly partial: boolean;
+	readonly complete: boolean;
+}
+
+// From codersdk/agenttime.go
+export type AgentTimeInterval = "day" | "month" | "week";
+
+export const AgentTimeIntervals: AgentTimeInterval[] = ["day", "month", "week"];
+
+// From codersdk/agenttime.go
+/**
+ * AgentTimeReport contains recorded time, not workspace uptime or elapsed
+ * execution intervals. Decimal millisecond strings preserve integer precision
+ * for JavaScript clients, including sums larger than a signed 64-bit integer.
+ */
+export interface AgentTimeReport {
+	readonly start_date: string;
+	readonly end_date: string;
+	readonly interval: AgentTimeInterval;
+	readonly total_agent_time_ms: string;
+	readonly buckets: readonly AgentTimeBucket[];
+	readonly rows: readonly AgentTimeBreakdown[];
+	readonly count: number;
+	readonly status: AgentTimeStatus;
+	readonly historical_notice: string;
+}
+
+// From codersdk/agenttime.go
+/**
+ * AgentTimeRequest selects a half-open UTC date range. Omitting StartDate
+ * includes all available recorded history. Omitting EndDate includes today.
+ */
+export interface AgentTimeRequest {
+	readonly start_date?: string;
+	readonly end_date?: string;
+	readonly interval?: AgentTimeInterval;
+	readonly organization_id?: string;
+	readonly user_id?: string;
+	readonly group_by?: string;
+	readonly limit?: number;
+	readonly offset?: number;
+	readonly sort_by?: string;
+	readonly sort_order?: string;
+}
+
+// From codersdk/agenttime.go
+/**
+ * AgentTimeStatus describes capture and recoverable-history backfill. A
+ * completed backfill cannot reconstruct previously deleted or unrecorded time.
+ */
+export interface AgentTimeStatus {
+	readonly capture_started_at: string;
+	readonly backfill_complete: boolean;
+	readonly backfill_error: string;
+	readonly processed_messages: string;
+	readonly earliest_date: string | null;
+}
+
 // From codersdk/aiproviders.go
 export type AgentsUnsupportedProviderType = "copilot";
 


### PR DESCRIPTION
Define precision-safe SDK types and internal report assembly for half-open UTC calendar ranges. Millisecond totals remain decimal strings, and unknown historical coverage is kept distinct from recorded zero time.

Part 4 of the Agent time reporting stack. The HTTP endpoints follow in part 5.

Depends on #28989.

<details>
<summary>Agent time stack (merge in order)</summary>

| Part | PR | Changed lines |
| --- | --- | ---: |
| 1 | #28987 Capture and retention protection | 1,062 |
| 2 | #28988 Bounded historical backfill | 1,147 |
| 3 | #28989 Aggregate queries and concurrency coverage | 836 |
| 4 | #28990 SDK and report assembly | 731 |
| 5 | #28991 Administrator HTTP API | 1,160 |
| 6 | #28993 UI helpers, chart, and table | 993 |
| 7 | #28994 Report view and data states | 862 |
| 8 | #28995 Page, URL state, and navigation | 649 |

Counts include additions, deletions, and generated files. Each PR is based on the preceding branch; retarget/rebase successors after their base is merged.

</details>
