### PR TITLE
feat: support Claude Platform for AWS on the Anthropic provider

### DIFF
--- a/aibridge/aibridgetest/aibridgetest.go
+++ b/aibridge/aibridgetest/aibridgetest.go
@@ -13,7 +13,16 @@ import (
 // if credential resolution fails.
 func NewAnthropicProvider(t testing.TB, cfg aibridge.AnthropicConfig, bedrockCfg *aibridge.AWSBedrockConfig) aibridge.Provider {
 	t.Helper()
-	p, err := aibridge.NewAnthropicProvider(context.Background(), cfg, bedrockCfg)
+	p, err := aibridge.NewAnthropicProvider(context.Background(), cfg, bedrockCfg, nil)
+	require.NoError(t, err)
+	return p
+}
+
+// NewClaudePlatformProvider builds an Anthropic provider configured for Claude
+// Platform for AWS, failing the test if credential resolution fails.
+func NewClaudePlatformProvider(t testing.TB, cfg aibridge.AnthropicConfig, claudePlatformCfg *aibridge.AWSClaudePlatformConfig) aibridge.Provider {
+	t.Helper()
+	p, err := aibridge.NewAnthropicProvider(context.Background(), cfg, nil, claudePlatformCfg)
 	require.NoError(t, err)
 	return p
 }

--- a/aibridge/api.go
+++ b/aibridge/api.go
@@ -36,18 +36,30 @@ type (
 	Metadata                = recorder.Metadata
 	ErrorType               = recorder.ErrorType
 
-	AnthropicConfig  = config.Anthropic
-	AWSBedrockConfig = config.AWSBedrock
-	OpenAIConfig     = config.OpenAI
-	CopilotConfig    = config.Copilot
+	AnthropicConfig         = config.Anthropic
+	AWSBedrockConfig        = config.AWSBedrock
+	AWSClaudePlatformConfig = config.AWSClaudePlatform
+	OpenAIConfig            = config.OpenAI
+	CopilotConfig           = config.Copilot
+
+	ClaudePlatformAuthMode = config.ClaudePlatformAuthMode
+)
+
+// Claude Platform for AWS authentication modes.
+const (
+	ClaudePlatformAuthModeIAM    = config.ClaudePlatformAuthModeIAM
+	ClaudePlatformAuthModeAPIKey = config.ClaudePlatformAuthModeAPIKey
 )
 
 func AsActor(ctx context.Context, actorID string, metadata recorder.Metadata) context.Context {
 	return aibcontext.AsActor(ctx, actorID, metadata)
 }
 
-func NewAnthropicProvider(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.AWSBedrock) (provider.Provider, error) {
-	return provider.NewAnthropic(ctx, cfg, bedrockCfg)
+// NewAnthropicProvider constructs the Anthropic provider. At most one of
+// bedrockCfg and claudePlatformCfg may be non-nil; both nil means direct
+// Anthropic API access.
+func NewAnthropicProvider(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.AWSBedrock, claudePlatformCfg *config.AWSClaudePlatform) (provider.Provider, error) {
+	return provider.NewAnthropic(ctx, cfg, bedrockCfg, claudePlatformCfg)
 }
 
 func NewOpenAIProvider(cfg config.OpenAI) provider.Provider {

--- a/aibridge/config/config.go
+++ b/aibridge/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -13,6 +14,92 @@ const (
 	ProviderOpenAI    = "openai"
 	ProviderCopilot   = "copilot"
 )
+
+// ClaudePlatformAuthMode selects how the gateway authenticates to Anthropic's
+// AWS-hosted Messages API.
+type ClaudePlatformAuthMode string
+
+const (
+	// ClaudePlatformAuthModeIAM signs requests with AWS SigV4.
+	ClaudePlatformAuthModeIAM ClaudePlatformAuthMode = "iam"
+	// ClaudePlatformAuthModeAPIKey authenticates with a workspace API key sent
+	// as x-api-key. The key comes from the provider's key pool, so this mode
+	// needs no AWS credentials.
+	ClaudePlatformAuthModeAPIKey ClaudePlatformAuthMode = "api_key"
+)
+
+// ClaudePlatformSigningService is the AWS SigV4 service name for Anthropic's
+// AWS-hosted Messages API.
+const ClaudePlatformSigningService = "aws-external-anthropic"
+
+// AWSClaudePlatform carries configuration for Claude Platform for AWS:
+// Anthropic's native Messages API hosted on AWS. Unlike Bedrock it speaks the
+// standard Messages wire format with standard Anthropic model IDs, so requests
+// and responses pass through unchanged; only routing and authentication differ.
+type AWSClaudePlatform struct {
+	// AuthMode selects SigV4 signing or a workspace API key. Required.
+	AuthMode ClaudePlatformAuthMode
+	// Region is the AWS region. It is always required, including when BaseURL
+	// is set, because SigV4 signatures are region-scoped and a proxy base URL
+	// must still be signed for the real upstream region.
+	Region string
+	// WorkspaceID is sent as the anthropic-workspace-id header on every
+	// request. Required in both auth modes.
+	WorkspaceID string
+	// AccessKey and AccessKeySecret select static AWS credentials. When unset,
+	// the AWS default credential chain resolves the base identity. IAM mode
+	// only.
+	AccessKey, AccessKeySecret string
+	// RoleARN, when set, is assumed via STS before signing. IAM mode only.
+	RoleARN string
+	// ExternalID is sent as the STS external ID on the AssumeRole call. It is
+	// meaningful only alongside RoleARN.
+	ExternalID string
+	// BaseURL overrides the default regional endpoint
+	// https://aws-external-anthropic.{region}.api.aws, for example to route
+	// through a proxy. Region still determines the signing scope.
+	BaseURL string
+}
+
+// ResolvedBaseURL returns the configured base URL, defaulting to the regional
+// Claude Platform endpoint.
+func (c AWSClaudePlatform) ResolvedBaseURL() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return fmt.Sprintf("https://aws-external-anthropic.%s.api.aws", c.Region)
+}
+
+// Validate verifies the Claude Platform configuration.
+func (c AWSClaudePlatform) Validate() error {
+	if c.Region == "" {
+		return xerrors.New("region required")
+	}
+	if c.WorkspaceID == "" {
+		return xerrors.New("workspace id required")
+	}
+	switch c.AuthMode {
+	case ClaudePlatformAuthModeIAM:
+		if (c.AccessKey == "") != (c.AccessKeySecret == "") {
+			return xerrors.New("both access key and access key secret must be provided together")
+		}
+	case ClaudePlatformAuthModeAPIKey:
+		// The workspace key lives in the provider's key pool, so no AWS
+		// identity may be configured; a stray access key or role would
+		// silently do nothing.
+		if c.AccessKey != "" || c.AccessKeySecret != "" {
+			return xerrors.New("access key credentials are not valid with api_key auth mode")
+		}
+		if c.RoleARN != "" {
+			return xerrors.New("role arn is not valid with api_key auth mode")
+		}
+	case "":
+		return xerrors.New("auth mode required")
+	default:
+		return xerrors.Errorf("unknown claude platform auth mode: %q", c.AuthMode)
+	}
+	return nil
+}
 
 // Anthropic carries configuration for an Anthropic provider.
 type Anthropic struct {

--- a/aibridge/config/config_test.go
+++ b/aibridge/config/config_test.go
@@ -111,3 +111,138 @@ func TestAWSBedrockValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSClaudePlatformValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      config.AWSClaudePlatform
+		errorMsg string
+	}{
+		{
+			name: "iam valid with default credential chain",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:    config.ClaudePlatformAuthModeIAM,
+				Region:      "us-east-1",
+				WorkspaceID: "wrkspc_123",
+			},
+		},
+		{
+			name: "iam valid with static credentials and role",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:        config.ClaudePlatformAuthModeIAM,
+				Region:          "us-east-1",
+				WorkspaceID:     "wrkspc_123",
+				AccessKey:       "AKIA",
+				AccessKeySecret: "secret",
+				RoleARN:         "arn:aws:iam::123456789012:role/claude",
+				ExternalID:      "coder-external-id",
+			},
+		},
+		{
+			name: "api key valid",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:    config.ClaudePlatformAuthModeAPIKey,
+				Region:      "us-east-1",
+				WorkspaceID: "wrkspc_123",
+			},
+		},
+		{
+			name: "missing region",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:    config.ClaudePlatformAuthModeIAM,
+				WorkspaceID: "wrkspc_123",
+			},
+			errorMsg: "region required",
+		},
+		{
+			name: "missing workspace id",
+			cfg: config.AWSClaudePlatform{
+				AuthMode: config.ClaudePlatformAuthModeIAM,
+				Region:   "us-east-1",
+			},
+			errorMsg: "workspace id required",
+		},
+		{
+			name: "missing auth mode",
+			cfg: config.AWSClaudePlatform{
+				Region:      "us-east-1",
+				WorkspaceID: "wrkspc_123",
+			},
+			errorMsg: "auth mode required",
+		},
+		{
+			name: "unknown auth mode",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:    config.ClaudePlatformAuthMode("sigv2"),
+				Region:      "us-east-1",
+				WorkspaceID: "wrkspc_123",
+			},
+			errorMsg: "unknown claude platform auth mode",
+		},
+		{
+			name: "iam access key without secret",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:    config.ClaudePlatformAuthModeIAM,
+				Region:      "us-east-1",
+				WorkspaceID: "wrkspc_123",
+				AccessKey:   "AKIA",
+			},
+			errorMsg: "must be provided together",
+		},
+		{
+			name: "api key mode rejects aws credentials",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:        config.ClaudePlatformAuthModeAPIKey,
+				Region:          "us-east-1",
+				WorkspaceID:     "wrkspc_123",
+				AccessKey:       "AKIA",
+				AccessKeySecret: "secret",
+			},
+			errorMsg: "access key credentials are not valid with api_key auth mode",
+		},
+		{
+			name: "api key mode rejects role arn",
+			cfg: config.AWSClaudePlatform{
+				AuthMode:    config.ClaudePlatformAuthModeAPIKey,
+				Region:      "us-east-1",
+				WorkspaceID: "wrkspc_123",
+				RoleARN:     "arn:aws:iam::123456789012:role/claude",
+			},
+			errorMsg: "role arn is not valid with api_key auth mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if tt.errorMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAWSClaudePlatformResolvedBaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("regional default", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.AWSClaudePlatform{Region: "us-west-2"}
+		require.Equal(t, "https://aws-external-anthropic.us-west-2.api.aws", cfg.ResolvedBaseURL())
+	})
+
+	t.Run("explicit override wins", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.AWSClaudePlatform{Region: "us-west-2", BaseURL: "https://proxy.internal/anthropic"}
+		require.Equal(t, "https://proxy.internal/anthropic", cfg.ResolvedBaseURL())
+	})
+}

