### PR TITLE
test(site/src/components/FormField): convert IgnorePasswordManagers story to Vitest

### DIFF
--- a/site/src/components/FormField/FormField.stories.tsx
+++ b/site/src/components/FormField/FormField.stories.tsx
@@ -12,7 +12,6 @@ interface ExampleFormFieldProps {
 	required?: boolean;
 	error?: string;
 	value?: string;
-	ignorePasswordManagers?: boolean;
 }
 
 const ExampleFormField: FC<ExampleFormFieldProps> = ({
@@ -23,7 +22,6 @@ const ExampleFormField: FC<ExampleFormFieldProps> = ({
 	required,
 	error,
 	value = "",
-	ignorePasswordManagers,
 }) => {
 	const form = useFormik({
 		initialValues: { value },
@@ -45,7 +43,6 @@ const ExampleFormField: FC<ExampleFormFieldProps> = ({
 			label={label}
 			description={description}
 			required={required}
-			ignorePasswordManagers={ignorePasswordManagers}
 		/>
 	);
 };
@@ -159,20 +156,5 @@ export const RequiredWithDescription: Story = {
 			"aria-describedby",
 			"story-field-description",
 		);
-	},
-};
-
-export const IgnorePasswordManagers: Story = {
-	args: {
-		ignorePasswordManagers: true,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const input = canvas.getByRole("textbox", { name: /Provider name/ });
-		await expect(input).toHaveAttribute("autocomplete", "off");
-		await expect(input).toHaveAttribute("data-1p-ignore", "true");
-		await expect(input).toHaveAttribute("data-lpignore", "true");
-		await expect(input).toHaveAttribute("data-form-type", "other");
-		await expect(input).toHaveAttribute("data-bwignore", "true");
 	},
 };

--- a/site/src/components/FormField/FormField.test.tsx
+++ b/site/src/components/FormField/FormField.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import type { FormHelpers } from "#/utils/formUtils";
+import { FormField } from "./FormField";
+
+const field: FormHelpers = {
+	name: "value",
+	id: "value",
+	value: "",
+	onChange: () => {},
+	onBlur: () => {},
+	error: false,
+};
+
+describe(FormField.name, () => {
+	it("applies password-manager ignore attributes when ignorePasswordManagers is set", () => {
+		render(
+			<FormField
+				id="story-field"
+				field={field}
+				label="Provider name"
+				ignorePasswordManagers
+			/>,
+		);
+
+		const input = screen.getByRole("textbox", { name: /Provider name/ });
+		expect(input).toHaveAttribute("autocomplete", "off");
+		expect(input).toHaveAttribute("data-1p-ignore", "true");
+		expect(input).toHaveAttribute("data-lpignore", "true");
+		expect(input).toHaveAttribute("data-form-type", "other");
+		expect(input).toHaveAttribute("data-bwignore", "true");
+	});
+
+	it("omits password-manager ignore attributes by default", () => {
+		render(<FormField id="story-field" field={field} label="Provider name" />);
+
+		const input = screen.getByRole("textbox", { name: /Provider name/ });
+		expect(input).not.toHaveAttribute("data-1p-ignore");
+		expect(input).not.toHaveAttribute("data-lpignore");
+		expect(input).not.toHaveAttribute("data-form-type");
+		expect(input).not.toHaveAttribute("data-bwignore");
+	});
+});


### PR DESCRIPTION
## Summary

Converts the `IgnorePasswordManagers` Storybook story in `FormField` to a Vitest/RTL test.

The story only asserted DOM attributes (`autocomplete`, `data-1p-ignore`, `data-lpignore`, `data-form-type`, `data-bwignore`) with no visual or interactive value, so it is a better fit for a unit test than a Pixel-captured story. This follows up on the review discussion in [#28998](https://github.com/coder/coder/pull/28998) ([comment](https://github.com/coder/coder/pull/28998/files#r3937699707)).

- Adds `FormField.test.tsx`: asserts the ignore attributes are applied when `ignorePasswordManagers` is set, and absent by default.
- Removes the `IgnorePasswordManagers` story and the now-unused `ignorePasswordManagers` plumbing from the story wrapper.

## Testing

- `pnpm test src/components/FormField/FormField.test.tsx` (2 passed)
- `pnpm test:storybook src/components/FormField/FormField.stories.tsx` (7 passed)
- `pnpm check`, `pnpm lint:types`, `pnpm format`

---
Generated by Coder Agents on behalf of @jeremyruppel.
