### PR TITLE
feat: set chat goals from messages and expose objectives to lifecycle hooks

### DIFF
--- a/coderd/x/agenthooks/dispatch/dispatcher.go
+++ b/coderd/x/agenthooks/dispatch/dispatcher.go
@@ -628,15 +628,16 @@ func validateUserPromptSubmitOverride(input json.RawMessage) error {
 		return xerrors.Errorf("user_prompt_submit input_override: %w", err)
 	}
 	var override struct {
-		Prompt *string `json:"prompt"`
+		Prompt        *string `json:"prompt"`
+		GoalObjective *string `json:"goal_objective"`
 	}
 	decoder := json.NewDecoder(bytes.NewReader(input))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&override); err != nil {
-		return xerrors.Errorf("user_prompt_submit input_override must be {\"prompt\": string}: %w", err)
+		return xerrors.Errorf("user_prompt_submit input_override must be {\"prompt\": string, \"goal_objective\": string} with at least one field: %w", err)
 	}
-	if override.Prompt == nil {
-		return xerrors.New("user_prompt_submit input_override must be {\"prompt\": string}")
+	if override.Prompt == nil && override.GoalObjective == nil {
+		return xerrors.New("user_prompt_submit input_override must be {\"prompt\": string, \"goal_objective\": string} with at least one field")
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return xerrors.New("user_prompt_submit input_override must contain one JSON object")

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1102,6 +1102,16 @@ var (
 	// model-visible conversation after the latest context boundary,
 	// so a clear would be a no-op.
 	ErrNothingToClear = xerrors.New("nothing to clear")
+	// ErrChatGoalInvalidMutation indicates a malformed goal mutation request.
+	ErrChatGoalInvalidMutation = xerrors.New("invalid chat goal mutation")
+	// ErrChatGoalNotRoot indicates goal mutation was attempted on a child chat.
+	ErrChatGoalNotRoot = xerrors.New("chat goal mutations require a root chat")
+	// ErrChatGoalBusy indicates a message-bound goal mutation cannot be queued.
+	ErrChatGoalBusy = xerrors.New("chat is busy")
+	// ErrChatGoalPlanMode indicates a goal set was rejected because plan mode is on.
+	// Plan-mode turns exclude goal completion behavior, so an active goal set
+	// alongside plan mode could never complete or resume.
+	ErrChatGoalPlanMode = xerrors.New("cannot set a goal while plan mode is on")
 )
 
 // CreateOptions controls chat creation in the shared chat mutation path.
@@ -1125,6 +1135,7 @@ type CreateOptions struct {
 	MCPServerIDs            []uuid.UUID
 	Labels                  database.StringMap
 	DynamicTools            json.RawMessage
+	GoalMutation            *codersdk.ChatGoalMutation
 }
 
 // SendMessageBusyBehavior controls what happens when a chat is already active.
@@ -1150,6 +1161,7 @@ type SendMessageOptions struct {
 	BusyBehavior    SendMessageBusyBehavior
 	PlanMode        *database.NullChatPlanMode
 	MCPServerIDs    *[]uuid.UUID
+	GoalMutation    *codersdk.ChatGoalMutation
 }
 
 // SendMessageResult contains the outcome of user message processing.
@@ -1162,6 +1174,7 @@ type SendMessageResult struct {
 	// insert messages by promoting the previous queue head.
 	InsertedMessages []database.ChatMessage
 	Chat             database.Chat
+	Goal             *database.ChatGoal
 }
 
 // EditMessageOptions controls user message edits via soft-delete and re-insert.
@@ -1208,6 +1221,26 @@ type PromoteQueuedResult struct {
 	PromotedMessage database.ChatMessage
 }
 
+// ChatGoalMutationError describes a user-correctable goal mutation failure.
+type ChatGoalMutationError struct {
+	Message string
+}
+
+func (e *ChatGoalMutationError) Error() string {
+	if e.Message == "" {
+		return ErrChatGoalInvalidMutation.Error()
+	}
+	return e.Message
+}
+
+func (*ChatGoalMutationError) Is(target error) bool {
+	return target == ErrChatGoalInvalidMutation
+}
+
+func isRootChat(chat database.Chat) bool {
+	return !chat.ParentChatID.Valid
+}
+
 func chatRootID(chat database.Chat) uuid.UUID {
 	if chat.RootChatID.Valid {
 		return chat.RootChatID.UUID
@@ -1228,6 +1261,101 @@ func currentChatGoal(ctx context.Context, db database.Store, rootChatID uuid.UUI
 		return nil, xerrors.Errorf("get current chat goal: %w", err)
 	}
 	return &goal, nil
+}
+
+func validateGoalObjectiveLength(objective string) error {
+	if len(objective) > codersdk.MaxChatGoalObjectiveBytes {
+		return &ChatGoalMutationError{Message: fmt.Sprintf(
+			"goal objective must be at most %d bytes",
+			codersdk.MaxChatGoalObjectiveBytes,
+		)}
+	}
+	return nil
+}
+
+func normalizeMessageGoalMutation(mutation *codersdk.ChatGoalMutation) (*codersdk.ChatGoalMutation, error) {
+	if mutation == nil {
+		//nolint:nilnil // No requested mutation is represented as nil.
+		return nil, nil
+	}
+	normalized := *mutation
+	if normalized.Action != codersdk.ChatGoalMutationActionSet {
+		return nil, &ChatGoalMutationError{Message: "goal_mutation action must be set when sending a message"}
+	}
+	objective := strings.TrimSpace(normalized.Objective)
+	if objective == "" {
+		return nil, &ChatGoalMutationError{Message: "goal objective is required"}
+	}
+	if err := validateGoalObjectiveLength(objective); err != nil {
+		return nil, err
+	}
+	if normalized.GoalID != nil {
+		return nil, &ChatGoalMutationError{Message: "goal_id is not allowed when setting a goal"}
+	}
+	if normalized.CompletionSummary != nil {
+		return nil, &ChatGoalMutationError{Message: "completion_summary is not allowed when setting a goal"}
+	}
+	normalized.Objective = objective
+	return &normalized, nil
+}
+
+// applyGoalObjectiveOverride returns the goal mutation with the hook
+// consumer's objective override applied under the same normalization as
+// the original submission. An override on a submission that sets no
+// goal is a consumer bug and rejects the submission rather than being
+// silently dropped.
+func applyGoalObjectiveOverride(mutation *codersdk.ChatGoalMutation, result *chathooks.Result) (*codersdk.ChatGoalMutation, error) {
+	override, overridden, err := chathooks.GoalObjectiveOverride(result)
+	if err != nil {
+		return nil, err
+	}
+	if !overridden {
+		return mutation, nil
+	}
+	if mutation == nil {
+		return nil, &ChatGoalMutationError{Message: "hook goal_objective override requires a goal-setting submission"}
+	}
+	objective := strings.TrimSpace(override)
+	if objective == "" {
+		return nil, &ChatGoalMutationError{Message: "hook goal_objective override must not be empty"}
+	}
+	if err := validateGoalObjectiveLength(objective); err != nil {
+		return nil, err
+	}
+	updated := *mutation
+	updated.Objective = objective
+	return &updated, nil
+}
+
+func applyGoalMutation(
+	ctx context.Context,
+	tx database.Store,
+	rootChatID uuid.UUID,
+	createdFromMessageID int64,
+	createdBy uuid.UUID,
+	mutation codersdk.ChatGoalMutation,
+) (*database.ChatGoal, error) {
+	switch mutation.Action {
+	case codersdk.ChatGoalMutationActionSet:
+		if err := tx.MarkCurrentChatGoalReplacedByRootChatID(ctx, rootChatID); err != nil {
+			return nil, xerrors.Errorf("replace current chat goal: %w", err)
+		}
+		goal, err := tx.InsertActiveChatGoal(ctx, database.InsertActiveChatGoalParams{
+			RootChatID: rootChatID,
+			CreatedFromMessageID: sql.NullInt64{
+				Int64: createdFromMessageID,
+				Valid: createdFromMessageID > 0,
+			},
+			Objective:       mutation.Objective,
+			CreatedByUserID: createdBy,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("insert active chat goal: %w", err)
+		}
+		return &goal, nil
+	default:
+		return nil, &ChatGoalMutationError{Message: "unsupported goal_mutation action"}
+	}
 }
 
 // forcedMCPServerConfigsForOwner filters enabled Force On configs
@@ -1316,6 +1444,16 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 	if len(opts.InitialUserContent) == 0 {
 		return database.Chat{}, xerrors.New("initial user content is required")
 	}
+	goalMutation, err := normalizeMessageGoalMutation(opts.GoalMutation)
+	if err != nil {
+		return database.Chat{}, err
+	}
+	if goalMutation != nil && opts.ParentChatID.Valid {
+		return database.Chat{}, ErrChatGoalNotRoot
+	}
+	if goalMutation != nil && opts.PlanMode.Valid && opts.PlanMode.ChatPlanMode == database.ChatPlanModePlan {
+		return database.Chat{}, ErrChatGoalPlanMode
+	}
 	// Ensure MCPServerIDs is non-nil so pq.Array produces '{}'
 	// instead of SQL NULL, which violates the NOT NULL column
 	// constraint.
@@ -1365,6 +1503,9 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		if err != nil {
 			return database.Chat{}, err
 		}
+		if goalMutation != nil {
+			promptMessage.GoalObjective = goalMutation.Objective
+		}
 		promptResult, err := p.hooks.Trigger(ctx, chathooks.Chat{
 			ID:          chatID,
 			OwnerID:     opts.OwnerID,
@@ -1382,6 +1523,10 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		// Avoid deriving titles from the prompt that policy replaced.
 		if overridden && opts.TitleDerivedFromContent {
 			opts.Title = chatprompt.FallbackTitle(chatprompt.TitleText(contentParts, nil))
+		}
+		goalMutation, err = applyGoalObjectiveOverride(goalMutation, promptResult)
+		if err != nil {
+			return database.Chat{}, err
 		}
 	}
 
@@ -1423,6 +1568,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 	initialMessages = append(initialMessages, systemMessage(workspaceAwarenessContent, opts.ModelConfigID))
 	initialMessages = append(initialMessages, userMessage(userContent, opts.ModelConfigID, opts.OwnerID, opts.ReasoningEffort))
 
+	var createdGoal *database.ChatGoal
 	result, err := chatstate.CreateChatWithID(ctx, p.db, p.pubsub, chatID, chatstate.CreateChatInput{
 		OrganizationID:    opts.OrganizationID,
 		OwnerID:           opts.OwnerID,
@@ -1447,6 +1593,27 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		ClientType:      opts.ClientType,
 		InitialMessages: initialMessages,
 		FileIDs:         chatprompt.FileIDs(contentParts),
+		AfterInsert: func(ctx context.Context, store database.Store, chat database.Chat, inserted []database.ChatMessage) error {
+			if goalMutation == nil {
+				return nil
+			}
+			var initialUserMessageID int64
+			for i := len(inserted) - 1; i >= 0; i-- {
+				if inserted[i].Role == database.ChatMessageRoleUser {
+					initialUserMessageID = inserted[i].ID
+					break
+				}
+			}
+			if initialUserMessageID == 0 {
+				return xerrors.New("initial user message not found for goal mutation")
+			}
+			goal, err := applyGoalMutation(ctx, store, chat.ID, initialUserMessageID, opts.OwnerID, *goalMutation)
+			if err != nil {
+				return err
+			}
+			createdGoal = goal
+			return nil
+		},
 	})
 	if err != nil {
 		return database.Chat{}, err
@@ -1460,6 +1627,10 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 	// committed and emitted its own state-machine notifications. The
 	// watch endpoint is maintained separately from chatstate notifications.
 	p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindCreated, nil)
+
+	if createdGoal != nil {
+		p.publishChatGoalChange(chat)
+	}
 
 	// Pin the chat to the agent's latest context snapshot if one exists.
 	// Best-effort: a chat created before its agent has pushed is hydrated
@@ -1494,6 +1665,11 @@ func (p *Server) SendMessage(
 		return SendMessageResult{}, xerrors.Errorf("invalid busy behavior %q", opts.BusyBehavior)
 	}
 
+	goalMutation, err := normalizeMessageGoalMutation(opts.GoalMutation)
+	if err != nil {
+		return SendMessageResult{}, err
+	}
+
 	contentParts := opts.Content
 	if p.hooks.Enabled() {
 		turnID := uuid.New()
@@ -1517,15 +1693,49 @@ func (p *Server) SendMessage(
 		if queuedCount >= chatstate.MaxQueueSize {
 			return SendMessageResult{}, &chatstate.MessageQueueFullError{Max: chatstate.MaxQueueSize}
 		}
+		// Root-ness is immutable, so a child-chat goal send can never
+		// commit; reject before dispatch so hook consumers never
+		// observe a prompt that cannot be admitted. The transaction
+		// rechecks it.
+		if goalMutation != nil && !isRootChat(chat) {
+			return SendMessageResult{}, ErrChatGoalNotRoot
+		}
+		// A goal-bound send on a busy chat would queue and then be
+		// rejected in the transaction; reject before dispatch so hook
+		// consumers never observe a prompt that cannot be admitted.
+		// Mirror chatstate's direct-admit states: waiting and error
+		// both insert immediately when the queue is empty.
+		if goalMutation != nil &&
+			((chat.Status != database.ChatStatusWaiting && chat.Status != database.ChatStatusError) || queuedCount > 0) {
+			return SendMessageResult{}, ErrChatGoalBusy
+		}
+		// Likewise reject a goal-bound send whose effective plan mode is
+		// plan before dispatch; the transaction rechecks the mode it
+		// commits with.
+		effectivePlanMode := chat.PlanMode
+		if opts.PlanMode != nil {
+			effectivePlanMode = *opts.PlanMode
+		}
+		if goalMutation != nil && effectivePlanMode.Valid &&
+			effectivePlanMode.ChatPlanMode == database.ChatPlanModePlan {
+			return SendMessageResult{}, ErrChatGoalPlanMode
+		}
 		promptMessage, err := chathooks.UserPromptMessage(contentParts)
 		if err != nil {
 			return SendMessageResult{}, err
+		}
+		if goalMutation != nil {
+			promptMessage.GoalObjective = goalMutation.Objective
 		}
 		promptResult, err := p.hooks.Trigger(ctx, chathooks.ChatFor(chat, &turnID), promptMessage, agenthooks.EventUserPromptSubmit, dispatch.CapacityClassAdmission)
 		if err != nil {
 			return SendMessageResult{}, p.handleUserPromptDispatchError(ctx, opts.ChatID, chathooks.UserPromptDenial(err))
 		}
 		contentParts, _, err = chathooks.ComposeUserPromptContent(contentParts, promptResult)
+		if err != nil {
+			return SendMessageResult{}, err
+		}
+		goalMutation, err = applyGoalObjectiveOverride(goalMutation, promptResult)
 		if err != nil {
 			return SendMessageResult{}, err
 		}
@@ -1550,6 +1760,9 @@ func (p *Server) SendMessage(
 		if lockedChat.Archived {
 			return ErrChatArchived
 		}
+		if goalMutation != nil && !isRootChat(lockedChat) {
+			return ErrChatGoalNotRoot
+		}
 
 		if requestedPlanMode != nil {
 			lockedChat, err = store.UpdateChatPlanModeByID(ctx, database.UpdateChatPlanModeByIDParams{
@@ -1559,6 +1772,12 @@ func (p *Server) SendMessage(
 			if err != nil {
 				return xerrors.Errorf("update chat plan mode: %w", err)
 			}
+		}
+		// Checked after the requested plan-mode write so the guard sees the
+		// mode this send runs with; a rejection rolls that write back.
+		if goalMutation != nil && lockedChat.PlanMode.Valid &&
+			lockedChat.PlanMode.ChatPlanMode == database.ChatPlanModePlan {
+			return ErrChatGoalPlanMode
 		}
 
 		modelConfigID, err := resolveSendMessageModelConfigID(
@@ -1593,6 +1812,9 @@ func (p *Server) SendMessage(
 		}
 
 		if sendResult.QueuedMessage != nil {
+			if goalMutation != nil {
+				return ErrChatGoalBusy
+			}
 			result.Queued = true
 			result.QueuedMessage = sendResult.QueuedMessage
 		} else if len(sendResult.InsertedMessages) > 0 {
@@ -1600,6 +1822,13 @@ func (p *Server) SendMessage(
 			// cancellation messages; the user message is always
 			// last in the inserted slice.
 			result.Message = sendResult.InsertedMessages[len(sendResult.InsertedMessages)-1]
+			if goalMutation != nil {
+				goal, err := applyGoalMutation(ctx, store, lockedChat.ID, result.Message.ID, messageCreatedBy, *goalMutation)
+				if err != nil {
+					return err
+				}
+				result.Goal = goal
+			}
 		}
 		// A queued send on an errored chat can also promote the
 		// previous queue head into history; report those inserts so
@@ -1628,6 +1857,9 @@ func (p *Server) SendMessage(
 	// Sidebar watch event keeps the chat list in sync. Stream side
 	// effects are handled by chat:update consumers.
 	p.publishChatPubsubEvent(result.Chat, codersdk.ChatWatchEventKindStatusChange, nil)
+	if result.Goal != nil {
+		p.publishChatGoalChange(result.Chat)
+	}
 	return result, nil
 }
 
@@ -1878,6 +2110,10 @@ func (p *Server) EditMessage(
 		}
 		contentParts, _, err = chathooks.ComposeUserPromptContent(contentParts, promptResult)
 		if err != nil {
+			return EditMessageResult{}, err
+		}
+		// Edits cannot set goals, so an objective override is a consumer bug.
+		if _, err := applyGoalObjectiveOverride(nil, promptResult); err != nil {
 			return EditMessageResult{}, err
 		}
 	}

--- a/coderd/x/chatd/chathooks/effects.go
+++ b/coderd/x/chatd/chathooks/effects.go
@@ -121,25 +121,46 @@ func RestoreToolCallOrder(content []fantasy.Content, calls []fantasy.ToolCallCon
 	}
 }
 
-func UserPromptOverride(result *Result) (string, bool, error) {
+type userPromptOverride struct {
+	Prompt        *string `json:"prompt"`
+	GoalObjective *string `json:"goal_objective"`
+}
+
+func decodeUserPromptOverride(result *Result) (userPromptOverride, error) {
+	var override userPromptOverride
 	if result == nil || len(result.InputOverride) == 0 {
-		return "", false, nil
-	}
-	var override struct {
-		Prompt *string `json:"prompt"`
+		return override, nil
 	}
 	decoder := json.NewDecoder(bytes.NewReader(result.InputOverride))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&override); err != nil {
-		return "", false, xerrors.Errorf("decode user prompt input override: %w", err)
+		return userPromptOverride{}, xerrors.Errorf("decode user prompt input override: %w", err)
 	}
-	if override.Prompt == nil {
-		return "", false, xerrors.New("decode user prompt input override: prompt is required")
+	if override.Prompt == nil && override.GoalObjective == nil {
+		return userPromptOverride{}, xerrors.New("decode user prompt input override: prompt or goal_objective is required")
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		return "", false, xerrors.New("decode user prompt input override: trailing JSON value")
+		return userPromptOverride{}, xerrors.New("decode user prompt input override: trailing JSON value")
+	}
+	return override, nil
+}
+
+func UserPromptOverride(result *Result) (string, bool, error) {
+	override, err := decodeUserPromptOverride(result)
+	if err != nil || override.Prompt == nil {
+		return "", false, err
 	}
 	return *override.Prompt, true, nil
+}
+
+// GoalObjectiveOverride returns the goal objective replacement carried
+// by a user_prompt_submit input override, when present.
+func GoalObjectiveOverride(result *Result) (string, bool, error) {
+	override, err := decodeUserPromptOverride(result)
+	if err != nil || override.GoalObjective == nil {
+		return "", false, err
+	}
+	return *override.GoalObjective, true, nil
 }
 
 func UserPromptParts(result *Result) []codersdk.ChatMessagePart {

--- a/coderd/x/chatd/chathooks/trigger.go
+++ b/coderd/x/chatd/chathooks/trigger.go
@@ -90,14 +90,17 @@ func (c Chat) ref() agenthooks.ChatRef {
 }
 
 type Message struct {
-	Source       string
-	Prompt       string
-	Parts        json.RawMessage
-	ToolUseID    string
-	ToolName     string
-	ToolInput    json.RawMessage
-	ToolResponse json.RawMessage
-	ToolError    string
+	Source string
+	Prompt string
+	Parts  json.RawMessage
+	// GoalObjective is set when a user_prompt_submit submission also
+	// sets a chat goal, so prompt policy observes the objective text.
+	GoalObjective string
+	ToolUseID     string
+	ToolName      string
+	ToolInput     json.RawMessage
+	ToolResponse  json.RawMessage
+	ToolError     string
 }
 
 func UserPromptMessage(parts []codersdk.ChatMessagePart) (Message, error) {
@@ -152,7 +155,7 @@ func (t *Trigger) Trigger(
 	case agenthooks.EventSessionStart:
 		data = agenthooks.SessionStartData{Source: msg.Source}
 	case agenthooks.EventUserPromptSubmit:
-		data = agenthooks.UserPromptSubmitData{Prompt: msg.Prompt, Parts: msg.Parts}
+		data = agenthooks.UserPromptSubmitData{Prompt: msg.Prompt, Parts: msg.Parts, GoalObjective: msg.GoalObjective}
 	case agenthooks.EventPreToolUse:
 		data = agenthooks.PreToolUseData{ToolUseID: msg.ToolUseID, ToolName: msg.ToolName, ToolInput: msg.ToolInput}
 	case agenthooks.EventPostToolUse:

--- a/coderd/x/chatd/chatstate/transitions.go
+++ b/coderd/x/chatd/chatstate/transitions.go
@@ -38,6 +38,10 @@ type CreateChatInput struct {
 	InitialMessages   []Message
 	// FileIDs are linked atomically with the initial messages.
 	FileIDs []uuid.UUID
+	// AfterInsert runs inside the create transaction after the chat and
+	// initial messages are inserted, but before the chat snapshot is
+	// reloaded and publish events are buffered.
+	AfterInsert func(context.Context, database.Store, database.Chat, []database.ChatMessage) error
 }
 
 // CreateChatResult is the value returned by [CreateChat]. It carries
@@ -136,6 +140,11 @@ func insertChat(
 		}
 		if err := LinkFiles(ctx, store, chat.ID, input.FileIDs); err != nil {
 			return err
+		}
+		if input.AfterInsert != nil {
+			if err := input.AfterInsert(ctx, store, chat, fromInsertedRows(inserted)); err != nil {
+				return err
+			}
 		}
 		refreshed, err := store.GetChatByID(ctx, chat.ID)
 		if err != nil {

--- a/coderd/x/chatd/hooks_test.go
+++ b/coderd/x/chatd/hooks_test.go
@@ -17,6 +17,7 @@ import (
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
@@ -703,4 +704,445 @@ func decodeHookData[T any](t *testing.T, request agenthooks.Request) T {
 	var data T
 	require.NoError(t, json.Unmarshal(request.Data, &data))
 	return data
+}
+
+// The goal objective bypasses message content, so user_prompt_submit
+// must observe it and its replacement must be persisted (create path).
+func TestCreateChatGoalObjectiveHookPayloadAndOverride(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	var received agenthooks.Request
+	consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request agenthooks.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		response := `{}`
+		if request.Type == agenthooks.EventUserPromptSubmit {
+			received = request
+			response = `{"permission":{"decision":"allow","input_override":{"goal_objective":"  scrubbed objective  "}}}`
+		}
+		_, err := w.Write([]byte(response))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(consumer.Close)
+	server := newHookTestServer(t, db, ps, consumer)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID:     org.ID,
+		OwnerID:            user.ID,
+		Title:              "goal create",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("kick off")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "original objective",
+		},
+	})
+	require.NoError(t, err)
+	promptData := decodeHookData[agenthooks.UserPromptSubmitData](t, received)
+	require.Equal(t, "original objective", promptData.GoalObjective)
+	require.Equal(t, "kick off", promptData.Prompt)
+	goals, err := db.GetCurrentChatGoalsByRootChatIDs(ctx, []uuid.UUID{chat.ID})
+	require.NoError(t, err)
+	require.Len(t, goals, 1)
+	require.Equal(t, "scrubbed objective", goals[0].Objective)
+}
+
+// Same contract on the send path: the hook payload carries the
+// objective and the override replaces it without touching the message.
+func TestSendMessageGoalObjectiveHookPayloadAndOverride(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+	})
+	var received agenthooks.Request
+	consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
+		_, err := w.Write([]byte(`{"permission":{"decision":"allow","input_override":{"goal_objective":"scrubbed objective"}}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(consumer.Close)
+	server := newHookTestServer(t, db, ps, consumer)
+
+	result, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:  chat.ID,
+		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue this")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "original objective",
+		},
+	})
+	require.NoError(t, err)
+	promptData := decodeHookData[agenthooks.UserPromptSubmitData](t, received)
+	require.Equal(t, "original objective", promptData.GoalObjective)
+	require.Equal(t, "pursue this", promptData.Prompt)
+	require.NotNil(t, result.Goal)
+	require.Equal(t, "scrubbed objective", result.Goal.Objective)
+	require.Equal(t, "pursue this", hookMessageText(t, result.Message))
+}
+
+// An objective override on a submission that sets no goal is a
+// consumer bug: the send is rejected and nothing is persisted.
+func TestSendMessageGoalObjectiveOverrideWithoutGoalRejected(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+	})
+	consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"permission":{"decision":"allow","input_override":{"goal_objective":"sneaky objective"}}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(consumer.Close)
+	server := newHookTestServer(t, db, ps, consumer)
+
+	_, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:  chat.ID,
+		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("no goal here")},
+	})
+	require.ErrorIs(t, err, chatd.ErrChatGoalInvalidMutation)
+	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{ChatID: chat.ID})
+	require.NoError(t, err)
+	require.Empty(t, messages)
+}
+
+// A known-busy goal send is inadmissible; hook consumers must never
+// observe its prompt.
+func TestSendMessageGoalBusyRejectedBeforeHookDispatch(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	var promptDispatches atomic.Int32
+	consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request agenthooks.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		if request.Type == agenthooks.EventUserPromptSubmit {
+			promptDispatches.Add(1)
+		}
+		_, err := w.Write([]byte(`{}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(consumer.Close)
+	server := newHookTestServer(t, db, ps, consumer)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID:     org.ID,
+		OwnerID:            user.ID,
+		Title:              "busy goal",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("running")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusRunning, chat.Status)
+	require.Equal(t, int32(1), promptDispatches.Load())
+
+	_, err = server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:  chat.ID,
+		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue this")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "goal on a busy chat",
+		},
+	})
+	require.ErrorIs(t, err, chatd.ErrChatGoalBusy)
+	require.Equal(t, int32(1), promptDispatches.Load(),
+		"user_prompt_submit must not be dispatched for an inadmissible goal send")
+}
+
+// A child-chat goal send can never commit because goals are root-only;
+// hook consumers must never observe its prompt.
+func TestSendMessageGoalChildChatRejectedBeforeHookDispatch(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	var promptDispatches atomic.Int32
+	consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request agenthooks.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		if request.Type == agenthooks.EventUserPromptSubmit {
+			promptDispatches.Add(1)
+		}
+		_, err := w.Write([]byte(`{}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(consumer.Close)
+	server := newHookTestServer(t, db, ps, consumer)
+
+	root, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID:     org.ID,
+		OwnerID:            user.ID,
+		Title:              "root chat",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("root start")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), promptDispatches.Load())
+
+	childContent, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+		codersdk.ChatMessageText("child question"),
+	})
+	require.NoError(t, err)
+	createdChild, err := chatstate.CreateChat(ctx, db, ps, chatstate.CreateChatInput{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		ParentChatID:      uuid.NullUUID{UUID: root.ID, Valid: true},
+		RootChatID:        uuid.NullUUID{UUID: root.ID, Valid: true},
+		LastModelConfigID: model.ID,
+		Title:             "child chat",
+		ClientType:        database.ChatClientTypeApi,
+		InitialMessages: []chatstate.Message{
+			{
+				Role:           database.ChatMessageRoleUser,
+				Content:        childContent,
+				Visibility:     database.ChatMessageVisibilityBoth,
+				ContentVersion: chatprompt.CurrentContentVersion,
+				CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+				ModelConfigID:  uuid.NullUUID{UUID: model.ID, Valid: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+	// Waiting status passes the busy pre-check, so only the root-only
+	// guard can reject before dispatch.
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     createdChild.Chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	_, err = server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:    createdChild.Chat.ID,
+		CreatedBy: user.ID,
+		Content:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue this")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "goal on a child chat",
+		},
+	})
+	require.ErrorIs(t, err, chatd.ErrChatGoalNotRoot)
+	require.Equal(t, int32(1), promptDispatches.Load(),
+		"user_prompt_submit must not be dispatched for a child-chat goal send")
+}
+
+func TestSendMessageGoalPlanModeRejectedBeforeHookDispatch(t *testing.T) {
+	t.Parallel()
+
+	planOn := database.NullChatPlanMode{ChatPlanMode: database.ChatPlanModePlan, Valid: true}
+	goalMutation := &codersdk.ChatGoalMutation{
+		Action:    codersdk.ChatGoalMutationActionSet,
+		Objective: "goal under plan mode",
+	}
+	newPromptCounter := func(t *testing.T) (*httptest.Server, *atomic.Int32) {
+		t.Helper()
+		var promptDispatches atomic.Int32
+		consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var request agenthooks.Request
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+			if request.Type == agenthooks.EventUserPromptSubmit {
+				promptDispatches.Add(1)
+			}
+			_, err := w.Write([]byte(`{}`))
+			require.NoError(t, err)
+		}))
+		t.Cleanup(consumer.Close)
+		return consumer, &promptDispatches
+	}
+
+	t.Run("InheritedPlanMode", func(t *testing.T) {
+		t.Parallel()
+		db, ps := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user, org, model := seedChatDependencies(t, db)
+		consumer, promptDispatches := newPromptCounter(t)
+		server := newHookTestServer(t, db, ps, consumer)
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+			PlanMode:          planOn,
+		})
+
+		_, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+			ChatID:       chat.ID,
+			Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue this")},
+			GoalMutation: goalMutation,
+		})
+		require.ErrorIs(t, err, chatd.ErrChatGoalPlanMode)
+		require.Equal(t, int32(0), promptDispatches.Load(),
+			"user_prompt_submit must not be dispatched for an inadmissible goal send")
+	})
+
+	t.Run("RequestedPlanMode", func(t *testing.T) {
+		t.Parallel()
+		db, ps := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user, org, model := seedChatDependencies(t, db)
+		consumer, promptDispatches := newPromptCounter(t)
+		server := newHookTestServer(t, db, ps, consumer)
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+		})
+
+		_, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+			ChatID:       chat.ID,
+			Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue this")},
+			PlanMode:     &planOn,
+			GoalMutation: goalMutation,
+		})
+		require.ErrorIs(t, err, chatd.ErrChatGoalPlanMode)
+		require.Equal(t, int32(0), promptDispatches.Load(),
+			"user_prompt_submit must not be dispatched for an inadmissible goal send")
+	})
+}
+
+// Plan-mode turns exclude goal completion behavior, so goal sets and
+// plan mode are mutually exclusive at the API layer, matching the
+// composer's mutually exclusive controls.
+func TestGoalSetPlanModeRejected(t *testing.T) {
+	t.Parallel()
+
+	planOn := database.NullChatPlanMode{ChatPlanMode: database.ChatPlanModePlan, Valid: true}
+	goalMutation := &codersdk.ChatGoalMutation{
+		Action:    codersdk.ChatGoalMutationActionSet,
+		Objective: "objective under plan mode",
+	}
+
+	t.Run("CreateRejected", func(t *testing.T) {
+		t.Parallel()
+		db, ps := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user, org, model := seedChatDependencies(t, db)
+		server := newTestServer(t, db, ps, uuid.New())
+
+		_, err := server.CreateChat(ctx, chatd.CreateOptions{
+			OrganizationID:     org.ID,
+			OwnerID:            user.ID,
+			Title:              "plan mode goal",
+			ModelConfigID:      model.ID,
+			PlanMode:           planOn,
+			GoalMutation:       goalMutation,
+			InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("start")},
+		})
+		require.ErrorIs(t, err, chatd.ErrChatGoalPlanMode)
+	})
+
+	t.Run("SendOnPlanModeChatRejected", func(t *testing.T) {
+		t.Parallel()
+		db, ps := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user, org, model := seedChatDependencies(t, db)
+		server := newTestServer(t, db, ps, uuid.New())
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+			PlanMode:          planOn,
+		})
+
+		_, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+			ChatID:       chat.ID,
+			Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue")},
+			GoalMutation: goalMutation,
+		})
+		require.ErrorIs(t, err, chatd.ErrChatGoalPlanMode)
+	})
+
+	t.Run("SendEnablingPlanModeRejected", func(t *testing.T) {
+		t.Parallel()
+		db, ps := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user, org, model := seedChatDependencies(t, db)
+		server := newTestServer(t, db, ps, uuid.New())
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+		})
+
+		requested := planOn
+		_, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+			ChatID:       chat.ID,
+			Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue")},
+			PlanMode:     &requested,
+			GoalMutation: goalMutation,
+		})
+		require.ErrorIs(t, err, chatd.ErrChatGoalPlanMode)
+	})
+
+	t.Run("SendDisablingPlanModeAllowed", func(t *testing.T) {
+		t.Parallel()
+		db, ps := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		user, org, model := seedChatDependencies(t, db)
+		server := newTestServer(t, db, ps, uuid.New())
+		chat := dbgen.Chat(t, db, database.Chat{
+			OrganizationID:    org.ID,
+			OwnerID:           user.ID,
+			LastModelConfigID: model.ID,
+			PlanMode:          planOn,
+		})
+
+		cleared := database.NullChatPlanMode{}
+		result, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+			ChatID:       chat.ID,
+			Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("pursue")},
+			PlanMode:     &cleared,
+			GoalMutation: goalMutation,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result.Goal)
+	})
+}
+
+// chatstate admits direct sends on waiting and empty-queue error
+// states, so a goal-bound recovery send on an idle errored chat must
+// reach hook dispatch instead of being rejected as busy.
+func TestSendMessageGoalOnErroredChatDispatchesHook(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Status:            database.ChatStatusError,
+	})
+	var received agenthooks.Request
+	consumer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
+		_, err := w.Write([]byte(`{}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(consumer.Close)
+	server := newHookTestServer(t, db, ps, consumer)
+
+	result, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:  chat.ID,
+		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("recover with a goal")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "recovery objective",
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, result.Queued)
+	require.NotNil(t, result.Goal)
+	require.Equal(t, "recovery objective", result.Goal.Objective)
+	require.Equal(t, agenthooks.EventUserPromptSubmit, received.Type)
+	require.Equal(t, "recovery objective", decodeHookData[agenthooks.UserPromptSubmitData](t, received).GoalObjective)
 }

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -1289,6 +1289,11 @@ func (p *Server) createChildSubagentChatWithOptions(
 			// The overridden prompt also feeds the fallback title below.
 			prompt = override
 		}
+		// Subagent chats cannot have goals, so an objective override is a
+		// consumer bug.
+		if _, err := applyGoalObjectiveOverride(nil, promptResult); err != nil {
+			return database.Chat{}, err
+		}
 	}
 	if title == "" {
 		title = subagentFallbackChatTitle(prompt)

--- a/codersdk/x/agenthooks/types.go
+++ b/codersdk/x/agenthooks/types.go
@@ -69,10 +69,14 @@ type SessionStartData struct {
 }
 
 // UserPromptSubmitData includes concatenated text and persisted parts.
-// Inspect Parts when structure matters.
+// Inspect Parts when structure matters. GoalObjective carries the chat
+// goal objective admitted with the prompt when the submission also sets
+// a goal; it feeds every subsequent generation's instructions, so
+// prompt policy must observe it even when it differs from the message.
 type UserPromptSubmitData struct {
-	Prompt string          `json:"prompt"`
-	Parts  json.RawMessage `json:"parts,omitempty"`
+	Prompt        string          `json:"prompt"`
+	Parts         json.RawMessage `json:"parts,omitempty"`
+	GoalObjective string          `json:"goal_objective,omitempty"`
 }
 
 // PreToolUseData describes a tool call before execution.

--- a/docs/admin/setup/chat-lifecycle-hooks.md
+++ b/docs/admin/setup/chat-lifecycle-hooks.md
@@ -65,7 +65,7 @@ Handle the events your policy needs, using the data Coder sends with each one:
 | Event                | When Coder sends it                                                 | Decision-relevant data                                                 |
 |----------------------|---------------------------------------------------------------------|------------------------------------------------------------------------|
 | `session_start`      | A chat session starts, resumes, or clears                           | `source` (`startup`, `resume`, or `clear`)                             |
-| `user_prompt_submit` | A user submits a prompt, or `spawn_agent` submits a subagent prompt | `prompt` and `parts`                                                   |
+| `user_prompt_submit` | A user submits a prompt, or `spawn_agent` submits a subagent prompt | `prompt`, `parts`, and `goal_objective`                                |
 | `pre_tool_use`       | Before a non-provider-executed tool runs                            | `tool_use_id`, `tool_name`, and `tool_input`                           |
 | `post_tool_use`      | After a non-provider-executed tool returns                          | `tool_use_id`, `tool_name`, and either `tool_response` or `tool_error` |
 | `pre_compact`        | Before Coder compacts chat context                                  | No event-specific fields                                               |
@@ -84,6 +84,8 @@ The chat `edit_files` tool reads `old_text` and `new_text` and, for rollout comp
 For `user_prompt_submit`, `prompt` concatenates the original submitted text parts, and `parts` carries the original structured message, including non-text parts such as file references.
 These values are captured before the consumer's override or injected context changes the stored prompt.
 A consumer that gates prompt content must inspect `parts`.
+When the submission also sets a chat goal, `goal_objective` carries the goal objective text.
+The objective feeds every subsequent generation's instructions, so a policy must inspect it even when it differs from the message text.
 
 ### Verify each request
 
@@ -123,10 +125,11 @@ Any other value causes the dispatch to fail closed.
 
 Permission rules depend on the event:
 
-- For `user_prompt_submit`, `allow` requires `input_override` in the exact form `{"prompt":"replacement text"}`.
-  Coder stores and sends the replacement prompt instead of the original prompt.
-  The override replaces only submitted text, matching the concatenated `prompt` field the consumer receives.
+- For `user_prompt_submit`, `allow` requires `input_override` as an object with at least one of `prompt` and `goal_objective`, for example `{"prompt":"replacement text"}` or `{"goal_objective":"replacement objective"}`.
+  Coder stores and sends the replacement prompt instead of the original prompt, and persists the replacement goal objective instead of the submitted one.
+  The `prompt` override replaces only submitted text, matching the concatenated `prompt` field the consumer receives.
   Attachments and file references remain in `parts`, so consumers that must block them should inspect `parts` and return `deny`.
+  A `goal_objective` override is rejected when the submission sets no goal.
 - For `pre_tool_use`, `allow` requires `input_override` containing the replacement tool input.
   Coder persists the replacement with the tool call and executes the tool with it.
   An override for a built-in tool must not repeat a key or vary the capitalization of a schema property; an ambiguous override fails the dispatch closed because the model can't correct it.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1511,11 +1511,15 @@ export interface AgentHookStopData {}
 // From agenthooks/types.go
 /**
  * UserPromptSubmitData includes concatenated text and persisted parts.
- * Inspect Parts when structure matters.
+ * Inspect Parts when structure matters. GoalObjective carries the chat
+ * goal objective admitted with the prompt when the submission also sets
+ * a goal; it feeds every subsequent generation's instructions, so
+ * prompt policy must observe it even when it differs from the message.
  */
 export interface AgentHookUserPromptSubmitData {
 	readonly prompt: string;
 	readonly parts?: unknown;
+	readonly goal_objective?: string;
 }
 
 // From codersdk/workspacebuilds.go


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

The first way a goal gets created: alongside a chat message. Setting a goal and exposing its objective to lifecycle hook policy land together on purpose, so there is no layer where a submitted objective bypasses `user_prompt_submit` policy.

## What changed

- `CreateChat` and `SendMessage` accept a `GoalMutation` (set only). The goal is inserted in the same transaction as the source message via a new `chatstate.CreateChatInput.AfterInsert` hook, replacing any current goal, and a `goal_change` event is published.
- Admission rules: goals are root-only, rejected while plan mode is on (inherited or requested in the same send), and rejected on busy chats instead of queued. Known-inadmissible sends are refused before hook dispatch so consumers never observe a prompt that cannot commit; the transaction rechecks every rule.
- Lifecycle hooks: `goal_objective` added to the `user_prompt_submit` payload, and `input_override` may carry `goal_objective` to replace it. An objective override on a submission that sets no goal (edits, subagent prompts, plain sends) is a consumer bug and fails the submission. Dispatcher validation, docs, and generated TypeScript updated.
- Tests: hook payload and override on create and send, override-without-goal rejection, pre-dispatch busy/child/plan-mode rejections, plan-mode matrix, and the errored-chat recovery send.

Code is unchanged from the reviewed #25622 apart from the split.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.
