### PR TITLE
fix(coderd/x/chatd): clarify chat delegation ownership

### DIFF
--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -24,7 +24,7 @@ IMPORTANT — obey every rule in this prompt before anything else.
 Do EXACTLY what the User asked, never more, never less.
 
 <behavior>
-You MUST execute AS MANY TOOLS to help the user accomplish their task.
+Use tools to resolve missing facts, perform requested actions, and verify results. Do not repeat work already completed or assigned to a subagent.
 You are COMFORTABLE with vague tasks - using your tools to collect the most relevant answer possible.
 If a user asks how something works, no matter how vague, you MUST use your tools to collect the most relevant answer possible.
 Use tools first to gather context and make progress.
@@ -52,7 +52,7 @@ Never treat the original request as confirmation. Confirmation must be separate 
 Analytical — You break problems into measurable steps, relying on tool output and data rather than intuition.
 Organized — You structure every interaction with clear tags, TODO lists, and section boundaries.
 Precision-Oriented — You insist on exact formatting, package-manager choice, and rule adherence.
-Efficiency-Focused — You minimize chatter, run tasks in parallel, and favor small, complete answers.
+Efficiency-Focused: You avoid redundant work and unnecessary coordination, and favor small, complete results.
 Clarity-Seeking — You resolve ambiguity with tools when possible and ask focused questions only when necessary.
 </personality>
 

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -608,10 +608,9 @@ func (p *Server) subagentTools(
 		),
 		fantasy.NewAgentTool(
 			"wait_agent",
-			"Wait until a spawned child agent finishes its task. "+
-				"Returns the agent's final response and status. "+
-				"Call this after "+spawnAgentToolName+" to collect the "+
-				"result before continuing your own work.",
+			"Wait for a child agent to finish and return its response and status. "+
+				"A timeout does not stop the child or release its task. "+
+				"If it is still working, wait again; do not take over its work without an acknowledged handoff.",
 			func(ctx context.Context, args waitAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
@@ -724,11 +723,11 @@ func (p *Server) subagentTools(
 		),
 		fantasy.NewAgentTool(
 			"message_agent",
-			"Send a follow-up message to a previously spawned child "+
-				"agent. Use this to provide additional instructions, "+
-				"corrections, or context to a running or completed "+
-				"agent. After sending, use wait_agent to collect the "+
-				"updated response.",
+			"Send a follow-up to an existing child agent. Set interrupt=true for corrections, changed scope, or stop/takeover instructions. "+
+				"Otherwise a busy child continues its current assignment and receives the message later. "+
+				"Interruption requests cancellation; it does not clear earlier queued messages or confirm the child has stopped. "+
+				"Use wait_agent to collect its response. Before taking over, require an explicit acknowledgment of your handoff instruction; "+
+				"a returned response or interrupting status alone is not an acknowledgment.",
 			func(ctx context.Context, args messageAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil

--- a/coderd/x/chatd/subagent_catalog.go
+++ b/coderd/x/chatd/subagent_catalog.go
@@ -20,21 +20,11 @@ const (
 	subagentTypeExplore     = "explore"
 	subagentTypeComputerUse = "computer_use"
 
-	defaultSystemPromptPlanningGuidance = "1. Use " + spawnAgentToolName +
-		" and wait_agent when delegation helps gather context. Prefer type=\"" +
-		subagentTypeGeneral +
-		"\" for substantial delegated research, analysis, reasoning, review, " +
-		"planning support, or implementation. Use type=\"" + subagentTypeGeneral +
-		"\" even for read-only work when the task is open-ended, multi-step, " +
-		"parallel, requires synthesis, or may later need edits. When planning, " +
-		"type=\"" + subagentTypeGeneral +
-		"\" remains non-mutating until implementation is approved. Use type=\"" +
-		subagentTypeExplore +
-		"\" only for narrow repository-local read-only code discovery or code " +
-		"tracing, such as locating files, callsites, or a bounded existing flow. " +
-		"Do not use type=\"" + subagentTypeExplore +
-		"\" for generic research, broad architecture analysis, planning synthesis, " +
-		"external or web research, parallel research, or tasks that may need edits."
+	defaultSystemPromptPlanningGuidance = "1. Delegate only after defining the " +
+		"question or deliverable, scope, available inputs, and completion criteria. " +
+		"Resolve shared implementation contracts before assigning dependent work. " +
+		"Follow the spawn_agent description for agent selection and ownership. " +
+		"Planning delegates must not modify project files."
 )
 
 type spawnAgentArgs struct {
@@ -279,8 +269,9 @@ func buildSpawnAgentDescription(
 	currentChat database.Chat,
 ) string {
 	availableDefs := availableSubagentDefinitions(ctx, p, currentChat)
-	description := "Spawn a delegated child subagent to work on a clearly scoped, " +
-		"independent task in parallel. Use the type field to choose " +
+	description := "Assign a clearly scoped, independent task to a child agent. " +
+		"Include its inputs, expected result, and completion criteria. " +
+		"Use the type field to choose " +
 		"the right specialist. Available type values: " +
 		formatSubagentDefinitions(availableDefs) + ". Do not use this for " +
 		"simple or quick operations you can handle directly with execute, " +
@@ -295,11 +286,13 @@ func buildSpawnAgentDescription(
 		"Do not use type=\"" + subagentTypeExplore +
 		"\" for generic research, broad architecture analysis, planning " +
 		"synthesis, external or web research, parallel research, or tasks that " +
-		"may need edits. Be careful when running parallel subagents: if two " +
-		"subagents modify the same files they will conflict with each other, " +
-		"so ensure parallel subagent tasks are independent. The child agent " +
-		"receives the same workspace tools but cannot spawn its own subagents. " +
-		"After spawning, use wait_agent to collect the result."
+		"may need edits. Each delegated task has one owner until its result " +
+		"is returned or a handoff is acknowledged. Do not investigate, implement, " +
+		"or edit that task alongside its owner. Separate files do not make tasks " +
+		"independent when they depend on unresolved shared contracts. After " +
+		"dispatching defined assignments, use wait_agent to wait for their results before continuing research or implementation. " +
+		"Validate returned evidence rather than repeating the entire investigation. " +
+		"The child agent receives the same workspace tools but cannot spawn its own subagents."
 	if currentChat.PlanMode.Valid && currentChat.PlanMode.ChatPlanMode == database.ChatPlanModePlan {
 		description += " During plan mode, type=\"" + subagentTypeGeneral +
 			"\" is for non-mutating substantial investigation and planning support, " +

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -2135,15 +2135,55 @@ func TestSpawnAgent_ExploreFallsBackWhenOverrideCredentialsAreUnavailable(t *tes
 	require.Equal(t, currentTurnModel.ID, childChat.LastModelConfigID)
 }
 
-func TestDefaultSystemPromptPlanningGuidance_SteersSubagentSelection(t *testing.T) {
+func TestDefaultSystemPromptPlanningGuidance_DefinesDelegationPrerequisites(t *testing.T) {
 	t.Parallel()
 
-	require.Contains(t, defaultSystemPromptPlanningGuidance, `Prefer type="general" for substantial delegated research, analysis, reasoning, review, planning support, or implementation`)
-	require.Contains(t, defaultSystemPromptPlanningGuidance, `Use type="general" even for read-only work when the task is open-ended, multi-step, parallel, requires synthesis, or may later need edits`)
-	require.Contains(t, defaultSystemPromptPlanningGuidance, `Use type="explore" only for narrow repository-local read-only code discovery or code tracing`)
-	require.Contains(t, defaultSystemPromptPlanningGuidance, `Do not use type="explore" for generic research, broad architecture analysis, planning synthesis, external or web research, parallel research, or tasks that may need edits`)
-	require.NotContains(t, defaultSystemPromptPlanningGuidance, "research the codebase")
-	require.NotContains(t, defaultSystemPromptPlanningGuidance, "Reserve type=\"general\" for writable delegated work")
+	for _, requirement := range []string{
+		"question or deliverable, scope, available inputs, and completion criteria",
+		"Resolve shared implementation contracts before assigning dependent work",
+		"Follow the spawn_agent description for agent selection and ownership",
+		"Planning delegates must not modify project files",
+	} {
+		t.Run(requirement, func(t *testing.T) {
+			t.Parallel()
+			require.Contains(t, defaultSystemPromptPlanningGuidance, requirement)
+		})
+	}
+}
+
+func TestSubagentToolDescriptions_DefineOwnershipAndDelivery(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+	ctx := chatdTestContext(t)
+	user, org, model := seedInternalChatDeps(t, db)
+	parent := createInternalParentChat(ctx, t, server, db, org.ID, user.ID, model.ID, "parent-delegation-contract")
+	tools := server.subagentTools(ctx, func() database.Chat { return parent }, parent.LastModelConfigID)
+
+	for _, tc := range []struct {
+		name string
+		tool string
+		text string
+	}{
+		{"ownership", "spawn_agent", "Each delegated task has one owner"},
+		{"parent_overlap", "spawn_agent", "Do not investigate, implement, or edit that task alongside its owner"},
+		{"dependencies", "spawn_agent", "Separate files do not make tasks independent"},
+		{"wait", "spawn_agent", "wait for their results before continuing research or implementation"},
+		{"timeout", "wait_agent", "A timeout does not stop the child or release its task"},
+		{"handoff", "wait_agent", "do not take over its work without an acknowledged handoff"},
+		{"corrections", "message_agent", "Set interrupt=true for corrections, changed scope, or stop/takeover instructions"},
+		{"queue", "message_agent", "a busy child continues its current assignment and receives the message later"},
+		{"cancellation", "message_agent", "does not clear earlier queued messages or confirm the child has stopped"},
+		{"acknowledgment", "message_agent", "a returned response or interrupting status alone is not an acknowledgment"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tool := findToolByName(tools, tc.tool)
+			require.NotNil(t, tool)
+			require.Contains(t, tool.Info().Description, tc.text)
+		})
+	}
 }
 
 func TestSpawnAgent_DescriptionListsAllAvailableTypes(t *testing.T) {


### PR DESCRIPTION
The delegation guidance encouraged parallel activity without defining ownership between the parent and child, and corrections default to queued delivery, so a parent could keep working against an assignment the child had not received.

Give each delegated task one owner. The parent continues independent work, waits with wait_agent when its next step depends on the child's result, and treats the report's findings as read context. Corrections and handoffs interrupt; a handoff is acknowledged only by the child's response through wait_agent. Agent selection stays in the spawn description instead of a second copy in planning guidance. Wording only; tool arguments and execution behavior are unchanged.

<details>
<summary>Review decisions and verification</summary>

- Independent parent work is allowed with three guards: spawn only once the assignment can be defined, delegate independent work that itself qualifies for delegation, wait when the report will answer the question.
- Sentence-matching tests removed, including the two description assertions in `TestWaitAgentToolSchema`. Composition and capability checks are in #29484.
- Relies on main treating `interrupting` as unfinished (#26673): a wait_agent return after an interrupt means the child stopped.
- Pre-commit (generation, formatting, lint, slim build) and `go test ./coderd/x/chatd/ -count=1 -parallel 4` passed. Default test fan-out exhausts the local PostgreSQL connection limit. No behavioral replay was run.
- Base of #29483 and #29484 (CODAGT-1079).

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