--- a/aibridge/intercept/client_headers.go
+++ b/aibridge/intercept/client_headers.go
@@ -36,6 +36,12 @@ var authHeaders = []string{
 	"X-Api-Key",
 }
 
+// HeaderAnthropicWorkspaceID identifies the Anthropic workspace a request is
+// attributed to. Claude Platform for AWS requires it on every data plane
+// request. It is set from provider configuration, never preserved from the
+// client, so a client cannot choose which workspace its traffic bills to.
+const HeaderAnthropicWorkspaceID = "Anthropic-Workspace-Id"
+
 // proxyHeaders describe the path the inbound request took to reach
 // aibridge. On bridge routes aibridge acts as a client, not a proxy,
 // so these headers are not meaningful on the outbound request.
@@ -75,6 +81,9 @@ func PrepareClientHeaders(clientHeaders http.Header) http.Header {
 	for _, h := range agentFirewallHeaders {
 		prepared.Del(h)
 	}
+	// Never forward a client-supplied workspace ID: providers that need one set
+	// it from their own configuration.
+	prepared.Del(HeaderAnthropicWorkspaceID)
 	return prepared
 }
 

--- a/aibridge/intercept/client_headers_test.go
+++ b/aibridge/intercept/client_headers_test.go
@@ -74,6 +74,22 @@ func TestPrepareClientHeaders(t *testing.T) {
 		assert.Equal(t, "preserved", result.Get("X-Custom"))
 	})
 
