### PR TITLE
feat(coderd/x/chatd): add chat goal lifecycle mutations

### DIFF
--- a/coderd/x/chatd/ARCHITECTURE.md
+++ b/coderd/x/chatd/ARCHITECTURE.md
@@ -53,6 +53,8 @@ If the distinction isn't completely clear to you at this point, don't worry. It 
 
 ## Execution states
 
+<!-- TODO(human): document chat goal lifecycle transitions. -->
+
 A chat's execution state lets the chat worker and the HTTP endpoints decide what they can do with the chat. In total, there are 13 execution states. The states are decided by what's in the database:
 
 - By whether a chat exists;

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1104,13 +1104,22 @@ var (
 	ErrNothingToClear = xerrors.New("nothing to clear")
 	// ErrChatGoalInvalidMutation indicates a malformed goal mutation request.
 	ErrChatGoalInvalidMutation = xerrors.New("invalid chat goal mutation")
+	// ErrChatGoalNotFound indicates the requested goal does not match the
+	// current goal.
+	ErrChatGoalNotFound = xerrors.New("chat goal not found")
 	// ErrChatGoalNotRoot indicates goal mutation was attempted on a child chat.
 	ErrChatGoalNotRoot = xerrors.New("chat goal mutations require a root chat")
 	// ErrChatGoalBusy indicates a message-bound goal mutation cannot be queued.
 	ErrChatGoalBusy = xerrors.New("chat is busy")
-	// ErrChatGoalPlanMode indicates a goal set was rejected because plan mode is on.
-	// Plan-mode turns exclude goal completion behavior, so an active goal set
-	// alongside plan mode could never complete or resume.
+	// ErrChatGoalResumeBusy indicates a resume was rejected because the
+	// chat is busy or has queued input.
+	ErrChatGoalResumeBusy = xerrors.New("cannot resume goal while chat is busy")
+	// ErrChatGoalResumePlanMode indicates a resume was rejected because
+	// plan mode is on.
+	ErrChatGoalResumePlanMode = xerrors.New("cannot resume goal while plan mode is on")
+	// ErrChatGoalPlanMode indicates a goal set was rejected because plan
+	// mode is on. Plan-mode turns exclude goal completion behavior, so an
+	// active goal set alongside plan mode could never complete or resume.
 	ErrChatGoalPlanMode = xerrors.New("cannot set a goal while plan mode is on")
 )
 
@@ -1237,6 +1246,151 @@ func (*ChatGoalMutationError) Is(target error) bool {
 	return target == ErrChatGoalInvalidMutation
 }
 
