### PR TITLE
test: bind more server tests to loopback

### DIFF
--- a/cli/resetpassword_test.go
+++ b/cli/resetpassword_test.go
@@ -39,7 +39,7 @@ func TestResetPassword(t *testing.T) {
 	serverDone := make(chan struct{})
 	serverinv, cfg := clitest.New(t,
 		"server",
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--postgres-url", connectionURL,
 		"--cache-dir", t.TempDir(),

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -229,7 +229,7 @@ func TestServer(t *testing.T) {
 
 		inv, cfg := clitest.New(t,
 			"server",
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--cache-dir", t.TempDir(),
 		)
@@ -252,7 +252,7 @@ func TestServer(t *testing.T) {
 
 		inv, _ := clitest.New(t,
 			"server",
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--ephemeral",
 		)
@@ -330,7 +330,7 @@ func TestServer(t *testing.T) {
 		inv, cfg := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://localhost:3000/",
 			"--cache-dir", t.TempDir(),
 		)
@@ -547,7 +547,7 @@ func TestServer(t *testing.T) {
 		inv, cfg := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://localhost:3000/",
 			"--cache-dir", t.TempDir(),
 		)
@@ -573,7 +573,7 @@ func TestServer(t *testing.T) {
 		inv, cfg := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "https://foobarbaz.mydomain",
 			"--cache-dir", t.TempDir(),
 		)
@@ -597,7 +597,7 @@ func TestServer(t *testing.T) {
 		inv, cfg := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "https://google.com",
 			"--cache-dir", t.TempDir(),
 		)
@@ -621,7 +621,7 @@ func TestServer(t *testing.T) {
 		root, _ := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "google.com",
 			"--cache-dir", t.TempDir(),
 		)
@@ -640,7 +640,7 @@ func TestServer(t *testing.T) {
 			"--http-address", "",
 			"--access-url", "http://example.com",
 			"--tls-enable",
-			"--tls-address", ":0",
+			"--tls-address", "127.0.0.1:0",
 			"--tls-min-version", "tls9",
 			"--cache-dir", t.TempDir(),
 		)
@@ -658,7 +658,7 @@ func TestServer(t *testing.T) {
 			"--http-address", "",
 			"--access-url", "http://example.com",
 			"--tls-enable",
-			"--tls-address", ":0",
+			"--tls-address", "127.0.0.1:0",
 			"--tls-client-auth", "something",
 			"--cache-dir", t.TempDir(),
 		)
@@ -707,7 +707,7 @@ func TestServer(t *testing.T) {
 				args := []string{
 					"server",
 					dbArg(t),
-					"--http-address", ":0",
+					"--http-address", "127.0.0.1:0",
 					"--access-url", "http://example.com",
 					"--cache-dir", t.TempDir(),
 				}
@@ -732,7 +732,7 @@ func TestServer(t *testing.T) {
 			"--http-address", "",
 			"--access-url", "https://example.com",
 			"--tls-enable",
-			"--tls-address", ":0",
+			"--tls-address", "127.0.0.1:0",
 			"--tls-cert-file", certPath,
 			"--tls-key-file", keyPath,
 			"--cache-dir", t.TempDir(),
@@ -768,7 +768,7 @@ func TestServer(t *testing.T) {
 			"--http-address", "",
 			"--access-url", "https://example.com",
 			"--tls-enable",
-			"--tls-address", ":0",
+			"--tls-address", "127.0.0.1:0",
 			"--tls-cert-file", cert1Path,
 			"--tls-key-file", key1Path,
 			"--tls-cert-file", cert2Path,
@@ -843,11 +843,11 @@ func TestServer(t *testing.T) {
 		inv, _ := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "https://example.com",
 			"--tls-enable",
 			"--tls-redirect-http-to-https=false",
-			"--tls-address", ":0",
+			"--tls-address", "127.0.0.1:0",
 			"--tls-cert-file", certPath,
 			"--tls-key-file", keyPath,
 			"--cache-dir", t.TempDir(),
@@ -962,7 +962,7 @@ func TestServer(t *testing.T) {
 
 				httpListenAddr := ""
 				if c.httpListener {
-					httpListenAddr = ":0"
+					httpListenAddr = "127.0.0.1:0"
 				}
 
 				certPath, keyPath := generateTLSCertificate(t)
@@ -975,7 +975,7 @@ func TestServer(t *testing.T) {
 				if c.tlsListener {
 					flags = append(flags,
 						"--tls-enable",
-						"--tls-address", ":0",
+						"--tls-address", "127.0.0.1:0",
 						"--tls-cert-file", certPath,
 						"--tls-key-file", keyPath,
 						"--wildcard-access-url", "*.example.com",
@@ -1163,7 +1163,7 @@ func TestServer(t *testing.T) {
 			inv, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--address", ":0",
+				"--address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--cache-dir", t.TempDir(),
 			)
@@ -1188,7 +1188,7 @@ func TestServer(t *testing.T) {
 			root, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--address", ":0",
+				"--address", "127.0.0.1:0",
 				"--access-url", "https://example.com",
 				"--tls-enable",
 				"--tls-cert-file", certPath,
@@ -1223,7 +1223,7 @@ func TestServer(t *testing.T) {
 		inv, _ := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--trace=true",
 			"--cache-dir", t.TempDir(),
@@ -1245,7 +1245,7 @@ func TestServer(t *testing.T) {
 		inv, cfg := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--telemetry",
 			"--telemetry-url", telemetryServerURL.String(),
@@ -1285,11 +1285,11 @@ func TestServer(t *testing.T) {
 			inv, _ := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--provisioner-daemons", "1",
 				"--prometheus-enable",
-				"--prometheus-address", ":0",
+				"--prometheus-address", "127.0.0.1:0",
 				// "--prometheus-collect-db-metrics", // disabled by default
 				"--cache-dir", t.TempDir(),
 			)
@@ -1346,11 +1346,11 @@ func TestServer(t *testing.T) {
 			inv, _ := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--provisioner-daemons", "1",
 				"--prometheus-enable",
-				"--prometheus-address", ":0",
+				"--prometheus-address", "127.0.0.1:0",
 				"--prometheus-collect-db-metrics",
 				"--cache-dir", t.TempDir(),
 			)
@@ -1402,7 +1402,7 @@ func TestServer(t *testing.T) {
 		inv, cfg := clitest.New(t,
 			"server",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--oauth2-github-allow-everyone",
 			"--oauth2-github-client-id", "fake",
@@ -1449,7 +1449,7 @@ func TestServer(t *testing.T) {
 			inv, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--oidc-client-id", "fake",
 				"--oidc-client-secret", "fake",
@@ -1525,7 +1525,7 @@ func TestServer(t *testing.T) {
 			inv, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--oidc-client-id", "fake",
 				"--oidc-client-secret", "fake",
@@ -1626,7 +1626,7 @@ func TestServer(t *testing.T) {
 			inv, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--oidc-client-id", "fake",
 				"--oidc-client-secret", "fake",
@@ -1678,7 +1678,7 @@ func TestServer(t *testing.T) {
 			root, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 			)
 			serverErr := make(chan error, 1)
@@ -1706,7 +1706,7 @@ func TestServer(t *testing.T) {
 			root, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--api-rate-limit", val,
 			)
@@ -1734,7 +1734,7 @@ func TestServer(t *testing.T) {
 			root, cfg := clitest.New(t,
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--api-rate-limit", "-1",
 			)
@@ -1766,7 +1766,7 @@ func TestServer(t *testing.T) {
 				"server",
 				"--log-filter=.*",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--provisioner-daemons=3",
 				"--provisioner-types=echo",
@@ -1785,7 +1785,7 @@ func TestServer(t *testing.T) {
 				"server",
 				"--log-filter=.*",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--provisioner-daemons=3",
 				"--provisioner-types=echo",
@@ -1804,7 +1804,7 @@ func TestServer(t *testing.T) {
 				"server",
 				"--log-filter=.*",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--provisioner-daemons=3",
 				"--provisioner-types=echo",
@@ -1828,7 +1828,7 @@ func TestServer(t *testing.T) {
 			args := []string{
 				"server",
 				dbArg(t),
-				"--http-address", ":0",
+				"--http-address", "127.0.0.1:0",
 				"--access-url", "http://example.com",
 				"--log-human", filepath.Join(t.TempDir(), "coder-logging-test-human"),
 				// We use ecdsa here because it's the fastest alternative algorithm.
@@ -2027,7 +2027,7 @@ func TestServer_ExternalAuthGitHubDefaultProvider(t *testing.T) {
 		args := []string{
 			"server",
 			"--postgres-url", dbURL,
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "https://example.com",
 		}
 		args = append(args, tc.args...)
@@ -2152,7 +2152,7 @@ func TestServer_Logging_NoParallel(t *testing.T) {
 			"server",
 			"--log-filter=.*",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--provisioner-daemons=3",
 			"--provisioner-types=echo",
@@ -2187,7 +2187,7 @@ func TestServer_Logging_NoParallel(t *testing.T) {
 			"server",
 			"--log-filter=.*",
 			dbArg(t),
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--provisioner-daemons=3",
 			"--provisioner-types=echo",
@@ -2244,7 +2244,7 @@ func TestServer_Production(t *testing.T) {
 
 	inv, cfg := clitest.New(t,
 		"server",
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		dbArg(t),
 		"--cache-dir", t.TempDir(),
@@ -2303,7 +2303,7 @@ func TestServer_InterruptShutdown(t *testing.T) {
 	root, cfg := clitest.New(t,
 		"server",
 		dbArg(t),
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--provisioner-daemons", "1",
 		"--cache-dir", t.TempDir(),
@@ -2340,7 +2340,7 @@ func TestServer_AIGatewayShutdownOrdering(t *testing.T) {
 	inv, cfg := clitest.New(t,
 		"server",
 		dbArg(t),
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--cache-dir", t.TempDir(),
 		// Explicit so the test catches the regression even if the
@@ -2382,7 +2382,7 @@ func TestServer_GracefulShutdown(t *testing.T) {
 	root, cfg := clitest.New(t,
 		"server",
 		dbArg(t),
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--provisioner-daemons", "1",
 		"--cache-dir", t.TempDir(),
@@ -2567,7 +2567,7 @@ func TestServer_DisabledDERP_EmptyBaseMap(t *testing.T) {
 	inv, cfg := clitest.New(t,
 		"server",
 		dbArg(t),
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--derp-server-enable=false",
 	)
@@ -2592,7 +2592,7 @@ func TestServer_DisabledDERP_ExternalMap(t *testing.T) {
 	inv, cfg := clitest.New(t,
 		"server",
 		dbArg(t),
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--derp-server-enable=false",
 		"--derp-config-url", srv.URL,
@@ -2630,7 +2630,7 @@ func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
 		inv, _ := clitest.New(t,
 			"server",
 			"--postgres-url", dbConnURL,
-			"--http-address", ":0",
+			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example.com",
 			"--telemetry="+strconv.FormatBool(!opts.telemetryDisabled),
 			"--telemetry-url", telemetryServerURL.String(),

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -2158,7 +2158,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 		// server canonicalizes all HTTP request headers it receives, so we
 		// can't use it to test that we forward non-canonical headers.
 		// #nosec
-		ln, err := net.Listen("tcp", ":0")
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		go func() {
 			for {

--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -46,7 +46,7 @@ func Test_ProxyServer_Headers(t *testing.T) {
 		"--primary-access-url", srv.URL,
 		"--proxy-session-token", "test-token",
 		"--access-url", "http://localhost:8080",
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--header", fmt.Sprintf("%s=%s", headerName1, headerVal1),
 		"--header-command", fmt.Sprintf("printf %s=%s", headerName2, headerVal2),
 	)
@@ -94,7 +94,7 @@ func TestWorkspaceProxy_Server_PrometheusEnabled(t *testing.T) {
 		"--primary-access-url", srv.URL,
 		"--proxy-session-token", "test-token",
 		"--access-url", "http://foobar:3001",
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--prometheus-enable",
 		"--prometheus-address", fmt.Sprintf("127.0.0.1:%d", prometheusPort),
 	)

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -386,7 +386,7 @@ func TestServerAIProviderKeysEncryptedWithDBCrypt(t *testing.T) {
 	inv, cfg := clitest.NewWithCommand(t, cmd,
 		"server",
 		"--postgres-url="+dbURL,
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 		"--external-token-encryption-keys", b64Key,
 		"--aibridge-enabled",

--- a/enterprise/cli/server_test.go
+++ b/enterprise/cli/server_test.go
@@ -38,7 +38,7 @@ func TestServer_Single(t *testing.T) {
 	inv, cfg := clitest.NewWithCommand(t, cmd,
 		"server",
 		dbArg(t),
-		"--http-address", ":0",
+		"--http-address", "127.0.0.1:0",
 		"--access-url", "http://example.com",
 	)
 	clitest.Start(t, inv.WithContext(ctx))


### PR DESCRIPTION
Follow up to https://github.com/coder/coder/pull/28980. The tests modified in this PR have the same flake potential as the test fixed in #28980.

Fixes https://linear.app/codercom/issue/PLAT-583/flake-testserveryamlwritethenreadconfig