+	t.Run("workspace id header is removed", func(t *testing.T) {
+		t.Parallel()
+
+		input := http.Header{
+			intercept.HeaderAnthropicWorkspaceID: {"wrkspc_from_client"},
+			"X-Custom":                           {"preserved"},
+		}
+
+		result := intercept.PrepareClientHeaders(input)
+
+		// Providers that need a workspace ID set it from their own config, so a
+		// client cannot choose which workspace its traffic bills to.
+		assert.Empty(t, result.Get(intercept.HeaderAnthropicWorkspaceID))
+		assert.Equal(t, "preserved", result.Get("X-Custom"))
+	})
+
 	t.Run("proxy headers are removed", func(t *testing.T) {
 		t.Parallel()
 

--- a/aibridge/intercept/keyfailover_test.go
+++ b/aibridge/intercept/keyfailover_test.go
@@ -95,9 +95,9 @@ var interceptorCases = []interceptorCase{
 
 			id, tracer := uuid.New(), otel.Tracer("keyfailover")
 			if streaming {
-				return messages.NewStreamingInterceptor(id, payload, cfg, cred, nil, http.Header{}, tracer)
+				return messages.NewStreamingInterceptor(id, payload, cfg, cred, messages.AuthRuntime{}, http.Header{}, tracer)
 			}
-			return messages.NewBlockingInterceptor(id, payload, cfg, cred, nil, http.Header{}, tracer)
+			return messages.NewBlockingInterceptor(id, payload, cfg, cred, messages.AuthRuntime{}, http.Header{}, tracer)
 		},
 	},
 	{

--- a/aibridge/intercept/messages/base.go
+++ b/aibridge/intercept/messages/base.go
@@ -74,14 +74,36 @@ type BedrockRuntime struct {
 	Creds aws.CredentialsProvider
 }
 
+// ClaudePlatformRuntime carries everything a Claude Platform for AWS
+// interception needs. Creds is nil in api_key mode, where the workspace key
+// comes from the provider's key pool instead of AWS signing.
+type ClaudePlatformRuntime struct {
+	Cfg   aibconfig.AWSClaudePlatform
+	Creds aws.CredentialsProvider
+}
+
+// AuthRuntime carries the provider-level authentication configuration resolved
+// once at provider construction. At most one variant is non-nil; all nil means
+// a plain bearer-token Anthropic provider (BYOK or a centralized key pool).
+//
+// Grouping the variants keeps the interceptor constructors from growing a
+// positional argument per authentication method.
+type AuthRuntime struct {
+	// Bedrock is set for AWS Bedrock providers.
+	Bedrock *BedrockRuntime
+	// ClaudePlatform is set for Claude Platform for AWS providers.
+	ClaudePlatform *ClaudePlatformRuntime
+}
+
 type interceptionBase struct {
 	id         uuid.UUID
 	reqPayload RequestPayload
 
 	cfg  intercept.Config
 	cred intercept.Credential
-	// bedrock is nil for non-Bedrock providers.
-	bedrock *BedrockRuntime
+	// auth carries the provider's resolved authentication runtime; its fields
+	// are nil for plain bearer-token providers.
+	auth AuthRuntime
 
 	// clientHeaders are the original HTTP headers from the client request.
 	clientHeaders http.Header
@@ -147,16 +169,22 @@ func (i *interceptionBase) CorrelatingToolCallID() *string {
 	return i.reqPayload.correlatingToolCallID()
 }
 
+// isClaudePlatform reports whether the interception targets Claude Platform
+// for AWS.
+func (i *interceptionBase) isClaudePlatform() bool {
+	return i.auth.ClaudePlatform != nil
+}
+
 // isBedrockMantle reports whether the interception targets the Bedrock mantle
 // protocol.
 func (i *interceptionBase) isBedrockMantle() bool {
-	return i.bedrock != nil && i.bedrock.Cfg.ResolvedProtocol() == aibconfig.BedrockProtocolMantle
+	return i.auth.Bedrock != nil && i.auth.Bedrock.Cfg.ResolvedProtocol() == aibconfig.BedrockProtocolMantle
 }
 
 // isBedrockInvokeModel reports whether the interception targets the Bedrock
 // InvokeModel protocol.
 func (i *interceptionBase) isBedrockInvokeModel() bool {
-	return i.bedrock != nil && i.bedrock.Cfg.ResolvedProtocol() == aibconfig.BedrockProtocolInvokeModel
+	return i.auth.Bedrock != nil && i.auth.Bedrock.Cfg.ResolvedProtocol() == aibconfig.BedrockProtocolInvokeModel
 }
 
 func (i *interceptionBase) Model() string {
@@ -169,9 +197,9 @@ func (i *interceptionBase) Model() string {
 	// passthrough, non-Bedrock providers) returns the model the client sent in
 	// the body.
 	if i.isBedrockInvokeModel() {
-		model := i.bedrock.Cfg.Model
+		model := i.auth.Bedrock.Cfg.Model
 		if i.isSmallFastModel() {
-			model = i.bedrock.Cfg.SmallFastModel
+			model = i.auth.Bedrock.Cfg.SmallFastModel
 		}
 		return model
 	}
@@ -187,10 +215,10 @@ func (i *interceptionBase) baseTraceAttributes(r *http.Request, streaming bool) 
 		attribute.String(tracing.Provider, i.cfg.ProviderName),
 		attribute.String(tracing.Model, i.Model()),
 		attribute.Bool(tracing.Streaming, streaming),
-		attribute.Bool(tracing.IsBedrock, i.bedrock != nil),
+		attribute.Bool(tracing.IsBedrock, i.auth.Bedrock != nil),
 	}
-	if i.bedrock != nil {
-		attrs = append(attrs, attribute.String(tracing.BedrockProtocol, string(i.bedrock.Cfg.ResolvedProtocol())))
+	if i.auth.Bedrock != nil {
+		attrs = append(attrs, attribute.String(tracing.BedrockProtocol, string(i.auth.Bedrock.Cfg.ResolvedProtocol())))
 	}
 	return attrs
 }
@@ -328,6 +356,16 @@ func (i *interceptionBase) newMessagesService(ctx context.Context, opts ...optio
 		opts = append(opts, bedrockOpts...)
 	}
 
+	if i.isClaudePlatform() {
+		ctx, cancel := context.WithTimeout(ctx, bedrockCredentialResolutionTimeout)
+		defer cancel()
+		claudePlatformOpts, err := i.withClaudePlatformOptions(ctx)
+		if err != nil {
+			return anthropic.MessageService{}, err
+		}
+		opts = append(opts, claudePlatformOpts...)
+	}
+
 	return anthropic.NewMessageService(opts...), nil
 }
 
@@ -342,13 +380,13 @@ func (i *interceptionBase) withBody() option.RequestOption {
 // withBedrockInvokeModelOptions returns request options for the AWS Bedrock
 // InvokeModel protocol.
 //
-// Credentials come from i.bedrock.Creds. It is a shared credentials cache, so the per-request Retrieve()
+// Credentials come from i.auth.Bedrock.Creds. It is a shared credentials cache, so the per-request Retrieve()
 // below is served from that cache and does not re-resolve or re-assume on every request.
 func (i *interceptionBase) withBedrockInvokeModelOptions(ctx context.Context) ([]option.RequestOption, error) {
-	if i.bedrock == nil {
+	if i.auth.Bedrock == nil {
 		return nil, xerrors.New("nil bedrock runtime")
 	}
-	cfg := i.bedrock.Cfg
+	cfg := i.auth.Bedrock.Cfg
 	if err := cfg.Validate(); err != nil {
 		return nil, xerrors.Errorf("bedrock invoke-model config: %w", err)
 	}
@@ -356,13 +394,13 @@ func (i *interceptionBase) withBedrockInvokeModelOptions(ctx context.Context) ([
 	// Fail fast: ensure credentials can be resolved before signing. Served from
 	// the shared cache on most requests (no network); on the cold or refresh
 	// path this performs the actual STS/IMDS call.
-	if _, err := i.bedrock.Creds.Retrieve(ctx); err != nil {
+	if _, err := i.auth.Bedrock.Creds.Retrieve(ctx); err != nil {
 		return nil, xerrors.Errorf("resolve AWS credentials: %w", err)
 	}
 
 	awsCfg := aws.Config{
 		Region:      cfg.Region,
-		Credentials: i.bedrock.Creds,
+		Credentials: i.auth.Bedrock.Creds,
 	}
 
 	var out []option.RequestOption
@@ -423,10 +461,10 @@ func withAWSSignedMessagesOptions(ctx context.Context, creds aws.CredentialsProv
 // the native Messages wire format, so this only SigV4-signs the request
 // (service "bedrock-mantle") and forwards it; the response is plain SSE.
 func (i *interceptionBase) withBedrockMantleOptions(ctx context.Context) ([]option.RequestOption, error) {
-	if i.bedrock == nil {
+	if i.auth.Bedrock == nil {
 		return nil, xerrors.New("nil bedrock runtime")
 	}
-	cfg := i.bedrock.Cfg
+	cfg := i.auth.Bedrock.Cfg
 	if err := cfg.Validate(); err != nil {
 		return nil, xerrors.Errorf("bedrock mantle config: %w", err)
 	}
@@ -441,7 +479,7 @@ func (i *interceptionBase) withBedrockMantleOptions(ctx context.Context) ([]opti
 		}),
 	}
 
-	signed, err := withAWSSignedMessagesOptions(ctx, i.bedrock.Creds, cfg.BaseURL, cfg.Region, awssig.ServiceBedrockMantle, nil)
+	signed, err := withAWSSignedMessagesOptions(ctx, i.auth.Bedrock.Creds, cfg.BaseURL, cfg.Region, awssig.ServiceBedrockMantle, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -449,12 +487,60 @@ func (i *interceptionBase) withBedrockMantleOptions(ctx context.Context) ([]opti
 	return append(out, signed...), nil
 }
 
+// withClaudePlatformOptions returns request options for Claude Platform for
+// AWS (aws-external-anthropic.{region}.api.aws/v1/messages). It speaks the
+// native Messages wire format with standard Anthropic model IDs, so nothing in
+// the request or response is translated.
+//
+// In IAM mode the request is SigV4-signed for the aws-external-anthropic
+// service. In api_key mode the workspace key is already carried by the
+// provider's key pool, so only routing and the workspace header apply.
+//
+// Bedrock's PRM attribution marker is deliberately not sent: it is a
+// Bedrock-specific revenue-attribution agreement.
+func (i *interceptionBase) withClaudePlatformOptions(ctx context.Context) ([]option.RequestOption, error) {
+	if i.auth.ClaudePlatform == nil {
+		return nil, xerrors.New("nil claude platform runtime")
+	}
+	cfg := i.auth.ClaudePlatform.Cfg
+	if err := cfg.Validate(); err != nil {
+		return nil, xerrors.Errorf("claude platform config: %w", err)
+	}
+
+	// anthropic-workspace-id is required on every data plane request. It is set
+	// from provider configuration rather than preserved from the client, so a
+	// client cannot choose which workspace its traffic is billed to.
+	headers := map[string]string{
+		intercept.HeaderAnthropicWorkspaceID: cfg.WorkspaceID,
+	}
+
+	if cfg.AuthMode == aibconfig.ClaudePlatformAuthModeAPIKey {
+		// The key pool supplies x-api-key; only route and set the header.
+		return []option.RequestOption{
+			option.WithBaseURL(cfg.ResolvedBaseURL()),
+			option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				for name, value := range headers {
+					req.Header.Set(name, value)
+				}
+				return next(req)
+			}),
+		}, nil
+	}
+
+	if i.auth.ClaudePlatform.Creds == nil {
+		return nil, xerrors.New("claude platform iam mode requires aws credentials")
+	}
+
+	return withAWSSignedMessagesOptions(ctx, i.auth.ClaudePlatform.Creds,
+		cfg.ResolvedBaseURL(), cfg.Region, aibconfig.ClaudePlatformSigningService, headers)
+}
+
 // augmentRequestForBedrockInvokeModel changes the model used for the request since AWS Bedrock doesn't support
 // Anthropics' model names. It also converts adaptive thinking to enabled with a budget for models that
 // don't support adaptive thinking natively, or enabled thinking to adaptive for models that only support
 // adaptive.
 func (i *interceptionBase) augmentRequestForBedrockInvokeModel() {
-	if i.bedrock == nil {
+	if i.auth.Bedrock == nil {
 		return
 	}
 

--- a/aibridge/intercept/messages/base_internal_test.go
+++ b/aibridge/intercept/messages/base_internal_test.go
@@ -179,10 +179,10 @@ func TestAWSBedrockValidation(t *testing.T) {
 			t.Parallel()
 
 			base := &interceptionBase{
-				bedrock: &BedrockRuntime{
+				auth: AuthRuntime{Bedrock: &BedrockRuntime{
 					Cfg:   tt.cfg,
 					Creds: credentials.NewStaticCredentialsProvider("test-key", "test-secret", ""),
-				},
+				}},
 			}
 			opts, err := base.withBedrockInvokeModelOptions(context.Background())
 
@@ -806,12 +806,12 @@ func TestAugmentRequestForBedrock_AdaptiveThinking(t *testing.T) {
 
 			i := &interceptionBase{
 				reqPayload: mustMessagesPayload(t, tc.requestBody),
-				bedrock: &BedrockRuntime{
+				auth: AuthRuntime{Bedrock: &BedrockRuntime{
 					Cfg: config.AWSBedrock{
 						Model:          tc.bedrockModel,
 						SmallFastModel: "anthropic.claude-haiku-3-5",
 					},
-				},
+				}},
 				clientHeaders: clientHeaders,
 				logger:        slog.Make(),
 			}
@@ -1159,14 +1159,14 @@ func TestBedrockMantleIsPassthrough(t *testing.T) {
 	i := &interceptionBase{
 		reqPayload: mustMessagesPayload(t,
 			`{"model":"anthropic.claude-opus-4-8","max_tokens":10000,"thinking":{"type":"adaptive"},"metadata":{"user_id":"u123"},"context_management":{"type":"auto"}}`),
-		bedrock: &BedrockRuntime{
+		auth: AuthRuntime{Bedrock: &BedrockRuntime{
 			Cfg: config.AWSBedrock{
 				Region:   "us-east-1",
 				BaseURL:  "https://bedrock-mantle.us-east-1.api.aws/anthropic",
 				Protocol: config.BedrockProtocolMantle,
 			},
 			Creds: credentials.NewStaticCredentialsProvider("test-key", "test-secret", ""),
-		},
+		}},
 		logger: slog.Make(),
 	}
 
@@ -1217,10 +1217,10 @@ func TestAWSMantleOptionsValidation(t *testing.T) {
 			t.Parallel()
 
 			base := &interceptionBase{
-				bedrock: &BedrockRuntime{
+				auth: AuthRuntime{Bedrock: &BedrockRuntime{
 					Cfg:   tt.cfg,
 					Creds: credentials.NewStaticCredentialsProvider("test-key", "test-secret", ""),
-				},
+				}},
 			}
 			opts, err := base.withBedrockMantleOptions(t.Context())
 			if tt.errorMsg != "" {

--- a/aibridge/intercept/messages/blocking.go
+++ b/aibridge/intercept/messages/blocking.go
@@ -36,7 +36,7 @@ func NewBlockingInterceptor(
 	reqPayload RequestPayload,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *BedrockRuntime,
+	auth AuthRuntime,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *BlockingInterception {
@@ -45,7 +45,7 @@ func NewBlockingInterceptor(
 		reqPayload:    reqPayload,
 		cfg:           cfg,
 		cred:          cred,
-		bedrock:       bedrock,
+		auth:          auth,
 		clientHeaders: clientHeaders,
 		tracer:        tracer,
 	}}

--- a/aibridge/intercept/messages/streaming.go
+++ b/aibridge/intercept/messages/streaming.go
@@ -41,7 +41,7 @@ func NewStreamingInterceptor(
 	reqPayload RequestPayload,
 	cfg intercept.Config,
 	cred intercept.Credential,
-	bedrock *BedrockRuntime,
+	auth AuthRuntime,
 	clientHeaders http.Header,
 	tracer trace.Tracer,
 ) *StreamingInterception {
@@ -50,7 +50,7 @@ func NewStreamingInterceptor(
 		reqPayload:    reqPayload,
 		cfg:           cfg,
 		cred:          cred,
-		bedrock:       bedrock,
+		auth:          auth,
 		clientHeaders: clientHeaders,
 		tracer:        tracer,
 	}}

--- a/aibridge/internal/integrationtest/bridge_internal_test.go
+++ b/aibridge/internal/integrationtest/bridge_internal_test.go
@@ -317,7 +317,7 @@ func TestAWSBedrockIntegration(t *testing.T) {
 			SmallFastModel:  "test-haiku",
 		}
 
-		_, err := provider.NewAnthropic(ctx, anthropicCfg("http://unused", apiKey), bedrockCfg)
+		_, err := provider.NewAnthropic(ctx, anthropicCfg("http://unused", apiKey), bedrockCfg, nil)
 		require.ErrorContains(t, err, "region or base url required")
 	})
 

--- a/aibridge/internal/integrationtest/claude_platform_internal_test.go
+++ b/aibridge/internal/integrationtest/claude_platform_internal_test.go
@@ -1,0 +1,221 @@
+package integrationtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/coder/coder/v2/aibridge/aibridgetest"
+	"github.com/coder/coder/v2/aibridge/config"
+	"github.com/coder/coder/v2/aibridge/fixtures"
+	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/awssig"
+	"github.com/coder/coder/v2/aibridge/internal/testutil"
+	"github.com/coder/coder/v2/aibridge/provider"
+)
+
+const claudePlatformWorkspaceID = "wrkspc_config"
+
+// claudePlatformCfg returns a Claude Platform for AWS config pointing at the
+// given URL. The base URL override keeps both bridged and passthrough routes
+// on the mock upstream while the signing scope stays region-based.
+func claudePlatformCfg(url string, authMode config.ClaudePlatformAuthMode) *config.AWSClaudePlatform {
+	cfg := &config.AWSClaudePlatform{
+		AuthMode:    authMode,
+		Region:      "us-west-2",
+		WorkspaceID: claudePlatformWorkspaceID,
+		BaseURL:     url,
+	}
+	if authMode == config.ClaudePlatformAuthModeIAM {
+		cfg.AccessKey = "test-access-key"
+		cfg.AccessKeySecret = "test-secret-key"
+	}
+	return cfg
+}
+
+// TestClaudePlatformIntegration covers Anthropic's AWS-hosted Messages API.
+// Unlike Bedrock it speaks the native Messages wire format, so only routing and
+// authentication differ from a direct Anthropic provider.
+func TestClaudePlatformIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid config", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		t.Cleanup(cancel)
+
+		cpCfg := claudePlatformCfg("http://unused", config.ClaudePlatformAuthModeIAM)
+		cpCfg.Region = ""
+
+		_, err := provider.NewAnthropic(ctx, config.Anthropic{}, nil, cpCfg)
+		require.ErrorContains(t, err, "region required")
+	})
+
+	// IAM mode signs the bridged request for the aws-external-anthropic
+	// service and forwards the client's model unchanged.
+	t.Run("iam/v1/messages", func(t *testing.T) {
+		for _, streaming := range []bool{true, false} {
+			t.Run(fmt.Sprintf("streaming=%v", streaming), func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+				t.Cleanup(cancel)
+
+				fix := fixtures.Parse(t, fixtures.AntSingleBuiltinTool)
+				upstream := testutil.NewMockUpstream(ctx, t, testutil.NewFixtureResponse(fix))
+
+				wantModel := gjson.GetBytes(fix.Request(), "model").String()
+				require.NotEmpty(t, wantModel)
+
+				cpCfg := claudePlatformCfg(upstream.URL, config.ClaudePlatformAuthModeIAM)
+				// No key pool: IAM mode authenticates by signing.
+				bridgeServer := newBridgeTestServer(ctx, t, upstream.URL,
+					withCustomProvider(aibridgetest.NewClaudePlatformProvider(t, config.Anthropic{}, cpCfg)),
+				)
+
+				reqBody, err := sjson.SetBytes(fix.Request(), "stream", streaming)
+				require.NoError(t, err)
+				resp, err := bridgeServer.makeRequest(t, http.MethodPost, pathAnthropicMessages, reqBody)
+				require.NoError(t, err)
+				defer resp.Body.Close()
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				_, err = io.ReadAll(resp.Body)
+				require.NoError(t, err)
+
+				received := upstream.ReceivedRequests()
+				require.Len(t, received, 1)
+
+				// Native passthrough: standard Messages path, model unchanged.
+				require.Equal(t, "/v1/messages", received[0].Path)
+				require.Equal(t, wantModel, gjson.GetBytes(received[0].Body, "model").String(),
+					"model should be forwarded unchanged")
+
+				authHeader := received[0].Header.Get("Authorization")
+				require.True(t, strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256"), "missing SigV4 auth: %q", authHeader)
+				require.Contains(t, authHeader, "/aws-external-anthropic/aws4_request",
+					"signature must be scoped to the aws-external-anthropic service")
+				require.Contains(t, authHeader, "/us-west-2/",
+					"signature must be scoped to the configured region, not the base URL host")
+
+				require.Equal(t, claudePlatformWorkspaceID, received[0].Header.Get(intercept.HeaderAnthropicWorkspaceID))
+				require.Empty(t, received[0].Header.Get(intercept.AuthHeaderXAPIKey),
+					"IAM mode must not send an API key")
+
+				// PRM attribution is a Bedrock-specific revenue agreement.
+				require.NotContains(t, received[0].Header.Get("User-Agent"), awssig.PRMUserAgent,
+					"Claude Platform must not send Bedrock PRM attribution")
+
+				interceptions := bridgeServer.Recorder.RecordedInterceptions()
+				require.Len(t, interceptions, 1)
+				require.Equal(t, wantModel, interceptions[0].Model)
+				bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
+			})
+		}
+	})
+
+	// api_key mode authenticates with a workspace key from the provider's key
+	// pool, exactly like a direct Anthropic provider, and signs nothing.
+	t.Run("api_key/v1/messages", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		t.Cleanup(cancel)
+
+		fix := fixtures.Parse(t, fixtures.AntSingleBuiltinTool)
+		upstream := testutil.NewMockUpstream(ctx, t, testutil.NewFixtureResponse(fix))
+
+		cpCfg := claudePlatformCfg(upstream.URL, config.ClaudePlatformAuthModeAPIKey)
+		bridgeServer := newBridgeTestServer(ctx, t, upstream.URL,
+			withCustomProvider(aibridgetest.NewClaudePlatformProvider(t, anthropicCfg(upstream.URL, apiKey), cpCfg)),
+		)
+
+		resp, err := bridgeServer.makeRequest(t, http.MethodPost, pathAnthropicMessages, fix.Request())
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		received := upstream.ReceivedRequests()
+		require.Len(t, received, 1)
+		require.Equal(t, "/v1/messages", received[0].Path)
+		require.Equal(t, apiKey, received[0].Header.Get(intercept.AuthHeaderXAPIKey))
+		require.Empty(t, received[0].Header.Get("Authorization"), "api_key mode must not sign")
+		require.Equal(t, claudePlatformWorkspaceID, received[0].Header.Get(intercept.HeaderAnthropicWorkspaceID))
+
+		bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
+	})
+
+	// A client-supplied key keeps precedence over IAM signing so BYOK keeps
+	// working when the deployment is configured for signing.
+	t.Run("byok wins over iam signing", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		t.Cleanup(cancel)
+
+		fix := fixtures.Parse(t, fixtures.AntSingleBuiltinTool)
+		upstream := testutil.NewMockUpstream(ctx, t, testutil.NewFixtureResponse(fix))
+
+		cpCfg := claudePlatformCfg(upstream.URL, config.ClaudePlatformAuthModeIAM)
+		bridgeServer := newBridgeTestServer(ctx, t, upstream.URL,
+			withCustomProvider(aibridgetest.NewClaudePlatformProvider(t, config.Anthropic{}, cpCfg)),
+		)
+
+		// The client also tries to pick its own workspace, which must be
+		// overridden by provider configuration.
+		resp, err := bridgeServer.makeRequest(t, http.MethodPost, pathAnthropicMessages, fix.Request(), http.Header{
+			intercept.AuthHeaderXAPIKey:          {"user-key"},
+			intercept.HeaderAnthropicWorkspaceID: {"wrkspc_from_client"},
+		})
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		received := upstream.ReceivedRequests()
+		require.Len(t, received, 1)
+		require.Equal(t, "user-key", received[0].Header.Get(intercept.AuthHeaderXAPIKey),
+			"BYOK key must be forwarded")
+		require.Equal(t, claudePlatformWorkspaceID, received[0].Header.Get(intercept.HeaderAnthropicWorkspaceID),
+			"provider configuration owns the workspace ID")
+
+		bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
+	})
+
+	// Passthrough routes bypass the SDK, so the provider signs them itself.
+	t.Run("iam passthrough", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		t.Cleanup(cancel)
+
+		upstream := testutil.NewMockUpstream(ctx, t, testutil.UpstreamResponse{
+			Blocking: []byte(`{"data":[]}`),
+		})
+
+		cpCfg := claudePlatformCfg(upstream.URL, config.ClaudePlatformAuthModeIAM)
+		bridgeServer := newBridgeTestServer(ctx, t, upstream.URL,
+			withCustomProvider(aibridgetest.NewClaudePlatformProvider(t, config.Anthropic{}, cpCfg)),
+		)
+
+		resp, err := bridgeServer.makeRequest(t, http.MethodGet, "/anthropic/v1/models", nil)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		received := upstream.ReceivedRequests()
+		require.Len(t, received, 1)
+		require.Equal(t, "/v1/models", received[0].Path)
+
+		authHeader := received[0].Header.Get("Authorization")
+		require.True(t, strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256"), "missing SigV4 auth: %q", authHeader)
+		require.Contains(t, authHeader, "/aws-external-anthropic/aws4_request")
+		require.Equal(t, claudePlatformWorkspaceID, received[0].Header.Get(intercept.HeaderAnthropicWorkspaceID))
+	})
+}

--- a/aibridge/passthrough.go
+++ b/aibridge/passthrough.go
@@ -43,6 +43,14 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
+	inner := apidump.NewPassthroughMiddleware(t, prov.APIDumpDir(), prov.Name(), logger, quartz.NewReal())
+	// Providers which authenticate passthrough requests themselves (for example
+	// AWS SigV4 signing) wrap the transport here, beneath key failover, so an
+	// existing BYOK or centralized-pool credential still takes precedence.
+	if wrapper, ok := prov.(provider.PassthroughTransportWrapper); ok {
+		inner = wrapper.WrapPassthroughTransport(inner)
+	}
+
 	// Build the passthrough proxy, reused across all requests for this provider.
 	// Rewrite sets proxy headers. For centralized requests, KeyFailoverTransport
 	// handles auth and failover. BYOK requests pass through.
@@ -51,7 +59,7 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 			rewritePassthroughRequest(pr, provBaseURL)
 		},
 		Transport: keypool.NewKeyFailoverTransport(
-			apidump.NewPassthroughMiddleware(t, prov.APIDumpDir(), prov.Name(), logger, quartz.NewReal()),
+			inner,
 			prov.KeyFailoverConfig(logger),
 		),
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, e error) {

--- a/aibridge/passthrough_internal_test.go
+++ b/aibridge/passthrough_internal_test.go
@@ -320,7 +320,7 @@ func TestPassthrough_KeyFailover(t *testing.T) {
 				p, err := provider.NewAnthropic(context.Background(), config.Anthropic{
 					BaseURL: baseURL,
 					KeyPool: pool,
-				}, nil)
+				}, nil, nil)
 				require.NoError(t, err)
 				return p
 			},

--- a/aibridge/provider/anthropic.go
+++ b/aibridge/provider/anthropic.go
@@ -29,8 +29,9 @@ var _ Provider = &Anthropic{}
 // Anthropic allows for interactions with the Anthropic API.
 type Anthropic struct {
 	cfg config.Anthropic
-	// bedrock is nil for non-Bedrock providers.
-	bedrock *messages.BedrockRuntime
+	// auth carries the provider's AWS-backed authentication runtime. Both
+	// fields are nil for a plain bearer-token Anthropic provider.
+	auth messages.AuthRuntime
 }
 
 const routeMessages = "/v1/messages" // https://docs.anthropic.com/en/api/messages
@@ -51,7 +52,7 @@ var anthropicIsFailure = func(statusCode int) bool {
 	return circuitbreaker.DefaultIsFailure(statusCode)
 }
 
-func NewAnthropic(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.AWSBedrock) (*Anthropic, error) {
+func NewAnthropic(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.AWSBedrock, claudePlatformCfg *config.AWSClaudePlatform) (*Anthropic, error) {
 	if cfg.Name == "" {
 		cfg.Name = config.ProviderAnthropic
 	}
@@ -62,12 +63,15 @@ func NewAnthropic(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.
 		cfg.CircuitBreaker.IsFailure = anthropicIsFailure
 		cfg.CircuitBreaker.OpenErrorResponse = anthropicOpenErrorResponse
 	}
+	if bedrockCfg != nil && claudePlatformCfg != nil {
+		return nil, xerrors.New("bedrock and claude platform configuration are mutually exclusive")
+	}
 
 	// Resolve the AWS credentials provider once and bundle it with the config.
 	// This performs no network call (the base identity and any AssumeRole
 	// resolve lazily on first retrieval); it only wires up the provider chain,
 	// so it is cheap to run at construction.
-	var bedrock *messages.BedrockRuntime
+	var auth messages.AuthRuntime
 	if bedrockCfg != nil {
 		creds, resolvedRegion, err := buildBedrockCredentials(ctx, *bedrockCfg)
 		if err != nil {
@@ -82,12 +86,38 @@ func NewAnthropic(ctx context.Context, cfg config.Anthropic, bedrockCfg *config.
 		if err := runtimeCfg.Validate(); err != nil {
 			return nil, xerrors.Errorf("bedrock config: %w", err)
 		}
-		bedrock = &messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds}
+		auth.Bedrock = &messages.BedrockRuntime{Cfg: runtimeCfg, Creds: creds}
+	}
+
+	if claudePlatformCfg != nil {
+		runtimeCfg := *claudePlatformCfg
+		// Unlike Bedrock, the region is never inferred from the AWS environment:
+		// it selects the upstream host and the signing scope, so an implicit
+		// value would silently route traffic to the wrong region.
+		if err := runtimeCfg.Validate(); err != nil {
+			return nil, xerrors.Errorf("claude platform config: %w", err)
+		}
+
+		runtime := &messages.ClaudePlatformRuntime{Cfg: runtimeCfg}
+		if runtimeCfg.AuthMode == config.ClaudePlatformAuthModeIAM {
+			creds, _, err := buildAWSCredentials(ctx, awsCredentialSpec{
+				Region:          runtimeCfg.Region,
+				AccessKey:       runtimeCfg.AccessKey,
+				AccessKeySecret: runtimeCfg.AccessKeySecret,
+				RoleARN:         runtimeCfg.RoleARN,
+				ExternalID:      runtimeCfg.ExternalID,
+			})
+			if err != nil {
+				return nil, xerrors.Errorf("build claude platform credentials: %w", err)
+			}
+			runtime.Creds = creds
+		}
+		auth.ClaudePlatform = runtime
 	}
 
 	return &Anthropic{
-		cfg:     cfg,
-		bedrock: bedrock,
+		cfg:  cfg,
+		auth: auth,
 	}, nil
 }
 
@@ -141,7 +171,7 @@ func (p *Anthropic) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tr
 
 	cfg := intercept.Config{
 		ProviderName:     p.Name(),
-		BaseURL:          p.cfg.BaseURL,
+		BaseURL:          p.BaseURL(),
 		APIDumpDir:       p.cfg.APIDumpDir,
 		SendActorHeaders: p.cfg.SendActorHeaders,
 	}
@@ -153,9 +183,9 @@ func (p *Anthropic) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tr
 
 	var interceptor intercept.Interceptor
 	if reqPayload.Stream() {
-		interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, p.bedrock, r.Header, tracer)
+		interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, p.auth, r.Header, tracer)
 	} else {
-		interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, p.bedrock, r.Header, tracer)
+		interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, p.auth, r.Header, tracer)
 	}
 	span.SetAttributes(interceptor.TraceAttributes(r)...)
 	return interceptor, nil
@@ -172,7 +202,8 @@ func (p *Anthropic) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tr
 //
 // When both BYOK headers are present, X-Api-Key takes priority to match
 // claude-code behavior. Centralized requests require a key pool, except for
-// Bedrock providers, which authenticate via AWS signing rather than a pool.
+// AWS-signed providers (Bedrock, and Claude Platform in IAM mode), which
+// authenticate via request signing rather than a pool.
 func (p *Anthropic) resolveCredential(r *http.Request) (intercept.Credential, error) {
 	if apiKey := r.Header.Get(intercept.AuthHeaderXAPIKey); apiKey != "" {
 		return intercept.BYOK{Secret: apiKey, Header: intercept.AuthHeaderXAPIKey}, nil
@@ -183,14 +214,38 @@ func (p *Anthropic) resolveCredential(r *http.Request) (intercept.Credential, er
 	if p.cfg.KeyPool != nil {
 		return &intercept.CentralizedPool{Pool: p.cfg.KeyPool, Header: p.AuthHeader()}, nil
 	}
-	if p.bedrock != nil {
-		return intercept.AWSSigV4{AccessKey: p.bedrock.Cfg.AccessKey}, nil
+	if p.auth.Bedrock != nil {
+		return intercept.AWSSigV4{AccessKey: p.auth.Bedrock.Cfg.AccessKey}, nil
+	}
+	if cp := p.auth.ClaudePlatform; cp != nil && cp.Cfg.AuthMode == config.ClaudePlatformAuthModeIAM {
+		return intercept.AWSSigV4{AccessKey: cp.Cfg.AccessKey}, nil
 	}
 	return nil, ErrNoCredential
 }
 
+// BaseURL returns the provider's upstream base URL. Claude Platform for AWS
+// derives it from the configured region unless explicitly overridden, so its
+// passthrough routes reach the same host as bridged requests.
 func (p *Anthropic) BaseURL() string {
+	if p.auth.ClaudePlatform != nil {
+		return p.auth.ClaudePlatform.Cfg.ResolvedBaseURL()
+	}
 	return p.cfg.BaseURL
+}
+
+// WrapPassthroughTransport authenticates passthrough routes for providers whose
+// credential is not a static header value. Passthrough auth is otherwise
+// key-pool driven, which leaves an IAM-mode Claude Platform provider sending
+// unsigned requests to /v1/models and friends.
+//
+// It is installed beneath the key failover transport, so a BYOK or centralized
+// key still wins; this only fills the gap where neither is present.
+func (p *Anthropic) WrapPassthroughTransport(inner http.RoundTripper) http.RoundTripper {
+	cp := p.auth.ClaudePlatform
+	if cp == nil {
+		return inner
+	}
+	return &claudePlatformPassthroughTransport{inner: inner, cfg: cp.Cfg, creds: cp.Creds}
 }
 
 func (*Anthropic) AuthHeader() string {

--- a/aibridge/provider/anthropic_internal_test.go
+++ b/aibridge/provider/anthropic_internal_test.go
@@ -24,7 +24,7 @@ import (
 // would create an import cycle.
 func newTestAnthropic(t testing.TB, cfg config.Anthropic, bedrockCfg *config.AWSBedrock) *Anthropic {
 	t.Helper()
-	p, err := NewAnthropic(context.Background(), cfg, bedrockCfg)
+	p, err := NewAnthropic(context.Background(), cfg, bedrockCfg, nil)
 	require.NoError(t, err)
 	return p
 }
@@ -124,10 +124,10 @@ func TestNewAnthropic_BedrockRegionResolution(t *testing.T) {
 			Protocol:        config.BedrockProtocolMantle,
 			AccessKey:       "test-key",
 			AccessKeySecret: "test-secret",
-		})
+		}, nil)
 		require.NoError(t, err)
-		require.NotNil(t, p.bedrock)
-		require.Equal(t, "us-west-2", p.bedrock.Cfg.Region)
+		require.NotNil(t, p.auth.Bedrock)
+		require.Equal(t, "us-west-2", p.auth.Bedrock.Cfg.Region)
 	})
 
 	t.Run("mantle_no_region_anywhere", func(t *testing.T) {
@@ -145,7 +145,7 @@ func TestNewAnthropic_BedrockRegionResolution(t *testing.T) {
 			Protocol:        config.BedrockProtocolMantle,
 			AccessKey:       "test-key",
 			AccessKeySecret: "test-secret",
-		})
+		}, nil)
 		require.ErrorContains(t, err, "region required")
 	})
 }

