### PR TITLE
test(site/src): delete duplicate storybook stories

### DIFF
--- a/site/src/modules/aiModels/ModelSelector.stories.tsx
+++ b/site/src/modules/aiModels/ModelSelector.stories.tsx
@@ -100,22 +100,6 @@ export const WithSelectedValue: Story = {
 	},
 };
 
-export const SelectedValueShowsProviderIcon: Story = {
-	args: {
-		options: allModels,
-		value: "anthropic/claude-sonnet-4",
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("combobox", { name: "Claude Sonnet 4" }),
-		).toBeInTheDocument();
-		expect(
-			canvas.getByTestId("model-selector-trigger-icon"),
-		).toBeInTheDocument();
-	},
-};
-
 export const SelectedValueShowsCustomProviderIcon: Story = {
 	args: {
 		options: [
@@ -139,21 +123,6 @@ export const SelectedValueShowsCustomProviderIcon: Story = {
 		).toBeInTheDocument();
 		const icon = canvas.getByTestId("model-selector-trigger-icon");
 		expect(icon.querySelector("img")).toHaveAttribute("src", "/icon/coder.svg");
-	},
-};
-
-export const PlaceholderShowsNoIcon: Story = {
-	args: {
-		value: "",
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("combobox", { name: "Select model" }),
-		).toBeInTheDocument();
-		expect(
-			canvas.queryByTestId("model-selector-trigger-icon"),
-		).not.toBeInTheDocument();
 	},
 };
 
@@ -254,60 +223,9 @@ export const MultipleProviders: Story = {
 	},
 };
 
-export const MultipleProvidersWithCustomLabel: Story = {
-	args: {
-		options: allModels,
-		value: "",
-		formatProviderLabel: (provider: string) => {
-			const labels: Record<string, string> = {
-				openai: "OpenAI",
-				anthropic: "Anthropic",
-			};
-			return labels[provider] ?? provider;
-		},
-	},
-};
-
-export const MultipleProviderInstances: Story = {
-	args: {
-		options: [
-			...openAIModels,
-			{
-				...MockModelSelectorOption,
-				id: "anthropic-primary/claude-sonnet-4",
-				provider: "anthropic",
-				providerId: "provider-anthropic-primary",
-				providerLabel: "Anthropic",
-				model: "claude-sonnet-4-20250514",
-				displayName: "Claude Sonnet 4",
-				contextLimit: 200_000,
-			},
-			{
-				...MockModelSelectorOption,
-				id: "anthropic-hyper/claude-opus-4",
-				provider: "anthropic",
-				providerId: "provider-anthropic-hyper",
-				providerLabel: "Hyper",
-				providerIcon: "/icon/coder.svg",
-				model: "claude-opus-4-20250514",
-				displayName: "Claude Opus 4",
-				contextLimit: 200_000,
-			},
-		],
-		value: "anthropic-primary/claude-sonnet-4",
-	},
-};
-
 // ---------------------------------------------------------------------------
 // Empty state
 // ---------------------------------------------------------------------------
-
-export const NoOptions: Story = {
-	args: {
-		options: [],
-		value: "",
-	},
-};
 
 // ---------------------------------------------------------------------------
 // Play function, selection interaction

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -36,9 +36,6 @@ import {
 	MockChatModelProviderDescriptor,
 } from "#/testHelpers/chatModels";
 import {
-	MockGroup,
-	MockOrganizationMember,
-	MockOrganizationMember2,
 	MockUserChatCompactionThresholds,
 	MockUserOwner,
 	MockUserPreferenceSettings,
@@ -1556,44 +1553,6 @@ export const NoLocalModelDisablesGeneration: Story = {
 	},
 };
 
-export const RootChatShareActionAvailable: Story = {
-	parameters: {
-		queries: buildQueries(
-			{
-				id: CHAT_ID,
-				...baseChatFields,
-				title: "Shareable root chat",
-				status: "waiting",
-			},
-			{ messages: [], queued_messages: [], has_more: false },
-			{ diffUrl: undefined },
-		),
-	},
-	beforeEach: () => {
-		spyOn(API.experimental, "getChatACL").mockResolvedValue({
-			users: [],
-			groups: [],
-		});
-		spyOn(API.experimental, "updateChatACL").mockResolvedValue(undefined);
-		spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
-			members: [MockOrganizationMember, MockOrganizationMember2],
-			count: 2,
-		});
-		spyOn(API, "getGroupsByOrganization").mockResolvedValue([MockGroup]);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.click(canvas.getByLabelText("Share chat"));
-		const body = within(document.body);
-		await waitFor(() => {
-			expect(body.getByText("Chat sharing")).toBeVisible();
-		});
-		await waitFor(() => {
-			expect(body.getByText("No shared members or groups yet")).toBeVisible();
-		});
-	},
-};
-
 /** Skeleton placeholder when no query data is available yet. */
 export const Loading: Story = {
 	parameters: {
@@ -1647,137 +1606,6 @@ export const QueuedForCapacityAfterPolling: Story = {
 		expect(callout).toHaveTextContent(
 			"This agent is queued and will start automatically when capacity is available.",
 		);
-	},
-};
-
-export const OtherUserChatReadOnly: Story = {
-	parameters: {
-		queries: buildQueries(
-			{
-				id: CHAT_ID,
-				...baseChatFields,
-				owner_id: "other-user-id",
-				owner_username: "OtherUser",
-				owner_name: "Other User",
-				title: "Other user's chat",
-				status: "waiting",
-			},
-			{ messages: [], queued_messages: [], has_more: false },
-			{ diffUrl: undefined },
-		),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const banner = await canvas.findByText(
-			"This chat is owned by Other User. It is read-only.",
-		);
-		expect(banner).toBeVisible();
-		expect(banner).toHaveAttribute("role", "status");
-		expect(canvas.getByRole("textbox")).toHaveAttribute(
-			"aria-disabled",
-			"true",
-		);
-	},
-};
-
-export const OtherUserChatWithMessages: Story = {
-	parameters: {
-		queries: buildQueries(
-			{
-				id: CHAT_ID,
-				...baseChatFields,
-				owner_id: "other-user-id",
-				owner_username: "OtherUser",
-				owner_name: "Other User",
-				title: "Other user's chat with messages",
-				status: "waiting",
-			},
-			{
-				messages: [
-					{
-						id: 1,
-						chat_id: CHAT_ID,
-						created_at: "2026-02-18T00:00:01.000Z",
-						role: "user",
-						content: [{ type: "text", text: "Please review this plan." }],
-					},
-					{
-						id: 2,
-						chat_id: CHAT_ID,
-						created_at: "2026-02-18T00:00:02.000Z",
-						role: "assistant",
-						content: [
-							{ type: "text", text: "I prepared a plan." },
-							{
-								type: "tool-call",
-								tool_call_id: "other-user-plan",
-								tool_name: "propose_plan",
-								args: { path: "/home/coder/PLAN.md" },
-							},
-							{
-								type: "tool-result",
-								tool_call_id: "other-user-plan",
-								tool_name: "propose_plan",
-								result: {
-									file_id: "other-user-plan-file",
-									content: "# Plan\n\n1. Keep this chat read-only.",
-								},
-							},
-						],
-					},
-				] as TypesGen.ChatMessage[],
-				queued_messages: [],
-				has_more: false,
-			},
-			{ diffUrl: undefined },
-		),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			await canvas.findByText(
-				"This chat is owned by Other User. It is read-only.",
-			),
-		).toBeVisible();
-		expect(await canvas.findByText("Please review this plan.")).toBeVisible();
-		expect(canvas.getByRole("textbox")).toHaveAttribute(
-			"aria-disabled",
-			"true",
-		);
-		expect(
-			canvas.queryByRole("button", { name: "Edit message" }),
-		).not.toBeInTheDocument();
-		expect(
-			canvas.queryByRole("button", { name: "Implement plan" }),
-		).not.toBeInTheDocument();
-	},
-};
-
-export const ArchivedOtherUserChat: Story = {
-	parameters: {
-		queries: buildQueries(
-			{
-				id: CHAT_ID,
-				...baseChatFields,
-				archived: true,
-				owner_id: "other-user-id",
-				owner_username: "OtherUser",
-				owner_name: "Other User",
-				title: "Archived other user's chat",
-				status: "waiting",
-			},
-			{ messages: [], queued_messages: [], has_more: false },
-			{ diffUrl: undefined },
-		),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			await canvas.findByText("This agent has been archived and is read-only."),
-		).toBeVisible();
-		expect(
-			canvas.queryByText(/^This chat is owned by/),
-		).not.toBeInTheDocument();
 	},
 };
 