+const defaultUserCompletionSummary = "Marked complete by user."
+
+// ApplyGoalMutationOptions controls a goal mutation sent without a
+// chat message.
+type ApplyGoalMutationOptions struct {
+	ChatID    uuid.UUID
+	CreatedBy uuid.UUID
+	Mutation  codersdk.ChatGoalUpdateRequest
+}
+
+// ApplyGoalMutationResult contains the current goal state after a mutation.
+type ApplyGoalMutationResult struct {
+	Goal *database.ChatGoal
+}
+
+// ApplyGoalMutation applies a goal lifecycle mutation without sending a
+// chat message. Completing a running goal requests interruption so the
+// active turn can drain partial output and stop. Resuming a paused goal
+// starts a turn on the idle chat via a hidden kick message; resume is
+// rejected while the chat is busy, has queued input, or plan mode is on
+// so an active goal never lands on a chat that is not working.
+//
+//nolint:staticcheck // Keep receiver naming consistent within this file.
+func (p *Server) ApplyGoalMutation(ctx context.Context, opts ApplyGoalMutationOptions) (ApplyGoalMutationResult, error) {
+	if opts.ChatID == uuid.Nil {
+		return ApplyGoalMutationResult{}, xerrors.New("chat_id is required")
+	}
+	mutation, err := normalizeMetadataGoalMutation(opts.Mutation)
+	if err != nil {
+		return ApplyGoalMutationResult{}, err
+	}
+	var result ApplyGoalMutationResult
+	var eventChat database.Chat
+	var publishStatusChange bool
+	machine := p.newChatMachine(opts.ChatID)
+	updateErr := machine.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		publishStatusChange = false
+		lockedChat, err := store.GetChatByID(ctx, opts.ChatID)
+		if err != nil {
+			return xerrors.Errorf("load chat: %w", err)
+		}
+		if lockedChat.Archived {
+			return ErrChatArchived
+		}
+		if !isRootChat(lockedChat) {
+			return ErrChatGoalNotRoot
+		}
+		if mutation.Action == codersdk.ChatGoalMutationActionResume {
+			if err := validateGoalResumeAdmission(ctx, store, lockedChat); err != nil {
+				return err
+			}
+		}
+		goal, err := applyGoalMutation(ctx, store, lockedChat.ID, 0, opts.CreatedBy, mutation)
+		if err != nil {
+			return err
+		}
+		eventChat = lockedChat
+		switch {
+		case mutation.Action == codersdk.ChatGoalMutationActionComplete &&
+			(lockedChat.Status == database.ChatStatusRunning || lockedChat.Status == database.ChatStatusRequiresAction):
+			if _, err := tx.Interrupt(chatstate.InterruptInput{Reason: "Chat goal marked complete by user"}); err != nil {
+				return xerrors.Errorf("interrupt completed chat goal run: %w", err)
+			}
+			latest, err := store.GetChatByID(ctx, opts.ChatID)
+			if err != nil {
+				return xerrors.Errorf("reload chat after goal mutation interruption: %w", err)
+			}
+			eventChat = latest
+			publishStatusChange = true
+		case mutation.Action == codersdk.ChatGoalMutationActionResume:
+			// Start a turn in the same transaction so the goal never
+			// commits as active on an idle chat. A kick insert failure
+			// rolls back the resume.
+			if err := sendGoalResumeKick(ctx, tx, store, lockedChat, goal.ID); err != nil {
+				return err
+			}
+			latest, err := store.GetChatByID(ctx, opts.ChatID)
+			if err != nil {
+				return xerrors.Errorf("reload chat after goal resume kick: %w", err)
+			}
+			eventChat = latest
+			publishStatusChange = true
+		}
+		result.Goal = goal
+		return nil
+	})
+	if updateErr != nil {
+		return ApplyGoalMutationResult{}, updateErr
+	}
+	if result.Goal != nil {
+		p.publishChatGoalChange(eventChat)
+	}
+	if publishStatusChange {
+		p.publishChatPubsubEvent(eventChat, codersdk.ChatWatchEventKindStatusChange, nil)
+	}
+	return result, nil
+}
+
+// validateGoalResumeAdmission rejects a goal resume unless the chat is
+// idle with no queued input and plan mode is off. Queued input wins over
+// the goal because queue promotion starts its own turn.
+func validateGoalResumeAdmission(ctx context.Context, store database.Store, chat database.Chat) error {
+	if chat.PlanMode.Valid && chat.PlanMode.ChatPlanMode == database.ChatPlanModePlan {
+		return ErrChatGoalResumePlanMode
+	}
+	queued, err := store.CountChatQueuedMessages(ctx, chat.ID)
+	if err != nil {
+		return xerrors.Errorf("count queued messages: %w", err)
+	}
+	switch chatstate.ClassifyExecutionState(chat, queued > 0, true) {
+	case chatstate.StateW, chatstate.StateE0:
+	default:
+		return ErrChatGoalResumeBusy
+	}
+	return nil
+}
+
+// sendGoalResumeKick inserts the hidden user message that starts the
+// resumed goal's turn. The chat is idle (W/E0), so SendMessage inserts
+// directly into history and the chat lands in running for the worker
+// pool to pick up.
+func sendGoalResumeKick(
+	ctx context.Context,
+	tx *chatstate.Tx,
+	store database.Store,
+	chat database.Chat,
+	goalID uuid.UUID,
+) error {
+	modelConfigID, err := resolveSendMessageModelConfigID(ctx, store, chat, uuid.Nil)
+	if err != nil {
+		return err
+	}
+	message, err := goalResumeKickMessage(goalID, modelConfigID, chat.OwnerID)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.SendMessage(chatstate.SendMessageInput{
+		Message:      message,
+		BusyBehavior: chatstate.BusyBehaviorQueue,
+	}); err != nil {
+		return xerrors.Errorf("send goal resume kick: %w", err)
+	}
+	return nil
+}
+
 func isRootChat(chat database.Chat) bool {
 	return !chat.ParentChatID.Valid
 }