--- a/aibridge/provider/claude_platform.go
+++ b/aibridge/provider/claude_platform.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/coder/coder/v2/aibridge/config"
+	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/intercept/awssig"
+)
+
+// claudePlatformPassthroughTransport authenticates non-bridged Claude Platform
+// routes (/v1/models, /v1/messages/count_tokens, /api/event_logging/).
+//
+// Bridged requests are authenticated by SDK request options, but passthrough
+// requests bypass the SDK entirely and are otherwise only authenticated by the
+// key pool. Without this, an IAM-mode provider would send unsigned passthrough
+// requests and the upstream would reject them.
+type claudePlatformPassthroughTransport struct {
+	inner http.RoundTripper
+	cfg   config.AWSClaudePlatform
+	// creds is nil in api_key mode, where the key pool supplies x-api-key.
+	creds aws.CredentialsProvider
+}
+
+var _ http.RoundTripper = &claudePlatformPassthroughTransport{}
+
+func (t *claudePlatformPassthroughTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The workspace header is required in both auth modes. Set it from provider
+	// configuration, overwriting anything the client sent.
+	req.Header.Set(intercept.HeaderAnthropicWorkspaceID, t.cfg.WorkspaceID)
+
+	// A request that already carries a credential is BYOK or a centralized key
+	// selected by the failover transport above us. Leave it alone: signing on
+	// top would produce two credentials on one request.
+	if req.Header.Get(intercept.AuthHeaderXAPIKey) != "" ||
+		req.Header.Get(intercept.AuthHeaderAuthorization) != "" {
+		return t.inner.RoundTrip(req)
+	}
+
+	if t.creds == nil {
+		// api_key mode with no key available. Forward unsigned and let the
+		// upstream reject it, matching how other providers surface a missing
+		// centralized key on passthrough routes.
+		return t.inner.RoundTrip(req)
+	}
+
+	//nolint:bodyclose // the response is returned to the caller, which closes it.
+	return awssig.SignMiddleware(t.creds, t.cfg.Region, config.ClaudePlatformSigningService)(
+		req,
+		func(r *http.Request) (*http.Response, error) {
+			return t.inner.RoundTrip(r)
+		},
+	)
+}

