### PR TITLE
feat(site): add chat goal UI

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3249,6 +3249,17 @@ class ExperimentalApiMethods {
 		);
 		return response.data;
 	};
+	updateChatGoal = async (
+		chatId: string,
+		req: TypesGen.ChatGoalUpdateRequest,
+	): Promise<TypesGen.ChatGoalResponse> => {
+		const response = await this.axios.patch<TypesGen.ChatGoalResponse>(
+			`/api/v2/chats/${chatId}/goal`,
+			req,
+		);
+		return response.data;
+	};
+
 	getChatMessages = async (
 		chatId: string,
 		opts?: { before_id?: number; after_id?: number; limit?: number },

--- a/site/src/api/queries/chatGoal.test.ts
+++ b/site/src/api/queries/chatGoal.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type * as TypesGen from "#/api/typesGenerated";
+import { chatGoalActionUnavailableReason, isChatBusyStatus } from "./chatGoal";
+
+describe("isChatBusyStatus", () => {
+	it.each([
+		{ status: "running", busy: true },
+		{ status: "interrupting", busy: true },
+		{ status: "requires_action", busy: true },
+		{ status: "waiting", busy: false },
+		{ status: "error", busy: false },
+		{ status: null, busy: false },
+		{ status: undefined, busy: false },
+	] as const)("$status is busy=$busy", ({ status, busy }) => {
+		expect(isChatBusyStatus(status)).toBe(busy);
+	});
+});
+
+describe("chatGoalActionUnavailableReason", () => {
+	const busyReason =
+		"The chat is busy. Resume becomes available when it is idle.";
+	const planModeReason = "Turn off plan mode to resume the goal.";
+	const noModelReason = "No AI model is available to resume the goal.";
+
+	it.each<{
+		name: string;
+		action: "pause" | "resume" | "complete" | "clear";
+		chatStatus?: TypesGen.ChatStatus | null;
+		hasQueuedInput?: boolean;
+		planModeEnabled?: boolean;
+		hasModelOptions?: boolean;
+		expected: string | undefined;
+	}>([
+		{
+			name: "resume on idle chat is available",
+			action: "resume",
+			chatStatus: "waiting",
+			expected: undefined,
+		},
+		{
+			name: "resume on errored chat without queue is available",
+			action: "resume",
+			chatStatus: "error",
+			expected: undefined,
+		},
+		{
+			name: "resume while running is unavailable",
+			action: "resume",
+			chatStatus: "running",
+			expected: busyReason,
+		},
+		{
+			name: "resume while interrupting is unavailable",
+			action: "resume",
+			chatStatus: "interrupting",
+			expected: busyReason,
+		},
+		{
+			name: "resume while requiring action is unavailable",
+			action: "resume",
+			chatStatus: "requires_action",
+			expected: busyReason,
+		},
+		{
+			name: "resume with queued input is unavailable",
+			action: "resume",
+			chatStatus: "error",
+			hasQueuedInput: true,
+			expected: busyReason,
+		},
+		{
+			name: "resume in plan mode is unavailable",
+			action: "resume",
+			chatStatus: "waiting",
+			planModeEnabled: true,
+			expected: planModeReason,
+		},
+		{
+			name: "busy wins over plan mode",
+			action: "resume",
+			chatStatus: "running",
+			planModeEnabled: true,
+			expected: busyReason,
+		},
+		{
+			name: "resume without a usable model is unavailable",
+			action: "resume",
+			chatStatus: "waiting",
+			hasModelOptions: false,
+			expected: noModelReason,
+		},
+		{
+			name: "resume with models available is available",
+			action: "resume",
+			chatStatus: "waiting",
+			hasModelOptions: true,
+			expected: undefined,
+		},
+		{
+			name: "pause is never gated by chat status",
+			action: "pause",
+			chatStatus: "running",
+			expected: undefined,
+		},
+		{
+			name: "complete is never gated by chat status",
+			action: "complete",
+			chatStatus: "running",
+			expected: undefined,
+		},
+		{
+			name: "clear is never gated by chat status",
+			action: "clear",
+			chatStatus: "running",
+			hasQueuedInput: true,
+			planModeEnabled: true,
+			expected: undefined,
+		},
+	])(
+		"$name",
+		({
+			action,
+			chatStatus,
+			hasQueuedInput,
+			planModeEnabled,
+			hasModelOptions,
+			expected,
+		}) => {
+			expect(
+				chatGoalActionUnavailableReason(action, {
+					chatStatus,
+					hasQueuedInput,
+					planModeEnabled,
+					hasModelOptions,
+				}),
+			).toBe(expected);
+		},
+	);
+});

--- a/site/src/api/queries/chatGoal.ts
+++ b/site/src/api/queries/chatGoal.ts
@@ -1,0 +1,74 @@
+import type * as TypesGen from "#/api/typesGenerated";
+
+export type ChatGoalAction = TypesGen.ChatGoalUpdateAction;
+export type CurrentChatGoalStatus = Extract<
+	TypesGen.ChatGoalStatus,
+	"active" | "paused" | "complete"
+>;
+
+const CHAT_GOAL_ACTIONS_BY_STATUS = {
+	active: ["pause", "complete", "clear"],
+	paused: ["resume", "clear"],
+	complete: ["clear"],
+} as const satisfies Record<CurrentChatGoalStatus, readonly ChatGoalAction[]>;
+
+export const isCurrentChatGoalStatus = (
+	status: TypesGen.ChatGoalStatus,
+): status is CurrentChatGoalStatus =>
+	Object.hasOwn(CHAT_GOAL_ACTIONS_BY_STATUS, status);
+
+export const currentChatGoal = (
+	goal: TypesGen.ChatGoal | undefined,
+): TypesGen.ChatGoal | undefined =>
+	goal && isCurrentChatGoalStatus(goal.status) ? goal : undefined;
+
+export const chatGoalActionsForStatus = (
+	status: CurrentChatGoalStatus,
+): readonly ChatGoalAction[] => CHAT_GOAL_ACTIONS_BY_STATUS[status];
+
+export const chatGoalActionAllowed = (
+	goal: TypesGen.ChatGoal,
+	action: ChatGoalAction,
+): boolean =>
+	isCurrentChatGoalStatus(goal.status) &&
+	chatGoalActionsForStatus(goal.status).includes(action);
+
+export const isChatBusyStatus = (
+	status: TypesGen.ChatStatus | null | undefined,
+): boolean =>
+	status === "running" ||
+	status === "interrupting" ||
+	status === "requires_action";
+
+type ChatGoalActionContext = {
+	chatStatus?: TypesGen.ChatStatus | null;
+	hasQueuedInput?: boolean;
+	planModeEnabled?: boolean;
+	hasModelOptions?: boolean;
+};
+
+/**
+ * Returns why a status-allowed goal action is unavailable right now, or
+ * undefined when it can proceed. Resume starts a turn on the chat, so it
+ * requires an idle chat with no queued input and plan mode off; the
+ * server rejects it otherwise.
+ */
+export const chatGoalActionUnavailableReason = (
+	action: ChatGoalAction,
+	context: ChatGoalActionContext,
+): string | undefined => {
+	if (action !== "resume") {
+		return undefined;
+	}
+	if (isChatBusyStatus(context.chatStatus) || context.hasQueuedInput) {
+		return "The chat is busy. Resume becomes available when it is idle.";
+	}
+	if (context.planModeEnabled) {
+		return "Turn off plan mode to resume the goal.";
+	}
+	// Resume starts a turn, which fails without a usable model.
+	if (context.hasModelOptions === false) {
+		return "No AI model is available to resume the goal.";
+	}
+	return undefined;
+};

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -13,6 +13,7 @@ import {
 	SUCCESS_STATUSES,
 } from "#/pages/AgentsPage/components/RightPanel/DebugPanel/debugPanelUtils";
 import {
+	MockChatGoal,
 	MockChatMessage,
 	MockMCPServerConfig,
 } from "#/testHelpers/chatEntities";
@@ -74,6 +75,7 @@ import {
 	invalidateChatDebugRuns,
 	invalidateChatDiffContents,
 	invalidateChatEntity,
+	invalidateChatGoalFamily,
 	invalidateChatListQueries,
 	invalidateChatMessages,
 	invalidateChatPrompts,
@@ -101,6 +103,7 @@ import {
 	reorderPinnedChat,
 	replaceChatMessagesHistory,
 	resetUnloadedChatEntity,
+	setCachedChatGoal,
 	setChatGroupRole,
 	setChatUserRole,
 	shouldInvalidateChatSearches,
@@ -109,6 +112,7 @@ import {
 	toChatListParams,
 	unarchiveChat,
 	unpinChat,
+	updateChatGoal,
 	updateChatModel,
 	updateChatModelACL,
 	updateChatPlanMode,
@@ -126,6 +130,7 @@ vi.mock("#/api/api", () => ({
 			updateChat: vi.fn(),
 			createChat: vi.fn(),
 			deleteChatQueuedMessage: vi.fn(),
+			getChat: vi.fn(),
 			getChats: vi.fn(),
 			getChatsByWorkspace: vi.fn(),
 			getChatCost: vi.fn(),
@@ -136,6 +141,7 @@ vi.mock("#/api/api", () => ({
 			proposeChatTitle: vi.fn(),
 			getChatAdvisorConfig: vi.fn(),
 			updateChatAdvisorConfig: vi.fn(),
+			updateChatGoal: vi.fn(),
 			getChatACL: vi.fn(),
 			updateChatACL: vi.fn(),
 			getChatModel: vi.fn(),
@@ -206,6 +212,13 @@ const makeChat = (
 	last_turn_summary: null,
 	summary: null,
 	children: [],
+	...overrides,
+});
+
+const makeGoal = (
+	overrides?: Partial<TypesGen.ChatGoal>,
+): TypesGen.ChatGoal => ({
+	...MockChatGoal,
 	...overrides,
 });
 
@@ -2970,6 +2983,45 @@ describe("mergeWatchedChatSummary", () => {
 		).toBeNull();
 	});
 
+	it("never merges goal state from goal_change events", () => {
+		// goal_change events carry no goal payload and concurrent
+		// publications can be reordered, so consumers refetch instead
+		// of merging; the cached goal must survive the event untouched.
+		const cachedGoal = makeGoal({ objective: "Current goal" });
+		const cachedChat = makeChat("chat-1", {
+			goal: cachedGoal,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			goal: undefined,
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "goal_change",
+			}).goal,
+		).toBe(cachedGoal);
+	});
+
+	it("preserves cached goals on non-goal events", () => {
+		const cachedGoal = makeGoal({ objective: "Completed goal" });
+		const cachedChat = makeChat("chat-1", {
+			goal: cachedGoal,
+			updated_at: "2025-01-01T00:00:00.000Z",
+		});
+		const watchedChat = makeChat("chat-1", {
+			goal: undefined,
+			updated_at: "2025-01-01T00:05:00.000Z",
+		});
+
+		expect(
+			mergeWatchedChatSummary(cachedChat, watchedChat, {
+				eventKind: "status_change",
+			}).goal,
+		).toBe(cachedGoal);
+	});
+
 	it("compares updated_at values as instants instead of strings", () => {
 		const cachedChat = makeChat("chat-1", {
 			status: "waiting",
@@ -3350,6 +3402,161 @@ describe("mergeWatchedChatIntoCaches", () => {
 		});
 	});
 
+	it("refreshes the family goal from the DB on goal_change instead of merging event state", async () => {
+		const queryClient = createTestQueryClient();
+		const rootId = "root-1";
+		const childId = "child-1";
+		const siblingId = "child-2";
+		const cachedGoal = makeGoal({ id: "goal-old", root_chat_id: rootId });
+		const eventGoal = makeGoal({ id: "goal-event", root_chat_id: rootId });
+		const fetchedGoal = makeGoal({
+			id: "goal-new",
+			root_chat_id: rootId,
+			status: "paused",
+			updated_at: "2025-01-01T00:10:00.000Z",
+		});
+		const child = makeChat(childId, {
+			parent_chat_id: rootId,
+			root_chat_id: rootId,
+			goal: cachedGoal,
+		});
+		const sibling = makeChat(siblingId, {
+			parent_chat_id: rootId,
+			root_chat_id: rootId,
+			goal: cachedGoal,
+		});
+		const root = makeChat(rootId, {
+			goal: cachedGoal,
+			children: [child, sibling],
+		});
+		seedInfiniteChats(queryClient, [root]);
+		queryClient.setQueryData(chatEntityKey(childId), child);
+		queryClient.setQueryData(chatEntityKey(siblingId), sibling);
+		vi.mocked(API.experimental.getChat).mockResolvedValue(
+			makeChat(childId, {
+				parent_chat_id: rootId,
+				root_chat_id: rootId,
+				goal: fetchedGoal,
+			}),
+		);
+
+		mergeWatchedChatIntoCaches(
+			queryClient,
+			makeChat(childId, {
+				parent_chat_id: rootId,
+				root_chat_id: rootId,
+				goal: eventGoal,
+			}),
+			{ eventKind: "goal_change" },
+		);
+
+		// The event payload's goal is ignored (events may be reordered);
+		// the DB-backed goal is fetched and applied across the family.
+		expect(API.experimental.getChat).toHaveBeenCalledWith(childId);
+		await vi.waitFor(() => {
+			expect(
+				queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(childId))?.goal,
+			).toEqual(fetchedGoal);
+			expect(
+				queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(siblingId))?.goal,
+			).toEqual(fetchedGoal);
+		});
+	});
+
+	it("applies the refreshed goal even when a later watch event cancels entity refetches", async () => {
+		// A server-side pause publishes goal_change inside the same event
+		// burst as the turn's status_change and summary_change, and every
+		// event cancels in-flight entity refetches to protect its merge
+		// writes. The goal refresh must survive those cancellations or an
+		// open, newly idle chat keeps rendering the stale active goal.
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const activeGoal = makeGoal({ status: "active" });
+		const pausedGoal = makeGoal({
+			status: "paused",
+			updated_at: "2025-01-01T00:10:00.000Z",
+		});
+		const cachedChat = makeChat(chatId, { goal: activeGoal });
+		seedInfiniteChats(queryClient, [cachedChat]);
+		queryClient.setQueryData(chatEntityKey(chatId), cachedChat);
+		const fetches: ReturnType<typeof createDeferred<TypesGen.Chat>>[] = [];
+		vi.mocked(API.experimental.getChat).mockImplementation(() => {
+			const deferred = createDeferred<TypesGen.Chat>();
+			fetches.push(deferred);
+			return deferred.promise;
+		});
+		// The page's observer was mounted long before the pause, so a
+		// mount refetch is not part of the reproduced burst.
+		const observer = new QueryObserver<TypesGen.Chat>(queryClient, {
+			queryKey: chatEntityKey(chatId),
+			queryFn: () => API.experimental.getChat(chatId),
+			refetchOnMount: false,
+		});
+		const unsubscribe = observer.subscribe(() => {});
+
+		try {
+			expect(fetches).toHaveLength(0);
+			mergeWatchedChatIntoCaches(queryClient, makeChat(chatId), {
+				eventKind: "goal_change",
+			});
+			// The burst's next event cancels list and entity refetches
+			// while the goal read is in flight. Only the first read ever
+			// resolves; a cancelled-and-replaced fetch stays pending, the
+			// way an idle chat never polls again in production.
+			await vi.waitFor(() => {
+				expect(fetches.length).toBeGreaterThan(0);
+			});
+			await cancelChatListRefetches(queryClient);
+			await cancelLoadedChatEntityRefetch(queryClient, chatId);
+			fetches[0].resolve(makeChat(chatId, { goal: pausedGoal }));
+
+			await vi.waitFor(() => {
+				expect(
+					queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(chatId))?.goal,
+				).toEqual(pausedGoal);
+			});
+		} finally {
+			unsubscribe();
+		}
+	});
+
+	it("single-flights goal_change bursts and rereads once for events that arrive mid-fetch", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const staleGoal = makeGoal({ status: "active" });
+		const finalGoal = makeGoal({
+			status: "paused",
+			updated_at: "2025-01-01T00:10:00.000Z",
+		});
+		const cachedChat = makeChat(chatId, { goal: staleGoal });
+		queryClient.setQueryData(chatEntityKey(chatId), cachedChat);
+		const firstFetch = createDeferred<TypesGen.Chat>();
+		vi.mocked(API.experimental.getChat)
+			.mockImplementationOnce(() => firstFetch.promise)
+			.mockResolvedValueOnce(makeChat(chatId, { goal: finalGoal }));
+
+		mergeWatchedChatIntoCaches(queryClient, makeChat(chatId), {
+			eventKind: "goal_change",
+		});
+		mergeWatchedChatIntoCaches(queryClient, makeChat(chatId), {
+			eventKind: "goal_change",
+		});
+		mergeWatchedChatIntoCaches(queryClient, makeChat(chatId), {
+			eventKind: "goal_change",
+		});
+		expect(API.experimental.getChat).toHaveBeenCalledTimes(1);
+		firstFetch.resolve(makeChat(chatId, { goal: staleGoal }));
+
+		// Events that arrived mid-fetch coalesce into exactly one reread,
+		// so the applied goal reflects a read started after the last event.
+		await vi.waitFor(() => {
+			expect(API.experimental.getChat).toHaveBeenCalledTimes(2);
+			expect(
+				queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(chatId))?.goal,
+			).toEqual(finalGoal);
+		});
+	});
+
 	it("does not let an older watch payload clobber newer cached metadata", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
@@ -3471,6 +3678,196 @@ describe("TERMINAL_RUN_STATUSES", () => {
 				SUCCESS_STATUSES.has(status) || ERROR_STATUSES.has(status);
 			expect(classified).toBe(true);
 		}
+	});
+});
+
+describe("chat goal query factories", () => {
+	it("updates cached chat goal from lifecycle mutation response", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const goal = makeGoal({ status: "paused" });
+		queryClient.setQueryData(chatEntityKey(chatId), makeChat(chatId));
+		seedInfiniteChats(queryClient, [makeChat(chatId)]);
+		vi.mocked(API.experimental.updateChatGoal).mockResolvedValue({ goal });
+
+		const mutation = updateChatGoal(queryClient);
+		const variables = {
+			chatId,
+			mutation: { action: "pause" as const, goal_id: goal.id },
+		};
+		const response = await mutation.mutationFn(variables);
+		await mutation.onSuccess?.(response, variables);
+
+		expect(API.experimental.updateChatGoal).toHaveBeenCalledWith(
+			chatId,
+			variables.mutation,
+		);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(chatId))?.goal,
+		).toBe(goal);
+		expect(readInfiniteChats(queryClient)?.[0]?.goal).toBe(goal);
+	});
+
+	it.each([
+		{ name: "undefined goal", responseStatus: undefined, kept: false },
+		{ name: "complete goal", responseStatus: "complete", kept: true },
+		{ name: "cleared goal", responseStatus: "cleared", kept: false },
+	] as const)(
+		"caches $name mutation responses only while current",
+		({ responseStatus, kept }) => {
+			const queryClient = createTestQueryClient();
+			const chatId = "chat-1";
+			const goal = makeGoal();
+			const responseGoal = responseStatus
+				? makeGoal({ status: responseStatus })
+				: undefined;
+			queryClient.setQueryData(
+				chatEntityKey(chatId),
+				makeChat(chatId, { goal }),
+			);
+			seedInfiniteChats(queryClient, [makeChat(chatId, { goal })]);
+
+			setCachedChatGoal(queryClient, chatId, responseGoal);
+
+			const expected = kept ? responseGoal : undefined;
+			expect(
+				queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(chatId))?.goal,
+			).toStrictEqual(expected);
+			expect(readInfiniteChats(queryClient)?.[0]?.goal).toStrictEqual(expected);
+		},
+	);
+
+	it("updates cached goal on parent-embedded child chats", () => {
+		const queryClient = createTestQueryClient();
+		const childId = "child-1";
+		const oldGoal = makeGoal({
+			id: "goal-old",
+			root_chat_id: "parent-1",
+			objective: "Old goal",
+		});
+		const newGoal = makeGoal({
+			id: "goal-new",
+			root_chat_id: "parent-1",
+			objective: "New goal",
+		});
+		const child = makeChat(childId, {
+			parent_chat_id: "parent-1",
+			root_chat_id: "parent-1",
+			goal: oldGoal,
+		});
+		const parent = makeChat("parent-1", { children: [child] });
+		seedInfiniteChats(queryClient, [parent]);
+		queryClient.setQueryData(chatEntityKey(childId), child);
+
+		setCachedChatGoal(queryClient, childId, newGoal);
+
+		expect(readInfiniteChats(queryClient)?.[0]?.children?.[0]?.goal).toEqual(
+			newGoal,
+		);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(childId))?.goal,
+		).toEqual(newGoal);
+	});
+
+	it("updates cached goals across root family detail and list entries", () => {
+		const queryClient = createTestQueryClient();
+		const rootId = "root-1";
+		const childId = "child-1";
+		const siblingId = "child-2";
+		const oldGoal = makeGoal({ id: "goal-old", root_chat_id: rootId });
+		const newGoal = makeGoal({ id: "goal-new", root_chat_id: rootId });
+		const child = makeChat(childId, {
+			parent_chat_id: rootId,
+			root_chat_id: rootId,
+			goal: oldGoal,
+		});
+		const sibling = makeChat(siblingId, {
+			parent_chat_id: rootId,
+			root_chat_id: rootId,
+			goal: oldGoal,
+		});
+		const root = makeChat(rootId, {
+			goal: oldGoal,
+			children: [child, sibling],
+		});
+		const otherGoal = makeGoal({ id: "other-goal", root_chat_id: "other" });
+		const other = makeChat("other", { goal: otherGoal });
+		seedInfiniteChats(queryClient, [root, other]);
+		queryClient.setQueryData(chatEntityKey(rootId), root);
+		queryClient.setQueryData(chatEntityKey(childId), child);
+		queryClient.setQueryData(chatEntityKey(siblingId), sibling);
+		queryClient.setQueryData(chatEntityKey("other"), other);
+
+		setCachedChatGoal(queryClient, childId, newGoal);
+
+		const [cachedRoot, cachedOther] = readInfiniteChats(queryClient) ?? [];
+		expect(cachedRoot?.goal).toEqual(newGoal);
+		expect(cachedRoot?.children?.[0]?.goal).toEqual(newGoal);
+		expect(cachedRoot?.children?.[1]?.goal).toEqual(newGoal);
+		expect(cachedOther?.goal).toEqual(otherGoal);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(rootId))?.goal,
+		).toEqual(newGoal);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(rootId))
+				?.children?.[0]?.goal,
+		).toEqual(newGoal);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(childId))?.goal,
+		).toEqual(newGoal);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey(siblingId))?.goal,
+		).toEqual(newGoal);
+		expect(
+			queryClient.getQueryData<TypesGen.Chat>(chatEntityKey("other"))?.goal,
+		).toEqual(otherGoal);
+	});
+
+	it("preserves infinite chat cache references when no chat goal changes", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const goal = makeGoal();
+		seedInfiniteChats(queryClient, [makeChat(chatId, { goal })]);
+		queryClient.setQueryData(chatEntityKey(chatId), makeChat(chatId, { goal }));
+		const before = queryClient.getQueryData<InfiniteData>(infiniteChatsTestKey);
+
+		setCachedChatGoal(queryClient, chatId, goal);
+
+		expect(queryClient.getQueryData<InfiniteData>(infiniteChatsTestKey)).toBe(
+			before,
+		);
+	});
+});
+
+describe("invalidateChatGoalFamily", () => {
+	it("cancels and invalidates every family entity plus the lists", async () => {
+		const queryClient = createTestQueryClient();
+		const rootId = "root-1";
+		const childId = "child-1";
+		const outsiderId = "outsider-1";
+		const child = makeChat(childId, {
+			parent_chat_id: rootId,
+			root_chat_id: rootId,
+		});
+		seedInfiniteChats(queryClient, [makeChat(rootId), makeChat(outsiderId)]);
+		queryClient.setQueryData(chatEntityKey(rootId), makeChat(rootId));
+		queryClient.setQueryData(chatEntityKey(childId), child);
+		queryClient.setQueryData(chatEntityKey(outsiderId), makeChat(outsiderId));
+
+		await invalidateChatGoalFamily(queryClient, rootId);
+
+		expect(
+			queryClient.getQueryState(chatEntityKey(rootId))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatEntityKey(childId))?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(chatEntityKey(outsiderId))?.isInvalidated,
+		).toBe(false);
+		expect(queryClient.getQueryState(infiniteChatsTestKey)?.isInvalidated).toBe(
+			true,
+		);
 	});
 });
 

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -13,6 +13,7 @@ import {
 import type * as TypesGen from "#/api/typesGenerated";
 import { ChatListSources } from "#/api/typesGenerated";
 import { authorizationKey } from "./authCheck";
+import { currentChatGoal } from "./chatGoal";
 import {
 	projectEditedConversationIntoCache,
 	reconcileEditedMessageInCache,
@@ -663,6 +664,12 @@ export const mergeWatchedChatIntoCaches = (
 			return mergeCachedChat(cachedChat);
 		},
 	);
+	if (options.eventKind === "goal_change") {
+		// goal_change events carry no goal payload (Postgres NOTIFY has a
+		// hard size cap), so read the DB-backed goal and patch it into
+		// the family's caches.
+		void refreshChatGoalFamily(queryClient, watchedChat.id);
+	}
 };
 
 const getNextOptimisticPinOrder = (queryClient: QueryClient): number => {
@@ -1386,6 +1393,196 @@ export const updateChatPlanMode = (queryClient: QueryClient) => ({
 			),
 		);
 		patchChatEntity(queryClient, chatId, () => previousChat);
+	},
+});
+
+type UpdateChatGoalVariables = {
+	chatId: string;
+	mutation: TypesGen.ChatGoalUpdateRequest;
+};
+
+const chatRootId = (chat: TypesGen.Chat): string =>
+	chat.root_chat_id ?? chat.parent_chat_id ?? chat.id;
+
+// Resolves a chat's family root by scanning the cached detail and list
+// queries. Used as a fallback when a goal update carries no goal payload
+// (for example a cleared goal) and so no root_chat_id.
+const cachedChatFamilyId = (
+	queryClient: QueryClient,
+	chatId: string,
+): string | undefined => {
+	const cachedChatFamilyIDs = new Map<string, string>();
+	const rememberChatFamily = (chat: TypesGen.Chat) => {
+		cachedChatFamilyIDs.set(chat.id, chatRootId(chat));
+		for (const child of chat.children ?? []) {
+			cachedChatFamilyIDs.set(child.id, chatRootId(child));
+		}
+	};
+
+	for (const [, chat] of queryClient.getQueriesData<TypesGen.Chat>({
+		queryKey: chatEntitiesFamilyKey,
+	})) {
+		if (chat) {
+			rememberChatFamily(chat);
+		}
+	}
+
+	for (const [, data] of queryClient.getQueriesData<InfiniteChatsCacheData>({
+		queryKey: chatListFamilyKey,
+	})) {
+		for (const page of data?.pages ?? []) {
+			for (const chat of page) {
+				rememberChatFamily(chat);
+			}
+		}
+	}
+
+	return cachedChatFamilyIDs.get(chatId);
+};
+
+/**
+ * Cancels and refetches every cached entity in the chat's family plus
+ * the chat lists. Reconciles goal mutations after they settle and backs
+ * up refreshChatGoalFamily when its direct read fails.
+ */
+export const invalidateChatGoalFamily = async (
+	queryClient: QueryClient,
+	chatId: string,
+) => {
+	const familyId = cachedChatFamilyId(queryClient, chatId) ?? chatId;
+	const entityIds = new Set<string>([chatId]);
+	for (const [, cachedChat] of queryClient.getQueriesData<TypesGen.Chat>({
+		queryKey: chatEntitiesFamilyKey,
+	})) {
+		if (cachedChat && chatRootId(cachedChat) === familyId) {
+			entityIds.add(cachedChat.id);
+		}
+	}
+	await Promise.all([
+		cancelChatListQueries(queryClient),
+		...[...entityIds].map((id) => cancelChatEntity(queryClient, id)),
+	]);
+	await Promise.all([
+		invalidateChatListQueries(queryClient),
+		...[...entityIds].map((id) => invalidateChatEntity(queryClient, id)),
+	]);
+};
+
+export const setCachedChatGoal = (
+	queryClient: QueryClient,
+	chatId: string,
+	goal: TypesGen.ChatGoal | undefined,
+) => {
+	const cachedGoal = currentChatGoal(goal);
+	const familyId =
+		goal?.root_chat_id ?? cachedChatFamilyId(queryClient, chatId) ?? chatId;
+	// Applied unconditionally: goal timestamps cannot order concurrent
+	// commits (serialized transactions can invert NOW()-based columns), and
+	// every goal commit publishes goal_change, so the refresh triggered by
+	// the newest event always reapplies DB truth last.
+	const applyGoal = (chat: TypesGen.Chat) =>
+		chatRootId(chat) === familyId && chat.goal !== cachedGoal
+			? { ...chat, goal: cachedGoal }
+			: chat;
+	const applyGoalToTree = (chat: TypesGen.Chat) => {
+		const nextChat = applyGoal(chat);
+		if (!chat.children?.length) {
+			return nextChat;
+		}
+
+		const nextChildren = chat.children.map(applyGoal);
+		return nextChildren.some((child, index) => child !== chat.children?.[index])
+			? { ...nextChat, children: nextChildren }
+			: nextChat;
+	};
+
+	updateInfiniteChatsCache(queryClient, (chats) => {
+		const nextChats = chats.map(applyGoalToTree);
+		return nextChats.some((chat, index) => chat !== chats[index])
+			? nextChats
+			: chats;
+	});
+	for (const [, cachedChat] of queryClient.getQueriesData<TypesGen.Chat>({
+		queryKey: chatEntitiesFamilyKey,
+	})) {
+		if (!cachedChat) {
+			continue;
+		}
+		const nextChat = applyGoalToTree(cachedChat);
+		if (nextChat !== cachedChat) {
+			patchChatEntity(queryClient, cachedChat.id, () => nextChat);
+		}
+	}
+};
+
+// Tracks in-flight goal_change reads per query client so event bursts
+// coalesce into at most one follow-up read.
+const pendingGoalRefreshes = new WeakMap<
+	QueryClient,
+	Map<string, { dirty: boolean }>
+>();
+
+/**
+ * Reads the DB-backed goal for a goal_change event's chat and patches it
+ * into the family's caches. Watch-event handlers cancel in-flight entity
+ * refetches to protect their merge writes, and a server-side pause lands
+ * in the same event burst as the turn's final status and summary events,
+ * so a query-machinery refetch would be cancelled and never rerun (an
+ * idle chat stops polling). This read bypasses the query cache so those
+ * cancellations cannot touch it; goal_change events arriving mid-read
+ * coalesce into one follow-up read, so the applied goal always reflects
+ * a read started after the latest event.
+ */
+const refreshChatGoalFamily = async (
+	queryClient: QueryClient,
+	chatId: string,
+): Promise<void> => {
+	let pending = pendingGoalRefreshes.get(queryClient);
+	if (!pending) {
+		pending = new Map();
+		pendingGoalRefreshes.set(queryClient, pending);
+	}
+	const inFlight = pending.get(chatId);
+	if (inFlight) {
+		inFlight.dirty = true;
+		return;
+	}
+	const state = { dirty: false };
+	pending.set(chatId, state);
+	try {
+		do {
+			state.dirty = false;
+			const chat = await API.experimental.getChat(chatId);
+			setCachedChatGoal(queryClient, chatId, chat.goal);
+		} while (state.dirty);
+	} catch {
+		// Leave the family marked stale so a later focus or remount
+		// refetch repairs the caches.
+		await invalidateChatGoalFamily(queryClient, chatId);
+	} finally {
+		pending.delete(chatId);
+	}
+};
+
+export const updateChatGoal = (queryClient: QueryClient) => ({
+	mutationFn: ({ chatId, mutation }: UpdateChatGoalVariables) =>
+		API.experimental.updateChatGoal(chatId, mutation),
+	onMutate: async ({ chatId }: UpdateChatGoalVariables) => {
+		await cancelChatListQueries(queryClient);
+		await cancelChatEntity(queryClient, chatId);
+	},
+	onSuccess: (
+		response: TypesGen.ChatGoalResponse,
+		{ chatId }: UpdateChatGoalVariables,
+	) => {
+		setCachedChatGoal(queryClient, chatId, response.goal);
+	},
+	onSettled: async (
+		_response: TypesGen.ChatGoalResponse | undefined,
+		_error: unknown,
+		{ chatId }: UpdateChatGoalVariables,
+	) => {
+		await invalidateChatGoalFamily(queryClient, chatId);
 	},
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -4234,3 +4234,79 @@ export const SendRejectedByHookDispatchFailure: Story = {
 		expect(canvas.queryByText("Request failed")).not.toBeInTheDocument();
 	},
 };
+
+/** Goals are root-chat only: a child chat's composer must not offer the
+ *  Pursue goal toggle even with the experiment enabled. */
+export const ChildChatHidesGoalControls: Story = {
+	parameters: {
+		experiments: ["chat-goals"],
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				parent_chat_id: "parent-chat-1",
+				title: "Child chat",
+				status: "waiting",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByRole("button", { name: "More options" }),
+		);
+		const body = within(document.body);
+		expect(
+			await body.findByRole("menuitemcheckbox", { name: "Plan first" }),
+		).toBeInTheDocument();
+		expect(
+			body.queryByRole("menuitemcheckbox", { name: "Pursue goal" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+/** Enabling goal mode requests a plan-mode disable; when that PATCH
+ *  fails, the optimistic plan mode rolls back on and goal mode must
+ *  clear with it instead of presenting both modes together. */
+export const GoalModeClearsWhenPlanModeDisableFails: Story = {
+	parameters: {
+		experiments: ["chat-goals"],
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Plan rollback",
+				status: "waiting",
+				plan_mode: "plan",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "updateChat").mockRejectedValue({
+			isAxiosError: true,
+			response: {
+				status: 500,
+				data: { message: "Failed to update chat plan mode." },
+			},
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			await canvas.findByRole("button", { name: "More options" }),
+		);
+		const body = within(document.body);
+		await userEvent.click(
+			await body.findByRole("menuitemcheckbox", { name: "Pursue goal" }),
+		);
+		// The failed PATCH restores plan mode; goal mode clears with it.
+		await waitFor(() =>
+			expect(canvas.getByTestId("planning-badge")).toBeInTheDocument(),
+		);
+		await waitFor(() =>
+			expect(canvas.queryByText("Pursuing goal")).not.toBeInTheDocument(),
+		);
+	},
+};

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -20,6 +20,11 @@ import type {
 import { getErrorMessage, getErrorStatus, isApiError } from "#/api/errors";
 import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import { checkAuthorization } from "#/api/queries/authCheck";
+import {
+	type ChatGoalAction,
+	chatGoalActionUnavailableReason,
+	isChatBusyStatus,
+} from "#/api/queries/chatGoal";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chatMessagesForInfiniteScroll,
@@ -37,6 +42,8 @@ import {
 	openChat,
 	patchChatEntity,
 	promoteChatQueuedMessage,
+	setCachedChatGoal,
+	updateChatGoal,
 	updateChatPlanMode,
 	updateChatWorkspace,
 	updateInfiniteChatsCache,
@@ -66,7 +73,10 @@ import {
 	AgentChatPageView,
 } from "./AgentChatPageView";
 import type { AgentsPageOutletContext } from "./AgentsPageLayout";
-import type { ChatMessageInputRef } from "./components/AgentChatInput";
+import type {
+	AgentChatInputSendOptions,
+	ChatMessageInputRef,
+} from "./components/AgentChatInput";
 import {
 	type ChatDetailError,
 	getPersistedDetailError,
@@ -104,6 +114,7 @@ import {
 import { getModelSelectorHelp } from "./components/ModelSelectorHelp";
 import { useAgentChatPanelPreference } from "./components/RightPanel/useAgentChatPanelPreference";
 import { getWorkspaceOptionsWithLinkedWorkspace } from "./components/workspaceOptions";
+import { runGoalAction } from "./goalActions";
 import {
 	BuiltInCommandPendingError,
 	useConversationEditingState,
@@ -234,6 +245,7 @@ const AgentChatPage: FC = () => {
 		workspace,
 		currentUser.id,
 	);
+	const areChatGoalsEnabled = experiments.includes("chat-goals");
 	const desktopEnabled = experiments.includes("chat-virtual-desktop");
 	const debugLoggingEnabled = Boolean(
 		userDebugLoggingQuery.data?.debug_logging_enabled,
@@ -414,6 +426,17 @@ const AgentChatPage: FC = () => {
 		},
 	});
 
+	const updateChatGoalBase = updateChatGoal(queryClient);
+	const {
+		isPending: isUpdateChatGoalPending,
+		mutateAsync: updateChatGoalAsync,
+	} = useMutation({
+		...updateChatGoalBase,
+		onError: (error) => {
+			toast.error(getErrorMessage(error, "Failed to update goal."));
+		},
+	});
+
 	const updateChatPlanModeBase = updateChatPlanMode(queryClient);
 	const {
 		isPending: isUpdateChatPlanModePending,
@@ -444,7 +467,7 @@ const AgentChatPage: FC = () => {
 	const trackPendingChatSettingSync = (
 		syncPromise: Promise<unknown>,
 		syncRef: { current: Promise<unknown> | null },
-	) => {
+	): Promise<unknown> => {
 		const trackedSync: Promise<unknown> = syncPromise.finally(() => {
 			if (syncRef.current === trackedSync) {
 				syncRef.current = null;
@@ -452,6 +475,7 @@ const AgentChatPage: FC = () => {
 		});
 		syncRef.current = trackedSync;
 		void trackedSync.catch(() => undefined);
+		return trackedSync;
 	};
 
 	const aiGatewayDisabled = !useAIGatewayEnabled();
@@ -589,7 +613,9 @@ const AgentChatPage: FC = () => {
 		isCompactPending ||
 		isClearPending;
 	const isChatSettingsPending =
-		isUpdateChatPlanModePending || isUpdateChatWorkspacePending;
+		isUpdateChatPlanModePending ||
+		isUpdateChatWorkspacePending ||
+		isUpdateChatGoalPending;
 	const isInputDisabled =
 		!hasModelOptions ||
 		isArchived ||
@@ -597,6 +623,22 @@ const AgentChatPage: FC = () => {
 		isViewerNotOwner ||
 		aiGatewayDisabled;
 	const canUpdateChatWorkspace = !isArchived && !isViewerNotOwner;
+	const canMutateGoal = areChatGoalsEnabled && isRootChat && !isViewerNotOwner;
+	const isGoalActionDisabled =
+		isArchived || isViewerNotOwner || aiGatewayDisabled;
+	const isChatWorking = isChatBusyStatus(liveChatStatus);
+	const hasQueuedInput = (chatQueuedMessages?.length ?? 0) > 0;
+	// Setting a goal is message-bound; a busy chat would queue the
+	// message and the server rejects queued goal mutations.
+	const canSetGoalNow = !isChatWorking && !hasQueuedInput;
+	const goalActionUnavailableReasons = {
+		resume: chatGoalActionUnavailableReason("resume", {
+			chatStatus: liveChatStatus,
+			hasQueuedInput,
+			planModeEnabled,
+			hasModelOptions,
+		}),
+	};
 	const selectedWorkspaceId = chatQuery.data?.workspace_id ?? null;
 
 	const isWorkspaceLoading =
@@ -605,13 +647,45 @@ const AgentChatPage: FC = () => {
 		if (enabled === planModeEnabled) {
 			return;
 		}
-		trackPendingChatSettingSync(
+		return trackPendingChatSettingSync(
 			updateChatPlanModeAsync({
 				chatId: agentId,
 				planMode: enabled ? "plan" : undefined,
 			}),
 			pendingPlanModeSyncRef,
 		);
+	};
+
+	const handleGoalAction = async (
+		action: ChatGoalAction,
+		completionSummary?: string,
+	) => {
+		if (!canMutateGoal) {
+			toast.warning("Goals can only be changed from the root chat.");
+			return;
+		}
+		await runGoalAction({
+			agentId,
+			goal: chatQuery.data?.goal,
+			action,
+			completionSummary,
+			updateGoal: updateChatGoalAsync,
+			liveChatStatus,
+			hasQueuedInput,
+			planModeEnabled,
+			hasModelOptions,
+			onMissingGoal: () => {
+				toast.info("No current goal.");
+			},
+			onActionUnavailable: (reason) => {
+				toast.info(reason);
+			},
+			onPausedRunningGoal: () => {
+				toast.info(
+					"Goal paused. The current turn keeps running; Stop halts it.",
+				);
+			},
+		}).catch(() => undefined);
 	};
 
 	const handleRequestError = (error: unknown): void => {
@@ -791,12 +865,14 @@ const AgentChatPage: FC = () => {
 		editedMessageID,
 		useComposerContent = true,
 		planModeSwitch,
+		goalMutation,
 	}: {
 		message: string;
 		attachments?: readonly PendingAttachment[];
 		editedMessageID?: number;
 		useComposerContent?: boolean;
 		planModeSwitch?: PlanModeSwitch;
+		goalMutation?: TypesGen.ChatGoalSetRequest;
 	}) {
 		const { content, hasContent } = buildChatInputContent({
 			message,
@@ -813,10 +889,13 @@ const AgentChatPage: FC = () => {
 			pendingWorkspaceSyncRef.current,
 		]);
 
-		// Built-ins only intercept new, text-only sends. A personal or workspace
-		// skill with the same name takes precedence.
+		// Built-ins only intercept new, text-only sends without a goal
+		// mutation; a goal objective that matches a command name is still
+		// a goal. A personal or workspace skill with the same name takes
+		// precedence.
 		const builtInCommand =
 			editedMessageID === undefined &&
+			goalMutation === undefined &&
 			content.length === 1 &&
 			content[0].type === "text"
 				? CHAT_SLASH_COMMANDS.find(
@@ -945,6 +1024,7 @@ const AgentChatPage: FC = () => {
 			content,
 			model_config_id: selectedModelConfigID,
 			reasoning_effort: effectiveReasoningEffort,
+			goal_mutation: goalMutation,
 			mcp_server_ids: [...effectiveMCPServerIds],
 			...(planModeSwitch !== undefined
 				? {
@@ -1039,6 +1119,9 @@ const AgentChatPage: FC = () => {
 				}
 			}
 		}
+		if ("goal" in response) {
+			setCachedChatGoal(queryClient, agentId, response.goal);
+		}
 		if (selectedModelConfigID) {
 			localStorage.setItem(lastModelConfigIDStorageKey, selectedModelConfigID);
 		} else {
@@ -1056,11 +1139,16 @@ const AgentChatPage: FC = () => {
 		message: string,
 		attachments?: readonly PendingAttachment[],
 		editedMessageID?: number,
+		options?: AgentChatInputSendOptions,
 	) {
 		await submitChatTurn({
 			message,
 			attachments,
 			editedMessageID,
+			goalMutation:
+				editedMessageID === undefined && canMutateGoal && !isGoalActionDisabled
+					? options?.goalMutation
+					: undefined,
 		});
 	}
 
@@ -1172,6 +1260,15 @@ const AgentChatPage: FC = () => {
 					gitWatcher={gitWatcher}
 					sshCommand={sshCommand}
 					handleCommit={handleCommit}
+					goal={areChatGoalsEnabled ? chatQuery.data?.goal : undefined}
+					showPursueGoal={areChatGoalsEnabled && isRootChat}
+					canMutateGoal={canMutateGoal}
+					isGoalActionPending={isUpdateChatGoalPending}
+					isGoalActionDisabled={isGoalActionDisabled}
+					isChatWorking={isChatWorking}
+					canSetGoalNow={canSetGoalNow}
+					goalActionUnavailableReasons={goalActionUnavailableReasons}
+					onGoalAction={handleGoalAction}
 					handleInterrupt={handleInterrupt}
 					handleDeleteQueuedMessage={handleDeleteQueuedMessage}
 					handlePromoteQueuedMessage={handlePromoteQueuedMessage}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
+import { type ChatGoalAction, currentChatGoal } from "#/api/queries/chatGoal";
 import { invalidateChatDiffContents } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatMessagePart } from "#/api/typesGenerated";
@@ -27,6 +28,7 @@ import { generateConnectionSessionId, generateUUID } from "#/utils/random";
 import { findWorkspaceAgent } from "#/utils/workspace";
 import {
 	AgentChatInput,
+	type AgentChatInputSendOptions,
 	type ChatMessageInputRef,
 } from "./components/AgentChatInput";
 import {
@@ -42,6 +44,7 @@ import {
 
 import { QueuedForCapacityCallout } from "./components/ChatConversation/QueuedForCapacityCallout";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
+import { ChatGoalBanner } from "./components/ChatGoalBanner";
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { ChatPageInput, ChatPageTimeline } from "./components/ChatPageContent";
 import { ChatSharingPopoverContent } from "./components/ChatSharingPopover";
@@ -95,7 +98,8 @@ interface EditingState {
 	handleSendFromInput: (
 		message: string,
 		attachments?: readonly PendingAttachment[],
-	) => void;
+		options?: AgentChatInputSendOptions,
+	) => Promise<void>;
 	handleContentChange: (
 		content: string,
 		serializedEditorState: string,
@@ -136,7 +140,7 @@ interface AgentChatPageViewProps {
 	aiGatewayDisabled?: boolean;
 	hasModelOptions: boolean;
 	isModelCatalogLoading?: boolean;
-	onPlanModeToggle?: (enabled: boolean) => void;
+	onPlanModeToggle?: (enabled: boolean) => unknown;
 	isInputDisabled: boolean;
 	isSubmissionPending: boolean;
 	isInterruptPending: boolean;
@@ -162,6 +166,16 @@ interface AgentChatPageViewProps {
 	// Workspace action handlers.
 	sshCommand: string | undefined;
 	handleCommit: (repoRoot: string) => void;
+
+	goal?: TypesGen.ChatGoal;
+	showPursueGoal?: boolean;
+	canMutateGoal?: boolean;
+	isGoalActionPending?: boolean;
+	isGoalActionDisabled?: boolean;
+	isChatWorking?: boolean;
+	canSetGoalNow?: boolean;
+	goalActionUnavailableReasons?: Partial<Record<ChatGoalAction, string>>;
+	onGoalAction?: (action: ChatGoalAction) => Promise<void> | void;
 
 	// Chat action handlers.
 	handleInterrupt: () => void;
@@ -314,6 +328,15 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	gitWatcher,
 	sshCommand,
 	handleCommit,
+	goal,
+	showPursueGoal = false,
+	canMutateGoal = false,
+	isGoalActionPending = false,
+	isGoalActionDisabled = false,
+	isChatWorking = false,
+	canSetGoalNow = true,
+	goalActionUnavailableReasons,
+	onGoalAction = () => {},
 	handleInterrupt,
 	handleDeleteQueuedMessage,
 	handlePromoteQueuedMessage,
@@ -781,6 +804,14 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const chatOwnerWarning = isOtherUserReadOnly
 		? `This chat is owned by ${chatOwnerLabel}. It is read-only.`
 		: undefined;
+	const topGoal = currentChatGoal(goal);
+	// The backend refuses edits that would rewrite or truncate away the
+	// goal's source message while the goal can still run; hide the
+	// affordance instead of surfacing a 409.
+	const goalSourceMessageId =
+		topGoal && topGoal.status !== "complete"
+			? topGoal.created_from_message_id
+			: undefined;
 
 	const hasLicense = entitlements.has_license;
 	const canManageLicenses = permissions.viewAllLicenses;
@@ -865,6 +896,19 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										This agent has been archived and is read-only.
 									</div>
 								)}
+								{topGoal && (
+									<div className="shrink-0 px-4 pt-3">
+										<ChatGoalBanner
+											goal={topGoal}
+											canMutateGoal={canMutateGoal}
+											isActionPending={isGoalActionPending}
+											isActionDisabled={isGoalActionDisabled}
+											isChatWorking={isChatWorking}
+											actionUnavailableReasons={goalActionUnavailableReasons}
+											onAction={onGoalAction}
+										/>
+									</div>
+								)}
 								<div
 									aria-hidden
 									className="pointer-events-none absolute inset-x-0 top-full z-10 h-3 sm:h-6 bg-surface-primary"
@@ -893,6 +937,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										: editing.handleEditUserMessage
 								}
 								editingMessageId={editing.editingMessageId}
+								goalSourceMessageId={goalSourceMessageId}
 								urlTransform={urlTransform}
 								mcpServers={mcpServers}
 								onImplementPlan={
@@ -939,6 +984,10 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									reasoningEffort={reasoningEffort}
 									onReasoningEffortChange={onReasoningEffortChange}
 									onPlanModeToggle={onPlanModeToggle}
+									showPursueGoal={showPursueGoal}
+									canPursueGoal={
+										canMutateGoal && !isGoalActionDisabled && canSetGoalNow
+									}
 									isModelCatalogLoading={isModelCatalogLoading}
 									workspaceOptions={workspaceOptions}
 									onWorkspaceChange={onWorkspaceChange}
@@ -1019,7 +1068,7 @@ interface AgentChatPageLoadingViewProps {
 	hasModelOptions: boolean;
 	isModelCatalogLoading?: boolean;
 	planModeEnabled?: boolean;
-	onPlanModeToggle?: (enabled: boolean) => void;
+	onPlanModeToggle?: (enabled: boolean) => unknown;
 	showRightPanel: boolean;
 }
 
@@ -1084,6 +1133,7 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 						planModeEnabled={planModeEnabled}
 						onPlanModeToggle={onPlanModeToggle}
 						isModelCatalogLoading={isModelCatalogLoading}
+						canPursueGoal={false}
 						hasModelOptions={hasModelOptions}
 						canConfigureAgentSetup={false}
 					/>

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -9,6 +9,7 @@ import type * as TypesGen from "#/api/typesGenerated";
 import { useWebpushNotifications } from "#/contexts/useWebpushNotifications";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { useAIGatewayEnabled } from "#/hooks/useEmbeddedMetadata";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import {
 	AgentCreateForm,
 	type CreateChatOptions,
@@ -26,6 +27,7 @@ const AgentCreatePage: FC = () => {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const { permissions } = useAuthenticated();
+	const { experiments } = useDashboard();
 	const aiGatewayDisabled = !useAIGatewayEnabled();
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const createMutation = useMutation(createChat(queryClient));
@@ -40,6 +42,7 @@ const AgentCreatePage: FC = () => {
 		reasoningEffort,
 		mcpServerIds,
 		organizationId,
+		goalMutation,
 		planMode,
 	}: CreateChatOptions) => {
 		const content: TypesGen.ChatInputPart[] = [];
@@ -57,6 +60,7 @@ const AgentCreatePage: FC = () => {
 			workspace_id: workspaceId,
 			mcp_server_ids:
 				mcpServerIds && mcpServerIds.length > 0 ? mcpServerIds : undefined,
+			goal_mutation: goalMutation,
 			plan_mode: planMode === "plan" ? "plan" : undefined,
 			client_type: "ui",
 			...(model ? { model_config_id: model } : {}),
@@ -110,6 +114,7 @@ const AgentCreatePage: FC = () => {
 				canCreateChat={permissions.createChat}
 				canConfigureAgentSetup={permissions.editDeploymentConfig}
 				aiGatewayDisabled={aiGatewayDisabled}
+				showPursueGoal={experiments.includes("chat-goals")}
 				workspaceCount={workspacesQuery.data?.count}
 				workspaceOptions={workspacesQuery.data?.workspaces ?? []}
 				workspacesError={workspacesQuery.error}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MonitorDotIcon } from "lucide-react";
-import { useEffect, useRef } from "react";
+import type { ComponentProps, FC } from "react";
+import { useEffect, useRef, useState } from "react";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
 import { preferenceSettingsKey } from "#/api/queries/users";
@@ -224,8 +225,139 @@ export const SendsAndClearsInput: Story = {
 		await userEvent.click(sendButton);
 
 		await waitFor(() => {
-			expect(args.onSend).toHaveBeenCalledWith("Run focused tests");
+			expect(args.onSend).toHaveBeenCalledWith("Run focused tests", undefined);
 		});
+	},
+};
+
+export const PursueGoalModeSendsGoalMutation: Story = {
+	args: {
+		onSend: fn().mockResolvedValue(undefined),
+		initialValue: "  stabilize the release  ",
+		onPlanModeToggle: fn(),
+		showPursueGoal: true,
+		canPursueGoal: true,
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		await userEvent.click(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Pursue goal",
+			}),
+		);
+
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		expect(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Pursue goal",
+			}),
+		).toHaveAttribute("aria-checked", "true");
+		expect(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Plan first",
+			}),
+		).toHaveAttribute("aria-disabled", "true");
+		await userEvent.keyboard("{Escape}");
+
+		await waitFor(() => {
+			expect(canvas.getByRole("button", { name: "Send" })).toBeEnabled();
+		});
+		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
+
+		await waitFor(() => {
+			expect(args.onSend).toHaveBeenCalledWith("stabilize the release", {
+				goalMutation: {
+					action: "set",
+					objective: "stabilize the release",
+				},
+			});
+		});
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		expect(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Pursue goal",
+			}),
+		).toHaveAttribute("aria-checked", "false");
+	},
+};
+
+export const PursueGoalDisabledWhileChatBusy: Story = {
+	args: {
+		onPlanModeToggle: fn(),
+		showPursueGoal: true,
+		// The page passes canPursueGoal={false} while the chat is busy
+		// because a goal set sent with a queued message is rejected.
+		canPursueGoal: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		const pursueGoal = within(document.body).getByRole("menuitemcheckbox", {
+			name: "Pursue goal",
+		});
+		expect(pursueGoal).toHaveAttribute("aria-disabled", "true");
+		// The unavailable item stays focusable but clicking it must not
+		// toggle goal mode.
+		pursueGoal.focus();
+		expect(pursueGoal).toHaveFocus();
+		await userEvent.click(pursueGoal);
+		expect(pursueGoal).toHaveAttribute("aria-checked", "false");
+	},
+};
+
+const GoalAvailabilityHarness: FC<ComponentProps<typeof AgentChatInput>> = (
+	props,
+) => {
+	const [canPursueGoal, setCanPursueGoal] = useState(true);
+	return (
+		<>
+			<button type="button" onClick={() => setCanPursueGoal((can) => !can)}>
+				Toggle goal availability
+			</button>
+			<AgentChatInput {...props} canPursueGoal={canPursueGoal} />
+		</>
+	);
+};
+
+export const GoalModeClearsWhenUnavailable: Story = {
+	args: {
+		onPlanModeToggle: fn(),
+		showPursueGoal: true,
+		canPursueGoal: true,
+	},
+	render: (args) => <GoalAvailabilityHarness {...args} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		await userEvent.click(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Pursue goal",
+			}),
+		);
+		await waitFor(() => {
+			expect(canvas.getByText("Pursuing goal")).toBeInTheDocument();
+		});
+
+		// Availability loss (for example the chat turns busy) clears the mode.
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Toggle goal availability" }),
+		);
+		await waitFor(() => {
+			expect(canvas.queryByText("Pursuing goal")).not.toBeInTheDocument();
+		});
+
+		// Availability returning must not silently reactivate the mode.
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Toggle goal availability" }),
+		);
+		expect(canvas.queryByText("Pursuing goal")).not.toBeInTheDocument();
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		expect(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Pursue goal",
+			}),
+		).toHaveAttribute("aria-checked", "false");
 	},
 };
 
@@ -245,7 +377,7 @@ export const EnterSendsByDefault: Story = {
 		await userEvent.keyboard("{Enter}");
 
 		await waitFor(() => {
-			expect(args.onSend).toHaveBeenCalledWith("Run focused tests");
+			expect(args.onSend).toHaveBeenCalledWith("Run focused tests", undefined);
 		});
 	},
 };
@@ -282,7 +414,7 @@ export const ModifierEnterSendsWhenRequired: Story = {
 
 		await userEvent.keyboard("{Control>}{Enter}{/Control}");
 		await waitFor(() => {
-			expect(args.onSend).toHaveBeenCalledWith("Run focused tests");
+			expect(args.onSend).toHaveBeenCalledWith("Run focused tests", undefined);
 		});
 	},
 };
@@ -610,6 +742,38 @@ export const AttachmentsOnly: Story = {
 			initialValue: "",
 		};
 	})(),
+};
+
+export const AttachmentsOnlyPursueGoalBlocksSend: Story = {
+	args: (() => {
+		const file = createMockFile("photo.png", "image/png");
+		return {
+			attachments: [file],
+			uploadStates: new Map<File, UploadState>([
+				[file, { status: "uploaded", fileId: "f-only" }],
+			]),
+			previewUrls: new Map<File, string>([[file, TINY_PNG]]),
+			onAttach: fn(),
+			onRemoveAttachment: fn(),
+			onSend: fn(),
+			initialValue: "",
+			showPursueGoal: true,
+			canPursueGoal: true,
+		};
+	})(),
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+		await userEvent.click(
+			within(document.body).getByRole("menuitemcheckbox", {
+				name: "Pursue goal",
+			}),
+		);
+
+		const sendButton = canvas.getByRole("button", { name: "Send" });
+		expect(sendButton).toBeDisabled();
+		expect(args.onSend).not.toHaveBeenCalled();
+	},
 };
 
 const LARGE_PASTE_MARKER = "__PASTE_MARKER_TEST__";

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -4,6 +4,7 @@ import {
 	ArrowUpIcon,
 	CheckIcon,
 	ChevronRightIcon,
+	type LucideIcon,
 	MicIcon,
 	MonitorIcon,
 	PaperclipIcon,
@@ -11,6 +12,7 @@ import {
 	PlusIcon,
 	ServerIcon,
 	SquareIcon,
+	TargetIcon,
 	UnlinkIcon,
 	XIcon,
 } from "lucide-react";
@@ -101,8 +103,15 @@ export {
 export type { ChatMessageInputRef } from "./ChatMessageInput/ChatMessageInput";
 export type { AgentContextUsage } from "./ContextUsageIndicator";
 
+export type AgentChatInputSendOptions = {
+	goalMutation?: TypesGen.ChatGoalSetRequest;
+};
+
 interface AgentChatInputProps {
-	onSend: (message: string) => void;
+	onSend: (
+		message: string,
+		options?: AgentChatInputSendOptions,
+	) => Promise<void> | void;
 	placeholder?: string;
 	isDisabled: boolean;
 	isLoading: boolean;
@@ -130,7 +139,9 @@ interface AgentChatInputProps {
 	reasoningEffort?: string;
 	onReasoningEffortChange?: (value: string) => void;
 	planModeEnabled?: boolean;
-	onPlanModeToggle?: (enabled: boolean) => void;
+	onPlanModeToggle?: (enabled: boolean) => unknown;
+	showPursueGoal?: boolean;
+	canPursueGoal?: boolean;
 	isModelCatalogLoading?: boolean;
 	// Streaming controls (optional, for the detail page).
 	isStreaming?: boolean;
@@ -358,6 +369,30 @@ const ToolBadge: FC<{
 	);
 };
 
+const MenuCheckboxItem: FC<{
+	icon: LucideIcon;
+	label: string;
+	checked: boolean;
+	disabled: boolean;
+	onClick: () => void;
+}> = ({ icon: Icon, label, checked, disabled, onClick }) => (
+	// An unavailable item stays focusable with aria-disabled so keyboard
+	// and screen-reader users can still discover it; a hard-disabled
+	// button cannot be focused.
+	<button
+		type="button"
+		role="menuitemcheckbox"
+		aria-checked={checked}
+		aria-disabled={disabled || undefined}
+		onClick={disabled ? undefined : onClick}
+		className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:text-content-secondary"
+	>
+		<Icon className="size-3.5 shrink-0" />
+		<span>{label}</span>
+		{checked && <CheckIcon className="ml-auto size-icon-sm shrink-0" />}
+	</button>
+);
+
 export const AgentChatInput: FC<AgentChatInputProps> = ({
 	onSend,
 	placeholder = "Type a message...",
@@ -377,6 +412,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	onReasoningEffortChange,
 	planModeEnabled = false,
 	onPlanModeToggle,
+	showPursueGoal = false,
+	canPursueGoal = false,
 	isModelCatalogLoading = false,
 	isStreaming = false,
 	onInterrupt,
@@ -470,6 +507,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const mcpDisconnectMutation = useMutation(
 		disconnectMCPServerOAuth2(queryClient),
 	);
+	const [pursueGoalEnabled, setPursueGoalEnabled] = useState(false);
 
 	const [hasFileReferences, setHasFileReferences] = useState(false);
 	const [cycleIndex, setCycleIndex] = useState<number | null>(null);
@@ -639,12 +677,43 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleRemoveMcp = (serverId: string) =>
 		handleMcpToggle(serverId, false);
 
+	const isGoalModeUnavailable =
+		!showPursueGoal || !canPursueGoal || isEditingHistoryMessage;
+	// Availability loss clears the stored selection during render so goal
+	// mode cannot silently reactivate once availability returns.
+	if (pursueGoalEnabled && isGoalModeUnavailable) {
+		setPursueGoalEnabled(false);
+	}
+	const isPursueGoalActive = pursueGoalEnabled && !isGoalModeUnavailable;
+
 	const handlePlanModeToggle = () => {
-		onPlanModeToggle?.(!planModeEnabled);
+		const nextEnabled = !planModeEnabled;
+		if (nextEnabled) {
+			setPursueGoalEnabled(false);
+		}
+		onPlanModeToggle?.(nextEnabled);
+		setPlusMenuOpen(false);
+	};
+
+	const handleGoalModeToggle = () => {
+		if (isDisabled || isGoalModeUnavailable) {
+			return;
+		}
+		const nextEnabled = !pursueGoalEnabled;
+		setPursueGoalEnabled(nextEnabled);
+		if (nextEnabled && planModeEnabled) {
+			// Persistent plan mode deterministically rejects a goal-bound
+			// send, so when the requested disable fails, clear goal mode
+			// instead of presenting both modes together.
+			void Promise.resolve(onPlanModeToggle?.(false)).catch(() =>
+				setPursueGoalEnabled(false),
+			);
+		}
 		setPlusMenuOpen(false);
 	};
 
 	const handleDisablePlanMode = () => onPlanModeToggle?.(false);
+	const handleDisableGoalMode = () => setPursueGoalEnabled(false);
 
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const [composerElement, setComposerElement] = useState<HTMLDivElement | null>(
@@ -903,15 +972,16 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const hasDraftContext =
 		hasContent || attachments.length > 0 || hasFileReferences;
 	const isComposerEffectivelyEmpty = !hasDraftContext;
-	const hasSendableContent =
-		hasContent || hasUploadedAttachments || hasFileReferences;
+	const hasSendableContent = isPursueGoalActive
+		? hasContent
+		: hasContent || hasUploadedAttachments || hasFileReferences;
 	const canSend =
 		!isDisabled &&
 		!isLoading &&
 		hasModelOptions &&
 		hasSendableContent &&
 		!hasActiveUploads;
-	const handleSubmit = () => {
+	const handleSubmit = async () => {
 		const text = internalRef.current?.getValue()?.trim() ?? "";
 
 		// If the input is empty and there are queued messages,
@@ -940,7 +1010,22 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			return;
 		}
 
-		onSend(text);
+		if (isPursueGoalActive && !text) {
+			return;
+		}
+
+		const sendOptions: AgentChatInputSendOptions | undefined =
+			isPursueGoalActive
+				? { goalMutation: { action: "set", objective: text } }
+				: undefined;
+		try {
+			await onSend(text, sendOptions);
+		} catch {
+			return;
+		}
+		if (pursueGoalEnabled) {
+			setPursueGoalEnabled(false);
+		}
 		resetPromptCycle();
 		if (!isMobileViewport()) {
 			internalRef.current?.focus();
@@ -1171,7 +1256,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 					remountKey={remountKey}
 					onChange={handleContentChange}
 					onKeyDown={handleEditorKeyDown}
-					onEnter={handleSubmit}
+					onEnter={() => {
+						void handleSubmit();
+					}}
 					sendShortcut={sendShortcut}
 					disabled={isDisabled || isLoading}
 					hasWorkspace={hasSkillsWorkspace}
@@ -1283,20 +1370,22 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											</button>
 										)}
 										{onPlanModeToggle && (
-											<button
-												type="button"
-												role="menuitemcheckbox"
-												aria-checked={planModeEnabled}
+											<MenuCheckboxItem
+												icon={PencilIcon}
+												label="Plan first"
+												checked={planModeEnabled}
+												disabled={isDisabled || isPursueGoalActive}
 												onClick={handlePlanModeToggle}
-												disabled={isDisabled}
-												className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
-											>
-												<PencilIcon className="size-3.5 shrink-0" />
-												<span>Plan first</span>
-												{planModeEnabled && (
-													<CheckIcon className="ml-auto size-icon-sm shrink-0" />
-												)}
-											</button>
+											/>
+										)}
+										{showPursueGoal && (
+											<MenuCheckboxItem
+												icon={TargetIcon}
+												label="Pursue goal"
+												checked={isPursueGoalActive}
+												disabled={isDisabled || isGoalModeUnavailable}
+												onClick={handleGoalModeToggle}
+											/>
 										)}
 										{workspaceOptions &&
 											onWorkspaceChange &&
@@ -1464,6 +1553,17 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 										isDisabled={isDisabled}
 									/>
 								)}
+							</span>
+						)}
+						{isPursueGoalActive && (
+							<span className="hidden shrink-0 items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-xs font-medium text-content-secondary sm:inline-flex">
+								<TargetIcon className="size-3" />
+								Pursuing goal
+								<BadgeDismissButton
+									onClick={handleDisableGoalMode}
+									ariaLabel="Disable goal mode"
+									isDisabled={isDisabled}
+								/>
 							</span>
 						)}
 						{/* Badges and the +N pill stay mounted for measurement:
@@ -1690,7 +1790,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 										variant="default"
 										className="size-7 rounded-full transition-colors [&>svg]:size-5! [&>svg]:p-0"
 										onClick={
-											speech.isRecording ? handleAcceptRecording : handleSubmit
+											speech.isRecording
+												? handleAcceptRecording
+												: () => {
+														void handleSubmit();
+													}
 										}
 										disabled={speech.isRecording ? false : !canSend}
 										aria-keyshortcuts={sendButtonKeyShortcuts}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -366,8 +366,57 @@ const getCreateOptions = (onCreateChat: unknown): CreateChatSubmission => {
 };
 
 type CreateChatSubmission = {
+	message: string;
 	model?: string;
 	reasoningEffort?: string;
+	goalMutation?: TypesGen.ChatGoalSetRequest;
+};
+
+const enablePursueGoal = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	await userEvent.click(canvas.getByRole("button", { name: "More options" }));
+	await userEvent.click(
+		screen.getByRole("menuitemcheckbox", { name: "Pursue goal" }),
+	);
+};
+
+export const PursueGoalCreatesGoal: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+		showPursueGoal: true,
+	},
+	play: async ({ canvasElement, args }) => {
+		await enablePursueGoal(canvasElement);
+		await submitMessage(canvasElement, "fix the flaky tests");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		expect(getCreateOptions(args.onCreateChat)).toMatchObject({
+			message: "fix the flaky tests",
+			goalMutation: {
+				action: "set",
+				objective: "fix the flaky tests",
+			},
+		});
+	},
+};
+
+export const SlashGoalSubmitsAsNormalText: Story = {
+	args: {
+		...defaultArgs,
+		onCreateChat: fn().mockResolvedValue(undefined),
+	},
+	play: async ({ canvasElement, args }) => {
+		await submitMessage(canvasElement, "/goal fix the flaky tests");
+		await waitFor(() => {
+			expect(args.onCreateChat).toHaveBeenCalled();
+		});
+		expect(getCreateOptions(args.onCreateChat)).toMatchObject({
+			message: "/goal fix the flaky tests",
+			goalMutation: undefined,
+		});
+	},
 };
 
 export const RootPersonalModelOverrideModelSelected: Story = {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -30,7 +30,10 @@ import {
 	pickReasoningEffort,
 	saveReasoningEffortForModel,
 } from "../utils/reasoningEffort";
-import { AgentChatInput } from "./AgentChatInput";
+import {
+	AgentChatInput,
+	type AgentChatInputSendOptions,
+} from "./AgentChatInput";
 import { ChatAccessDeniedAlert } from "./ChatAccessDeniedAlert";
 import {
 	isChatHookDeniedResponse,
@@ -61,6 +64,7 @@ export type CreateChatOptions = {
 	reasoningEffort?: string;
 	mcpServerIds?: string[];
 	organizationId: string;
+	goalMutation?: TypesGen.ChatGoalSetRequest;
 	planMode?: TypesGen.ChatPlanMode;
 };
 
@@ -136,6 +140,7 @@ interface AgentCreateFormProps {
 	canCreateChat: boolean;
 	canConfigureAgentSetup: boolean;
 	aiGatewayDisabled?: boolean;
+	showPursueGoal?: boolean;
 	workspaceCount: number | undefined;
 	workspaceOptions: readonly TypesGen.Workspace[];
 	workspacesError: unknown;
@@ -149,6 +154,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	canCreateChat,
 	canConfigureAgentSetup,
 	aiGatewayDisabled,
+	showPursueGoal = false,
 	workspaceCount: _workspaceCount,
 	workspaceOptions,
 	workspacesError,
@@ -514,7 +520,11 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		saveReasoningEffortForModel(selectedModel, value);
 	};
 
-	const handleSend = async (message: string, fileIDs?: string[]) => {
+	const handleSend = async (
+		message: string,
+		fileIDs?: string[],
+		options?: AgentChatInputSendOptions,
+	) => {
 		submitDraft();
 		await onCreateChat({
 			message,
@@ -523,6 +533,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			model: submittedModel,
 			reasoningEffort: effectiveReasoningEffort,
 			organizationId,
+			goalMutation: options?.goalMutation,
 			mcpServerIds:
 				effectiveMCPServerIds.length > 0
 					? [...effectiveMCPServerIds]
@@ -534,7 +545,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		});
 	};
 
-	const handleSendWithAttachments = async (message: string) => {
+	const handleSendWithAttachments = async (
+		message: string,
+		options?: AgentChatInputSendOptions,
+	) => {
 		const fileIds: string[] = [];
 		let skippedErrors = 0;
 		for (const file of attachments) {
@@ -553,12 +567,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			);
 		}
 		const fileArg = fileIds.length > 0 ? fileIds : undefined;
-		try {
-			await handleSend(message, fileArg);
-			resetAttachments();
-		} catch {
-			// Attachments preserved for retry on failure.
-		}
+		await handleSend(message, fileArg, options);
+		resetAttachments();
 	};
 
 	return (
@@ -659,6 +669,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						isModelCatalogLoading={isModelDataPending}
 						hasModelOptions={hasModelOptions}
 						planModeEnabled={planModeEnabled}
+						showPursueGoal={showPursueGoal}
+						canPursueGoal={showPursueGoal}
 						onPlanModeToggle={setPlanModeEnabled}
 						attachments={attachments}
 						// Files attached before org adoption cannot upload and would be discarded

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -251,17 +251,20 @@ const buildUserMessage = ({
 	text,
 	files = [],
 	createdAt = baseMessage.created_at,
+	sentAsGoal = false,
 }: {
 	id?: number;
 	text?: string;
 	files?: TypesGen.ChatFilePart[];
 	createdAt?: string;
+	sentAsGoal?: boolean;
 }): TypesGen.ChatMessage => ({
 	...baseMessage,
 	created_at: createdAt,
 	id,
 	role: "user",
 	content: [...(text ? [buildTextPart(text)] : []), ...files],
+	...(sentAsGoal ? { sent_as_goal: true } : {}),
 });
 
 const buildStoryArgs = (...messages: TypesGen.ChatMessage[]) => ({
@@ -862,6 +865,37 @@ export const UserMessageBubbleAlignment: Story = {
 	},
 };
 
+/**
+ * The goal's source message and everything before it must not offer
+ * editing, because such an edit would rewrite or truncate the source.
+ */
+export const GoalSourceMessageEditHidden: Story = {
+	args: {
+		...buildStoryArgs(
+			buildUserMessage({ id: 1, text: "Some earlier request" }),
+			buildUserMessage({ id: 3, text: "Ship the release", sentAsGoal: true }),
+			buildUserMessage({ id: 5, text: "Also update the changelog" }),
+		),
+		onEditUserMessage: fn(),
+		goalSourceMessageId: 3,
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Only the message after the goal's source may be edited, so exactly
+		// one edit affordance renders and it targets that message.
+		const editButtons = await canvas.findAllByRole("button", {
+			name: "Edit message",
+		});
+		expect(editButtons).toHaveLength(1);
+		await userEvent.click(editButtons[0]);
+		expect(args.onEditUserMessage).toHaveBeenCalledWith(
+			5,
+			"Also update the changelog",
+			undefined,
+		);
+	},
+};
+
 /** Regression guard: a single image attachment must not be duplicated. */
 export const UserMessageWithSingleImage: Story = {
 	args: {
@@ -1457,6 +1491,29 @@ export const UserMessageTextOnly: Story = {
 		const images = canvas.queryAllByRole("img", { name: "Attached image" });
 		expect(images).toHaveLength(0);
 		expect(canvas.getByText("Just a plain text message")).toBeInTheDocument();
+	},
+};
+
+/** Goal-sent user messages show a durable transcript marker. */
+export const UserMessageSentAsGoalMarker: Story = {
+	args: buildStoryArgs(
+		buildUserMessage({
+			id: 1,
+			text: "Use this screenshot as the goal",
+			files: [buildInlineAttachmentPart("image/png", TEST_PNG_B64)],
+			sentAsGoal: true,
+		}),
+		{
+			...baseMessage,
+			id: 2,
+			role: "assistant",
+			content: [{ type: "text", text: "I will pursue that goal." }],
+		},
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Sent as goal")).toBeVisible();
+		expect(canvas.getAllByText("Sent as goal")).toHaveLength(1);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -8,6 +8,7 @@ import {
 	ChevronRightIcon,
 	InfoIcon,
 	PencilIcon,
+	TargetIcon,
 } from "lucide-react";
 import { type FC, memo, type ReactNode, useState } from "react";
 import type { UrlTransform } from "streamdown";
@@ -76,6 +77,13 @@ const TimelineNotice: FC<{ children?: ReactNode }> = ({ children }) => (
 			<InfoIcon className="size-icon-sm mt-[3px] text-highlight-sky" />
 			<div className="min-w-0 flex-1">{children}</div>
 		</div>
+	</div>
+);
+
+const SentAsGoalMarker: FC = () => (
+	<div className="flex h-6 items-center gap-1 px-1 text-xs font-medium text-content-secondary">
+		<TargetIcon className="size-3 shrink-0" aria-hidden />
+		<span>Sent as goal</span>
 	</div>
 );
 
@@ -181,6 +189,19 @@ const ChatMessageItem = memo<{
 						isAwaitingFirstStreamChunk,
 					})
 				: undefined;
+		const hasUserMessageJumpControls = Boolean(
+			isUser &&
+				onJumpToUserMessage &&
+				(prevUserMessageKey !== undefined || nextUserMessageKey !== undefined),
+		);
+		const hasMessageControls = Boolean(
+			displayState?.hasCopyableContent ||
+				(isUser && messageId !== undefined && onEditUserMessage) ||
+				hasUserMessageJumpControls,
+		);
+		const showsSentAsGoalMarker = isUser && message?.sent_as_goal === true;
+		const showsMessageActionRow =
+			!hideActions && (hasMessageControls || showsSentAsGoalMarker);
 		if (displayState?.shouldHide) {
 			return null;
 		}
@@ -277,103 +298,105 @@ const ChatMessageItem = memo<{
 						{notice}
 					</LifecycleHookNotice>
 				))}
-				{displayState &&
-					!hideActions &&
-					(displayState.hasCopyableContent ||
-						(isUser && onEditUserMessage)) && (
-						<div
-							className={cn(
-								"mt-0.5 flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/msg:opacity-100",
-								isUser && "w-full justify-end",
-							)}
-							data-testid="message-actions"
-						>
-							{displayState.hasCopyableContent && parsed && (
-								<CopyButton
-									text={parsed.markdown}
-									label="Copy message"
-									className="size-6"
-									tooltipSide="bottom"
-								/>
-							)}
-							{isUser && messageId !== undefined && onEditUserMessage && (
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											size="icon"
-											variant="subtle"
-											className="size-6"
-											aria-label="Edit message"
-											onClick={() => {
-												const { text, fileBlocks } =
-													getEditableUserMessagePayload(message);
-												onEditUserMessage(messageId, text, fileBlocks);
-											}}
-										>
-											<PencilIcon />
-											<span className="sr-only">Edit message</span>
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="bottom">Edit message</TooltipContent>
-								</Tooltip>
-							)}
-							{isUser &&
-								onJumpToUserMessage &&
-								(prevUserMessageKey !== undefined ||
-									nextUserMessageKey !== undefined) && (
-									<>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Button
-													size="icon"
-													variant="subtle"
-													className="size-6"
-													aria-label="Jump to previous user message"
-													disabled={prevUserMessageKey === undefined}
-													onClick={() => {
-														if (prevUserMessageKey !== undefined) {
-															onJumpToUserMessage(prevUserMessageKey);
-														}
-													}}
-												>
-													<ChevronLeftIcon />
-													<span className="sr-only">
-														Jump to previous user message
-													</span>
-												</Button>
-											</TooltipTrigger>
-											<TooltipContent side="bottom">
-												Jump to previous user message
-											</TooltipContent>
-										</Tooltip>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Button
-													size="icon"
-													variant="subtle"
-													className="size-6"
-													aria-label="Jump to next user message"
-													disabled={nextUserMessageKey === undefined}
-													onClick={() => {
-														if (nextUserMessageKey !== undefined) {
-															onJumpToUserMessage(nextUserMessageKey);
-														}
-													}}
-												>
-													<ChevronRightIcon />
-													<span className="sr-only">
-														Jump to next user message
-													</span>
-												</Button>
-											</TooltipTrigger>
-											<TooltipContent side="bottom">
-												Jump to next user message
-											</TooltipContent>
-										</Tooltip>
-									</>
+				{showsMessageActionRow && (
+					<div
+						className={cn(
+							"mt-0.5 flex items-center gap-1",
+							isUser && "w-full justify-end",
+						)}
+						data-testid="message-actions"
+					>
+						{hasMessageControls && (
+							<div className="flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/msg:opacity-100">
+								{displayState?.hasCopyableContent && parsed && (
+									<CopyButton
+										text={parsed.markdown}
+										label="Copy message"
+										className="size-6"
+										tooltipSide="bottom"
+									/>
 								)}
-						</div>
-					)}
+								{isUser && messageId !== undefined && onEditUserMessage && (
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												size="icon"
+												variant="subtle"
+												className="size-6"
+												aria-label="Edit message"
+												onClick={() => {
+													const { text, fileBlocks } =
+														getEditableUserMessagePayload(message);
+													onEditUserMessage(messageId, text, fileBlocks);
+												}}
+											>
+												<PencilIcon />
+												<span className="sr-only">Edit message</span>
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent side="bottom">Edit message</TooltipContent>
+									</Tooltip>
+								)}
+								{isUser &&
+									onJumpToUserMessage &&
+									(prevUserMessageKey !== undefined ||
+										nextUserMessageKey !== undefined) && (
+										<>
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Button
+														size="icon"
+														variant="subtle"
+														className="size-6"
+														aria-label="Jump to previous user message"
+														disabled={prevUserMessageKey === undefined}
+														onClick={() => {
+															if (prevUserMessageKey !== undefined) {
+																onJumpToUserMessage(prevUserMessageKey);
+															}
+														}}
+													>
+														<ChevronLeftIcon />
+														<span className="sr-only">
+															Jump to previous user message
+														</span>
+													</Button>
+												</TooltipTrigger>
+												<TooltipContent side="bottom">
+													Jump to previous user message
+												</TooltipContent>
+											</Tooltip>
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Button
+														size="icon"
+														variant="subtle"
+														className="size-6"
+														aria-label="Jump to next user message"
+														disabled={nextUserMessageKey === undefined}
+														onClick={() => {
+															if (nextUserMessageKey !== undefined) {
+																onJumpToUserMessage(nextUserMessageKey);
+															}
+														}}
+													>
+														<ChevronRightIcon />
+														<span className="sr-only">
+															Jump to next user message
+														</span>
+													</Button>
+												</TooltipTrigger>
+												<TooltipContent side="bottom">
+													Jump to next user message
+												</TooltipContent>
+											</Tooltip>
+										</>
+									)}
+							</div>
+						)}
+						{showsSentAsGoalMarker && <SentAsGoalMarker />}
+					</div>
+				)}
 				{displayState?.needsAssistantBottomSpacer && !isLastMessage && (
 					<div className="min-h-6" data-testid="assistant-bottom-spacer" />
 				)}
@@ -412,6 +435,10 @@ interface ConversationTimelineProps {
 		fileBlocks?: readonly TypesGen.ChatMessagePart[],
 	) => void;
 	editingMessageId?: number | null;
+	// The backend refuses edits that would rewrite or truncate away the
+	// current goal's source message, so the edit affordance is hidden
+	// for the source and everything before it.
+	goalSourceMessageId?: number;
 	onImplementPlan?: () => Promise<void> | void;
 	onSendAskUserQuestionResponse?: (message: string) => Promise<void> | void;
 	isChatCompleted?: boolean;
@@ -435,6 +462,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		subagentVariants,
 		onEditUserMessage,
 		editingMessageId,
+		goalSourceMessageId,
 		onImplementPlan,
 		onSendAskUserQuestionResponse,
 		isChatCompleted,
@@ -594,7 +622,13 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 								renderKey={row.key}
 								message={message}
 								parsed={parsed}
-								onEditUserMessage={isUser ? onEditUserMessage : undefined}
+								onEditUserMessage={
+									isUser &&
+									(goalSourceMessageId === undefined ||
+										message.id > goalSourceMessageId)
+										? onEditUserMessage
+										: undefined
+								}
 								editingMessageId={editingMessageId}
 								onImplementPlan={onImplementPlan}
 								onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}

--- a/site/src/pages/AgentsPage/components/ChatGoalBanner.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatGoalBanner.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import type * as TypesGen from "#/api/typesGenerated";
+import { MockChatGoal } from "#/testHelpers/chatEntities";
+import { ChatGoalBanner } from "./ChatGoalBanner";
+
+const storyNow = new Date().toISOString();
+
+const longGoalObjective =
+	"Ensure coder/coder has no frontend components using MUI, migrate remaining components to shared primitives, and leave tests and stories covering the replacement.";
+
+const goal = (
+	overrides: Partial<TypesGen.ChatGoal> = {},
+): TypesGen.ChatGoal => ({
+	...MockChatGoal,
+	objective: longGoalObjective,
+	created_at: storyNow,
+	updated_at: storyNow,
+	...overrides,
+});
+
+const meta: Meta<typeof ChatGoalBanner> = {
+	title: "pages/AgentsPage/ChatGoalBanner",
+	component: ChatGoalBanner,
+	args: {
+		goal: goal(),
+		onAction: fn(),
+		canMutateGoal: true,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatGoalBanner>;
+
+export const ActivePursuing: Story = {
+	args: {
+		isChatWorking: true,
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByLabelText("Current goal")).toBeVisible();
+		expect(canvas.getByText("Pursuing goal")).toBeVisible();
+		expect(canvas.getByText(longGoalObjective)).toBeVisible();
+
+		await userEvent.click(canvas.getByRole("button", { name: /Pause/i }));
+		await userEvent.click(canvas.getByRole("button", { name: /Complete/i }));
+		await userEvent.click(canvas.getByRole("button", { name: /Clear/i }));
+
+		expect(args.onAction).toHaveBeenNthCalledWith(1, "pause");
+		expect(args.onAction).toHaveBeenNthCalledWith(2, "complete");
+		expect(args.onAction).toHaveBeenNthCalledWith(3, "clear");
+	},
+};
+
+export const ActiveIdle: Story = {
+	args: {
+		isChatWorking: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Goal active")).toBeVisible();
+		expect(canvas.queryByText("Pursuing goal")).toBeNull();
+	},
+};
+
+export const Paused: Story = {
+	args: {
+		goal: goal({ status: "paused" }),
+		onAction: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Goal paused")).toBeVisible();
+
+		await userEvent.click(canvas.getByRole("button", { name: /Resume/i }));
+		await userEvent.click(canvas.getByRole("button", { name: /Clear/i }));
+
+		expect(args.onAction).toHaveBeenNthCalledWith(1, "resume");
+		expect(args.onAction).toHaveBeenNthCalledWith(2, "clear");
+	},
+};
+
+export const PausedResumeUnavailable: Story = {
+	args: {
+		goal: goal({ status: "paused" }),
+		isChatWorking: true,
+		actionUnavailableReasons: {
+			resume: "The chat is busy. Resume becomes available when it is idle.",
+		},
+		onAction: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const resume = canvas.getByRole("button", { name: /Resume/i });
+		// The gated action stays keyboard-focusable with an accessible
+		// description instead of a hard disable, and clicking it no-ops.
+		expect(resume).not.toBeDisabled();
+		expect(resume).toHaveAttribute("aria-disabled", "true");
+		expect(resume).toHaveAccessibleDescription(
+			"The chat is busy. Resume becomes available when it is idle.",
+		);
+		resume.focus();
+		expect(resume).toHaveFocus();
+		await userEvent.click(resume);
+		expect(args.onAction).not.toHaveBeenCalledWith("resume");
+		// Clear stays available while resume is gated.
+		await userEvent.click(canvas.getByRole("button", { name: /Clear/i }));
+		expect(args.onAction).toHaveBeenCalledWith("clear");
+	},
+};
+
+export const Complete: Story = {
+	args: {
+		goal: goal({
+			status: "complete",
+			completion_summary: "Verified and shipped.",
+		}),
+		onAction: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Goal complete")).toBeVisible();
+		expect(canvas.getByText("Summary: Verified and shipped.")).toBeVisible();
+
+		await userEvent.click(canvas.getByRole("button", { name: /Clear/i }));
+
+		expect(args.onAction).toHaveBeenCalledWith("clear");
+	},
+};
+
+export const ReadOnlyChildGoal: Story = {
+	args: {
+		goal: goal(),
+		canMutateGoal: false,
+		onAction: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByLabelText("Current goal")).toBeVisible();
+		expect(canvas.getByText("Goal active")).toBeVisible();
+		expect(canvas.queryByRole("button", { name: /Pause/i })).toBeNull();
+		expect(args.onAction).not.toHaveBeenCalled();
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatGoalBanner.tsx
+++ b/site/src/pages/AgentsPage/components/ChatGoalBanner.tsx
@@ -1,0 +1,176 @@
+import {
+	CheckIcon,
+	CirclePauseIcon,
+	CirclePlayIcon,
+	type LucideIcon,
+	TargetIcon,
+	Trash2Icon,
+} from "lucide-react";
+import type { ComponentProps, FC } from "react";
+import { Fragment, useId } from "react";
+import {
+	type ChatGoalAction,
+	type CurrentChatGoalStatus,
+	chatGoalActionsForStatus,
+	isCurrentChatGoalStatus,
+} from "#/api/queries/chatGoal";
+import type * as TypesGen from "#/api/typesGenerated";
+import { Badge } from "#/components/Badge/Badge";
+import { Button } from "#/components/Button/Button";
+import { relativeTime, shortRelativeTime } from "#/utils/time";
+
+type ChatGoalBannerProps = {
+	goal: TypesGen.ChatGoal | undefined;
+	canMutateGoal?: boolean;
+	isActionPending?: boolean;
+	isActionDisabled?: boolean;
+	/**
+	 * Whether the chat is actively working (running, interrupting, or
+	 * requires action). Drives the active-goal label so the banner never
+	 * claims the agent is pursuing a goal while the chat sits idle.
+	 */
+	isChatWorking?: boolean;
+	/**
+	 * Per-action unavailability reasons. A present entry disables that
+	 * action's button and explains why in its tooltip.
+	 */
+	actionUnavailableReasons?: Partial<Record<ChatGoalAction, string>>;
+	onAction: (action: ChatGoalAction) => Promise<void> | void;
+};
+
+type GoalStatusUI = {
+	label: string;
+	variant: ComponentProps<typeof Badge>["variant"];
+};
+
+const GOAL_STATUS_UI = {
+	active: { label: "Goal active", variant: "info" },
+	paused: { label: "Goal paused", variant: "warning" },
+	complete: { label: "Goal complete", variant: "green" },
+} satisfies Record<CurrentChatGoalStatus, GoalStatusUI>;
+
+type GoalActionUI = {
+	label: string;
+	Icon: LucideIcon;
+};
+
+const GOAL_ACTION_UI = {
+	pause: { label: "Pause", Icon: CirclePauseIcon },
+	resume: { label: "Resume", Icon: CirclePlayIcon },
+	complete: { label: "Complete", Icon: CheckIcon },
+	clear: { label: "Clear", Icon: Trash2Icon },
+} satisfies Record<ChatGoalAction, GoalActionUI>;
+
+export const ChatGoalBanner: FC<ChatGoalBannerProps> = ({
+	goal,
+	canMutateGoal = false,
+	isActionPending = false,
+	isActionDisabled = false,
+	isChatWorking = false,
+	actionUnavailableReasons,
+	onAction,
+}) => {
+	const baseId = useId();
+	if (!goal || !isCurrentChatGoalStatus(goal.status)) {
+		return null;
+	}
+
+	const statusUI =
+		goal.status === "active" && isChatWorking
+			? { label: "Pursuing goal", variant: "info" as const }
+			: GOAL_STATUS_UI[goal.status];
+	const actions = canMutateGoal ? chatGoalActionsForStatus(goal.status) : [];
+	const disabled = isActionPending || isActionDisabled;
+	const age = shortRelativeTime(goal.created_at);
+
+	return (
+		<section
+			aria-label="Current goal"
+			className="mx-auto mb-2 w-full max-w-3xl overflow-hidden rounded-xl border border-border-default/70 bg-surface-secondary/80 px-3 py-2.5 text-sm shadow-sm ring-1 ring-border-default/20"
+		>
+			<div className="flex min-w-0 items-start gap-2.5">
+				<div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full border border-border-default bg-surface-primary/70">
+					<TargetIcon className="size-4 text-content-secondary" />
+				</div>
+				<div className="min-w-0 flex-1 space-y-2">
+					<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+						<Badge size="sm" variant={statusUI.variant}>
+							{statusUI.label}
+						</Badge>
+						<span
+							className="text-xs text-content-secondary"
+							title={`Started ${relativeTime(goal.created_at)}`}
+						>
+							Started {age}
+						</span>
+					</div>
+					<p
+						className="line-clamp-3 whitespace-pre-wrap text-sm leading-5 text-content-primary [overflow-wrap:anywhere]"
+						title={goal.objective}
+					>
+						{goal.objective}
+					</p>
+					{goal.completion_summary ? (
+						<p
+							className="line-clamp-2 text-xs leading-5 text-content-secondary [overflow-wrap:anywhere]"
+							title={goal.completion_summary}
+						>
+							Summary: {goal.completion_summary}
+						</p>
+					) : null}
+					{actions.length > 0 ? (
+						<div className="flex min-w-0 items-center justify-end gap-1.5 overflow-x-auto border-t border-border-default/60 pt-2">
+							{actions.map((action) => {
+								const actionUI = GOAL_ACTION_UI[action];
+								const Icon = actionUI.Icon;
+								const unavailableReason = actionUnavailableReasons?.[action];
+								const isUnavailable = unavailableReason !== undefined;
+								// An unavailable action stays focusable with aria-disabled
+								// so keyboard and screen-reader users can reach the
+								// explanation; a hard-disabled button cannot be focused.
+								return (
+									<Fragment key={action}>
+										<Button
+											size="xs"
+											variant={action === "clear" ? "subtle" : "outline"}
+											disabled={disabled}
+											aria-disabled={isUnavailable || undefined}
+											aria-describedby={
+												isUnavailable
+													? `${baseId}-goal-action-${action}-unavailable`
+													: undefined
+											}
+											title={unavailableReason}
+											className={
+												isUnavailable
+													? "text-content-disabled hover:text-content-disabled"
+													: undefined
+											}
+											onClick={() => {
+												if (isUnavailable) {
+													return;
+												}
+												void onAction(action);
+											}}
+										>
+											<Icon />
+											{actionUI.label}
+										</Button>
+										{isUnavailable ? (
+											<span
+												id={`${baseId}-goal-action-${action}-unavailable`}
+												className="sr-only"
+											>
+												{unavailableReason}
+											</span>
+										) : null}
+									</Fragment>
+								);
+							})}
+						</div>
+					) : null}
+				</div>
+			</div>
+		</section>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -21,6 +21,7 @@ import {
 import { CHAT_SLASH_COMMANDS } from "../utils/slashCommands";
 import {
 	AgentChatInput,
+	type AgentChatInputSendOptions,
 	type AttachedWorkspaceInfo,
 	type ChatMessageInputRef,
 	isUploadInProgress,
@@ -108,6 +109,7 @@ interface ChatPageTimelineProps {
 		fileBlocks?: readonly TypesGen.ChatMessagePart[],
 	) => void;
 	editingMessageId?: number | null;
+	goalSourceMessageId?: number;
 	onImplementPlan?: () => Promise<void> | void;
 	onSendAskUserQuestionResponse?: (message: string) => Promise<void> | void;
 	urlTransform?: UrlTransform;
@@ -127,6 +129,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	onFetchMoreMessages,
 	onEditUserMessage,
 	editingMessageId,
+	goalSourceMessageId,
 	onImplementPlan,
 	onSendAskUserQuestionResponse,
 	urlTransform,
@@ -214,6 +217,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					subagentVariants={subagentVariants}
 					onEditUserMessage={onEditUserMessage}
 					editingMessageId={editingMessageId}
+					goalSourceMessageId={goalSourceMessageId}
 					onImplementPlan={onImplementPlan}
 					onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
 					isChatCompleted={isChatCompleted}
@@ -250,6 +254,7 @@ interface ChatPageInputProps {
 	onSend: (
 		message: string,
 		attachments?: readonly PendingAttachment[],
+		options?: AgentChatInputSendOptions,
 	) => Promise<void> | void;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
@@ -271,6 +276,8 @@ interface ChatPageInputProps {
 	unsupportedProviderNames?: readonly string[];
 	aiGatewayDisabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
+	showPursueGoal?: boolean;
+	canPursueGoal?: boolean;
 	isModelCatalogLoading?: boolean;
 	// Imperative editor handle plus the one-time initial draft,
 	// owned by the conversation component.
@@ -328,6 +335,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	unsupportedProviderNames,
 	aiGatewayDisabled,
 	onPlanModeToggle,
+	showPursueGoal = false,
+	canPursueGoal = false,
 	isModelCatalogLoading = false,
 	inputRef,
 	initialValue,
@@ -504,52 +513,45 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 
 	const inputElement = (
 		<AgentChatInput
-			onSend={(message) => {
-				void (async () => {
-					const hasActiveUploads = attachments.some((file) =>
-						isUploadInProgress(uploadStates.get(file)),
+			onSend={async (message, options) => {
+				const hasActiveUploads = attachments.some((file) =>
+					isUploadInProgress(uploadStates.get(file)),
+				);
+				if (hasActiveUploads) {
+					toast.warning("Wait for file uploads to finish before sending.");
+					return;
+				}
+				// Collect uploaded attachment metadata for the optimistic
+				// transcript builder while keeping the server payload
+				// shape unchanged downstream.
+				const pendingAttachments: PendingAttachment[] = [];
+				let skippedErrors = 0;
+				for (const file of attachments) {
+					const state = uploadStates.get(file);
+					if (state?.status === "error") {
+						skippedErrors++;
+						continue;
+					}
+					if (state?.status === "uploaded" && state.fileId) {
+						pendingAttachments.push({
+							fileId: state.fileId,
+							mediaType: file.type || "application/octet-stream",
+						});
+					}
+				}
+				if (skippedErrors > 0) {
+					toast.warning(
+						`${skippedErrors} attachment${skippedErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
 					);
-					if (hasActiveUploads) {
-						toast.warning("Wait for file uploads to finish before sending.");
-						return;
-					}
-					// Collect uploaded attachment metadata for the optimistic
-					// transcript builder while keeping the server payload
-					// shape unchanged downstream.
-					const pendingAttachments: PendingAttachment[] = [];
-					let skippedErrors = 0;
-					for (const file of attachments) {
-						const state = uploadStates.get(file);
-						if (state?.status === "error") {
-							skippedErrors++;
-							continue;
-						}
-						if (state?.status === "uploaded" && state.fileId) {
-							pendingAttachments.push({
-								fileId: state.fileId,
-								mediaType: file.type || "application/octet-stream",
-							});
-						}
-					}
-					if (skippedErrors > 0) {
-						toast.warning(
-							`${skippedErrors} attachment${skippedErrors > 1 ? "s" : ""} could not be sent (upload failed)`,
-						);
-					}
-					const attachmentArg =
-						pendingAttachments.length > 0 ? pendingAttachments : undefined;
-					try {
-						await onSend(message, attachmentArg);
-					} catch {
-						// Attachments preserved for retry on failure.
-						return;
-					}
-					if (isEditing) {
-						editAttachments.resetAttachments();
-					} else {
-						composeAttachments.resetAttachments();
-					}
-				})();
+				}
+				const attachmentArg =
+					pendingAttachments.length > 0 ? pendingAttachments : undefined;
+				await onSend(message, attachmentArg, options);
+				if (isEditing) {
+					editAttachments.resetAttachments();
+				} else {
+					composeAttachments.resetAttachments();
+				}
 			}}
 			attachments={attachments}
 			onAttach={handleAttach}
@@ -585,6 +587,8 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			onReasoningEffortChange={onReasoningEffortChange}
 			planModeEnabled={planModeEnabled}
 			onPlanModeToggle={onPlanModeToggle}
+			showPursueGoal={showPursueGoal}
+			canPursueGoal={canPursueGoal}
 			isModelCatalogLoading={isModelCatalogLoading}
 			workspaceOptions={workspaceOptions}
 			chatOrganizationId={organizationId}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.stories.tsx
@@ -14,7 +14,7 @@ import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { userChatProviderConfigsKey } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { Chat } from "#/api/typesGenerated";
-import { MockChat } from "#/testHelpers/chatEntities";
+import { MockChat, MockChatGoal } from "#/testHelpers/chatEntities";
 import { MockUserOwner, mockApiError } from "#/testHelpers/entities";
 import {
 	withAuthProvider,
@@ -61,6 +61,17 @@ const buildChat = (overrides: Partial<Chat> = {}): Chat => ({
 	...MockChat,
 	id: "chat-default",
 	last_model_config_id: defaultModelConfigs[0].id,
+	created_at: oneWeekAgo,
+	updated_at: oneWeekAgo,
+	...overrides,
+});
+
+const buildGoal = (
+	overrides: Partial<TypesGen.ChatGoal> = {},
+): TypesGen.ChatGoal => ({
+	...MockChatGoal,
+	root_chat_id: "chat-default",
+	objective: "Migrate coder/coder away from MUI",
 	created_at: oneWeekAgo,
 	updated_at: oneWeekAgo,
 	...overrides,
@@ -297,6 +308,29 @@ export const ChatStreamingOverridesTurnSummary: Story = {
 		expect(
 			canvas.queryByText("Added Docker and Terraform validation"),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const ActiveGoalChat: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "active-goal-chat",
+				title: "Generic chat title",
+				status: "running",
+				goal: buildGoal({ root_chat_id: "active-goal-chat" }),
+			}),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await expect(
+			canvas.getByText("Migrate coder/coder away from MUI"),
+		).toBeInTheDocument();
+		await expect(canvas.getByText("GPT-4o streaming…")).toBeInTheDocument();
+		await expect(canvas.getByLabelText("Active goal")).toBeInTheDocument();
+		expect(canvas.queryByText("Generic chat title")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -3,6 +3,7 @@ import {
 	ChevronDownIcon,
 	ChevronRightIcon,
 	EllipsisVerticalIcon,
+	TargetIcon,
 	UsersIcon,
 } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
@@ -33,7 +34,7 @@ import {
 import { asNonEmptyString } from "../../ChatConversation/blockUtils";
 import { normalizeLocationSearch } from "../locationSearch";
 import { useChatTree } from "./ChatTreeContext";
-import { getParentChatID } from "./chatTree";
+import { activeGoalObjective, getParentChatID } from "./chatTree";
 import { getModelDisplayName } from "./modelDisplayName";
 import { getChatDisplayConfig } from "./statusConfig";
 
@@ -85,6 +86,8 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, depth = 0 }) => {
 			? chatErrorReasons[chat.id] || chat.last_error?.message || undefined
 			: undefined;
 	const lastTurnSummary = asNonEmptyString(chat.last_turn_summary);
+	const goalObjective = activeGoalObjective(chat);
+	const displayTitle = goalObjective ?? chat.title;
 	const isStreaming = chat.status === "running";
 	const streamingSubtitle =
 		isStreaming && modelName ? `${modelName} streaming…` : undefined;
@@ -243,6 +246,13 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, depth = 0 }) => {
 							{({ isActive }) => (
 								<div className="min-w-0 flex-1 overflow-hidden text-left">
 									<div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+										{goalObjective && (
+											<TargetIcon
+												className="size-3.5 shrink-0 text-content-secondary"
+												aria-label="Active goal"
+												data-testid={`agents-tree-active-goal-${chat.id}`}
+											/>
+										)}
 										<span
 											className={cn(
 												"block flex-1 truncate text-[13px] text-content-primary",
@@ -250,7 +260,7 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, depth = 0 }) => {
 													"opacity-85 [@media(hover:hover)]:group-hover:opacity-100",
 											)}
 										>
-											{chat.title}
+											{displayTitle}
 										</span>
 										{chat.has_unread && !isActiveChat && (
 											<span className="sr-only">(unread)</span>

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/chatTree.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/chatTree.ts
@@ -74,6 +74,21 @@ export const buildChatTree = (chats: readonly Chat[]): ChatTree => {
 	};
 };
 
+// The active goal objective shown in place of the title. Goals are
+// root-chat-only, so child chats never replace their title even when
+// search renders them at the top level.
+export const activeGoalObjective = (chat: Chat): string | undefined =>
+	!getParentChatID(chat) && chat.goal?.status === "active"
+		? asNonEmptyString(chat.goal.objective)
+		: undefined;
+
+const chatMatchesSearch = (chat: Chat, search: string): boolean => {
+	if (chat.title.toLowerCase().includes(search)) {
+		return true;
+	}
+	return activeGoalObjective(chat)?.toLowerCase().includes(search) ?? false;
+};
+
 export const collectVisibleChatIDs = ({
 	chats,
 	search,
@@ -95,7 +110,7 @@ export const collectVisibleChatIDs = ({
 
 	const allChats = chats.flatMap((chat) => [chat, ...(chat.children ?? [])]);
 	const matchedChatIDs = allChats
-		.filter((chat) => chat.title.toLowerCase().includes(search))
+		.filter((chat) => chatMatchesSearch(chat, search))
 		.map((chat) => chat.id);
 	if (matchedChatIDs.length === 0) {
 		return new Set<string>();

--- a/site/src/pages/AgentsPage/goalActions.test.ts
+++ b/site/src/pages/AgentsPage/goalActions.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChatGoal } from "#/api/typesGenerated";
+import { MockChatGoal } from "#/testHelpers/chatEntities";
+import { runGoalAction } from "./goalActions";
+
+describe("runGoalAction", () => {
+	const makeGoal = (status: ChatGoal["status"]): ChatGoal => ({
+		...MockChatGoal,
+		status,
+	});
+
+	it.each([
+		{ status: "active", action: "clear", completionSummary: undefined },
+		{ status: "paused", action: "clear", completionSummary: undefined },
+		{ status: "paused", action: "resume", completionSummary: undefined },
+		{ status: "complete", action: "clear", completionSummary: undefined },
+		{
+			status: "active",
+			action: "complete",
+			completionSummary: "Shipped and verified.",
+		},
+	] as const)(
+		"sends $action mutations for $status goals",
+		async ({ status, action, completionSummary }) => {
+			const updateGoal = vi.fn(async () => undefined);
+
+			await runGoalAction({
+				agentId: "chat-1",
+				goal: makeGoal(status),
+				action,
+				completionSummary,
+				updateGoal,
+			});
+
+			expect(updateGoal).toHaveBeenCalledWith({
+				chatId: "chat-1",
+				mutation: {
+					action,
+					goal_id: "goal-1",
+					completion_summary: completionSummary,
+				},
+			});
+		},
+	);
+
+	it.each([
+		{ liveChatStatus: "running", notified: true },
+		{ liveChatStatus: "waiting", notified: false },
+	] as const)(
+		"notifies on pause only for running goals (status $liveChatStatus)",
+		async ({ liveChatStatus, notified }) => {
+			const updateGoal = vi.fn(async () => undefined);
+			const onPausedRunningGoal = vi.fn();
+
+			await runGoalAction({
+				agentId: "chat-1",
+				goal: makeGoal("active"),
+				action: "pause",
+				updateGoal,
+				liveChatStatus,
+				onPausedRunningGoal,
+			});
+
+			expect(onPausedRunningGoal).toHaveBeenCalledTimes(notified ? 1 : 0);
+		},
+	);
+
+	it("does not send lifecycle mutations without a current goal", async () => {
+		const updateGoal = vi.fn(async () => undefined);
+		const onMissingGoal = vi.fn();
+
+		await runGoalAction({
+			agentId: "chat-1",
+			goal: undefined,
+			action: "clear",
+			updateGoal,
+			onMissingGoal,
+		});
+
+		expect(updateGoal).not.toHaveBeenCalled();
+		expect(onMissingGoal).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		{
+			name: "running chat",
+			liveChatStatus: "running",
+			hasQueuedInput: false,
+			planModeEnabled: false,
+		},
+		{
+			name: "interrupting chat",
+			liveChatStatus: "interrupting",
+			hasQueuedInput: false,
+			planModeEnabled: false,
+		},
+		{
+			name: "queued input",
+			liveChatStatus: "error",
+			hasQueuedInput: true,
+			planModeEnabled: false,
+		},
+		{
+			name: "plan mode",
+			liveChatStatus: "waiting",
+			hasQueuedInput: false,
+			planModeEnabled: true,
+		},
+	] as const)(
+		"does not resume with $name",
+		async ({ liveChatStatus, hasQueuedInput, planModeEnabled }) => {
+			const updateGoal = vi.fn(async () => undefined);
+			const onActionUnavailable = vi.fn();
+
+			await runGoalAction({
+				agentId: "chat-1",
+				goal: makeGoal("paused"),
+				action: "resume",
+				updateGoal,
+				liveChatStatus,
+				hasQueuedInput,
+				planModeEnabled,
+				onActionUnavailable,
+			});
+
+			expect(updateGoal).not.toHaveBeenCalled();
+			expect(onActionUnavailable).toHaveBeenCalledOnce();
+			expect(onActionUnavailable).toHaveBeenCalledWith(expect.any(String));
+		},
+	);
+
+	it("resumes on an idle chat", async () => {
+		const updateGoal = vi.fn(async () => undefined);
+		const onActionUnavailable = vi.fn();
+
+		await runGoalAction({
+			agentId: "chat-1",
+			goal: makeGoal("paused"),
+			action: "resume",
+			updateGoal,
+			liveChatStatus: "waiting",
+			hasQueuedInput: false,
+			planModeEnabled: false,
+			onActionUnavailable,
+		});
+
+		expect(onActionUnavailable).not.toHaveBeenCalled();
+		expect(updateGoal).toHaveBeenCalledWith({
+			chatId: "chat-1",
+			mutation: {
+				action: "resume",
+				goal_id: "goal-1",
+				completion_summary: undefined,
+			},
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/goalActions.ts
+++ b/site/src/pages/AgentsPage/goalActions.ts
@@ -1,0 +1,70 @@
+import {
+	type ChatGoalAction,
+	chatGoalActionAllowed,
+	chatGoalActionUnavailableReason,
+} from "#/api/queries/chatGoal";
+import type * as TypesGen from "#/api/typesGenerated";
+
+/** @internal Exported for testing. */
+export const runGoalAction = async (params: {
+	agentId: string | undefined;
+	goal: TypesGen.ChatGoal | undefined;
+	action: ChatGoalAction;
+	completionSummary?: string;
+	updateGoal: (variables: {
+		chatId: string;
+		mutation: TypesGen.ChatGoalUpdateRequest;
+	}) => Promise<unknown>;
+	liveChatStatus?: TypesGen.ChatStatus | null;
+	hasQueuedInput?: boolean;
+	planModeEnabled?: boolean;
+	hasModelOptions?: boolean;
+	onMissingGoal?: () => void;
+	onActionUnavailable?: (reason: string) => void;
+	onPausedRunningGoal?: () => void;
+}): Promise<void> => {
+	const {
+		agentId,
+		goal,
+		action,
+		completionSummary,
+		updateGoal,
+		liveChatStatus,
+		hasQueuedInput,
+		planModeEnabled,
+		hasModelOptions,
+		onMissingGoal,
+		onActionUnavailable,
+		onPausedRunningGoal,
+	} = params;
+	if (!agentId) {
+		return;
+	}
+	if (!goal?.id || !chatGoalActionAllowed(goal, action)) {
+		onMissingGoal?.();
+		return;
+	}
+	// Mirror the server-side admission rules so the UI explains a
+	// rejection instead of surfacing a 409.
+	const unavailableReason = chatGoalActionUnavailableReason(action, {
+		chatStatus: liveChatStatus,
+		hasQueuedInput,
+		planModeEnabled,
+		hasModelOptions,
+	});
+	if (unavailableReason) {
+		onActionUnavailable?.(unavailableReason);
+		return;
+	}
+	await updateGoal({
+		chatId: agentId,
+		mutation: {
+			action,
+			goal_id: goal.id,
+			completion_summary: completionSummary,
+		},
+	});
+	if (action === "pause" && liveChatStatus === "running") {
+		onPausedRunningGoal?.();
+	}
+};

--- a/site/src/pages/AgentsPage/hooks/useConversationEditingState.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useConversationEditingState.test.ts
@@ -263,7 +263,7 @@ describe("useConversationEditingState", () => {
 		// the same text, so the editor is forced to reinitialize.
 		expect(result.current.remountKey).toBe(remountKeyAfterSend + 1);
 		expect(result.current.editorInitialValue).toBe("hello");
-		expect(onSend).toHaveBeenCalledWith("hello", undefined, 7);
+		expect(onSend).toHaveBeenCalledWith("hello", undefined, 7, undefined);
 		unmount();
 	});
 
@@ -281,7 +281,7 @@ describe("useConversationEditingState", () => {
 			await result.current.handleSendFromInput("hello", attachments);
 		});
 
-		expect(onSend).toHaveBeenCalledWith("hello", attachments, 7);
+		expect(onSend).toHaveBeenCalledWith("hello", attachments, 7, undefined);
 		unmount();
 	});
 
@@ -358,7 +358,12 @@ describe("useConversationEditingState", () => {
 			await result.current.handleSendFromInput("hello");
 		});
 
-		expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined);
+		expect(onSend).toHaveBeenCalledWith(
+			"hello",
+			undefined,
+			undefined,
+			undefined,
+		);
 		expect(mockInput.clear).toHaveBeenCalled();
 		expect(mockInput.focus).toHaveBeenCalled();
 		expect(localStorage.getItem(expectedKey)).toBeNull();
@@ -401,7 +406,12 @@ describe("useConversationEditingState", () => {
 		await act(async () => {
 			result.current.handleSendFromInput("hello");
 			await vi.waitFor(() => {
-				expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined);
+				expect(onSend).toHaveBeenCalledWith(
+					"hello",
+					undefined,
+					undefined,
+					undefined,
+				);
 			});
 		});
 

--- a/site/src/pages/AgentsPage/hooks/useConversationEditingState.ts
+++ b/site/src/pages/AgentsPage/hooks/useConversationEditingState.ts
@@ -1,7 +1,10 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import type { ChatMessagePart } from "#/api/typesGenerated";
 import { isMobileViewport } from "#/utils/mobile";
-import type { ChatMessageInputRef } from "../components/AgentChatInput";
+import type {
+	AgentChatInputSendOptions,
+	ChatMessageInputRef,
+} from "../components/AgentChatInput";
 import type { PendingAttachment } from "../components/ChatPageContent";
 import {
 	draftInputStorageKeyPrefix,
@@ -18,6 +21,7 @@ export function useConversationEditingState(deps: {
 		message: string,
 		attachments?: readonly PendingAttachment[],
 		editedMessageID?: number,
+		options?: AgentChatInputSendOptions,
 	) => Promise<void>;
 	chatInputRef: React.RefObject<ChatMessageInputRef | null>;
 	inputValueRef: React.RefObject<string>;
@@ -156,10 +160,11 @@ export function useConversationEditingState(deps: {
 	const handleSendFromInput = async (
 		message: string,
 		attachments?: readonly PendingAttachment[],
+		options?: AgentChatInputSendOptions,
 	) => {
 		const editedMessageID =
 			editingMessageId !== null ? editingMessageId : undefined;
-		const sendPromise = onSend(message, attachments, editedMessageID);
+		const sendPromise = onSend(message, attachments, editedMessageID, options);
 
 		// For history edits, clear input immediately and prepare
 		// a rollback in case the send fails.

--- a/site/src/testHelpers/chatEntities.ts
+++ b/site/src/testHelpers/chatEntities.ts
@@ -2,6 +2,7 @@ import type {
 	Chat,
 	ChatContext,
 	ChatContextResource,
+	ChatGoal,
 	ChatMessage,
 	ChatQueuedMessage,
 	MCPServerConfig,
@@ -78,6 +79,17 @@ const MockChatContextResources: ChatContextResource[] = [
 		error: 'front-matter name "coder-review" does not match directory "moo"',
 	},
 ];
+
+export const MockChatGoal: ChatGoal = {
+	id: "goal-1",
+	root_chat_id: MockChat.id,
+	objective: "Fix the flaky tests",
+	status: "active",
+	created_by_user_id: MockUserOwner.id,
+	completed_by_agent: false,
+	created_at: MOCK_TIMESTAMP,
+	updated_at: MOCK_TIMESTAMP,
+};
 
 export const MockChatContextClean: ChatContext = {
 	dirty: false,


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

The base goal UI: setting a goal from the composer, the goal banner, sidebar titles, and the `sent_as_goal` marker in the timeline.

## What changed

- `AgentChatInput` and `AgentCreateForm`: pursue-goal mode, message-bound and root-only, mutually exclusive with plan mode, unavailable while busy or queued. Failed sends preserve goal mode, draft, and attachments.
- `ChatGoalBanner`: active and paused states with pause/resume/clear/complete actions.
- Sidebar: active root goals replace generic titles.
- Conversation timeline: `sent_as_goal` marker on the source message.
- Queries: goal cache updates on the chat entity and list caches, driven by `goal_change` watch events (refetch, since the event carries no payload).
- Stories and tests for every state above.

Code is unchanged from the reviewed #25622 apart from following main's AgentsPage restructuring (#29029 through #29038): the `runGoalAction` helper and its tests now live in `goalActions.ts` / `goalActions.test.ts` instead of `AgentChatPage.tsx` / the deleted `AgentChatPage.test.ts`, and the `useConversationEditingState` goal plumbing lives in `hooks/useConversationEditingState.ts` with its test beside it.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.

