### PR TITLE
[example] fix(coderd): merge stray top-level MCP tool args instead of silently dropping them

### DIFF
--- a/coderd/x/chatd/mcpclient/export_test.go
+++ b/coderd/x/chatd/mcpclient/export_test.go
@@ -46,6 +46,10 @@ var BuildAuthHeadersForTest = buildAuthHeaders
 // SummaryErrorForTest exposes summaryError for external tests.
 var SummaryErrorForTest = summaryError
 
+// UnwrapModelIntentForTest exposes unwrapModelIntent for external
+// tests.
+var UnwrapModelIntentForTest = unwrapModelIntent
+
 // MaxSummaryErrorLenForTest exposes the persisted-error byte cap for
 // external tests.
 const MaxSummaryErrorLenForTest = maxSummaryErrorLen

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -850,11 +850,14 @@ func (t *mcpToolWrapper) SetProviderOptions(
 
 // unwrapModelIntent strips the model_intent wrapper from tool
 // call input so the remote MCP server receives only the original
-// arguments. It handles three shapes the model may produce:
+// arguments. It handles four shapes the model may produce:
 //
 //  1. { model_intent, properties: {...} } — correct format
 //  2. { model_intent, key: val, ... } — flat, no properties wrapper
-//  3. Anything else — returned as-is
+//  3. { model_intent, key: val, ..., properties: {...} } — hybrid:
+//     stray top-level keys are merged into properties instead of
+//     being dropped; on conflict the value inside properties wins
+//  4. Anything else — returned as-is
 func unwrapModelIntent(input string) string {
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(input), &parsed); err != nil {
@@ -864,7 +867,24 @@ func unwrapModelIntent(input string) string {
 	delete(parsed, "model_intent")
 
 	// Case 1: correct { model_intent, properties: {...} } format.
+	// Case 3: hybrid — some models place arguments both inside
+	// properties and at the top level. Merge stray top-level keys
+	// into properties rather than silently dropping them. On
+	// conflict the value inside properties wins, since the
+	// correctly nested value is more trustworthy than the stray
+	// top-level one.
 	if props, ok := parsed["properties"]; ok {
+		if propsMap, isMap := props.(map[string]any); isMap {
+			for k, v := range parsed {
+				if k == "properties" {
+					continue
+				}
+				if _, exists := propsMap[k]; !exists {
+					propsMap[k] = v
+				}
+			}
+			props = propsMap
+		}
 		if b, err := json.Marshal(props); err == nil {
 			return string(b)
 		}

--- a/coderd/x/chatd/mcpclient/mcpclient_test.go
+++ b/coderd/x/chatd/mcpclient/mcpclient_test.go
@@ -1572,6 +1572,66 @@ func TestModelIntent_Run_FallbackOnBadJSON(t *testing.T) {
 	assert.True(t, resp.IsError, "malformed input should produce an error response")
 }
 
+func TestUnwrapModelIntent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "CorrectWrapper",
+			input: `{"model_intent":"Testing","properties":{"input":"hello"}}`,
+			want:  `{"input":"hello"}`,
+		},
+		{
+			name:  "FlatNoWrapper",
+			input: `{"model_intent":"Testing","input":"world"}`,
+			want:  `{"input":"world"}`,
+		},
+		{
+			// Hybrid: stray top-level keys sit next to properties.
+			// They must be merged in, not silently dropped.
+			name:  "HybridMergesTopLevelKeys",
+			input: `{"model_intent":"Testing","owner":"coder","repo":"solstice","ref":"main","properties":{"path":"README.md"}}`,
+			want:  `{"owner":"coder","path":"README.md","ref":"main","repo":"solstice"}`,
+		},
+		{
+			// On conflict, the value inside properties wins over the
+			// stray top-level one.
+			name:  "HybridConflictPrefersProperties",
+			input: `{"model_intent":"Testing","path":"stray.md","properties":{"path":"nested.md"}}`,
+			want:  `{"path":"nested.md"}`,
+		},
+		{
+			// properties present but not an object: forwarded as-is,
+			// matching the prior behavior.
+			name:  "PropertiesNotAnObject",
+			input: `{"model_intent":"Testing","owner":"coder","properties":"README.md"}`,
+			want:  `"README.md"`,
+		},
+		{
+			name:  "NonJSONReturnedAsIs",
+			input: `not-json`,
+			want:  `not-json`,
+		},
+		{
+			name:  "JSONArrayReturnedAsIs",
+			input: `[1,2,3]`,
+			want:  `[1,2,3]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mcpclient.UnwrapModelIntentForTest(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestConvertCallResult_UTF8Sanitization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

## Why

While testing smaller open-weight models with Coder Agents, we noticed they fail tool-heavy tasks that stronger models handle fine. One recurring cause lives in our MCP tool wrapper.

Coder wraps every MCP tool schema so all arguments sit inside a `properties` object, next to a top-level `model_intent` label. Smaller models are used to the flat public shape (`{owner, repo, path}`) and often emit a hybrid of the two:

```json
{"owner": "coder", "repo": "coder", "ref": "main", "properties": {"path": "README.md"}}
```

`unwrapModelIntent` sees the `properties` key, forwards only `{path}`, and silently drops `owner`, `repo`, and `ref`. The MCP server then answers `missing required parameter: owner`. From the model's point of view that error is contradictory (it did pass `owner`), so it typically concludes the tooling is broken and gives up. We watched one model fail the same `get_file_contents` call 4 times in a row this way and then report the tool layer as defective to the user.

Funnily enough, the function already has a leniency fallback for a *fully flat* call, so a completely wrong shape works today. Only the half-right hybrid loses arguments.

## Impact

- Hybrid-shaped calls now work: stray top-level keys are merged into `properties`, so the call the model meant to make is the call that runs.
- No behavior change for well-formed calls: pure wrapper shape, pure flat shape, and non-object `properties` behave exactly as before. Strong models are unaffected.
- Smaller models stop dying to one unlucky first call (models tend to copy their own earlier calls, so a single early failure repeats).

Related: CODAGT-1015 (do not auto-close; issue is in triage)

## Fix

Merge instead of drop. When `properties` exists as an object and other top-level keys remain after removing `model_intent`, merge those stray top-level keys into the properties map before forwarding. On key conflict, the value inside `properties` wins — the correctly nested value is more trustworthy than the stray top-level one. If `properties` is present but not an object (e.g. a string), behavior is unchanged: it is forwarded as-is.

The function's doc comment now documents the hybrid shape as a fourth handled case.

## Tests

New table-driven `TestUnwrapModelIntent` (via a `UnwrapModelIntentForTest` export, matching the file's existing pattern):

- Correct wrapper — unchanged behavior
- Flat shape (leniency fallback) — unchanged behavior
- Hybrid shape — stray top-level keys merged into properties
- Hybrid conflict — properties value wins
- `properties` present but not an object — prior behavior (forwarded as-is)
- Non-JSON and JSON-array inputs — returned as-is

`go test ./coderd/x/chatd/mcpclient/...` passes; `gofmt` clean.