--- a/aibridge/provider/claude_platform_internal_test.go
+++ b/aibridge/provider/claude_platform_internal_test.go
@@ -1,0 +1,257 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/aibridge/config"
+	"github.com/coder/coder/v2/aibridge/intercept"
+	"github.com/coder/coder/v2/aibridge/internal/testutil"
+)
+
+func claudePlatformIAMCfg() *config.AWSClaudePlatform {
+	return &config.AWSClaudePlatform{
+		AuthMode:        config.ClaudePlatformAuthModeIAM,
+		Region:          "us-west-2",
+		WorkspaceID:     "wrkspc_config",
+		AccessKey:       "test-access-key",
+		AccessKeySecret: "test-secret-key",
+	}
+}
+
+func claudePlatformAPIKeyCfg() *config.AWSClaudePlatform {
+	return &config.AWSClaudePlatform{
+		AuthMode:    config.ClaudePlatformAuthModeAPIKey,
+		Region:      "us-west-2",
+		WorkspaceID: "wrkspc_config",
+	}
+}
+
+func newTestClaudePlatform(t testing.TB, cfg config.Anthropic, cpCfg *config.AWSClaudePlatform) *Anthropic {
+	t.Helper()
+	p, err := NewAnthropic(context.Background(), cfg, nil, cpCfg)
+	require.NoError(t, err)
+	return p
+}
+
+func TestNewAnthropic_ClaudePlatform(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mutually exclusive with bedrock", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewAnthropic(context.Background(), config.Anthropic{}, &config.AWSBedrock{
+			Region:         "us-west-2",
+			Model:          "beddel",
+			SmallFastModel: "modrock",
+		}, claudePlatformIAMCfg())
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("invalid config rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cpCfg := claudePlatformIAMCfg()
+		cpCfg.WorkspaceID = ""
+
+		_, err := NewAnthropic(context.Background(), config.Anthropic{}, nil, cpCfg)
+		require.ErrorContains(t, err, "workspace id required")
+	})
+
+	t.Run("iam mode resolves credentials", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformIAMCfg())
+		require.NotNil(t, p.auth.ClaudePlatform)
+		require.Nil(t, p.auth.Bedrock)
+		require.NotNil(t, p.auth.ClaudePlatform.Creds)
+	})
+
+	t.Run("api key mode resolves no credentials", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformAPIKeyCfg())
+		require.NotNil(t, p.auth.ClaudePlatform)
+		// The workspace key comes from the key pool, so no AWS identity is
+		// resolved and nothing is signed.
+		require.Nil(t, p.auth.ClaudePlatform.Creds)
+	})
+}
+
+func TestAnthropic_ClaudePlatformBaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("regional default", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformIAMCfg())
+		require.Equal(t, "https://aws-external-anthropic.us-west-2.api.aws", p.BaseURL())
+	})
+
+	t.Run("override wins over anthropic base url", func(t *testing.T) {
+		t.Parallel()
+
+		cpCfg := claudePlatformIAMCfg()
+		cpCfg.BaseURL = "https://proxy.internal"
+
+		// The Claude Platform base URL is authoritative: the generic Anthropic
+		// base URL is not consulted, so both bridged and passthrough routes
+		// reach the same host.
+		p := newTestClaudePlatform(t, config.Anthropic{BaseURL: "https://api.anthropic.com"}, cpCfg)
+		require.Equal(t, "https://proxy.internal", p.BaseURL())
+	})
+}
+
+func TestAnthropic_ClaudePlatformResolveCredential(t *testing.T) {
+	t.Parallel()
+
+	t.Run("iam mode signs when no key is present", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformIAMCfg())
+
+		cred, err := p.resolveCredential(httptest.NewRequest(http.MethodPost, routeMessages, nil))
+		require.NoError(t, err)
+		sig, ok := cred.(intercept.AWSSigV4)
+		require.True(t, ok, "expected AWS SigV4 credential, got %T", cred)
+		require.Equal(t, "test-access-key", sig.AccessKey)
+	})
+
+	t.Run("byok takes precedence over signing", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformIAMCfg())
+
+		req := httptest.NewRequest(http.MethodPost, routeMessages, nil)
+		req.Header.Set(intercept.AuthHeaderXAPIKey, "user-key")
+
+		cred, err := p.resolveCredential(req)
+		require.NoError(t, err)
+		require.Equal(t, intercept.BYOK{Secret: "user-key", Header: intercept.AuthHeaderXAPIKey}, cred)
+	})
+
+	t.Run("api key mode uses the key pool", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{
+			KeyPool: testutil.SingleKeyPool(config.ProviderAnthropic, "workspace-key"),
+		}, claudePlatformAPIKeyCfg())
+
+		cred, err := p.resolveCredential(httptest.NewRequest(http.MethodPost, routeMessages, nil))
+		require.NoError(t, err)
+		require.IsType(t, &intercept.CentralizedPool{}, cred)
+	})
+
+	t.Run("api key mode without a pool has no credential", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformAPIKeyCfg())
+
+		_, err := p.resolveCredential(httptest.NewRequest(http.MethodPost, routeMessages, nil))
+		require.ErrorIs(t, err, ErrNoCredential)
+	})
+}
+
+// captureTransport records the last request it saw and returns an empty 200.
+type captureTransport struct {
+	req *http.Request
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.req = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestAnthropic_WrapPassthroughTransport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not wrapped for plain anthropic", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestAnthropic(t, config.Anthropic{}, nil)
+		inner := &captureTransport{}
+		require.Same(t, http.RoundTripper(inner), p.WrapPassthroughTransport(inner))
+	})
+
+	t.Run("not wrapped for bedrock", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestAnthropic(t, config.Anthropic{}, &config.AWSBedrock{
+			Region:         "us-west-2",
+			Model:          "beddel",
+			SmallFastModel: "modrock",
+		})
+		inner := &captureTransport{}
+		require.Same(t, http.RoundTripper(inner), p.WrapPassthroughTransport(inner))
+	})
+
+	t.Run("iam mode signs and sets the workspace header", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformIAMCfg())
+		inner := &captureTransport{}
+
+		req := httptest.NewRequest(http.MethodGet, "https://aws-external-anthropic.us-west-2.api.aws/v1/models", nil)
+		req.Header.Set(intercept.HeaderAnthropicWorkspaceID, "wrkspc_from_client")
+
+		resp, err := p.WrapPassthroughTransport(inner).RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.NotNil(t, inner.req)
+		require.Equal(t, "wrkspc_config", inner.req.Header.Get(intercept.HeaderAnthropicWorkspaceID),
+			"provider configuration must own the workspace ID")
+
+		auth := inner.req.Header.Get(intercept.AuthHeaderAuthorization)
+		require.True(t, strings.HasPrefix(auth, "AWS4-HMAC-SHA256"), "missing SigV4 auth: %q", auth)
+		require.Contains(t, auth, "/aws-external-anthropic/aws4_request",
+			"signature must be scoped to the aws-external-anthropic service")
+	})
+
+	t.Run("byok is forwarded unsigned", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformIAMCfg())
+		inner := &captureTransport{}
+
+		req := httptest.NewRequest(http.MethodGet, "https://aws-external-anthropic.us-west-2.api.aws/v1/models", nil)
+		req.Header.Set(intercept.AuthHeaderXAPIKey, "user-key")
+
+		resp, err := p.WrapPassthroughTransport(inner).RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.NotNil(t, inner.req)
+		require.Equal(t, "user-key", inner.req.Header.Get(intercept.AuthHeaderXAPIKey))
+		require.Empty(t, inner.req.Header.Get(intercept.AuthHeaderAuthorization),
+			"a request that already carries a credential must not also be signed")
+		require.Equal(t, "wrkspc_config", inner.req.Header.Get(intercept.HeaderAnthropicWorkspaceID))
+	})
+
+	t.Run("api key mode only sets the workspace header", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestClaudePlatform(t, config.Anthropic{}, claudePlatformAPIKeyCfg())
+		inner := &captureTransport{}
+
+		req := httptest.NewRequest(http.MethodGet, "https://aws-external-anthropic.us-west-2.api.aws/v1/models", nil)
+
+		resp, err := p.WrapPassthroughTransport(inner).RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.NotNil(t, inner.req)
+		require.Equal(t, "wrkspc_config", inner.req.Header.Get(intercept.HeaderAnthropicWorkspaceID))
+		require.Empty(t, inner.req.Header.Get(intercept.AuthHeaderAuthorization))
+	})
+}

