### PR TITLE
feat(site): surface goal continuation, pause reasons, and blocked states

### DIFF
--- a/site/src/api/queries/chatGoal.ts
+++ b/site/src/api/queries/chatGoal.ts
@@ -3,12 +3,13 @@ import type * as TypesGen from "#/api/typesGenerated";
 export type ChatGoalAction = TypesGen.ChatGoalUpdateAction;
 export type CurrentChatGoalStatus = Extract<
 	TypesGen.ChatGoalStatus,
-	"active" | "paused" | "complete"
+	"active" | "paused" | "blocked" | "complete"
 >;
 
 const CHAT_GOAL_ACTIONS_BY_STATUS = {
 	active: ["pause", "complete", "clear"],
 	paused: ["resume", "clear"],
+	blocked: ["resume", "clear"],
 	complete: ["clear"],
 } as const satisfies Record<CurrentChatGoalStatus, readonly ChatGoalAction[]>;
 

--- a/site/src/pages/AgentsPage/components/ChatGoalBanner.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatGoalBanner.stories.tsx
@@ -63,14 +63,27 @@ export const ActiveIdle: Story = {
 	},
 };
 
+export const ActiveAutoContinuing: Story = {
+	args: {
+		goal: goal({ continuation_count: 3 }),
+		isChatWorking: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Pursuing goal")).toBeVisible();
+		expect(canvas.getByText("Auto-continue 3/10")).toBeVisible();
+	},
+};
+
 export const Paused: Story = {
 	args: {
-		goal: goal({ status: "paused" }),
+		goal: goal({ status: "paused", paused_reason: "user" }),
 		onAction: fn(),
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("Goal paused")).toBeVisible();
+		expect(canvas.getByText("Paused by you")).toBeVisible();
 
 		await userEvent.click(canvas.getByRole("button", { name: /Resume/i }));
 		await userEvent.click(canvas.getByRole("button", { name: /Clear/i }));
@@ -80,9 +93,45 @@ export const Paused: Story = {
 	},
 };
 