@@ -1268,6 +1422,16 @@ func validateGoalObjectiveLength(objective string) error {
 		return &ChatGoalMutationError{Message: fmt.Sprintf(
 			"goal objective must be at most %d bytes",
 			codersdk.MaxChatGoalObjectiveBytes,
+		)}
+	}
+	return nil
+}
+
+func validateGoalCompletionSummaryLength(summary string) error {
+	if len(summary) > codersdk.MaxChatGoalCompletionSummaryBytes {
+		return &ChatGoalMutationError{Message: fmt.Sprintf(
+			"goal completion_summary must be at most %d bytes",
+			codersdk.MaxChatGoalCompletionSummaryBytes,
 		)}
 	}
 	return nil
@@ -1327,6 +1491,57 @@ func applyGoalObjectiveOverride(mutation *codersdk.ChatGoalMutation, result *cha
 	return &updated, nil
 }
 
+func normalizeMetadataGoalMutation(req codersdk.ChatGoalUpdateRequest) (codersdk.ChatGoalMutation, error) {
+	normalized := codersdk.ChatGoalMutation{
+		Action:            codersdk.ChatGoalMutationAction(req.Action),
+		GoalID:            req.GoalID,
+		CompletionSummary: req.CompletionSummary,
+	}
+	if normalized.CompletionSummary != nil {
+		summary := strings.TrimSpace(*normalized.CompletionSummary)
+		normalized.CompletionSummary = &summary
+	}
+
+	switch normalized.Action {
+	case codersdk.ChatGoalMutationActionClear,
+		codersdk.ChatGoalMutationActionPause,
+		codersdk.ChatGoalMutationActionResume:
+		if normalized.GoalID == nil || *normalized.GoalID == uuid.Nil {
+			return codersdk.ChatGoalMutation{}, &ChatGoalMutationError{Message: "goal_id is required"}
+		}
+		if normalized.CompletionSummary != nil {
+			return codersdk.ChatGoalMutation{}, &ChatGoalMutationError{Message: "completion_summary is only allowed when completing a goal"}
+		}
+	case codersdk.ChatGoalMutationActionComplete:
+		if normalized.GoalID == nil || *normalized.GoalID == uuid.Nil {
+			return codersdk.ChatGoalMutation{}, &ChatGoalMutationError{Message: "goal_id is required"}
+		}
+		if normalized.CompletionSummary == nil || *normalized.CompletionSummary == "" {
+			summary := defaultUserCompletionSummary
+			normalized.CompletionSummary = &summary
+		}
+		if err := validateGoalCompletionSummaryLength(*normalized.CompletionSummary); err != nil {
+			return codersdk.ChatGoalMutation{}, err
+		}
+	case codersdk.ChatGoalMutationActionSet:
+		return codersdk.ChatGoalMutation{}, &ChatGoalMutationError{Message: "set goal mutations must be sent with a chat message"}
+	default:
+		return codersdk.ChatGoalMutation{}, &ChatGoalMutationError{Message: "unsupported goal_mutation action"}
+	}
+	return normalized, nil
+}
+
+func requireCurrentChatGoal(ctx context.Context, db database.Store, rootChatID uuid.UUID, expectedID *uuid.UUID) (database.ChatGoal, error) {
+	current, err := currentChatGoal(ctx, db, rootChatID)
+	if err != nil {
+		return database.ChatGoal{}, err
+	}
+	if current == nil || current.ID != *expectedID {
+		return database.ChatGoal{}, ErrChatGoalNotFound
+	}
+	return *current, nil
+}
+
 func applyGoalMutation(
 	ctx context.Context,
 	tx database.Store,
@@ -1353,9 +1568,89 @@ func applyGoalMutation(
 			return nil, xerrors.Errorf("insert active chat goal: %w", err)
 		}
 		return &goal, nil
+	case codersdk.ChatGoalMutationActionClear:
+		// Only the current goal may be cleared. Without this check a
+		// stale goal ID could clear a historical completed goal after a
+		// newer goal became current.
+		_, err := requireCurrentChatGoal(ctx, tx, rootChatID, mutation.GoalID)
+		if err != nil {
+			return nil, err
+		}
+		goal, err := tx.ClearChatGoalByID(ctx, database.ClearChatGoalByIDParams{
+			RootChatID: rootChatID,
+			ID:         *mutation.GoalID,
+		})
+		if err != nil {
+			return nil, goalMutationUpdateError("clear chat goal", err)
+		}
+		return &goal, nil
+	case codersdk.ChatGoalMutationActionPause:
+		current, err := requireCurrentChatGoal(ctx, tx, rootChatID, mutation.GoalID)
+		if err != nil {
+			return nil, err
+		}
+		if current.Status != database.ChatGoalStatusActive {
+			return nil, &ChatGoalMutationError{Message: "current goal is not active"}
+		}
+		goal, err := tx.PauseChatGoalByID(ctx, database.PauseChatGoalByIDParams{
+			RootChatID: rootChatID,
+			ID:         *mutation.GoalID,
+		})
+		if err != nil {
+			return nil, goalMutationUpdateError("pause chat goal", err)
+		}
+		return &goal, nil
+	case codersdk.ChatGoalMutationActionResume:
+		current, err := requireCurrentChatGoal(ctx, tx, rootChatID, mutation.GoalID)
+		if err != nil {
+			return nil, err
+		}
+		if current.Status != database.ChatGoalStatusPaused {
+			return nil, &ChatGoalMutationError{Message: "current goal is not paused"}
+		}
+		goal, err := tx.ResumeChatGoalByID(ctx, database.ResumeChatGoalByIDParams{
+			RootChatID: rootChatID,
+			ID:         *mutation.GoalID,
+		})
+		if err != nil {
+			return nil, goalMutationUpdateError("resume chat goal", err)
+		}
+		return &goal, nil
+	case codersdk.ChatGoalMutationActionComplete:
+		current, err := requireCurrentChatGoal(ctx, tx, rootChatID, mutation.GoalID)
+		if err != nil {
+			return nil, err
+		}
+		if current.Status != database.ChatGoalStatusActive {
+			return nil, &ChatGoalMutationError{Message: "current goal is not active"}
+		}
+		goal, err := tx.CompleteChatGoalByID(ctx, database.CompleteChatGoalByIDParams{
+			RootChatID: rootChatID,
+			ID:         *mutation.GoalID,
+			CompletionSummary: sql.NullString{
+				String: *mutation.CompletionSummary,
+				Valid:  true,
+			},
+			CompletedByUserID: uuid.NullUUID{
+				UUID:  createdBy,
+				Valid: createdBy != uuid.Nil,
+			},
+			CompletedByAgent: false,
+		})
+		if err != nil {
+			return nil, goalMutationUpdateError("complete chat goal", err)
+		}
+		return &goal, nil
 	default:
 		return nil, &ChatGoalMutationError{Message: "unsupported goal_mutation action"}
 	}
+}
+
+func goalMutationUpdateError(action string, err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrChatGoalNotFound
+	}
+	return xerrors.Errorf("%s: %w", action, err)
 }
 
 // forcedMCPServerConfigsForOwner filters enabled Force On configs

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	skillspkg "github.com/coder/coder/v2/coderd/x/skills"
 	"github.com/coder/coder/v2/codersdk"
@@ -1792,6 +1793,105 @@ func requireFieldValue(t *testing.T, entry slog.SinkEntry, name string, expected
 	t.Fatalf("field %q not found in log entry", name)
 }
 
