### PR TITLE
refactor(site/src/pages/AgentsPage): extract AgentChatPage helpers and hooks

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -321,7 +321,6 @@ const AgentChatPage: FC = () => {
 		chatRecord !== undefined && currentUser.id !== chatRecord.owner_id;
 	const isRootChat =
 		chatRecord !== undefined && getParentChatID(chatRecord) === undefined;
-	const shouldCheckCanShareChat = isRootChat;
 	const chatAuthorizationObject =
 		chatRecord !== undefined
 			? {
@@ -331,7 +330,7 @@ const AgentChatPage: FC = () => {
 				}
 			: undefined;
 	const chatAuthorizationChecks: TypesGen.AuthorizationRequest["checks"] = {};
-	if (chatAuthorizationObject !== undefined && shouldCheckCanShareChat) {
+	if (chatAuthorizationObject !== undefined && isRootChat) {
 		chatAuthorizationChecks.canShareChat = {
 			object: chatAuthorizationObject,
 			action: "share",
@@ -751,7 +750,6 @@ const AgentChatPage: FC = () => {
 		</title>
 	);
 
-	const parentChat = parentChatQuery.data;
 	const sshCommand =
 		workspace && workspaceAgent && sshConfigQuery.data?.hostname_suffix
 			? `ssh ${workspaceAgent.name}.${workspace.name}.${workspace.owner_name}.${sshConfigQuery.data.hostname_suffix}`
@@ -1265,7 +1263,7 @@ const AgentChatPage: FC = () => {
 			)}
 			organizationId={chatQuery.data?.organization_id}
 			chatTitle={chatTitle}
-			parentChat={parentChat}
+			parentChat={parentChatQuery.data}
 			persistedError={persistedError}
 			isArchived={isArchived}
 			isSharedChat={isSharedChat}
@@ -1356,7 +1354,7 @@ const AgentChatPage: FC = () => {
 			onMCPAuthComplete={handleMCPAuthComplete}
 			chatContext={chatQuery.data?.context}
 			queuedForCapacity={chatQuery.data?.queued_for_capacity ?? false}
-			workspaceSkills={workspaceSkillsFromChat(chatQuery.data)}
+			workspaceSkills={chatWorkspaceSkills}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -264,8 +264,9 @@ const AgentChatPage: FC = () => {
 		currentUser.id,
 	);
 	const desktopEnabled = experiments.includes("chat-virtual-desktop");
-	const debugLoggingEnabled =
-		userDebugLoggingQuery.data?.debug_logging_enabled ?? false;
+	const debugLoggingEnabled = Boolean(
+		userDebugLoggingQuery.data?.debug_logging_enabled,
+	);
 
 	// MCP server selection state.
 	const mcpServers = mcpServersQuery.data ?? [];
@@ -315,8 +316,8 @@ const AgentChatPage: FC = () => {
 	const { proxy } = useProxy();
 
 	const chatRecord = chatQuery.data;
-	const isArchived = chatRecord?.archived ?? false;
-	const isSharedChat = chatRecord?.shared ?? false;
+	const isArchived = Boolean(chatRecord?.archived);
+	const isSharedChat = Boolean(chatRecord?.shared);
 	const isViewerNotOwner =
 		chatRecord !== undefined && currentUser.id !== chatRecord.owner_id;
 	const isRootChat =
@@ -406,7 +407,7 @@ const AgentChatPage: FC = () => {
 			? {
 					messages: chatMessagesList,
 					queued_messages: chatQueuedMessages ?? [],
-					has_more: chatMessagesQuery.data?.pages.at(-1)?.has_more ?? false,
+					has_more: Boolean(chatMessagesQuery.data?.pages.at(-1)?.has_more),
 				}
 			: undefined;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
@@ -588,9 +589,7 @@ const AgentChatPage: FC = () => {
 	})();
 	const hasModelOptions = modelOptions.length > 0;
 	const hasResolvedModelData =
-		!isModelDataPending &&
-		modelsQuery.data !== undefined &&
-		modelsQuery.error == null;
+		!isModelDataPending && Boolean(modelsQuery.data) && !modelsQuery.error;
 	const hasUnavailableHistoricalModel =
 		hasResolvedModelData &&
 		isUnavailableHistoricalModelID(chatLastModelConfigID, modelOptions);
@@ -1327,7 +1326,7 @@ const AgentChatPage: FC = () => {
 						!chatFamilyAllowsArchive(liveChatStatus, activeChatChildren)
 					}
 					urlTransform={urlTransform}
-					hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
+					hasMoreMessages={Boolean(chatMessagesQuery.hasNextPage)}
 					isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
 					isHydratingMessages={isHydratingMessages}
 					hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
@@ -1338,7 +1337,7 @@ const AgentChatPage: FC = () => {
 					onMCPSelectionChange={handleMCPSelectionChange}
 					onMCPAuthComplete={handleMCPAuthComplete}
 					chatContext={chatQuery.data?.context}
-					queuedForCapacity={chatQuery.data?.queued_for_capacity ?? false}
+					queuedForCapacity={Boolean(chatQuery.data?.queued_for_capacity)}
 					workspaceSkills={chatWorkspaceSkills}
 				/>
 			)}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -2,7 +2,7 @@ import {
 	MessageScroller,
 	useMessageScroller,
 } from "@shadcn/react/message-scroller";
-import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 
 import {
 	useInfiniteQuery,
@@ -1177,184 +1177,171 @@ const AgentChatPage: FC = () => {
 		});
 	};
 
-	let page: ReactNode;
-	if (chatQuery.isLoading || chatMessagesQuery.isLoading) {
-		page = (
-			<AgentChatPageLoadingView
-				sendShortcut={getAgentChatSendShortcut(
-					preferencesQuery.data?.agent_chat_send_shortcut,
-					preferencesQuery.isLoading,
-				)}
-				inputRef={editing.chatInputRef}
-				initialValue={editing.editorInitialValue}
-				initialEditorState={editing.initialEditorState}
-				remountKey={editing.remountKey}
-				onContentChange={editing.handleLoadingDraftChange}
-				isInputDisabled={isInputDisabled}
-				effectiveSelectedModel={effectiveSelectedModel}
-				setSelectedModel={setSelectedModel}
-				modelOptions={modelOptions}
-				modelSelectorPlaceholder={modelSelectorPlaceholder}
-				hasModelOptions={hasModelOptions}
-				isModelCatalogLoading={isModelDataPending}
-				planModeEnabled={planModeEnabled}
-				onPlanModeToggle={handlePlanModeToggle}
-				isSidebarCollapsed={isSidebarCollapsed}
-				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-				showRightPanel={showSidebarPanel}
-			/>
-		);
-	} else if (chatQuery.isLoadingError || chatMessagesQuery.isLoadingError) {
-		if (getErrorStatus(chatQuery.error) === 404) {
-			page = (
-				<AgentChatPageNotFoundView
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-				/>
-			);
-		} else {
-			page = (
-				<AgentChatPageErrorView
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-					error={
-						chatQuery.isLoadingError ? chatQuery.error : chatMessagesQuery.error
-					}
-					onRetry={() => {
-						if (chatQuery.isLoadingError) {
-							void chatQuery.refetch();
-						}
-						if (chatMessagesQuery.isLoadingError) {
-							void chatMessagesQuery.refetch();
-						}
-					}}
-				/>
-			);
-		}
-	} else if (
-		!chatQuery.data ||
-		!chatMessagesQuery.data?.pages?.length ||
-		!agentId
-	) {
-		page = (
-			<AgentChatPageNotFoundView
-				isSidebarCollapsed={isSidebarCollapsed}
-				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-			/>
-		);
-	} else {
-		page = (
-			<AgentChatPageView
-				key={agentId}
-				agentId={agentId}
-				sendShortcut={getAgentChatSendShortcut(
-					preferencesQuery.data?.agent_chat_send_shortcut,
-					preferencesQuery.isLoading,
-				)}
-				organizationId={chatQuery.data?.organization_id}
-				chatTitle={chatTitle}
-				parentChat={parentChatQuery.data}
-				persistedError={persistedError}
-				isArchived={isArchived}
-				isSharedChat={isSharedChat}
-				chatOwner={chatOwner}
-				canShareChat={canShareChat}
-				workspace={workspace}
-				workspaceAgent={workspaceAgent}
-				chatBuildId={chatQuery.data?.build_id}
-				store={store}
-				initialChatStatus={chatQuery.data.status}
-				initialMessages={chatMessagesList ?? []}
-				editing={{ ...editing, handleEditUserMessage }}
-				effectiveSelectedModel={effectiveSelectedModel}
-				setSelectedModel={setSelectedModel}
-				modelOptions={modelOptions}
-				modelSelectorPlaceholder={modelSelectorPlaceholder}
-				modelSelectorHelp={modelSelectorHelp}
-				modelCatalogError={modelsQuery.error}
-				unavailableModelNotice={unavailableModelNotice}
-				reasoningEffort={effectiveReasoningEffort}
-				onReasoningEffortChange={(value) => {
-					setSelectedReasoningEffort(value);
-					if (editing.editingMessageId !== null) {
-						isEditReasoningEffortDirtyRef.current = true;
-					}
-				}}
-				canConfigureAgentSetup={permissions.editDeploymentConfig}
-				providerCount={providerCount}
-				modelCount={modelCount}
-				unsupportedProviderNames={unsupportedProviderNames}
-				aiGatewayDisabled={aiGatewayDisabled}
-				hasModelOptions={hasModelOptions}
-				isModelCatalogLoading={isModelDataPending}
-				planModeEnabled={planModeEnabled}
-				onPlanModeToggle={handlePlanModeToggle}
-				compressionThreshold={compressionThreshold}
-				isInputDisabled={isInputDisabled}
-				isSubmissionPending={isSubmissionPending}
-				isInterruptPending={isInterruptPending}
-				workspaceOptions={workspaceOptions}
-				selectedWorkspaceId={selectedWorkspaceId}
-				onWorkspaceChange={
-					canUpdateChatWorkspace ? handleWorkspaceChange : undefined
-				}
-				isWorkspaceLoading={isWorkspaceLoading}
-				isSidebarCollapsed={isSidebarCollapsed}
-				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-				showSidebarPanel={showSidebarPanel}
-				onSetShowSidebarPanel={handleSetShowSidebarPanel}
-				prNumber={prNumber}
-				diffStatusData={chatQuery.data?.diff_status}
-				debugLoggingEnabled={debugLoggingEnabled}
-				gitWatcher={gitWatcher}
-				sshCommand={sshCommand}
-				handleCommit={handleCommit}
-				handleInterrupt={handleInterrupt}
-				handleDeleteQueuedMessage={handleDeleteQueuedMessage}
-				handlePromoteQueuedMessage={handlePromoteQueuedMessage}
-				onImplementPlan={handleImplementPlan}
-				onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
-				handleArchiveAgentAction={handleArchiveAgentAction}
-				handleUnarchiveAgentAction={handleUnarchiveAgentAction}
-				handleArchiveAndDeleteWorkspaceAction={
-					handleArchiveAndDeleteWorkspaceAction
-				}
-				handlePinAgentAction={handlePinAgentAction}
-				handleUnpinAgentAction={handleUnpinAgentAction}
-				handleOpenRenameDialogAction={handleOpenRenameDialogAction}
-				isArchivingThisChat={
-					isArchiving &&
-					(archivingChatId === undefined || archivingChatId === agentId)
-				}
-				isPinned={(chatRecord?.pin_order ?? 0) > 0}
-				isChildChat={parentChatID !== undefined}
-				isArchiveBlocked={
-					!chatFamilyAllowsArchive(liveChatStatus, activeChatChildren)
-				}
-				urlTransform={urlTransform}
-				hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
-				isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
-				isHydratingMessages={isHydratingMessages}
-				hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
-				onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-				desktopChatId={desktopEnabled ? agentId : undefined}
-				mcpServers={mcpServers}
-				selectedMCPServerIds={effectiveMCPServerIds}
-				onMCPSelectionChange={handleMCPSelectionChange}
-				onMCPAuthComplete={handleMCPAuthComplete}
-				chatContext={chatQuery.data?.context}
-				queuedForCapacity={chatQuery.data?.queued_for_capacity ?? false}
-				workspaceSkills={chatWorkspaceSkills}
-			/>
-		);
-	}
-
 	return (
 		<>
 			<title>
 				{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
 			</title>
-			{page}
+			{chatQuery.isLoading || chatMessagesQuery.isLoading ? (
+				<AgentChatPageLoadingView
+					sendShortcut={getAgentChatSendShortcut(
+						preferencesQuery.data?.agent_chat_send_shortcut,
+						preferencesQuery.isLoading,
+					)}
+					inputRef={editing.chatInputRef}
+					initialValue={editing.editorInitialValue}
+					initialEditorState={editing.initialEditorState}
+					remountKey={editing.remountKey}
+					onContentChange={editing.handleLoadingDraftChange}
+					isInputDisabled={isInputDisabled}
+					effectiveSelectedModel={effectiveSelectedModel}
+					setSelectedModel={setSelectedModel}
+					modelOptions={modelOptions}
+					modelSelectorPlaceholder={modelSelectorPlaceholder}
+					hasModelOptions={hasModelOptions}
+					isModelCatalogLoading={isModelDataPending}
+					planModeEnabled={planModeEnabled}
+					onPlanModeToggle={handlePlanModeToggle}
+					isSidebarCollapsed={isSidebarCollapsed}
+					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+					showRightPanel={showSidebarPanel}
+				/>
+			) : chatQuery.isLoadingError || chatMessagesQuery.isLoadingError ? (
+				getErrorStatus(chatQuery.error) === 404 ? (
+					<AgentChatPageNotFoundView
+						isSidebarCollapsed={isSidebarCollapsed}
+						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+					/>
+				) : (
+					<AgentChatPageErrorView
+						isSidebarCollapsed={isSidebarCollapsed}
+						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+						error={
+							chatQuery.isLoadingError
+								? chatQuery.error
+								: chatMessagesQuery.error
+						}
+						onRetry={() => {
+							if (chatQuery.isLoadingError) {
+								void chatQuery.refetch();
+							}
+							if (chatMessagesQuery.isLoadingError) {
+								void chatMessagesQuery.refetch();
+							}
+						}}
+					/>
+				)
+			) : !chatQuery.data ||
+				!chatMessagesQuery.data?.pages?.length ||
+				!agentId ? (
+				<AgentChatPageNotFoundView
+					isSidebarCollapsed={isSidebarCollapsed}
+					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+				/>
+			) : (
+				<AgentChatPageView
+					key={agentId}
+					agentId={agentId}
+					sendShortcut={getAgentChatSendShortcut(
+						preferencesQuery.data?.agent_chat_send_shortcut,
+						preferencesQuery.isLoading,
+					)}
+					organizationId={chatQuery.data?.organization_id}
+					chatTitle={chatTitle}
+					parentChat={parentChatQuery.data}
+					persistedError={persistedError}
+					isArchived={isArchived}
+					isSharedChat={isSharedChat}
+					chatOwner={chatOwner}
+					canShareChat={canShareChat}
+					workspace={workspace}
+					workspaceAgent={workspaceAgent}
+					chatBuildId={chatQuery.data?.build_id}
+					store={store}
+					initialChatStatus={chatQuery.data.status}
+					initialMessages={chatMessagesList ?? []}
+					editing={{ ...editing, handleEditUserMessage }}
+					effectiveSelectedModel={effectiveSelectedModel}
+					setSelectedModel={setSelectedModel}
+					modelOptions={modelOptions}
+					modelSelectorPlaceholder={modelSelectorPlaceholder}
+					modelSelectorHelp={modelSelectorHelp}
+					modelCatalogError={modelsQuery.error}
+					unavailableModelNotice={unavailableModelNotice}
+					reasoningEffort={effectiveReasoningEffort}
+					onReasoningEffortChange={(value) => {
+						setSelectedReasoningEffort(value);
+						if (editing.editingMessageId !== null) {
+							isEditReasoningEffortDirtyRef.current = true;
+						}
+					}}
+					canConfigureAgentSetup={permissions.editDeploymentConfig}
+					providerCount={providerCount}
+					modelCount={modelCount}
+					unsupportedProviderNames={unsupportedProviderNames}
+					aiGatewayDisabled={aiGatewayDisabled}
+					hasModelOptions={hasModelOptions}
+					isModelCatalogLoading={isModelDataPending}
+					planModeEnabled={planModeEnabled}
+					onPlanModeToggle={handlePlanModeToggle}
+					compressionThreshold={compressionThreshold}
+					isInputDisabled={isInputDisabled}
+					isSubmissionPending={isSubmissionPending}
+					isInterruptPending={isInterruptPending}
+					workspaceOptions={workspaceOptions}
+					selectedWorkspaceId={selectedWorkspaceId}
+					onWorkspaceChange={
+						canUpdateChatWorkspace ? handleWorkspaceChange : undefined
+					}
+					isWorkspaceLoading={isWorkspaceLoading}
+					isSidebarCollapsed={isSidebarCollapsed}
+					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+					showSidebarPanel={showSidebarPanel}
+					onSetShowSidebarPanel={handleSetShowSidebarPanel}
+					prNumber={prNumber}
+					diffStatusData={chatQuery.data?.diff_status}
+					debugLoggingEnabled={debugLoggingEnabled}
+					gitWatcher={gitWatcher}
+					sshCommand={sshCommand}
+					handleCommit={handleCommit}
+					handleInterrupt={handleInterrupt}
+					handleDeleteQueuedMessage={handleDeleteQueuedMessage}
+					handlePromoteQueuedMessage={handlePromoteQueuedMessage}
+					onImplementPlan={handleImplementPlan}
+					onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
+					handleArchiveAgentAction={handleArchiveAgentAction}
+					handleUnarchiveAgentAction={handleUnarchiveAgentAction}
+					handleArchiveAndDeleteWorkspaceAction={
+						handleArchiveAndDeleteWorkspaceAction
+					}
+					handlePinAgentAction={handlePinAgentAction}
+					handleUnpinAgentAction={handleUnpinAgentAction}
+					handleOpenRenameDialogAction={handleOpenRenameDialogAction}
+					isArchivingThisChat={
+						isArchiving &&
+						(archivingChatId === undefined || archivingChatId === agentId)
+					}
+					isPinned={(chatRecord?.pin_order ?? 0) > 0}
+					isChildChat={parentChatID !== undefined}
+					isArchiveBlocked={
+						!chatFamilyAllowsArchive(liveChatStatus, activeChatChildren)
+					}
+					urlTransform={urlTransform}
+					hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
+					isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
+					isHydratingMessages={isHydratingMessages}
+					hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
+					onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
+					desktopChatId={desktopEnabled ? agentId : undefined}
+					mcpServers={mcpServers}
+					selectedMCPServerIds={effectiveMCPServerIds}
+					onMCPSelectionChange={handleMCPSelectionChange}
+					onMCPAuthComplete={handleMCPAuthComplete}
+					chatContext={chatQuery.data?.context}
+					queuedForCapacity={chatQuery.data?.queued_for_capacity ?? false}
+					workspaceSkills={chatWorkspaceSkills}
+				/>
+			)}
 		</>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -2,7 +2,7 @@ import {
 	MessageScroller,
 	useMessageScroller,
 } from "@shadcn/react/message-scroller";
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
 
 import {
 	useInfiniteQuery,
@@ -744,12 +744,6 @@ const AgentChatPage: FC = () => {
 
 	const chatTitle = chatQuery.data?.title;
 
-	const titleElement = (
-		<title>
-			{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
-		</title>
-	);
-
 	const sshCommand =
 		workspace && workspaceAgent && sshConfigQuery.data?.hostname_suffix
 			? `ssh ${workspaceAgent.name}.${workspace.name}.${workspace.owner_name}.${sshConfigQuery.data.hostname_suffix}`
@@ -1183,14 +1177,14 @@ const AgentChatPage: FC = () => {
 		});
 	};
 
+	let page: ReactNode;
 	if (chatQuery.isLoading || chatMessagesQuery.isLoading) {
-		return (
+		page = (
 			<AgentChatPageLoadingView
 				sendShortcut={getAgentChatSendShortcut(
 					preferencesQuery.data?.agent_chat_send_shortcut,
 					preferencesQuery.isLoading,
 				)}
-				titleElement={titleElement}
 				inputRef={editing.chatInputRef}
 				initialValue={editing.editorInitialValue}
 				initialEditorState={editing.initialEditorState}
@@ -1210,152 +1204,158 @@ const AgentChatPage: FC = () => {
 				showRightPanel={showSidebarPanel}
 			/>
 		);
-	}
-
-	if (chatQuery.isLoadingError || chatMessagesQuery.isLoadingError) {
+	} else if (chatQuery.isLoadingError || chatMessagesQuery.isLoadingError) {
 		if (getErrorStatus(chatQuery.error) === 404) {
-			return (
+			page = (
 				<AgentChatPageNotFoundView
-					titleElement={titleElement}
 					isSidebarCollapsed={isSidebarCollapsed}
 					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 				/>
 			);
+		} else {
+			page = (
+				<AgentChatPageErrorView
+					isSidebarCollapsed={isSidebarCollapsed}
+					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+					error={
+						chatQuery.isLoadingError ? chatQuery.error : chatMessagesQuery.error
+					}
+					onRetry={() => {
+						if (chatQuery.isLoadingError) {
+							void chatQuery.refetch();
+						}
+						if (chatMessagesQuery.isLoadingError) {
+							void chatMessagesQuery.refetch();
+						}
+					}}
+				/>
+			);
 		}
-
-		return (
-			<AgentChatPageErrorView
-				titleElement={titleElement}
+	} else if (
+		!chatQuery.data ||
+		!chatMessagesQuery.data?.pages?.length ||
+		!agentId
+	) {
+		page = (
+			<AgentChatPageNotFoundView
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-				error={
-					chatQuery.isLoadingError ? chatQuery.error : chatMessagesQuery.error
-				}
-				onRetry={() => {
-					if (chatQuery.isLoadingError) {
-						void chatQuery.refetch();
-					}
-					if (chatMessagesQuery.isLoadingError) {
-						void chatMessagesQuery.refetch();
-					}
-				}}
 			/>
 		);
-	}
-
-	if (!chatQuery.data || !chatMessagesQuery.data?.pages?.length || !agentId) {
-		return (
-			<AgentChatPageNotFoundView
-				titleElement={titleElement}
+	} else {
+		page = (
+			<AgentChatPageView
+				key={agentId}
+				agentId={agentId}
+				sendShortcut={getAgentChatSendShortcut(
+					preferencesQuery.data?.agent_chat_send_shortcut,
+					preferencesQuery.isLoading,
+				)}
+				organizationId={chatQuery.data?.organization_id}
+				chatTitle={chatTitle}
+				parentChat={parentChatQuery.data}
+				persistedError={persistedError}
+				isArchived={isArchived}
+				isSharedChat={isSharedChat}
+				chatOwner={chatOwner}
+				canShareChat={canShareChat}
+				workspace={workspace}
+				workspaceAgent={workspaceAgent}
+				chatBuildId={chatQuery.data?.build_id}
+				store={store}
+				initialChatStatus={chatQuery.data.status}
+				initialMessages={chatMessagesList ?? []}
+				editing={{ ...editing, handleEditUserMessage }}
+				effectiveSelectedModel={effectiveSelectedModel}
+				setSelectedModel={setSelectedModel}
+				modelOptions={modelOptions}
+				modelSelectorPlaceholder={modelSelectorPlaceholder}
+				modelSelectorHelp={modelSelectorHelp}
+				modelCatalogError={modelsQuery.error}
+				unavailableModelNotice={unavailableModelNotice}
+				reasoningEffort={effectiveReasoningEffort}
+				onReasoningEffortChange={(value) => {
+					setSelectedReasoningEffort(value);
+					if (editing.editingMessageId !== null) {
+						isEditReasoningEffortDirtyRef.current = true;
+					}
+				}}
+				canConfigureAgentSetup={permissions.editDeploymentConfig}
+				providerCount={providerCount}
+				modelCount={modelCount}
+				unsupportedProviderNames={unsupportedProviderNames}
+				aiGatewayDisabled={aiGatewayDisabled}
+				hasModelOptions={hasModelOptions}
+				isModelCatalogLoading={isModelDataPending}
+				planModeEnabled={planModeEnabled}
+				onPlanModeToggle={handlePlanModeToggle}
+				compressionThreshold={compressionThreshold}
+				isInputDisabled={isInputDisabled}
+				isSubmissionPending={isSubmissionPending}
+				isInterruptPending={isInterruptPending}
+				workspaceOptions={workspaceOptions}
+				selectedWorkspaceId={selectedWorkspaceId}
+				onWorkspaceChange={
+					canUpdateChatWorkspace ? handleWorkspaceChange : undefined
+				}
+				isWorkspaceLoading={isWorkspaceLoading}
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+				showSidebarPanel={showSidebarPanel}
+				onSetShowSidebarPanel={handleSetShowSidebarPanel}
+				prNumber={prNumber}
+				diffStatusData={chatQuery.data?.diff_status}
+				debugLoggingEnabled={debugLoggingEnabled}
+				gitWatcher={gitWatcher}
+				sshCommand={sshCommand}
+				handleCommit={handleCommit}
+				handleInterrupt={handleInterrupt}
+				handleDeleteQueuedMessage={handleDeleteQueuedMessage}
+				handlePromoteQueuedMessage={handlePromoteQueuedMessage}
+				onImplementPlan={handleImplementPlan}
+				onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
+				handleArchiveAgentAction={handleArchiveAgentAction}
+				handleUnarchiveAgentAction={handleUnarchiveAgentAction}
+				handleArchiveAndDeleteWorkspaceAction={
+					handleArchiveAndDeleteWorkspaceAction
+				}
+				handlePinAgentAction={handlePinAgentAction}
+				handleUnpinAgentAction={handleUnpinAgentAction}
+				handleOpenRenameDialogAction={handleOpenRenameDialogAction}
+				isArchivingThisChat={
+					isArchiving &&
+					(archivingChatId === undefined || archivingChatId === agentId)
+				}
+				isPinned={(chatRecord?.pin_order ?? 0) > 0}
+				isChildChat={parentChatID !== undefined}
+				isArchiveBlocked={
+					!chatFamilyAllowsArchive(liveChatStatus, activeChatChildren)
+				}
+				urlTransform={urlTransform}
+				hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
+				isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
+				isHydratingMessages={isHydratingMessages}
+				hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
+				onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
+				desktopChatId={desktopEnabled ? agentId : undefined}
+				mcpServers={mcpServers}
+				selectedMCPServerIds={effectiveMCPServerIds}
+				onMCPSelectionChange={handleMCPSelectionChange}
+				onMCPAuthComplete={handleMCPAuthComplete}
+				chatContext={chatQuery.data?.context}
+				queuedForCapacity={chatQuery.data?.queued_for_capacity ?? false}
+				workspaceSkills={chatWorkspaceSkills}
 			/>
 		);
 	}
 
 	return (
-		<AgentChatPageView
-			key={agentId}
-			agentId={agentId}
-			sendShortcut={getAgentChatSendShortcut(
-				preferencesQuery.data?.agent_chat_send_shortcut,
-				preferencesQuery.isLoading,
-			)}
-			organizationId={chatQuery.data?.organization_id}
-			chatTitle={chatTitle}
-			parentChat={parentChatQuery.data}
-			persistedError={persistedError}
-			isArchived={isArchived}
-			isSharedChat={isSharedChat}
-			chatOwner={chatOwner}
-			canShareChat={canShareChat}
-			workspace={workspace}
-			workspaceAgent={workspaceAgent}
-			chatBuildId={chatQuery.data?.build_id}
-			store={store}
-			initialChatStatus={chatQuery.data.status}
-			initialMessages={chatMessagesList ?? []}
-			editing={{ ...editing, handleEditUserMessage }}
-			effectiveSelectedModel={effectiveSelectedModel}
-			setSelectedModel={setSelectedModel}
-			modelOptions={modelOptions}
-			modelSelectorPlaceholder={modelSelectorPlaceholder}
-			modelSelectorHelp={modelSelectorHelp}
-			modelCatalogError={modelsQuery.error}
-			unavailableModelNotice={unavailableModelNotice}
-			reasoningEffort={effectiveReasoningEffort}
-			onReasoningEffortChange={(value) => {
-				setSelectedReasoningEffort(value);
-				if (editing.editingMessageId !== null) {
-					isEditReasoningEffortDirtyRef.current = true;
-				}
-			}}
-			canConfigureAgentSetup={permissions.editDeploymentConfig}
-			providerCount={providerCount}
-			modelCount={modelCount}
-			unsupportedProviderNames={unsupportedProviderNames}
-			aiGatewayDisabled={aiGatewayDisabled}
-			hasModelOptions={hasModelOptions}
-			isModelCatalogLoading={isModelDataPending}
-			planModeEnabled={planModeEnabled}
-			onPlanModeToggle={handlePlanModeToggle}
-			compressionThreshold={compressionThreshold}
-			isInputDisabled={isInputDisabled}
-			isSubmissionPending={isSubmissionPending}
-			isInterruptPending={isInterruptPending}
-			workspaceOptions={workspaceOptions}
-			selectedWorkspaceId={selectedWorkspaceId}
-			onWorkspaceChange={
-				canUpdateChatWorkspace ? handleWorkspaceChange : undefined
-			}
-			isWorkspaceLoading={isWorkspaceLoading}
-			isSidebarCollapsed={isSidebarCollapsed}
-			onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-			showSidebarPanel={showSidebarPanel}
-			onSetShowSidebarPanel={handleSetShowSidebarPanel}
-			prNumber={prNumber}
-			diffStatusData={chatQuery.data?.diff_status}
-			debugLoggingEnabled={debugLoggingEnabled}
-			gitWatcher={gitWatcher}
-			sshCommand={sshCommand}
-			handleCommit={handleCommit}
-			handleInterrupt={handleInterrupt}
-			handleDeleteQueuedMessage={handleDeleteQueuedMessage}
-			handlePromoteQueuedMessage={handlePromoteQueuedMessage}
-			onImplementPlan={handleImplementPlan}
-			onSendAskUserQuestionResponse={handleSendAskUserQuestionResponse}
-			handleArchiveAgentAction={handleArchiveAgentAction}
-			handleUnarchiveAgentAction={handleUnarchiveAgentAction}
-			handleArchiveAndDeleteWorkspaceAction={
-				handleArchiveAndDeleteWorkspaceAction
-			}
-			handlePinAgentAction={handlePinAgentAction}
-			handleUnpinAgentAction={handleUnpinAgentAction}
-			handleOpenRenameDialogAction={handleOpenRenameDialogAction}
-			isArchivingThisChat={
-				isArchiving &&
-				(archivingChatId === undefined || archivingChatId === agentId)
-			}
-			isPinned={(chatRecord?.pin_order ?? 0) > 0}
-			isChildChat={parentChatID !== undefined}
-			isArchiveBlocked={
-				!chatFamilyAllowsArchive(liveChatStatus, activeChatChildren)
-			}
-			urlTransform={urlTransform}
-			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
-			isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
-			isHydratingMessages={isHydratingMessages}
-			hasFetchMoreError={chatMessagesQuery.isFetchNextPageError}
-			onFetchMoreMessages={chatMessagesQuery.fetchNextPage}
-			desktopChatId={desktopEnabled ? agentId : undefined}
-			mcpServers={mcpServers}
-			selectedMCPServerIds={effectiveMCPServerIds}
-			onMCPSelectionChange={handleMCPSelectionChange}
-			onMCPAuthComplete={handleMCPAuthComplete}
-			chatContext={chatQuery.data?.context}
-			queuedForCapacity={chatQuery.data?.queued_for_capacity ?? false}
-			workspaceSkills={chatWorkspaceSkills}
-		/>
+		<>
+			<title>
+				{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
+			</title>
+			{page}
+		</>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageErrorView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageErrorView.tsx
@@ -1,11 +1,10 @@
 import { RotateCcwIcon } from "lucide-react";
-import type { FC, ReactNode } from "react";
+import type { FC } from "react";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
 import { Button } from "#/components/Button/Button";
 import { ChatTopBar } from "./components/ChatTopBar";
 
 interface AgentChatPageErrorViewProps {
-	titleElement: ReactNode;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
 	error: unknown;
@@ -13,7 +12,6 @@ interface AgentChatPageErrorViewProps {
 }
 
 export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
-	titleElement,
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
 	error,
@@ -23,7 +21,6 @@ export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
 
 	return (
 		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
-			{titleElement}
 			<ChatTopBar
 				panel={{
 					showSidebarPanel: false,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -905,7 +905,6 @@ export const Loading: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -929,7 +928,6 @@ export const LoadingWithModelOptions: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -952,7 +950,6 @@ export const LoadingWithRightPanel: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -976,7 +973,6 @@ export const LoadingSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -1113,7 +1109,6 @@ export const EditingMessage: Story = {
 export const NotFound: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found — Agents</title>}
 			isSidebarCollapsed={false}
 			onToggleSidebarCollapsed={fn()}
 		/>
@@ -1124,7 +1119,6 @@ export const NotFound: Story = {
 export const NotFoundSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found — Agents</title>}
 			isSidebarCollapsed
 			onToggleSidebarCollapsed={fn()}
 		/>

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -26,7 +26,6 @@ import {
 import { WorkspaceAppFrame } from "#/modules/apps/WorkspaceAppFrame";
 import { findWorkspaceAppWithAgent } from "#/modules/apps/workspaceApps";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
-import { pageTitle } from "#/utils/page";
 import { generateConnectionSessionId, generateUUID } from "#/utils/random";
 import { findWorkspaceAgent } from "#/utils/workspace";
 import {
@@ -854,12 +853,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 			? runtimeHours.hard_limit
 			: undefined;
 
-	const titleElement = (
-		<title>
-			{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
-		</title>
-	);
-
 	return (
 		<TerminalClientSessionContext value={clientSessionId}>
 			<ChatWorkspaceContext
@@ -872,7 +865,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							shouldShowSidebar && !visualExpanded && "flex-row",
 						)}
 					>
-						{titleElement}
 						<div
 							data-testid="agents-chat-panel"
 							className={cn(
@@ -1100,7 +1092,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 
 interface AgentChatPageLoadingViewProps {
 	sendShortcut: AgentChatSendShortcut;
-	titleElement: React.ReactNode;
 	inputRef: RefObject<ChatMessageInputRef | null>;
 	initialValue: string;
 	initialEditorState: string | undefined;
@@ -1126,7 +1117,6 @@ interface AgentChatPageLoadingViewProps {
 
 export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	sendShortcut,
-	titleElement,
 	inputRef,
 	initialValue,
 	initialEditorState,
@@ -1153,7 +1143,6 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 				showRightPanel && "flex-row",
 			)}
 		>
-			{titleElement}
 			<div className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col sm:min-w-(--agents-chat-panel-min-width,0px)">
 				<ChatTopBar
 					panel={{
@@ -1219,19 +1208,16 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 };
 
 interface AgentChatPageNotFoundViewProps {
-	titleElement: React.ReactNode;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
 }
 
 export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
-	titleElement,
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
 }) => {
 	return (
 		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
-			{titleElement}
 			<ChatTopBar
 				panel={{
 					showSidebarPanel: false,


### PR DESCRIPTION
> 🤖 Refactoring with Cursor.

Pull already-tested helpers and the conversation-editing, workspace-watch, and right-panel preference logic out of AgentChatPage into colocated modules. The document title now lives on the page instead of being passed through views.

Behavior is unchanged. The send pipeline and AgentChatPageView stay put.