### PR TITLE
fix(dogfood): bump Mux module to 2.0.0

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -335,7 +335,7 @@ module "personalize" {
 module "mux" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder/mux/coder"
-  version              = "1.5.0"
+  version              = "2.0.0"
   agent_id             = coder_agent.dev.id
   subdomain            = true
   display_name         = "Mux"


### PR DESCRIPTION
Bump the dogfood Mux registry module from 1.5.0 to 2.0.0 so it installs `@coder/xum` directly instead of the `mux` compatibility package, avoiding the publish-order dependency race during workspace startup. Keep `install_version = "next"` and all other settings unchanged.

Picks up https://github.com/coder/registry/pull/1102, released in https://github.com/coder/registry/releases/tag/release%2Fcoder%2Fmux%2Fv2.0.0.