### PR TITLE
fix(site): resolve jsx-no-useless-fragment lint error in HighlightText

### DIFF
--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/HighlightText.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/HighlightText.tsx
@@ -8,7 +8,7 @@ export const HighlightText: FC<{ text: string; query: string }> = ({
 }) => {
 	const segments = splitMatchSegments(text, query);
 	if (segments.length === 1 && !segments[0].match) {
-		return <>{text}</>;
+		return text;
 	}
 	return (
 		<>


### PR DESCRIPTION
Fixes this lint failure: https://github.com/coder/coder/actions/runs/34037787752/job/101498985581

I don't have access to my usual workspace right now so I asked Coder Agents to do it.

I verified that this is the correct solution here:
https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-no-useless-fragment.html