--- a/aibridge/provider/copilot.go
+++ b/aibridge/provider/copilot.go
@@ -198,9 +198,9 @@ func (p *Copilot) CreateInterceptor(_ http.ResponseWriter, r *http.Request, trac
 		}
 
 		if reqPayload.Stream() {
-			interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, nil, r.Header, tracer)
+			interceptor = messages.NewStreamingInterceptor(id, reqPayload, cfg, cred, messages.AuthRuntime{}, r.Header, tracer)
 		} else {
-			interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, nil, r.Header, tracer)
+			interceptor = messages.NewBlockingInterceptor(id, reqPayload, cfg, cred, messages.AuthRuntime{}, r.Header, tracer)
 		}
 
 	default:

--- a/aibridge/provider/provider.go
+++ b/aibridge/provider/provider.go
@@ -13,7 +13,21 @@ import (
 	"github.com/coder/coder/v2/aibridge/recorder"
 )
 
+// ErrUnknownRoute is returned when a request path does not match any of the
+// provider's routes.
 var ErrUnknownRoute = xerrors.New("unknown route")
+
+// PassthroughTransportWrapper is an optional capability implemented by
+// providers that authenticate by signing requests or by minting tokens rather
+// than by injecting a static key. Passthrough auth is otherwise driven entirely
+// by the key pool, so without this the provider's passthrough routes would be
+// unauthenticated.
+//
+// The returned transport wraps inner and is installed beneath the key failover
+// transport, so BYOK and centralized keys still take precedence.
+type PassthroughTransportWrapper interface {
+	WrapPassthroughTransport(inner http.RoundTripper) http.RoundTripper
+}
 
 // ErrNoCredential is returned when a request resolves to centralized
 // authentication but the provider has no centralized keys configured (and the

