### PR TITLE
chore(site): enable oxlint no-extraneous-class rule

### DIFF
--- a/site/.oxlintrc.jsonc
+++ b/site/.oxlintrc.jsonc
@@ -58,6 +58,7 @@
 		"prefer-numeric-literals": "error",
 		"prefer-optional-chain": "error",
 		"prefer-regex-literals": "error",
+		"no-extraneous-class": "error",
 
 		// --- correctness ---
 		"no-children-prop": "error",
@@ -208,7 +209,6 @@
 		"role-supports-aria-props": "off", // a11y/useAriaPropsSupportedByRole (small)
 		"click-events-have-key-events": "off", // a11y/useKeyWithClickEvents (small)
 		"prefer-function-type": "off", // style/useShorthandFunctionType (small)
-		"no-extraneous-class": "off", // complexity/noStaticOnlyClass (small)
 		"no-empty-interface": "off", // suspicious/noEmptyInterface (small)
 		"no-danger": "off", // security/noDangerouslySetInnerHtml (small: Biome suppression to migrate)
 		"no-noninteractive-tabindex": "off", // a11y/noNoninteractiveTabindex (small)

--- a/site/src/components/ErrorBoundary/GlobalErrorBoundary.stories.tsx
+++ b/site/src/components/ErrorBoundary/GlobalErrorBoundary.stories.tsx
@@ -67,7 +67,7 @@ export const ReactRouterErrorResponse: Story = {
 
 export const UnparsableError: Story = {
 	args: {
-		error: class WellThisIsDefinitelyWrong {},
+		error: { thisIsDefinitelyWrong: true },
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);


### PR DESCRIPTION
Enables the `no-extraneous-class` oxlint rule (Biome's `complexity/noStaticOnlyClass`) and clears it from the migration backlog in `site/.oxlintrc.jsonc`, moving it into the enabled `complexity` section.

The only violation was in the `GlobalErrorBoundary` story `UnparsableError`, which used an empty static-only class purely as an arbitrary non-error value. It is replaced with an equivalent plain object that is still neither an `Error` nor a route error response, so the story's assertion (the "Show error" button stays hidden) is unchanged.

<sub>Opened by Coder Agents on behalf of @jeremyruppel.</sub>
