### PR TITLE
refactor(site/src/pages/AgentsPage): pass Chat into AgentChatPageView

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -22,7 +22,7 @@ import { chatProviderConfigs } from "#/api/queries/aiProviders";
 import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
-	chat,
+	chat as chatById,
 	chatMessagesForInfiniteScroll,
 	chatModels,
 	chatQueueConvergence,
@@ -129,7 +129,6 @@ import {
 	resolveModelOptionId,
 	resolveModelSelector,
 } from "./utils/modelOptions";
-import { parsePullRequestUrl } from "./utils/pullRequest";
 import { pickReasoningEffort } from "./utils/reasoningEffort";
 import {
 	CHAT_SLASH_COMMANDS,
@@ -227,7 +226,7 @@ const AgentChatPage: FC = () => {
 	});
 	const parentChatID = getParentChatID(chatQuery.data);
 	const parentChatQuery = useQuery({
-		...chat(parentChatID ?? ""),
+		...chatById(parentChatID ?? ""),
 		enabled: Boolean(parentChatID),
 	});
 	const workspaceId = chatQuery.data?.workspace_id;
@@ -313,19 +312,17 @@ const AgentChatPage: FC = () => {
 	const workspaceAgent = getWorkspaceAgent(workspace, chatAgentId);
 	const { proxy } = useProxy();
 
-	const chatRecord = chatQuery.data;
-	const isArchived = Boolean(chatRecord?.archived);
-	const isSharedChat = Boolean(chatRecord?.shared);
+	const chat = chatQuery.data;
+	const isArchived = Boolean(chat?.archived);
 	const isViewerNotOwner =
-		chatRecord !== undefined && currentUser.id !== chatRecord.owner_id;
-	const isRootChat =
-		chatRecord !== undefined && getParentChatID(chatRecord) === undefined;
+		chat !== undefined && currentUser.id !== chat.owner_id;
+	const isRootChat = chat !== undefined && getParentChatID(chat) === undefined;
 	const chatAuthorizationObject =
-		chatRecord !== undefined
+		chat !== undefined
 			? {
 					resource_type: "chat" as const,
-					owner_id: chatRecord.owner_id,
-					organization_id: chatRecord.organization_id,
+					owner_id: chat.owner_id,
+					organization_id: chat.organization_id,
 				}
 			: undefined;
 	const chatAuthorizationChecks: TypesGen.AuthorizationRequest["checks"] = {};
@@ -341,15 +338,7 @@ const AgentChatPage: FC = () => {
 	});
 	const canShareChat =
 		isRootChat && Boolean(chatAuthorizationQuery.data?.canShareChat);
