### PR TITLE
feat(coderd): add the get_goal and complete_goal chat tools

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/coder/coder/v2/coderd/usage/usagetypes"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -15783,6 +15784,378 @@ func TestChatPinOrderConstraints(t *testing.T) {
 		err = db.PinChatByID(ctx, chat.ID)
 		require.Error(t, err)
 		require.True(t, database.IsCheckViolation(err, database.CheckChatsPinOrderArchivedCheck))
+	})
+}
+
+func TestChatGoals(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	setup := func(t *testing.T) (database.Store, *sql.DB, context.Context, database.User, database.Chat) {
+		t.Helper()
+
+		store, _, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		owner := dbgen.User(t, store, database.User{})
+		org := dbgen.Organization(t, store, database.Organization{})
+		dbgen.OrganizationMember(t, store, database.OrganizationMember{UserID: owner.ID, OrganizationID: org.ID})
+
+		provider := dbgen.ChatProvider(t, store, database.ChatProvider{
+			Provider:             "openai",
+			DisplayName:          "OpenAI",
+			APIKey:               "test-key",
+			Enabled:              true,
+			CentralApiKeyEnabled: true,
+		})
+
+		modelCfg, err := store.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
+			Model:                "test-model-" + uuid.NewString(),
+			DisplayName:          "Test Model",
+			CreatedBy:            uuid.NullUUID{UUID: owner.ID, Valid: true},
+			UpdatedBy:            uuid.NullUUID{UUID: owner.ID, Valid: true},
+			Enabled:              true,
+			IsDefault:            true,
+			ContextLimit:         128000,
+			CompressionThreshold: 80,
+			Options:              json.RawMessage(`{}`),
+			AIProviderID:         uuid.NullUUID{UUID: provider.ID, Valid: true},
+			OrganizationID:       org.ID,
+		})
+		require.NoError(t, err)
+
+		chat, err := store.InsertChat(ctx, database.InsertChatParams{
+			OrganizationID:    org.ID,
+			Status:            database.ChatStatusWaiting,
+			ClientType:        database.ChatClientTypeUi,
+			OwnerID:           owner.ID,
+			LastModelConfigID: modelCfg.ID,
+			Title:             "goal-test-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		return store, sqlDB, ctx, owner, chat
+	}
+
+	insertGoal := func(t *testing.T, store database.Store, ctx context.Context, chat database.Chat, owner database.User, objective string) database.ChatGoal {
+		t.Helper()
+
+		message := dbgen.ChatMessage(t, store, database.ChatMessage{
+			ChatID:    chat.ID,
+			CreatedBy: uuid.NullUUID{UUID: owner.ID, Valid: true},
+			Role:      database.ChatMessageRoleUser,
+		})
+		goal, err := store.InsertActiveChatGoal(ctx, database.InsertActiveChatGoalParams{
+			RootChatID: chat.ID,
+			CreatedFromMessageID: sql.NullInt64{
+				Int64: message.ID,
+				Valid: true,
+			},
+			Objective:       objective,
+			CreatedByUserID: owner.ID,
+		})
+		require.NoError(t, err)
+		require.True(t, goal.CreatedFromMessageID.Valid)
+		require.Equal(t, message.ID, goal.CreatedFromMessageID.Int64)
+		return goal
+	}
+
+	setGoalCreatedAt := func(t *testing.T, sqlDB *sql.DB, ctx context.Context, createdAt time.Time, goals ...database.ChatGoal) {
+		t.Helper()
+
+		ids := make([]uuid.UUID, 0, len(goals))
+		for _, goal := range goals {
+			ids = append(ids, goal.ID)
+		}
+
+		result, err := sqlDB.ExecContext(ctx, "UPDATE chat_goals SET created_at = $1 WHERE id = ANY($2)", createdAt, pq.Array(ids))
+		require.NoError(t, err)
+		rowsAffected, err := result.RowsAffected()
+		require.NoError(t, err)
+		require.Equal(t, int64(len(ids)), rowsAffected)
+	}
+
+	t.Run("CurrentGoalInvariant", func(t *testing.T) {
+		t.Parallel()
+
+		store, _, ctx, owner, chat := setup(t)
+		first := insertGoal(t, store, ctx, chat, owner, "ship goal persistence")
+		require.Equal(t, database.ChatGoalStatusActive, first.Status)
+
+		goalMessageIDs, err := store.GetChatGoalMessageIDsByRootChatAndMessageIDs(ctx, database.GetChatGoalMessageIDsByRootChatAndMessageIDsParams{
+			RootChatID: chat.ID,
+			MessageIds: []int64{first.CreatedFromMessageID.Int64},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []int64{first.CreatedFromMessageID.Int64}, goalMessageIDs)
+
+		// The marker lookup is scoped to the chat that created the goal.
+		otherChatGoalMessageIDs, err := store.GetChatGoalMessageIDsByRootChatAndMessageIDs(ctx, database.GetChatGoalMessageIDsByRootChatAndMessageIDsParams{
+			RootChatID: uuid.New(),
+			MessageIds: []int64{first.CreatedFromMessageID.Int64},
+		})
+		require.NoError(t, err)
+		require.Empty(t, otherChatGoalMessageIDs)
+
+		_, err = store.InsertActiveChatGoal(ctx, database.InsertActiveChatGoalParams{
+			RootChatID:      chat.ID,
+			Objective:       "conflicting active goal",
+			CreatedByUserID: owner.ID,
+		})
+		require.Error(t, err)
+		require.True(t, database.IsUniqueViolation(err, database.UniqueIndexChatGoalsCurrent))
+
+		paused, err := store.PauseChatGoalByID(ctx, database.PauseChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         first.ID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusPaused, paused.Status)
+
+		_, err = store.InsertActiveChatGoal(ctx, database.InsertActiveChatGoalParams{
+			RootChatID:      chat.ID,
+			Objective:       "conflicting paused goal",
+			CreatedByUserID: owner.ID,
+		})
+		require.Error(t, err)
+		require.True(t, database.IsUniqueViolation(err, database.UniqueIndexChatGoalsCurrent))
+
+		cleared, err := store.ClearChatGoalByID(ctx, database.ClearChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         first.ID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusCleared, cleared.Status)
+		require.True(t, cleared.ClearedAt.Valid)
+
+		second := insertGoal(t, store, ctx, chat, owner, "new current goal")
+		require.Equal(t, database.ChatGoalStatusActive, second.Status)
+	})
+
+	t.Run("LifecycleUsesOptimisticGoalID", func(t *testing.T) {
+		t.Parallel()
+
+		store, _, ctx, owner, chat := setup(t)
+		goal := insertGoal(t, store, ctx, chat, owner, "complete the task")
+
+		current, err := chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, goal.ID, current.ID)
+
+		paused, err := store.PauseChatGoalByID(ctx, database.PauseChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         goal.ID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusPaused, paused.Status)
+
+		_, err = store.PauseChatGoalByID(ctx, database.PauseChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         goal.ID,
+		})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		resumed, err := store.ResumeChatGoalByID(ctx, database.ResumeChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         goal.ID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusActive, resumed.Status)
+
+		_, err = store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID:       chat.ID,
+			ID:               uuid.New(),
+			CompletedByAgent: true,
+		})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		const summary = "done"
+		completed, err := store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         goal.ID,
+			CompletionSummary: sql.NullString{
+				String: summary,
+				Valid:  true,
+			},
+			CompletedByUserID: uuid.NullUUID{UUID: owner.ID, Valid: true},
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusComplete, completed.Status)
+		require.Equal(t, summary, completed.CompletionSummary.String)
+		require.True(t, completed.CompletedAt.Valid)
+		require.Equal(t, owner.ID, completed.CompletedByUserID.UUID)
+
+		current, err = chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusComplete, current.Status)
+		require.Equal(t, goal.ID, current.ID)
+
+		cleared, err := store.ClearChatGoalByID(ctx, database.ClearChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         goal.ID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusCleared, cleared.Status)
+		require.False(t, cleared.CompletedAt.Valid)
+		require.False(t, cleared.CompletionSummary.Valid)
+		require.False(t, cleared.CompletedByUserID.Valid)
+		require.False(t, cleared.CompletedByAgent)
+		require.True(t, cleared.ClearedAt.Valid)
+
+		_, err = chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("LatestGoalControlsVisibility", func(t *testing.T) {
+		t.Parallel()
+
+		store, _, ctx, owner, chat := setup(t)
+		first := insertGoal(t, store, ctx, chat, owner, "finished goal")
+		completed, err := store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         first.ID,
+			CompletionSummary: sql.NullString{
+				String: "done",
+				Valid:  true,
+			},
+			CompletedByUserID: uuid.NullUUID{UUID: owner.ID, Valid: true},
+		})
+		require.NoError(t, err)
+		require.Equal(t, database.ChatGoalStatusComplete, completed.Status)
+
+		current, err := chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, first.ID, current.ID)
+		require.Equal(t, database.ChatGoalStatusComplete, current.Status)
+
+		second := insertGoal(t, store, ctx, chat, owner, "next goal")
+		current, err = chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, second.ID, current.ID)
+		require.Equal(t, database.ChatGoalStatusActive, current.Status)
+
+		_, err = store.ClearChatGoalByID(ctx, database.ClearChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         second.ID,
+		})
+		require.NoError(t, err)
+
+		_, err = chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("CurrentGoalUsesGoalOrderForCreatedAtTies", func(t *testing.T) {
+		t.Parallel()
+
+		store, sqlDB, ctx, owner, chat := setup(t)
+		first := insertGoal(t, store, ctx, chat, owner, "first tied goal")
+		_, err := store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID:       chat.ID,
+			ID:               first.ID,
+			CompletedByAgent: true,
+		})
+		require.NoError(t, err)
+
+		second := insertGoal(t, store, ctx, chat, owner, "second tied goal")
+		setGoalCreatedAt(t, sqlDB, ctx, dbtime.Now(), first, second)
+
+		current, err := chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, second.ID, current.ID)
+		require.Equal(t, database.ChatGoalStatusActive, current.Status)
+	})
+
+	t.Run("LatestHiddenGoalSuppressesTiedVisibleHistory", func(t *testing.T) {
+		t.Parallel()
+
+		store, sqlDB, ctx, owner, chat := setup(t)
+		first := insertGoal(t, store, ctx, chat, owner, "visible tied goal")
+		_, err := store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID:       chat.ID,
+			ID:               first.ID,
+			CompletedByAgent: true,
+		})
+		require.NoError(t, err)
+
+		second := insertGoal(t, store, ctx, chat, owner, "hidden tied goal")
+		_, err = store.ClearChatGoalByID(ctx, database.ClearChatGoalByIDParams{
+			RootChatID: chat.ID,
+			ID:         second.ID,
+		})
+		require.NoError(t, err)
+
+		setGoalCreatedAt(t, sqlDB, ctx, dbtime.Now(), first, second)
+		_, err = chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("BulkCurrentGoalsUseGoalOrderForCreatedAtTies", func(t *testing.T) {
+		t.Parallel()
+
+		store, sqlDB, ctx, owner, chat := setup(t)
+		visibleFirst := insertGoal(t, store, ctx, chat, owner, "bulk visible first")
+		_, err := store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID:       chat.ID,
+			ID:               visibleFirst.ID,
+			CompletedByAgent: true,
+		})
+		require.NoError(t, err)
+		visibleSecond := insertGoal(t, store, ctx, chat, owner, "bulk visible second")
+		setGoalCreatedAt(t, sqlDB, ctx, dbtime.Now(), visibleFirst, visibleSecond)
+
+		hiddenChat, err := store.InsertChat(ctx, database.InsertChatParams{
+			OrganizationID:    chat.OrganizationID,
+			Status:            database.ChatStatusWaiting,
+			ClientType:        database.ChatClientTypeUi,
+			OwnerID:           owner.ID,
+			LastModelConfigID: chat.LastModelConfigID,
+			Title:             "goal-test-hidden-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		hiddenFirst := insertGoal(t, store, ctx, hiddenChat, owner, "bulk hidden first")
+		_, err = store.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID:       hiddenChat.ID,
+			ID:               hiddenFirst.ID,
+			CompletedByAgent: true,
+		})
+		require.NoError(t, err)
+		hiddenSecond := insertGoal(t, store, ctx, hiddenChat, owner, "bulk hidden second")
+		_, err = store.ClearChatGoalByID(ctx, database.ClearChatGoalByIDParams{
+			RootChatID: hiddenChat.ID,
+			ID:         hiddenSecond.ID,
+		})
+		require.NoError(t, err)
+		setGoalCreatedAt(t, sqlDB, ctx, dbtime.Now(), hiddenFirst, hiddenSecond)
+
+		currentGoals, err := store.GetCurrentChatGoalsByRootChatIDs(ctx, []uuid.UUID{chat.ID, hiddenChat.ID})
+		require.NoError(t, err)
+		require.Len(t, currentGoals, 1)
+		require.Equal(t, visibleSecond.ID, currentGoals[0].ID)
+		require.Equal(t, chat.ID, currentGoals[0].RootChatID)
+	})
+
+	t.Run("ReplaceCurrentGoal", func(t *testing.T) {
+		t.Parallel()
+
+		store, sqlDB, ctx, owner, chat := setup(t)
+		first := insertGoal(t, store, ctx, chat, owner, "old goal")
+
+		err := store.MarkCurrentChatGoalReplacedByRootChatID(ctx, chat.ID)
+		require.NoError(t, err)
+
+		var replacedStatus database.ChatGoalStatus
+		var replacedAt sql.NullTime
+		row := sqlDB.QueryRowContext(ctx, "SELECT status, replaced_at FROM chat_goals WHERE id = $1", first.ID)
+		require.NoError(t, row.Scan(&replacedStatus, &replacedAt))
+		require.Equal(t, database.ChatGoalStatusReplaced, replacedStatus)
+		require.True(t, replacedAt.Valid)
+
+		second := insertGoal(t, store, ctx, chat, owner, "replacement goal")
+		current, err := chattool.CurrentChatGoalByRootChatID(ctx, store, chat.ID)
+		require.NoError(t, err)
+		require.Equal(t, second.ID, current.ID)
+		require.Equal(t, database.ChatGoalStatusActive, current.Status)
 	})
 }
 

