### PR TITLE
fix(examples): set fsGroupChangePolicy OnRootMismatch in k8s template

### DIFF
--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -281,6 +281,10 @@ resource "kubernetes_deployment_v1" "main" {
           run_as_user     = 1000
           fs_group        = 1000
           run_as_non_root = true
+          // Only chown the home volume when its root is not already owned by fs_group.
+          // The default policy ("Always") recursively chowns every file on each start,
+          // which can take many minutes on large volumes.
+          fs_group_change_policy = "OnRootMismatch"
         }
 
         container {


### PR DESCRIPTION
## Problem

`examples/templates/kubernetes/main.tf` sets `fs_group = 1000` on the workspace pod and mounts the home PVC at `/home/coder`. With the kubelet default `fsGroupChangePolicy: Always`, every workspace start recursively chowns the entire home volume before the container can run. On small volumes this is invisible; on large ones (hundreds of GB, millions of files) the pod sits in `Init:0/1` / `ContainerCreating` for 10-40 minutes with `VolumePermissionChangeInProgress ... processed N files` events, and a stop/restart resets the walk.

Because this template is the starting point most Kubernetes deployments copy from, the slow-start behaviour propagates to derived templates.

## Fix

Add `fs_group_change_policy = "OnRootMismatch"` to the pod `security_context`, with a short comment explaining why. Kubernetes then only chowns when the volume root's owner/group differ from `fs_group`, which after the first start is never. The attribute has been in `hashicorp/kubernetes` since v2.16.0 (Nov 2022); the template does not pin the provider, so no version bump is required.

Only the `kubernetes` template is affected: `kubernetes-devcontainer` uses an empty `security_context {}` and `kubernetes-envbox` runs a privileged container without `fs_group`.

## How tested

- `terraform fmt -check -recursive examples/templates/kubernetes` passes.
- `terraform init -backend=false && terraform validate` in `examples/templates/kubernetes` succeeds (hashicorp/kubernetes v3.2.1, coder/coder v2.18.0).
- The same one-line change was applied to a derived template on an EKS-hosted Coder deployment where a workspace with a ~750 Gi home PVC (~6.4 M inodes, ~11.4 M walked entries) took ~15 minutes per start. Pod events before the change:
  ```
  Warning  VolumePermissionChangeInProgress  Setting volume ownership for .../pvc-<uid>  is taking longer than expected, consider using OnRootMismatch
  ... processed 5038142 files.
  ```
  Verified live first by patching the workspace Deployment's `securityContext.fsGroupChangePolicy` to `OnRootMismatch`: the replacement pod went from volume attach to `Running` in about 40 seconds. The template change then made it permanent.
- `examples/examples.gen.json` is generated from README front matter only, so `make gen` produces no diff for this change.

## Links

No existing upstream issue or PR for this; searched `fsGroupChangePolicy`, `fs_group_change_policy`, `OnRootMismatch`, `VolumePermissionChangeInProgress`.
Related: kubernetes/kubernetes docs on [Configure volume permission and ownership change policy for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods).

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

