### PR TITLE
refactor(site/src/pages/AgentsPage): pass Chat instead of sliced chat flags

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -36,7 +36,6 @@ import {
 	RightPanelSkeleton,
 } from "./components/AgentsSkeletons";
 import type { ChatDetailError } from "./components/ChatConversation/chatError";
-import { getParentChatID } from "./components/ChatConversation/chatHelpers";
 import type { useChatStore } from "./components/ChatConversation/chatStore";
 import { QueuedForCapacityCallout } from "./components/ChatConversation/QueuedForCapacityCallout";
 import type { ModelSelectorOption } from "./components/ChatElements/ModelSelector";
@@ -839,7 +838,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							<div className="relative z-10 shrink-0 overflow-visible">
 								{" "}
 								<ChatTopBar
-									chatTitle={chat.title}
+									chat={chat}
 									parentChat={parentChat}
 									panel={{
 										showSidebarPanel,
@@ -854,14 +853,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									onPinAgent={handlePinAgentAction}
 									onUnpinAgent={handleUnpinAgentAction}
 									onOpenRenameDialog={handleOpenRenameDialogAction}
-									isPinned={chat.pin_order > 0}
-									isChildChat={getParentChatID(chat) !== undefined}
 									isArchiving={isArchivingThisChat}
 									isArchiveBlocked={isArchiveBlocked}
 									hasWorkspace={Boolean(workspace)}
-									isArchived={isArchived}
-									diffStatusData={chat.diff_status}
-									isSharedChat={chat.shared}
 									renderChatSharingContent={
 										canShareChat
 											? (open) => (
@@ -954,7 +948,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							/>
 							<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 scrollbar-gutter-stable scrollbar-thin">
 								<ChatPageInput
-									organizationId={organizationId}
+									chat={chat}
 									sendShortcut={sendShortcut}
 									store={store}
 									compressionThreshold={compressionThreshold}
@@ -978,12 +972,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									modelSelectorHelp={modelSelectorHelp}
 									reasoningEffort={reasoningEffort}
 									onReasoningEffortChange={onReasoningEffortChange}
-									planModeEnabled={chat.plan_mode === "plan"}
 									onPlanModeToggle={onPlanModeToggle}
 									isModelCatalogLoading={isModelCatalogLoading}
 									workspaceOptions={workspaceOptions}
-									chatOrganizationId={organizationId}
-									selectedWorkspaceId={chat.workspace_id ?? null}
 									onWorkspaceChange={onWorkspaceChange}
 									isWorkspaceLoading={isWorkspaceLoading}
 									inputRef={editing.chatInputRef}
@@ -998,11 +989,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									selectedMCPServerIds={selectedMCPServerIds}
 									onMCPSelectionChange={onMCPSelectionChange}
 									onMCPAuthComplete={onMCPAuthComplete}
-									chatContext={chat.context}
 									workspaceSkills={workspaceSkills}
 									workspace={workspace}
 									workspaceAgent={workspaceAgent}
-									chatId={agentId}
 									sshCommand={sshCommand}
 									attachedWorkspace={attachedWorkspace}
 									folder={preferredFolder}

--- a/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageLayout.stories.tsx
@@ -196,7 +196,7 @@ const setInnerWidthForStory = (width: number) => {
 const AgentTopBarRouteElement = () => {
 	return (
 		<ChatTopBar
-			chatTitle="Collapsed sidebar agent"
+			chat={{ ...MockChat, title: "Collapsed sidebar agent" }}
 			panel={{ showSidebarPanel: false, onToggleSidebar: fn() }}
 			onArchiveAgent={fn()}
 			onArchiveAndDeleteWorkspace={fn()}

--- a/site/src/pages/AgentsPage/components/ChatActionsMenuItems.tsx
+++ b/site/src/pages/AgentsPage/components/ChatActionsMenuItems.tsx
@@ -17,6 +17,7 @@ import type {
 	DropdownMenuItem,
 	DropdownMenuSeparator,
 } from "#/components/DropdownMenu/DropdownMenu";
+import { getParentChatID } from "./ChatConversation/chatHelpers";
 
 // Backend chatstate permits archive only from W, E0, and E1. Unknown status
 // stays fail-open so the server conflict response remains the backstop.
@@ -50,18 +51,11 @@ type SeparatorComponent =
  * therefore has no menu actions at all; call sites use this to hide the menu
  * trigger instead of rendering an empty menu.
  */
-export const chatHasMenuActions = ({
-	isArchived,
-	isChildChat,
-}: {
-	isArchived: boolean;
-	isChildChat: boolean;
-}): boolean => !(isArchived && isChildChat);
+export const chatHasMenuActions = (chat: TypesGen.Chat): boolean =>
+	!(chat.archived && getParentChatID(chat) !== undefined);
 
 interface ChatActionsMenuItemsProps {
-	readonly isArchived: boolean;
-	readonly isPinned: boolean;
-	readonly isChildChat: boolean;
+	readonly chat: TypesGen.Chat;
 	readonly hasWorkspace: boolean;
 	readonly isArchiving?: boolean;
 	readonly isArchiveBlocked?: boolean;
@@ -80,9 +74,7 @@ interface ChatActionsMenuItemsProps {
 }
 
 export const ChatActionsMenuItems: FC<ChatActionsMenuItemsProps> = ({
-	isArchived,
-	isPinned,
-	isChildChat,
+	chat,
 	hasWorkspace,
 	isArchiving = false,
 	isArchiveBlocked = false,
@@ -98,6 +90,9 @@ export const ChatActionsMenuItems: FC<ChatActionsMenuItemsProps> = ({
 	Item,
 	Separator,
 }) => {
+	const isArchived = chat.archived;
+	const isPinned = chat.pin_order > 0;
+	const isChildChat = getParentChatID(chat) !== undefined;
 	const showSubagentsToggle = Boolean(onToggleSubagents) && subagentCount > 0;
 	const showPinAction =
 		!isArchived && !isChildChat && Boolean(onPinAgent && onUnpinAgent);

--- a/site/src/pages/AgentsPage/components/ChatActionsMenuItems.tsx
+++ b/site/src/pages/AgentsPage/components/ChatActionsMenuItems.tsx
@@ -51,8 +51,10 @@ type SeparatorComponent =
  * therefore has no menu actions at all; call sites use this to hide the menu
  * trigger instead of rendering an empty menu.
  */
-export const chatHasMenuActions = (chat: TypesGen.Chat): boolean =>
-	!(chat.archived && getParentChatID(chat) !== undefined);
+export const chatHasMenuActions = (chat: TypesGen.Chat): boolean => {
+	const isArchivedChild = chat.archived && getParentChatID(chat) !== undefined;
+	return !isArchivedChild;
+};
 
 interface ChatActionsMenuItemsProps {
 	readonly chat: TypesGen.Chat;

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
-import { MockChatQueuedMessage } from "#/testHelpers/chatEntities";
+import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -36,16 +36,15 @@ type Story = StoryObj<typeof meta>;
 
 const CHAT_ID = "chat-page-content-stories";
 
-// Renders only the composer half of the chat page. chatId and
-// organizationId stay undefined so the prompt-history and draft
-// attachment queries stay disabled.
+// Renders only the composer half of the chat page. Empty chat id and
+// organization keep the prompt-history and draft attachment queries disabled.
 const StoryChatPageInput: FC<{
 	store: ReturnType<typeof createChatStore>;
 	onInterrupt?: () => void;
 }> = ({ store, onInterrupt }) => (
 	<div className="mx-auto w-full max-w-3xl p-4">
 		<ChatPageInput
-			organizationId={undefined}
+			chat={{ ...MockChat, id: "", organization_id: "" }}
 			store={store}
 			compressionThreshold={undefined}
 			onSend={fn()}
@@ -72,7 +71,6 @@ const StoryChatPageInput: FC<{
 			isEditing={false}
 			onCancelHistoryEdit={fn()}
 			workspaceOptions={[]}
-			selectedWorkspaceId={null}
 			isWorkspaceLoading={false}
 		/>
 	</div>

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -238,8 +238,7 @@ export type PendingAttachment = {
 };
 
 interface ChatPageInputProps {
-	// Organization that owns this chat. Used to scope file uploads.
-	organizationId: string | undefined;
+	chat: TypesGen.Chat;
 	store: ChatStoreHandle;
 	compressionThreshold: number | undefined;
 	onSend: (
@@ -266,7 +265,6 @@ interface ChatPageInputProps {
 	modelCount?: number;
 	unsupportedProviderNames?: readonly string[];
 	aiGatewayDisabled?: boolean;
-	planModeEnabled?: boolean;
 	onPlanModeToggle?: (enabled: boolean) => void;
 	isModelCatalogLoading?: boolean;
 	// Imperative editor handle plus the one-time initial draft,
@@ -290,27 +288,21 @@ interface ChatPageInputProps {
 	selectedMCPServerIds?: readonly string[];
 	onMCPSelectionChange?: (ids: string[]) => void;
 	onMCPAuthComplete?: (serverId: string) => void;
-	// Pinned workspace-context state for the chat, surfaced by the
-	// context indicator (dirty marker and pinned resources).
-	chatContext?: TypesGen.ChatContext;
 	// Workspace skill menu data derived from the resolved chat detail;
 	// undefined while the chat is still loading.
 	workspaceSkills?: readonly SkillMetadata[];
 	workspaceOptions: readonly TypesGen.Workspace[];
-	chatOrganizationId?: string;
-	selectedWorkspaceId: string | null;
 	onWorkspaceChange?: (workspaceId: string | null) => void;
 	isWorkspaceLoading: boolean;
 	workspace?: TypesGen.Workspace;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
-	chatId?: string;
 	sshCommand?: string;
 	attachedWorkspace?: AttachedWorkspaceInfo;
 	folder?: string;
 }
 
 export const ChatPageInput: FC<ChatPageInputProps> = ({
-	organizationId,
+	chat,
 	store,
 	compressionThreshold,
 	onSend,
@@ -334,7 +326,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	modelCount,
 	unsupportedProviderNames,
 	aiGatewayDisabled,
-	planModeEnabled,
 	onPlanModeToggle,
 	isModelCatalogLoading = false,
 	inputRef,
@@ -349,20 +340,21 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	selectedMCPServerIds,
 	onMCPSelectionChange,
 	onMCPAuthComplete,
-	chatContext,
 	workspaceSkills,
 	workspaceOptions,
-	chatOrganizationId,
-	selectedWorkspaceId,
 	onWorkspaceChange,
 	isWorkspaceLoading,
 	workspace,
 	workspaceAgent,
-	chatId,
 	sshCommand,
 	attachedWorkspace,
 	folder,
 }) => {
+	const organizationId = chat.organization_id;
+	const chatId = chat.id;
+	const chatContext = chat.context;
+	const planModeEnabled = chat.plan_mode === "plan";
+	const selectedWorkspaceId = chat.workspace_id ?? null;
 	const messagesByID = useChatSelector(store, selectMessagesByID);
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
 	const hasStreamState = useChatSelector(store, selectHasStreamState);
@@ -589,7 +581,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			onPlanModeToggle={onPlanModeToggle}
 			isModelCatalogLoading={isModelCatalogLoading}
 			workspaceOptions={workspaceOptions}
-			chatOrganizationId={chatOrganizationId}
+			chatOrganizationId={organizationId}
 			selectedWorkspaceId={selectedWorkspaceId}
 			onWorkspaceChange={onWorkspaceChange}
 			isWorkspaceLoading={isWorkspaceLoading}

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { PopoverContent } from "#/components/Popover/Popover";
+import { MockChat } from "#/testHelpers/chatEntities";
 import { ChatTopBar } from "./ChatTopBar";
 
 // Probe element rendered at /agents to verify search params are preserved
@@ -12,8 +13,13 @@ const AgentsSearchProbe = () => {
 	return <div data-testid="agents-search">{location.search}</div>;
 };
 
+const defaultChat = {
+	...MockChat,
+	title: "Build authentication feature",
+};
+
 const defaultProps = {
-	chatTitle: "Build authentication feature",
+	chat: defaultChat,
 	panel: {
 		showSidebarPanel: false,
 		onToggleSidebar: fn(),
@@ -41,7 +47,10 @@ export const Default: Story = {};
 
 export const SharedChat: Story = {
 	args: {
-		isSharedChat: true,
+		chat: {
+			...defaultChat,
+			shared: true,
+		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -62,25 +71,9 @@ export const WithPanelOpen: Story = {
 export const WithParentChat: Story = {
 	args: {
 		parentChat: {
+			...MockChat,
 			id: "parent-chat-1",
-			organization_id: "test-org-id",
-			owner_id: "owner-id",
-			owner_username: "owner",
-			last_model_config_id: "model-config-1",
-			mcp_server_ids: [],
-			labels: {},
 			title: "Set up CI/CD pipeline",
-			status: "waiting",
-			last_turn_summary: null,
-			summary: null,
-			created_at: "2026-02-18T00:00:00.000Z",
-			updated_at: "2026-02-18T00:00:00.000Z",
-			archived: false,
-			shared: false,
-			pin_order: 0,
-			has_unread: false,
-			client_type: "ui",
-			children: [],
 		},
 	},
 };
@@ -116,13 +109,16 @@ export const SidebarCollapsed: Story = {
 
 export const Archived: Story = {
 	args: {
-		isArchived: true,
+		chat: {
+			...defaultChat,
+			archived: true,
+		},
 	},
 };
 
 export const NoTitle: Story = {
 	args: {
-		chatTitle: undefined,
+		chat: undefined,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -134,62 +130,74 @@ export const NoTitle: Story = {
 
 export const WithOpenPR: Story = {
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/123",
-			pull_request_title: "fix: resolve race condition in workspace builds",
-			pull_request_draft: false,
-			changes_requested: false,
-			additions: 42,
-			deletions: 7,
-			changed_files: 5,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/123",
+				pull_request_title: "fix: resolve race condition in workspace builds",
+				pull_request_draft: false,
+				changes_requested: false,
+				additions: 42,
+				deletions: 7,
+				changed_files: 5,
+			},
 		},
 	},
 };
 
 export const WithDraftPR: Story = {
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/456",
-			pull_request_title: "feat: add new notification system",
-			pull_request_draft: true,
-			changes_requested: false,
-			additions: 120,
-			deletions: 30,
-			changed_files: 8,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/456",
+				pull_request_title: "feat: add new notification system",
+				pull_request_draft: true,
+				changes_requested: false,
+				additions: 120,
+				deletions: 30,
+				changed_files: 8,
+			},
 		},
 	},
 };
 
 export const WithMergedPR: Story = {
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/789",
-			pull_request_title: "chore: update dependencies",
-			pull_request_state: "merged",
-			pull_request_draft: false,
-			changes_requested: false,
-			additions: 5,
-			deletions: 3,
-			changed_files: 1,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/789",
+				pull_request_title: "chore: update dependencies",
+				pull_request_state: "merged",
+				pull_request_draft: false,
+				changes_requested: false,
+				additions: 5,
+				deletions: 3,
+				changed_files: 1,
+			},
 		},
 	},
 };
 
 export const WithClosedPR: Story = {
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/101",
-			pull_request_title: "fix: deprecated API cleanup",
-			pull_request_state: "closed",
-			pull_request_draft: false,
-			changes_requested: false,
-			additions: 0,
-			deletions: 50,
-			changed_files: 3,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/101",
+				pull_request_title: "fix: deprecated API cleanup",
+				pull_request_state: "closed",
+				pull_request_draft: false,
+				changes_requested: false,
+				additions: 0,
+				deletions: 50,
+				changed_files: 3,
+			},
 		},
 	},
 };
@@ -211,15 +219,18 @@ export const MobileWithOpenPR: Story = {
 	decorators: mobileDecorator,
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/123",
-			pull_request_title: "fix: resolve race condition in workspace builds",
-			pull_request_draft: false,
-			changes_requested: false,
-			additions: 42,
-			deletions: 7,
-			changed_files: 5,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/123",
+				pull_request_title: "fix: resolve race condition in workspace builds",
+				pull_request_draft: false,
+				changes_requested: false,
+				additions: 42,
+				deletions: 7,
+				changed_files: 5,
+			},
 		},
 	},
 };
@@ -228,15 +239,18 @@ export const MobileWithDraftPR: Story = {
 	decorators: mobileDecorator,
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/456",
-			pull_request_title: "feat: add new notification system",
-			pull_request_draft: true,
-			changes_requested: false,
-			additions: 120,
-			deletions: 30,
-			changed_files: 8,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/456",
+				pull_request_title: "feat: add new notification system",
+				pull_request_draft: true,
+				changes_requested: false,
+				additions: 120,
+				deletions: 30,
+				changed_files: 8,
+			},
 		},
 	},
 };
@@ -245,16 +259,19 @@ export const MobileWithMergedPR: Story = {
 	decorators: mobileDecorator,
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/789",
-			pull_request_title: "chore: update dependencies",
-			pull_request_state: "merged",
-			pull_request_draft: false,
-			changes_requested: false,
-			additions: 5,
-			deletions: 3,
-			changed_files: 1,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/789",
+				pull_request_title: "chore: update dependencies",
+				pull_request_state: "merged",
+				pull_request_draft: false,
+				changes_requested: false,
+				additions: 5,
+				deletions: 3,
+				changed_files: 1,
+			},
 		},
 	},
 };
@@ -263,16 +280,19 @@ export const MobileWithClosedPR: Story = {
 	decorators: mobileDecorator,
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
-		diffStatusData: {
-			chat_id: "chat-1",
-			url: "https://github.com/coder/coder/pull/101",
-			pull_request_title: "fix: deprecated API cleanup",
-			pull_request_state: "closed",
-			pull_request_draft: false,
-			changes_requested: false,
-			additions: 0,
-			deletions: 50,
-			changed_files: 3,
+		chat: {
+			...defaultChat,
+			diff_status: {
+				chat_id: "chat-1",
+				url: "https://github.com/coder/coder/pull/101",
+				pull_request_title: "fix: deprecated API cleanup",
+				pull_request_state: "closed",
+				pull_request_draft: false,
+				changes_requested: false,
+				additions: 0,
+				deletions: 50,
+				changed_files: 3,
+			},
 		},
 	},
 };
@@ -313,7 +333,10 @@ export const PinAgentItem: Story = {
 
 export const UnpinAgentItem: Story = {
 	args: {
-		isPinned: true,
+		chat: {
+			...defaultChat,
+			pin_order: 1,
+		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -331,7 +354,10 @@ export const UnpinAgentItem: Story = {
 
 export const ChildChatHidesPinAndArchiveActions: Story = {
 	args: {
-		isChildChat: true,
+		chat: {
+			...defaultChat,
+			parent_chat_id: "parent-chat-1",
+		},
 		hasWorkspace: true,
 	},
 	play: async ({ canvasElement }) => {
@@ -354,8 +380,11 @@ export const ChildChatHidesPinAndArchiveActions: Story = {
 
 export const ArchivedChildChatHasNoActionsMenu: Story = {
 	args: {
-		isChildChat: true,
-		isArchived: true,
+		chat: {
+			...defaultChat,
+			parent_chat_id: "parent-chat-1",
+			archived: true,
+		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -512,7 +541,10 @@ export const ShareChatButtonHiddenWithoutPermission: Story = {
 
 export const ArchivedWithUnarchive: Story = {
 	args: {
-		isArchived: true,
+		chat: {
+			...defaultChat,
+			archived: true,
+		},
 		onUnarchiveAgent: fn(),
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -13,13 +13,8 @@ const AgentsSearchProbe = () => {
 	return <div data-testid="agents-search">{location.search}</div>;
 };
 
-const defaultChat = {
-	...MockChat,
-	title: "Build authentication feature",
-};
-
 const defaultProps = {
-	chat: defaultChat,
+	chat: MockChat,
 	panel: {
 		showSidebarPanel: false,
 		onToggleSidebar: fn(),
@@ -48,7 +43,7 @@ export const Default: Story = {};
 export const SharedChat: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			shared: true,
 		},
 	},
@@ -110,7 +105,7 @@ export const SidebarCollapsed: Story = {
 export const Archived: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			archived: true,
 		},
 	},
@@ -131,7 +126,7 @@ export const NoTitle: Story = {
 export const WithOpenPR: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/123",
@@ -149,7 +144,7 @@ export const WithOpenPR: Story = {
 export const WithDraftPR: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/456",
@@ -167,7 +162,7 @@ export const WithDraftPR: Story = {
 export const WithMergedPR: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/789",
@@ -186,7 +181,7 @@ export const WithMergedPR: Story = {
 export const WithClosedPR: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/101",
@@ -220,7 +215,7 @@ export const MobileWithOpenPR: Story = {
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/123",
@@ -240,7 +235,7 @@ export const MobileWithDraftPR: Story = {
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/456",
@@ -260,7 +255,7 @@ export const MobileWithMergedPR: Story = {
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/789",
@@ -281,7 +276,7 @@ export const MobileWithClosedPR: Story = {
 	parameters: { pixel: { matrix: { viewports: ["phone"] } } },
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			diff_status: {
 				chat_id: "chat-1",
 				url: "https://github.com/coder/coder/pull/101",
@@ -334,7 +329,7 @@ export const PinAgentItem: Story = {
 export const UnpinAgentItem: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			pin_order: 1,
 		},
 	},
@@ -355,7 +350,7 @@ export const UnpinAgentItem: Story = {
 export const ChildChatHidesPinAndArchiveActions: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			parent_chat_id: "parent-chat-1",
 		},
 		hasWorkspace: true,
@@ -381,7 +376,7 @@ export const ChildChatHidesPinAndArchiveActions: Story = {
 export const ArchivedChildChatHasNoActionsMenu: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			parent_chat_id: "parent-chat-1",
 			archived: true,
 		},
@@ -389,9 +384,7 @@ export const ArchivedChildChatHasNoActionsMenu: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await waitFor(() => {
-			expect(
-				canvas.getByText("Build authentication feature"),
-			).toBeInTheDocument();
+			expect(canvas.getByText(MockChat.title)).toBeInTheDocument();
 		});
 		// Archive state is root-only, so an archived child chat has no menu
 		// actions at all and the actions trigger is hidden entirely.
@@ -542,7 +535,7 @@ export const ShareChatButtonHiddenWithoutPermission: Story = {
 export const ArchivedWithUnarchive: Story = {
 	args: {
 		chat: {
-			...defaultChat,
+			...MockChat,
 			archived: true,
 		},
 		onUnarchiveAgent: fn(),

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -27,7 +27,6 @@ import {
 	ChatActionsMenuItems,
 	chatHasMenuActions,
 } from "./ChatActionsMenuItems";
-import { getParentChatID } from "./ChatConversation/chatHelpers";
 import { useEmbedContext } from "./EmbedContext";
 import { PrStateIcon } from "./GitPanel/GitPanel";
 
@@ -110,9 +109,6 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 		useOutletContext<AgentsPageOutletContext | undefined>() ?? {};
 
 	const chatTitle = chat?.title;
-	const isArchived = chat?.archived ?? false;
-	const isChildChat = getParentChatID(chat) !== undefined;
-	const isPinned = (chat?.pin_order ?? 0) > 0;
 	const isSharedChat = chat?.shared;
 	const diffStatus = chat?.diff_status;
 	const prUrl = diffStatus?.url;
@@ -195,43 +191,39 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 				{/* Actions menu sits inline with the title so it tracks the title's right edge.
 				   Suppressed when there is no chat to act on (loading and not-found views)
 				   and when the chat has no menu actions (archived child chats). */}
-				{!isEmbedded &&
-					chatTitle &&
-					chatHasMenuActions({ isArchived, isChildChat }) && (
-						<DropdownMenu>
-							<DropdownMenuTrigger asChild>
-								<Button
-									size="icon"
-									variant="subtle"
-									className="size-7 shrink-0 text-content-secondary hover:text-content-primary"
-									aria-label="Open agent actions"
-								>
-									<EllipsisVerticalIcon className="size-4" />
-								</Button>
-							</DropdownMenuTrigger>
-							<DropdownMenuContent
-								align="start"
-								className="mobile-full-width-dropdown mobile-full-width-dropdown-top [&_[role=menuitem]]:text-[13px]"
+				{!isEmbedded && chat && chatTitle && chatHasMenuActions(chat) && (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								size="icon"
+								variant="subtle"
+								className="size-7 shrink-0 text-content-secondary hover:text-content-primary"
+								aria-label="Open agent actions"
 							>
-								<ChatActionsMenuItems
-									isArchived={isArchived}
-									isPinned={isPinned}
-									isChildChat={isChildChat}
-									hasWorkspace={hasWorkspace}
-									isArchiving={isArchiving}
-									isArchiveBlocked={isArchiveBlocked}
-									onPinAgent={onPinAgent}
-									onUnpinAgent={onUnpinAgent}
-									onArchiveAgent={onArchiveAgent}
-									onUnarchiveAgent={onUnarchiveAgent}
-									onArchiveAndDeleteWorkspace={onArchiveAndDeleteWorkspace}
-									onOpenRenameDialog={onOpenRenameDialog}
-									Item={DropdownMenuItem}
-									Separator={DropdownMenuSeparator}
-								/>
-							</DropdownMenuContent>
-						</DropdownMenu>
-					)}
+								<EllipsisVerticalIcon className="size-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent
+							align="start"
+							className="mobile-full-width-dropdown mobile-full-width-dropdown-top [&_[role=menuitem]]:text-[13px]"
+						>
+							<ChatActionsMenuItems
+								chat={chat}
+								hasWorkspace={hasWorkspace}
+								isArchiving={isArchiving}
+								isArchiveBlocked={isArchiveBlocked}
+								onPinAgent={onPinAgent}
+								onUnpinAgent={onUnpinAgent}
+								onArchiveAgent={onArchiveAgent}
+								onUnarchiveAgent={onUnarchiveAgent}
+								onArchiveAndDeleteWorkspace={onArchiveAndDeleteWorkspace}
+								onOpenRenameDialog={onOpenRenameDialog}
+								Item={DropdownMenuItem}
+								Separator={DropdownMenuSeparator}
+							/>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				)}
 			</div>
 			{/* PR link. On mobile: icon + number; on desktop: icon + title.
 			   Hidden on desktop when the sidebar panel is open

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -12,7 +12,6 @@ import {
 import { type FC, Fragment, type ReactNode, useState } from "react";
 import { Link, useLocation, useOutletContext } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
-import type { ChatDiffStatus } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import {
 	DropdownMenu,
@@ -28,6 +27,7 @@ import {
 	ChatActionsMenuItems,
 	chatHasMenuActions,
 } from "./ChatActionsMenuItems";
+import { getParentChatID } from "./ChatConversation/chatHelpers";
 import { useEmbedContext } from "./EmbedContext";
 import { PrStateIcon } from "./GitPanel/GitPanel";
 
@@ -41,7 +41,7 @@ type ChatSharingTopBarButtonProps = {
 };
 
 type ChatTopBarProps = {
-	chatTitle?: string;
+	chat?: TypesGen.Chat;
 	parentChat?: TypesGen.Chat;
 	panel: SidebarPanelState;
 	onArchiveAgent: () => void;
@@ -51,13 +51,8 @@ type ChatTopBarProps = {
 	onUnpinAgent?: () => void;
 	onOpenRenameDialog?: () => void;
 	hasWorkspace?: boolean;
-	isArchived?: boolean;
 	isArchiving?: boolean;
 	isArchiveBlocked?: boolean;
-	isChildChat?: boolean;
-	isPinned?: boolean;
-	diffStatusData?: ChatDiffStatus;
-	isSharedChat?: boolean;
 	renderChatSharingContent?: (open: boolean) => ReactNode;
 };
 
@@ -95,7 +90,7 @@ const ChatSharingTopBarButton: FC<ChatSharingTopBarButtonProps> = ({
 };
 
 export const ChatTopBar: FC<ChatTopBarProps> = ({
-	chatTitle,
+	chat,
 	parentChat,
 	panel,
 	onArchiveAgent,
@@ -105,13 +100,8 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 	onUnpinAgent,
 	onOpenRenameDialog,
 	hasWorkspace = false,
-	isArchived = false,
 	isArchiving = false,
 	isArchiveBlocked = false,
-	isChildChat = false,
-	isPinned = false,
-	diffStatusData,
-	isSharedChat,
 	renderChatSharingContent,
 }) => {
 	const { isEmbedded } = useEmbedContext();
@@ -119,13 +109,18 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 	const { isSidebarCollapsed, onToggleSidebarCollapsed } =
 		useOutletContext<AgentsPageOutletContext | undefined>() ?? {};
 
-	const prUrl = diffStatusData?.url;
-	const prState = diffStatusData?.pull_request_state;
-	const prDraft = diffStatusData?.pull_request_draft;
-	const prTitle = diffStatusData?.pull_request_title;
+	const chatTitle = chat?.title;
+	const isArchived = chat?.archived ?? false;
+	const isChildChat = getParentChatID(chat) !== undefined;
+	const isPinned = (chat?.pin_order ?? 0) > 0;
+	const isSharedChat = chat?.shared;
+	const diffStatus = chat?.diff_status;
+	const prUrl = diffStatus?.url;
+	const prState = diffStatus?.pull_request_state;
+	const prDraft = diffStatus?.pull_request_draft;
+	const prTitle = diffStatus?.pull_request_title;
 	const parsedPr = parsePullRequestUrl(prUrl);
-	const prNumberMatch =
-		diffStatusData?.pr_number?.toString() ?? parsedPr?.number;
+	const prNumberMatch = diffStatus?.pr_number?.toString() ?? parsedPr?.number;
 	const hasPR = Boolean(prState || prNumberMatch || parsedPr);
 
 	return (

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/chats/ChatsPanel.tsx
@@ -524,11 +524,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 														(disablePinnedReordering ? (
 															<div className="flex flex-col gap-0.5">
 																{sortedPinnedChats.map((chat) => (
-																	<ChatTreeNode
-																		key={chat.id}
-																		chat={chat}
-																		isChildNode={false}
-																	/>
+																	<ChatTreeNode key={chat.id} chat={chat} />
 																))}
 															</div>
 														) : (
@@ -582,11 +578,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 													{!collapsedSections[SHARED_WITH_YOU_SECTION_KEY] && (
 														<div className="flex flex-col gap-0.5">
 															{sharedWithYouChats.map((chat) => (
-																<ChatTreeNode
-																	key={chat.id}
-																	chat={chat}
-																	isChildNode={false}
-																/>
+																<ChatTreeNode key={chat.id} chat={chat} />
 															))}
 														</div>
 													)}
@@ -607,11 +599,7 @@ export const ChatsPanel: FC<ChatsPanelProps> = ({
 														{isSectionExpanded && (
 															<div className="flex flex-col gap-0.5">
 																{section.chats.map((chat) => (
-																	<ChatTreeNode
-																		key={chat.id}
-																		chat={chat}
-																		isChildNode={false}
-																	/>
+																	<ChatTreeNode key={chat.id} chat={chat} />
 																))}
 															</div>
 														)}

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/ChatTreeNode.tsx
@@ -39,17 +39,12 @@ import { getChatDisplayConfig } from "./statusConfig";
 
 interface ChatTreeNodeProps {
 	readonly chat: Chat;
-	readonly isChildNode: boolean;
 	readonly depth?: number;
 }
 
 const CHILD_INDENT_PX = 26;
 
-export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
-	chat,
-	isChildNode,
-	depth = 0,
-}) => {
+export const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, depth = 0 }) => {
 	const location = useLocation();
 	const locationSearch = normalizeLocationSearch(location.search);
 	const {
@@ -152,19 +147,14 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 	const isArchivingThisChat = isArchiving && archivingChatId === chat.id;
 	const isExpanded = normalizedSearch ? true : (expandedById[chatID] ?? false);
 
-	const hasMenuActions = chatHasMenuActions({
-		isArchived: chat.archived,
-		isChildChat: isChildNode,
-	});
+	const hasMenuActions = chatHasMenuActions(chat);
 
 	const hoverLayout =
 		"[@media(hover:hover)]:hover:-mx-2 [@media(hover:hover)]:hover:pl-3 [@media(hover:hover)]:hover:pr-3.5 [@media(hover:hover)]:hover:rounded-none";
 	const activeLayout =
 		"has-[[aria-current=page]]:-mx-2 has-[[aria-current=page]]:pl-[11px] has-[[aria-current=page]]:pr-3.5 has-[[aria-current=page]]:rounded-none has-[[aria-current=page]]:border-l has-[[aria-current=page]]:border-content-primary [@media(hover:hover)]:has-[[aria-current=page]]:hover:pl-[11px]";
 	const sharedMenuItemProps = {
-		isArchived: chat.archived,
-		isPinned: chat.pin_order > 0,
-		isChildChat: isChildNode,
+		chat,
 		hasWorkspace: Boolean(workspaceId),
 		isArchiving,
 		isArchiveBlocked: !chatFamilyAllowsArchive(chat.status, chat.children),
@@ -421,7 +411,6 @@ export const ChatTreeNode: FC<ChatTreeNodeProps> = ({
 							<ChatTreeNode
 								key={childChat.id}
 								chat={childChat}
-								isChildNode
 								depth={depth + 1}
 							/>
 						);

--- a/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SortableChatTreeNode.tsx
+++ b/site/src/pages/AgentsPage/components/ChatsSidebar/tree/SortableChatTreeNode.tsx
@@ -42,7 +42,7 @@ export const SortableChatTreeNode: FC<{
 			{...attributes}
 			{...listeners}
 		>
-			<ChatTreeNode chat={chat} isChildNode={false} />
+			<ChatTreeNode chat={chat} />
 		</div>
 	);
 };


### PR DESCRIPTION
Pass the chat record into ChatTopBar, ChatPageInput, and ChatActionsMenuItems instead of deriving title, pin, archive, child, share, diff, plan mode, workspace, context, and ids at each parent. Handlers stay props. Loading, error, not-found, and the create composer still omit chat because they have no record yet.

- ChatTopBar reads title, share, pin, archive, parent, and diff from chat
- ChatPageInput reads org, id, plan mode, workspace, and context from chat
- ChatActionsMenuItems reads archive/pin/child from chat, so the sidebar tree drops isChildNode