### PR TITLE
refactor(site/src): track dynamic parameter socket connection in state

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -459,16 +459,21 @@ describe("CreateWorkspacePage", () => {
 
 	describe("Dynamic Parameter Types", () => {
 		it("displays parameter validation errors", async () => {
-			mockDynamicParameterWebSocket((publisher) => {
-				publisher.publishOpen(new Event("open"));
-				publisher.publishMessage(
+			const [, mockPublisher] = mockDynamicParameterWebSocket();
+
+			renderCreateWorkspacePage();
+
+			await waitFor(() => {
+				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+			});
+			await act(async () => {
+				mockPublisher.publishOpen(new Event("open"));
+				mockPublisher.publishMessage(
 					new MessageEvent("message", {
 						data: JSON.stringify(MockDynamicParametersResponseWithError),
 					}),
 				);
 			});
-
-			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
 
 			await waitFor(() => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -57,6 +57,7 @@ const CreateWorkspacePage: FC = () => {
 	const wsResponseId = useRef<number>(-1);
 	const ws = useRef<WebSocket | null>(null);
 	const [wsError, setWsError] = useState<Error | null>(null);
+	const [isConnecting, setIsConnecting] = useState(false);
 	// The expected ID of the init message, so we can wait until the initial
 	// parameters have gone through before rendering the form.
 	const [initId, setInitId] = useState(Number.NaN);
@@ -223,6 +224,9 @@ const CreateWorkspacePage: FC = () => {
 			{
 				// Send initial parameters once the web socket is open.
 				onOpen: () => {
+					if (ws.current === socket) {
+						setIsConnecting(false);
+					}
 					sendInitialParameters();
 				},
 				// Record the latest message every time we get one from the web
@@ -234,11 +238,13 @@ const CreateWorkspacePage: FC = () => {
 				},
 				onError: (error) => {
 					if (ws.current === socket) {
+						setIsConnecting(false);
 						setWsError(error);
 					}
 				},
 				onClose: () => {
 					if (ws.current === socket) {
+						setIsConnecting(false);
 						setWsError(
 							new DetailedError(
 								"Websocket connection for dynamic parameters unexpectedly closed.",
@@ -250,6 +256,7 @@ const CreateWorkspacePage: FC = () => {
 			},
 		);
 
+		setIsConnecting(true);
 		ws.current = socket;
 
 		return () => {
@@ -267,7 +274,7 @@ const CreateWorkspacePage: FC = () => {
 	} = useExternalAuth(realizedVersionId, owner.id);
 
 	const isLoadingFormData =
-		ws.current?.readyState === WebSocket.CONNECTING ||
+		isConnecting ||
 		templateQuery.isLoading ||
 		// isPending stays true until the permission data exists, covering the
 		// renders where the query is still disabled or has not started fetching,
@@ -393,7 +400,7 @@ const CreateWorkspacePage: FC = () => {
 		!latestResponse ||
 		Number.isNaN(initId) ||
 		latestResponse.id < initId ||
-		(ws.current && ws.current.readyState === WebSocket.CONNECTING);
+		isConnecting;
 
 	const shouldShowLoader =
 		!templateQuery.data ||

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.test.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.test.tsx
@@ -1,10 +1,14 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
+import { API } from "#/api/api";
 import type { DynamicParametersResponse } from "#/api/typesGenerated";
 import { MockPreviewParameter, MockTemplate } from "#/testHelpers/entities";
 import { renderWithAuth } from "#/testHelpers/renderHelpers";
-import { mockDynamicParameterWebSocket } from "#/testHelpers/websockets";
+import {
+	type MockWebSocketServer,
+	mockDynamicParameterWebSocket,
+} from "#/testHelpers/websockets";
 import { TemplateLayout } from "../TemplateLayout";
 import TemplateEmbedPage from "./TemplateEmbedPage";
 
@@ -25,6 +29,21 @@ function getSearchParams(url: string): URLSearchParams {
 		return new URLSearchParams();
 	}
 	return new URLSearchParams(url.slice(startOf));
+}
+
+async function connectAndRespond(
+	publisher: MockWebSocketServer,
+	response: DynamicParametersResponse,
+): Promise<void> {
+	await waitFor(() => {
+		expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+	});
+	await act(async () => {
+		publisher.publishOpen(new Event("open"));
+		publisher.publishMessage(
+			new MessageEvent("message", { data: JSON.stringify(response) }),
+		);
+	});
 }
 
 const paramRegion = {
@@ -63,20 +82,15 @@ describe("TemplateEmbedPage", () => {
 	});
 
 	it("populates parameters", async () => {
-		mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: 0,
-						parameters: [paramRegion, paramCpu],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, publisher] = mockDynamicParameterWebSocket();
 
 		renderEmbedPage();
+
+		await connectAndRespond(publisher, {
+			id: 0,
+			parameters: [paramRegion, paramCpu],
+			diagnostics: [],
+		});
 
 		await waitFor(() => {
 			expect(screen.getByDisplayValue("us-east-1")).toBeInTheDocument();
@@ -98,20 +112,15 @@ describe("TemplateEmbedPage", () => {
 			ephemeral: true,
 		};
 
-		mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: 0,
-						parameters: [paramRegion, paramEphemeral],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, publisher] = mockDynamicParameterWebSocket();
 
 		renderEmbedPage();
+
+		await connectAndRespond(publisher, {
+			id: 0,
+			parameters: [paramRegion, paramEphemeral],
+			diagnostics: [],
+		});
 
 		await waitFor(() => {
 			expect(screen.getByDisplayValue("us-east-1")).toBeInTheDocument();
@@ -134,20 +143,15 @@ describe("TemplateEmbedPage", () => {
 			order: 0,
 		};
 
-		mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: 0,
-						parameters: [param],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, publisher] = mockDynamicParameterWebSocket();
 
 		renderEmbedPage();
+
+		await connectAndRespond(publisher, {
+			id: 0,
+			parameters: [param],
+			diagnostics: [],
+		});
 
 		// Wait for the parameter to be rendered
 		await waitFor(() => {
@@ -181,20 +185,15 @@ describe("TemplateEmbedPage", () => {
 	});
 
 	it("changes mode to auto when selected", async () => {
-		mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: 0,
-						parameters: [paramRegion],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, publisher] = mockDynamicParameterWebSocket();
 
 		renderEmbedPage();
+
+		await connectAndRespond(publisher, {
+			id: 0,
+			parameters: [paramRegion],
+			diagnostics: [],
+		});
 
 		await waitFor(() => {
 			expect(screen.getByDisplayValue("us-east-1")).toBeInTheDocument();
@@ -226,20 +225,15 @@ describe("TemplateEmbedPage", () => {
 	});
 
 	it("sends updated values when a parameter changes", async () => {
-		const [mockWebSocket] = mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: 0,
-						parameters: [paramRegion],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [mockWebSocket, publisher] = mockDynamicParameterWebSocket();
 
 		renderEmbedPage();
+
+		await connectAndRespond(publisher, {
+			id: 0,
+			parameters: [paramRegion],
+			diagnostics: [],
+		});
 
 		await waitFor(() => {
 			expect(screen.getByDisplayValue("us-east-1")).toBeInTheDocument();
@@ -257,20 +251,15 @@ describe("TemplateEmbedPage", () => {
 	});
 
 	it("updates form state when server responds", async () => {
-		const [_, mockPublisher] = mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: 0,
-						parameters: [paramRegion],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, mockPublisher] = mockDynamicParameterWebSocket();
 
 		renderEmbedPage();
+
+		await connectAndRespond(mockPublisher, {
+			id: 0,
+			parameters: [paramRegion],
+			diagnostics: [],
+		});
 
 		await waitFor(() => {
 			expect(screen.getByDisplayValue("us-east-1")).toBeInTheDocument();

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
@@ -18,6 +18,7 @@ const TemplateEmbedPage: React.FC = () => {
 	const wsResponseId = useRef<number>(-1);
 	const ws = useRef<WebSocket | null>(null);
 	const [wsError, setWsError] = useState<Error | null>(null);
+	const [isConnecting, setIsConnecting] = useState(false);
 
 	const sendMessage = (formValues: Record<string, string>) => {
 		const request: DynamicParametersRequest = {
@@ -49,13 +50,20 @@ const TemplateEmbedPage: React.FC = () => {
 			me.id,
 			{
 				onMessage,
+				onOpen: () => {
+					if (ws.current === socket) {
+						setIsConnecting(false);
+					}
+				},
 				onError: (error) => {
 					if (ws.current === socket) {
+						setIsConnecting(false);
 						setWsError(error);
 					}
 				},
 				onClose: () => {
 					if (ws.current === socket) {
+						setIsConnecting(false);
 						setWsError(
 							new DetailedError(
 								"Websocket connection for dynamic parameters unexpectedly closed.",
@@ -67,6 +75,7 @@ const TemplateEmbedPage: React.FC = () => {
 			},
 		);
 
+		setIsConnecting(true);
 		ws.current = socket;
 
 		return () => {
@@ -83,8 +92,7 @@ const TemplateEmbedPage: React.FC = () => {
 			.sort((a, b) => a.order - b.order);
 	}, [latestResponse?.parameters]);
 
-	const isLoading =
-		ws.current?.readyState === WebSocket.CONNECTING || !latestResponse;
+	const isLoading = isConnecting || !latestResponse;
 
 	return (
 		<>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
@@ -22,8 +22,29 @@ import {
 	renderWithWorkspaceSettingsLayout,
 	waitForLoaderToBeRemoved,
 } from "#/testHelpers/renderHelpers";
-import { mockDynamicParameterWebSocket } from "#/testHelpers/websockets";
+import {
+	type MockWebSocketServer,
+	mockDynamicParameterWebSocket,
+} from "#/testHelpers/websockets";
 import WorkspaceParametersPage from "./WorkspaceParametersPage";
+
+async function connectWithInitialParameters(
+	mockPublisher: MockWebSocketServer,
+	parameters: readonly TypesGen.PreviewParameter[],
+): Promise<void> {
+	await waitFor(() => {
+		expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+	});
+	await act(async () => {
+		mockPublisher.publishOpen(new Event("open"));
+		// The initial message always has the default values.
+		mockPublisher.publishMessage(
+			new MessageEvent("message", {
+				data: JSON.stringify({ id: -1, parameters, diagnostics: [] }),
+			}),
+		);
+	});
+}
 
 describe("WorkspaceParametersPage", () => {
 	const renderWorkspaceParametersPage = (
@@ -62,35 +83,19 @@ describe("WorkspaceParametersPage", () => {
 			createDeferred<TypesGen.WorkspaceBuildParameter[]>();
 		vi.spyOn(API, "getWorkspaceBuildParameters").mockReturnValueOnce(promise);
 
-		const [_, mockPublisher] = mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			// The initial message always has the default values.
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: -1,
-						parameters: [
-							MockPreviewParameter1,
-							MockPreviewParameter4,
-							MockPreviewParameter7,
-						],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [_, mockPublisher] = mockDynamicParameterWebSocket();
 
 		renderWorkspaceParametersPage();
 
-		// Wait for both requests to have been made.  Client should not have sent
-		// any message yet since build parameters have not resolved.
-		await waitFor(() => {
-			expect(API.getWorkspaceBuildParameters).toHaveBeenCalled();
-			expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
-			expect(mockPublisher.clientSentData).toHaveLength(0);
-		});
+		await connectWithInitialParameters(mockPublisher, [
+			MockPreviewParameter1,
+			MockPreviewParameter4,
+			MockPreviewParameter7,
+		]);
 
-		// Build parameters now resolve.
+		expect(API.getWorkspaceBuildParameters).toHaveBeenCalled();
+		expect(mockPublisher.clientSentData).toHaveLength(0);
+
 		const buildParameters = [
 			MockWorkspaceBuildParameter1,
 			MockWorkspaceBuildParameter4,
@@ -161,35 +166,19 @@ describe("WorkspaceParametersPage", () => {
 			createDeferred<TypesGen.WorkspaceBuildParameter[]>();
 		vi.spyOn(API, "getWorkspaceBuildParameters").mockReturnValueOnce(promise);
 
-		const [_, mockPublisher] = mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			// The initial message always has the default values.
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: -1,
-						parameters: [
-							MockPreviewParameter1,
-							MockPreviewParameter4,
-							MockPreviewParameter7,
-						],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [_, mockPublisher] = mockDynamicParameterWebSocket();
 
 		renderWorkspaceParametersPage();
 
-		// Wait for both requests to have been made.  Client should not have sent
-		// any message yet since build parameters have not resolved.
-		await waitFor(() => {
-			expect(API.getWorkspaceBuildParameters).toHaveBeenCalled();
-			expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
-			expect(mockPublisher.clientSentData).toHaveLength(0);
-		});
+		await connectWithInitialParameters(mockPublisher, [
+			MockPreviewParameter1,
+			MockPreviewParameter4,
+			MockPreviewParameter7,
+		]);
 
-		// Build parameters now resolve.
+		expect(API.getWorkspaceBuildParameters).toHaveBeenCalled();
+		expect(mockPublisher.clientSentData).toHaveLength(0);
+
 		await act(async () => {
 			resolve([]);
 		});
@@ -223,25 +212,15 @@ describe("WorkspaceParametersPage", () => {
 			buildParameters,
 		);
 
-		const [, mockPublisher] = mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			// The initial message always has the default values.
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: -1,
-						parameters: [
-							MockPreviewParameter1,
-							MockPreviewParameter4,
-							MockPreviewParameter7,
-						],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, mockPublisher] = mockDynamicParameterWebSocket();
 
 		renderWorkspaceParametersPage();
+
+		await connectWithInitialParameters(mockPublisher, [
+			MockPreviewParameter1,
+			MockPreviewParameter4,
+			MockPreviewParameter7,
+		]);
 
 		// Wait for the client's init message then respond with different values.
 		await waitFor(() => {
@@ -293,25 +272,15 @@ describe("WorkspaceParametersPage", () => {
 	it("does not clobber edited parameters", async () => {
 		vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValueOnce([]);
 
-		const [, mockPublisher] = mockDynamicParameterWebSocket((publisher) => {
-			publisher.publishOpen(new Event("open"));
-			// The initial message always has the default values.
-			publisher.publishMessage(
-				new MessageEvent("message", {
-					data: JSON.stringify({
-						id: -1,
-						parameters: [
-							MockPreviewParameter1,
-							MockPreviewParameter4,
-							MockPreviewParameter7,
-						],
-						diagnostics: [],
-					}),
-				}),
-			);
-		});
+		const [, mockPublisher] = mockDynamicParameterWebSocket();
 
 		renderWorkspaceParametersPage();
+
+		await connectWithInitialParameters(mockPublisher, [
+			MockPreviewParameter1,
+			MockPreviewParameter4,
+			MockPreviewParameter7,
+		]);
 
 		// Page should render with the default values.
 		await waitForLoaderToBeRemoved();

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -60,6 +60,7 @@ const WorkspaceParametersPage: FC = () => {
 	const wsResponseId = useRef<number>(-1);
 	const ws = useRef<WebSocket | null>(null);
 	const [wsError, setWsError] = useState<Error | null>(null);
+	const [isConnecting, setIsConnecting] = useState(false);
 	// The expected ID of the init message, so we can wait until the initial
 	// parameters have gone through before rendering the form.
 	const [initId, setInitId] = useState(Number.NaN);
@@ -133,6 +134,9 @@ const WorkspaceParametersPage: FC = () => {
 			workspace.owner_id,
 			{
 				onOpen: () => {
+					if (ws.current === socket) {
+						setIsConnecting(false);
+					}
 					// If we already have the build parameters, send them now.
 					sendInitialParameters();
 				},
@@ -145,11 +149,13 @@ const WorkspaceParametersPage: FC = () => {
 				},
 				onError: (error) => {
 					if (ws.current === socket) {
+						setIsConnecting(false);
 						setWsError(error);
 					}
 				},
 				onClose: () => {
 					if (ws.current === socket) {
+						setIsConnecting(false);
 						setWsError(
 							new DetailedError(
 								"Websocket connection for dynamic parameters unexpectedly closed.",
@@ -161,6 +167,7 @@ const WorkspaceParametersPage: FC = () => {
 			},
 		);
 
+		setIsConnecting(true);
 		ws.current = socket;
 
 		return () => {
@@ -256,7 +263,7 @@ const WorkspaceParametersPage: FC = () => {
 		!latestResponse ||
 		Number.isNaN(initId) ||
 		latestResponse.id < initId ||
-		(ws.current && ws.current.readyState === WebSocket.CONNECTING);
+		isConnecting;
 
 	let submitLabel = "Update and start";
 	if (restartWithParameters.isPending) {

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -53,6 +53,7 @@ export function createMockWebSocket(
 		: (protocol ?? "");
 
 	let isOpen = true;
+	let readyStateValue: 0 | 1 | 2 | 3 = 0; // CONNECTING
 	const store: CallbackStore = {
 		message: new Set(),
 		error: new Set(),
@@ -70,7 +71,9 @@ export function createMockWebSocket(
 
 		url,
 		protocol: activeProtocol,
-		readyState: 1,
+		get readyState() {
+			return readyStateValue;
+		},
 		binaryType: "blob",
 		bufferedAmount: 0,
 		extensions: "",
@@ -127,6 +130,7 @@ export function createMockWebSocket(
 			if (!isOpen) {
 				return;
 			}
+			readyStateValue = 1; // OPEN
 			for (const sub of store.open) {
 				sub(event);
 			}
@@ -163,9 +167,10 @@ export function createMockWebSocket(
 	return [mockSocket, publisher] as const;
 }
 
-export function mockDynamicParameterWebSocket(
-	onOpen?: (server: MockWebSocketServer) => void,
-): readonly [MockWebSocket, MockWebSocketServer] {
+export function mockDynamicParameterWebSocket(): readonly [
+	MockWebSocket,
+	MockWebSocketServer,
+] {
 	const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
 	vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
 		(_versionId, _ownerId, callbacks) => {
@@ -183,7 +188,6 @@ export function mockDynamicParameterWebSocket(
 			mockWebSocket.addEventListener("close", () => {
 				callbacks.onClose();
 			});
-			onOpen?.(mockPublisher);
 			return mockWebSocket;
 		},
 	);


### PR DESCRIPTION
The three dynamic-parameter pages (`CreateWorkspacePage`, `WorkspaceParametersPage`, `TemplateEmbedPage`) read `ws.current.readyState` during render to decide loading state, sourcing render output from a mutable ref. This replaces those reads with an `isConnecting` state toggled from the socket callbacks.

The mock dynamic-parameter socket is updated to match: it now starts in `CONNECTING` and transitions to `OPEN` when `publishOpen` is called, and no longer fires `onOpen` during construction. Tests emit the open event imperatively via `mockPublisher.publishOpen()` after mount, mirroring the real WebSocket lifecycle.

Making the mock faithful also surfaced a latent bug: when the socket errored before opening, the loader stayed up forever. Tracking `isConnecting` in state fixes that (see the `handles error gracefully` test).

Prepares these pages for the `react/refs` lint rule enabled in the stacked follow-up.

<sub>Opened by Coder Agents on behalf of @jeremyruppel.</sub>