### PR TITLE
chore(site/src/pages/AgentsPage): removal barrel exports

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -43,7 +43,7 @@ import {
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import { buildLongConversation } from "./components/ChatConversation/storyFixtures";
-import type { ModelSelectorOption } from "./components/ChatElements";
+import type { ModelSelectorOption } from "./components/ChatElements/ModelSelector";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
 
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -39,7 +39,7 @@ import type { ChatDetailError } from "./components/ChatConversation/chatError";
 import { getParentChatID } from "./components/ChatConversation/chatHelpers";
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import { QueuedForCapacityCallout } from "./components/ChatConversation/QueuedForCapacityCallout";
-import type { ModelSelectorOption } from "./components/ChatElements";
+import type { ModelSelectorOption } from "./components/ChatElements/ModelSelector";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
 import type { SkillMetadata } from "./components/ChatMessageInput/SkillsTriggerMenu";
 import type { PendingAttachment } from "./components/ChatPageContent";

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.stories.tsx
@@ -11,7 +11,7 @@ import {
 	AgentSettingsUserAgentsPageView,
 	type AgentSettingsUserAgentsPageViewProps,
 } from "./AgentSettingsUserAgentsPageView";
-import type { ModelSelectorOption } from "./components/ChatElements";
+import type { ModelSelectorOption } from "./components/ChatElements/ModelSelector";
 
 const UNAVAILABLE_WARNING =
 	"The saved model is unavailable and will be ignored until you choose a valid model override.";

--- a/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUserAgentsPageView.tsx
@@ -7,7 +7,7 @@ import {
 	getOrganizationLabel,
 	OrganizationAutocomplete,
 } from "#/components/OrganizationAutocomplete/OrganizationAutocomplete";
-import type { ModelSelectorOption } from "./components/ChatElements";
+import type { ModelSelectorOption } from "./components/ChatElements/ModelSelector";
 import {
 	PersonalModelOverrideRow,
 	type SavePersonalOverride,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -79,7 +79,10 @@ import {
 	isUploadInProgress,
 	type UploadState,
 } from "./AttachmentPreview";
-import { ModelSelector, type ModelSelectorOption } from "./ChatElements";
+import {
+	ModelSelector,
+	type ModelSelectorOption,
+} from "./ChatElements/ModelSelector";
 import {
 	ChatMessageInput,
 	type ChatMessageInputRef,

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -38,7 +38,7 @@ import {
 	isChatHookDispatchFailedResponse,
 } from "./ChatConversation/chatError";
 import { getErrorTitle } from "./ChatConversation/chatStatusHelpers";
-import { CompactOrgSelector } from "./ChatElements";
+import { CompactOrgSelector } from "./ChatElements/CompactOrgSelector";
 import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,

--- a/site/src/pages/AgentsPage/components/ChatConversation/AssistantOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AssistantOutput.tsx
@@ -1,7 +1,7 @@
 import { cn } from "cn";
 import { PauseIcon } from "lucide-react";
 import type { FC } from "react";
-import { Shimmer } from "../ChatElements";
+import { Shimmer } from "../ChatElements/Shimmer";
 import { ToolIcon } from "../ChatElements/tools/ToolIcon";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import type { LiveStatusModel } from "./liveStatusModel";

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -21,12 +21,9 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 
-import {
-	ConversationItem,
-	Message,
-	MessageContent,
-	Response,
-} from "../ChatElements";
+import { ConversationItem } from "../ChatElements/Conversation";
+import { Message, MessageContent } from "../ChatElements/Message";
+import { Response } from "../ChatElements/Response";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";

--- a/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/MessageBlocks.tsx
@@ -5,15 +5,16 @@ import type { UrlTransform } from "streamdown";
 import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ThinkingDisplayMode } from "#/api/typesGenerated";
-import { Response, Tool } from "../ChatElements";
-import { WebSearchSources } from "../ChatElements/tools";
+import { Response } from "../ChatElements/Response";
 import { ReadFilesTool } from "../ChatElements/tools/ReadFilesTool";
 import {
 	getReadFileToolData,
 	ReadFileTool,
 } from "../ChatElements/tools/ReadFileTool";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
+import { Tool } from "../ChatElements/tools/Tool";
 import { ToolCall } from "../ChatElements/tools/ToolCall";
+import WebSearchSources from "../ChatElements/tools/WebSearchSources";
 import {
 	AttachmentBlock,
 	type PreviewTextAttachment,

--- a/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/UserMessageContent.tsx
@@ -1,6 +1,6 @@
 import { cn } from "cn";
 import { type FC, Fragment } from "react";
-import { Message, MessageContent } from "../ChatElements";
+import { Message, MessageContent } from "../ChatElements/Message";
 import { FileReferenceChip } from "../ChatMessageInput/FileReferenceChip";
 import {
 	hasInlineContentAfter,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChatMessage } from "#/testHelpers/chatEntities";
-import type { ModelSelectorOption } from "../ChatElements";
+import type { ModelSelectorOption } from "../ChatElements/ModelSelector";
 import {
 	extractContextUsageFromMessage,
 	getLatestContextUsage,

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
@@ -1,7 +1,7 @@
 import type * as TypesGen from "#/api/typesGenerated";
 import { findWorkspaceAgent } from "#/utils/workspace";
 import type { AgentContextUsage } from "../AgentChatInput";
-import type { ModelSelectorOption } from "../ChatElements";
+import type { ModelSelectorOption } from "../ChatElements/ModelSelector";
 import { asString } from "../ChatElements/runtimeTypeUtils";
 import { asNonEmptyString } from "./blockUtils";
 

--- a/site/src/pages/AgentsPage/components/ChatElements/index.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/index.ts
@@ -1,8 +1,0 @@
-export { CompactOrgSelector } from "./CompactOrgSelector";
-export { ConversationItem } from "./Conversation";
-export { Message, MessageContent } from "./Message";
-export type { ModelSelectorOption } from "./ModelSelector";
-export { ModelSelector } from "./ModelSelector";
-export { Response } from "./Response";
-export { Shimmer } from "./Shimmer";
-export { Tool } from "./tools";

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/index.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/index.ts
@@ -1,2 +1,0 @@
-export { Tool } from "./Tool";
-export { default as WebSearchSources } from "./WebSearchSources";

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -49,7 +49,7 @@ import {
 } from "./ChatConversation/messageParsing";
 import { buildStreamTools } from "./ChatConversation/streamState";
 import { useOnRenderProfiler } from "./ChatConversation/useOnRenderProfiler";
-import type { ModelSelectorOption } from "./ChatElements";
+import type { ModelSelectorOption } from "./ChatElements/ModelSelector";
 import type { SkillMetadata } from "./ChatMessageInput/SkillsTriggerMenu";
 import { ChatMessageScroller } from "./ChatMessageScroller";
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/ChatsSidebar.tsx
@@ -5,7 +5,8 @@ import { userChatProviderConfigs } from "#/api/queries/chats";
 import type { Chat, ChatModel } from "#/api/typesGenerated";
 import type { AgentSidebarFilters } from "../../utils/agentSidebarFilters";
 import { ChatsPanel } from "./chats/ChatsPanel";
-import { ChatSearchDialog, RenameChatDialog } from "./dialogs";
+import { ChatSearchDialog } from "./dialogs/ChatSearchDialog";
+import { RenameChatDialog } from "./dialogs/RenameChatDialog";
 import { SettingsPanel } from "./settings/SettingsPanel";
 import { isSettingsView, sidebarViewFromPath } from "./sidebarView";
 

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/index.ts
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/dialogs/index.ts
@@ -1,2 +1,0 @@
-export { ChatSearchDialog } from "./ChatSearchDialog";
-export { RenameChatDialog } from "./RenameChatDialog";

--- a/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
+++ b/site/src/pages/AgentsPage/components/PersonalModelOverrideRow.tsx
@@ -4,7 +4,10 @@ import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { pickReasoningEffort } from "../utils/reasoningEffort";
-import { ModelSelector, type ModelSelectorOption } from "./ChatElements";
+import {
+	ModelSelector,
+	type ModelSelectorOption,
+} from "./ChatElements/ModelSelector";
 import { ModelOverrideAlerts } from "./ModelOverrideAlerts";
 import { SectionHeader } from "./SectionHeader";
 

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -1,6 +1,6 @@
 import type * as TypesGen from "#/api/typesGenerated";
 import { normalizeProvider } from "#/modules/aiModels/helpers";
-import type { ModelSelectorOption } from "../components/ChatElements";
+import type { ModelSelectorOption } from "../components/ChatElements/ModelSelector";
 import {
 	asNumber,
 	asString,


### PR DESCRIPTION
Using barrel-exports goes against best practice in this codebase.

```
Do not use barrel files. Imports should be directly from the file that defines the value
```

https://github.com/coder/coder/blob/a89f41dadfb6698e2a38622c954fc2c5ca2ccd58/docs/about/contributing/frontend.md?plain=1#L68-L69

[FRONTEND.md](https://github.com/coder/coder/blob/a89f41dadfb6698e2a38622c954fc2c5ca2ccd58/docs/about/contributing/frontend.md?plain=1#L68-L69)
