### PR TITLE
fix(coderd): surface external auth login link when creating a workspace

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1553,7 +1554,10 @@ func TestCreateTaskExternalAuth(t *testing.T) {
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
 		require.Equal(t, externalAuthRequiredMessage, apiErr.Message)
-		require.Equal(t, "The workspace owner must authenticate with the following external auth providers: GitHub.", apiErr.Detail)
+		require.Equal(t, fmt.Sprintf(
+			"The workspace owner must authenticate with the following external auth providers: GitHub (%s/external-auth/github).",
+			strings.TrimSuffix(client.URL.String(), "/"),
+		), apiErr.Detail)
 		require.Equal(t, []codersdk.ValidationError{{
 			Field:  "external_auth",
 			Detail: "github",

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -888,6 +888,12 @@ func (api *API) requireWorkspaceOwnerExternalAuth(ctx context.Context, templateV
 		if name == "" {
 			name = provider.ID
 		}
+		// The authenticate URL is included so clients without a
+		// preflight external auth check (such as the chat tools) can
+		// surface a usable login link to the user.
+		if provider.AuthenticateURL != "" {
+			name = fmt.Sprintf("%s (%s)", name, provider.AuthenticateURL)
+		}
 		missingNames = append(missingNames, name)
 		validations = append(validations, codersdk.ValidationError{
 			Field:  "external_auth",

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1604,7 +1604,10 @@ func TestCreateWorkspaceExternalAuth(t *testing.T) {
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
 		require.Equal(t, externalAuthRequiredMessage, apiErr.Message)
-		require.Equal(t, "The workspace owner must authenticate with the following external auth providers: GitHub.", apiErr.Detail)
+		require.Equal(t, fmt.Sprintf(
+			"The workspace owner must authenticate with the following external auth providers: GitHub (%s/external-auth/github).",
+			strings.TrimSuffix(client.URL.String(), "/"),
+		), apiErr.Detail)
 		require.Equal(t, []codersdk.ValidationError{{
 			Field:  "external_auth",
 			Detail: "github",

--- a/coderd/x/chatd/chattool/chattool.go
+++ b/coderd/x/chatd/chattool/chattool.go
@@ -16,6 +16,23 @@ import (
 
 const templateNotAvailableMessage = "template not available for chat workspaces; use list_templates to find allowed templates"
 
+// externalAuthRequiredMessage tells the model how to unblock a request that
+// failed because the workspace owner has not authenticated with a required
+// external auth provider. The login links are in the response detail.
+const externalAuthRequiredMessage = "the workspace owner must authenticate with the listed external auth providers before this template can be used. " +
+	"Show the user the authentication link(s) from detail so they can open them, then retry create_workspace once they confirm they have authenticated"
+
+// hasExternalAuthValidation reports whether any validation error identifies a
+// missing external auth provider.
+func hasExternalAuthValidation(validations []codersdk.ValidationError) bool {
+	for _, validation := range validations {
+		if validation.Field == "external_auth" {
+			return true
+		}
+	}
+	return false
+}
+
 func marshalToolResponse(result any) fantasy.ToolResponse {
 	data, err := json.Marshal(result)
 	if err != nil {
@@ -56,6 +73,9 @@ func responseErrorResult(resp codersdk.Response) map[string]any {
 	}
 	if len(resp.Validations) > 0 {
 		result["validations"] = resp.Validations
+	}
+	if hasExternalAuthValidation(resp.Validations) {
+		result["action_required"] = externalAuthRequiredMessage
 	}
 	return result
 }

--- a/coderd/x/chatd/chattool/createworkspace_internal_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_internal_test.go
@@ -860,6 +860,117 @@ func TestCreateWorkspace_ResponderErrorPreservesStructuredFields(t *testing.T) {
 	}}, result.Validations)
 }
 
+func TestCreateWorkspace_ExternalAuthRequiredGuidance(t *testing.T) {
+	t.Parallel()
+
+	const authenticateURL = "https://coder.example.com/external-auth/github"
+
+	tests := []struct {
+		name               string
+		validations        []codersdk.ValidationError
+		wantActionRequired bool
+	}{
+		{
+			name: "ExternalAuth",
+			validations: []codersdk.ValidationError{{
+				Field:  "external_auth",
+				Detail: "github",
+			}},
+			wantActionRequired: true,
+		},
+		{
+			name: "OtherValidation",
+			validations: []codersdk.ValidationError{{
+				Field:  "region",
+				Detail: "region must be set",
+			}},
+			wantActionRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			db := newCreateWorkspaceMockStore(ctrl)
+
+			ownerID := uuid.New()
+			orgID := uuid.New()
+			chatID := uuid.New()
+			templateID := uuid.New()
+
+			detail := fmt.Sprintf(
+				"The workspace owner must authenticate with the following external auth providers: GitHub (%s).",
+				authenticateURL,
+			)
+
+			db.EXPECT().
+				GetChatByID(gomock.Any(), chatID).
+				Return(database.Chat{ID: chatID}, nil)
+
+			db.EXPECT().
+				GetAuthorizationUserRoles(gomock.Any(), ownerID).
+				Return(database.GetAuthorizationUserRolesRow{
+					ID:     ownerID,
+					Roles:  []string{},
+					Groups: []string{},
+					Status: database.UserStatusActive,
+				}, nil)
+
+			db.EXPECT().
+				GetTemplateByID(gomock.Any(), templateID).
+				Return(database.Template{
+					ID:             templateID,
+					OrganizationID: orgID,
+					AgentsAllowed:  true,
+				}, nil)
+
+			db.EXPECT().
+				GetChatWorkspaceTTL(gomock.Any()).
+				Return("0s", nil)
+
+			tool := CreateWorkspace(db, orgID, chatID, CreateWorkspaceOptions{
+				OwnerID: ownerID,
+				CreateFn: func(context.Context, uuid.UUID, codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
+					return codersdk.Workspace{}, httperror.NewResponseError(http.StatusForbidden, codersdk.Response{
+						Message:     "External authentication is required to create a workspace with this template.",
+						Detail:      detail,
+						Validations: tt.validations,
+					})
+				},
+				WorkspaceMu: &sync.Mutex{},
+				Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			})
+
+			input := fmt.Sprintf(`{"template_id":%q,"name":"test-external-auth"}`, templateID.String())
+			resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+				ID:    "call-1",
+				Name:  "create_workspace",
+				Input: input,
+			})
+			require.NoError(t, err)
+			require.False(t, resp.IsError)
+
+			var result struct {
+				Error          string                     `json:"error"`
+				Detail         string                     `json:"detail"`
+				Validations    []codersdk.ValidationError `json:"validations"`
+				ActionRequired string                     `json:"action_required"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+			require.Equal(t, detail, result.Detail)
+			require.Contains(t, result.Detail, authenticateURL)
+			require.Equal(t, tt.validations, result.Validations)
+			if tt.wantActionRequired {
+				require.Equal(t, externalAuthRequiredMessage, result.ActionRequired)
+			} else {
+				require.Empty(t, result.ActionRequired)
+			}
+		})
+	}
+}
+
 func TestCreateWorkspaceWithNameRetry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When a template requires a non-optional external auth provider that the workspace owner hasn't linked yet, `create_workspace` rejects the request with a 403, but the error never included a way to actually resolve it. The web UI and CLI don't hit this path in practice, since they preflight-check `/templateversions/{id}/external-auth` and render a login button before ever submitting. Coder Agents' `create_workspace` chat tool has no such preflight, so it's the one place a real user hits this error, and the assistant could only repeat "external authentication is required" with no way forward.

`requireWorkspaceOwnerExternalAuth` now includes each missing provider's authenticate URL in the error `Detail`, and the chatd `create_workspace` tool's `responseErrorResult` adds an `action_required` hint so the model reliably tells the user to open the link and retry, instead of just echoing the raw error.

Fixes [CODAGT-1011](https://linear.app/codercom/issue/CODAGT-1011/external-authentication-is-required-is-a-dead-end-in-coder-agents)

![Demo](https://raw.githubusercontent.com/coder/coder/recordings/recordings/chatd-external-auth-link/recording.gif)

<details>
<summary>Full recording and thumbnail</summary>

- [mp4](https://raw.githubusercontent.com/coder/coder/recordings/recordings/chatd-external-auth-link/recording.mp4)
- [Thumbnail](https://raw.githubusercontent.com/coder/coder/recordings/recordings/chatd-external-auth-link/thumbnail.jpg)
</details>

<details>
<summary>Implementation notes</summary>

- Only the free-text `Detail` string changed. The `Validations` shape (`Field: "external_auth"`, `Detail: provider.ID`) is untouched, since it's a separate, tested, machine-readable contract that other code may rely on.
- Recorded against a local dev instance with a dummy GitHub OAuth client, so the clip ends right after the assistant surfaces the link. Following the link past Coder's own external-auth page would fail regardless of this fix, since there's no real OAuth client secret configured in that environment.
- Generated by Coder Agents on behalf of @bpmct.
</details>