--- a/cli/aibridged.go
+++ b/cli/aibridged.go
@@ -311,7 +311,7 @@ func buildProvider(ctx context.Context, spec aiProviderSpec, cfg codersdk.AIBrid
 			APIDumpDir:       dumpDir,
 			CircuitBreaker:   cbCfg,
 			SendActorHeaders: sendActorHeaders,
-		}, bedrock)
+		}, bedrock, nil)
 
 	case database.AIProviderTypeCopilot:
 		// Copilot is always BYOK; the per-user token is supplied on each


### PR DESCRIPTION
Stacked on #29047. Review that first; this PR's diff is only the last commit.

## What

Adds Claude Platform for AWS support to `aibridge`'s existing Anthropic provider. Claude Platform is Anthropic's native Messages API hosted on AWS: standard wire format, standard Anthropic model IDs. Only routing and authentication differ, so it is an authentication variant of `type=anthropic`, not a new provider type.

Two authentication modes:

| Mode | Credential | Upstream default |
|---|---|---|
| `iam` | AWS SigV4, service `aws-external-anthropic` | `https://aws-external-anthropic.{region}.api.aws` |
| `api_key` | workspace key from the existing key pool (`x-api-key`) | same |

`region` is always required, including when `base_url` overrides the endpoint, because the signature is region-scoped.

