### PR TITLE
fix(dogfood/coder): derive AI Gateway URLs from deployment access URL

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -456,9 +456,9 @@ resource "coder_agent" "dev" {
       MISE_DATA_DIR : "/home/coder/.local/share/mise",
     },
     {
-      ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/anthropic",
+      ANTHROPIC_BASE_URL : "${trimsuffix(data.coder_workspace.me.access_url, "/")}/api/v2/ai-gateway/anthropic",
       ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token,
-      OPENAI_BASE_URL : "https://dev.coder.com/api/v2/ai-gateway/openai/v1",
+      OPENAI_BASE_URL : "${trimsuffix(data.coder_workspace.me.access_url, "/")}/api/v2/ai-gateway/openai/v1",
       OPENAI_API_KEY : data.coder_workspace_owner.me.session_token,
     }
   )


### PR DESCRIPTION
The dogfood template hard-coded `dev.coder.com` for both AI provider base URLs even though the active deployment is now `dogfood.cdr.dev`. Derive the origin from `data.coder_workspace.me.access_url`, trimming a trailing slash, while preserving the provider suffixes and session-token wiring.

Current main registers `/api/v2/ai-gateway` as canonical and `/api/v2/aibridge` as a legacy alias, so this keeps the canonical paths documented for Anthropic and OpenAI clients. Only the two URL assignments change.

**Validated:** repository pre-commit-light hooks, Terraform formatter, `terraform fmt -check`, `terraform init -backend=false -input=false`, `terraform validate`, and 12 Terraform-console URL checks covering both providers, three origins, and optional trailing slashes. The original main values reproduce the regression; session-token wiring and all other template content are unchanged.

**Rollout:** publish the updated template through the normal release process, then update and restart affected workspaces to pick up the environment. No template deployment, Terraform apply, live infrastructure, or Mux configuration changes were performed.

> Xum acted on behalf of Michael Suchacz (@ibetitsmike).
