### PR TITLE
feat(site/src): add agent time presentation primitives

### DIFF
--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeBreakdownTable.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeBreakdownTable.tsx
@@ -1,0 +1,212 @@
+import { cn } from "cn";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import type { AgentTimeReport } from "#/api/typesGenerated";
+import { Badge } from "#/components/Badge/Badge";
+import { Button } from "#/components/Button/Button";
+import {
+	PaginationContainer,
+	type PaginationResult,
+} from "#/components/PaginationWidget/PaginationContainer";
+import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import {
+	type AgentTimeSortBy,
+	type AgentTimeSortOrder,
+	type AgentTimeTableGroup,
+	entityHeading,
+	formatAgentTimeHours,
+	formatShare,
+	rowName,
+} from "./agentTimeUtils";
+
+function SortIcon({
+	active,
+	order,
+}: {
+	active: boolean;
+	order: AgentTimeSortOrder;
+}) {
+	if (!active) {
+		return null;
+	}
+	return order === "asc" ? (
+		<ChevronUpIcon className="size-3.5" />
+	) : (
+		<ChevronDownIcon className="size-3.5" />
+	);
+}
+
+function SortHeader({
+	children,
+	column,
+	sortBy,
+	sortOrder,
+	onSortChange,
+	className,
+}: {
+	children: ReactNode;
+	column: AgentTimeSortBy;
+	sortBy: AgentTimeSortBy;
+	sortOrder: AgentTimeSortOrder;
+	onSortChange: (sortBy: AgentTimeSortBy) => void;
+	className?: string;
+}) {
+	const active = sortBy === column;
+	return (
+		<TableHead
+			className={className}
+			aria-sort={
+				active ? (sortOrder === "asc" ? "ascending" : "descending") : "none"
+			}
+		>
+			<button
+				type="button"
+				className={cn(
+					"inline-flex items-center gap-1 border-0 bg-transparent p-0 text-left font-semibold text-inherit",
+					"cursor-pointer hover:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-content-link",
+					className?.includes("text-right") && "justify-end",
+				)}
+				onClick={() => onSortChange(column)}
+			>
+				{children}
+				<SortIcon active={active} order={sortOrder} />
+			</button>
+		</TableHead>
+	);
+}
+
+export function BreakdownTable({
+	query,
+	tableGroup,
+	totalAgentTimeMs,
+	sortBy,
+	sortOrder,
+	selectedUserId,
+	onSortChange,
+	onSelectOrganization,
+	onSelectUser,
+}: {
+	query: PaginationResult<AgentTimeReport>;
+	tableGroup: AgentTimeTableGroup;
+	totalAgentTimeMs: string;
+	sortBy: AgentTimeSortBy;
+	sortOrder: AgentTimeSortOrder;
+	selectedUserId?: string;
+	onSortChange: (sortBy: AgentTimeSortBy) => void;
+	onSelectOrganization: (organizationId: string) => void;
+	onSelectUser: (userId: string) => void;
+}) {
+	const rows = query.data?.rows ?? [];
+	return (
+		<PaginationContainer
+			query={query}
+			paginationUnitLabel={entityHeading(tableGroup).toLowerCase()}
+		>
+			<p className="text-xs text-content-secondary sm:hidden">
+				Scroll the table horizontally to see all columns.
+			</p>
+			<ScrollArea
+				orientation="horizontal"
+				viewportAriaLabel={`${entityHeading(tableGroup)} table, scroll horizontally`}
+				viewportTabIndex={0}
+				viewportClassName="focus-visible:outline focus-visible:outline-2 focus-visible:outline-content-link"
+			>
+				<Table
+					wrapperClassName="overflow-visible"
+					className="min-w-[600px]"
+					aria-label={`${entityHeading(tableGroup)} agent time`}
+				>
+					<TableHeader>
+						<TableRow>
+							<SortHeader
+								column="name"
+								sortBy={sortBy}
+								sortOrder={sortOrder}
+								onSortChange={onSortChange}
+							>
+								Name
+							</SortHeader>
+							<SortHeader
+								column="agent_time"
+								sortBy={sortBy}
+								sortOrder={sortOrder}
+								onSortChange={onSortChange}
+								className="text-right"
+							>
+								Agent time
+							</SortHeader>
+							<TableHead className="text-right">Share</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead className="text-right">Action</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{rows.map((row) => {
+							const name = rowName(row, tableGroup);
+							const isSelectedUser =
+								tableGroup === "user" && row.id === selectedUserId;
+							return (
+								<TableRow key={row.id}>
+									<TableCell>
+										<div className="flex min-w-0 flex-col gap-1">
+											<div className="flex min-w-0 items-center gap-2">
+												<span className="truncate font-medium text-content-primary">
+													{name}
+												</span>
+												{row.deleted && (
+													<Badge variant="warning" size="sm">
+														Deleted
+													</Badge>
+												)}
+											</div>
+											<span className="truncate font-mono text-xs text-content-disabled">
+												{row.id}
+											</span>
+										</div>
+									</TableCell>
+									<TableCell className="text-right tabular-nums text-content-primary">
+										{formatAgentTimeHours(row.agent_time_ms)}
+									</TableCell>
+									<TableCell className="text-right tabular-nums">
+										{formatShare(row.agent_time_ms, totalAgentTimeMs)}
+									</TableCell>
+									<TableCell>{row.deleted ? "Deleted" : "Active"}</TableCell>
+									<TableCell className="text-right">
+										{tableGroup === "organization" ? (
+											<Button
+												variant="subtle"
+												size="sm"
+												type="button"
+												onClick={() => onSelectOrganization(row.id)}
+											>
+												View users
+											</Button>
+										) : (
+											<Button
+												variant={isSelectedUser ? "outline" : "subtle"}
+												size="sm"
+												type="button"
+												onClick={() => onSelectUser(row.id)}
+												disabled={isSelectedUser}
+											>
+												{isSelectedUser ? "Selected" : "View user"}
+											</Button>
+										)}
+									</TableCell>
+								</TableRow>
+							);
+						})}
+					</TableBody>
+				</Table>
+			</ScrollArea>
+		</PaginationContainer>
+	);
+}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeChart.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeChart.tsx
@@ -1,0 +1,123 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { AgentTimeBucket, AgentTimeReport } from "#/api/typesGenerated";
+import {
+	type ChartConfig,
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "#/components/Chart/Chart";
+import {
+	formatAgentTimeHours,
+	formatBucketRange,
+	msToHours,
+} from "./agentTimeUtils";
+
+const chartConfig = {
+	hours: {
+		label: "Agent time",
+		color: "hsl(var(--highlight-purple))",
+	},
+} satisfies ChartConfig;
+
+type ChartDatum = {
+	bucket: AgentTimeBucket;
+	label: string;
+	hours: number | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isAgentTimeBucket(value: unknown): value is AgentTimeBucket {
+	return (
+		isRecord(value) &&
+		typeof value.start_date === "string" &&
+		typeof value.end_date === "string" &&
+		(typeof value.agent_time_ms === "string" || value.agent_time_ms === null) &&
+		typeof value.partial === "boolean" &&
+		typeof value.complete === "boolean"
+	);
+}
+
+function chartDatumFromPayload(value: unknown): ChartDatum | undefined {
+	if (
+		isRecord(value) &&
+		isAgentTimeBucket(value.bucket) &&
+		typeof value.label === "string" &&
+		(typeof value.hours === "number" || value.hours === null)
+	) {
+		return {
+			bucket: value.bucket,
+			label: value.label,
+			hours: value.hours,
+		};
+	}
+	return undefined;
+}
+
+export function AgentTimeChart({ report }: { report: AgentTimeReport }) {
+	const data: ChartDatum[] = report.buckets.map((bucket) => ({
+		bucket,
+		label: `${formatBucketRange(bucket)}${bucket.partial ? " (partial)" : ""}`,
+		hours: msToHours(bucket.agent_time_ms),
+	}));
+
+	return (
+		<ChartContainer config={chartConfig} className="aspect-auto h-[260px]">
+			<BarChart
+				accessibilityLayer
+				data={data}
+				margin={{ top: 8, right: 8, bottom: 0, left: -12 }}
+			>
+				<CartesianGrid vertical={false} />
+				<XAxis
+					dataKey="label"
+					tickLine={false}
+					tickMargin={12}
+					minTickGap={28}
+				/>
+				<YAxis
+					tickLine={false}
+					axisLine={false}
+					tickMargin={4}
+					width={44}
+					tickFormatter={(value: number) =>
+						value === 0 ? "" : `${String(value)}h`
+					}
+				/>
+				<ChartTooltip
+					cursor={false}
+					content={
+						<ChartTooltipContent
+							labelFormatter={(_value, payload) => {
+								const item = payload?.find(
+									(entry) => chartDatumFromPayload(entry.payload) !== undefined,
+								);
+								const datum = chartDatumFromPayload(item?.payload);
+								return datum?.label ?? "";
+							}}
+							formatter={(_value, _name, item) => {
+								const datum = chartDatumFromPayload(item.payload);
+								return (
+									<div className="flex w-full items-center justify-between gap-4">
+										<span className="text-content-secondary">Agent time</span>
+										<span className="font-mono font-medium tabular-nums text-content-primary">
+											{formatAgentTimeHours(datum?.bucket.agent_time_ms)}
+										</span>
+									</div>
+								);
+							}}
+						/>
+					}
+				/>
+				<Bar
+					dataKey="hours"
+					fill="var(--color-hours)"
+					radius={[4, 4, 0, 0]}
+					isAnimationActive={false}
+				/>
+			</BarChart>
+		</ChartContainer>
+	);
+}

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeComponents.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeComponents.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import {
+	MockAgentTimeOrganizationOneId,
+	MockAgentTimeOrganizationReport,
+	MockAgentTimeReport,
+	MockAgentTimeUserOneId,
+} from "#/testHelpers/agentTime";
+import { BreakdownTable } from "./AgentTimeBreakdownTable";
+import { AgentTimeChart } from "./AgentTimeChart";
+
+const meta = {
+	title: "pages/AISettingsPage/CoderAgentsPage/AgentTimeComponents",
+	component: BreakdownTable,
+	args: {
+		query: {
+			data: MockAgentTimeReport,
+			isPlaceholderData: false,
+			currentPage: 1,
+			limit: 25,
+			onPageChange: fn(),
+			goToPreviousPage: fn(),
+			goToNextPage: fn(),
+			goToFirstPage: fn(),
+			isSuccess: true,
+			hasNextPage: false,
+			hasPreviousPage: false,
+			totalRecords: 3,
+			totalPages: 1,
+			currentOffsetStart: 1,
+			countIsCapped: false,
+		},
+		tableGroup: "organization",
+		totalAgentTimeMs: MockAgentTimeReport.total_agent_time_ms,
+		sortBy: "agent_time",
+		sortOrder: "desc",
+		onSortChange: fn(),
+		onSelectOrganization: fn(),
+		onSelectUser: fn(),
+	},
+} satisfies Meta<typeof BreakdownTable>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Organizations: Story = {
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		const row = canvas.getByRole("row", { name: /Acme Engineering/ });
+		await userEvent.click(
+			within(row).getByRole("button", { name: "View users" }),
+		);
+		await expect(args.onSelectOrganization).toHaveBeenCalledWith(
+			MockAgentTimeOrganizationOneId,
+		);
+		await userEvent.click(canvas.getByRole("button", { name: "Agent time" }));
+		await expect(args.onSortChange).toHaveBeenCalledWith("agent_time");
+	},
+};
+export const Users: Story = {
+	args: {
+		query: { ...meta.args.query, data: MockAgentTimeOrganizationReport },
+		tableGroup: "user",
+		selectedUserId: MockAgentTimeUserOneId,
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			within(canvas.getByRole("row", { name: /Alice Ng/ })).getByRole(
+				"button",
+				{ name: "Selected" },
+			),
+		).toBeDisabled();
+		await userEvent.click(
+			within(canvas.getByRole("row", { name: /Bob Stone/ })).getByRole(
+				"button",
+				{ name: "View user" },
+			),
+		);
+		await expect(args.onSelectUser).toHaveBeenCalled();
+	},
+};
+export const Chart: Story = {
+	render: () => <AgentTimeChart report={MockAgentTimeReport} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(await canvas.findByRole("application")).toBeVisible();
+		await expect(await canvas.findByText("12h")).toBeVisible();
+	},
+};

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/agentTimeUtils.test.ts
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/agentTimeUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { MockAgentTimeNow } from "#/testHelpers/agentTime";
+import * as utils from "./agentTimeUtils";
+
+describe("agent time UTC calendar controls", () => {
+	it("normalizes inclusive picker dates to exclusive calendar boundaries", () => {
+		expect(utils.todayUTC(MockAgentTimeNow)).toBe("2026-09-04");
+		expect(utils.tomorrowUTC(MockAgentTimeNow)).toBe("2026-09-05");
+		const start = utils.dateOnlyToLocalDate("2026-08-29");
+		const end = utils.inclusiveLocalDateFromExclusiveEnd("2026-09-05");
+		expect(utils.localDateToDateOnly(start)).toBe("2026-08-29");
+		expect(
+			utils.normalizeDateRange({ startDate: start, endDate: end }),
+		).toEqual({ startDate: "2026-08-29", endDate: "2026-09-05" });
+		expect(utils.parseDateParam("2026-02-30")).toBeUndefined();
+		expect(utils.parseDateParam("2026-09-04")).toBe("2026-09-04");
+		expect(utils.formatRange("2026-08-29", "2026-09-05")).toBe(
+			"Aug 29, 2026 to Sep 4, 2026",
+		);
+		expect(utils.formatDate("2026-09-04")).toBe("Sep 4, 2026");
+	});
+	it("selects supported intervals and preserves explicit URL controls", () => {
+		expect(utils.autoInterval(undefined, "2026-09-05")).toBe("month");
+		expect(utils.autoInterval("2026-08-29", "2026-09-05")).toBe("day");
+		expect(
+			utils.approximateBucketCount("day", "2026-08-29", "2026-09-05"),
+		).toBe(7);
+		expect(utils.intervalLabel("week")).toBe("Weekly");
+		for (const option of utils.intervalOptions)
+			expect(utils.isAgentTimeInterval(option.value)).toBe(true);
+		expect(utils.isAgentTimeInterval("hour")).toBe(false);
+		expect(utils.isAgentTimeSortBy("agent_time")).toBe(true);
+		expect(utils.isAgentTimeSortBy("runtime")).toBe(false);
+		expect(utils.isAgentTimeSortOrder("desc")).toBe(true);
+		expect(utils.isAgentTimeTableGroup("user")).toBe(true);
+		expect(utils.isAgentTimeTableGroup("group")).toBe(false);
+		expect(
+			utils.readSearchParam(
+				new URLSearchParams("interval=week"),
+				"interval",
+				utils.isAgentTimeInterval,
+				"day",
+			),
+		).toBe("week");
+	});
+	it("uses UTC date presets including month and year boundaries", () => {
+		const selectedPreset: utils.AgentTimeDatePreset = "today";
+		expect(utils.presetRange(selectedPreset, MockAgentTimeNow).startDate).toBe(
+			"2026-09-04",
+		);
+		expect(utils.entityLabel("organization")).toBe("organization");
+		expect(utils.presetRange("last_7_days", MockAgentTimeNow)).toEqual({
+			startDate: "2026-08-29",
+			endDate: "2026-09-05",
+		});
+		expect(
+			utils.activePreset("2026-08-29", "2026-09-05", MockAgentTimeNow),
+		).toBe("last_7_days");
+		expect(utils.activePreset(undefined, "2026-09-05", MockAgentTimeNow)).toBe(
+			"all_history",
+		);
+		for (const preset of utils.datePresetOptions) {
+			if (preset.value !== "all_history")
+				expect(
+					utils.presetRange(preset.value, MockAgentTimeNow).startDate,
+				).toMatch(/^2026-/);
+		}
+	});
+});
+
+describe("precision-safe agent time presentation", () => {
+	it("keeps integer milliseconds exact until display", () => {
+		expect(utils.parseAgentTimeMs("9007199254740993")).toBe(9007199254740993n);
+		expect(utils.formatAgentTimeHours("3600000")).toBe("1.00 hours");
+		expect(utils.formatAgentTimeHours(null)).toBe("Unavailable");
+		expect(utils.msToHours(null)).toBeNull();
+		expect(utils.msToHours("3600000")).toBe(1);
+		expect(utils.formatShare("1", "3")).toBe("33.33%");
+		expect(utils.formatProcessedMessages("1000")).toBe("1,000");
+		expect(utils.shortId("11111111-1111-1111-1111-111111111111")).toBe(
+			"11111111...1111",
+		);
+	});
+});

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/agentTimeUtils.ts
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/agentTimeUtils.ts
@@ -1,0 +1,365 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import type {
+	AgentTimeBreakdown,
+	AgentTimeBucket,
+	AgentTimeInterval,
+} from "#/api/typesGenerated";
+import type { DateRangeValue } from "#/components/DateRangePicker/DateRangePicker";
+
+dayjs.extend(utc);
+
+export type AgentTimeDatePreset =
+	| "today"
+	| "last_7_days"
+	| "last_30_days"
+	| "this_month"
+	| "last_month"
+	| "this_year"
+	| "all_history"
+	| "custom";
+
+export type AgentTimeTableGroup = "organization" | "user";
+export type AgentTimeSortBy = "agent_time" | "name";
+export type AgentTimeSortOrder = "asc" | "desc";
+
+const dateFormat = "YYYY-MM-DD";
+
+export const datePresetOptions: readonly {
+	value: Exclude<AgentTimeDatePreset, "custom">;
+	label: string;
+}[] = [
+	{ value: "today", label: "Today" },
+	{ value: "last_7_days", label: "Last 7 days" },
+	{ value: "last_30_days", label: "Last 30 days" },
+	{ value: "this_month", label: "This month" },
+	{ value: "last_month", label: "Last month" },
+	{ value: "this_year", label: "This year" },
+	{ value: "all_history", label: "All history" },
+];
+
+export const intervalOptions: readonly {
+	value: AgentTimeInterval;
+	label: string;
+}[] = [
+	{ value: "day", label: "Daily" },
+	{ value: "week", label: "Weekly" },
+	{ value: "month", label: "Monthly" },
+];
+
+export function isAgentTimeTableGroup(
+	value: string,
+): value is AgentTimeTableGroup {
+	return value === "organization" || value === "user";
+}
+
+export function isAgentTimeInterval(value: string): value is AgentTimeInterval {
+	return value === "day" || value === "week" || value === "month";
+}
+
+export function isAgentTimeSortBy(value: string): value is AgentTimeSortBy {
+	return value === "agent_time" || value === "name";
+}
+
+export function isAgentTimeSortOrder(
+	value: string,
+): value is AgentTimeSortOrder {
+	return value === "asc" || value === "desc";
+}
+
+export function parseDateParam(value: string | null): string | undefined {
+	if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		return undefined;
+	}
+	const parsed = dayjs.utc(value);
+	return parsed.isValid() && parsed.format(dateFormat) === value
+		? value
+		: undefined;
+}
+
+export function dateOnlyToLocalDate(value: string): Date {
+	return dayjs(value, dateFormat).toDate();
+}
+
+export function inclusiveLocalDateFromExclusiveEnd(endDate: string): Date {
+	return new Date(dateOnlyToLocalDate(endDate).getTime() - 1);
+}
+
+export function localDateToDateOnly(value: Date): string {
+	return dayjs(value).format(dateFormat);
+}
+
+function isLocalMidnight(value: Date): boolean {
+	return (
+		value.getHours() === 0 &&
+		value.getMinutes() === 0 &&
+		value.getSeconds() === 0 &&
+		value.getMilliseconds() === 0
+	);
+}
+
+export function normalizeDateRange(value: DateRangeValue): {
+	startDate: string;
+	endDate: string;
+} {
+	const startDate = localDateToDateOnly(value.startDate);
+	const endBoundary = isLocalMidnight(value.endDate)
+		? dayjs(value.endDate)
+		: dayjs(value.endDate).startOf("day").add(1, "day");
+	return {
+		startDate,
+		endDate: endBoundary.format(dateFormat),
+	};
+}
+
+export function tomorrowUTC(now: Date): string {
+	return dayjs.utc(now).startOf("day").add(1, "day").format(dateFormat);
+}
+
+export function todayUTC(now: Date): string {
+	return dayjs.utc(now).startOf("day").format(dateFormat);
+}
+
+export function presetRange(
+	preset: Exclude<AgentTimeDatePreset, "custom" | "all_history">,
+	now: Date,
+): { startDate: string; endDate: string } {
+	const today = dayjs.utc(now).startOf("day");
+	const endDate = today.add(1, "day").format(dateFormat);
+
+	switch (preset) {
+		case "today":
+			return { startDate: today.format(dateFormat), endDate };
+		case "last_7_days":
+			return {
+				startDate: today.subtract(6, "day").format(dateFormat),
+				endDate,
+			};
+		case "last_30_days":
+			return {
+				startDate: today.subtract(29, "day").format(dateFormat),
+				endDate,
+			};
+		case "this_month":
+			return { startDate: today.startOf("month").format(dateFormat), endDate };
+		case "last_month": {
+			const start = today.subtract(1, "month").startOf("month");
+			return {
+				startDate: start.format(dateFormat),
+				endDate: start.add(1, "month").format(dateFormat),
+			};
+		}
+		case "this_year":
+			return { startDate: today.startOf("year").format(dateFormat), endDate };
+	}
+}
+
+function dayCount(
+	startDate: string | undefined,
+	endDate: string,
+): number | undefined {
+	if (startDate === undefined) {
+		return undefined;
+	}
+	const start = dayjs.utc(startDate);
+	const end = dayjs.utc(endDate);
+	if (!start.isValid() || !end.isValid()) {
+		return undefined;
+	}
+	return Math.max(end.diff(start, "day"), 1);
+}
+
+export function autoInterval(
+	startDate: string | undefined,
+	endDate: string,
+): AgentTimeInterval {
+	const days = dayCount(startDate, endDate);
+	if (days === undefined) {
+		return "month";
+	}
+	if (days <= 90) {
+		return "day";
+	}
+	if (days <= 730) {
+		return "week";
+	}
+	return "month";
+}
+
+export function activePreset(
+	startDate: string | undefined,
+	endDate: string,
+	now: Date,
+): AgentTimeDatePreset {
+	if (startDate === undefined) {
+		return "all_history";
+	}
+	const rangePresets: readonly Exclude<
+		AgentTimeDatePreset,
+		"custom" | "all_history"
+	>[] = [
+		"today",
+		"last_7_days",
+		"last_30_days",
+		"this_month",
+		"last_month",
+		"this_year",
+	];
+
+	for (const preset of rangePresets) {
+		const range = presetRange(preset, now);
+		if (range.startDate === startDate && range.endDate === endDate) {
+			return preset;
+		}
+	}
+	return "custom";
+}
+
+export function readSearchParam<T extends string>(
+	searchParams: URLSearchParams,
+	key: string,
+	isAllowed: (value: string) => value is T,
+	fallback: T,
+): T {
+	const value = searchParams.get(key);
+	return value !== null && isAllowed(value) ? value : fallback;
+}
+
+export function parseAgentTimeMs(value: string | null | undefined): bigint {
+	if (!value) {
+		return 0n;
+	}
+	const trimmed = value.trim();
+	if (!/^\d+$/.test(trimmed)) {
+		return 0n;
+	}
+	return BigInt(trimmed);
+}
+
+export function formatAgentTimeHours(value: string | null | undefined): string {
+	if (value === null) {
+		return "Unavailable";
+	}
+	const ms = parseAgentTimeMs(value);
+	if (ms === 0n) {
+		return "0 hours";
+	}
+	const hundredths = (ms * 100n + 1_800_000n) / 3_600_000n;
+	if (hundredths === 0n) {
+		return "<0.01 hours";
+	}
+	const whole = hundredths / 100n;
+	const fraction = (hundredths % 100n).toString().padStart(2, "0");
+	if (whole >= 1_000n) {
+		return `${whole.toLocaleString("en-US")} hours`;
+	}
+	return `${whole.toString()}.${fraction} hours`;
+}
+
+export function formatShare(value: string, total: string): string {
+	const ms = parseAgentTimeMs(value);
+	const totalMs = parseAgentTimeMs(total);
+	if (ms === 0n || totalMs === 0n) {
+		return "0%";
+	}
+	const basisPoints = (ms * 10_000n + totalMs / 2n) / totalMs;
+	if (basisPoints === 0n) {
+		return "<0.01%";
+	}
+	const whole = basisPoints / 100n;
+	const fraction = (basisPoints % 100n).toString().padStart(2, "0");
+	return fraction === "00"
+		? `${whole.toString()}%`
+		: `${whole.toString()}.${fraction}%`;
+}
+
+export function msToHours(value: string | null): number | null {
+	if (value === null) {
+		return null;
+	}
+	const hours = Number(parseAgentTimeMs(value)) / 3_600_000;
+	return Number.isFinite(hours) ? hours : null;
+}
+
+export function formatDate(value: string): string {
+	return dayjs.utc(value).format("MMM D, YYYY");
+}
+
+function formatShortDate(value: string): string {
+	return dayjs.utc(value).format("MMM D");
+}
+
+export function formatBucketRange(bucket: AgentTimeBucket): string {
+	const start = formatShortDate(bucket.start_date);
+	const inclusiveEnd = dayjs.utc(bucket.end_date).subtract(1, "day");
+	if (bucket.start_date === inclusiveEnd.format(dateFormat)) {
+		return start;
+	}
+	return `${start} to ${inclusiveEnd.format("MMM D")}`;
+}
+
+export function formatRange(
+	startDate: string | undefined,
+	endDate: string,
+): string {
+	const end = dayjs.utc(endDate).subtract(1, "day").format("MMM D, YYYY");
+	return startDate === undefined
+		? `All history to ${end}`
+		: `${formatDate(startDate)} to ${end}`;
+}
+
+export function formatProcessedMessages(value: string): string {
+	return parseAgentTimeMs(value).toLocaleString("en-US");
+}
+
+export function approximateBucketCount(
+	interval: AgentTimeInterval,
+	startDate: string | undefined,
+	endDate: string,
+): number | undefined {
+	if (startDate === undefined) {
+		return undefined;
+	}
+	const days = dayjs.utc(endDate).diff(dayjs.utc(startDate), "day");
+	if (days <= 0) {
+		return 1;
+	}
+	if (interval === "day") {
+		return days;
+	}
+	if (interval === "week") {
+		return Math.ceil(days / 7);
+	}
+	return (
+		dayjs.utc(endDate).diff(dayjs.utc(startDate).startOf("month"), "month") + 1
+	);
+}
+
+export function intervalLabel(interval: AgentTimeInterval): string {
+	return (
+		intervalOptions.find((option) => option.value === interval)?.label ??
+		interval
+	);
+}
+
+export function entityLabel(tableGroup: AgentTimeTableGroup): string {
+	return tableGroup === "organization" ? "organization" : "user";
+}
+
+export function entityHeading(tableGroup: AgentTimeTableGroup): string {
+	return tableGroup === "organization" ? "Organizations" : "Users";
+}
+
+export function rowName(
+	row: AgentTimeBreakdown,
+	tableGroup: AgentTimeTableGroup,
+): string {
+	if (row.name) {
+		return row.name;
+	}
+	return row.deleted ? `Deleted ${entityLabel(tableGroup)}` : row.id;
+}
+
+export function shortId(id: string): string {
+	return id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id;
+}

