### PR TITLE
fix(site): offer every authorized organization in the templates filter

### DIFF
--- a/site/src/pages/TemplatesPage/TemplatesFilter.test.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.test.tsx
@@ -1,0 +1,67 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { API } from "#/api/api";
+import type { UseFilterResult } from "#/components/Filter/Filter";
+import { DashboardContext } from "#/modules/dashboard/DashboardProvider";
+import {
+	MockAppearanceConfig,
+	MockBuildInfo,
+	MockEntitlements,
+	MockOrganization,
+} from "#/testHelpers/entities";
+import { renderWithAuth } from "#/testHelpers/renderHelpers";
+import { TemplatesFilter } from "./TemplatesFilter";
+
+const createFilter = (): UseFilterResult => ({
+	query: "",
+	values: {},
+	used: false,
+	update: vi.fn(),
+	debounceUpdate: vi.fn(),
+	cancelDebounce: vi.fn(),
+});
+
+// An organization the user has template permissions in but is not a member of.
+// Its templates show up in the table, so the picker has to offer it too.
+const nonMemberOrganization = {
+	...MockOrganization,
+	id: "d1b4a2ee-9d2e-4c9b-9c0f-2b2f0f0c9a11",
+	name: "not-a-member",
+	display_name: "Not A Member",
+};
+
+describe("TemplatesFilter", () => {
+	it("offers organizations the user is not a member of", async () => {
+		vi.spyOn(API, "getOrganizations").mockResolvedValue([
+			MockOrganization,
+			nonMemberOrganization,
+		]);
+		vi.spyOn(API, "getMyOrganizations").mockResolvedValue([MockOrganization]);
+
+		renderWithAuth(
+			<DashboardContext.Provider
+				value={{
+					entitlements: MockEntitlements,
+					experiments: [],
+					appearance: MockAppearanceConfig,
+					buildInfo: MockBuildInfo,
+					organizations: [MockOrganization],
+					showOrganizations: true,
+					canViewOrganizationSettings: true,
+				}}
+			>
+				<TemplatesFilter filter={createFilter()} error={undefined} />
+			</DashboardContext.Provider>,
+		);
+
+		await userEvent.click(
+			await screen.findByLabelText("Select an organization"),
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(nonMemberOrganization.display_name),
+			).toBeInTheDocument();
+		});
+	});
+});

--- a/site/src/pages/TemplatesPage/TemplatesFilter.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.tsx
@@ -90,7 +90,12 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 			return orgOption(org);
 		},
 		getOptions: async () => {
-			const orgs = await API.getMyOrganizations();
+			// The tables this filter drives are scoped by template permissions,
+			// not by membership, so an organization whose templates are listed
+			// has to be offered here even when the user is not a member of it.
+			// getSelectedOption below already resolves such an organization, so
+			// the query works when typed into the URL; only the picker hid it.
+			const orgs = await API.getOrganizations();
 			return orgs.map(orgOption);
 		},
 	});


### PR DESCRIPTION
Closes #28985.

`TemplatesFilter`'s organization dropdown gets its options from `API.getMyOrganizations()`, which is `GET /api/v2/users/me/organizations` and therefore membership-scoped. The tables the filter drives are permission-scoped: `TemplatesPage` narrows `useDashboard().organizations` by `updateTemplates`. A user with template permissions in an organization they are not a member of sees that organization's templates in the table and cannot pick it in the dropdown.

Switched to `API.getOrganizations()`, which is what the issue suggests and what the rest of the component already assumes: `getSelectedOption` a few lines up resolves the organization through `API.getOrganization(...)` with no membership check, so filtering by such an organization already works if you put it in the URL by hand. Only the picker hid it.

New `TemplatesFilter.test.tsx` stubs the two endpoints so they disagree, with one organization in both and one only in `getOrganizations`, opens the picker, and asserts the non-member organization is offered. Against the current code it fails with

    Unable to find an element with the text: Not A Member

and passes with the change. `tsc --noEmit` and `biome check` are clean on both files.

I left the related `useOrganizationsFilterMenu` note in the issue alone. It gates options on `audit_log:read`, which is right for the Audit and Connection Log pages and wrong for Workspaces, so the fix there is to make the gate a parameter rather than to drop it, and that felt like a separate change from this one.