### PR TITLE
feat: add the chat goal HTTP API

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -2742,6 +2742,56 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/chats/{chat}/goal": {
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat goal",
+                "operationId": "update-chat-goal",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Chat goal update",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatGoalUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatGoalResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/api/v2/chats/{chat}/interrupt": {
             "post": {
                 "produces": [
@@ -20022,6 +20072,127 @@ const docTemplate = `{
                 },
                 "size_bytes": {
                     "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatGoal": {
+            "description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+            "type": "object",
+            "properties": {
+                "cleared_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "completed_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "completed_by_agent": {
+                    "type": "boolean"
+                },
+                "completed_by_user_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "completion_summary": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "created_by_user_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "created_from_message_id": {
+                    "description": "CreatedFromMessageID identifies the user message whose send set\nthis goal, when the goal was set alongside a message.",
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "objective": {
+                    "type": "string"
+                },
+                "root_chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "status": {
+                    "$ref": "#/definitions/codersdk.ChatGoalStatus"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatGoalResponse": {
+            "description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "$ref": "#/definitions/codersdk.ChatGoal"
+                }
+            }
+        },
+        "codersdk.ChatGoalStatus": {
+            "description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+            "type": "string",
+            "enum": [
+                "active",
+                "paused",
+                "complete",
+                "cleared"
+            ],
+            "x-enum-varnames": [
+                "ChatGoalStatusActive",
+                "ChatGoalStatusPaused",
+                "ChatGoalStatusComplete",
+                "ChatGoalStatusCleared"
+            ]
+        },
+        "codersdk.ChatGoalUpdateAction": {
+            "description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+            "type": "string",
+            "enum": [
+                "clear",
+                "pause",
+                "resume",
+                "complete"
+            ],
+            "x-enum-varnames": [
+                "ChatGoalUpdateActionClear",
+                "ChatGoalUpdateActionPause",
+                "ChatGoalUpdateActionResume",
+                "ChatGoalUpdateActionComplete"
+            ]
+        },
+        "codersdk.ChatGoalUpdateRequest": {
+            "description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+            "type": "object",
+            "properties": {
+                "action": {
+                    "enum": [
+                        "clear",
+                        "pause",
+                        "resume",
+                        "complete"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ChatGoalUpdateAction"
+                        }
+                    ]
+                },
+                "completion_summary": {
+                    "type": "string"
+                },
+                "goal_id": {
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -2413,6 +2413,50 @@
 				]
 			}
 		},
+		"/api/v2/chats/{chat}/goal": {
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat goal",
+				"operationId": "update-chat-goal",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Chat goal update",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatGoalUpdateRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatGoalResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/api/v2/chats/{chat}/interrupt": {
 			"post": {
 				"produces": ["application/json"],
@@ -18035,6 +18079,112 @@
 				},
 				"size_bytes": {
 					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatGoal": {
+			"description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+			"type": "object",
+			"properties": {
+				"cleared_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"completed_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"completed_by_agent": {
+					"type": "boolean"
+				},
+				"completed_by_user_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"completion_summary": {
+					"type": "string"
+				},
+				"created_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"created_by_user_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"created_from_message_id": {
+					"description": "CreatedFromMessageID identifies the user message whose send set\nthis goal, when the goal was set alongside a message.",
+					"type": "integer"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"objective": {
+					"type": "string"
+				},
+				"root_chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"status": {
+					"$ref": "#/definitions/codersdk.ChatGoalStatus"
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatGoalResponse": {
+			"description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+			"type": "object",
+			"properties": {
+				"goal": {
+					"$ref": "#/definitions/codersdk.ChatGoal"
+				}
+			}
+		},
+		"codersdk.ChatGoalStatus": {
+			"description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+			"type": "string",
+			"enum": ["active", "paused", "complete", "cleared"],
+			"x-enum-varnames": [
+				"ChatGoalStatusActive",
+				"ChatGoalStatusPaused",
+				"ChatGoalStatusComplete",
+				"ChatGoalStatusCleared"
+			]
+		},
+		"codersdk.ChatGoalUpdateAction": {
+			"description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+			"type": "string",
+			"enum": ["clear", "pause", "resume", "complete"],
+			"x-enum-varnames": [
+				"ChatGoalUpdateActionClear",
+				"ChatGoalUpdateActionPause",
+				"ChatGoalUpdateActionResume",
+				"ChatGoalUpdateActionComplete"
+			]
+		},
+		"codersdk.ChatGoalUpdateRequest": {
+			"description": "x-apidocgen:skip experiment-gated (chat-goals) schema.",
+			"type": "object",
+			"properties": {
+				"action": {
+					"enum": ["clear", "pause", "resume", "complete"],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ChatGoalUpdateAction"
+						}
+					]
+				},
+				"completion_summary": {
+					"type": "string"
+				},
+				"goal_id": {
+					"type": "string",
+					"format": "uuid"
 				}
 			}
 		},

--- a/coderd/chat_routes.go
+++ b/coderd/chat_routes.go
@@ -146,6 +146,12 @@ func (api *API) registerChatAPIRoutes(r chi.Router, apiKeyMiddleware func(http.H
 			})
 			r.Get("/", api.getChat)
 			r.Patch("/", api.patchChat)
+			r.Group(func(r chi.Router) {
+				// Goals use the exact experiment list everywhere (handlers,
+				// chatd, UI), so the route gate must not dev-bypass it.
+				r.Use(httpmw.RequireExperiment(api.Experiments, codersdk.ExperimentChatGoals))
+				r.Patch("/goal", api.patchChatGoal)
+			})
 			r.Get("/cost", api.getChatCost)
 			r.Get("/messages", api.getChatMessages)
 			r.Post("/messages", api.postChatMessages)

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -544,9 +544,16 @@ func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sdkChats := db2sdk.ChatRowsWithChildren(chatRows, childRows, diffStatusesByChatID)
-	api.enrichChatsWithMissingAgentIDs(ctx, sdkChats)
-	httpapi.Write(ctx, rw, http.StatusOK, sdkChats)
+	response := db2sdk.ChatRowsWithChildren(chatRows, childRows, diffStatusesByChatID)
+	api.enrichChatsWithMissingAgentIDs(ctx, response)
+	if err := api.hydrateChatGoals(ctx, response); err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to load chat goals.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
 // enrichChatsWithMissingAgentIDs skips existing bindings on list reads to avoid
@@ -654,6 +661,143 @@ func (api *API) getChatDiffStatusesByChatID(
 		statusesByChatID[status.ChatID] = status
 	}
 	return statusesByChatID, nil
+}
+
+func sdkChatRootID(chat codersdk.Chat) uuid.UUID {
+	if chat.RootChatID != nil {
+		return *chat.RootChatID
+	}
+	if chat.ParentChatID != nil {
+		return *chat.ParentChatID
+	}
+	return chat.ID
+}
+
+func (api *API) hydrateChatGoals(ctx context.Context, chats []codersdk.Chat) error {
+	if len(chats) == 0 {
+		return nil
+	}
+
+	if !api.chatGoalsEnabled() {
+		return nil
+	}
+
+	rootIDs := map[uuid.UUID]struct{}{}
+	var collectRootIDs func([]codersdk.Chat)
+	collectRootIDs = func(values []codersdk.Chat) {
+		for _, chat := range values {
+			rootIDs[sdkChatRootID(chat)] = struct{}{}
+			if len(chat.Children) > 0 {
+				collectRootIDs(chat.Children)
+			}
+		}
+	}
+	collectRootIDs(chats)
+	if len(rootIDs) == 0 {
+		return nil
+	}
+
+	ids := make([]uuid.UUID, 0, len(rootIDs))
+	for id := range rootIDs {
+		ids = append(ids, id)
+	}
+	goals, err := api.Database.GetCurrentChatGoalsByRootChatIDs(ctx, ids)
+	if err != nil {
+		return xerrors.Errorf("get current chat goals: %w", err)
+	}
+	goalsByRootID := make(map[uuid.UUID]*codersdk.ChatGoal, len(goals))
+	for _, goal := range goals {
+		sdkGoal := db2sdk.ChatGoal(goal)
+		goalsByRootID[goal.RootChatID] = &sdkGoal
+	}
+
+	var hydrate func([]codersdk.Chat)
+	hydrate = func(values []codersdk.Chat) {
+		for i := range values {
+			values[i].Goal = goalsByRootID[sdkChatRootID(values[i])]
+			if len(values[i].Children) > 0 {
+				hydrate(values[i].Children)
+			}
+		}
+	}
+	hydrate(chats)
+	return nil
+}
+
+func chatGoalResponse(goal *database.ChatGoal) codersdk.ChatGoalResponse {
+	if goal == nil {
+		return codersdk.ChatGoalResponse{}
+	}
+	sdkGoal := db2sdk.ChatGoal(*goal)
+	return codersdk.ChatGoalResponse{Goal: &sdkGoal}
+}
+
+func (api *API) chatGoalsEnabled() bool {
+	return api.Experiments.Enabled(codersdk.ExperimentChatGoals)
+}
+
+func writeChatGoalsDisabled(ctx context.Context, rw http.ResponseWriter) {
+	httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+		Message: "Chat goals are not enabled.",
+	})
+}
+
+func (api *API) requireChatGoalsEnabled(ctx context.Context, rw http.ResponseWriter) bool {
+	if !api.chatGoalsEnabled() {
+		writeChatGoalsDisabled(ctx, rw)
+		return false
+	}
+	return true
+}
+
+// errChatPlanModeActiveGoal aborts a plan-mode update transaction when
+// the current goal is still active.
+var errChatPlanModeActiveGoal = xerrors.New("cannot enable plan mode with an active chat goal")
+
+// messageGoalMutation widens a set-only request into the internal goal
+// mutation shape. The action is copied verbatim so chatd still rejects
+// a non-set action explicitly.
+func messageGoalMutation(req *codersdk.ChatGoalSetRequest) *codersdk.ChatGoalMutation {
+	if req == nil {
+		return nil
+	}
+	return &codersdk.ChatGoalMutation{
+		Action:    codersdk.ChatGoalMutationAction(req.Action),
+		Objective: req.Objective,
+	}
+}
+
+func writeChatGoalMutationError(ctx context.Context, rw http.ResponseWriter, err error) bool {
+	var mutationErr *chatd.ChatGoalMutationError
+	switch {
+	case errors.As(err, &mutationErr):
+		message := strings.TrimSpace(mutationErr.Error())
+		if !strings.HasSuffix(message, ".") {
+			message += "."
+		}
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: message})
+		return true
+	case errors.Is(err, chatd.ErrChatGoalNotRoot):
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Goal mutations are only supported on root chats."})
+		return true
+	case errors.Is(err, chatd.ErrChatGoalNotFound):
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{Message: "Current goal does not match the request."})
+		return true
+	case errors.Is(err, chatd.ErrChatGoalBusy):
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{Message: "Cannot set a goal while the chat is busy."})
+		return true
+	case errors.Is(err, chatd.ErrChatGoalResumeBusy):
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{Message: "Cannot resume a goal while the chat is busy."})
+		return true
+	case errors.Is(err, chatd.ErrChatGoalResumePlanMode):
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{Message: "Cannot resume a goal while plan mode is on."})
+		return true
+	case errors.Is(err, chatd.ErrChatGoalPlanMode):
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{Message: "Cannot set a goal while plan mode is on."})
+		return true
+	default:
+		return false
+	}
 }
 
 func planModeToNullChatPlanMode(mode codersdk.ChatPlanMode) database.NullChatPlanMode {
@@ -1214,6 +1358,10 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.GoalMutation != nil && !api.requireChatGoalsEnabled(ctx, rw) {
+		return
+	}
+
 	aReq, commitAudit := audit.InitRequest[database.Chat](rw, &audit.RequestParams{
 		Audit:          *api.Auditor.Load(),
 		Log:            api.Logger,
@@ -1390,6 +1538,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		InitialUserContent:      contentBlocks,
 		MCPServerIDs:            mcpServerIDs,
 		Labels:                  labels,
+		GoalMutation:            messageGoalMutation(req.GoalMutation),
 		DynamicTools:            dynamicToolsJSON,
 		// IMPORTANT: users can only create root chats at the time of writing.
 		ParentChatID: uuid.NullUUID{},
@@ -1406,6 +1555,9 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 				Message: "Invalid model config ID.",
 				Detail:  err.Error(),
 			})
+			return
+		}
+		if writeChatGoalMutationError(ctx, rw, err) {
 			return
 		}
 		if database.IsForeignKeyViolation(
@@ -1458,6 +1610,20 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 
 	chatFiles := api.fetchChatFileMetadata(ctx, chat.ID)
 	response := db2sdk.Chat(chat, nil, chatFiles)
+	if req.GoalMutation != nil {
+		createdResponse := []codersdk.Chat{response}
+		// The chat and goal already committed; a transient read failure
+		// must not turn the create into a 500 that invites a duplicate
+		// retry. Clients converge through the goal_change watch event.
+		if err := api.hydrateChatGoals(ctx, createdResponse); err != nil {
+			api.Logger.Warn(ctx, "failed to hydrate goal on created chat",
+				slog.F("chat_id", chat.ID),
+				slog.Error(err),
+			)
+		} else {
+			response = createdResponse[0]
+		}
+	}
 	httpapi.Write(ctx, rw, http.StatusCreated, response)
 }
 
@@ -1562,7 +1728,87 @@ func (api *API) getChat(rw http.ResponseWriter, r *http.Request) {
 	api.repairChatAgentIDs(ctx, enriched)
 	sdkChat = enriched[0]
 
-	httpapi.Write(ctx, rw, http.StatusOK, sdkChat)
+	if err := api.hydrateChatGoals(ctx, enriched); err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to load chat goals.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, enriched[0])
+}
+
+// @Summary Update chat goal
+// @ID update-chat-goal
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param chat path string true "Chat ID" format(uuid)
+// @Param request body codersdk.ChatGoalUpdateRequest true "Chat goal update"
+// @Success 200 {object} codersdk.ChatGoalResponse
+// @Router /api/v2/chats/{chat}/goal [patch]
+// @x-apidocgen {"skip": true}
+func (api *API) patchChatGoal(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+	chat := httpmw.ChatParam(r)
+
+	if !api.Authorize(r, policy.ActionUpdate, chat.RBACObject()) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+
+	// Only the chat owner may mutate goals. Shared readers with the
+	// owner role pass the RBAC check above, but the goal controls the
+	// chat owner's future agent behavior.
+	if apiKey.UserID != chat.OwnerID {
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			Message: "Only the chat owner may update goals.",
+		})
+		return
+	}
+
+	if !api.requireChatGoalsEnabled(ctx, rw) {
+		return
+	}
+
+	if !api.requireChatDaemon(ctx, rw) {
+		return
+	}
+
+	var req codersdk.ChatGoalUpdateRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	result, err := api.chatDaemon.ApplyGoalMutation(ctx, chatd.ApplyGoalMutationOptions{
+		ChatID:    chat.ID,
+		CreatedBy: apiKey.UserID,
+		Mutation:  req,
+	})
+	if err != nil {
+		if writeChatGoalMutationError(ctx, rw, err) {
+			return
+		}
+		if errors.Is(err, chatd.ErrChatArchived) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Cannot mutate a goal on an archived chat."})
+			return
+		}
+		// Resume starts a turn, so it can fail model resolution like a
+		// message send when no usable model remains.
+		if errors.Is(err, chatd.ErrNoDefaultChatModelConfig) {
+			writeNoLocalChatModelResponse(ctx, rw)
+			return
+		}
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to update chat goal.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, chatGoalResponse(result.Goal))
 }
 
 // @Summary List chat messages
@@ -1660,8 +1906,20 @@ func (api *API) getChatMessages(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var sentAsGoalIDs map[int64]struct{}
+	if len(messages) > 0 && api.chatGoalsEnabled() {
+		sentAsGoalIDs, err = chatGoalMessageIDs(ctx, api.Database, chatID, messages)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to get chat goal message markers.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+	}
+
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatMessagesResponse{
-		Messages:       convertChatMessages(messages),
+		Messages:       db2sdk.ChatMessagesWithSentAsGoalIDs(messages, sentAsGoalIDs),
 		QueuedMessages: convertChatQueuedMessages(queuedMessages),
 		HasMore:        hasMore,
 	})
@@ -2114,26 +2372,28 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 	logger.Debug(ctx, "desktop Bicopy finished")
 }
 
+// validateChatTitle normalizes a requested chat title, returning the
+// rejection response when it is empty or too long.
+func validateChatTitle(rawTitle string) (string, *codersdk.Response) {
+	trimmedTitle := strings.TrimSpace(rawTitle)
+	if trimmedTitle == "" {
+		return "", &codersdk.Response{Message: "Title cannot be empty."}
+	}
+	const maxChatTitleRunes = 200
+	if utf8.RuneCountInString(trimmedTitle) > maxChatTitleRunes {
+		return "", &codersdk.Response{Message: fmt.Sprintf("Title must be at most %d characters.", maxChatTitleRunes)}
+	}
+	return trimmedTitle, nil
+}
+
+// applyChatTitleUpdate persists a title already validated by
+// validateChatTitle.
 func (api *API) applyChatTitleUpdate(
 	ctx context.Context,
 	rw http.ResponseWriter,
 	chat database.Chat,
-	rawTitle string,
+	trimmedTitle string,
 ) (database.Chat, bool) {
-	trimmedTitle := strings.TrimSpace(rawTitle)
-	if trimmedTitle == "" {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Title cannot be empty.",
-		})
-		return chat, true
-	}
-	const maxChatTitleRunes = 200
-	if utf8.RuneCountInString(trimmedTitle) > maxChatTitleRunes {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf("Title must be at most %d characters.", maxChatTitleRunes),
-		})
-		return chat, true
-	}
 	if trimmedTitle == chat.Title {
 		return chat, false
 	}
@@ -2263,13 +2523,19 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 		planModeUpdate = &resolvedPlanMode
 	}
 
+	// Validate every requested field before applying any of them so a
+	// later-invalid field cannot fail the request after an earlier
+	// field already committed.
+	var trimmedTitle string
 	if req.Title != nil {
-		updatedChat, handled := api.applyChatTitleUpdate(ctx, rw, chat, *req.Title)
-		if handled {
+		title, errResp := validateChatTitle(*req.Title)
+		if errResp != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, *errResp)
 			return
 		}
-		chat = updatedChat
+		trimmedTitle = title
 	}
+	var labelsJSON []byte
 	if req.Labels != nil {
 		if errs := httpapi.ValidateChatLabels(*req.Labels); len(errs) > 0 {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -2278,7 +2544,7 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		labelsJSON, err := json.Marshal(*req.Labels)
+		marshaled, err := json.Marshal(*req.Labels)
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to marshal labels.",
@@ -2286,6 +2552,130 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		labelsJSON = marshaled
+	}
+	if req.Archived != nil {
+		// Archive invariant is one-way: parent archived implies
+		// child archived. Archive state changes target the root
+		// chat and cascade atomically across the family; child
+		// chats cannot be archived or unarchived independently.
+		// This check precedes the no-op check so any child attempt
+		// surfaces the root-only error regardless of the chat's
+		// current archived value.
+		if chat.ParentChatID.Valid {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Chat archive state can only be changed on the root chat.",
+			})
+			return
+		}
+		if *req.Archived == chat.Archived {
+			state := "archived"
+			if !*req.Archived {
+				state = "not archived"
+			}
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: fmt.Sprintf("Chat is already %s.", state),
+			})
+			return
+		}
+	}
+	if req.PinOrder != nil {
+		switch {
+		case *req.PinOrder < 0:
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Pin order must be non-negative.",
+			})
+			return
+		case *req.PinOrder > 0 && chat.Archived:
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Cannot pin an archived chat.",
+			})
+			return
+		case *req.PinOrder > 0 && chat.ParentChatID.Valid:
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Cannot pin a child chat.",
+			})
+			return
+		}
+	}
+	workspaceBinding := uuid.NullUUID{}
+	if req.WorkspaceID != nil && *req.WorkspaceID != uuid.Nil {
+		workspaceID, workspace, status, resp := api.validateChatWorkspaceSelection(ctx, r, req.WorkspaceID)
+		if resp != nil {
+			httpapi.Write(ctx, rw, status, *resp)
+			return
+		}
+		if workspace.OrganizationID != chat.OrganizationID {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Workspace does not belong to this chat's organization.",
+			})
+			return
+		}
+		workspaceBinding = workspaceID
+	}
+
+	// All requested fields are validated above; plan mode applies first
+	// among the writes so its transactional goal-conflict rejection
+	// cannot follow another field's commit.
+	if planModeUpdate != nil {
+		var updatedChat database.Chat
+		err := api.Database.InTx(func(tx database.Store) error {
+			// Plan-mode turns exclude goal completion behavior, so
+			// enabling plan mode would strand an active goal: it could
+			// neither complete nor pause itself, and Resume rejects
+			// plan-mode chats. Goal transitions commit under the chat
+			// row lock, so checking after locking the same row closes
+			// the window where a goal-bound send or resume commits
+			// between the check and the plan-mode write.
+			if api.chatGoalsEnabled() && !chat.ParentChatID.Valid &&
+				planModeUpdate.Valid && planModeUpdate.ChatPlanMode == database.ChatPlanModePlan {
+				if _, err := tx.GetChatByIDForUpdate(ctx, chat.ID); err != nil {
+					return xerrors.Errorf("lock chat for plan mode update: %w", err)
+				}
+				goals, err := tx.GetCurrentChatGoalsByRootChatIDs(ctx, []uuid.UUID{chat.ID})
+				if err != nil {
+					return xerrors.Errorf("load the current chat goal: %w", err)
+				}
+				if len(goals) > 0 && goals[0].Status == database.ChatGoalStatusActive {
+					return errChatPlanModeActiveGoal
+				}
+			}
+			var err error
+			updatedChat, err = tx.UpdateChatPlanModeByID(ctx, database.UpdateChatPlanModeByIDParams{
+				PlanMode: *planModeUpdate,
+				ID:       chat.ID,
+			})
+			return err
+		}, nil)
+		if err != nil {
+			if errors.Is(err, errChatPlanModeActiveGoal) {
+				httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+					Message: "Cannot enable plan mode while the chat goal is active.",
+					Detail:  "Pause, complete, or clear the goal first.",
+				})
+				return
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				httpapi.ResourceNotFound(rw)
+				return
+			}
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to update chat plan mode.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		chat = updatedChat
+	}
+
+	if req.Title != nil {
+		updatedChat, handled := api.applyChatTitleUpdate(ctx, rw, chat, trimmedTitle)
+		if handled {
+			return
+		}
+		chat = updatedChat
+	}
+	if req.Labels != nil {
 		updatedChat, err := api.Database.UpdateChatLabelsByID(ctx, database.UpdateChatLabelsByIDParams{
 			ID:     chat.ID,
 			Labels: labelsJSON,
@@ -2306,32 +2696,6 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 
 	if req.Archived != nil {
 		archived := *req.Archived
-
-		// Archive invariant is one-way: parent archived implies
-		// child archived. Archive state changes target the root
-		// chat and cascade atomically across the family; child
-		// chats cannot be archived or unarchived independently.
-		// This check precedes the no-op check so any child attempt
-		// surfaces the root-only error regardless of the chat's
-		// current archived value.
-		if chat.ParentChatID.Valid {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Chat archive state can only be changed on the root chat.",
-			})
-			return
-		}
-
-		if archived == chat.Archived {
-			state := "archived"
-			if !archived {
-				state = "not archived"
-			}
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: fmt.Sprintf("Chat is already %s.", state),
-			})
-			return
-		}
-
 		var err error
 		if archived {
 			err = api.chatDaemon.ArchiveChat(ctx, chat)
@@ -2373,27 +2737,6 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 
 	if req.PinOrder != nil {
 		pinOrder := *req.PinOrder
-		if pinOrder < 0 {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Pin order must be non-negative.",
-			})
-			return
-		}
-
-		if pinOrder > 0 && chat.Archived {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Cannot pin an archived chat.",
-			})
-			return
-		}
-
-		if pinOrder > 0 && chat.ParentChatID.Valid {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Cannot pin a child chat.",
-			})
-			return
-		}
-
 		// The behavior depends on current pin state:
 		// - pinOrder == 0: unpin.
 		// - pinOrder > 0 && already pinned: reorder (shift
@@ -2438,27 +2781,9 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.WorkspaceID != nil {
-		workspaceID := uuid.NullUUID{}
-		workspace := database.Workspace{}
-		if *req.WorkspaceID != uuid.Nil {
-			var status int
-			var resp *codersdk.Response
-			workspaceID, workspace, status, resp = api.validateChatWorkspaceSelection(ctx, r, req.WorkspaceID)
-			if resp != nil {
-				httpapi.Write(ctx, rw, status, *resp)
-				return
-			}
-			if workspace.OrganizationID != chat.OrganizationID {
-				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: "Workspace does not belong to this chat's organization.",
-				})
-				return
-			}
-		}
-
 		updatedChat, err := api.Database.UpdateChatWorkspaceBinding(ctx, database.UpdateChatWorkspaceBindingParams{
 			ID:          chat.ID,
-			WorkspaceID: workspaceID,
+			WorkspaceID: workspaceBinding,
 			BuildID:     uuid.NullUUID{},
 			AgentID:     uuid.NullUUID{},
 		})
@@ -2469,25 +2794,6 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 			}
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to update chat workspace binding.",
-				Detail:  err.Error(),
-			})
-			return
-		}
-		chat = updatedChat
-	}
-
-	if planModeUpdate != nil {
-		updatedChat, err := api.Database.UpdateChatPlanModeByID(ctx, database.UpdateChatPlanModeByIDParams{
-			PlanMode: *planModeUpdate,
-			ID:       chat.ID,
-		})
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				httpapi.ResourceNotFound(rw)
-				return
-			}
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Failed to update chat plan mode.",
 				Detail:  err.Error(),
 			})
 			return
@@ -2602,6 +2908,10 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.GoalMutation != nil && !api.requireChatGoalsEnabled(ctx, rw) {
+		return
+	}
+
 	contentBlocks, _, inputError := createChatInputFromParts(ctx, api.Database, req.Content, "content")
 	if inputError != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -2672,6 +2982,7 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 			ReasoningEffort: reasoningEffort,
 			BusyBehavior:    busyBehavior,
 			PlanMode:        sendPlanMode,
+			GoalMutation:    messageGoalMutation(req.GoalMutation),
 			MCPServerIDs:    req.MCPServerIDs,
 		},
 	)
@@ -2680,6 +2991,9 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if writeChatFileError(ctx, rw, sendErr) {
+			return
+		}
+		if writeChatGoalMutationError(ctx, rw, sendErr) {
 			return
 		}
 		if xerrors.Is(sendErr, chatd.ErrChatArchived) {
@@ -2737,8 +3051,15 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 			response.QueuedMessage = convertChatQueuedMessagePtr(*sendResult.QueuedMessage)
 		}
 	} else {
-		message := convertChatMessage(sendResult.Message)
+		message := db2sdk.ChatMessageWithSentAsGoal(
+			sendResult.Message,
+			chatMessageSentAsGoal(sendResult.Message, sendResult.Goal),
+		)
 		response.Message = &message
+	}
+	if sendResult.Goal != nil {
+		sdkGoal := db2sdk.ChatGoal(*sendResult.Goal)
+		response.Goal = &sdkGoal
 	}
 	// Return the full user-visible inserted batch. A queued send on an errored
 	// chat can promote the previous queue head, which clients must cache.
@@ -2746,7 +3067,12 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 		if inserted.Visibility == database.ChatMessageVisibilityModel {
 			continue
 		}
-		response.Messages = append(response.Messages, convertChatMessage(inserted))
+		// Clients prefer the batch over response.Message, so the goal
+		// source must carry its marker here too.
+		response.Messages = append(response.Messages, db2sdk.ChatMessageWithSentAsGoal(
+			inserted,
+			chatMessageSentAsGoal(inserted, sendResult.Goal),
+		))
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, response)
@@ -2864,6 +3190,11 @@ func (api *API) patchChatMessage(rw http.ResponseWriter, r *http.Request) {
 			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
 				Message: "Chat message not found.",
 				Detail:  "Message does not belong to this chat.",
+			})
+		case xerrors.Is(editErr, chatd.ErrChatGoalSourceMessageEdit):
+			httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+				Message: "Cannot edit a message that would discard the current goal's source message.",
+				Detail:  "Clear or complete the goal first.",
 			})
 		case xerrors.Is(editErr, chatd.ErrEditedMessageNotUser):
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -6671,16 +7002,34 @@ func convertChatQueuedMessages(msgs []database.ChatQueuedMessage) []codersdk.Cha
 	return result
 }
 
-func convertChatMessage(m database.ChatMessage) codersdk.ChatMessage {
-	return db2sdk.ChatMessage(m)
+func chatMessageSentAsGoal(message database.ChatMessage, goal *database.ChatGoal) bool {
+	return goal != nil && goal.CreatedFromMessageID.Valid && goal.CreatedFromMessageID.Int64 == message.ID
 }
 
-func convertChatMessages(messages []database.ChatMessage) []codersdk.ChatMessage {
-	result := make([]codersdk.ChatMessage, 0, len(messages))
-	for _, m := range messages {
-		result = append(result, convertChatMessage(m))
+func chatGoalMessageIDs(ctx context.Context, store database.Store, chatID uuid.UUID, messages []database.ChatMessage) (map[int64]struct{}, error) {
+	messageIDs := make([]int64, 0, len(messages))
+	for _, message := range messages {
+		messageIDs = append(messageIDs, message.ID)
 	}
-	return result
+	if len(messageIDs) == 0 {
+		return map[int64]struct{}{}, nil
+	}
+	ids, err := store.GetChatGoalMessageIDsByRootChatAndMessageIDs(ctx, database.GetChatGoalMessageIDsByRootChatAndMessageIDsParams{
+		RootChatID: chatID,
+		MessageIds: messageIDs,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("get chat goal message ids: %w", err)
+	}
+	set := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
+func convertChatMessage(m database.ChatMessage) codersdk.ChatMessage {
+	return db2sdk.ChatMessage(m)
 }
 
 func parseUserAIProviderID(r *http.Request) (uuid.UUID, error) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -82,6 +82,7 @@ func newChatTestOptions(
 			string(codersdk.ExperimentChatAdvisor),
 			string(codersdk.ExperimentChatVirtualDesktop),
 			string(codersdk.ExperimentAgentLifecycleHooks),
+			string(codersdk.ExperimentChatGoals),
 		}
 	}
 
@@ -712,6 +713,447 @@ func insertAssistantMessage(
 		Role:          database.ChatMessageRoleAssistant,
 		Content:       assistantContent,
 	})
+}
+
+func TestChatGoalsRequireExperiment(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	// Deploy without the chat-goals experiment.
+	values := coderdtest.DeploymentValues(t)
+	values.Experiments = serpent.StringArray{
+		string(codersdk.ExperimentChatAdvisor),
+	}
+	client := newChatClientWithDeploymentValues(t, values)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	_ = createChatModel(t, client)
+
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start without a goal",
+		}},
+	})
+	require.NoError(t, err)
+	require.Nil(t, chat.Goal)
+
+	goalID := uuid.New()
+	_, err = client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionPause,
+		GoalID: &goalID,
+	})
+	sdkErr := requireSDKError(t, err, http.StatusForbidden)
+	// The route gate is a strict RequireExperiment with no dev bypass,
+	// matching the handler, chatd, and UI enablement checks.
+	require.Contains(t, sdkErr.Message, "requires enabling the 'chat-goals' experiment")
+
+	_, err = client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start with a disabled goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "disabled objective",
+		},
+	})
+	sdkErr = requireSDKError(t, err, http.StatusForbidden)
+	require.Contains(t, sdkErr.Message, "Chat goals are not enabled")
+
+	// A deployment with the experiment accepts goal mutations.
+	enabledClient, _ := newChatClientWithDatabase(t)
+	enabledUser := coderdtest.CreateFirstUser(t, enabledClient.Client)
+	_ = createChatModel(t, enabledClient)
+	enabledChat, err := enabledClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: enabledUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start with an enabled goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "enabled objective",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, enabledChat.Goal)
+}
+
+// failingGoalReadStore fails current-goal reads on demand so tests can
+// exercise post-commit goal hydration failures.
+type failingGoalReadStore struct {
+	database.Store
+	failGoalReads atomic.Bool
+}
+
+func (s *failingGoalReadStore) GetCurrentChatGoalsByRootChatIDs(ctx context.Context, ids []uuid.UUID) ([]database.ChatGoal, error) {
+	if s.failGoalReads.Load() {
+		return nil, xerrors.New("transient goal read failure")
+	}
+	return s.Store.GetCurrentChatGoalsByRootChatIDs(ctx, ids)
+}
+
+// A goal-bound create commits the chat, message, and goal before the
+// response hydrates the goal; a transient hydration failure must not
+// become a 500 that invites a duplicate-create retry.
+func TestCreateChatGoalHydrationFailureNonfatal(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	rawDB, pubsub := dbtestutil.NewDB(t)
+	store := &failingGoalReadStore{Store: rawDB}
+	client := newChatClient(t, func(opts *coderdtest.Options) {
+		opts.Database = store
+		opts.Pubsub = pubsub
+	})
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	_ = createChatModel(t, client)
+
+	store.failGoalReads.Store(true)
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start with a goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "survive hydration failure",
+		},
+	})
+	require.NoError(t, err, "the create must succeed despite the goal read failure")
+	require.Nil(t, chat.Goal, "the response omits the goal it could not read")
+
+	store.failGoalReads.Store(false)
+	gotChat, err := client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotChat.Goal, "the goal committed despite the response omission")
+	require.Equal(t, codersdk.ChatGoalStatusActive, gotChat.Goal.Status)
+}
+
+// Enabling plan mode would strand an active goal: plan-mode turns
+// exclude goal completion behavior and Resume rejects plan-mode chats,
+// so the settings update is refused until the goal is paused, cleared,
+// or completed.
+func TestPatchChatPlanModeActiveGoalRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := newChatClient(t)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	_ = createChatModel(t, client)
+
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start with a goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "active objective",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, chat.Goal)
+
+	planMode := codersdk.ChatPlanModePlan
+	newTitle := "renamed alongside plan mode"
+	err = client.UpdateChat(ctx, chat.ID, codersdk.UpdateChatRequest{Title: &newTitle, PlanMode: &planMode})
+	sdkErr := requireSDKError(t, err, http.StatusConflict)
+	require.Contains(t, sdkErr.Message, "plan mode")
+	gotChat, err := client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotEqual(t, newTitle, gotChat.Title,
+		"a rejected plan-mode PATCH must not commit other requested fields")
+
+	_, err = client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionPause,
+		GoalID: &chat.Goal.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t,
+		client.UpdateChat(ctx, chat.ID, codersdk.UpdateChatRequest{PlanMode: &planMode}),
+		"a paused goal does not block plan mode")
+}
+
+func TestPatchChatValidatesAllFieldsBeforeApplying(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client := newChatClient(t)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	_ = createChatModel(t, client)
+
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "plain chat",
+		}},
+	})
+	require.NoError(t, err)
+
+	planMode := codersdk.ChatPlanModePlan
+	invalidLabels := map[string]string{"": "invalid"}
+	err = client.UpdateChat(ctx, chat.ID, codersdk.UpdateChatRequest{
+		PlanMode: &planMode,
+		Labels:   &invalidLabels,
+	})
+	sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+	require.Contains(t, sdkErr.Message, "Invalid labels")
+
+	gotChat, err := client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotEqual(t, codersdk.ChatPlanModePlan, gotChat.PlanMode,
+		"a rejected PATCH must not commit plan mode before later-field validation")
+}
+
+func TestChatGoalAPI(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client, db := newChatClientWithDatabase(t)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	_ = createChatModel(t, client)
+
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start with a goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "  ship the API  ",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, chat.Goal)
+	require.Equal(t, "ship the API", chat.Goal.Objective)
+	require.Equal(t, codersdk.ChatGoalStatusActive, chat.Goal.Status)
+
+	sentAsGoalMessages := func(t *testing.T) []codersdk.ChatMessage {
+		t.Helper()
+
+		messages, err := client.GetChatMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+		var out []codersdk.ChatMessage
+		for _, message := range messages.Messages {
+			if message.SentAsGoal {
+				out = append(out, message)
+			}
+		}
+		return out
+	}
+
+	sentAsGoal := sentAsGoalMessages(t)
+	require.Len(t, sentAsGoal, 1)
+	require.Equal(t, codersdk.ChatMessageRoleUser, sentAsGoal[0].Role)
+
+	gotChat, err := client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotChat.Goal)
+	require.Equal(t, chat.Goal.ID, gotChat.Goal.ID)
+
+	paused, err := client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionPause,
+		GoalID: &chat.Goal.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, paused.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusPaused, paused.Goal.Status)
+	gotChat, err = client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotChat.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusPaused, gotChat.Goal.Status)
+
+	// Resume while the chat is busy is rejected: resume starts a turn
+	// and only proceeds from idle states.
+	_, err = client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionResume,
+		GoalID: &chat.Goal.ID,
+	})
+	sdkErr := requireSDKError(t, err, http.StatusConflict)
+	require.Contains(t, sdkErr.Message, "Cannot resume a goal while the chat is busy")
+
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	resumed, err := client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionResume,
+		GoalID: &chat.Goal.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resumed.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusActive, resumed.Goal.Status)
+
+	// Resume kicks off a turn on the idle chat.
+	gotChat, err = client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, codersdk.ChatStatusRunning, gotChat.Status)
+
+	completed, err := client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionComplete,
+		GoalID: &chat.Goal.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, completed.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusComplete, completed.Goal.Status)
+	require.NotNil(t, completed.Goal.CompletionSummary)
+	require.Equal(t, "Marked complete by user.", *completed.Goal.CompletionSummary)
+
+	gotChat, err = client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotChat.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusComplete, gotChat.Goal.Status)
+
+	cleared, err := client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionClear,
+		GoalID: &chat.Goal.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cleared.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusCleared, cleared.Goal.Status)
+
+	gotChat, err = client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Nil(t, gotChat.Goal)
+
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	messageResponse, err := client.CreateChatMessage(ctx, chat.ID, codersdk.CreateChatMessageRequest{
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "send a new goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "ship the message response marker",
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, messageResponse.Queued)
+	require.NotNil(t, messageResponse.Message)
+	require.True(t, messageResponse.Message.SentAsGoal)
+	require.NotNil(t, messageResponse.Goal)
+	batchIdx := slices.IndexFunc(messageResponse.Messages, func(m codersdk.ChatMessage) bool {
+		return m.ID == messageResponse.Message.ID
+	})
+	require.NotEqual(t, -1, batchIdx, "the inserted batch must include the sent message")
+	require.True(t, messageResponse.Messages[batchIdx].SentAsGoal,
+		"clients prefer the batch over response.message, so it must carry the goal marker")
+
+	sentAsGoal = sentAsGoalMessages(t)
+	require.Len(t, sentAsGoal, 2)
+
+	// A stale goal ID must not clear a historical completed goal after
+	// a newer goal became current.
+	staleGoal := messageResponse.Goal
+	_, err = client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionComplete,
+		GoalID: &staleGoal.ID,
+	})
+	require.NoError(t, err)
+
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+	newerResponse, err := client.CreateChatMessage(ctx, chat.ID, codersdk.CreateChatMessageRequest{
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "send a replacement goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "ship the replacement goal",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, newerResponse.Goal)
+
+	_, err = client.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionClear,
+		GoalID: &staleGoal.ID,
+	})
+	requireSDKError(t, err, http.StatusConflict)
+
+	gotChat, err = client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotChat.Goal)
+	require.Equal(t, newerResponse.Goal.ID, gotChat.Goal.ID)
+}
+
+func TestPatchChatGoalRequiresOwnerForSharedSiteOwner(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ownerClient, db := newChatClientWithDatabase(t)
+	firstUser := coderdtest.CreateFirstUser(t, ownerClient.Client)
+	_ = createChatModel(t, ownerClient)
+
+	sharedOwnerRaw, sharedOwner := coderdtest.CreateAnotherUser(
+		t,
+		ownerClient.Client,
+		firstUser.OrganizationID,
+		rbac.RoleOwner(),
+	)
+	sharedOwnerClient := codersdk.NewExperimentalClient(sharedOwnerRaw)
+
+	chat, err := ownerClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: firstUser.OrganizationID,
+		Content: []codersdk.ChatInputPart{{
+			Type: codersdk.ChatInputPartTypeText,
+			Text: "start with an owner goal",
+		}},
+		GoalMutation: &codersdk.ChatGoalSetRequest{
+			Action:    codersdk.ChatGoalSetActionSet,
+			Objective: "protect goal updates",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, chat.Goal)
+
+	err = db.UpdateChatACLByID(dbauthz.As(ctx, rbac.Subject{
+		ID:    firstUser.UserID.String(),
+		Roles: rbac.RoleIdentifiers{rbac.RoleOwner()},
+		Scope: rbac.ScopeAll,
+	}), database.UpdateChatACLByIDParams{
+		ID: chat.ID,
+		UserACL: database.ChatACL{
+			sharedOwner.ID.String(): database.ChatACLEntry{Permissions: []policy.Action{policy.ActionRead}},
+		},
+		GroupACL: database.ChatACL{},
+	})
+	require.NoError(t, err)
+
+	sharedChat, err := sharedOwnerClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, sharedChat.Goal)
+	require.Equal(t, chat.Goal.ID, sharedChat.Goal.ID)
+
+	_, err = sharedOwnerClient.UpdateChatGoal(ctx, chat.ID, codersdk.ChatGoalUpdateRequest{
+		Action: codersdk.ChatGoalUpdateActionPause,
+		GoalID: &chat.Goal.ID,
+	})
+	sdkErr := requireSDKError(t, err, http.StatusForbidden)
+	require.Contains(t, sdkErr.Message, "Only the chat owner")
+
+	ownerChat, err := ownerClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, ownerChat.Goal)
+	require.Equal(t, codersdk.ChatGoalStatusActive, ownerChat.Goal.Status)
 }
 
 func TestPostChats(t *testing.T) {

--- a/coderd/x/chatd/stream_loop.go
+++ b/coderd/x/chatd/stream_loop.go
@@ -20,7 +20,11 @@ type streamLoop struct {
 	chatID uuid.UUID
 	db     database.Store
 	logger slog.Logger
-	state  streamLocalState
+	// goalMarkers enables sent-as-goal enrichment of streamed messages.
+	// It is set only for root chats with the chat-goals experiment on,
+	// matching the REST message list path.
+	goalMarkers bool
+	state       streamLocalState
 }
 
 type streamLocalState struct {
@@ -65,14 +69,17 @@ type streamDBSnapshot struct {
 	queueChanged bool
 	queue        []database.ChatQueuedMessage
 
+	goalMessageIDs map[int64]struct{}
+
 	actionRequired *codersdk.ChatStreamActionRequired
 }
 
-func newStreamLoop(chat database.Chat, db database.Store, logger slog.Logger, afterMessageID int64) *streamLoop {
+func newStreamLoop(chat database.Chat, db database.Store, logger slog.Logger, afterMessageID int64, goalMarkers bool) *streamLoop {
 	return &streamLoop{
-		chatID: chat.ID,
-		db:     db,
-		logger: logger,
+		chatID:      chat.ID,
+		db:          db,
+		logger:      logger,
+		goalMarkers: goalMarkers,
 		state: streamLocalState{
 			knownMessages:  make(map[int64]int64),
 			afterMessageID: afterMessageID,
@@ -170,6 +177,12 @@ func (l *streamLoop) loadDBSnapshot(ctx context.Context) (streamDBSnapshot, erro
 				})
 				if err != nil {
 					return xerrors.Errorf("get full chat history: %w", err)
+				}
+			}
+			if l.goalMarkers {
+				snapshot.goalMessageIDs, err = l.loadGoalMessageIDs(ctx, tx, snapshot)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -311,7 +324,7 @@ func (l *streamLoop) messageEvents(snapshot streamDBSnapshot) []codersdk.ChatStr
 		clear(l.state.knownMessages)
 		for _, msg := range snapshot.fullHistory {
 			l.state.knownMessages[msg.ID] = msg.Revision
-			sdkMsg := db2sdk.ChatMessage(msg)
+			sdkMsg := streamSDKMessage(msg, snapshot.goalMessageIDs)
 			events = append(events, codersdk.ChatStreamEvent{
 				Type:    codersdk.ChatStreamEventTypeMessage,
 				ChatID:  l.chatID,
@@ -331,7 +344,7 @@ func (l *streamLoop) messageEvents(snapshot streamDBSnapshot) []codersdk.ChatStr
 		if !l.state.initialMessageSyncDone && msg.ID <= l.state.afterMessageID {
 			continue
 		}
-		sdkMsg := db2sdk.ChatMessage(msg)
+		sdkMsg := streamSDKMessage(msg, snapshot.goalMessageIDs)
 		events = append(events, codersdk.ChatStreamEvent{
 			Type:    codersdk.ChatStreamEventTypeMessage,
 			ChatID:  l.chatID,
@@ -339,6 +352,40 @@ func (l *streamLoop) messageEvents(snapshot streamDBSnapshot) []codersdk.ChatStr
 		})
 	}
 	return events
+}
+
+// loadGoalMessageIDs marks which of the snapshot's messages created a
+// chat goal so streamed messages carry the same sent-as-goal provenance
+// as the REST list path and cannot erase a truthful marker on replace.
+func (l *streamLoop) loadGoalMessageIDs(ctx context.Context, tx database.Store, snapshot streamDBSnapshot) (map[int64]struct{}, error) {
+	set := map[int64]struct{}{}
+	messages := snapshot.changedMessages
+	if snapshot.historyReset {
+		messages = snapshot.fullHistory
+	}
+	if len(messages) == 0 {
+		return set, nil
+	}
+	messageIDs := make([]int64, 0, len(messages))
+	for _, msg := range messages {
+		messageIDs = append(messageIDs, msg.ID)
+	}
+	ids, err := tx.GetChatGoalMessageIDsByRootChatAndMessageIDs(ctx, database.GetChatGoalMessageIDsByRootChatAndMessageIDsParams{
+		RootChatID: l.chatID,
+		MessageIds: messageIDs,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("get goal message ids for stream: %w", err)
+	}
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
+func streamSDKMessage(msg database.ChatMessage, goalMessageIDs map[int64]struct{}) codersdk.ChatMessage {
+	_, sentAsGoal := goalMessageIDs[msg.ID]
+	return db2sdk.ChatMessageWithSentAsGoal(msg, sentAsGoal)
 }
 
 func (l *streamLoop) chatError(chat database.Chat) *codersdk.ChatError {

--- a/coderd/x/chatd/stream_loop_internal_test.go
+++ b/coderd/x/chatd/stream_loop_internal_test.go
@@ -94,7 +94,7 @@ func TestStreamLoopMessageSyncAfterIDAndEdits(t *testing.T) {
 	t.Parallel()
 
 	chatID := uuid.New()
-	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 1)
+	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 1, false)
 	initial := streamDBSnapshot{
 		chat: database.Chat{
 			ID:              chatID,
@@ -139,7 +139,7 @@ func TestStreamLoopHistoryReset(t *testing.T) {
 	t.Parallel()
 
 	chatID := uuid.New()
-	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0)
+	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0, false)
 	loop.state.snapshotVersion = 1
 	loop.state.historyVersion = 1
 	loop.state.status = database.ChatStatusRunning
@@ -183,7 +183,7 @@ func TestStreamLoopQueueStatusRetryErrorActionRequiredAndPreviewReset(t *testing
 	errorRaw, err := json.Marshal(chatError)
 	require.NoError(t, err)
 
-	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0)
+	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0, false)
 	loop.state.snapshotVersion = 1
 	loop.state.historyVersion = 1
 	loop.state.queueVersion = 1
@@ -216,7 +216,7 @@ func TestStreamLoopQueueStatusRetryErrorActionRequiredAndPreviewReset(t *testing
 	require.Equal(t, chatError.Message, events[2].Error.Message)
 	require.Equal(t, retry.Attempt, events[3].Retry.Attempt)
 
-	actionLoop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0)
+	actionLoop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0, false)
 	actionEvents := actionLoop.applyDBSnapshot(streamDBSnapshot{
 		chat: database.Chat{
 			ID:              chatID,
@@ -246,7 +246,7 @@ func TestStreamLoopActionRequiredFromHistory(t *testing.T) {
 		ToolName:   "browser",
 		Args:       json.RawMessage(`{"url":"https://example.com"}`),
 	}}, false)
-	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0)
+	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0, false)
 	action, err := loop.actionRequiredFromHistory(database.Chat{
 		ID:           chatID,
 		DynamicTools: pqtype.NullRawMessage{RawMessage: toolDefs, Valid: true},
@@ -257,11 +257,99 @@ func TestStreamLoopActionRequiredFromHistory(t *testing.T) {
 	require.Equal(t, "browser", action.ToolCalls[0].ToolName)
 }
 
+// Streamed and history-reset messages must carry the same sent-as-goal
+// provenance as the REST list path so a stream replace-by-ID cannot
+// erase a truthful marker.
+func TestStreamLoopMessagesCarryGoalMarker(t *testing.T) {
+	t.Parallel()
+
+	chatID := uuid.New()
+	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, nil), 0, true)
+
+	events := loop.applyDBSnapshot(streamDBSnapshot{
+		chat: database.Chat{
+			ID:              chatID,
+			Status:          database.ChatStatusWaiting,
+			SnapshotVersion: 1,
+			HistoryVersion:  1,
+		},
+		changedMessages: []database.ChatMessage{
+			streamMessage(t, chatID, 1, 1, database.ChatMessageRoleUser, "goal prompt", false),
+			streamMessage(t, chatID, 2, 1, database.ChatMessageRoleAssistant, "reply", false),
+		},
+		goalMessageIDs: map[int64]struct{}{1: {}},
+	})
+	require.GreaterOrEqual(t, len(events), 2)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, events[0].Type)
+	require.True(t, events[0].Message.SentAsGoal)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, events[1].Type)
+	require.False(t, events[1].Message.SentAsGoal)
+
+	resetEvents := loop.applyDBSnapshot(streamDBSnapshot{
+		chat: database.Chat{
+			ID:              chatID,
+			Status:          database.ChatStatusWaiting,
+			SnapshotVersion: 2,
+			HistoryVersion:  2,
+		},
+		historyReset: true,
+		fullHistory: []database.ChatMessage{
+			streamMessage(t, chatID, 1, 2, database.ChatMessageRoleUser, "goal prompt", false),
+			streamMessage(t, chatID, 2, 2, database.ChatMessageRoleAssistant, "reply", false),
+		},
+		goalMessageIDs: map[int64]struct{}{1: {}},
+	})
+	require.GreaterOrEqual(t, len(resetEvents), 3)
+	require.Equal(t, codersdk.ChatStreamEventTypeHistoryReset, resetEvents[0].Type)
+	require.True(t, resetEvents[1].Message.SentAsGoal)
+	require.False(t, resetEvents[2].Message.SentAsGoal)
+}
+
+// The snapshot load must resolve goal provenance inside the same read
+// lock that loads changed messages.
+func TestStreamLoopLoadsGoalMessageIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	tx := dbmock.NewMockStore(ctrl)
+	chatID := uuid.New()
+	loop := newStreamLoop(database.Chat{ID: chatID}, db, slogtest.Make(t, nil), 0, true)
+
+	chat := database.Chat{
+		ID:              chatID,
+		Status:          database.ChatStatusWaiting,
+		SnapshotVersion: 1,
+		HistoryVersion:  1,
+	}
+	db.EXPECT().InTx(gomock.Any(), nil).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error { return fn(tx) },
+	)
+	tx.EXPECT().GetChatByIDForShare(gomock.Any(), chatID).Return(chat, nil)
+	tx.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil)
+	tx.EXPECT().GetChatMessagesByRevisionForStream(gomock.Any(), database.GetChatMessagesByRevisionForStreamParams{
+		ChatID: chatID,
+	}).Return([]database.ChatMessage{
+		streamMessage(t, chatID, 1, 1, database.ChatMessageRoleUser, "goal prompt", false),
+	}, nil)
+	tx.EXPECT().GetChatGoalMessageIDsByRootChatAndMessageIDs(gomock.Any(), database.GetChatGoalMessageIDsByRootChatAndMessageIDsParams{
+		RootChatID: chatID,
+		MessageIds: []int64{1},
+	}).Return([]int64{1}, nil)
+
+	events, _, changed, err := loop.syncDB(ctx)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, codersdk.ChatStreamEventTypeMessage, events[0].Type)
+	require.True(t, events[0].Message.SentAsGoal)
+}
+
 func TestStreamLoopPartValidation(t *testing.T) {
 	t.Parallel()
 
 	chatID := uuid.New()
-	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), 0)
+	loop := newStreamLoop(database.Chat{ID: chatID}, nil, slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), 0, false)
 	loop.state.historyVersion = 7
 	loop.state.generationAttempt = 3
 
@@ -295,7 +383,7 @@ func TestStreamLoopInitialSyncRecoversWithoutHint(t *testing.T) {
 	db := dbmock.NewMockStore(ctrl)
 	tx := dbmock.NewMockStore(ctrl)
 	chatID := uuid.New()
-	loop := newStreamLoop(database.Chat{ID: chatID}, db, slogtest.Make(t, nil), 0)
+	loop := newStreamLoop(database.Chat{ID: chatID}, db, slogtest.Make(t, nil), 0, false)
 	loop.state.snapshotVersion = 1
 	loop.state.status = database.ChatStatusRunning
 

--- a/coderd/x/chatd/stream_subscribe.go
+++ b/coderd/x/chatd/stream_subscribe.go
@@ -59,7 +59,8 @@ func (p *Server) subscribeStreamLoop(
 	}
 
 	pollerCh, unregisterPoller := p.streamSyncPoller.Register(chatID)
-	loop := newStreamLoop(chat, p.db, logger, afterMessageID)
+	goalMarkers := p.experiments.Enabled(codersdk.ExperimentChatGoals) && isRootChat(chat)
+	loop := newStreamLoop(chat, p.db, logger, afterMessageID, goalMarkers)
 	// The immediate sync builds the initial snapshot returned to the caller
 	// and the relay target for the forwarder. Hints only fire on state
 	// changes, so without it an idle chat would never deliver a snapshot and

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -3121,6 +3121,20 @@ func (c *Client) RefreshChatContext(ctx context.Context, chatID uuid.UUID) (Chat
 	return chat, ReadBodyAsJSON(res, &chat)
 }
 
+// UpdateChatGoal applies a metadata-only chat goal mutation.
+func (c *Client) UpdateChatGoal(ctx context.Context, chatID uuid.UUID, req ChatGoalUpdateRequest) (ChatGoalResponse, error) {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/chats/%s/goal", chatID), req)
+	if err != nil {
+		return ChatGoalResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatGoalResponse{}, ReadBodyAsError(res)
+	}
+	var resp ChatGoalResponse
+	return resp, ReadBodyAsJSON(res, &resp)
+}
+
 func (c *Client) GetChatACL(ctx context.Context, chatID uuid.UUID) (ChatACL, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/chats/%s/acl", chatID), nil)
 	if err != nil {


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

The HTTP surface for goals, plus the message provenance marker on both read paths (REST list and WebSocket stream) so clients can render which message set a goal.

## What changed

- `exp_chats.go`: goal mutation on create/send (`goal_mutation`), `PATCH /api/experimental/chats/{chat}/goal` for clear/pause/resume/complete, current-goal hydration on chat reads, `sent_as_goal` on message lists, plan-mode toggle rejected while a goal is active, and the experiment gate on every goal surface.
- `stream_loop.go`: streamed messages carry the same `sent_as_goal` marker (root chats, experiment on) so a replace cannot erase a truthful marker. Moved here from the former #29020 because it belongs with the read path.
- Route registration, SDK client methods, apidoc regeneration, and API tests (experiment gate, hydration failure is non-fatal, plan-mode rejection, the goal API matrix, and owner-only PATCH for shared chats).

Code is unchanged from the reviewed #25622 apart from the split.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.
