### PR TITLE
feat(site/src): add ignorePasswordManagers prop to FormField

### DIFF
--- a/site/src/components/FormField/FormField.stories.tsx
+++ b/site/src/components/FormField/FormField.stories.tsx
@@ -170,9 +170,9 @@ export const IgnorePasswordManagers: Story = {
 		const canvas = within(canvasElement);
 		const input = canvas.getByRole("textbox", { name: /Provider name/ });
 		await expect(input).toHaveAttribute("autocomplete", "off");
-		await expect(input).toHaveAttribute("data-1p-ignore");
+		await expect(input).toHaveAttribute("data-1p-ignore", "true");
 		await expect(input).toHaveAttribute("data-lpignore", "true");
 		await expect(input).toHaveAttribute("data-form-type", "other");
-		await expect(input).toHaveAttribute("data-bwignore");
+		await expect(input).toHaveAttribute("data-bwignore", "true");
 	},
 };

--- a/site/src/components/FormField/FormField.stories.tsx
+++ b/site/src/components/FormField/FormField.stories.tsx
@@ -12,6 +12,7 @@ interface ExampleFormFieldProps {
 	required?: boolean;
 	error?: string;
 	value?: string;
+	ignorePasswordManagers?: boolean;
 }
 
 const ExampleFormField: FC<ExampleFormFieldProps> = ({
@@ -22,6 +23,7 @@ const ExampleFormField: FC<ExampleFormFieldProps> = ({
 	required,
 	error,
 	value = "",
+	ignorePasswordManagers,
 }) => {
 	const form = useFormik({
 		initialValues: { value },
@@ -43,6 +45,7 @@ const ExampleFormField: FC<ExampleFormFieldProps> = ({
 			label={label}
 			description={description}
 			required={required}
+			ignorePasswordManagers={ignorePasswordManagers}
 		/>
 	);
 };
@@ -156,5 +159,20 @@ export const RequiredWithDescription: Story = {
 			"aria-describedby",
 			"story-field-description",
 		);
+	},
+};
+
+export const IgnorePasswordManagers: Story = {
+	args: {
+		ignorePasswordManagers: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const input = canvas.getByRole("textbox", { name: /Provider name/ });
+		await expect(input).toHaveAttribute("autocomplete", "off");
+		await expect(input).toHaveAttribute("data-1p-ignore");
+		await expect(input).toHaveAttribute("data-lpignore", "true");
+		await expect(input).toHaveAttribute("data-form-type", "other");
+		await expect(input).toHaveAttribute("data-bwignore");
 	},
 };

--- a/site/src/components/FormField/FormField.tsx
+++ b/site/src/components/FormField/FormField.tsx
@@ -2,7 +2,10 @@ import { cn } from "cn";
 import { type FC, type HTMLAttributes, type ReactNode, useId } from "react";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
-import type { FormHelpers } from "#/utils/formUtils";
+import {
+	type FormHelpers,
+	passwordManagerIgnoreProps,
+} from "#/utils/formUtils";
 
 type ControlProps = Pick<
 	HTMLAttributes<HTMLElement>,
@@ -13,6 +16,12 @@ type FormFieldProps = React.ComponentPropsWithRef<"input"> & {
 	field: FormHelpers;
 	label: ReactNode;
 	description?: ReactNode;
+	/**
+	 * When true, discourages password managers (1Password, LastPass, Bitwarden,
+	 * etc.) from offering to autofill or save this field. Has no effect when a
+	 * custom `control` is provided.
+	 */
+	ignorePasswordManagers?: boolean;
 	/**
 	 * Renders in place of the default `Input` element
 	 */
@@ -25,6 +34,7 @@ export const FormField: FC<FormFieldProps> = ({
 	description,
 	className,
 	control,
+	ignorePasswordManagers,
 	...inputProps
 }) => {
 	const generatedId = useId();
@@ -39,6 +49,9 @@ export const FormField: FC<FormFieldProps> = ({
 		.filter(Boolean)
 		.join(" ");
 	const required = inputProps.required ?? false;
+	const passwordManagerProps = ignorePasswordManagers
+		? passwordManagerIgnoreProps
+		: {};
 	const controlProps: ControlProps = {
 		id,
 		"aria-invalid": field.error,
@@ -71,6 +84,7 @@ export const FormField: FC<FormFieldProps> = ({
 					value={field.value}
 					onChange={field.onChange}
 					onBlur={field.onBlur}
+					{...passwordManagerProps}
 					{...inputProps}
 					{...controlProps}
 					className={cn(field.error && "border-border-destructive", className)}

--- a/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerAuthSection.tsx
+++ b/site/src/pages/AISettingsPage/MCPServersPage/components/MCPServerAuthSection.tsx
@@ -10,6 +10,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "#/components/Select/Select";
+import { passwordManagerIgnoreProps } from "#/utils/formUtils";
 import { Field } from "./MCPServerFormFieldPrimitives";
 import {
 	AUTH_TYPE_OPTIONS,
@@ -198,11 +199,7 @@ const SecretInput: FC<{
 		id={id}
 		className="font-mono shadow-none [-webkit-text-security:disc]"
 		type="text"
-		autoComplete="off"
-		data-1p-ignore
-		data-lpignore="true"
-		data-form-type="other"
-		data-bwignore
+		{...passwordManagerIgnoreProps}
 		value={value}
 		onChange={(event) => {
 			onTouch();

--- a/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAPIKeysPageView.tsx
@@ -8,6 +8,7 @@ import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
 import { Input } from "#/components/Input/Input";
 import { Loader } from "#/components/Loader/Loader";
+import { passwordManagerIgnoreProps } from "#/utils/formUtils";
 import { SectionHeader } from "./components/SectionHeader";
 
 const API_KEY_PLACEHOLDER = "••••••••••••••••";
@@ -151,11 +152,7 @@ const ProviderKeyPanel: FC<ProviderKeyPanelProps> = ({
 							id={apiKeyInputId}
 							name={`provider-api-key-${provider.provider_id}`}
 							type="password"
-							autoComplete="off"
-							data-1p-ignore
-							data-lpignore="true"
-							data-form-type="other"
-							data-bwignore
+							{...passwordManagerIgnoreProps}
 							className="h-9 font-mono text-[13px]"
 							placeholder="sk-..."
 							value={apiKey}

--- a/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
+++ b/site/src/pages/UserSettingsPage/SecretsPage/SecretDialog.tsx
@@ -333,13 +333,10 @@ const SecretFields: FC<SecretFieldsProps> = ({
 					)
 				}
 				placeholder="Secret name"
-				autoComplete="off"
 				className="placeholder:text-content-disabled"
 				disabled={disableName}
 				aria-required={showRequiredLabels}
-				data-lpignore="true"
-				data-1p-ignore="true"
-				data-form-type="other"
+				ignorePasswordManagers
 			/>
 			<FormField
 				field={getFieldHelpers("env_name", {
@@ -348,11 +345,8 @@ const SecretFields: FC<SecretFieldsProps> = ({
 				})}
 				label="Environment variable"
 				placeholder="SERVICE_TOKEN"
-				autoComplete="off"
 				className="placeholder:text-content-disabled"
-				data-lpignore="true"
-				data-1p-ignore="true"
-				data-form-type="other"
+				ignorePasswordManagers
 			/>
 			<FormField
 				field={getFieldHelpers("file_path", {
@@ -361,11 +355,8 @@ const SecretFields: FC<SecretFieldsProps> = ({
 				})}
 				label="File path"
 				placeholder="~/api-key.txt"
-				autoComplete="off"
 				className="placeholder:text-content-disabled"
-				data-lpignore="true"
-				data-1p-ignore="true"
-				data-form-type="other"
+				ignorePasswordManagers
 			/>
 			{showValue && (
 				<SecretValueField

--- a/site/src/utils/formUtils.ts
+++ b/site/src/utils/formUtils.ts
@@ -120,3 +120,11 @@ export const displayNameValidator = (displayName: string): Yup.StringSchema =>
 		.optional();
 
 export const iconValidator = Yup.string().label("Icon").max(256);
+
+export const passwordManagerIgnoreProps = {
+	autoComplete: "off",
+	"data-1p-ignore": true,
+	"data-lpignore": "true",
+	"data-form-type": "other",
+	"data-bwignore": true,
+} as const;


### PR DESCRIPTION
## Summary

Formalizes the password-manager ignore pattern (1Password, LastPass, Bitwarden, Dashlane) that was duplicated across several inputs.

- Adds a shared `passwordManagerIgnoreProps` constant in `formUtils.ts` (`autoComplete: "off"`, `data-1p-ignore`, `data-lpignore`, `data-form-type: "other"`, `data-bwignore`) for spreading directly onto any `<input>`/`<Input>`.
- Adds an `ignorePasswordManagers` prop to `<FormField>`. When set, it applies the shared attributes to the default `Input`. Applied before `...inputProps` so callers can still override individual attributes; no effect when a custom `control` is used.
- Refactors existing manual usages: `SecretDialog` `<FormField>`s use the new prop; `MCPServerAuthSection` and `AgentSettingsAPIKeysPageView` direct inputs spread the constant.
- Adds an `IgnorePasswordManagers` Storybook story asserting all five attributes are applied.

## Testing

- `pnpm check`, `pnpm lint`, `pnpm lint:types` pass.
- Affected story tests pass (`FormField`, `AgentSettingsAPIKeysPage`, `SecretsPageView`).

<details>
<summary>Decision log</summary>

- Named the prop `ignorePasswordManagers` and the shared constant `passwordManagerIgnoreProps`.
- The two `SecretDialog` `<FormField>` usages previously lacked `data-bwignore`; the shared prop now adds it for consistency across all inputs.
- `passwordManagerIgnoreProps` is spread before `...inputProps`, so an explicit `autoComplete` or `data-*` passed by a caller wins.
- The prop only affects the built-in `Input`; when a custom `control` render prop is provided, callers are responsible for their own attributes.
- Pre-existing unrelated failure: `AddMCPServerPageView > Default` also fails on a clean `main` (`pointer-events: none` on the submit button), so it is out of scope here.

</details>

---
Generated by Coder Agents on behalf of @jeremyruppel.