+export const PausedAtTurnLimit: Story = {
+	args: {
+		goal: goal({
+			status: "paused",
+			paused_reason: "turn_limit",
+			continuation_count: 10,
+		}),
+		onAction: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Goal paused")).toBeVisible();
+		expect(canvas.getByText("Turn limit reached")).toBeVisible();
+		expect(canvas.getByRole("button", { name: /Resume/i })).toBeEnabled();
+	},
+};
+
+export const Blocked: Story = {
+	args: {
+		goal: goal({
+			status: "blocked",
+			blocked_reason:
+				"The migration requires a decision on whether to keep the legacy theme package. Reply with the direction and resume the goal.",
+		}),
+		onAction: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Goal blocked")).toBeVisible();
+		expect(canvas.getByText(/Blocked: The migration requires/)).toBeVisible();
+
+		await userEvent.click(canvas.getByRole("button", { name: /Resume/i }));
+		expect(args.onAction).toHaveBeenCalledWith("resume");
+	},
+};
+
 export const PausedResumeUnavailable: Story = {
 	args: {
-		goal: goal({ status: "paused" }),
+		goal: goal({ status: "paused", paused_reason: "user" }),
 		isChatWorking: true,
 		actionUnavailableReasons: {
 			resume: "The chat is busy. Resume becomes available when it is idle.",

--- a/site/src/pages/AgentsPage/components/ChatGoalBanner.tsx
+++ b/site/src/pages/AgentsPage/components/ChatGoalBanner.tsx
@@ -15,6 +15,7 @@ import {
 	isCurrentChatGoalStatus,
 } from "#/api/queries/chatGoal";
 import type * as TypesGen from "#/api/typesGenerated";
+import { ChatGoalMaxContinuationTurns } from "#/api/typesGenerated";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { relativeTime, shortRelativeTime } from "#/utils/time";
@@ -46,8 +47,17 @@ type GoalStatusUI = {
 const GOAL_STATUS_UI = {
 	active: { label: "Goal active", variant: "info" },
 	paused: { label: "Goal paused", variant: "warning" },
+	blocked: { label: "Goal blocked", variant: "warning" },
 	complete: { label: "Goal complete", variant: "green" },
 } satisfies Record<CurrentChatGoalStatus, GoalStatusUI>;
+
+const PAUSED_REASON_LABELS: Record<TypesGen.ChatGoalPausedReason, string> = {
+	user: "Paused by you",
+	interrupt: "Paused by Stop",
+	turn_limit: "Turn limit reached",
+	usage_limit: "Usage limit reached",
+	error: "Paused after an error",
+};
 
 type GoalActionUI = {
 	label: string;
@@ -60,6 +70,16 @@ const GOAL_ACTION_UI = {
 	complete: { label: "Complete", Icon: CheckIcon },
 	clear: { label: "Clear", Icon: Trash2Icon },
 } satisfies Record<ChatGoalAction, GoalActionUI>;
+
+const goalStatusDetail = (goal: TypesGen.ChatGoal): string | undefined => {
+	if (goal.status === "active" && goal.continuation_count > 0) {
+		return `Auto-continue ${goal.continuation_count}/${ChatGoalMaxContinuationTurns}`;
+	}
+	if (goal.status === "paused" && goal.paused_reason) {
+		return PAUSED_REASON_LABELS[goal.paused_reason];
+	}
+	return undefined;
+};
 
 export const ChatGoalBanner: FC<ChatGoalBannerProps> = ({
 	goal,
@@ -82,6 +102,7 @@ export const ChatGoalBanner: FC<ChatGoalBannerProps> = ({
 	const actions = canMutateGoal ? chatGoalActionsForStatus(goal.status) : [];
 	const disabled = isActionPending || isActionDisabled;
 	const age = shortRelativeTime(goal.created_at);
+	const statusDetail = goalStatusDetail(goal);
 
 	return (
 		<section
@@ -97,6 +118,11 @@ export const ChatGoalBanner: FC<ChatGoalBannerProps> = ({
 						<Badge size="sm" variant={statusUI.variant}>
 							{statusUI.label}
 						</Badge>
+						{statusDetail ? (
+							<span className="text-xs text-content-secondary">
+								{statusDetail}
+							</span>
+						) : null}
 						<span
 							className="text-xs text-content-secondary"
 							title={`Started ${relativeTime(goal.created_at)}`}
@@ -116,6 +142,14 @@ export const ChatGoalBanner: FC<ChatGoalBannerProps> = ({
 							title={goal.completion_summary}
 						>
 							Summary: {goal.completion_summary}
+						</p>
+					) : null}
+					{goal.status === "blocked" && goal.blocked_reason ? (
+						<p
+							className="line-clamp-2 text-xs leading-5 text-content-warning [overflow-wrap:anywhere]"
+							title={goal.blocked_reason}
+						>
+							Blocked: {goal.blocked_reason}
 						</p>
 					) : null}
 					{actions.length > 0 ? (

--- a/site/src/pages/AgentsPage/goalActions.test.ts
+++ b/site/src/pages/AgentsPage/goalActions.test.ts
@@ -13,6 +13,8 @@ describe("runGoalAction", () => {
 		{ status: "active", action: "clear", completionSummary: undefined },
 		{ status: "paused", action: "clear", completionSummary: undefined },
 		{ status: "paused", action: "resume", completionSummary: undefined },
+		{ status: "blocked", action: "resume", completionSummary: undefined },
+		{ status: "blocked", action: "clear", completionSummary: undefined },
 		{ status: "complete", action: "clear", completionSummary: undefined },
 		{
 			status: "active",


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

Surface what the continuation backend added: why a goal paused, that it is blocked, and how many automatic turns it has used.

## What changed

- `ChatGoalBanner`: pause reasons (user, interrupt, turn limit, usage limit, error), blocked state with the agent's reason and a resume action, and the continuation counter (hidden at 0 after a resume until it reaches 1/10).
- Goal query types for the new fields, stories for each state, and page tests.

Code is unchanged from the reviewed #27043.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.