@@ -2639,143 +2467,6 @@ export const StreamedReasoning: Story = {
 // setTimeout(0) which resolves before the chat store subscribes.
 // This made the stories render empty chats and fail interaction
 // tests in both local and CI environments.
-
-const mockNewestMessage: TypesGen.ChatMessage = {
-	...MockChatMessage,
-	id: 30,
-	role: "assistant",
-	content: [{ type: "text", text: "Newest message" }],
-};
-
-const mockOlderRevision: TypesGen.ChatMessage = {
-	...MockChatMessage,
-	id: 20,
-	role: "assistant",
-	content: [{ type: "text", text: "Old revision" }],
-};
-
-const mockFreshRevision: TypesGen.ChatMessage = {
-	...mockOlderRevision,
-	content: [{ type: "text", text: "Fresh revision" }],
-};
-
-export const DurableUpdateFansOutToOlderPage: Story = {
-	parameters: {
-		queries: [
-			...withoutQuery(
-				buildQueries(
-					{
-						id: CHAT_ID,
-						...baseChatFields,
-						title: "Fan-out chat",
-						status: "waiting",
-					},
-					{ messages: [], queued_messages: [], has_more: false },
-				),
-				chatMessagesKey(CHAT_ID),
-			),
-			{
-				key: chatMessagesKey(CHAT_ID),
-				data: {
-					pages: [
-						{
-							messages: [mockNewestMessage],
-							queued_messages: [],
-							has_more: true,
-						},
-						{
-							messages: [mockOlderRevision],
-							queued_messages: [],
-							has_more: false,
-						},
-					],
-					pageParams: [undefined, 30],
-				},
-			},
-		],
-		webSocket: {
-			"/chats/": [
-				{
-					event: "message",
-					data: JSON.stringify([
-						{
-							type: "message",
-							chat_id: CHAT_ID,
-							message: mockFreshRevision,
-						},
-					] satisfies TypesGen.ChatStreamEvent[]),
-				},
-			],
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(await canvas.findByText("Fresh revision")).toBeVisible();
-		await waitFor(() => {
-			expect(canvas.getAllByText("Fresh revision")).toHaveLength(1);
-		});
-		expect(canvas.queryByText("Old revision")).not.toBeInTheDocument();
-	},
-};
-
-/**
- * The streamed thinking block is asserted via its disclosure header
- * because smoothed body text never reveals in the test iframe
- * (requestAnimationFrame is suspended).
- */
-export const StreamedPartWhileStatusWaiting: Story = {
-	parameters: {
-		queries: buildQueries(
-			{
-				id: CHAT_ID,
-				...baseChatFields,
-				title: "Stale status stream",
-				status: "waiting",
-			},
-			{
-				messages: [
-					{
-						id: 1,
-						chat_id: CHAT_ID,
-						created_at: "2026-02-18T00:05:00.000Z",
-						role: "user",
-						content: [{ type: "text", text: "Start the next turn" }],
-					},
-				],
-				queued_messages: [],
-				has_more: false,
-			},
-			{ diffUrl: undefined },
-		),
-		webSocket: {
-			"/chats/": [
-				{
-					event: "message",
-					data: JSON.stringify([
-						{
-							type: "message_part",
-							chat_id: CHAT_ID,
-							message_part: {
-								part: {
-									type: "reasoning",
-									text: "Streaming while the chat still reads waiting",
-								},
-							},
-						},
-					] satisfies TypesGen.ChatStreamEvent[]),
-				},
-			],
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await canvas.findByText("Start the next turn");
-		// The disclosure header is the only "Thinking" text in the DOM
-		// at this point: the generic indicator is suppressed at status
-		// "waiting".
-		expect(await canvas.findByText("Thinking")).toBeVisible();
-	},
-};
 
 /**
  * Live agent turn with streaming reasoning and a back-to-back flurry of
@@ -3904,29 +3595,6 @@ export const DetailQueryError: Story = {
 	},
 };
 
-export const InitialMessagesError: Story = {
-	parameters: {
-		queries: withoutQuery(
-			buildQueries(mockErrorChat, {
-				messages: [],
-				queued_messages: [],
-				has_more: false,
-			}),
-			chatMessagesKey(CHAT_ID),
-		),
-	},
-	beforeEach: () => {
-		spyOn(API.experimental, "getChatMessages").mockRejectedValue(
-			mockServerError,
-		);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(await canvas.findByText("Failed to load chat")).toBeVisible();
-		expect(canvas.queryByText("Chat not found")).not.toBeInTheDocument();
-	},
-};
-
 export const ErrorRetryRecovers: Story = {
 	parameters: {
 		queries: withoutQuery(
@@ -4036,30 +3704,6 @@ export const ProviderRequiresUserApiKey: Story = {
 			"href",
 			"/agents/settings/api-keys",
 		);
-	},
-};
-
-export const ChatNotFound: Story = {
-	parameters: {
-		queries: withoutQuery(
-			buildQueries(mockErrorChat, {
-				messages: [],
-				queued_messages: [],
-				has_more: false,
-			}),
-			chatEntityKey(CHAT_ID),
-		),
-	},
-	beforeEach: () => {
-		spyOn(API.experimental, "getChat").mockRejectedValue({
-			...mockApiError({ message: "Chat not found." }),
-			status: 404,
-		});
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(await canvas.findByText("Chat not found")).toBeVisible();
-		expect(canvas.queryByText("Failed to load chat")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -491,16 +491,6 @@ export const QueuedForCapacityPremiumHardLimit: Story = {
 	},
 };
 
-export const NotQueuedForCapacity: Story = {
-	render: () => <StoryAgentChatPageView />,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.queryByText(/limit for active agents/),
-		).not.toBeInTheDocument();
-	},
-};
-
 /** Shows the parent chat link in the top bar when a parent exists. */
 export const WithParentChat: Story = {
 	parameters: {

--- a/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsGeneralPageView.stories.tsx
@@ -116,17 +116,6 @@ export const SavesUserPrompt: Story = {
 	},
 };
 
-export const RendersChatLayoutSection: Story = {
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-
-		expect(await canvas.findByText("Chat layout")).toBeInTheDocument();
-		expect(
-			await canvas.findByRole("switch", { name: "Full-width chat" }),
-		).toBeInTheDocument();
-	},
-};
-
 export const TogglesSendShortcut: Story = {
 	beforeEach: () => {
 		let agentChatSendShortcut: AgentChatSendShortcut =
@@ -165,16 +154,6 @@ export const TogglesSendShortcut: Story = {
 	},
 };
 
-export const RendersAgentDisplayModeSettings: Story = {
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-
-		expect(await canvas.findByText("Thinking display")).toBeVisible();
-		expect(await canvas.findByText("Shell output display")).toBeVisible();
-		expect(await canvas.findByText("Code diff display")).toBeVisible();
-	},
-};
-
 export const ShowsChatDebugLoggingToggle: Story = {
 	args: {
 		userDebugLoggingData: {
@@ -198,25 +177,5 @@ export const ShowsChatDebugLoggingToggle: Story = {
 				debug_logging_enabled: true,
 			});
 		});
-	},
-};
-
-export const HidesChatDebugLoggingToggle: Story = {
-	args: {
-		userDebugLoggingData: {
-			debug_logging_enabled: false,
-			user_toggle_allowed: false,
-			forced_by_deployment: false,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-
-		expect(canvas.queryByText("Record debug logs for my chats")).toBeNull();
-		expect(
-			canvas.queryByRole("switch", {
-				name: "Enable personal chat debug logging",
-			}),
-		).toBeNull();
 	},
 };

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -787,66 +787,6 @@ export const SidebarCollapsed: Story = {
 	},
 };
 
-export const EmptyStateZoom200Desktop: Story = {
-	parameters: {
-		viewport: { defaultViewport: "desktopZoom200" },
-		// CLEANUP: this desktop-at-200%-zoom snapshot still uses the Chromatic
-		// viewport param; migrate it to a pixel viewport.
-		chromatic: { viewports: [720] },
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const layout = await canvas.findByTestId("agents-page-layout");
-		const sidebar = await canvas.findByTestId("agents-sidebar-panel");
-		const main = await canvas.findByTestId("agents-main-panel");
-
-		await waitFor(() => {
-			const layoutStyles = getComputedStyle(layout);
-			const sidebarStyles = getComputedStyle(sidebar);
-			const mainStyles = getComputedStyle(main);
-			const sidebarRect = sidebar.getBoundingClientRect();
-			const mainRect = main.getBoundingClientRect();
-
-			expect(layoutStyles.flexDirection).toBe("row");
-			expect(sidebarStyles.display).not.toBe("none");
-			expect(mainStyles.display).toBe("flex");
-			expect(sidebarRect.width).toBeGreaterThan(0);
-			expect(mainRect.width).toBeGreaterThan(0);
-			expect(sidebarRect.left).toBeLessThan(mainRect.left);
-			expect(sidebarRect.right).toBeLessThanOrEqual(mainRect.left + 1);
-		});
-
-		await expect(canvas.getByRole("link", { name: "Settings" })).toBeVisible();
-		await expect(canvas.getByRole("link", { name: "New chat" })).toBeVisible();
-		await expect(
-			canvas.getByRole("button", { name: "Collapse sidebar" }),
-		).toBeVisible();
-		await expect(
-			canvas.getByRole("button", { name: /TestUser/ }),
-		).toBeVisible();
-	},
-};
-
-export const CollapsedSidebarZoom200Desktop: Story = {
-	parameters: {
-		viewport: { defaultViewport: "desktopZoom200" },
-		// CLEANUP: this desktop-at-200%-zoom snapshot still uses the Chromatic
-		// viewport param; migrate it to a pixel viewport.
-		chromatic: { viewports: [720] },
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.click(
-			await canvas.findByRole("button", { name: "Collapse sidebar" }),
-		);
-		const expandButton = await canvas.findByRole("button", {
-			name: "Expand sidebar",
-		});
-
-		await expect(expandButton).toBeVisible();
-	},
-};
-
 export const CollapsedSidebarZoom200DesktopWithAgent: Story = {
 	beforeEach: () => {
 		mockChats([

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -140,15 +140,6 @@ const missingAPIKeyCatalog: TypesGen.OrganizationChatModelsResponse = {
 	})),
 };
 
-const fetchFailedCatalog: TypesGen.OrganizationChatModelsResponse = {
-	...defaultModelCatalog,
-	providers: defaultModelCatalog.providers.map((provider) => ({
-		...provider,
-		available: false,
-		unavailable_reason: "fetch_failed",
-	})),
-};
-
 const unsupportedProviderCatalog: TypesGen.OrganizationChatModelsResponse = {
 	models: [],
 	providers: [
@@ -166,22 +157,6 @@ const unsupportedProviderCatalog: TypesGen.OrganizationChatModelsResponse = {
 		{ provider: "copilot", display_name: "GitHub Copilot" },
 	],
 };
-
-const unsupportedProviderWithDisabledSupportedCatalog: TypesGen.OrganizationChatModelsResponse =
-	{
-		...unsupportedProviderCatalog,
-		providers: [
-			...unsupportedProviderCatalog.providers,
-			{
-				...MockChatModelProviderDescriptor,
-				id: "provider-anthropic",
-				type: "anthropic",
-				display_name: "Anthropic",
-				enabled: false,
-				available: false,
-			},
-		],
-	};
 
 const defaultUserProviderConfigs: TypesGen.UserChatProviderConfig[] = [
 	{
@@ -1144,21 +1119,6 @@ export const ProviderMissingAPIKey: Story = {
 	},
 };
 
-export const ProviderFetchFailed: Story = {
-	parameters: {
-		queries: [
-			{
-				key: organizationChatModelsKey(MockDefaultOrganization.id),
-				data: fetchFailedCatalog,
-			},
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText(/AI models aren't available yet/)).toBeVisible();
-	},
-};
-
 export const UnsupportedProviderOnly: Story = {
 	args: { ...defaultArgs, canConfigureAgentSetup: true },
 	parameters: {
@@ -1169,26 +1129,6 @@ export const UnsupportedProviderOnly: Story = {
 			},
 			{ key: aiProvidersListKey, data: [] },
 		],
-	},
-};
-
-export const UnsupportedProviderAndDisabledSupportedProvider: Story = {
-	args: { ...defaultArgs, canConfigureAgentSetup: true },
-	parameters: {
-		queries: [
-			{
-				key: organizationChatModelsKey(MockDefaultOrganization.id),
-				data: unsupportedProviderWithDisabledSupportedCatalog,
-			},
-			{ key: aiProvidersListKey, data: [] },
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText(/GitHub Copilot is configured but/i)).toBeVisible();
-		expect(
-			canvas.getByRole("link", { name: "not supported by Coder Agents" }),
-		).toBeVisible();
 	},
 };
 
@@ -1574,40 +1514,6 @@ export const RestrictedUserKeepsPersistedWorkspace: Story = {
 				}),
 			);
 		});
-	},
-};
-
-export const RestrictedUserKeepsPersistedAttachments: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-	},
-	beforeEach: () => {
-		localStorage.clear();
-		localStorage.setItem(
-			"agents.persisted-attachments",
-			JSON.stringify([
-				{
-					fileId: "file-permitted-org",
-					fileName: "notes.txt",
-					fileType: "text/plain",
-					lastModified: 1700000000000,
-					organizationId: MockOrganization2.id,
-				},
-			]),
-		);
-		mockPermittedOrganizations({
-			[MockDefaultOrganization.id]: false,
-			[MockOrganization2.id]: true,
-		});
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await waitFor(() => {
-			expect(canvas.getByLabelText("Remove notes.txt")).toBeInTheDocument();
-		});
-		const stored = localStorage.getItem("agents.persisted-attachments");
-		expect(stored).toContain("file-permitted-org");
 	},
 };
 
