### PR TITLE
fix(aibridge): re-index relayed content blocks across spliced streams

### DIFF
--- a/aibridge/intercept/messages/streaming.go
+++ b/aibridge/intercept/messages/streaming.go
@@ -147,6 +147,15 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 	// Accumulate usage across the entire streaming interaction (including tool reinvocations).
 	var cumulativeUsage anthropic.Usage
 
+	// relayedBlocks counts the content blocks already relayed to the client
+	// across all stitched upstream messages; it is the next client-facing
+	// content block index to assign. The bridge presents multiple upstream
+	// messages (one per agentic tool round) as a single client message, but
+	// each upstream message restarts its content block indices at 0. Without
+	// re-indexing, the client would see a non-monotonic index sequence (e.g.
+	// 0 then 0 again), which a spec-compliant accumulator rejects.
+	var relayedBlocks int64
+
 	var lastErr error
 	var interceptionErr error
 
@@ -217,6 +226,12 @@ newStream:
 		var message anthropic.Message
 		var lastToolName string
 		var serviceTier anthropic.UsageServiceTier
+
+		// clientBlockIndex maps this upstream message's content block indices to
+		// the contiguous client-facing indices assigned as blocks are relayed. It
+		// resets each iteration because every upstream message restarts its own
+		// indices at 0.
+		clientBlockIndex := make(map[int64]int64)
 
 		pendingToolCalls := make(map[string]string)
 
@@ -506,7 +521,10 @@ newStream:
 			}
 
 			// Overwrite response identifier since proxy obscures injected tool call invocations.