+func TestApplyGoalMutationCompleteInterruptsRunningChat(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	f := newWorkerTestFixture(t)
+	chat := f.createRunningChat(t)
+	goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: f.user.ID,
+	})
+	require.NoError(t, err)
+
+	pubsub := newRecordingPubsub(f.pubsub)
+	server := &Server{
+		db:     f.db,
+		pubsub: pubsub,
+		logger: testutil.Logger(t),
+		clock:  quartz.NewReal(),
+	}
+	summary := "done by user"
+	result, err := server.ApplyGoalMutation(dbauthz.AsSystemRestricted(ctx), ApplyGoalMutationOptions{
+		ChatID:    chat.ID,
+		CreatedBy: f.user.ID,
+		Mutation: codersdk.ChatGoalUpdateRequest{
+			Action:            codersdk.ChatGoalUpdateActionComplete,
+			GoalID:            &goal.ID,
+			CompletionSummary: &summary,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Goal)
+	require.Equal(t, database.ChatGoalStatusComplete, result.Goal.Status)
+
+	latest, err := f.db.GetChatByID(dbauthz.AsSystemRestricted(ctx), chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusInterrupting, latest.Status)
+
+	var sawGoalChange bool
+	var sawStatusChange bool
+	for _, event := range pubsub.watchEvents(t) {
+		if event.Chat.ID != chat.ID {
+			continue
+		}
+		switch event.Kind {
+		case codersdk.ChatWatchEventKindGoalChange:
+			sawGoalChange = true
+		case codersdk.ChatWatchEventKindStatusChange:
+			sawStatusChange = true
+			require.Equal(t, codersdk.ChatStatusInterrupting, event.Chat.Status)
+		}
+	}
+	require.True(t, sawGoalChange)
+	require.True(t, sawStatusChange)
+}
+
+// Completing a goal while the chat is parked in requires_action must
+// cancel the pending client-executed tool call instead of leaving the
+// user to act on an already-completed goal.
+func TestApplyGoalMutationCompleteInterruptsRequiresActionChat(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	f := newWorkerTestFixture(t)
+	chat := f.createRequiresActionChat(t)
+	goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: f.user.ID,
+	})
+	require.NoError(t, err)
+
+	pubsub := newRecordingPubsub(f.pubsub)
+	server := &Server{
+		db:     f.db,
+		pubsub: pubsub,
+		logger: testutil.Logger(t),
+		clock:  quartz.NewReal(),
+	}
+	summary := "done by user"
+	result, err := server.ApplyGoalMutation(dbauthz.AsSystemRestricted(ctx), ApplyGoalMutationOptions{
+		ChatID:    chat.ID,
+		CreatedBy: f.user.ID,
+		Mutation: codersdk.ChatGoalUpdateRequest{
+			Action:            codersdk.ChatGoalUpdateActionComplete,
+			GoalID:            &goal.ID,
+			CompletionSummary: &summary,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Goal)
+	require.Equal(t, database.ChatGoalStatusComplete, result.Goal.Status)
+
+	latest, err := f.db.GetChatByID(dbauthz.AsSystemRestricted(ctx), chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusRunning, latest.Status,
+		"pending action must be canceled and the chat handed back to the runner")
+}
+
 func TestExclusiveGenerationToolNames(t *testing.T) {
 	t.Parallel()
 	require.Nil(t, exclusiveGenerationToolNames(false, false))
@@ -1839,6 +1939,189 @@ func TestCurrentChatGoalOrdersBySerializedGoalOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, current)
 	require.Equal(t, second.ID, current.ID)
+}
+
+func TestApplyGoalMutationResumeStartsTurn(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	f := newWorkerTestFixture(t)
+	chat := f.createRunningChat(t)
+	goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: f.user.ID,
+	})
+	require.NoError(t, err)
+	_, err = f.db.PauseChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.PauseChatGoalByIDParams{
+		RootChatID: chat.ID,
+		ID:         goal.ID,
+	})
+	require.NoError(t, err)
+	_, err = f.db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	pubsub := newRecordingPubsub(f.pubsub)
+	server := &Server{
+		db:          f.db,
+		pubsub:      pubsub,
+		logger:      testutil.Logger(t),
+		clock:       quartz.NewReal(),
+		experiments: codersdk.Experiments{codersdk.ExperimentChatGoals},
+	}
+	result, err := server.ApplyGoalMutation(dbauthz.AsSystemRestricted(ctx), ApplyGoalMutationOptions{
+		ChatID:    chat.ID,
+		CreatedBy: f.user.ID,
+		Mutation: codersdk.ChatGoalUpdateRequest{
+			Action: codersdk.ChatGoalUpdateActionResume,
+			GoalID: &goal.ID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Goal)
+	require.Equal(t, database.ChatGoalStatusActive, result.Goal.Status)
+
+	latest, err := f.db.GetChatByID(dbauthz.AsSystemRestricted(ctx), chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusRunning, latest.Status)
+
+	hidden, err := f.db.GetChatHiddenUserMessagesByChatID(dbauthz.AsSystemRestricted(ctx), chat.ID)
+	require.NoError(t, err)
+	var kicks []database.ChatMessage
+	for _, msg := range hidden {
+		kickGoalID, kick, err := parseGoalResumeKickMessage(msg)
+		require.NoError(t, err)
+		if kick {
+			require.Equal(t, goal.ID, kickGoalID)
+			kicks = append(kicks, msg)
+		}
+	}
+	require.Len(t, kicks, 1)
+	kick := kicks[0]
+	require.Equal(t, database.ChatMessageRoleUser, kick.Role)
+	require.Equal(t, database.ChatMessageVisibilityModel, kick.Visibility)
+	require.Equal(t, f.model.ID, kick.ModelConfigID.UUID)
+	require.Equal(t, f.user.ID, kick.CreatedBy.UUID)
+
+	var sawGoalChange bool
+	var sawStatusChange bool
+	for _, event := range pubsub.watchEvents(t) {
+		if event.Chat.ID != chat.ID {
+			continue
+		}
+		switch event.Kind {
+		case codersdk.ChatWatchEventKindGoalChange:
+			sawGoalChange = true
+		case codersdk.ChatWatchEventKindStatusChange:
+			sawStatusChange = true
+			require.Equal(t, codersdk.ChatStatusRunning, event.Chat.Status)
+		}
+	}
+	require.True(t, sawGoalChange)
+	require.True(t, sawStatusChange)
+}
+
+func TestApplyGoalMutationResumeRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, ctx context.Context, f *workerTestFixture, chat database.Chat)
+		wantErr error
+	}{
+		{
+			name:    "RunningChat",
+			setup:   func(*testing.T, context.Context, *workerTestFixture, database.Chat) {},
+			wantErr: ErrChatGoalResumeBusy,
+		},
+		{
+			name: "ErrorChatWithQueuedMessage",
+			setup: func(t *testing.T, ctx context.Context, f *workerTestFixture, chat database.Chat) {
+				machine := chatstate.NewChatMachine(f.db, f.pubsub, chat.ID)
+				require.NoError(t, machine.Update(ctx, func(tx *chatstate.Tx, _ database.Store) error {
+					_, err := tx.SendMessage(chatstate.SendMessageInput{
+						Message:      userTextMessage(t, "queued while running", f.user.ID, f.model.ID, f.apiKey.ID),
+						BusyBehavior: chatstate.BusyBehaviorQueue,
+					})
+					return err
+				}))
+				_, err := f.db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+					ID:     chat.ID,
+					Status: database.ChatStatusError,
+				})
+				require.NoError(t, err)
+			},
+			wantErr: ErrChatGoalResumeBusy,
+		},
+		{
+			name: "PlanMode",
+			setup: func(t *testing.T, ctx context.Context, f *workerTestFixture, chat database.Chat) {
+				_, err := f.db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+					ID:     chat.ID,
+					Status: database.ChatStatusWaiting,
+				})
+				require.NoError(t, err)
+				_, err = f.db.UpdateChatPlanModeByID(dbauthz.AsSystemRestricted(ctx), database.UpdateChatPlanModeByIDParams{
+					ID: chat.ID,
+					PlanMode: database.NullChatPlanMode{
+						ChatPlanMode: database.ChatPlanModePlan,
+						Valid:        true,
+					},
+				})
+				require.NoError(t, err)
+			},
+			wantErr: ErrChatGoalResumePlanMode,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			f := newWorkerTestFixture(t)
+			chat := f.createRunningChat(t)
+			goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+				RootChatID:      chat.ID,
+				Objective:       "finish the work",
+				CreatedByUserID: f.user.ID,
+			})
+			require.NoError(t, err)
+			_, err = f.db.PauseChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.PauseChatGoalByIDParams{
+				RootChatID: chat.ID,
+				ID:         goal.ID,
+			})
+			require.NoError(t, err)
+			tc.setup(t, ctx, f, chat)
+
+			server := &Server{
+				db:          f.db,
+				pubsub:      f.pubsub,
+				logger:      testutil.Logger(t),
+				clock:       quartz.NewReal(),
+				experiments: codersdk.Experiments{codersdk.ExperimentChatGoals},
+			}
+			_, err = server.ApplyGoalMutation(dbauthz.AsSystemRestricted(ctx), ApplyGoalMutationOptions{
+				ChatID:    chat.ID,
+				CreatedBy: f.user.ID,
+				Mutation: codersdk.ChatGoalUpdateRequest{
+					Action: codersdk.ChatGoalUpdateActionResume,
+					GoalID: &goal.ID,
+				},
+			})
+			require.ErrorIs(t, err, tc.wantErr)
+
+			latest, err := currentChatGoal(dbauthz.AsSystemRestricted(ctx), f.db, chat.ID)
+			require.NoError(t, err)
+			require.NotNil(t, latest)
+			require.Equal(t, goal.ID, latest.ID)
+			require.Equal(t, database.ChatGoalStatusPaused, latest.Status)
+		})
+	}
 }
 
 func TestActiveGoalSystemPrompt(t *testing.T) {

--- a/coderd/x/chatd/generation.go
+++ b/coderd/x/chatd/generation.go
@@ -437,7 +437,7 @@ func (s *taskStarter) StartGeneration(ctx context.Context, input chatWorkerTaskS
 	}
 	machine := chatstate.NewChatMachine(s.opts.Store, s.opts.Pubsub, input.ChatID)
 	for {
-		chat, messages, err := loadGenerationState(ctx, machine, input)
+		chat, messages, err := s.loadGenerationState(ctx, machine, input)
 		if err != nil {
 			return xerrors.Errorf("load generation state: %w", err)
 		}
@@ -566,7 +566,22 @@ func (s *taskStarter) StartGeneration(ctx context.Context, input chatWorkerTaskS
 	}
 }
 
-func loadGenerationState(
+// goalHistoryEnabled reports whether hidden goal rows can exist for
+// the chat and should join decision history. Goal rows persist across
+// every status transition, so the existence check is a stable gate
+// that spares goalless chats the hidden-history read on each pass.
+func (s *taskStarter) goalHistoryEnabled(ctx context.Context, store database.Store, chat database.Chat) (bool, error) {
+	if s.server == nil || !s.server.experiments.Enabled(codersdk.ExperimentChatGoals) || !isRootChat(chat) {
+		return false, nil
+	}
+	exists, err := store.ChatGoalExistsByRootChatID(ctx, chat.ID)
+	if err != nil {
+		return false, xerrors.Errorf("check chat goal existence: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *taskStarter) loadGenerationState(
 	ctx context.Context,
 	machine *chatstate.ChatMachine,
 	input chatWorkerTaskStartInput,
@@ -578,12 +593,13 @@ func loadGenerationState(
 		if err != nil {
 			return xerrors.Errorf("load chat for task: %w", err)
 		}
-		loadedMessages, err := store.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-			ChatID:  input.ChatID,
-			AfterID: 0,
-		})
+		includeGoalRows, err := s.goalHistoryEnabled(ctx, store, loadedChat)
 		if err != nil {
-			return xerrors.Errorf("load chat messages: %w", err)
+			return err
+		}
+		loadedMessages, err := loadDecisionMessages(ctx, store, input.ChatID, includeGoalRows)
+		if err != nil {
+			return err
 		}
 		chat = loadedChat
 		messages = loadedMessages
@@ -593,6 +609,34 @@ func loadGenerationState(
 		return database.Chat{}, nil, normalizeTaskInfrastructureError(err, "lock chat for generation")
 	}
 	return chat, messages, nil
+}
+
+// loadDecisionMessages loads the message history that generation
+// decisions operate on: all user-visible messages plus, when goal rows
+// can exist for the chat, model-only goal messages (resume kicks). Goal
+// rows are loaded independently of the compaction prompt window so turn
+// boundaries stay visible when a compaction summary hides earlier rows
+// from the prompt. Skipping the
+// hidden-row scan for goalless chats keeps every generation step from
+// re-reading full history under the chat machine lock.
+//
+//nolint:revive // includeGoalRows states whether goal rows can exist for the chat, not caller control coupling.
+func loadDecisionMessages(ctx context.Context, store database.Store, chatID uuid.UUID, includeGoalRows bool) ([]database.ChatMessage, error) {
+	loaded, err := store.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:  chatID,
+		AfterID: 0,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("load chat messages: %w", err)
+	}
+	if !includeGoalRows {
+		return loaded, nil
+	}
+	hidden, err := store.GetChatHiddenUserMessagesByChatID(ctx, chatID)
+	if err != nil {
+		return nil, xerrors.Errorf("load hidden chat messages: %w", err)
+	}
+	return appendHiddenGoalMessages(loaded, hidden)
 }
 
 func (*taskStarter) recordGenerationRetry(

--- a/coderd/x/chatd/generation_internal_test.go
+++ b/coderd/x/chatd/generation_internal_test.go
@@ -1,18 +1,41 @@
 package chatd //nolint:testpackage // Exercises unexported generation helpers.
 
 import (
+	"context"
 	"testing"
 
 	"charm.land/fantasy"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatloop"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
 	"github.com/coder/coder/v2/testutil"
 )
+
+// The strict mock fails the test if the goalless path still scans
+// hidden rows via GetChatHiddenUserMessagesByChatID.
+func TestLoadDecisionMessagesSkipsHiddenScanWithoutGoalRows(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	store := dbmock.NewMockStore(ctrl)
+	chatID := uuid.New()
+	want := []database.ChatMessage{{ID: 7, Role: database.ChatMessageRoleUser}}
+	store.EXPECT().
+		GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{ChatID: chatID}).
+		Return(want, nil)
+
+	messages, err := loadDecisionMessages(context.Background(), store, chatID, false)
+	require.NoError(t, err)
+	require.Equal(t, want, messages)
+}
 
 func TestExclusiveBatchRejected(t *testing.T) {
 	t.Parallel()

--- a/coderd/x/chatd/goal_continuation.go
+++ b/coderd/x/chatd/goal_continuation.go
@@ -1,0 +1,141 @@
+package chatd
+
+import (
+	"cmp"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+const (
+	goalResumeKickOpenTag  = "<goal-resumed>"
+	goalResumeKickCloseTag = "</goal-resumed>"
+)
+
+func goalTaggedPayload(goalID uuid.UUID, openTag, closeTag string) (string, error) {
+	payload, err := json.Marshal(struct {
+		GoalID string `json:"goal_id"`
+	}{
+		GoalID: goalID.String(),
+	})
+	if err != nil {
+		return "", xerrors.Errorf("marshal goal message payload: %w", err)
+	}
+	return openTag + "\n" + string(payload) + "\n" + closeTag, nil
+}
+
+func goalResumeKickText(goalID uuid.UUID) (string, error) {
+	tagged, err := goalTaggedPayload(goalID, goalResumeKickOpenTag, goalResumeKickCloseTag)
+	if err != nil {
+		return "", err
+	}
+	return tagged + "\n\n" +
+		"The user resumed the chat goal.\n" +
+		"Continue working toward the objective.\n" +
+		"Call complete_goal with this goal_id when the objective is verifiably done.", nil
+}
+
+func hiddenGoalUserMessage(text string, modelConfigID uuid.UUID, createdBy uuid.UUID) (chatstate.Message, error) {
+	content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{codersdk.ChatMessageText(text)})
+	if err != nil {
+		return chatstate.Message{}, xerrors.Errorf("marshal hidden goal message: %w", err)
+	}
+	return chatstate.Message{
+		Role:           database.ChatMessageRoleUser,
+		Content:        content,
+		Visibility:     database.ChatMessageVisibilityModel,
+		ModelConfigID:  uuid.NullUUID{UUID: modelConfigID, Valid: modelConfigID != uuid.Nil},
+		CreatedBy:      uuid.NullUUID{UUID: createdBy, Valid: createdBy != uuid.Nil},
+		ContentVersion: chatprompt.CurrentContentVersion,
+	}, nil
+}
+
+// goalResumeKickMessage builds the hidden user message that starts a
+// turn when a paused goal is resumed on an idle chat. It is a real turn
+// boundary: step counting and stop-after scoping reset at the kick.
+func goalResumeKickMessage(goalID uuid.UUID, modelConfigID uuid.UUID, createdBy uuid.UUID) (chatstate.Message, error) {
+	text, err := goalResumeKickText(goalID)
+	if err != nil {
+		return chatstate.Message{}, err
+	}
+	return hiddenGoalUserMessage(text, modelConfigID, createdBy)
+}
+
+// appendHiddenGoalMessages merges model-only goal messages (resume
+// kicks) from promptRows into messages. Generation decisions need them
+// because they open the turn the decision loop is driving.
+func appendHiddenGoalMessages(messages []database.ChatMessage, promptRows []database.ChatMessage) ([]database.ChatMessage, error) {
+	seen := make(map[int64]struct{}, len(messages))
+	for _, msg := range messages {
+		seen[msg.ID] = struct{}{}
+	}
+	for _, msg := range promptRows {
+		if _, ok := seen[msg.ID]; ok {
+			continue
+		}
+		hidden, err := isHiddenGoalMessage(msg)
+		if err != nil {
+			return nil, err
+		}
+		if hidden {
+			messages = append(messages, msg)
+			seen[msg.ID] = struct{}{}
+		}
+	}
+	slices.SortFunc(messages, func(a, b database.ChatMessage) int {
+		return cmp.Compare(a.ID, b.ID)
+	})
+	return messages, nil
+}
+
+func isHiddenGoalMessage(msg database.ChatMessage) (bool, error) {
+	_, kick, err := parseGoalResumeKickMessage(msg)
+	return kick, err
+}
+
+func isGoalTurnBoundaryMessageBestEffort(msg database.ChatMessage) bool {
+	_, resume, err := parseGoalResumeKickMessage(msg)
+	return err == nil && resume
+}
+
+func parseGoalResumeKickMessage(msg database.ChatMessage) (uuid.UUID, bool, error) {
+	return parseGoalTaggedMessage(msg, goalResumeKickOpenTag, goalResumeKickCloseTag)
+}
+
+func parseGoalTaggedMessage(msg database.ChatMessage, openTag, closeTag string) (uuid.UUID, bool, error) {
+	if msg.Role != database.ChatMessageRoleUser || msg.Visibility != database.ChatMessageVisibilityModel {
+		return uuid.Nil, false, nil
+	}
+	parts, err := chatprompt.ParseContent(msg)
+	if err != nil {
+		return uuid.Nil, false, xerrors.Errorf("parse goal tagged message candidate: %w", err)
+	}
+	text := textFromParts(parts)
+	remainder, ok := strings.CutPrefix(text, openTag+"\n")
+	if !ok {
+		return uuid.Nil, false, nil
+	}
+	payload, _, ok := strings.Cut(remainder, "\n"+closeTag)
+	if !ok {
+		return uuid.Nil, false, nil
+	}
+	var data struct {
+		GoalID string `json:"goal_id"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(payload)), &data); err != nil {
+		return uuid.Nil, false, nil
+	}
+	goalID, err := uuid.Parse(data.GoalID)
+	if err != nil {
+		return uuid.Nil, false, nil
+	}
+	return goalID, true, nil
+}

--- a/coderd/x/chatd/goal_continuation_internal_test.go
+++ b/coderd/x/chatd/goal_continuation_internal_test.go
@@ -1,0 +1,100 @@
+package chatd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatstate"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestGoalHistoryEnabledRequiresGoalRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	f := newWorkerTestFixture(t)
+	chat, _ := setupGoalTurn(ctx, t, f)
+	starter := newGoalTaskStarter(t, f)
+
+	enabled, err := starter.goalHistoryEnabled(ctx, f.db, chat)
+	require.NoError(t, err)
+	require.False(t, enabled, "a chat that never had a goal must skip the hidden-history read")
+
+	insertActiveGoal(ctx, t, f, chat.ID)
+	enabled, err = starter.goalHistoryEnabled(ctx, f.db, chat)
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func setupGoalTurn(ctx context.Context, t *testing.T, f *workerTestFixture) (database.Chat, chatWorkerTaskStartInput) {
+	t.Helper()
+	chat := f.createRunningChat(t)
+	workerID := uuid.New()
+	runnerID := uuid.New()
+	chat = acquireChat(t, f, chat.ID, workerID, runnerID)
+	machine := chatstate.NewChatMachine(f.db, f.pubsub, chat.ID)
+	require.NoError(t, machine.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		_, err := tx.CommitStep(chatstate.CommitStepInput{
+			Messages: []chatstate.Message{assistantTextMessage(t, "done", f.model.ID)},
+		})
+		return err
+	}))
+	chat, err := f.db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	return chat, chatWorkerTaskStartInput{
+		TaskID:            uuid.New(),
+		ChatID:            chat.ID,
+		WorkerID:          workerID,
+		RunnerID:          runnerID,
+		HistoryVersion:    chat.HistoryVersion,
+		GenerationAttempt: chat.GenerationAttempt,
+		Status:            chat.Status,
+		StopNudges:        &stopNudgeTracker{},
+	}
+}
+
+func insertActiveGoal(ctx context.Context, t *testing.T, f *workerTestFixture, rootChatID uuid.UUID) database.ChatGoal {
+	t.Helper()
+	goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      rootChatID,
+		Objective:       "finish the work",
+		CreatedByUserID: f.user.ID,
+	})
+	require.NoError(t, err)
+	return goal
+}
+
+func newGoalTaskStarter(t *testing.T, f *workerTestFixture) *taskStarter {
+	t.Helper()
+	logger := testutil.Logger(t)
+	clock := quartz.NewReal()
+	// The finish paths spawn detached finalize goroutines through
+	// Server.goInflight, so the server needs a lifecycle context and
+	// config cache even in tests.
+	server := &Server{
+		ctx:         context.Background(),
+		db:          f.db,
+		pubsub:      f.pubsub,
+		logger:      logger,
+		clock:       clock,
+		configCache: newChatConfigCache(context.Background(), f.db, clock),
+		experiments: codersdk.Experiments{codersdk.ExperimentChatGoals},
+	}
+	return &taskStarter{
+		server: server,
+		opts: chatWorkerOptions{
+			Store:  f.db,
+			Pubsub: f.pubsub,
+			Logger: logger,
+			Clock:  clock,
+		},
+		routeStateHint: func(context.Context, runnerStateUpdate) {},
+	}
+}

--- a/coderd/x/chatd/message_conversion.go
+++ b/coderd/x/chatd/message_conversion.go
@@ -468,15 +468,15 @@ func hasClearableMessageAfter(messages []database.ChatMessage, index int) bool {
 	return false
 }
 
-// Hook model-context messages use the user role but must not reset
-// per-turn guards.
+// Hook model-context messages use the user role but do not start a new turn.
+// Goal resume messages do.
 func lastUserPromptIndex(messages []database.ChatMessage) int {
 	index := -1
 	for i, msg := range messages {
 		if msg.Deleted || msg.Compressed {
 			continue
 		}
-		if msg.Role == database.ChatMessageRoleUser && msg.Visibility != database.ChatMessageVisibilityModel {
+		if msg.Role == database.ChatMessageRoleUser && (msg.Visibility != database.ChatMessageVisibilityModel || isGoalTurnBoundaryMessageBestEffort(msg)) {
 			index = i
 		}
 	}

--- a/coderd/x/chatd/message_conversion_test.go
+++ b/coderd/x/chatd/message_conversion_test.go
@@ -417,6 +417,22 @@ func TestCurrentTurnStepCount_IgnoresHookModelContext(t *testing.T) {
 	require.Equal(t, 2, got)
 }
 
+// A resume kick starts a turn, so a resumed goal does not inherit the
+// previous run's step count.
+func TestCurrentTurnStepCount_GoalResumeKickStartsNewTurn(t *testing.T) {
+	t.Parallel()
+
+	goalID := uuid.MustParse("01234567-89ab-4def-8123-456789abcdef")
+	messages := []database.ChatMessage{
+		dbMessage(t, 1, database.ChatMessageRoleUser, false, codersdk.ChatMessageText("new")),
+		dbMessage(t, 2, database.ChatMessageRoleAssistant, false, codersdk.ChatMessageText("one")),
+		goalResumeKickDBMessage(t, 3, goalID),
+		dbMessage(t, 4, database.ChatMessageRoleAssistant, false, codersdk.ChatMessageText("two")),
+	}
+	got := currentTurnStepCount(messages)
+	require.Equal(t, 1, got)
+}
+
 func TestDecisionCompactsAgainAfterPostCompactionTurn(t *testing.T) {
 	t.Parallel()
 
@@ -1075,6 +1091,15 @@ func dbMessage(t *testing.T, id int64, role database.ChatMessageRole, compressed
 		Visibility:     database.ChatMessageVisibilityBoth,
 		Compressed:     compressed,
 	}
+}
+
+func goalResumeKickDBMessage(t *testing.T, id int64, goalID uuid.UUID) database.ChatMessage {
+	t.Helper()
+	text, err := goalResumeKickText(goalID)
+	require.NoError(t, err)
+	msg := dbMessage(t, id, database.ChatMessageRoleUser, false, codersdk.ChatMessageText(text))
+	msg.Visibility = database.ChatMessageVisibilityModel
+	return msg
 }
 
 func withUsage(msg database.ChatMessage, inputTokens int64, contextLimit int64) database.ChatMessage {


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

Managing a goal after it exists: the metadata-only mutations the HTTP API (#29021) will expose, without a message.

## What changed

- `Server.ApplyGoalMutation`: clear, pause, resume, and complete with optimistic `goal_id` checks against the current goal. Completing a running or requires-action chat requests an interrupt in the same transaction so the turn drains and stops.
- Resume starts a turn: it is admitted only on an idle chat with no queued input and plan mode off, then inserts a hidden `<goal-resumed>` kick message inside the same transaction so an active goal never lands on an idle chat.
- `goal_continuation.go`: hidden goal message builders and parsers, and `appendHiddenGoalMessages`. Generation decisions load hidden goal rows (`loadDecisionMessages`, gated by `ChatGoalExistsByRootChatID` so goalless chats skip the extra read) because `GetChatMessagesByChatID` excludes model-only rows; without this the decision loop would treat the kicked turn as already complete. `lastUserPromptIndex` treats the kick as a turn boundary so step counting resets.
- Tests: complete-interrupts-running and requires-action chats, resume starts a turn and publishes events, resume rejections, hidden-history gating, and kick boundary handling.

The file is named `goal_continuation.go` from the start so #29023 extends it in place rather than renaming it. Otherwise unchanged from the reviewed #25622.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.