--- a/coderd/x/chatd/chattool/goal.go
+++ b/coderd/x/chatd/chattool/goal.go
@@ -1,0 +1,303 @@
+package chattool
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk/chatgoal"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+const (
+	// GetGoalToolName is the registered name of the get_goal tool.
+	GetGoalToolName = "get_goal"
+	// CompleteGoalToolName is the registered name of the complete_goal tool.
+	CompleteGoalToolName = "complete_goal"
+)
+
+// GoalToolOptions configures the goal tools.
+type GoalToolOptions struct {
+	ChatID        uuid.UUID
+	RootChatID    uuid.UUID
+	IsRootChat    bool
+	OnGoalUpdated func(context.Context, database.Chat, database.ChatGoal)
+	// Fence, when set, must still describe the chat when complete_goal
+	// commits. It prevents a stale generation (interrupted or taken over
+	// by another worker) from completing the durable goal after its tool
+	// result would be rejected by the generation fence.
+	Fence *GoalToolFence
+}
+
+// GoalToolFence pins the goal mutation to the generation turn that
+// offered the tool.
+type GoalToolFence struct {
+	WorkerID       uuid.UUID
+	RunnerID       uuid.UUID
+	HistoryVersion int64
+}
+
+var errGoalFenceMismatch = xerrors.New("goal tool fence mismatch")
+
+// verifyGoalToolFence locks the chat row and checks that the turn that
+// offered complete_goal still owns the chat.
+func verifyGoalToolFence(ctx context.Context, tx database.Store, chatID uuid.UUID, fence *GoalToolFence) error {
+	if fence == nil {
+		return nil
+	}
+	chat, err := tx.GetChatByIDForUpdate(ctx, chatID)
+	if err != nil {
+		return err
+	}
+	if !chat.WorkerID.Valid || chat.WorkerID.UUID != fence.WorkerID ||
+		!chat.RunnerID.Valid || chat.RunnerID.UUID != fence.RunnerID ||
+		chat.Status != database.ChatStatusRunning ||
+		chat.HistoryVersion != fence.HistoryVersion {
+		return errGoalFenceMismatch
+	}
+	return nil
+}
+
+type getGoalArgs struct{}
+
+type completeGoalArgs struct {
+	GoalID  string `json:"goal_id" description:"The expected current goal ID as a UUIDv4 string. The tool fails if the current goal changed."`
+	Summary string `json:"summary" description:"A concise non-empty summary of how the goal was completed."`
+}
+
+type goalResult struct {
+	Goal *codersdk.ChatGoal `json:"goal"`
+}
+
+type completeGoalResult struct {
+	Goal      *codersdk.ChatGoal `json:"goal"`
+	Completed bool               `json:"completed"`
+	Summary   string             `json:"summary"`
+}
+
+// CurrentChatGoalByRootChatID returns the current goal for rootChatID, or
+// sql.ErrNoRows when no current goal exists.
+func CurrentChatGoalByRootChatID(ctx context.Context, db database.Store, rootChatID uuid.UUID) (database.ChatGoal, error) {
+	goals, err := db.GetCurrentChatGoalsByRootChatIDs(ctx, []uuid.UUID{rootChatID})
+	if err != nil {
+		return database.ChatGoal{}, err
+	}
+	if len(goals) == 0 {
+		return database.ChatGoal{}, sql.ErrNoRows
+	}
+	return goals[0], nil
+}
+
+// GetGoal returns a read-only tool for inspecting the current root goal.
+func GetGoal(db database.Store, options GoalToolOptions) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		GetGoalToolName,
+		"Inspect the current durable goal for this root chat. Returns null when no current goal exists.",
+		func(ctx context.Context, _ getGoalArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			goal, err := CurrentChatGoalByRootChatID(ctx, db, options.RootChatID)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return marshalToolResponse(goalResult{}), nil
+				}
+				return fantasy.NewTextErrorResponse("get goal: " + err.Error()), nil
+			}
+			sdkGoal := chatgoal.ToSDK(goal)
+			return marshalToolResponse(goalResult{Goal: &sdkGoal}), nil
+		},
+	)
+}
+
+// CompleteGoal returns a root-only tool that marks the active goal complete.
+func CompleteGoal(db database.Store, options GoalToolOptions) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		CompleteGoalToolName,
+		"Mark the active chat goal complete after the objective is done. Requires the current goal_id and a concise completion summary. Only use this when the active goal has been satisfied.",
+		func(ctx context.Context, args completeGoalArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if !options.IsRootChat {
+				return fantasy.NewTextErrorResponse("complete_goal can only be used from the root chat"), nil
+			}
+			goalID, err := parseGoalIDArg(args.GoalID)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(err.Error()), nil
+			}
+			summary := strings.TrimSpace(args.Summary)
+			if summary == "" {
+				return fantasy.NewTextErrorResponse("summary is required"), nil
+			}
+			if len(summary) > codersdk.MaxChatGoalCompletionSummaryBytes {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf(
+					"summary must be at most %d bytes",
+					codersdk.MaxChatGoalCompletionSummaryBytes,
+				)), nil
+			}
+
+			completed, chat, err := mutateCurrentActiveGoal(ctx, db, options, goalID, func(tx database.Store) (database.ChatGoal, error) {
+				return tx.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+					RootChatID: options.RootChatID,
+					ID:         goalID,
+					CompletionSummary: sql.NullString{
+						String: summary,
+						Valid:  true,
+					},
+					CompletedByUserID: uuid.NullUUID{},
+					CompletedByAgent:  true,
+				})
+			})
+			if err != nil {
+				switch {
+				case errors.Is(err, sql.ErrNoRows):
+					return fantasy.NewTextErrorResponse("current active goal does not match goal_id"), nil
+				case errors.Is(err, errGoalNotActive):
+					if result, replayed, ok := agentCompletedGoalReplay(ctx, db, options.RootChatID, goalID); ok {
+						notifyGoalReplay(ctx, db, options, replayed)
+						return marshalToolResponse(result), nil
+					}
+					return fantasy.NewTextErrorResponse("current goal is not active"), nil
+				case errors.Is(err, errGoalFenceMismatch):
+					return fantasy.NewTextErrorResponse("the chat turn changed before the goal could be completed; the goal was not modified"), nil
+				default:
+					return fantasy.NewTextErrorResponse("complete goal: " + err.Error()), nil
+				}
+			}
+
+			if options.OnGoalUpdated != nil {
+				options.OnGoalUpdated(ctx, chat, completed)
+			}
+			sdkGoal := chatgoal.ToSDK(completed)
+			return marshalToolResponse(completeGoalResult{
+				Goal:      &sdkGoal,
+				Completed: true,
+				Summary:   summary,
+			}), nil
+		},
+	)
+}
+
+// notifyGoalReplay re-publishes the goal change for a replayed call.
+// The original run may have crashed after the transition committed but
+// before OnGoalUpdated ran, so clients may never have seen the change;
+// a duplicate event is idempotent while a missing one is not
+// recoverable without a refetch.
+func notifyGoalReplay(ctx context.Context, db database.Store, options GoalToolOptions, goal database.ChatGoal) {
+	if options.OnGoalUpdated == nil {
+		return
+	}
+	chat, err := db.GetChatByID(ctx, options.ChatID)
+	if err != nil {
+		return
+	}
+	options.OnGoalUpdated(ctx, chat, goal)
+}
+
+var (
+	errGoalNotActive  = xerrors.New("goal is not active")
+	errGoalIDRequired = xerrors.New("goal_id is required")
+	errGoalIDInvalid  = xerrors.New("goal_id must be a valid UUID")
+)
+
+// parseGoalIDArg parses the goal_id tool argument shared by the goal
+// mutation tools. The returned error message is suitable as the tool's
+// error response.
+func parseGoalIDArg(raw string) (uuid.UUID, error) {
+	goalIDStr := strings.TrimSpace(raw)
+	if goalIDStr == "" {
+		return uuid.Nil, errGoalIDRequired
+	}
+	goalID, err := uuid.Parse(goalIDStr)
+	if err != nil {
+		return uuid.Nil, errGoalIDInvalid
+	}
+	return goalID, nil
+}
+
+// mutateCurrentActiveGoal runs the transaction shared by the goal
+// mutation tools: it locks the chat row for the fence check, verifies
+// the current goal matches goalID and is active, applies update, and
+// reloads the chat for post-commit callbacks.
+func mutateCurrentActiveGoal(
+	ctx context.Context,
+	db database.Store,
+	options GoalToolOptions,
+	goalID uuid.UUID,
+	update func(tx database.Store) (database.ChatGoal, error),
+) (database.ChatGoal, database.Chat, error) {
+	var updated database.ChatGoal
+	var chat database.Chat
+	err := db.InTx(func(tx database.Store) error {
+		// Lock the chat row first (matching the API mutation paths) so
+		// the fence check and goal update are atomic with respect to
+		// interrupts and worker takeovers.
+		if err := verifyGoalToolFence(ctx, tx, options.ChatID, options.Fence); err != nil {
+			return err
+		}
+		current, err := CurrentChatGoalByRootChatID(ctx, tx, options.RootChatID)
+		if err != nil {
+			return err
+		}
+		if current.ID != goalID {
+			return sql.ErrNoRows
+		}
+		if current.Status != database.ChatGoalStatusActive {
+			return errGoalNotActive
+		}
+		updated, err = update(tx)
+		if err != nil {
+			return err
+		}
+		chat, err = tx.GetChatByID(ctx, options.ChatID)
+		return err
+	}, nil)
+	return updated, chat, err
+}
+
+// agentCompletedGoalReplay rebuilds the successful complete_goal result
+// from the durable goal row when the current goal is the same goal the
+// agent already completed. A crash, takeover, or interrupt between the
+// goal transition and its tool-result commit replays or cancels the
+// call; the replay must not report an error for work that durably
+// succeeded.
+func agentCompletedGoalReplay(ctx context.Context, db database.Store, rootChatID, goalID uuid.UUID) (completeGoalResult, database.ChatGoal, bool) {
+	current, err := CurrentChatGoalByRootChatID(ctx, db, rootChatID)
+	if err != nil || current.ID != goalID ||
+		current.Status != database.ChatGoalStatusComplete || !current.CompletedByAgent {
+		return completeGoalResult{}, database.ChatGoal{}, false
+	}
+	sdkGoal := chatgoal.ToSDK(current)
+	return completeGoalResult{
+		Goal:      &sdkGoal,
+		Completed: true,
+		Summary:   current.CompletionSummary.String,
+	}, current, true
+}
+
+// AgentCompletedGoalReplayPayload returns the successful complete_goal
+// result payload for a committed call whose result was never committed,
+// when rawArgs names the current agent-completed goal. ok is false when
+// the durable goal state does not prove the call succeeded.
+func AgentCompletedGoalReplayPayload(ctx context.Context, db database.Store, rootChatID uuid.UUID, rawArgs string) (json.RawMessage, bool) {
+	var args completeGoalArgs
+	if err := json.Unmarshal([]byte(rawArgs), &args); err != nil {
+		return nil, false
+	}
+	goalID, err := parseGoalIDArg(args.GoalID)
+	if err != nil {
+		return nil, false
+	}
+	result, _, ok := agentCompletedGoalReplay(ctx, db, rootChatID, goalID)
+	if !ok {
+		return nil, false
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, false
+	}
+	return payload, true
+}