@@ -2284,47 +2190,6 @@ export const PermittedOrgsResolvesToSubset: Story = {
 			throw new Error("Expected onCreateChat to receive options");
 		}
 		expect(options.organizationId).toBe(MockOrganization2.id);
-	},
-};
-
-export const MemberScopedPermissionsShowOrgPicker: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-	},
-	beforeEach: () => {
-		spyOn(API, "getOrganizations").mockResolvedValue([
-			MockDefaultOrganization,
-			MockOrganization2,
-		]);
-		spyOn(API, "checkAuthorization").mockImplementation(async ({ checks }) =>
-			Object.fromEntries(
-				Object.entries(checks).map(([id, check]) => [
-					id,
-					check.object.owner_id === "me",
-				]),
-			),
-		);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const picker = await canvas.findByRole(
-			"button",
-			{ name: /^Organization:/ },
-			{ timeout: 3000 },
-		);
-		await userEvent.click(picker);
-		await screen.findByRole("option", {
-			name: MockDefaultOrganization.display_name,
-		});
-		await userEvent.click(
-			screen.getByRole("option", { name: MockOrganization2.display_name }),
-		);
-		expect(
-			canvas.getByRole("button", {
-				name: `Organization: ${MockOrganization2.display_name}`,
-			}),
-		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -12,7 +12,6 @@ import {
 } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { getChatFileURL } from "../../utils/chatAttachments";
-import { encodeInlineTextAttachment } from "../../utils/fetchTextAttachment";
 import { ChatMessageScroller } from "../ChatMessageScroller";
 import { ConversationTimeline } from "./ConversationTimeline";
 import { parseMessagesWithMergedTools } from "./messageParsing";
@@ -1263,41 +1262,6 @@ export const UserMessageWithFailedTextAttachment: Story = {
 	},
 };
 
-export const UserMessageWithInlineTextAttachment: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: parseMessagesWithMergedTools([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [
-					{ type: "text", text: "Here is inline context:" },
-					{
-						type: "file",
-						media_type: "text/plain",
-						data: encodeInlineTextAttachment(
-							"Inline deployment note: verify the feature flag before rollout.",
-						),
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const textButton = await canvas.findByRole("button", {
-			name: "View text attachment",
-		});
-		expect(textButton).toHaveTextContent(/Pasted text/i);
-		expectNoCopyMessageButtonForElement(textButton);
-		await userEvent.click(textButton);
-		expect(
-			await canvas.findByText(/Inline deployment note/i),
-		).toBeInTheDocument();
-	},
-};
-
 /**
  * Non-JSON error bodies (a bare `Temporary failure` text body with status 503)
  * still surface the shared failure tile, and the raw body must not leak into
@@ -1476,54 +1440,6 @@ export const AssistantMessageWithMismatchedExtensionFile: Story = {
 	},
 };
 
-const iosDownloadStoryArgs: Story["args"] = buildStoryArgs(
-	buildUserMessage({
-		text: "I attached the deployment report.",
-		files: [
-			buildFilePart({
-				media_type: "application/pdf",
-				file_id: "storybook-ios-share-report",
-				name: "deployment-report.pdf",
-			}),
-		],
-	}),
-);
-
-export const DownloadInIOSStandaloneSharesFile: Story = {
-	args: iosDownloadStoryArgs,
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const share = fn().mockResolvedValue(undefined);
-		// Read-only Navigator values must be shadowed with removable own
-		// properties.
-		const overrides: Record<string, unknown> = {
-			userAgent:
-				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
-			standalone: true,
-			share,
-			canShare: fn().mockReturnValue(true),
-		};
-		for (const [key, value] of Object.entries(overrides)) {
-			Object.defineProperty(navigator, key, { value, configurable: true });
-		}
-		try {
-			await userEvent.click(
-				canvas.getByRole("link", { name: "Download deployment-report.pdf" }),
-			);
-			await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
-			const shared: { files: File[] } = share.mock.calls[0][0];
-			expect(shared.files).toHaveLength(1);
-			expect(shared.files[0].name).toBe("deployment-report.pdf");
-			expect(shared.files[0].type).toBe("application/pdf");
-			expect(getAttachmentFetchCount("storybook-ios-share-report")).toBe(1);
-		} finally {
-			for (const key of Object.keys(overrides)) {
-				Reflect.deleteProperty(navigator, key);
-			}
-		}
-	},
-};
-
 /** Images and file-references coexist without interfering. */
 export const UserMessageWithImagesAndFileRefs: Story = {
 	args: {
@@ -1586,43 +1502,6 @@ export const UserMessageWithInlineFileRef: Story = {
 				],
 			},
 		]),
-	},
-};
-
-/** Multiple file references render inline, no separate section. */
-export const UserMessageWithMultipleInlineFileRefs: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [
-					{ type: "text", text: "Compare " },
-					{
-						type: "file-reference",
-						file_name: "api/handler.go",
-						start_line: 1,
-						end_line: 50,
-						content: "...",
-					},
-					{ type: "text", text: " with " },
-					{
-						type: "file-reference",
-						file_name: "api/handler_test.go",
-						start_line: 10,
-						end_line: 30,
-						content: "...",
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText(/handler\.go/)).toBeInTheDocument();
-		expect(canvas.getByText(/handler_test\.go/)).toBeInTheDocument();
 	},
 };
 