-	const chatOwner = isViewerNotOwner
-		? {
-				...(chatRecord?.owner_username
-					? { username: chatRecord.owner_username }
-					: {}),
-				...(chatRecord?.owner_name ? { name: chatRecord.owner_name } : {}),
-			}
-		: undefined;
-	const planModeEnabled = chatRecord?.plan_mode === "plan";
+	const planModeEnabled = chat?.plan_mode === "plan";
 
 	// Initialize MCP selection from chat record or defaults.
 	const effectiveMCPServerIds = (() => {
@@ -358,8 +347,8 @@ const AgentChatPage: FC = () => {
 		}
 		// If the chat has MCP server IDs recorded (even empty, meaning
 		// the user deliberately opted out), use those.
-		if (chatRecord?.mcp_server_ids) {
-			return chatRecord.mcp_server_ids;
+		if (chat?.mcp_server_ids) {
+			return chat.mcp_server_ids;
 		}
 		// Check for a previously saved selection in localStorage.
 		const saved = chatOrganizationId
@@ -408,7 +397,7 @@ const AgentChatPage: FC = () => {
 					has_more: Boolean(chatMessagesQuery.data?.pages.at(-1)?.has_more),
 				}
 			: undefined;
-	const chatLastModelConfigID = chatRecord?.last_model_config_id;
+	const chatLastModelConfigID = chat?.last_model_config_id;
 
 	// Destructure mutation results directly so the React Compiler
 	// tracks stable primitives/functions instead of the whole result
@@ -505,7 +494,7 @@ const AgentChatPage: FC = () => {
 	} = useChatStore({
 		chatID: agentId,
 		chatMessages: chatMessagesList,
-		chatRecord,
+		chatRecord: chat,
 		chatRecordUpdatedAt: chatQuery.dataUpdatedAt,
 		chatMessagesData,
 		chatQueuedMessages,
@@ -514,10 +503,10 @@ const AgentChatPage: FC = () => {
 		aiGatewayDisabled,
 	});
 	const liveChatStatus =
-		useChatSelector(store, selectChatStatus) ?? chatRecord?.status ?? null;
+		useChatSelector(store, selectChatStatus) ?? chat?.status ?? null;
 	const persistedError = getPersistedDetailError({
 		chatStatus: liveChatStatus,
-		chatRecord,
+		chatRecord: chat,
 		cachedError: agentId ? chatErrorReasons[agentId] : undefined,
 	});
 
@@ -549,13 +538,6 @@ const AgentChatPage: FC = () => {
 		chatInputRef.current?.focus();
 	};
 
-	// Prefer the explicit PR number from the API, and only fall back to URL
-	// parsing when older metadata does not provide it.
-	const parsedPrNumber = Number(
-		parsePullRequestUrl(chatQuery.data?.diff_status?.url)?.number,
-	);
-	const prNumber =
-		chatQuery.data?.diff_status?.pr_number ?? (parsedPrNumber || undefined);
 	// Validate explicit and historical choices against organization options.
 	// Prefer the usable organization default before another organization model.
 	const effectiveSelectedModel = (() => {
@@ -609,7 +591,7 @@ const AgentChatPage: FC = () => {
 	);
 	const effectiveReasoningEffort = effectiveModelOption
 		? pickReasoningEffort(
-				selectedReasoningEffort || chatRecord?.last_reasoning_effort,
+				selectedReasoningEffort || chat?.last_reasoning_effort,
 				effectiveModelOption.reasoningEfforts ?? [],
 				effectiveModelOption.reasoningEffortDefault,
 			)
@@ -782,12 +764,12 @@ const AgentChatPage: FC = () => {
 	};
 
 	const handleOpenRenameDialogAction =
-		onOpenRenameDialog && chatRecord
+		onOpenRenameDialog && chat
 			? () => {
 					if (isArchived) {
 						return;
 					}
-					onOpenRenameDialog(chatRecord);
+					onOpenRenameDialog(chat);
 				}
 			: undefined;
 
@@ -1221,31 +1203,22 @@ const AgentChatPage: FC = () => {
 						}}
 					/>
 				)
-			) : !chatQuery.data ||
-				!chatMessagesQuery.data?.pages?.length ||
-				!agentId ? (
+			) : !chat || !chatMessagesQuery.data?.pages?.length || !agentId ? (
 				<AgentChatPageNotFoundView />
 			) : (
 				<AgentChatPageView
 					key={agentId}
-					agentId={agentId}
+					chat={chat}
 					sendShortcut={getAgentChatSendShortcut(
 						preferencesQuery.data?.agent_chat_send_shortcut,
 						preferencesQuery.isLoading,
 					)}
-					organizationId={chatQuery.data?.organization_id}
-					chatTitle={chatTitle}
 					parentChat={parentChatQuery.data}
 					persistedError={persistedError}
-					isArchived={isArchived}
-					isSharedChat={isSharedChat}
-					chatOwner={chatOwner}
 					canShareChat={canShareChat}
 					workspace={workspace}
 					workspaceAgent={workspaceAgent}
-					chatBuildId={chatQuery.data?.build_id}
 					store={store}
-					initialChatStatus={chatQuery.data.status}
 					initialMessages={chatMessagesList ?? []}
 					editing={{ ...editing, handleEditUserMessage }}
 					effectiveSelectedModel={effectiveSelectedModel}
@@ -1269,22 +1242,18 @@ const AgentChatPage: FC = () => {
 					aiGatewayDisabled={aiGatewayDisabled}
 					hasModelOptions={hasModelOptions}
 					isModelCatalogLoading={isModelDataPending}
-					planModeEnabled={planModeEnabled}
 					onPlanModeToggle={handlePlanModeToggle}
 					compressionThreshold={compressionThreshold}
 					isInputDisabled={isInputDisabled}
 					isSubmissionPending={isSubmissionPending}
 					isInterruptPending={isInterruptPending}
 					workspaceOptions={workspaceOptions}
-					selectedWorkspaceId={selectedWorkspaceId}
 					onWorkspaceChange={
 						canUpdateChatWorkspace ? handleWorkspaceChange : undefined
 					}
 					isWorkspaceLoading={isWorkspaceLoading}
 					showSidebarPanel={showSidebarPanel}
 					onSetShowSidebarPanel={handleSetShowSidebarPanel}
-					prNumber={prNumber}
-					diffStatusData={chatQuery.data?.diff_status}
 					debugLoggingEnabled={debugLoggingEnabled}
 					gitWatcher={gitWatcher}
 					sshCommand={sshCommand}
@@ -1306,8 +1275,6 @@ const AgentChatPage: FC = () => {
 						isArchiving &&
 						(archivingChatId === undefined || archivingChatId === agentId)
 					}
-					isPinned={(chatRecord?.pin_order ?? 0) > 0}
-					isChildChat={parentChatID !== undefined}
 					isArchiveBlocked={
 						!chatFamilyAllowsArchive(liveChatStatus, activeChatChildren)
 					}
@@ -1322,8 +1289,6 @@ const AgentChatPage: FC = () => {
 					selectedMCPServerIds={effectiveMCPServerIds}
 					onMCPSelectionChange={handleMCPSelectionChange}
 					onMCPAuthComplete={handleMCPAuthComplete}
-					chatContext={chatQuery.data?.context}
-					queuedForCapacity={Boolean(chatQuery.data?.queued_for_capacity)}
 					workspaceSkills={chatWorkspaceSkills}
 				/>
 			)}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -67,9 +67,6 @@ const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 const buildChat = (overrides: Partial<TypesGen.Chat> = {}): TypesGen.Chat => ({
 	...MockChat,
 	id: AGENT_ID,
-	owner_id: "owner-1",
-	owner_username: "owner",
-	owner_name: "Owner",
 	title: "Help me refactor",
 	last_model_config_id: defaultModelID,
 	created_at: oneWeekAgo,
@@ -146,27 +143,25 @@ const collapsedSidebarRouter = reactRouterParameters({
 // ---------------------------------------------------------------------------
 type StoryProps = Omit<
 	Partial<ComponentProps<typeof AgentChatPageView>>,
-	"editing"
+	"editing" | "chat"
 > & {
 	editing?: Partial<ComponentProps<typeof AgentChatPageView>["editing"]>;
+	chat?: Partial<TypesGen.Chat>;
 };
 
-const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
+const StoryAgentChatPageView: FC<StoryProps> = ({
+	editing,
+	chat,
+	...overrides
+}) => {
 	const defaultStoreRef = useRef(createChatStore());
 	const store = overrides.store ?? defaultStoreRef.current;
 
 	const props = {
-		agentId: AGENT_ID,
+		chat: buildChat(chat),
 		sendShortcut: "enter" as const,
-		organizationId: "test-org-id",
-		chatTitle: "Help me refactor",
 		persistedError: undefined as ChatDetailError | undefined,
 		parentChat: undefined as TypesGen.Chat | undefined,
-		isArchived: false,
-		isSharedChat: false,
-		chatOwner: undefined as ComponentProps<
-			typeof AgentChatPageView
-		>["chatOwner"],
 		effectiveSelectedModel: defaultModelID,
 		setSelectedModel: fn(),
 		modelOptions: defaultModelOptions,
@@ -178,10 +173,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		isInterruptPending: false,
 		showSidebarPanel: false,
 		onSetShowSidebarPanel: fn(),
-		prNumber: undefined as number | undefined,
-		diffStatusData: undefined as ComponentProps<
-			typeof AgentChatPageView
-		>["diffStatusData"],
 		debugLoggingEnabled: false,
 		gitWatcher: buildGitWatcher(),
 		sshCommand: undefined as string | undefined,
@@ -207,7 +198,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		canConfigureAgentSetup: true,
 		providerCount: 1,
 		modelCount: 1,
-		initialChatStatus: "waiting" as const,
 		initialMessages: [],
 		...overrides,
 		store,
@@ -290,13 +280,19 @@ export const CachedModelsWithRefetchError: Story = {
 
 /** Archived agent displays the read-only banner below the top bar. */
 export const Archived: Story = {
-	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,
+	render: () => (
+		<StoryAgentChatPageView chat={{ archived: true }} isInputDisabled />
+	),
 };
 
 export const OtherUserChatReadOnly: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			chatOwner={{ username: "OtherUser", name: "Other User" }}
+			chat={{
+				owner_id: "other-user",
+				owner_username: "OtherUser",
+				owner_name: "Other User",
+			}}
 			isInputDisabled
 		/>
 	),
@@ -317,7 +313,11 @@ export const OtherUserChatReadOnly: Story = {
 export const OtherUserChatUsernameFallback: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			chatOwner={{ username: "OtherUser" }}
+			chat={{
+				owner_id: "other-user",
+				owner_username: "OtherUser",
+				owner_name: undefined,
+			}}
 			isInputDisabled
 		/>
 	),
@@ -336,7 +336,16 @@ export const OtherUserChatUsernameFallback: Story = {
 };
 
 export const OtherUserChatOwnerFallback: Story = {
-	render: () => <StoryAgentChatPageView chatOwner={{}} isInputDisabled />,
+	render: () => (
+		<StoryAgentChatPageView
+			chat={{
+				owner_id: "other-user",
+				owner_username: undefined,
+				owner_name: undefined,
+			}}
+			isInputDisabled
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = canvas.getByText(
@@ -355,9 +364,13 @@ export const OtherUserChatOwnerFallback: Story = {
 export const ArchivedOtherUserChat: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			isArchived
+			chat={{
+				archived: true,
+				owner_id: "other-user",
+				owner_username: "OtherUser",
+				owner_name: undefined,
+			}}
 			isInputDisabled
-			chatOwner={{ username: "OtherUser" }}
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -375,7 +388,7 @@ export const QueuedForCapacityCommunityAdmin: Story = {
 	parameters: {
 		permissions: { viewAllLicenses: true },
 	},
-	render: () => <StoryAgentChatPageView queuedForCapacity />,
+	render: () => <StoryAgentChatPageView chat={{ queued_for_capacity: true }} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const callout = within(canvas.getByRole("alert"));
@@ -399,7 +412,7 @@ export const QueuedForCapacityCommunityAdmin: Story = {
 };
 
 export const QueuedForCapacityCommunityMember: Story = {
-	render: () => <StoryAgentChatPageView queuedForCapacity />,
+	render: () => <StoryAgentChatPageView chat={{ queued_for_capacity: true }} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const message = canvas.getByText(
@@ -422,7 +435,7 @@ export const QueuedForCapacityPremiumAdmin: Story = {
 		features: ["multiple_organizations"],
 		permissions: { viewAllLicenses: true },
 	},
-	render: () => <StoryAgentChatPageView queuedForCapacity />,
+	render: () => <StoryAgentChatPageView chat={{ queued_for_capacity: true }} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const message = canvas.getByText(
@@ -444,7 +457,7 @@ export const QueuedForCapacityPremiumMember: Story = {
 	parameters: {
 		features: ["multiple_organizations"],
 	},
-	render: () => <StoryAgentChatPageView queuedForCapacity />,
+	render: () => <StoryAgentChatPageView chat={{ queued_for_capacity: true }} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const message = canvas.getByText(
@@ -475,7 +488,7 @@ export const QueuedForCapacityPremiumHardLimit: Story = {
 		],
 		permissions: { viewAllLicenses: true },
 	},
-	render: () => <StoryAgentChatPageView queuedForCapacity />,
+	render: () => <StoryAgentChatPageView chat={{ queued_for_capacity: true }} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const message = canvas.getByText(
@@ -551,19 +564,19 @@ export const WithSidebarPanel: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
-			prNumber={123}
-			diffStatusData={
-				{
+			chat={{
+				diff_status: {
 					chat_id: AGENT_ID,
 					url: "https://github.com/coder/coder/pull/123",
+					pr_number: 123,
 					pull_request_title: "fix: resolve race condition in workspace builds",
 					pull_request_draft: false,
 					changes_requested: false,
 					additions: 42,
 					deletions: 7,
 					changed_files: 5,
-				} satisfies ChatDiffStatus
-			}
+				} satisfies ChatDiffStatus,
+			}}
 		/>
 	),
 	beforeEach: () => {
@@ -635,19 +648,19 @@ export const RefreshInvalidatesPRDiff: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
-			prNumber={123}
-			diffStatusData={
-				{
+			chat={{
+				diff_status: {
 					chat_id: AGENT_ID,
 					url: "https://github.com/coder/coder/pull/123",
+					pr_number: 123,
 					pull_request_title: "fix: resolve race condition in workspace builds",
 					pull_request_draft: false,
 					changes_requested: false,
 					additions: 42,
 					deletions: 7,
 					changed_files: 5,
-				} satisfies ChatDiffStatus
-			}
+				} satisfies ChatDiffStatus,
+			}}
 		/>
 	),
 	beforeEach: () => {
@@ -907,7 +920,7 @@ export const WorkspaceNoAgent: Story = {
 		<StoryAgentChatPageView
 			workspace={MockWorkspace}
 			workspaceOptions={[MockWorkspace]}
-			selectedWorkspaceId={MockWorkspace.id}
+			chat={{ workspace_id: MockWorkspace.id }}
 			onWorkspaceChange={fn()}
 		/>
 	),
@@ -1067,7 +1080,11 @@ const otherUserActionMessages: TypesGen.ChatMessage[] = [
 export const OtherUserChatHidesInlineActions: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			chatOwner={{ username: "OtherUser", name: "Other User" }}
+			chat={{
+				owner_id: "other-user",
+				owner_username: "OtherUser",
+				owner_name: "Other User",
+			}}
 			isInputDisabled
 			onImplementPlan={fn()}
 			store={buildStoreWithMessages(otherUserActionMessages)}
@@ -1917,7 +1934,7 @@ export const DoesNotPersistForArchivedChat: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			showSidebarPanel
-			isArchived
+			chat={{ archived: true }}
 			isInputDisabled
 			workspace={MockWorkspace}
 			workspaceAgent={MockWorkspaceAgent}
@@ -1946,10 +1963,12 @@ export const DoesNotPersistForArchivedChat: Story = {
 export const ArchivedWithSharing: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			isArchived
+			chat={{
+				archived: true,
+				organization_id: MockDefaultOrganization.id,
+			}}
 			isInputDisabled
 			canShareChat
-			organizationId={MockDefaultOrganization.id}
 		/>
 	),
 	beforeEach: () => {
@@ -1985,7 +2004,7 @@ export const ShareChatPopoverFromTopBar: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			canShareChat
-			organizationId={MockDefaultOrganization.id}
+			chat={{ organization_id: MockDefaultOrganization.id }}
 		/>
 	),
 	beforeEach: () => {

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -13,7 +13,6 @@ import { invalidateChatDiffContents } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type {
 	AgentChatSendShortcut,
-	ChatDiffStatus,
 	ChatMessagePart,
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
@@ -37,6 +36,7 @@ import {
 	RightPanelSkeleton,
 } from "./components/AgentsSkeletons";
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
+import { getParentChatID } from "./components/ChatConversation/chatHelpers";
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import { QueuedForCapacityCallout } from "./components/ChatConversation/QueuedForCapacityCallout";
 import type { ModelSelectorOption } from "./components/ChatElements";
@@ -60,6 +60,7 @@ import { TerminalPanel } from "./components/TerminalPanel";
 import { ChatWorkspaceContext } from "./context/ChatWorkspaceContext";
 import { TerminalClientSessionContext } from "./context/TerminalClientSessionContext";
 import { chatWidthClass, useChatFullWidth } from "./hooks/useChatFullWidth";
+import { parsePullRequestUrl } from "./utils/pullRequest";
 import {
 	getPersistedDefaultTerminalHidden,
 	getPersistedRightPanelTabs,
@@ -77,11 +78,6 @@ import {
 } from "./utils/sidebarTabStorage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
-
-type ChatOwnerInfo = {
-	name?: string;
-	username?: string;
-};
 
 interface EditingState {
 	chatInputRef: RefObject<ChatMessageInputRef | null>;
@@ -108,26 +104,16 @@ interface EditingState {
 }
 
 interface AgentChatPageViewProps {
-	// Chat data.
-	agentId: string;
+	chat: TypesGen.Chat;
 	sendShortcut: AgentChatSendShortcut;
-	organizationId: string | undefined;
-	chatTitle: string | undefined;
 	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
-	isArchived: boolean;
-	isSharedChat: boolean;
-	chatOwner: ChatOwnerInfo | undefined;
-	queuedForCapacity?: boolean;
 	canShareChat: boolean;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
-	chatBuildId?: string;
 
 	// Store handle.
 	store: ChatStoreHandle;
-	/** Chat status when the page first loaded, before any in-session turn. */
-	initialChatStatus: TypesGen.ChatStatus;
 	/** Messages as first loaded; read once at mount for the initial anchor. */
 	initialMessages: readonly TypesGen.ChatMessage[];
 
@@ -151,14 +137,12 @@ interface AgentChatPageViewProps {
 	aiGatewayDisabled?: boolean;
 	hasModelOptions: boolean;
 	isModelCatalogLoading?: boolean;
-	planModeEnabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
 	compressionThreshold: number | undefined;
 	isInputDisabled: boolean;
 	isSubmissionPending: boolean;
 	isInterruptPending: boolean;
 	workspaceOptions?: readonly TypesGen.Workspace[];
-	selectedWorkspaceId?: string | null;
 	onWorkspaceChange?: (workspaceId: string | null) => void;
 	isWorkspaceLoading?: boolean;
 
@@ -168,8 +152,6 @@ interface AgentChatPageViewProps {
 	onSetShowSidebarPanel: (next: boolean) => void;
 
 	// Sidebar content data.
-	prNumber: number | undefined;
-	diffStatusData: ChatDiffStatus | undefined;
 	debugLoggingEnabled: boolean;
 	gitWatcher: {
 		repositories: ReadonlyMap<string, TypesGen.WorkspaceAgentRepoChanges>;
@@ -198,8 +180,6 @@ interface AgentChatPageViewProps {
 	handlePinAgentAction?: () => void;
 	handleUnpinAgentAction?: () => void;
 	handleOpenRenameDialogAction?: () => void;
-	isPinned?: boolean;
-	isChildChat?: boolean;
 	isArchivingThisChat?: boolean;
 	isArchiveBlocked?: boolean;
 
@@ -221,7 +201,6 @@ interface AgentChatPageViewProps {
 	// Desktop chat ID (optional).
 	desktopChatId?: string;
 
-	chatContext?: TypesGen.ChatContext;
 	workspaceSkills?: readonly SkillMetadata[];
 }
 
@@ -311,22 +290,14 @@ const UserTabContent: FC<UserTabContentProps> = ({
 };
 
 export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
-	agentId,
+	chat,
 	sendShortcut,
-	organizationId,
-	chatTitle,
 	parentChat,
 	persistedError,
-	isArchived,
-	isSharedChat,
-	chatOwner,
-	queuedForCapacity,
 	canShareChat,
 	workspaceAgent,
 	workspace,
-	chatBuildId,
 	store,
-	initialChatStatus,
 	initialMessages,
 	editing,
 	effectiveSelectedModel,
@@ -345,20 +316,16 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	aiGatewayDisabled,
 	hasModelOptions,
 	isModelCatalogLoading = false,
-	planModeEnabled,
 	onPlanModeToggle,
 	compressionThreshold,
 	isInputDisabled,
 	isSubmissionPending,
 	isInterruptPending,
 	workspaceOptions = [],
-	selectedWorkspaceId = null,
 	onWorkspaceChange,
 	isWorkspaceLoading = false,
 	showSidebarPanel,
 	onSetShowSidebarPanel,
-	prNumber,
-	diffStatusData,
 	debugLoggingEnabled,
 	gitWatcher,
 	sshCommand,
@@ -374,8 +341,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	handlePinAgentAction,
 	handleUnpinAgentAction,
 	handleOpenRenameDialogAction,
-	isPinned,
-	isChildChat,
 	isArchivingThisChat,
 	isArchiveBlocked,
 	hasMoreMessages,
@@ -389,16 +354,20 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	onMCPSelectionChange,
 	onMCPAuthComplete,
 	desktopChatId,
-	chatContext,
 	workspaceSkills,
 }) => {
 	const queryClient = useQueryClient();
 	const { proxy } = useProxy();
 	const { entitlements } = useDashboard();
-	const { permissions } = useAuthenticated();
+	const { permissions, user: currentUser } = useAuthenticated();
 	const wildcardHostname = proxy.preferredWildcardHostname;
-
-	const canOpenChatSharing = canShareChat && organizationId !== undefined;
+	const agentId = chat.id;
+	const organizationId = chat.organization_id;
+	const isArchived = chat.archived;
+	const parsedPrNumber = Number(
+		parsePullRequestUrl(chat.diff_status?.url)?.number,
+	);
+	const prNumber = chat.diff_status?.pr_number ?? (parsedPrNumber || undefined);
 
 	// Wrap the git watcher refresh to also invalidate the cached
 	// remote/PR diff contents so the panel re-fetches from GitHub.
@@ -422,7 +391,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	// sequence, so every user row created after mount (sends, queue
 	// promotions, edit re-sends) has an id above the initial maximum.
 	const [initialActiveTurnMaxMessageId] = useState<number | undefined>(() =>
-		initialChatStatus === "running" || initialChatStatus === "interrupting"
+		chat.status === "running" || chat.status === "interrupting"
 			? (initialMessages.at(-1)?.id ?? -1)
 			: undefined,
 	);
@@ -724,7 +693,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						onRefresh={handleRefresh}
 						onCommit={handleCommit}
 						isExpanded={visualExpanded}
-						remoteDiffStats={diffStatusData}
+						remoteDiffStats={chat.diff_status}
 						chatInputRef={editing.chatInputRef}
 					/>
 				);
@@ -827,11 +796,11 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 
 	const isEditing = editing.editingMessageId !== null;
 
-	const chatOwnerUsername = chatOwner?.username?.trim();
+	const chatOwnerUsername = chat.owner_username?.trim();
 	const chatOwnerLabel =
-		chatOwner?.name?.trim() ||
+		chat.owner_name?.trim() ||
 		(chatOwnerUsername ? `@${chatOwnerUsername}` : "another user");
-	const isOtherUserReadOnly = !isArchived && chatOwner !== undefined;
+	const isOtherUserReadOnly = !isArchived && currentUser.id !== chat.owner_id;
 	const chatOwnerWarning = isOtherUserReadOnly
 		? `This chat is owned by ${chatOwnerLabel}. It is read-only.`
 		: undefined;
@@ -850,7 +819,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	return (
 		<TerminalClientSessionContext value={clientSessionId}>
 			<ChatWorkspaceContext
-				value={{ workspaceId: workspace?.id, buildId: chatBuildId }}
+				value={{ workspaceId: workspace?.id, buildId: chat.build_id }}
 			>
 				<DesktopPanelContext value={desktopPanelCtx}>
 					<div
@@ -870,7 +839,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							<div className="relative z-10 shrink-0 overflow-visible">
 								{" "}
 								<ChatTopBar
-									chatTitle={chatTitle}
+									chatTitle={chat.title}
 									parentChat={parentChat}
 									panel={{
 										showSidebarPanel,
@@ -885,16 +854,16 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									onPinAgent={handlePinAgentAction}
 									onUnpinAgent={handleUnpinAgentAction}
 									onOpenRenameDialog={handleOpenRenameDialogAction}
-									isPinned={isPinned}
-									isChildChat={isChildChat}
+									isPinned={chat.pin_order > 0}
+									isChildChat={getParentChatID(chat) !== undefined}
 									isArchiving={isArchivingThisChat}
 									isArchiveBlocked={isArchiveBlocked}
 									hasWorkspace={Boolean(workspace)}
 									isArchived={isArchived}
-									diffStatusData={diffStatusData}
-									isSharedChat={isSharedChat}
+									diffStatusData={chat.diff_status}
+									isSharedChat={chat.shared}
 									renderChatSharingContent={
-										canOpenChatSharing
+										canShareChat
 											? (open) => (
 													<ChatSharingPopoverContent
 														chatId={agentId}
@@ -974,7 +943,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										: canSendAskUserQuestionResponse
 								}
 								footer={
-									queuedForCapacity ? (
+									chat.queued_for_capacity ? (
 										<QueuedForCapacityCallout
 											hasLicense={hasLicense}
 											canManageLicenses={canManageLicenses}
@@ -1009,12 +978,12 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									modelSelectorHelp={modelSelectorHelp}
 									reasoningEffort={reasoningEffort}
 									onReasoningEffortChange={onReasoningEffortChange}
-									planModeEnabled={planModeEnabled}
+									planModeEnabled={chat.plan_mode === "plan"}
 									onPlanModeToggle={onPlanModeToggle}
 									isModelCatalogLoading={isModelCatalogLoading}
 									workspaceOptions={workspaceOptions}
 									chatOrganizationId={organizationId}
-									selectedWorkspaceId={selectedWorkspaceId}
+									selectedWorkspaceId={chat.workspace_id ?? null}
 									onWorkspaceChange={onWorkspaceChange}
 									isWorkspaceLoading={isWorkspaceLoading}
 									inputRef={editing.chatInputRef}
@@ -1029,7 +998,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									selectedMCPServerIds={selectedMCPServerIds}
 									onMCPSelectionChange={onMCPSelectionChange}
 									onMCPAuthComplete={onMCPAuthComplete}
-									chatContext={chatContext}
+									chatContext={chat.context}
 									workspaceSkills={workspaceSkills}
 									workspace={workspace}
 									workspaceAgent={workspaceAgent}
@@ -1068,7 +1037,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								onToggleExpanded={() =>
 									setIsRightPanelExpanded((prev) => !prev)
 								}
-								chatTitle={chatTitle}
+								chatTitle={chat.title}
 							/>
 						</RightPanel>
 					</div>


### PR DESCRIPTION
Pass the chat entity into AgentChatPageView instead of slicing it into page props. The view reads archive, share, pin, parent, org, workspace, diff, and related fields from that record. Behavior is unchanged.