### PR TITLE
feat(coderd/x/chatd): pause goals on interrupt and protect goal source messages

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1117,6 +1117,9 @@ var (
 	// ErrChatGoalResumePlanMode indicates a resume was rejected because
 	// plan mode is on.
 	ErrChatGoalResumePlanMode = xerrors.New("cannot resume goal while plan mode is on")
+	// ErrChatGoalSourceMessageEdit indicates an edit would rewrite or
+	// truncate away the source message of the current goal.
+	ErrChatGoalSourceMessageEdit = xerrors.New("cannot edit a message that would discard the current goal's source message")
 	// ErrChatGoalPlanMode indicates a goal set was rejected because plan
 	// mode is on. Plan-mode turns exclude goal completion behavior, so an
 	// active goal set alongside plan mode could never complete or resume.
@@ -2298,21 +2301,42 @@ func validateModelConfigOverride(
 	return uuid.NullUUID{UUID: requested, Valid: true}, nil
 }
 
-func validateEditTarget(ctx context.Context, store database.Store, chatID uuid.UUID, messageID int64) error {
+func (p *Server) validateEditTarget(ctx context.Context, store database.Store, chat database.Chat, messageID int64) (database.ChatMessage, error) {
 	target, err := store.GetChatMessageByID(ctx, messageID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ErrEditedMessageNotFound
+			return database.ChatMessage{}, ErrEditedMessageNotFound
 		}
-		return xerrors.Errorf("get edited message: %w", err)
+		return database.ChatMessage{}, xerrors.Errorf("get edited message: %w", err)
 	}
-	if target.ChatID != chatID || target.Deleted {
-		return ErrEditedMessageNotFound
+	if target.ChatID != chat.ID || target.Deleted {
+		return database.ChatMessage{}, ErrEditedMessageNotFound
 	}
 	if target.Role != database.ChatMessageRoleUser {
-		return ErrEditedMessageNotUser
+		return database.ChatMessage{}, ErrEditedMessageNotUser
 	}
-	return nil
+	// Only root-chat edits can touch the goal's source message: the
+	// source row lives in the root history, and message IDs are
+	// allocated globally, so comparing against a child chat's IDs
+	// would misfire even though editing child history cannot delete
+	// the source row.
+	if p.experiments.Enabled(codersdk.ExperimentChatGoals) && isRootChat(chat) {
+		goal, err := currentChatGoal(ctx, store, chat.ID)
+		if err != nil {
+			return database.ChatMessage{}, err
+		}
+		// The source message anchors the current goal's objective, and
+		// an edit soft-deletes every message after the edited target.
+		// Editing the source rewrites it and editing an older message
+		// erases it, in both cases leaving the goal pursuing an
+		// objective the conversation no longer shows, so refuse while
+		// the goal can still run.
+		if goal != nil && goal.CreatedFromMessageID.Valid && goal.CreatedFromMessageID.Int64 >= messageID &&
+			(goal.Status == database.ChatGoalStatusActive || goal.Status == database.ChatGoalStatusPaused) {
+			return database.ChatMessage{}, ErrChatGoalSourceMessageEdit
+		}
+	}
+	return target, nil
 }
 
 func loadEffectiveChatModelConfigs(
@@ -2385,7 +2409,7 @@ func (p *Server) EditMessage(
 		if chat.Archived {
 			return EditMessageResult{}, ErrChatArchived
 		}
-		if err := validateEditTarget(ctx, p.db, opts.ChatID, opts.EditedMessageID); err != nil {
+		if _, err := p.validateEditTarget(ctx, p.db, chat, opts.EditedMessageID); err != nil {
 			return EditMessageResult{}, err
 		}
 		if _, err := validateModelConfigOverride(ctx, p.db, chat.OrganizationID, opts.ModelConfigID); err != nil {
@@ -2434,21 +2458,9 @@ func (p *Server) EditMessage(
 		// Capture the target message for the post-commit debug
 		// cleanup hook below. The transition itself revalidates
 		// chat ownership and user-message constraints.
-		target, err := store.GetChatMessageByID(ctx, opts.EditedMessageID)
+		target, err := p.validateEditTarget(ctx, store, lockedChat, opts.EditedMessageID)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrEditedMessageNotFound
-			}
-			return xerrors.Errorf("get edited message: %w", err)
-		}
-		if target.ChatID != opts.ChatID {
-			return ErrEditedMessageNotFound
-		}
-		if target.Deleted {
-			return ErrEditedMessageNotFound
-		}
-		if target.Role != database.ChatMessageRoleUser {
-			return ErrEditedMessageNotUser
+			return err
 		}
 		editedMsg = target
 
@@ -2895,6 +2907,10 @@ func translateToolResultValidationError(err error) error {
 // transition. Active runs land in `interrupting`; requires-action
 // chats synthesize cancellation messages and return to running.
 //
+// Interrupting a root chat also pauses its active goal in the same
+// transaction: Stop is a halt gesture, and a halted chat must not
+// report an active goal.
+//
 // Returns the post-transition chat and an error so callers can map
 // state conflicts deliberately. Idle chats return a
 // chatstate.ErrTransitionNotAllowed wrapper.
@@ -2907,8 +2923,10 @@ func (p *Server) InterruptChat(
 	}
 
 	var refreshed database.Chat
+	var pausedGoal *database.ChatGoal
 	machine := p.newChatMachine(chat.ID)
 	err := machine.Update(ctx, func(tx *chatstate.Tx, store database.Store) error {
+		pausedGoal = nil
 		if _, err := tx.Interrupt(chatstate.InterruptInput{
 			Reason: "Tool execution interrupted by user",
 		}); err != nil {
@@ -2922,6 +2940,12 @@ func (p *Server) InterruptChat(
 			return xerrors.Errorf("reload chat after interrupt: %w", err)
 		}
 		refreshed = latest
+
+		goal, err := p.pauseActiveGoalOnInterrupt(ctx, store, latest)
+		if err != nil {
+			return err
+		}
+		pausedGoal = goal
 		return nil
 	})
 	if err != nil {
@@ -2929,6 +2953,9 @@ func (p *Server) InterruptChat(
 	}
 
 	p.publishChatPubsubEvent(refreshed, codersdk.ChatWatchEventKindStatusChange, nil)
+	if pausedGoal != nil {
+		p.publishChatGoalChange(refreshed)
+	}
 	return refreshed, nil
 }
 
@@ -3057,6 +3084,38 @@ func (p *Server) ClearChat(
 
 	p.publishChatPubsubEvent(refreshed, codersdk.ChatWatchEventKindStatusChange, nil)
 	return refreshed, nil
+}
+
+// pauseActiveGoalOnInterrupt pauses the chat's active goal as part of a
+// user-initiated interrupt. Returns the paused goal, or nil when there
+// is nothing to pause (goals disabled, child chat, no current goal, or
+// the goal is not active). A concurrent goal transition is tolerated:
+// the interrupt must not fail because the goal changed underneath it.
+func (p *Server) pauseActiveGoalOnInterrupt(ctx context.Context, store database.Store, chat database.Chat) (*database.ChatGoal, error) {
+	if !p.experiments.Enabled(codersdk.ExperimentChatGoals) || !isRootChat(chat) {
+		//nolint:nilnil // Nothing to pause is represented as nil.
+		return nil, nil
+	}
+	current, err := currentChatGoal(ctx, store, chat.ID)
+	if err != nil {
+		return nil, err
+	}
+	if current == nil || current.Status != database.ChatGoalStatusActive {
+		//nolint:nilnil // Nothing to pause is represented as nil.
+		return nil, nil
+	}
+	paused, err := store.PauseChatGoalByID(ctx, database.PauseChatGoalByIDParams{
+		RootChatID: chat.ID,
+		ID:         current.ID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			//nolint:nilnil // The goal left `active` concurrently; nothing to pause.
+			return nil, nil
+		}
+		return nil, xerrors.Errorf("pause chat goal on interrupt: %w", err)
+	}
+	return &paused, nil
 }
 
 // ReconcileInvalidStateChat recovers a chat stuck in an invalid

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1941,6 +1941,118 @@ func TestCurrentChatGoalOrdersBySerializedGoalOrder(t *testing.T) {
 	require.Equal(t, second.ID, current.ID)
 }
 
+func TestInterruptChatPausesActiveGoal(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	f := newWorkerTestFixture(t)
+	chat := f.createRunningChat(t)
+	goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+		RootChatID:      chat.ID,
+		Objective:       "finish the work",
+		CreatedByUserID: f.user.ID,
+	})
+	require.NoError(t, err)
+
+	pubsub := newRecordingPubsub(f.pubsub)
+	server := &Server{
+		db:          f.db,
+		pubsub:      pubsub,
+		logger:      testutil.Logger(t),
+		clock:       quartz.NewReal(),
+		experiments: codersdk.Experiments{codersdk.ExperimentChatGoals},
+	}
+	updated, err := server.InterruptChat(dbauthz.AsSystemRestricted(ctx), chat)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusInterrupting, updated.Status)
+
+	paused, err := currentChatGoal(dbauthz.AsSystemRestricted(ctx), f.db, chat.ID)
+	require.NoError(t, err)
+	require.NotNil(t, paused)
+	require.Equal(t, goal.ID, paused.ID)
+	require.Equal(t, database.ChatGoalStatusPaused, paused.Status)
+
+	var sawGoalChange bool
+	for _, event := range pubsub.watchEvents(t) {
+		if event.Chat.ID == chat.ID && event.Kind == codersdk.ChatWatchEventKindGoalChange {
+			sawGoalChange = true
+			// Goal events carry no goal payload; consumers refetch.
+			require.Nil(t, event.Chat.Goal)
+		}
+	}
+	require.True(t, sawGoalChange)
+}
+
+func TestInterruptChatLeavesGoalUntouched(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		experiments codersdk.Experiments
+		pauseFirst  bool
+		wantStatus  database.ChatGoalStatus
+	}{
+		{
+			name:        "ExperimentDisabled",
+			experiments: codersdk.Experiments{},
+			wantStatus:  database.ChatGoalStatusActive,
+		},
+		{
+			name:        "GoalAlreadyPaused",
+			experiments: codersdk.Experiments{codersdk.ExperimentChatGoals},
+			pauseFirst:  true,
+			wantStatus:  database.ChatGoalStatusPaused,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			f := newWorkerTestFixture(t)
+			chat := f.createRunningChat(t)
+			goal, err := f.db.InsertActiveChatGoal(dbauthz.AsSystemRestricted(ctx), database.InsertActiveChatGoalParams{
+				RootChatID:      chat.ID,
+				Objective:       "finish the work",
+				CreatedByUserID: f.user.ID,
+			})
+			require.NoError(t, err)
+			if tc.pauseFirst {
+				_, err := f.db.PauseChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.PauseChatGoalByIDParams{
+					RootChatID: chat.ID,
+					ID:         goal.ID,
+				})
+				require.NoError(t, err)
+			}
+
+			pubsub := newRecordingPubsub(f.pubsub)
+			server := &Server{
+				db:          f.db,
+				pubsub:      pubsub,
+				logger:      testutil.Logger(t),
+				clock:       quartz.NewReal(),
+				experiments: tc.experiments,
+			}
+			_, err = server.InterruptChat(dbauthz.AsSystemRestricted(ctx), chat)
+			require.NoError(t, err)
+
+			latest, err := currentChatGoal(dbauthz.AsSystemRestricted(ctx), f.db, chat.ID)
+			require.NoError(t, err)
+			require.NotNil(t, latest)
+			require.Equal(t, goal.ID, latest.ID)
+			require.Equal(t, tc.wantStatus, latest.Status)
+
+			for _, event := range pubsub.watchEvents(t) {
+				if event.Chat.ID == chat.ID {
+					require.NotEqual(t, codersdk.ChatWatchEventKindGoalChange, event.Kind)
+				}
+			}
+		})
+	}
+}
+
 func TestApplyGoalMutationResumeStartsTurn(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/hooks_test.go
+++ b/coderd/x/chatd/hooks_test.go
@@ -1146,3 +1146,175 @@ func TestSendMessageGoalOnErroredChatDispatchesHook(t *testing.T) {
 	require.Equal(t, agenthooks.EventUserPromptSubmit, received.Type)
 	require.Equal(t, "recovery objective", decodeHookData[agenthooks.UserPromptSubmitData](t, received).GoalObjective)
 }
+
+// The source message anchors the current goal's objective; editing it
+// would start a turn from new text while the goal pursues the old
+// objective, so the edit is refused until the goal can no longer run.
+func TestEditMessageGoalSourceRejected(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	server := newTestServer(t, db, ps, uuid.New())
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID:     org.ID,
+		OwnerID:            user.ID,
+		Title:              "goal source edit",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("objective text")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "objective text",
+		},
+	})
+	require.NoError(t, err)
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	goals, err := db.GetCurrentChatGoalsByRootChatIDs(dbauthz.AsSystemRestricted(ctx), []uuid.UUID{chat.ID})
+	require.NoError(t, err)
+	require.Len(t, goals, 1)
+	goal := goals[0]
+	require.True(t, goal.CreatedFromMessageID.Valid)
+	sourceID := goal.CreatedFromMessageID.Int64
+
+	edit := func(messageID int64) (chatd.EditMessageResult, error) {
+		return server.EditMessage(ctx, chatd.EditMessageOptions{
+			ChatID:          chat.ID,
+			CreatedBy:       user.ID,
+			EditedMessageID: messageID,
+			Content:         []codersdk.ChatMessagePart{codersdk.ChatMessageText("rewritten")},
+		})
+	}
+	_, err = edit(sourceID)
+	require.ErrorIs(t, err, chatd.ErrChatGoalSourceMessageEdit)
+
+	_, err = db.PauseChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.PauseChatGoalByIDParams{
+		RootChatID: chat.ID,
+		ID:         goal.ID,
+	})
+	require.NoError(t, err)
+	_, err = edit(sourceID)
+	require.ErrorIs(t, err, chatd.ErrChatGoalSourceMessageEdit,
+		"a paused goal can resume, so its source stays locked")
+
+	_, err = db.ResumeChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.ResumeChatGoalByIDParams{
+		RootChatID: chat.ID,
+		ID:         goal.ID,
+	})
+	require.NoError(t, err)
+	_, err = db.CompleteChatGoalByID(dbauthz.AsSystemRestricted(ctx), database.CompleteChatGoalByIDParams{
+		RootChatID:       chat.ID,
+		ID:               goal.ID,
+		CompletedByAgent: true,
+	})
+	require.NoError(t, err)
+	replaced, err := edit(sourceID)
+	require.NoError(t, err, "a completed goal no longer locks its source message")
+
+	// A goal anchored to a later message locks every earlier message
+	// too: the edit's suffix deletion would truncate the source away.
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+	sendResult, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:    chat.ID,
+		CreatedBy: user.ID,
+		Content:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("second objective")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "second objective",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sendResult.Goal)
+	require.Less(t, replaced.Message.ID, sendResult.Message.ID)
+	_, err = edit(replaced.Message.ID)
+	require.ErrorIs(t, err, chatd.ErrChatGoalSourceMessageEdit,
+		"editing a message older than the goal source would delete the source")
+}
+
+// Message IDs are allocated globally, so a child chat's rows can be
+// older than the root goal's source message. Editing child history
+// cannot delete the source row and must not trip the guard.
+func TestEditMessageChildChatIgnoresGoalSourceGuard(t *testing.T) {
+	t.Parallel()
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(t, db)
+	server := newTestServer(t, db, ps, uuid.New())
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID:     org.ID,
+		OwnerID:            user.ID,
+		Title:              "root without goal",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("root start")},
+	})
+	require.NoError(t, err)
+
+	childContent, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+		codersdk.ChatMessageText("child question"),
+	})
+	require.NoError(t, err)
+	createdChild, err := chatstate.CreateChat(ctx, db, ps, chatstate.CreateChatInput{
+		OrganizationID:    org.ID,
+		OwnerID:           user.ID,
+		ParentChatID:      uuid.NullUUID{UUID: chat.ID, Valid: true},
+		RootChatID:        uuid.NullUUID{UUID: chat.ID, Valid: true},
+		LastModelConfigID: model.ID,
+		Title:             "child before goal",
+		ClientType:        database.ChatClientTypeApi,
+		InitialMessages: []chatstate.Message{
+			{
+				Role:           database.ChatMessageRoleUser,
+				Content:        childContent,
+				Visibility:     database.ChatMessageVisibilityBoth,
+				ContentVersion: chatprompt.CurrentContentVersion,
+				CreatedBy:      uuid.NullUUID{UUID: user.ID, Valid: true},
+				ModelConfigID:  uuid.NullUUID{UUID: model.ID, Valid: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+	childMessageID := createdChild.InitialMessages[len(createdChild.InitialMessages)-1].ID
+
+	// Set the root goal after the child message exists so the goal
+	// source ID exceeds the child message ID.
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+	sendResult, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:    chat.ID,
+		CreatedBy: user.ID,
+		Content:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("objective text")},
+		GoalMutation: &codersdk.ChatGoalMutation{
+			Action:    codersdk.ChatGoalMutationActionSet,
+			Objective: "objective text",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sendResult.Goal)
+	require.Greater(t, sendResult.Message.ID, childMessageID)
+
+	_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+		ID:     createdChild.Chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+	_, err = server.EditMessage(ctx, chatd.EditMessageOptions{
+		ChatID:          createdChild.Chat.ID,
+		CreatedBy:       user.ID,
+		EditedMessageID: childMessageID,
+		Content:         []codersdk.ChatMessagePart{codersdk.ChatMessageText("rewritten child question")},
+	})
+	require.NoError(t, err, "editing child history cannot delete the root goal source")
+}


### PR DESCRIPTION
## Stack Context

This PR is part of the **agent chat goals** stack (#29019 → #29056 → #29057 → #29058 → #29059 → #29060 → #29021 → #29022 → #29023 → #29024), which introduces durable goals for agent chats: a user sets an objective on a root chat, the agent pursues it across turns with automatic continuation, and `block_goal`/`complete_goal` tools plus a banner UI manage the lifecycle.

| # | Layer |
|---|---|
| #29019 | Database persistence and SDK types |
| #29056 | `get_goal` and `complete_goal` chat tools |
| #29057 | Goal-aware generation turns |
| #29058 | Message-bound goal setting and lifecycle hook payload |
| #29059 | Goal lifecycle mutations (clear, pause, resume, complete) |
| #29060 | Interrupt pause and goal source-message guard |
| #29021 | HTTP API and stream markers |
| #29022 | Base UI |
| #29023 | Automatic continuation backend |
| #29024 | Continuation UI |

It replaces the former two large PRs #25622 and #27043 (both fully reviewed with clean verdicts and green CI on their final heads), rebased onto current main and split into independently reviewable, independently green layers. The former #29020 (the whole chatd engine in one PR) was split into #29056 through #29060. The assembled stack tip matches the validated combination of the two original PRs plus the rebase, with one deliberate delta: the interim goal completion reminder mechanism (superseded by automatic continuation in #29023 before the feature ships) is no longer introduced and then deleted inside the stack, so its legacy row parser and tests are gone from the final tree as well.

## Why

Two safety rules that keep goal state truthful under user actions, kept separate because each is a small, self-contained argument.

## What changed

- `InterruptChat` pauses the root chat's active goal in the same transaction: Stop is a halt gesture, and a halted chat must not report an active goal. A concurrent goal transition is tolerated.
- `EditMessage` refuses to edit the current goal's source message, or any older message whose edit would truncate it away, while the goal is active or paused. The guard applies to root chats only, since message IDs are global and child history cannot delete the root source row.
- Tests for both rules, including the completed-goal unlock and the child-chat exemption.

Code is unchanged from the reviewed #25622.

> 🤖 This pull request was created by Xum, an AI coding agent, acting on behalf of @ibetitsmike.