-			payload, err := i.marshalEvent(event)
+			// Re-index relayed content blocks so the stitched client stream stays
+			// contiguous and monotonic across agentic tool rounds.
+			indexOverride := i.clientContentBlockIndex(event, clientBlockIndex, &relayedBlocks)
+			payload, err := i.marshalEvent(event, indexOverride)
 			if err != nil {
 				logger.Warn(ctx, "failed to marshal event", slog.Error(err), slog.F("event", event.RawJSON()))
 				lastErr = xerrors.Errorf("marshal event: %w", err)
@@ -631,7 +649,7 @@ func (*StreamingInterception) mapStreamError(ctx context.Context, logger slog.Lo
 	return nil
 }
 
-func (i *StreamingInterception) marshalEvent(event anthropic.MessageStreamEventUnion) ([]byte, error) {
+func (i *StreamingInterception) marshalEvent(event anthropic.MessageStreamEventUnion, indexOverride *int64) ([]byte, error) {
 	sj, err := sjson.Set(event.RawJSON(), "message.id", i.ID().String())
 	if err != nil {
 		return nil, xerrors.Errorf("marshal event id failed: %w", err)
@@ -642,7 +660,43 @@ func (i *StreamingInterception) marshalEvent(event anthropic.MessageStreamEventU
 		return nil, xerrors.Errorf("marshal event usage failed: %w", err)
 	}
 
+	// Rewrite the content block index for content_block_* events so the
+	// client-facing stream presents a single coherent message even though the
+	// bridge stitches multiple upstream messages together.
+	if indexOverride != nil {
+		sj, err = sjson.Set(sj, "index", *indexOverride)
+		if err != nil {
+			return nil, xerrors.Errorf("marshal event index failed: %w", err)
+		}
+	}
+
 	return i.encodeForStream([]byte(sj), event.Type), nil
+}
+
+// clientContentBlockIndex returns the client-facing content block index to use
+// when relaying event, or nil for events that carry no content block index.
+//
+// The bridge presents multiple upstream messages (one per agentic tool round)
+// as a single client message. Each upstream message restarts its content block
+// indices at 0, and injected tool blocks are dropped from the relayed stream,
+// so the indices must be remapped to a contiguous, monotonic client sequence.
+// A content_block_start is assigned the next free client index; the matching
+// content_block_delta and content_block_stop reuse that mapping.
+func (*StreamingInterception) clientContentBlockIndex(event anthropic.MessageStreamEventUnion, clientBlockIndex map[int64]int64, relayedBlocks *int64) *int64 {
+	switch event.Type {
+	case string(constant.ValueOf[constant.ContentBlockStart]()):
+		clientIdx := *relayedBlocks
+		clientBlockIndex[event.Index] = clientIdx
+		*relayedBlocks++
+		return &clientIdx
+	case string(constant.ValueOf[constant.ContentBlockDelta]()), string(constant.ValueOf[constant.ContentBlockStop]()):
+		if clientIdx, ok := clientBlockIndex[event.Index]; ok {
+			return &clientIdx
+		}
+		return nil
+	default:
+		return nil
+	}
 }
 
 func (i *StreamingInterception) marshal(payload any) ([]byte, error) {

--- a/aibridge/intercept/messages/streaming_internal_test.go
+++ b/aibridge/intercept/messages/streaming_internal_test.go
@@ -1,0 +1,89 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientContentBlockIndex verifies that relayed content blocks are
+// re-indexed into a single contiguous, monotonic client sequence across the
+// stitched upstream messages of an agentic tool loop. Each upstream message
+// restarts its own indices at 0, and injected tool blocks are dropped from the
+// relayed stream, so the client must never see a gap or a repeated index.
+func TestClientContentBlockIndex(t *testing.T) {
+	t.Parallel()
+
+	var i StreamingInterception
+
+	start := func(idx int64) anthropic.MessageStreamEventUnion {
+		return anthropic.MessageStreamEventUnion{Type: "content_block_start", Index: idx}
+	}
+	delta := func(idx int64) anthropic.MessageStreamEventUnion {
+		return anthropic.MessageStreamEventUnion{Type: "content_block_delta", Index: idx}
+	}
+	stop := func(idx int64) anthropic.MessageStreamEventUnion {
+		return anthropic.MessageStreamEventUnion{Type: "content_block_stop", Index: idx}
+	}
+
+	var relayedBlocks int64
+
+	// First upstream message: a single relayed text block at upstream index 0.
+	// (Its injected tool_use block at index 1 is suppressed before relay, so it
+	// never reaches the remapper.)
+	first := make(map[int64]int64)
+	require.Equal(t, int64(0), derefBlockIndex(t, i.clientContentBlockIndex(start(0), first, &relayedBlocks)))
+	require.Equal(t, int64(0), derefBlockIndex(t, i.clientContentBlockIndex(delta(0), first, &relayedBlocks)))
+	require.Equal(t, int64(0), derefBlockIndex(t, i.clientContentBlockIndex(stop(0), first, &relayedBlocks)))
+
+	// Second upstream message: its text block restarts at upstream index 0 but
+	// must be relayed as the next contiguous client index (1).
+	second := make(map[int64]int64)
+	require.Equal(t, int64(1), derefBlockIndex(t, i.clientContentBlockIndex(start(0), second, &relayedBlocks)))
+	require.Equal(t, int64(1), derefBlockIndex(t, i.clientContentBlockIndex(delta(0), second, &relayedBlocks)))
+	require.Equal(t, int64(1), derefBlockIndex(t, i.clientContentBlockIndex(stop(0), second, &relayedBlocks)))
+
+	require.Equal(t, int64(2), relayedBlocks)
+}
+
+// TestClientContentBlockIndexNonContentEvents verifies that events without a
+// content block index (message_start, message_delta, message_stop) are not
+// remapped and do not consume a client index.
+func TestClientContentBlockIndexNonContentEvents(t *testing.T) {
+	t.Parallel()
+
+	var i StreamingInterception
+	var relayedBlocks int64
+	m := make(map[int64]int64)
+
+	for _, typ := range []string{"message_start", "message_delta", "message_stop", "ping"} {
+		require.Nil(t, i.clientContentBlockIndex(anthropic.MessageStreamEventUnion{Type: typ}, m, &relayedBlocks))
+	}
+	require.Equal(t, int64(0), relayedBlocks)
+
+	// A multi-block message relays contiguous indices unchanged.
+	require.Equal(t, int64(0), derefBlockIndex(t, i.clientContentBlockIndex(anthropic.MessageStreamEventUnion{Type: "content_block_start", Index: 0}, m, &relayedBlocks)))
+	require.Equal(t, int64(1), derefBlockIndex(t, i.clientContentBlockIndex(anthropic.MessageStreamEventUnion{Type: "content_block_start", Index: 1}, m, &relayedBlocks)))
+}
+
+// TestClientContentBlockIndexUnmappedContinuation verifies that a delta or stop
+// arriving for an upstream index that never had a start is left unmapped rather
+// than being assigned a spurious client index.
+func TestClientContentBlockIndexUnmappedContinuation(t *testing.T) {
+	t.Parallel()
+
+	var i StreamingInterception
+	var relayedBlocks int64
+	m := make(map[int64]int64)
+
+	require.Nil(t, i.clientContentBlockIndex(anthropic.MessageStreamEventUnion{Type: "content_block_delta", Index: 7}, m, &relayedBlocks))
+	require.Nil(t, i.clientContentBlockIndex(anthropic.MessageStreamEventUnion{Type: "content_block_stop", Index: 7}, m, &relayedBlocks))
+	require.Equal(t, int64(0), relayedBlocks)
+}
+
+func derefBlockIndex(t *testing.T, p *int64) int64 {
+	t.Helper()
+	require.NotNil(t, p)
+	return *p
+}

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -1523,6 +1523,60 @@ func TestAnthropicInjectedTools(t *testing.T) {
 	}
 }
 
+// TestAnthropicStreamRenumbering pins the content_block_* index mapping the
+// client observes when an injected tool splices two upstream streams into
+// one client-facing message. Upstream indices restart at zero on the
+// continuation and the swallowed tool_use block claims no client index, so
+// the continuation's block 0 must be relayed as block 1. The strict SDK
+// accumulator in TestAnthropicInjectedTools only covers this implicitly;
+// a regression here should fail with a readable index diff.
+func TestAnthropicStreamRenumbering(t *testing.T) {
+	t.Parallel()
+
+	_, _, resp := setupInjectedToolTest(t, fixtures.AntSingleInjectedTool, true, defaultTracer, pathAnthropicMessages, anthropicToolResultValidator(t))
+	defer resp.Body.Close()
+
+	type indexedEvent struct {
+		Type  string
+		Index int64
+	}
+	var got []indexedEvent
+	decoder := ssestream.NewDecoder(resp)
+	stream := ssestream.NewStream[anthropic.MessageStreamEventUnion](decoder, nil)
+	for stream.Next() {
+		event := stream.Current()
+		if !strings.HasPrefix(event.Type, "content_block_") {
+			continue
+		}
+		got = append(got, indexedEvent{Type: event.Type, Index: event.Index})
+	}
+	require.NoError(t, stream.Err(), "stream error")
+
+	want := []indexedEvent{
+		// Iteration 1: upstream text block 0 relayed verbatim. Its
+		// tool_use block 1 is swallowed and claims no client index.
+		{Type: "content_block_start", Index: 0},
+		{Type: "content_block_delta", Index: 0},
+		{Type: "content_block_delta", Index: 0},
+		{Type: "content_block_delta", Index: 0},
+		{Type: "content_block_stop", Index: 0},
+		// Continuation: upstream indices restart at 0 but the client
+		// has already seen one block, so they are renumbered to 1.
+		{Type: "content_block_start", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_delta", Index: 1},
+		{Type: "content_block_stop", Index: 1},
+	}
+	require.Equal(t, want, got)
+}
+
 func TestOpenAIInjectedTools(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The bridge presents multiple upstream messages (one per agentic tool round) as a single client-facing message, but relayed each upstream message's `content_block_*` indices verbatim. Every upstream message restarts its indices at 0, so a client stitching an injected-tool conversation observed a non-monotonic index sequence (0, then 0 again). A spec-compliant accumulator rejects that.

## Fix

Track the number of blocks already relayed across the stitched stream, and map each upstream message's block indices onto a contiguous, monotonic client sequence.

- `content_block_start` claims the next free client index; the matching `content_block_delta` and `content_block_stop` reuse that mapping.
- Blocks swallowed before relay, such as injected `tool_use` blocks, claim no client index.
- Events carrying no content block index are left untouched.
- A delta or stop for an upstream index that never had a start is left unmapped rather than assigned a spurious index.

## Testing

- Unit tests cover the remapping in isolation, including the non-content-event and unmapped-continuation cases.
- An integration test pins the exact `(type, index)` sequence a client observes across an injected-tool splice. This path was previously covered only implicitly by the strict SDK accumulator; a regression now fails with a readable index diff.
- Verified the tests actually catch the defect by temporarily reverting the fix: `TestAnthropicStreamRenumbering` fails with `Index: (int64) 1` → `0`.
- `go test ./aibridge/... -count=1` green; `-race` green on both changed packages; `gofmt` clean; `golangci-lint` reports 0 issues.

## Context

This fix was independently implemented on two in-flight branches, `seth/aigov-484-claude-platform-aws` and `seth/aigov-506-anthropic-wif`. Landing it once here, ahead of both, avoids a duplicate implementation and shrinks the `streaming.go` rebase for each. It is an independent defect and carries no dependency on either.

<details>
<summary>Coder Agents disclosure</summary>

This pull request was generated by Coder Agents on behalf of @Shelnutt2.

</details>
