### PR TITLE
feat(site): enable react compiler for template builder pages

### DIFF
--- a/site/scripts/check-compiler.mjs
+++ b/site/scripts/check-compiler.mjs
@@ -21,6 +21,7 @@ const siteDir = new URL("..", import.meta.url).pathname;
 const targetDirs = [
 	"src/pages/AgentsPage",
 	"src/pages/AIBridgePage",
+	"src/pages/TemplateBuilder",
 ];
 
 const skipPatterns = [".test.", ".stories.", ".jest."];

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPage.tsx
@@ -30,7 +30,7 @@ const TemplateBuilderPage: FC = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const { data, error, isLoading } = useQuery(deploymentConfig());
 	const createMutation = useMutation(createTemplateFromBuilder());
-	const sessionMutation = useMutation(recordTemplateBuilderSession());
+	const { mutate: recordSession } = useMutation(recordTemplateBuilderSession());
 
 	// Stable session ID for the lifetime of this page mount, shared
 	// across wizard_entry and compose_completion telemetry events.
@@ -42,11 +42,11 @@ const TemplateBuilderPage: FC = () => {
 
 	// Report wizard_entry once the builder is ready and accessible.
 	const reportEntry = useCallback(() => {
-		sessionMutation.mutate({
+		recordSession({
 			session_id: sessionId,
 			event_type: "wizard_entry",
 		});
-	}, [sessionMutation.mutate, sessionId]);
+	}, [recordSession, sessionId]);
 
 	// Report compose_completion when the create request settles. Duration
 	// is captured at submit time so it measures wizard usage, not the
@@ -57,7 +57,7 @@ const TemplateBuilderPage: FC = () => {
 			success: boolean,
 			durationSeconds: number,
 		) => {
-			sessionMutation.mutate({
+			recordSession({
 				session_id: state.sessionId,
 				event_type: "compose_completion",
 				base_template_id: state.baseTemplateId ?? undefined,
@@ -66,7 +66,7 @@ const TemplateBuilderPage: FC = () => {
 				success,
 			});
 		},
-		[sessionMutation.mutate],
+		[recordSession],
 	);
 
 	useEffect(() => {

--- a/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
+++ b/site/src/pages/TemplateBuilder/TemplateBuilderPageView.tsx
@@ -1,6 +1,5 @@
 import {
 	type FC,
-	type ReactNode,
 	useCallback,
 	useEffect,
 	useReducer,
@@ -301,17 +300,17 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 				{/* Main content area */}
 				<div className="flex-1 min-w-0">
 					<div className="p-6 border border-solid rounded-lg overflow-x-auto">
-						{renderStepContent(
-							currentStep.id,
-							state,
-							dispatch,
-							moduleVarMap,
-							createError,
-							handleProvisionerStatusChange,
-							handleDeselectModule,
-							registerModuleRef,
-							handleCreate,
-						)}
+						<StepContent
+							stepId={currentStep.id}
+							state={state}
+							dispatch={dispatch}
+							moduleVarMap={moduleVarMap}
+							createError={createError}
+							onProvisionerStatusChange={handleProvisionerStatusChange}
+							onRemoveModule={handleDeselectModule}
+							registerModuleRef={registerModuleRef}
+							onCreate={handleCreate}
+						/>
 					</div>
 
 					{/* Navigation controls */}
@@ -368,17 +367,29 @@ export const TemplateBuilderPageView: FC<TemplateBuilderPageViewProps> = ({
 	);
 };
 
-function renderStepContent(
-	stepId: StepId,
-	state: TemplateBuilderWizardState,
-	dispatch: (action: WizardAction) => void,
-	moduleVarMap: Record<string, Record<string, string>>,
-	createError: Error | null,
-	onProvisionerStatusChange: (value: boolean | undefined) => void,
-	onRemoveModule: (moduleId: string) => void,
-	registerModuleRef: (moduleId: string, node: HTMLDivElement | null) => void,
-	onCreate: (values: CustomizationsFormValues) => void,
-): ReactNode {
+interface StepContentProps {
+	stepId: StepId;
+	state: TemplateBuilderWizardState;
+	dispatch: (action: WizardAction) => void;
+	moduleVarMap: Record<string, Record<string, string>>;
+	createError: Error | null;
+	onProvisionerStatusChange: (value: boolean | undefined) => void;
+	onRemoveModule: (moduleId: string) => void;
+	registerModuleRef: (moduleId: string, node: HTMLDivElement | null) => void;
+	onCreate: (values: CustomizationsFormValues) => void;
+}
+
+const StepContent: FC<StepContentProps> = ({
+	stepId,
+	state,
+	dispatch,
+	moduleVarMap,
+	createError,
+	onProvisionerStatusChange,
+	onRemoveModule,
+	registerModuleRef,
+	onCreate,
+}) => {
 	switch (stepId) {
 		case "base-infra":
 			return (
@@ -441,7 +452,7 @@ function renderStepContent(
 		default:
 			return null;
 	}
-}
+};
 
 function computeCanContinue(
 	stepId: StepId,

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -19,7 +19,11 @@ compilerPreset.rolldown.filter = {
 	...compilerPreset.rolldown.filter,
 	id: {
 		// Keep in sync with targetDirs in scripts/check-compiler.mjs.
-		include: [/src\/pages\/AgentsPage\//, /src\/pages\/AIBridgePage\//, /src\/pages\/TemplateBuilder\//]
+		include: [
+			/src\/pages\/AgentsPage\//,
+			/src\/pages\/AIBridgePage\//,
+			/src\/pages\/TemplateBuilder\//,
+		],
 	},
 };
 

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -19,7 +19,7 @@ compilerPreset.rolldown.filter = {
 	...compilerPreset.rolldown.filter,
 	id: {
 		// Keep in sync with targetDirs in scripts/check-compiler.mjs.
-		include: [/src\/pages\/AgentsPage\//, /src\/pages\/AIBridgePage\//],
+		include: [/src\/pages\/AgentsPage\//, /src\/pages\/AIBridgePage\//, /src\/pages\/TemplateBuilder\//]
 	},
 };
 


### PR DESCRIPTION
## Summary

Opts `src/pages/TemplateBuilder` into the React Compiler and fixes the two compiler diagnostics that surfaced (`pnpm lint:compiler` now passes cleanly).

- **`TemplateBuilderPage.tsx`** (`PreserveManualMemo`): the `useCallback` deps listed `sessionMutation.mutate`, but the compiler inferred the whole `sessionMutation` object, so manual memoization could not be preserved. Destructured `const { mutate: recordSession } = useMutation(...)` so the declared deps match the inferred dependency (the same pattern already used in `AgentChatPage`).
- **`TemplateBuilderPageView.tsx`** (`Cannot access refs during render`): the ref-accessing `registerModuleRef` callback was passed as an argument into the plain `renderStepContent(...)` helper called during render, which the compiler treats as ref access in render. Converted the helper into a `StepContent` component rendered as JSX, so the callback is a normal prop. Removed the now-unused `ReactNode` import.
- Registered the directory in both `scripts/check-compiler.mjs` (`targetDirs`) and `vite.config.mts` (rolldown `include` filter).

## Testing

- `pnpm lint:compiler` — 0 diagnostics (437 functions compiled).
- `tsc --noEmit` — no new errors in the changed files.
- `biome check` — clean.

---

> Generated by Coder Agents on behalf of @jeremyruppel.