--- a/coderd/x/chatd/chattool/goal_test.go
+++ b/coderd/x/chatd/chattool/goal_test.go
@@ -1,0 +1,393 @@
+package chattool_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestGoalTools(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "goal-tools",
+	})
+	goal, err := db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: user.ID,
+	})
+	require.NoError(t, err)
+
+	getTool := chattool.GetGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+	})
+	getResp, err := getTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{ID: "call-1", Name: chattool.GetGoalToolName, Input: "{}"})
+	require.NoError(t, err)
+	require.False(t, getResp.IsError)
+	require.Contains(t, getResp.Content, goal.ID.String())
+
+	var published bool
+	completeTool := chattool.CompleteGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+		OnGoalUpdated: func(_ context.Context, updated database.Chat, completed database.ChatGoal) {
+			published = true
+			require.Equal(t, chat.ID, updated.ID)
+			require.Equal(t, goal.ID, completed.ID)
+		},
+	})
+	completeResp, err := completeTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-2",
+		Name:  chattool.CompleteGoalToolName,
+		Input: `{"goal_id":"` + goal.ID.String() + `","summary":"done"}`,
+	})
+	require.NoError(t, err)
+	require.False(t, completeResp.IsError)
+	require.True(t, published)
+	var payload struct {
+		Completed bool `json:"completed"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(completeResp.Content), &payload))
+	require.True(t, payload.Completed)
+
+	completedGoal, err := chattool.CurrentChatGoalByRootChatID(dbauthz.AsSystemRestricted(ctx), db, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, goal.ID, completedGoal.ID)
+	require.Equal(t, database.ChatGoalStatusComplete, completedGoal.Status)
+}
+
+func TestCompleteGoalRejectsFenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "goal-fence",
+	})
+	goal, err := db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: user.ID,
+	})
+	require.NoError(t, err)
+
+	// The chat is not owned by the fenced worker/runner, so the tool
+	// must refuse to mutate the goal.
+	completeTool := chattool.CompleteGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+		Fence: &chattool.GoalToolFence{
+			WorkerID:       uuid.New(),
+			RunnerID:       uuid.New(),
+			HistoryVersion: chat.HistoryVersion,
+		},
+		OnGoalUpdated: func(context.Context, database.Chat, database.ChatGoal) {
+			t.Fatal("goal update published despite fence mismatch")
+		},
+	})
+	resp, err := completeTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  chattool.CompleteGoalToolName,
+		Input: `{"goal_id":"` + goal.ID.String() + `","summary":"done"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "the goal was not modified")
+
+	current, err := chattool.CurrentChatGoalByRootChatID(dbauthz.AsSystemRestricted(ctx), db, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatGoalStatusActive, current.Status)
+}
+
+func TestCompleteGoalSchemaUsesStringGoalID(t *testing.T) {
+	t.Parallel()
+
+	tool := chattool.CompleteGoal(nil, chattool.GoalToolOptions{})
+	info := tool.Info()
+	goalIDParam, ok := info.Parameters["goal_id"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "string", goalIDParam["type"])
+	require.Contains(t, goalIDParam["description"], "UUIDv4 string")
+}
+
+func TestGetGoalReturnsNullWithoutCurrentGoal(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "goal-tools-empty",
+	})
+
+	getTool := chattool.GetGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+	})
+	getResp, err := getTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{ID: "call-1", Name: chattool.GetGoalToolName, Input: "{}"})
+	require.NoError(t, err)
+	require.False(t, getResp.IsError)
+	var payload struct {
+		Goal *json.RawMessage `json:"goal"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(getResp.Content), &payload))
+	require.Nil(t, payload.Goal)
+}
+
+func TestCompleteGoalValidatesInput(t *testing.T) {
+	t.Parallel()
+
+	completeTool := chattool.CompleteGoal(nil, chattool.GoalToolOptions{
+		ChatID:     uuid.New(),
+		RootChatID: uuid.New(),
+		IsRootChat: true,
+	})
+
+	longSummaryInput := `{"goal_id":"00000000-0000-4000-8000-000000000001","summary":"` +
+		strings.Repeat("x", codersdk.MaxChatGoalCompletionSummaryBytes+1) +
+		`"}`
+
+	for _, tt := range []struct {
+		name    string
+		input   string
+		message string
+	}{
+		{
+			name:    "missing goal id",
+			input:   `{"summary":"done"}`,
+			message: "goal_id is required",
+		},
+		{
+			name:    "empty goal id",
+			input:   `{"goal_id":"   ","summary":"done"}`,
+			message: "goal_id is required",
+		},
+		{
+			name:    "invalid goal id",
+			input:   `{"goal_id":"not-a-uuid","summary":"done"}`,
+			message: "goal_id must be a valid UUID",
+		},
+		{
+			name:    "empty summary",
+			input:   `{"goal_id":"00000000-0000-4000-8000-000000000001","summary":"  "}`,
+			message: "summary is required",
+		},
+		{
+			name:    "long summary",
+			input:   longSummaryInput,
+			message: "at most",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, err := completeTool.Run(context.Background(), fantasy.ToolCall{
+				ID:    "call-" + tt.name,
+				Name:  chattool.CompleteGoalToolName,
+				Input: tt.input,
+			})
+			require.NoError(t, err)
+			require.True(t, resp.IsError)
+			require.Contains(t, resp.Content, tt.message)
+		})
+	}
+}
+
+func TestCompleteGoalRejectsChildAndPaused(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "goal-tools-paused",
+	})
+	goal, err := db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: user.ID,
+	})
+	require.NoError(t, err)
+	_, err = db.PauseChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.PauseChatGoalByIDParams{
+		RootChatID: chat.ID,
+		ID:         goal.ID,
+	})
+	require.NoError(t, err)
+
+	childTool := chattool.CompleteGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: false,
+	})
+	childResp, err := childTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  chattool.CompleteGoalToolName,
+		Input: `{"goal_id":"` + goal.ID.String() + `","summary":"done"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, childResp.IsError)
+	require.Contains(t, childResp.Content, "root chat")
+
+	rootTool := chattool.CompleteGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+	})
+	pausedResp, err := rootTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-2",
+		Name:  chattool.CompleteGoalToolName,
+		Input: `{"goal_id":"` + goal.ID.String() + `","summary":"done"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, pausedResp.IsError)
+	require.Contains(t, pausedResp.Content, "not active")
+}
+
+// A crash, takeover, or interrupt between the goal transition and its
+// tool-result commit re-executes complete_goal; the replay must succeed
+// from the durable row instead of erroring for work that already landed.
+func TestCompleteGoalReplaysAgentCompletedGoal(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "goal-replay",
+	})
+	goal, err := db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: user.ID,
+	})
+	require.NoError(t, err)
+
+	var publishes int
+	completeTool := chattool.CompleteGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+		OnGoalUpdated: func(context.Context, database.Chat, database.ChatGoal) {
+			publishes++
+		},
+	})
+	input := `{"goal_id":"` + goal.ID.String() + `","summary":"done"}`
+	firstResp, err := completeTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  chattool.CompleteGoalToolName,
+		Input: input,
+	})
+	require.NoError(t, err)
+	require.False(t, firstResp.IsError)
+	require.Equal(t, 1, publishes)
+
+	replayResp, err := completeTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-2",
+		Name:  chattool.CompleteGoalToolName,
+		Input: input,
+	})
+	require.NoError(t, err)
+	require.False(t, replayResp.IsError, "re-executing a durably completed goal must replay success")
+	var payload struct {
+		Completed bool   `json:"completed"`
+		Summary   string `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(replayResp.Content), &payload))
+	require.True(t, payload.Completed)
+	require.Equal(t, "done", payload.Summary)
+	require.Equal(t, 2, publishes,
+		"a replay must re-publish the goal change because the original run may have crashed before publishing")
+}
+
+// A goal completed by the user is not proof the agent's call succeeded,
+// so the tool must keep reporting an error instead of replaying success.
+func TestCompleteGoalUserCompletedGoalDoesNotReplay(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	model := dbgen.ChatModelConfig(t, db, database.ChatModelConfig{})
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "goal-user-complete",
+	})
+	goal, err := db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: user.ID,
+	})
+	require.NoError(t, err)
+	_, err = db.CompleteChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.CompleteChatGoalByIDParams{
+		RootChatID:        chat.ID,
+		ID:                goal.ID,
+		CompletedByUserID: uuid.NullUUID{UUID: user.ID, Valid: true},
+		CompletedByAgent:  false,
+	})
+	require.NoError(t, err)
+
+	completeTool := chattool.CompleteGoal(db, chattool.GoalToolOptions{
+		ChatID:     chat.ID,
+		RootChatID: chat.ID,
+		IsRootChat: true,
+	})
+	resp, err := completeTool.Run(dbauthz.AsSystemRestricted(ctx), fantasy.ToolCall{
+		ID:    "call-1",
+		Name:  chattool.CompleteGoalToolName,
+		Input: `{"goal_id":"` + goal.ID.String() + `","summary":"done"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "not active")
+}


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