## Notable behavior

- `anthropic-workspace-id` is set from provider configuration on every request, and a client-supplied value is now stripped in `PrepareClientHeaders`, so a client cannot choose which workspace its traffic bills to. The header is covered by the signature.
- BYOK and centralized keys keep precedence over signing.
- Passthrough routes (`/v1/models` and friends) bypass the SDK, so providers can now opt into wrapping the passthrough transport via `provider.PassthroughTransportWrapper`. It is installed beneath key failover so BYOK still wins.
- Bedrock is untouched, including its PRM attribution user-agent. That marker is a Bedrock-specific revenue agreement and is deliberately not sent for Claude Platform.

## Scope

aibridge only. The code is directly unit and integration tested but not yet reachable from configuration; the `codersdk`/`coderd` settings, CLI, and UI follow in later PRs in this stack. `cli/aibridged.go` changes only to pass the new `nil` argument.

## Testing

- `aibridge/config`: auth-mode and credential validation, regional default URL and override.
- `aibridge/provider`: mutual exclusion with Bedrock, credential resolution per mode, BYOK precedence, passthrough transport signing and workspace-header ownership.
- `aibridge/internal/integrationtest`: bridged `/v1/messages` in both modes (streaming and blocking), signature scoped to `aws-external-anthropic` and the configured region, model forwarded unchanged, no PRM marker, BYOK precedence, and a signed passthrough route.
- `go test ./aibridge/... -count=1`, `go test -race ./aibridge/...`, `golangci-lint run aibridge/...`, full pre-commit and pre-push.
- Mutation-checked the signing assertions by temporarily changing the service name; the relevant tests failed as expected.

<details>
<summary>Design notes</summary>

Why this is not a new provider type:

1. The wire format is identical to direct Anthropic, so no request or response translation exists to justify a separate interceptor path.
2. A new `AIProviderType` would require a database enum migration and generated-code churn for what is a credential difference.
3. Bedrock remains first class and externally unchanged. The only overlap is generic AWS SigV4 signing plus the AWS credential chain, which the parent PR extracted into `aibridge/intercept/awssig` and `provider.buildAWSCredentials`.

Why the workspace key uses the key pool rather than a settings field: it preserves key pooling, rotation, masking, failover, and BYOK behavior for free, and keeps the credential out of provider settings.

Why `auth_mode` is explicit rather than inferred from which fields are set: inference makes a partially filled form silently pick a different credential path. Validation instead rejects AWS credentials or a role ARN in `api_key` mode.

Open item tracked outside this PR: whether Claude Platform traffic should carry an AWS PRM attribution user-agent, and which one. Until AWS confirms, `PRMUserAgent` stays Bedrock-only.

</details>

---

This PR was generated by Coder Agents on behalf of @Shelnutt2.