### PR TITLE
refactor(site/src/pages/AgentsPage): read sidebar collapse from outlet context

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -174,8 +174,6 @@ const AgentChatPage: FC = () => {
 		archivingChatId,
 		activeChatChildren,
 		onOpenRenameDialog,
-		isSidebarCollapsed,
-		onToggleSidebarCollapsed,
 		onChatReady,
 	} = useOutletContext<AgentsPageOutletContext>();
 	const queryClient = useQueryClient();
@@ -1201,20 +1199,13 @@ const AgentChatPage: FC = () => {
 					isModelCatalogLoading={isModelDataPending}
 					planModeEnabled={planModeEnabled}
 					onPlanModeToggle={handlePlanModeToggle}
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 					showRightPanel={showSidebarPanel}
 				/>
 			) : chatQuery.isLoadingError || chatMessagesQuery.isLoadingError ? (
 				getErrorStatus(chatQuery.error) === 404 ? (
-					<AgentChatPageNotFoundView
-						isSidebarCollapsed={isSidebarCollapsed}
-						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-					/>
+					<AgentChatPageNotFoundView />
 				) : (
 					<AgentChatPageErrorView
-						isSidebarCollapsed={isSidebarCollapsed}
-						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 						error={
 							chatQuery.isLoadingError
 								? chatQuery.error
@@ -1233,10 +1224,7 @@ const AgentChatPage: FC = () => {
 			) : !chatQuery.data ||
 				!chatMessagesQuery.data?.pages?.length ||
 				!agentId ? (
-				<AgentChatPageNotFoundView
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-				/>
+				<AgentChatPageNotFoundView />
 			) : (
 				<AgentChatPageView
 					key={agentId}
@@ -1293,8 +1281,6 @@ const AgentChatPage: FC = () => {
 						canUpdateChatWorkspace ? handleWorkspaceChange : undefined
 					}
 					isWorkspaceLoading={isWorkspaceLoading}
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 					showSidebarPanel={showSidebarPanel}
 					onSetShowSidebarPanel={handleSetShowSidebarPanel}
 					prNumber={prNumber}

--- a/site/src/pages/AgentsPage/AgentChatPageErrorView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageErrorView.tsx
@@ -5,15 +5,11 @@ import { Button } from "#/components/Button/Button";
 import { ChatTopBar } from "./components/ChatTopBar";
 
 interface AgentChatPageErrorViewProps {
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
 	error: unknown;
 	onRetry: () => void;
 }
 
 export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
 	error,
 	onRetry,
 }) => {
@@ -30,8 +26,6 @@ export const AgentChatPageErrorView: FC<AgentChatPageErrorViewProps> = ({
 				onUnarchiveAgent={() => {}}
 				onArchiveAndDeleteWorkspace={() => {}}
 				hasWorkspace={false}
-				isSidebarCollapsed={isSidebarCollapsed}
-				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>
 			<div className="flex flex-1 items-center justify-center px-6 text-center">
 				<div className="flex flex-col items-center">

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1,6 +1,7 @@
 import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { type ComponentProps, type FC, useRef, useState } from "react";
+import { Outlet } from "react-router";
 import {
 	expect,
 	fireEvent,
@@ -109,6 +110,31 @@ const agentsRouting = [
 	...{ path: string; useStoryElement: boolean }[],
 ];
 
+const collapsedSidebarRouter = reactRouterParameters({
+	location: {
+		path: `/agents/${AGENT_ID}`,
+		pathParams: { agentId: AGENT_ID },
+	},
+	routing: [
+		{
+			path: "/",
+			element: (
+				<Outlet
+					context={{
+						isSidebarCollapsed: true,
+						onToggleSidebarCollapsed: () => {},
+						onExpandSidebar: () => {},
+					}}
+				/>
+			),
+			children: [
+				{ path: "agents/:agentId", useStoryElement: true },
+				{ path: "agents", useStoryElement: true },
+			],
+		},
+	],
+});
+
 // ---------------------------------------------------------------------------
 // Wrapper component.
 //
@@ -150,8 +176,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		isInputDisabled: false,
 		isSubmissionPending: false,
 		isInterruptPending: false,
-		isSidebarCollapsed: false,
-		onToggleSidebarCollapsed: fn(),
 		showSidebarPanel: false,
 		onSetShowSidebarPanel: fn(),
 		prNumber: undefined as number | undefined,
@@ -671,7 +695,8 @@ index abc1234..def5678 100644
 
 /** Left sidebar is collapsed. */
 export const SidebarCollapsed: Story = {
-	render: () => <StoryAgentChatPageView isSidebarCollapsed />,
+	parameters: { reactRouter: collapsedSidebarRouter },
+	render: () => <StoryAgentChatPageView />,
 };
 
 /** No model options available — shows a disabled status message. */
@@ -916,8 +941,6 @@ export const Loading: Story = {
 			modelOptions={defaultModelOptions}
 			modelSelectorPlaceholder="Select a model"
 			hasModelOptions
-			isSidebarCollapsed={false}
-			onToggleSidebarCollapsed={fn()}
 			showRightPanel={false}
 		/>
 	),
@@ -939,8 +962,6 @@ export const LoadingWithModelOptions: Story = {
 			modelOptions={defaultModelOptions}
 			modelSelectorPlaceholder="Select a model"
 			hasModelOptions
-			isSidebarCollapsed={false}
-			onToggleSidebarCollapsed={fn()}
 			showRightPanel={false}
 		/>
 	),
@@ -961,8 +982,6 @@ export const LoadingWithRightPanel: Story = {
 			modelOptions={defaultModelOptions}
 			modelSelectorPlaceholder="Select a model"
 			hasModelOptions
-			isSidebarCollapsed={false}
-			onToggleSidebarCollapsed={fn()}
 			showRightPanel
 		/>
 	),
@@ -970,6 +989,7 @@ export const LoadingWithRightPanel: Story = {
 
 /** Loading state with the left sidebar collapsed. */
 export const LoadingSidebarCollapsed: Story = {
+	parameters: { reactRouter: collapsedSidebarRouter },
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
@@ -984,8 +1004,6 @@ export const LoadingSidebarCollapsed: Story = {
 			modelOptions={defaultModelOptions}
 			modelSelectorPlaceholder="Select a model"
 			hasModelOptions
-			isSidebarCollapsed
-			onToggleSidebarCollapsed={fn()}
 			showRightPanel={false}
 		/>
 	),
@@ -1107,22 +1125,13 @@ export const EditingMessage: Story = {
 
 /** Shows the "Chat not found" message. */
 export const NotFound: Story = {
-	render: () => (
-		<AgentChatPageNotFoundView
-			isSidebarCollapsed={false}
-			onToggleSidebarCollapsed={fn()}
-		/>
-	),
+	render: () => <AgentChatPageNotFoundView />,
 };
 
 /** "Chat not found" with the left sidebar collapsed. */
 export const NotFoundSidebarCollapsed: Story = {
-	render: () => (
-		<AgentChatPageNotFoundView
-			isSidebarCollapsed
-			onToggleSidebarCollapsed={fn()}
-		/>
-	),
+	parameters: { reactRouter: collapsedSidebarRouter },
+	render: () => <AgentChatPageNotFoundView />,
 };
 
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -162,10 +162,6 @@ interface AgentChatPageViewProps {
 	onWorkspaceChange?: (workspaceId: string | null) => void;
 	isWorkspaceLoading?: boolean;
 
-	// Sidebar / panel state.
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
-
 	// Right panel state (owned by the parent so loading and
 	// loaded views share the same layout).
 	showSidebarPanel: boolean;
@@ -359,8 +355,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	selectedWorkspaceId = null,
 	onWorkspaceChange,
 	isWorkspaceLoading = false,
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
 	showSidebarPanel,
 	onSetShowSidebarPanel,
 	prNumber,
@@ -899,8 +893,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									isArchived={isArchived}
 									diffStatusData={diffStatusData}
 									isSharedChat={isSharedChat}
-									isSidebarCollapsed={isSidebarCollapsed}
-									onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 									renderChatSharingContent={
 										canOpenChatSharing
 											? (open) => (
@@ -1054,8 +1046,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							onToggleExpanded={() => setIsRightPanelExpanded((prev) => !prev)}
 							onClose={() => onSetShowSidebarPanel(false)}
 							onVisualExpandedChange={setDragVisualExpanded}
-							isSidebarCollapsed={isSidebarCollapsed}
-							onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 						>
 							<SidebarTabView
 								effectiveTabId={effectiveSidebarTabId}
@@ -1078,8 +1068,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								onToggleExpanded={() =>
 									setIsRightPanelExpanded((prev) => !prev)
 								}
-								isSidebarCollapsed={isSidebarCollapsed}
-								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 								chatTitle={chatTitle}
 							/>
 						</RightPanel>
@@ -1110,8 +1098,6 @@ interface AgentChatPageLoadingViewProps {
 	isModelCatalogLoading?: boolean;
 	planModeEnabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
 	showRightPanel: boolean;
 }
 
@@ -1131,8 +1117,6 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	isModelCatalogLoading = false,
 	planModeEnabled,
 	onPlanModeToggle,
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
 	showRightPanel,
 }) => {
 	const [chatFullWidth] = useChatFullWidth();
@@ -1153,8 +1137,6 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 					onUnarchiveAgent={() => {}}
 					onArchiveAndDeleteWorkspace={() => {}}
 					hasWorkspace={false}
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 				/>
 				<div className="min-h-0 flex-1 overflow-y-auto scrollbar-gutter-stable scrollbar-thin [scrollbar-color:hsl(var(--surface-quaternary))_transparent]">
 					<div className="px-4">
@@ -1197,8 +1179,6 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 					isExpanded={false}
 					onToggleExpanded={() => {}}
 					onClose={() => {}}
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 				>
 					<RightPanelSkeleton />
 				</RightPanel>
@@ -1207,15 +1187,7 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 	);
 };
 
-interface AgentChatPageNotFoundViewProps {
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
-}
-
-export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
-}) => {
+export const AgentChatPageNotFoundView: FC = () => {
 	return (
 		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
 			<ChatTopBar
@@ -1227,8 +1199,6 @@ export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
 				onUnarchiveAgent={() => {}}
 				onArchiveAndDeleteWorkspace={() => {}}
 				hasWorkspace={false}
-				isSidebarCollapsed={isSidebarCollapsed}
-				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>
 			<div className="flex flex-1 items-center justify-center text-content-secondary">
 				Chat not found

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
-import { Navigate, useOutletContext } from "react-router";
+import { Navigate } from "react-router";
 import {
 	expect,
 	fireEvent,
@@ -43,9 +43,7 @@ import AgentCreatePage from "./AgentCreatePage";
 import AgentSettingsCompactionPage from "./AgentSettingsCompactionPage";
 import AgentSettingsGeneralPage from "./AgentSettingsGeneralPage";
 import AgentSettingsLayout from "./AgentSettingsLayout";
-import AgentsPageLayout, {
-	type AgentsPageOutletContext,
-} from "./AgentsPageLayout";
+import AgentsPageLayout from "./AgentsPageLayout";
 import {
 	AGENTS_MAIN_PANEL_MIN_WIDTH,
 	clampLeftSidebarWidth,
@@ -196,8 +194,6 @@ const setInnerWidthForStory = (width: number) => {
 };
 
 const AgentTopBarRouteElement = () => {
-	const { isSidebarCollapsed, onToggleSidebarCollapsed } =
-		useOutletContext<AgentsPageOutletContext>();
 	return (
 		<ChatTopBar
 			chatTitle="Collapsed sidebar agent"
@@ -205,8 +201,6 @@ const AgentTopBarRouteElement = () => {
 			onArchiveAgent={fn()}
 			onArchiveAndDeleteWorkspace={fn()}
 			onUnarchiveAgent={fn()}
-			isSidebarCollapsed={isSidebarCollapsed}
-			onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useLocation } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { PopoverContent } from "#/components/Popover/Popover";
@@ -24,8 +24,6 @@ const defaultProps = {
 	onUnpinAgent: fn(),
 	onOpenRenameDialog: fn(),
 	onUnarchiveAgent: fn(),
-	isSidebarCollapsed: false,
-	onToggleSidebarCollapsed: fn(),
 } satisfies React.ComponentProps<typeof ChatTopBar>;
 
 const meta: Meta<typeof ChatTopBar> = {
@@ -88,8 +86,31 @@ export const WithParentChat: Story = {
 };
 
 export const SidebarCollapsed: Story = {
-	args: {
-		isSidebarCollapsed: true,
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents/chat-1" },
+			routing: [
+				{
+					path: "/",
+					element: (
+						<Outlet
+							context={{
+								isSidebarCollapsed: true,
+								onToggleSidebarCollapsed: fn(),
+								onExpandSidebar: () => {},
+							}}
+						/>
+					),
+					children: [{ path: "agents/:agentId", useStoryElement: true }],
+				},
+			],
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("button", { name: "Expand sidebar" }),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -10,7 +10,7 @@ import {
 	UsersIcon,
 } from "lucide-react";
 import { type FC, Fragment, type ReactNode, useState } from "react";
-import { Link, useLocation } from "react-router";
+import { Link, useLocation, useOutletContext } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
@@ -22,6 +22,7 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import { Popover, PopoverTrigger } from "#/components/Popover/Popover";
+import type { AgentsPageOutletContext } from "../AgentsPageLayout";
 import { parsePullRequestUrl } from "../utils/pullRequest";
 import {
 	ChatActionsMenuItems,
@@ -55,8 +56,6 @@ type ChatTopBarProps = {
 	isArchiveBlocked?: boolean;
 	isChildChat?: boolean;
 	isPinned?: boolean;
-	isSidebarCollapsed: boolean;
-	onToggleSidebarCollapsed: () => void;
 	diffStatusData?: ChatDiffStatus;
 	isSharedChat?: boolean;
 	renderChatSharingContent?: (open: boolean) => ReactNode;
@@ -111,14 +110,14 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 	isArchiveBlocked = false,
 	isChildChat = false,
 	isPinned = false,
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
 	diffStatusData,
 	isSharedChat,
 	renderChatSharingContent,
 }) => {
 	const { isEmbedded } = useEmbedContext();
 	const location = useLocation();
+	const { isSidebarCollapsed, onToggleSidebarCollapsed } =
+		useOutletContext<AgentsPageOutletContext | undefined>() ?? {};
 
 	const prUrl = diffStatusData?.url;
 	const prState = diffStatusData?.pull_request_state;

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tabs/SidebarTabView.tsx
@@ -17,7 +17,9 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useOutletContext } from "react-router";
 import { Button } from "#/components/Button/Button";
+import type { AgentsPageOutletContext } from "../../../AgentsPageLayout";
 
 /** A single tab definition for the sidebar panel. */
 export interface SidebarTab {
@@ -39,10 +41,6 @@ interface SidebarTabViewProps {
 	isExpanded: boolean;
 	/** Callback to toggle expanded state. */
 	onToggleExpanded: () => void;
-	/** Whether the left sidebar is collapsed. */
-	isSidebarCollapsed?: boolean;
-	/** Callback to toggle left sidebar. */
-	onToggleSidebarCollapsed?: () => void;
 	/** Shown in center when expanded. */
 	chatTitle?: string;
 	/** Callback to close the panel (used on mobile). */
@@ -152,14 +150,14 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	tabs,
 	isExpanded,
 	onToggleExpanded,
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
 	chatTitle,
 	onClose,
 	effectiveTabId,
 	onActiveTabChange,
 	addTabControl,
 }) => {
+	const { isSidebarCollapsed, onToggleSidebarCollapsed } =
+		useOutletContext<AgentsPageOutletContext | undefined>() ?? {};
 	const tabIdPrefix = useId();
 	const {
 		ref: tabScrollRef,

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
@@ -6,6 +6,8 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useOutletContext } from "react-router";
+import type { AgentsPageOutletContext } from "../../AgentsPageLayout";
 import { AGENTS_MAIN_PANEL_MIN_WIDTH } from "../ChatsSidebar/sidebarWidth";
 
 export const RIGHT_PANEL_OPEN_KEY = "agents.right-panel-open";
@@ -65,8 +67,6 @@ interface RightPanelProps {
 	 * null when the drag ends so the parent falls back to the
 	 * committed isExpanded prop. */
 	onVisualExpandedChange?: (visualExpanded: boolean | null) => void;
-	isSidebarCollapsed?: boolean;
-	onToggleSidebarCollapsed?: () => void;
 	children: ReactNode;
 }
 
@@ -202,10 +202,10 @@ export const RightPanel = ({
 	onToggleExpanded,
 	onClose,
 	onVisualExpandedChange,
-	isSidebarCollapsed,
-	onToggleSidebarCollapsed,
 	children,
 }: RightPanelProps) => {
+	const { isSidebarCollapsed, onToggleSidebarCollapsed } =
+		useOutletContext<AgentsPageOutletContext | undefined>() ?? {};
 	const [width, setWidth] = useState(loadPersistedWidth);
 	const panelRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
ChatTopBar, RightPanel, and SidebarTabView now read sidebar collapse from the agents layout outlet, same as AgentPageHeader. AgentChatPage no longer threads those props through the loading, error, and ready views.
