### PR TITLE
fix: trust cloned repository mise config

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -666,13 +666,11 @@ resource "coder_script" "install-deps" {
     # writes this file when it's absent.
     [settings]
     trusted_config_paths = [
+      "${local.repo_dir}",
       "/etc/mise",
     ]
     TRUST
     fi
-
-    # Trust the resolved clone path.
-    mise trust --yes --cd "${local.repo_dir}"
 
     # Install playwright dependencies
     # We want to use the playwright version from site/package.json

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -666,7 +666,6 @@ resource "coder_script" "install-deps" {
     # writes this file when it's absent.
     [settings]
     trusted_config_paths = [
-      "/home/coder/coder",
       "/etc/mise",
     ]
     TRUST

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -671,7 +671,7 @@ resource "coder_script" "install-deps" {
     TRUST
     fi
 
-    # Trust the resolved clone path so custom base directories work.
+    # Trust the resolved clone path.
     mise trust --yes --cd "${local.repo_dir}"
 
     # Install playwright dependencies

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -672,6 +672,9 @@ resource "coder_script" "install-deps" {
     TRUST
     fi
 
+    # Trust the resolved clone path so custom base directories work.
+    mise trust --yes --cd "${local.repo_dir}"
+
     # Install playwright dependencies
     # We want to use the playwright version from site/package.json
     cd "${local.repo_dir}" && make clean


### PR DESCRIPTION
Dogfood workspaces with a custom repository base directory do not trust the cloned repository's mise configuration.

Trust the resolved clone path before running dependency setup.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents.
</details>