--- a/site/src/testHelpers/agentTime.ts
+++ b/site/src/testHelpers/agentTime.ts
@@ -1,0 +1,120 @@
+import type { AgentTimeReport } from "#/api/typesGenerated";
+
+export const MockAgentTimeNow = new Date("2026-09-04T12:00:00Z");
+
+export const MockAgentTimeOrganizationOneId =
+	"11111111-1111-1111-1111-111111111111";
+const MockAgentTimeOrganizationTwoId = "22222222-2222-2222-2222-222222222222";
+const MockAgentTimeOrganizationThreeId = "33333333-3333-3333-3333-333333333333";
+export const MockAgentTimeUserOneId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const MockAgentTimeUserTwoId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const MockAgentTimeUserThreeId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const MockAgentTimeBuckets = [
+	{
+		start_date: "2026-08-30",
+		end_date: "2026-08-31",
+		agent_time_ms: "18000000",
+		partial: false,
+		complete: true,
+	},
+	{
+		start_date: "2026-08-31",
+		end_date: "2026-09-01",
+		agent_time_ms: "25200000",
+		partial: false,
+		complete: true,
+	},
+	{
+		start_date: "2026-09-01",
+		end_date: "2026-09-02",
+		agent_time_ms: "28800000",
+		partial: false,
+		complete: true,
+	},
+	{
+		start_date: "2026-09-02",
+		end_date: "2026-09-03",
+		agent_time_ms: "36000000",
+		partial: false,
+		complete: true,
+	},
+	{
+		start_date: "2026-09-03",
+		end_date: "2026-09-04",
+		agent_time_ms: "43200000",
+		partial: false,
+		complete: true,
+	},
+	{
+		start_date: "2026-09-04",
+		end_date: "2026-09-05",
+		agent_time_ms: "28800000",
+		partial: true,
+		complete: false,
+	},
+] satisfies AgentTimeReport["buckets"];
+
+export const MockAgentTimeReport: AgentTimeReport = {
+	start_date: "2026-08-06",
+	end_date: "2026-09-05",
+	interval: "day",
+	total_agent_time_ms: "180000000",
+	buckets: MockAgentTimeBuckets,
+	rows: [
+		{
+			id: MockAgentTimeOrganizationOneId,
+			name: "Acme Engineering",
+			deleted: false,
+			agent_time_ms: "108000000",
+		},
+		{
+			id: MockAgentTimeOrganizationTwoId,
+			name: "Sunset Labs",
+			deleted: true,
+			agent_time_ms: "54000000",
+		},
+		{
+			id: MockAgentTimeOrganizationThreeId,
+			name: "Platform Team",
+			deleted: false,
+			agent_time_ms: "18000000",
+		},
+	],
+	count: 3,
+	status: {
+		capture_started_at: "2026-08-01T00:00:00Z",
+		backfill_complete: true,
+		backfill_error: "",
+		processed_messages: "4200",
+		earliest_date: "2026-08-01",
+	},
+	historical_notice:
+		"Agent time is available from captured aggregates. Deleted messages from before capture may not be recoverable.",
+};
+
+export const MockAgentTimeOrganizationReport: AgentTimeReport = {
+	...MockAgentTimeReport,
+	total_agent_time_ms: "108000000",
+	rows: [
+		{
+			id: MockAgentTimeUserOneId,
+			name: "Alice Ng",
+			deleted: false,
+			agent_time_ms: "72000000",
+		},
+		{
+			id: MockAgentTimeUserTwoId,
+			name: "Bob Stone",
+			deleted: false,
+			agent_time_ms: "27000000",
+		},
+		{
+			id: MockAgentTimeUserThreeId,
+			name: "Former teammate",
+			deleted: true,
+			agent_time_ms: "9000000",
+		},
+	],
+	count: 3,
+};


### PR DESCRIPTION
Add the agent time chart, ranked table, UTC calendar helpers, and precision-safe display formatting as independently exercisable presentation components. The page and navigation are not exposed by this PR.

Part 6 of the Agent time reporting stack.

Depends on #28991.

<details>
<summary>Agent time stack (merge in order)</summary>

| Part | PR | Changed lines |
| --- | --- | ---: |
| 1 | #28987 Capture and retention protection | 1,062 |
| 2 | #28988 Bounded historical backfill | 1,147 |
| 3 | #28989 Aggregate queries and concurrency coverage | 836 |
| 4 | #28990 SDK and report assembly | 731 |
| 5 | #28991 Administrator HTTP API | 1,160 |
| 6 | #28993 UI helpers, chart, and table | 993 |
| 7 | #28994 Report view and data states | 862 |
| 8 | #28995 Page, URL state, and navigation | 649 |

Counts include additions, deletions, and generated files. Each PR is based on the preceding branch; retarget/rebase successors after their base is merged.

</details>