@@ -1897,64 +1776,6 @@ export const AssistantMessageCopyButton: Story = {
 	},
 };
 
-/**
- * Assistant messages that end with a tool call get no copy button,
- * because the action row would otherwise render directly below the
- * tool row instead of below copyable text.
- */
-export const NoCopyButtonAfterTrailingToolCall: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [{ type: "text", text: "Run the tests" }],
-			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [
-					{ type: "text", text: "Running the test suite now." },
-					{
-						type: "tool-call",
-						tool_call_id: "call-exec-1",
-						tool_name: "execute",
-						args: { command: "make test" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 3,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						tool_call_id: "call-exec-1",
-						tool_name: "execute",
-						result: { output: "ok" },
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await canvas.findByText("Running the test suite now.");
-		// The assistant message ends with a tool call, so no copy button.
-		const actions = canvas.getAllByTestId("message-actions");
-		expect(actions).toHaveLength(1);
-		for (const actionRow of actions) {
-			expect(
-				within(actionRow).getByRole("button", { name: "Copy message" }),
-			).toBeInTheDocument();
-		}
-	},
-};
-
 /** Persisted ask-user-question answers survive reloads. */
 export const AskUserQuestionSubmittedAnswer: Story = {
 	args: {
@@ -2000,62 +1821,6 @@ export const AskUserQuestionSubmittedAnswer: Story = {
 				content: [{ type: "text", text: askUserQuestionSubmittedResponse }],
 			},
 		]),
-	},
-};
-
-/** No copy button when assistant message has no markdown content. */
-export const AssistantMessageNoCopyWhenToolOnly: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [{ type: "text", text: "Run the tests" }],
-			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [
-					{
-						type: "tool-call",
-						tool_call_id: "tool-1",
-						tool_name: "execute",
-						args: { command: "go test ./..." },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 3,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						tool_call_id: "tool-1",
-						result: { output: "PASS" },
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		// Force the hover-reveal toolbar visible.
-		for (const el of canvasElement.querySelectorAll("[class]")) {
-			if (
-				el instanceof HTMLElement &&
-				el.className.includes("group-hover/msg:opacity-100")
-			) {
-				el.style.opacity = "1";
-			}
-		}
-		// Only the user message should have actions; the tool-only
-		// assistant message has no copyable content.
-		const actions = canvas.getAllByTestId("message-actions");
-		expect(actions).toHaveLength(1);
 	},
 };
 
@@ -2116,185 +1881,6 @@ export const CopyButtonWritesToClipboard: Story = {
 	},
 };
 
