### PR TITLE
feat(site/src): wire agent time settings and navigation

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -364,6 +364,9 @@ const userSkillPath = (user: string, name: string) =>
 	`${userSkillsPath(user)}/${encodeURIComponent(name)}`;
 const userAIProviderKeysPath = (user = "me") =>
 	`/api/v2/users/${encodeURIComponent(user)}/ai-provider-keys`;
+const agentTimePath = "/api/v2/agent-time";
+const organizationAgentTimePath = (organization: string) =>
+	`/api/v2/organizations/${encodeURIComponent(organization)}/agent-time`;
 const mcpServerConfigsPath = (organization: string) =>
 	`/api/v2/organizations/${encodeURIComponent(organization)}/mcp-servers`;
 const mcpServerConfigPath = (organization: string, id: string) =>
@@ -2809,6 +2812,31 @@ class ApiMethods {
 		const searchParams = new URLSearchParams(params);
 		const response = await this.axios.get(
 			`/api/v2/insights/templates?${searchParams}`,
+		);
+
+		return response.data;
+	};
+
+	getAgentTime = async (
+		request: TypesGen.AgentTimeRequest,
+		signal?: AbortSignal,
+	): Promise<TypesGen.AgentTimeReport> => {
+		const response = await this.axios.get<TypesGen.AgentTimeReport>(
+			getURLWithSearchParams(agentTimePath, request),
+			{ signal },
+		);
+
+		return response.data;
+	};
+
+	getOrganizationAgentTime = async (
+		organization: string,
+		request: TypesGen.AgentTimeRequest,
+		signal?: AbortSignal,
+	): Promise<TypesGen.AgentTimeReport> => {
+		const response = await this.axios.get<TypesGen.AgentTimeReport>(
+			getURLWithSearchParams(organizationAgentTimePath(organization), request),
+			{ signal },
 		);
 
 		return response.data;

--- a/site/src/api/queries/agenttime.ts
+++ b/site/src/api/queries/agenttime.ts
@@ -1,0 +1,68 @@
+import type { AgentTimeReport, AgentTimeRequest } from "#/api/typesGenerated";
+import type { UsePaginatedQueryOptions } from "#/hooks/usePaginatedQuery";
+import { API } from "../api";
+
+type AgentTimeQueryOptions = Readonly<{
+	organization?: string;
+	searchParams?: URLSearchParams;
+}>;
+
+type AgentTimeQueryPayload = Readonly<{
+	organization?: string;
+	request: AgentTimeRequest;
+}>;
+
+type AgentTimeQueryKey = readonly ["agentTime", AgentTimeQueryPayload, number];
+
+const agentTimeQueryKey = (
+	payload: AgentTimeQueryPayload,
+	pageNumber: number,
+): AgentTimeQueryKey => ["agentTime", payload, pageNumber];
+
+function withoutOrganizationFilter(
+	request: AgentTimeRequest,
+): AgentTimeRequest {
+	const { organization_id: _organizationId, ...organizationRequest } = request;
+	return organizationRequest;
+}
+
+export const agentTime = (
+	request: AgentTimeRequest,
+	options: AgentTimeQueryOptions = {},
+): UsePaginatedQueryOptions<
+	AgentTimeReport,
+	AgentTimeQueryPayload,
+	unknown,
+	AgentTimeReport,
+	AgentTimeQueryKey
+> => {
+	return {
+		searchParams: options.searchParams,
+		queryPayload: ({ limit, offset }) => {
+			const payload = {
+				request: {
+					...request,
+					limit,
+					offset,
+				},
+			};
+			return options.organization === undefined
+				? payload
+				: { ...payload, organization: options.organization };
+		},
+		queryKey: ({ payload, pageNumber }) =>
+			agentTimeQueryKey(payload, pageNumber),
+		queryFn: ({ payload, signal }) => {
+			if (payload.organization !== undefined) {
+				return API.getOrganizationAgentTime(
+					payload.organization,
+					withoutOrganizationFilter(payload.request),
+					signal,
+				);
+			}
+
+			return API.getAgentTime(payload.request, signal);
+		},
+		staleTime: 60_000,
+	};
+};

--- a/site/src/modules/management/AISettingsSidebarView.tsx
+++ b/site/src/modules/management/AISettingsSidebarView.tsx
@@ -83,8 +83,13 @@ const AISettingsSidebarView: FC<AISettingsSidebarViewProps> = ({
 				{(canAccessAnyChatModelConfig(permissions) ||
 					canAccessOrganizationModels) && <ModelsSidebarNavItem />}
 				{(permissions.editDeploymentConfig || canAccessOrganizationModels) && (
-					<SidebarNavItem href="/ai/settings/coder-agents">
+					<SidebarNavItem href="/ai/settings/coder-agents" end>
 						Coder Agents
+					</SidebarNavItem>
+				)}
+				{permissions.viewDeploymentConfig && (
+					<SidebarNavItem href="/ai/settings/coder-agents/agent-time">
+						Agent time
 					</SidebarNavItem>
 				)}
 				{permissions.editDeploymentConfig && (

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeNavigation.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimeNavigation.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import AISettingsSidebarView from "#/modules/management/AISettingsSidebarView";
+import { MockNoPermissions } from "#/testHelpers/entities";
+
+const routePath = "/ai/settings/coder-agents/agent-time";
+
+const meta = {
+	title: "pages/AISettingsPage/CoderAgentsPage/AgentTimeNavigation",
+	component: AISettingsSidebarView,
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: routePath },
+			routing: [
+				{ path: "/ai/settings/coder-agents", element: <h1>Coder Agents</h1> },
+				{ path: routePath, useStoryElement: true },
+			],
+		}),
+	},
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			viewDeploymentConfig: true,
+		},
+	},
+} satisfies Meta<typeof AISettingsSidebarView>;
+
+export default meta;
+type Story = StoryObj<typeof AISettingsSidebarView>;
+
+export const DeploymentConfigReader: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const link = canvas.getByRole("link", { name: "Agent time" });
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute("aria-current", "page");
+		await expect(
+			canvas.queryByRole("link", { name: "Coder Agents" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const CoderAgentsParentKeepsSeparateActiveState: Story = {
+	args: {
+		permissions: {
+			...MockNoPermissions,
+			viewDeploymentConfig: true,
+			editDeploymentConfig: true,
+		},
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/ai/settings/coder-agents" },
+			routing: [
+				{ path: "/ai/settings/coder-agents", useStoryElement: true },
+				{ path: routePath, element: <h1>Agent time route</h1> },
+			],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const coderAgents = canvas.getByRole("link", { name: "Coder Agents" });
+		await expect(coderAgents).toHaveAttribute("aria-current", "page");
+		await userEvent.click(canvas.getByRole("link", { name: "Agent time" }));
+	},
+};

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimePage.stories.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimePage.stories.tsx
@@ -1,0 +1,202 @@
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { FC } from "react";
+import { useSearchParams } from "react-router";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import {
+	MockAgentTimeMonthlyReport,
+	MockAgentTimeNow,
+	MockAgentTimeOrganizationOneId,
+	MockAgentTimeOrganizationReport,
+	MockAgentTimeReport,
+	MockAgentTimeUserOneId,
+} from "#/testHelpers/agentTime";
+import { MockPermissions, MockUserOwner } from "#/testHelpers/entities";
+import { withAuthProvider } from "#/testHelpers/storybook";
+import AgentTimePage from "./AgentTimePage";
+
+const routePath = "/ai/settings/coder-agents/agent-time";
+
+const AgentTimeSearchParamsProbe: FC = () => {
+	const [searchParams] = useSearchParams();
+	return (
+		<output aria-label="Agent time search params">
+			{searchParams.toString() || "none"}
+		</output>
+	);
+};
+
+const withAgentTimeSearchParamsProbe: Decorator = (Story) => (
+	<>
+		<AgentTimeSearchParamsProbe />
+		<Story />
+	</>
+);
+
+const meta = {
+	title: "pages/AISettingsPage/CoderAgentsPage/AgentTimePage",
+	component: AgentTimePage,
+	decorators: [withAgentTimeSearchParamsProbe, withAuthProvider],
+	args: {
+		now: MockAgentTimeNow,
+	},
+	parameters: {
+		user: MockUserOwner,
+		permissions: {
+			...MockPermissions,
+			viewDeploymentConfig: true,
+			editDeploymentConfig: false,
+		},
+		reactRouter: reactRouterParameters({
+			location: { path: routePath },
+			routing: { path: routePath },
+		}),
+	},
+} satisfies Meta<typeof AgentTimePage>;
+
+export default meta;
+type Story = StoryObj<typeof AgentTimePage>;
+
+export const AllHistoryDefaultsToMonthly: Story = {
+	beforeEach: () => {
+		spyOn(API, "getAgentTime").mockImplementation(async (request) => {
+			if (request.interval !== "month") {
+				throw new Error("Expected all history to use monthly buckets");
+			}
+			if (request.start_date !== undefined) {
+				throw new Error("Expected all history to omit start_date");
+			}
+			if (request.end_date !== "2026-09-05") {
+				throw new Error("Expected end_date to be the exclusive tomorrow date");
+			}
+			return MockAgentTimeMonthlyReport;
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("heading", { name: "Agent time" }),
+		).toBeVisible();
+		await expect(canvas.getByText("All history to Sep 4, 2026")).toBeVisible();
+	},
+};
+
+export const PresetUpdatesUrlState: Story = {
+	beforeEach: () => {
+		spyOn(API, "getAgentTime").mockResolvedValue(MockAgentTimeReport);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("heading", { name: "Agent time" }),
+		).toBeVisible();
+		await userEvent.click(canvas.getByRole("button", { name: "Last 7 days" }));
+		await expect(
+			await canvas.findByText("Aug 29, 2026 to Sep 4, 2026"),
+		).toBeVisible();
+		await waitFor(() => {
+			expect(
+				canvas.getByLabelText("Agent time search params"),
+			).toHaveTextContent("start_date=2026-08-29");
+			expect(
+				canvas.getByLabelText("Agent time search params"),
+			).toHaveTextContent("end_date=2026-09-05");
+		});
+	},
+};
+
+export const OrganizationAndUserUrlState: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: routePath,
+				searchParams: {
+					organization_id: MockAgentTimeOrganizationOneId,
+					user_id: MockAgentTimeUserOneId,
+					interval: "week",
+				},
+			},
+			routing: { path: routePath },
+		}),
+	},
+	beforeEach: () => {
+		spyOn(API, "getAgentTime").mockResolvedValue(MockAgentTimeReport);
+		spyOn(API, "getOrganizationAgentTime").mockImplementation(
+			async (organization, request) => {
+				if (organization !== MockAgentTimeOrganizationOneId) {
+					throw new Error("Expected organization route parameter");
+				}
+				if (request.organization_id !== undefined) {
+					throw new Error(
+						"Expected organization_id to stay out of org request",
+					);
+				}
+				if (request.user_id !== MockAgentTimeUserOneId) {
+					throw new Error("Expected user_id from the URL state");
+				}
+				return MockAgentTimeOrganizationReport;
+			},
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			await canvas.findByRole("heading", { name: "Users" }),
+		).toBeVisible();
+		await userEvent.click(
+			canvas.getByRole("button", { name: "All organizations" }),
+		);
+		await waitFor(() => {
+			const output = canvas.getByLabelText("Agent time search params");
+			expect(output).not.toHaveTextContent("organization_id=");
+			expect(output).not.toHaveTextContent("user_id=");
+		});
+	},
+};
+
+export const DeploymentUsers: Story = {
+	beforeEach: () => {
+		spyOn(API, "getAgentTime").mockImplementation(async (request) =>
+			request.group_by === "user"
+				? MockAgentTimeOrganizationReport
+				: MockAgentTimeReport,
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(await canvas.findByRole("button", { name: "Users" }));
+		await expect(
+			await canvas.findByRole("heading", { name: "Users" }),
+		).toBeVisible();
+		await userEvent.click(
+			within(canvas.getByRole("row", { name: /Alice Ng/ })).getByRole(
+				"button",
+				{ name: "View user" },
+			),
+		);
+		await waitFor(() => {
+			expect(
+				canvas.getByLabelText("Agent time search params"),
+			).toHaveTextContent("group_by=user");
+			expect(
+				canvas.getByLabelText("Agent time search params"),
+			).toHaveTextContent(`user_id=${MockAgentTimeUserOneId}`);
+			expect(
+				canvas.getByLabelText("Agent time search params"),
+			).not.toHaveTextContent("organization_id=");
+		});
+		await userEvent.click(canvas.getByRole("button", { name: /Clear user/ }));
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Organizations" }),
+		);
+		await expect(
+			await canvas.findByRole("heading", {
+				name: "Organizations",
+			}),
+		).toBeVisible();
+		await expect(
+			canvas.getByLabelText("Agent time search params"),
+		).not.toHaveTextContent("user_id=");
+	},
+};