The two built-in tools the agent uses to observe and finish a goal, as a standalone package with no wiring yet. Nothing registers them until #29057, so this layer can be read as a library: inputs, fences, and replay semantics.

## What changed

- `chattool/goal.go`: `get_goal` (read-only, returns the current root goal or null) and `complete_goal` (root-only, requires the current `goal_id` and a bounded summary). `complete_goal` locks the chat row and checks a worker/runner/history-version fence so a stale or taken-over generation cannot complete a goal after its own tool result would be rejected. Argument parsing and the fenced mutation transaction live in `parseGoalIDArg` and `mutateCurrentActiveGoal`, which later goal tools reuse.
- Crash replay: when the same agent-completed goal is already durable, `complete_goal` returns its successful result instead of an error and re-publishes the goal change (the original run may have crashed before publishing), and `AgentCompletedGoalReplayPayload` exposes that for interrupted-call replay in later layers.
- `CurrentChatGoalByRootChatID` helper over the bulk lookup query.
- Tests: tool behavior, fence mismatch, input validation, child/paused rejection, replay, and `TestChatGoals` in `querier_test.go` covering the current-goal invariant, optimistic goal IDs, visibility, and `created_at` tie ordering. The query tests live here rather than in #29019 because they exercise the helper.

Code is unchanged from the reviewed #25622.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.