-/** All messages get copy actions regardless of turn state. */
-export const CopyButtonDuringActiveTurn: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [{ type: "text", text: "Fix the bug" }],
-			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [{ type: "text", text: "Let me look at the code." }],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		// Force the hover-reveal toolbar visible.
-		for (const el of canvasElement.querySelectorAll("[class]")) {
-			if (
-				el instanceof HTMLElement &&
-				el.className.includes("group-hover/msg:opacity-100")
-			) {
-				el.style.opacity = "1";
-			}
-		}
-		// Both user and assistant messages should have actions.
-		const actions = canvas.getAllByTestId("message-actions");
-		expect(actions).toHaveLength(2);
-	},
-};
-
-/** All assistant messages with text content get a copy button. */
-export const MultiAssistantTurnCopyButton: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [{ type: "text", text: "Help me refactor" }],
-			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [
-					{ type: "text", text: "Let me check the code first." },
-					{
-						type: "tool-call",
-						tool_call_id: "tool-1",
-						tool_name: "read_file",
-						args: { path: "main.go" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 3,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						tool_call_id: "tool-1",
-						result: { output: "package main" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 4,
-				role: "assistant",
-				content: [
-					{ type: "text", text: "Here is the **refactored** version." },
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		// Force the hover-reveal toolbar visible.
-		for (const el of canvasElement.querySelectorAll("[class]")) {
-			if (
-				el instanceof HTMLElement &&
-				el.className.includes("group-hover/msg:opacity-100")
-			) {
-				el.style.opacity = "1";
-			}
-		}
-		// The first assistant message (id=2) is mid-chain so its
-		// actions are hidden. Only the user and the last assistant
-		// (id=4) get action bars.
-		const actions = canvas.getAllByTestId("message-actions");
-		expect(actions).toHaveLength(2);
-	},
-};
-
-/**
- * Thinking-only assistant messages must have consistent
- * bottom spacing before the next user bubble. A spacer div fills the
- * gap that would normally come from the invisible action bar.
- */
-export const ThinkingOnlyAssistantSpacing: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [{ type: "text", text: "Explain this code" }],
-			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [
-					{
-						type: "reasoning",
-						text: "Let me think about this step by step. The user wants me to explain the code they shared.",
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 3,
-				role: "user",
-				content: [{ type: "text", text: "Any progress?" }],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		// The thinking-only assistant message has no action bar, but
-		// it should still have visible text and a spacer element.
-		expect(canvas.getByText("Explain this code")).toBeInTheDocument();
-		expect(canvas.getByText("Any progress?")).toBeInTheDocument();
-		expect(canvas.getByTestId("assistant-bottom-spacer")).toBeInTheDocument();
-	},
-};
-
-/** No following bubble to space against; the spacer would be a dangling blank. */
-export const NoSpacerAfterTrailingThinkingMessage: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "user",
-				content: [{ type: "text", text: "Explain this code" }],
-			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [
-					{
-						type: "reasoning",
-						text: "Let me think about this step by step.",
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Explain this code")).toBeInTheDocument();
-		expect(
-			canvas.queryByTestId("assistant-bottom-spacer"),
-		).not.toBeInTheDocument();
-	},
-};
-
 /**
  * Regression: sources-only assistant messages must have consistent
  * bottom spacing before the next user bubble. A spacer div fills the
@@ -2348,72 +1934,6 @@ export const SourcesOnlyAssistantSpacing: Story = {
 		expect(
 			canvas.getByRole("link", { name: "API Reference" }),
 		).toBeInTheDocument();
-	},
-};
-
-/**
- * Regression: assistant messages whose only tool row resolves to null
- * must not leave behind an empty transcript wrapper or an extra gap.
- */
-export const HiddenAssistantToolMessageDoesNotRenderGap: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 201,
-				role: "user",
-				content: [{ type: "text", text: "Run the command" }],
-			},
-			{
-				...baseMessage,
-				id: 202,
-				role: "assistant",
-				content: [{ type: "text", text: "Done." }],
-			},
-			{
-				...baseMessage,
-				id: 203,
-				role: "assistant",
-				content: [
-					{
-						type: "tool-call",
-						tool_call_id: "hidden-execute",
-						tool_name: "execute",
-						args: {},
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 204,
-				role: "user",
-				content: [{ type: "text", text: "Thanks!" }],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.queryByText("Message has no renderable content."),
-		).not.toBeInTheDocument();
-
-		for (const el of canvasElement.querySelectorAll(
-			'[data-testid="message-actions"]',
-		)) {
-			if (el instanceof HTMLElement) {
-				el.style.opacity = "1";
-			}
-		}
-
-		const timeline = canvas.getByTestId("conversation-timeline");
-		const renderedRows = Array.from(
-			timeline.querySelectorAll('[data-role="user"], [data-role="assistant"]'),
-		);
-		expect(renderedRows).toHaveLength(3);
-		expect(renderedRows[1]).toHaveAttribute("data-role", "assistant");
-		expect(renderedRows[1]).toHaveTextContent("Done.");
-		expect(canvas.getAllByTestId("message-actions")).toHaveLength(3);
 	},
 };
 
@@ -2782,26 +2302,6 @@ export const GroupedReadFilesRewrittenByHook: Story = {
 	},
 };
 
-export const ReadFileNotRewrittenByHook: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: [
-			buildParsedReadFileEntry({
-				messageId: 1,
-				toolId: "read-plain-1",
-				path: "site/src/plain.ts",
-				status: "completed",
-				content: "export const plain = true;\n",
-			}),
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(await canvas.findByText(/plain\.ts/)).toBeVisible();
-		expect(canvas.queryByText("Modified by policy")).not.toBeInTheDocument();
-	},
-};
-
 export const SequentialReadFilesEmptyAndErrorStates: Story = {
 	args: {
 		...defaultArgs,
@@ -3046,113 +2546,5 @@ export const ThinkingBlockWithShellTools: Story = {
 				],
 			},
 		]),