--- a/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimePage.tsx
+++ b/site/src/pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimePage.tsx
@@ -1,0 +1,245 @@
+import { type FC, useState } from "react";
+import { useSearchParams } from "react-router";
+import { agentTime } from "#/api/queries/agenttime";
+import type { AgentTimeInterval, AgentTimeRequest } from "#/api/typesGenerated";
+import type { DateRangeValue } from "#/components/DateRangePicker/DateRangePicker";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
+import { RequirePermission } from "#/modules/permissions/RequirePermission";
+import AgentTimePageView from "./AgentTimePageView";
+import {
+	type AgentTimeDatePreset,
+	type AgentTimeSortBy,
+	type AgentTimeSortOrder,
+	type AgentTimeTableGroup,
+	activePreset,
+	autoInterval,
+	dateOnlyToLocalDate,
+	inclusiveLocalDateFromExclusiveEnd,
+	isAgentTimeInterval,
+	isAgentTimeSortBy,
+	isAgentTimeSortOrder,
+	isAgentTimeTableGroup,
+	normalizeDateRange,
+	parseDateParam,
+	presetRange,
+	readSearchParam,
+	todayUTC,
+	tomorrowUTC,
+} from "./agentTimeUtils";
+
+const startDateParam = "start_date";
+const endDateParam = "end_date";
+const intervalParam = "interval";
+const organizationParam = "organization_id";
+const userParam = "user_id";
+const sortByParam = "sort_by";
+const sortOrderParam = "sort_order";
+
+function optionalSearchParam(value: string | null): string | undefined {
+	return value === null || value === "" ? undefined : value;
+}
+
+interface AgentTimePageProps {
+	now?: Date;
+}
+
+const AgentTimePage: FC<AgentTimePageProps> = ({ now }) => {
+	const { permissions } = useAuthenticated();
+	const [initialNow] = useState(() => now ?? new Date());
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const startDate = parseDateParam(searchParams.get(startDateParam));
+	const endDate =
+		parseDateParam(searchParams.get(endDateParam)) ?? tomorrowUTC(initialNow);
+	const interval = readSearchParam<AgentTimeInterval>(
+		searchParams,
+		intervalParam,
+		isAgentTimeInterval,
+		autoInterval(startDate, endDate),
+	);
+	const selectedOrganizationId = optionalSearchParam(
+		searchParams.get(organizationParam),
+	);
+	const selectedUserId = optionalSearchParam(searchParams.get(userParam));
+	const sortBy = readSearchParam<AgentTimeSortBy>(
+		searchParams,
+		sortByParam,
+		isAgentTimeSortBy,
+		"agent_time",
+	);
+	const sortOrder = readSearchParam<AgentTimeSortOrder>(
+		searchParams,
+		sortOrderParam,
+		isAgentTimeSortOrder,
+		"desc",
+	);
+	const groupBy = readSearchParam<AgentTimeTableGroup>(
+		searchParams,
+		"group_by",
+		isAgentTimeTableGroup,
+		selectedOrganizationId || selectedUserId ? "user" : "organization",
+	);
+
+	const request: AgentTimeRequest = {
+		...(startDate === undefined ? {} : { start_date: startDate }),
+		end_date: endDate,
+		interval,
+		...(selectedOrganizationId === undefined
+			? {}
+			: { organization_id: selectedOrganizationId }),
+		...(selectedUserId === undefined ? {} : { user_id: selectedUserId }),
+		group_by: groupBy,
+		sort_by: sortBy,
+		sort_order: sortOrder,
+	};
+
+	const query = usePaginatedQuery({
+		...agentTime(request, {
+			organization: selectedOrganizationId,
+			searchParams,
+		}),
+		enabled: permissions.viewDeploymentConfig,
+	});
+
+	const resetPageAndSetParams = (update: (next: URLSearchParams) => void) => {
+		setSearchParams((prev) => {
+			const next = new URLSearchParams(prev);
+			update(next);
+			next.delete("page");
+			return next;
+		});
+	};
+
+	const handleDateRangeChange = (value: DateRangeValue) => {
+		const range = normalizeDateRange(value);
+		resetPageAndSetParams((next) => {
+			next.set(startDateParam, range.startDate);
+			next.set(endDateParam, range.endDate);
+		});
+	};
+
+	const handlePresetChange = (preset: AgentTimeDatePreset) => {
+		resetPageAndSetParams((next) => {
+			if (preset === "all_history") {
+				next.delete(startDateParam);
+				next.delete(endDateParam);
+				next.delete(intervalParam);
+				return;
+			}
+			if (preset === "custom") {
+				return;
+			}
+			const range = presetRange(preset, initialNow);
+			next.set(startDateParam, range.startDate);
+			next.set(endDateParam, range.endDate);
+		});
+	};
+
+	const handleIntervalChange = (nextInterval: AgentTimeInterval) => {
+		resetPageAndSetParams((next) => {
+			next.set(intervalParam, nextInterval);
+		});
+	};
+
+	const handleSortChange = (nextSortBy: AgentTimeSortBy) => {
+		resetPageAndSetParams((next) => {
+			const currentSortBy = readSearchParam<AgentTimeSortBy>(
+				next,
+				sortByParam,
+				isAgentTimeSortBy,
+				"agent_time",
+			);
+			const currentSortOrder = readSearchParam<AgentTimeSortOrder>(
+				next,
+				sortOrderParam,
+				isAgentTimeSortOrder,
+				"desc",
+			);
+			next.set(sortByParam, nextSortBy);
+			next.set(
+				sortOrderParam,
+				currentSortBy === nextSortBy && currentSortOrder === "desc"
+					? "asc"
+					: "desc",
+			);
+		});
+	};
+
+	const handleSelectOrganization = (organizationId: string) => {
+		resetPageAndSetParams((next) => {
+			next.set(organizationParam, organizationId);
+			next.set("group_by", "user");
+			next.delete(userParam);
+			next.set(sortByParam, "agent_time");
+			next.set(sortOrderParam, "desc");
+		});
+	};
+
+	const handleClearOrganization = () => {
+		resetPageAndSetParams((next) => {
+			next.delete(organizationParam);
+			next.set("group_by", "organization");
+			next.delete(userParam);
+			next.set(sortByParam, "agent_time");
+			next.set(sortOrderParam, "desc");
+		});
+	};
+
+	const handleSelectUser = (userId: string) => {
+		resetPageAndSetParams((next) => {
+			next.set(userParam, userId);
+		});
+	};
+
+	const handleClearUser = () => {
+		resetPageAndSetParams((next) => {
+			next.delete(userParam);
+		});
+	};
+
+	const fallbackStartDate =
+		startDate ?? query.data?.start_date ?? todayUTC(initialNow);
+	const dateRange: DateRangeValue = {
+		startDate: dateOnlyToLocalDate(fallbackStartDate),
+		endDate: inclusiveLocalDateFromExclusiveEnd(endDate),
+	};
+
+	return (
+		<RequirePermission isFeatureVisible={permissions.viewDeploymentConfig}>
+			<AgentTimePageView
+				query={query}
+				now={initialNow}
+				dateRange={dateRange}
+				activePreset={activePreset(startDate, endDate, initialNow)}
+				isAllHistory={startDate === undefined}
+				endDate={endDate}
+				interval={interval}
+				sortBy={sortBy}
+				sortOrder={sortOrder}
+				tableGroup={groupBy}
+				onGroupChange={(nextGroup) => {
+					resetPageAndSetParams((next) => {
+						next.set("group_by", nextGroup);
+						next.delete(userParam);
+					});
+				}}
+				selectedOrganizationId={selectedOrganizationId}
+				selectedUserId={selectedUserId}
+				onDateRangeChange={handleDateRangeChange}
+				onPresetChange={handlePresetChange}
+				onIntervalChange={handleIntervalChange}
+				onSortChange={handleSortChange}
+				onSelectOrganization={handleSelectOrganization}
+				onClearOrganization={handleClearOrganization}
+				onSelectUser={handleSelectUser}
+				onClearUser={handleClearUser}
+				onRetry={() => {
+					void query.refetch();
+				}}
+			/>
+		</RequirePermission>
+	);
+};
+
+export default AgentTimePage;

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -386,6 +386,12 @@ const AISettingsLifecyclePage = lazy(
 const CoderAgentsPage = lazy(
 	() => import("./pages/AISettingsPage/CoderAgentsPage/CoderAgentsPage"),
 );
+const AISettingsAgentTimePage = lazy(
+	() =>
+		import(
+			"./pages/AISettingsPage/CoderAgentsPage/AgentTimePage/AgentTimePage"
+		),
+);
 const AgentSettingsUserAgentsPage = lazy(
 	() => import("./pages/AgentsPage/AgentSettingsUserAgentsPage"),
 );
@@ -757,6 +763,10 @@ export const router = createBrowserRouter(
 							element={<AISettingsInstructionsPage />}
 						/>
 						<Route path="lifecycle" element={<AISettingsLifecyclePage />} />
+						<Route
+							path="coder-agents/agent-time"
+							element={<AISettingsAgentTimePage />}
+						/>
 						<Route path="coder-agents" element={<CoderAgentsPage />} />
 						<Route path="templates" element={<AISettingsTemplatesPage />} />
 						<Route path="mcp-servers" element={<AISettingsMCPServersPage />} />

--- a/site/src/testHelpers/agentTime.ts
+++ b/site/src/testHelpers/agentTime.ts
@@ -166,6 +166,28 @@ export const MockAgentTimePartialHistoryReport: AgentTimeReport = {
 	],
 };
 
+export const MockAgentTimeMonthlyReport: AgentTimeReport = {
+	...MockAgentTimeReport,
+	start_date: "",
+	interval: "month",
+	buckets: [
+		{
+			start_date: "2026-08-01",
+			end_date: "2026-09-01",
+			agent_time_ms: "108000000",
+			partial: false,
+			complete: true,
+		},
+		{
+			start_date: "2026-09-01",
+			end_date: "2026-10-01",
+			agent_time_ms: "72000000",
+			partial: true,
+			complete: false,
+		},
+	],
+};
+
 export function mockAgentTimeReportWithCount(count: number): AgentTimeReport {
 	return {
 		...MockAgentTimeReport,


### PR DESCRIPTION
Register `/ai/settings/coder-agents/agent-time` and its permission-gated navigation entry. Wire UTC date ranges, intervals, organization/user drill-down, sorting, and pagination to the reporting API while preserving controls in URL parameters.

Part 8 of the Agent time reporting stack. This is the final integration slice; it remains available without a paid license.

Depends on #28994.

<details>
<summary>Agent time stack (merge in order)</summary>

| Part | PR | Changed lines |
| --- | --- | ---: |
| 1 | #28987 Capture and retention protection | 1,062 |
| 2 | #28988 Bounded historical backfill | 1,147 |
| 3 | #28989 Aggregate queries and concurrency coverage | 836 |
| 4 | #28990 SDK and report assembly | 731 |
| 5 | #28991 Administrator HTTP API | 1,160 |
| 6 | #28993 UI helpers, chart, and table | 993 |
| 7 | #28994 Report view and data states | 862 |
| 8 | #28995 Page, URL state, and navigation | 649 |

Counts include additions, deletions, and generated files. Each PR is based on the preceding branch; retarget/rebase successors after their base is merged.

</details>