-	},
-};
-
-/**
- * A completed thinking block with auto mode should be collapsed
- * (non-streaming state means auto collapses).
- */
-export const ThinkingBlockAutoMode: Story = {
-	parameters: {
-		queries: [
-			{
-				key: ["me", "preferences"],
-				data: {
-					task_notification_alert_dismissed: false,
-					thinking_display_mode: "auto" as const,
-					shell_tool_display_mode: "auto" as const,
-					code_diff_display_mode: "auto" as const,
-					agent_chat_send_shortcut: "enter" as const,
-				},
-			},
-		],
-	},
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "assistant",
-				content: [
-					{
-						type: "reasoning",
-						text: "Let me think about this step by step.",
-					},
-					{
-						type: "text",
-						text: "Here is the answer.",
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Thinking")).toBeInTheDocument();
-		expect(
-			canvas.queryByText(/Let me think about this step by step/),
-		).not.toBeInTheDocument();
-		await userEvent.click(canvas.getByText("Thinking"));
-		await waitFor(() => {
-			expect(
-				canvas.getByText(/Let me think about this step by step/),
-			).toBeVisible();
-		});
-	},
-};
-
-/**
- * A completed thinking block with preview mode should be collapsed
- * (non-streaming state means preview collapses).
- */
-export const ThinkingBlockPreviewMode: Story = {
-	parameters: {
-		queries: [
-			{
-				key: ["me", "preferences"],
-				data: {
-					task_notification_alert_dismissed: false,
-					thinking_display_mode: "preview" as const,
-					shell_tool_display_mode: "auto" as const,
-					code_diff_display_mode: "auto" as const,
-					agent_chat_send_shortcut: "enter" as const,
-				},
-			},
-		],
-	},
-	args: {
-		...defaultArgs,
-		parsedMessages: buildMessages([
-			{
-				...baseMessage,
-				id: 1,
-				role: "assistant",
-				content: [
-					{
-						type: "reasoning",
-						text: "Let me think about this step by step.",
-					},
-					{
-						type: "text",
-						text: "Here is the answer.",
-					},
-				],
-			},
-		]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Thinking")).toBeInTheDocument();
-		expect(
-			canvas.queryByText(/Let me think about this step by step/),
-		).not.toBeInTheDocument();
-		await userEvent.click(canvas.getByText("Thinking"));
-		await waitFor(() => {
-			expect(
-				canvas.getByText(/Let me think about this step by step/),
-			).toBeVisible();
-		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/CompactOrgSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/CompactOrgSelector.stories.tsx
@@ -66,10 +66,3 @@ export const NoSelection: Story = {
 		value: null,
 	},
 };
-
-export const SingleOption: Story = {
-	args: {
-		options: [mockOrgs[0]],
-		value: mockOrgs[0],
-	},
-};

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
@@ -239,27 +239,20 @@ export const RelativeImageRendersImmediately: Story = {
 	},
 };
 
-// The consent gate must also apply while streaming.
-export const StreamingExternalImageConsentGate: Story = {
-	args: {
-		children: `![diagram](${externalImageURL})`,
-		streaming: true,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const loadButton = await canvas.findByRole("button", {
-			name: /load external image/i,
-		});
-		expect(loadButton).toBeInTheDocument();
-		expect(canvasElement.querySelector("img")).toBeNull();
-	},
-};
-
 // Verifies that streaming mode closes incomplete inline markdown via
 // remend so the user never sees raw syntax during the reveal animation.
 export const StreamingInlineMarkdown: Story = {
 	args: {
 		children: "This is **bold text that has not been close",
+		streaming: true,
+	},
+};
+
+// The streaming external-image consent gate: the placeholder renders
+// instead of an <img>, so no external request fires mid-stream.
+export const StreamingExternalImageConsentGate: Story = {
+	args: {
+		children: `![diagram](${externalImageURL})`,
 		streaming: true,
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/AskUserQuestionTool.stories.tsx
@@ -126,20 +126,12 @@ export const Running: Story = {
 	},
 };
 
+// The running state with no questions: the live status region renders
+// instead of a form.
 export const RunningEmptyQuestions: Story = {
 	args: {
 		status: "running",
 		args: { questions: [] },
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const liveRegion = canvas.getByRole("status");
-
-		expect(liveRegion).toHaveAttribute("aria-live", "polite");
-		expect(canvas.getByText("Asking for clarification...")).toBeInTheDocument();
-		expect(
-			canvas.getByRole("img", { name: "Tool call running" }),
-		).toBeInTheDocument();
 	},
 };
 
@@ -415,24 +407,6 @@ export const CompletedRewrittenByHook: Story = {
 		isLatestAskUserQuestion: false,
 		hookRewritten: true,
 		onSendAskUserQuestionResponse: fn(),
-	},
-};
-
-export const CompletedNotRewrittenByHook: Story = {
-	args: {
-		status: "completed",
-		result: JSON.stringify(multipleQuestionsPayload),
-		isChatCompleted: true,
-		isLatestAskUserQuestion: false,
-		onSendAskUserQuestionResponse: fn(),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-
-		expect(
-			await canvas.findByText(/How should we structure the database migration/),
-		).toBeInTheDocument();
-		expect(canvas.queryByText("Modified by policy")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/InlineDesktopPreview.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/InlineDesktopPreview.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn } from "storybook/test";
 import { InlineDesktopPreview } from "./InlineDesktopPreview";
 
 const meta: Meta<typeof InlineDesktopPreview> = {
@@ -33,23 +33,6 @@ export const Idle: Story = {
 // ---------------------------------------------------------------------------
 // Connecting — WebSocket handshake in progress.
 // ---------------------------------------------------------------------------
-
-export const Connecting: Story = {
-	args: {
-		connectionOverride: {
-			status: "connecting",
-			hasConnected: false,
-			reconnect: fn(),
-			attach: fn(),
-			rfb: null,
-			remoteClipboardText: null,
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByTitle("Loading spinner")).toBeInTheDocument();
-	},
-};
 
 // ---------------------------------------------------------------------------
 // Connected — VNC canvas attached.

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessSignalTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProcessSignalTool.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
 import { Tool } from "./Tool";
 
 const PROCESS_ID = "376b2458-e318-4442-8b87-51a0f9727f0e";
@@ -125,15 +124,3 @@ export const ProtocolErrorStructured: Story = {
 // ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
-
-/** No args parsed yet (streamed tool call with partial data). */
-export const NoArgs: Story = {
-	args: {
-		status: "running",
-		args: undefined,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Sending signal…")).toBeInTheDocument();
-	},
-};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
@@ -171,27 +171,6 @@ export const FileIDLoading: Story = {
 	},
 };
 
-export const FileIDCompleted: Story = {
-	args: {
-		status: "completed",
-		args: { path: defaultPlanPath },
-		result: {
-			ok: true,
-			path: defaultPlanPath,
-			kind: "plan",
-			file_id: "test-file-id-success",
-			media_type: "text/markdown",
-		},
-	},
-	beforeEach: () => {
-		spyOn(API.experimental, "getChatFileText").mockResolvedValue(samplePlan);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(await canvas.findByText("Implementation Plan")).toBeInTheDocument();
-	},
-};
-
 export const FileIDFetchError: Story = {
 	args: {
 		status: "completed",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -417,21 +417,6 @@ export const ExecuteRewrittenByHook: Story = {
 	},
 };
 
-export const ExecuteNotRewrittenByHook: Story = {
-	args: {
-		name: "execute",
-		status: "completed",
-		args: { command: "echo original" },
-		parsedCommands: [["echo", "original"]],
-		result: { output: "original", exit_code: 0 },
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText(/Ran echo/)).toBeVisible();
-		expect(canvas.queryByText("Modified by policy")).not.toBeInTheDocument();
-	},
-};
-
 export const WriteFileRewrittenByHook: Story = {
 	args: {
 		name: "write_file",
@@ -472,22 +457,6 @@ export const NonCollapsibleRewrittenByHook: Story = {
 		result: {
 			template: { name: "go-template", display_name: "Go Development" },
 		},
-	},
-};
-
-export const NonCollapsibleNotRewrittenByHook: Story = {
-	args: {
-		name: "read_template",
-		status: "completed",
-		args: { template_id: "template-1" },
-		result: {
-			template: { name: "go-template", display_name: "Go Development" },
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Read template Go Development")).toBeVisible();
-		expect(canvas.queryByText("Modified by policy")).not.toBeInTheDocument();
 	},
 };
 
@@ -710,32 +679,6 @@ export const SubagentRunning: Story = {
 	},
 };
 
-export const SubagentMalformedChatIdLinksToRecoverableChatId: Story = {
-	args: {
-		name: "spawn_agent",
-		status: "completed",
-		args: {
-			title: "Workspace diagnostics",
-			prompt: "Collect logs and summarize why startup failed.",
-		},
-		result: {
-			chat_id: ["8f3a6131-1ce8-46f5-9", "b", "a8-4a36-beb2? no"].join(""),
-			title: "Workspace diagnostics",
-			status: "completed",
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("button", { name: /Spawned Workspace diagnostics/ }),
-		).toBeInTheDocument();
-		expect(canvas.getByRole("link", { name: "View agent" })).toHaveAttribute(
-			"href",
-			["/agents/8f3a6131-1ce8-46f5-9", "b", "a8-4a36-beb2"].join(""),
-		);
-	},
-};
-
 const mockChatModel = {
 	...MockChatModel,
 	id: "8b29eba2-53a9-4c9a-95bb-b0326ac0a2fe",
@@ -903,43 +846,6 @@ export const SubagentMessageLinkCard: Story = {
 			"href",
 			"/agents/child-chat-id",
 		);
-	},
-};
-
-export const SubagentCompletedDelegatedPending: Story = {
-	args: {
-		name: "spawn_agent",
-		args: undefined,
-		result: { chat_id: "child-chat-id", status: "pending" },
-		status: "completed",
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByRole("link", { name: "View agent" })).toHaveAttribute(
-			"href",
-			"/agents/child-chat-id",
-		);
-		expect(
-			canvas.getByRole("button", { name: /Spawned Sub-agent/ }),
-		).toBeInTheDocument();
-		expect(canvasElement.querySelector(".animate-spin")).toBeNull();
-	},
-};
-
-export const SubagentStreamOverrideStatus: Story = {
-	args: {
-		name: "spawn_agent",
-		args: undefined,
-		result: { chat_id: "child-chat-id", status: "pending" },
-		status: "completed",
-		subagentStatusOverrides: new Map([["child-chat-id", "completed"]]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("button", { name: /Spawned Sub-agent/ }),
-		).toBeInTheDocument();
-		expect(canvasElement.querySelector(".animate-spin")).toBeNull();
 	},
 };
 
@@ -1114,24 +1020,6 @@ export const MessageAgentExploreStreamingFromResult: Story = {
 			type: "explore",
 			status: "pending",
 		},
-	},
-};
-
-export const InterruptAgentRunningWithoutChatId: Story = {
-	args: {
-		name: "interrupt_agent",
-		status: "running",
-		args: {},
-		result: { status: "running" },
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await waitFor(() => {
-			expect(canvasElement.textContent?.trim()).toBe("");
-		});
-		expect(canvasElement.querySelector("[data-transcript-row]")).toBeNull();
-		expect(canvas.queryByRole("button")).toBeNull();
-		expect(canvas.queryByRole("link", { name: "View agent" })).toBeNull();
 	},
 };
 
@@ -2166,29 +2054,6 @@ export const ComputerError: Story = {
 	},
 };
 
-export const ComputerArrayResult: Story = {
-	args: {
-		name: "computer",
-		status: "completed",
-		result: [
-			{
-				type: "image",
-				data: DESKTOP_SCREENSHOT_BASE64,
-				mime_type: "image/jpeg",
-			},
-			{ type: "text", text: "Clicked on button" },
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const img = canvas.getByRole("img", {
-			name: "Screenshot from computer tool",
-		});
-		expect(img).toBeInTheDocument();
-		expect(img.getAttribute("src")).toContain("data:image/jpeg;base64,");
-	},
-};
-
 export const ComputerPromotedAttachmentArrayResult: Story = {
 	args: {
 		name: "computer",
@@ -2218,6 +2083,23 @@ export const ComputerPromotedAttachmentArrayResult: Story = {
 	},
 };
 
+// The array-form computer result without an attachment, rendered as an
+// image rather than text.
+export const ComputerArrayResult: Story = {
+	args: {
+		name: "computer",
+		status: "completed",
+		result: [
+			{
+				type: "image",
+				data: DESKTOP_SCREENSHOT_BASE64,
+				mime_type: "image/jpeg",
+			},
+			{ type: "text", text: "Clicked on button" },
+		],
+	},
+};
+
 export const AttachFileLabelFallsBackToPathBasename: Story = {
 	args: {
 		name: "attach_file",
@@ -2243,42 +2125,12 @@ export const GenericToolFailed: Story = {
 	},
 };
 
-export const GenericToolFailedNoResult: Story = {
-	args: {
-		name: "web_search",
-		status: "error",
-		isError: true,
-	},
-	play: async ({ canvasElement }) => {
-		expect(
-			canvasElement.querySelector(".lucide-triangle-alert"),
-		).not.toBeNull();
-	},
-};
-
 export const GenericToolStringError: Story = {
 	args: {
 		name: "web_search",
 		status: "error",
 		isError: true,
 		result: "Network unreachable",
-	},
-};
-
-export const GenericMCPToolStringError: Story = {
-	args: {
-		name: "linear__list_issues",
-		status: "error",
-		isError: true,
-		result: "Authentication token expired",
-		mcpServerConfigId: "mcp-server-1",
-		mcpServers: sampleMCPServers,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(
-			canvas.getByRole("img", { name: "List issues failed" }),
-		).toBeVisible();
 	},
 };
 
@@ -2375,26 +2227,7 @@ export const SubagentWaitTimedOut: Story = {
 	},
 };
 
-export const SubagentWaitTimedOutWithTitle: Story = {
-	args: {
-		name: "wait_agent",
-		status: "error",
-		isError: true,
-		args: { chat_id: "timed-out-child" },
-		result: {
-			chat_id: "timed-out-child",
-			error: "timed out waiting for delegated subagent completion",
-			title: "Fix login bug",
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvasElement.querySelector(".lucide-clock")).not.toBeNull();
-		expect(canvas.getByText(/Timed out waiting for/)).toBeInTheDocument();
-		expect(canvas.getByText("Fix login bug")).toBeInTheDocument();
-	},
-};
-
+// The title from the subagentTitles map instead of the fallback descriptor.
 export const SubagentWaitTimedOutTitleFromMap: Story = {
 	args: {
 		name: "wait_agent",
@@ -2403,11 +2236,6 @@ export const SubagentWaitTimedOutTitleFromMap: Story = {
 		args: { chat_id: "timed-out-child" },
 		result: "timed out waiting for delegated subagent completion",
 		subagentTitles: new Map([["timed-out-child", "Refactor auth module"]]),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Refactor auth module")).toBeInTheDocument();
-		expect(canvas.getByText(/Timed out waiting for/)).toBeInTheDocument();
 	},
 };
 
@@ -2455,26 +2283,6 @@ export const SubagentWaitError: Story = {
 			status: "error",
 			title: "Lint codebase",
 		},
-	},
-};
-
-export const MCPToolFailedUnifiedStyle: Story = {
-	args: {
-		name: "linear__list_issues",
-		status: "error",
-		isError: true,
-		args: { project: "backend" },
-		result: { error: "Authentication token expired" },
-		mcpServerConfigId: "mcp-server-1",
-		mcpServers: sampleMCPServers,
-	},
-	play: async ({ canvasElement }) => {
-		// Should show warning triangle icon.
-		expect(
-			canvasElement.querySelector(".lucide-triangle-alert"),
-		).not.toBeNull();
-		// Icon should NOT be red.
-		expect(canvasElement.querySelector(".text-content-destructive")).toBeNull();
 	},
 };
 
@@ -2759,21 +2567,6 @@ export const StartWorkspaceCompleted: Story = {
 	},
 };
 
-export const StartWorkspaceLegacy: Story = {
-	args: {
-		name: "start_workspace",
-		status: "completed",
-		result: {
-			started: true,
-			workspace_name: "legacy-workspace",
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Started legacy-workspace")).toBeInTheDocument();
-	},
-};
-
 export const StartWorkspaceError: Story = {
 	args: {
 		name: "start_workspace",
@@ -2923,21 +2716,6 @@ export const CreateWorkspaceQuotaReached: Story = {
 				data: [],
 			},
 		],
-	},
-};
-
-export const CreateWorkspaceLegacy: Story = {
-	args: {
-		name: "create_workspace",
-		status: "completed",
-		result: {
-			created: true,
-			workspace_name: "legacy-workspace",
-		},
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Created legacy-workspace")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolCall.stories.tsx
@@ -45,6 +45,8 @@ export const Failed: Story = {
 	),
 };
 
+// A running tool call stays active even when the backend reports an
+// error; the error icon only appears once the status leaves "running".
 export const RunningWithBackendError: Story = {
 	render: () => (
 		<ToolCall.Root
@@ -56,16 +58,6 @@ export const RunningWithBackendError: Story = {
 			<ToolCall.Header iconName="read_file" label="Reading README.md" />
 		</ToolCall.Root>
 	),
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText("Reading README.md")).toBeVisible();
-		expect(
-			canvas.getByRole("img", { name: "Tool call running" }),
-		).toBeVisible();
-		expect(
-			canvas.queryByRole("img", { name: "Failed to read file" }),
-		).not.toBeInTheDocument();
-	},
 };
 
 export const Collapsible: Story = {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WorkspaceBuildLogSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WorkspaceBuildLogSection.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, spyOn, waitFor, within } from "storybook/test";
+import { spyOn } from "storybook/test";
 import { API } from "#/api/api";
 import type { ProvisionerJobLog } from "#/api/typesGenerated";
 import { ChatWorkspaceContext } from "../../../context/ChatWorkspaceContext";
@@ -109,37 +109,5 @@ export const CompletedEmptyLogs: Story = {
 				data: [],
 			},
 		],
-	},
-};
-
-/**
- * Tool is running with an active build in progress. The workspace
- * query returns a latest_build with status="starting", so the
- * component derives an activeBuildId and shows the loading state
- * while waiting for the WebSocket stream.
- */
-export const Running: Story = {
-	args: {
-		status: "running",
-	},
-	parameters: {
-		queries: [
-			{
-				key: ["workspace", TEST_WORKSPACE_ID],
-				data: {
-					id: TEST_WORKSPACE_ID,
-					latest_build: {
-						id: TEST_BUILD_ID,
-						status: "starting",
-					},
-				},
-			},
-		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await waitFor(() => {
-			expect(canvas.getByText("Loading build logs\u2026")).toBeInTheDocument();
-		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -1411,38 +1411,6 @@ export const RenameChatGenerateLateResponseDoesNotClobberSameChatReopen: Story =
 		},
 	};
 
-export const ActiveFilterShowsActiveAgents: Story = {
-	args: {
-		chats: [
-			buildChat({
-				id: "active-1",
-				title: "Active agent one",
-				updated_at: recentTimestamp,
-			}),
-			buildChat({
-				id: "active-2",
-				title: "Active agent two",
-				updated_at: recentTimestamp,
-			}),
-		],
-		sidebarFilters: defaultSidebarFilters,
-	},
-	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/agents" },
-			routing: agentsRouting,
-		}),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await waitFor(() => {
-			expect(canvas.getByText("Active agent one")).toBeInTheDocument();
-			expect(canvas.getByText("Active agent two")).toBeInTheDocument();
-		});
-		expect(canvas.getByLabelText("Filter agents")).toBeInTheDocument();
-	},
-};
-
 export const ArchivedFilterShowsArchivedAgents: Story = {
 	args: {
 		chats: [
@@ -2382,40 +2350,6 @@ export const SettingsAPIKeysAdmin: Story = {
 	},
 };
 
-export const SettingsAPIKeysNonAdmin: Story = {
-	args: {
-		chats: [],
-		isAdmin: false,
-	},
-	parameters: {
-		queries: [
-			{
-				key: userChatProviderConfigsKey,
-				data: [
-					{
-						provider_id: "prov-1",
-						provider: "openai",
-						display_name: "OpenAI",
-						icon: "",
-						has_user_api_key: false,
-						has_central_api_key_fallback: false,
-						byok_enabled: true,
-					},
-				],
-			},
-		],
-		reactRouter: reactRouterParameters({
-			location: { path: "/agents/settings/api-keys" },
-			routing: settingsRouting,
-		}),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await expect(
-			canvas.getByRole("link", { name: "Secrets (API keys)" }),
-		).toBeInTheDocument();
-	},
-};
 export const SettingsUserAgentsNonAdmin: Story = {
 	args: {
 		chats: [],
@@ -2460,33 +2394,6 @@ export const SettingsUserAgentsFeatureDisabled: Story = {
 			location: { path: "/agents/settings/general" },
 			routing: settingsRouting,
 		}),
-	},
-};
-
-export const SettingsUserAgentsOverridesLoading: Story = {
-	args: {
-		chats: [],
-		isAdmin: false,
-		isPersonalModelOverridesEnabled: undefined,
-	},
-	parameters: {
-		queries: [
-			{
-				key: userChatProviderConfigsKey,
-				data: [],
-			},
-		],
-		reactRouter: reactRouterParameters({
-			location: { path: "/agents/settings/general" },
-			routing: settingsRouting,
-		}),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByRole("link", { name: "General" })).toBeInTheDocument();
-		expect(
-			canvas.queryByRole("link", { name: "Agents" }),
-		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/ChatSearchDialog.stories.tsx
@@ -363,26 +363,6 @@ export const ErrorState: Story = {
 	},
 };
 
-export const ClearingErrorReturnsToDefaultView: Story = {
-	beforeEach: () => {
-		spyOn(API.experimental, "getChats").mockRejectedValue(
-			new Error("Bad filter"),
-		);
-	},
-	play: async () => {
-		const body = within(document.body);
-		const searchInput = body.getByRole("combobox", { name: "Search chats" });
-
-		await userEvent.type(searchInput, "backend failure");
-		await expect(await body.findByRole("alert")).toBeInTheDocument();
-
-		await userEvent.clear(searchInput);
-
-		await expect(await body.findByText("Recent chats")).toBeInTheDocument();
-		await expect(body.queryByRole("alert")).not.toBeInTheDocument();
-	},
-};
-
 export const ErrorStateWithStackTrace: Story = {
 	beforeEach: () => {
 		const err = new Error(
@@ -425,16 +405,6 @@ export const ErrorStateWithStackTrace: Story = {
 // ---------------------------------------------------------------------------
 // Interaction states: default view, filter pills, dropdown.
 // ---------------------------------------------------------------------------
-
-export const DefaultViewWithRecentChats: Story = {
-	play: async () => {
-		const body = within(document.body);
-		await expect(await body.findByText("Recent chats")).toBeInTheDocument();
-		await expect(
-			body.getByText("Fix race condition in auth middleware"),
-		).toBeInTheDocument();
-	},
-};
 
 export const FilterDropdownOnFocus: Story = {
 	play: async () => {
@@ -780,29 +750,6 @@ export const CommittedFilterDoesNotLeakStaleText: Story = {
 			limit: CHAT_SEARCH_LIMIT,
 			q: 'pr_status:open search:"open"',
 		});
-	},
-};
-
-export const EmptySearchResultsShowNoAlert: Story = {
-	beforeEach: () => {
-		spyOn(API.experimental, "getChats").mockResolvedValue([]);
-	},
-	play: async () => {
-		const body = within(document.body);
-		const searchInput = body.getByRole("combobox", { name: "Search chats" });
-
-		await userEvent.type(searchInput, "or");
-
-		await waitFor(() => {
-			expect(API.experimental.getChats).toHaveBeenCalledWith({
-				limit: CHAT_SEARCH_LIMIT,
-				q: 'search:"or"',
-			});
-		});
-		await expect(
-			await body.findByText("No matching chats", { exact: false }),
-		).toBeInTheDocument();
-		await expect(body.queryByRole("alert")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.stories.tsx
@@ -78,12 +78,6 @@ export const EmptyState: Story = {
 	},
 };
 
-export const DesktopHidden: Story = {
-	args: {
-		tabs: [],
-	},
-};
-
 export const ExpandedWithTitle: Story = {
 	args: {
 		tabs: [gitTab],

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
@@ -1117,16 +1117,6 @@ export const ExportSingleRunDownloadError: Story = {
 	},
 };
 
-// These stories intentionally use the real saveAs default for manual
-// agent-browser dogfooding of browser downloads.
-export const ExportAllRunsDogfood: Story = {
-	parameters: ExportAllRuns.parameters,
-};
-
-export const ExportSingleRunDogfood: Story = {
-	parameters: ExportSingleRun.parameters,
-};
-
 export const MultiStepRunWithRetries: Story = {
 	parameters: {
 		queries: [

--- a/site/src/pages/AgentsPage/components/VideoLightbox.stories.tsx
+++ b/site/src/pages/AgentsPage/components/VideoLightbox.stories.tsx
@@ -36,20 +36,6 @@ export const Default: Story = {
 	},
 };
 
-export const AccessibleTitle: Story = {
-	args: {
-		src: TINY_MP4,
-		open: true,
-		onClose: fn(),
-	},
-	play: async ({ canvasElement }) => {
-		const screen = within(canvasElement.ownerDocument.body);
-		expect(
-			screen.getByRole("dialog", { name: "Recording playback" }),
-		).toBeInTheDocument();
-	},
-};
-
 export const VideoError: Story = {
 	args: {
 		src: TINY_MP4,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.test.tsx
@@ -59,6 +59,25 @@ describe("useFileAttachments org scoping", () => {
 		expect(uploadedFileIds(result.current)).toStrictEqual(["file-b"]);
 	});
 
+	it("keeps the persisted entry in storage after adopting it for its own org", async () => {
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([
+				persistEntry("file-permitted-org", "notes.txt", "org-b"),
+			]),
+		);
+		const { result } = renderAttachments({ orgId: "org-b" });
+
+		await waitFor(() => {
+			expect(uploadedFileIds(result.current)).toStrictEqual([
+				"file-permitted-org",
+			]);
+		});
+		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toContain(
+			"file-permitted-org",
+		);
+	});
+
 	it("drops another org's attachments when the org changes", async () => {
 		localStorage.setItem(
 			persistedAttachmentsStorageKey,


### PR DESCRIPTION
Each of these stories renders a visual state that a surviving story in the same file already captures for Pixel, or asserts behavior that an existing Vitest suite already covers. They add screenshot and test time without adding coverage.

70 deletion candidates were reviewed; 65 are deleted. The other five carry a visual state or security property with no surviving duplicate, so they are kept as play-less stories and Pixel owns them:

- `SubagentWaitTimedOutTitleFromMap` and `ComputerArrayResult` (`Tool.stories.tsx`): the subagentTitles map title and the array-form computer result rendered as an image.
- `RunningEmptyQuestions` (`AskUserQuestionTool.stories.tsx`): the live status region rendered instead of a form.
- `StreamingExternalImageConsentGate` (`Response.stories.tsx`): the Cure53 CDM-02-006 streaming consent gate; the placeholder must render instead of an `<img>` so no external request fires mid-stream. The static-mode gate is the surviving `ExternalImageConsentGate` story.
- `RunningWithBackendError` (`ToolCall.stories.tsx`): running-over-error icon precedence, inherently visual.

Every duplicate relationship and cited test was verified against the code before deletion; the pixel-excluded stories are untouched. Fixtures and imports that only the deleted stories used are removed with them.

Where a deleted story held the only coverage of a hook-level behavior, `useFileAttachments.test.tsx` gains a storage-retention test in this same PR, so the PR stays coverage-neutral on its own.

Stacked on #29017; base branch set to that PR. Merge order: #29017, then this one.

Generated by Coder Agents on behalf of @DanielleMaywood.