### PR TITLE
fix(agent): exclude stderr from metadata values

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -683,6 +683,12 @@ func (a *agent) collectMetadata(ctx context.Context, md codersdk.WorkspaceAgentM
 			err = errors.Join(err, xerrors.Errorf("stderr: %s", strings.TrimSpace(stderr.String())))
 		}
 		result.Error = fmt.Sprintf("run cmd: %+v", err)
+		// coderd replaces errors above 2048 bytes, discarding their diagnostics.
+		const maxErrorLen = 2048
+		const truncated = " [truncated]"
+		if len(result.Error) > maxErrorLen {
+			result.Error = strings.ToValidUTF8(result.Error[:maxErrorLen-len(truncated)], "") + truncated
+		}
 	}
 	result.Value = stdout.String()
 	return result

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -631,7 +631,7 @@ func (a *agent) runLoop() {
 }
 
 func (a *agent) collectMetadata(ctx context.Context, md codersdk.WorkspaceAgentMetadataDescription, now time.Time) *codersdk.WorkspaceAgentMetadataResult {
-	var out bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	result := &codersdk.WorkspaceAgentMetadataResult{
 		// CollectedAt is set here for testing purposes and overrode by
 		// coderd to the time of server receipt to solve clock skew.
@@ -647,8 +647,11 @@ func (a *agent) collectMetadata(ctx context.Context, md codersdk.WorkspaceAgentM
 	}
 	cmd := cmdPty.AsExec()
 
-	cmd.Stdout = &out
-	cmd.Stderr = &out
+	// Shell startup files commonly write to stderr on every invocation, so
+	// stderr must not become part of the reported value. It is surfaced in the
+	// error instead, where it can explain a failure.
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	cmd.Stdin = io.LimitReader(nil, 0)
 
 	// We split up Start and Wait instead of calling Run so that we can return a more precise error.
@@ -661,21 +664,27 @@ func (a *agent) collectMetadata(ctx context.Context, md codersdk.WorkspaceAgentM
 	// This error isn't mutually exclusive with useful output.
 	err = cmd.Wait()
 	const bufLimit = 10 << 10
-	if out.Len() > bufLimit {
+	if stdout.Len() > bufLimit {
 		err = errors.Join(
 			err,
-			xerrors.Errorf("output truncated from %v to %v bytes", out.Len(), bufLimit),
+			xerrors.Errorf("output truncated from %v to %v bytes", stdout.Len(), bufLimit),
 		)
-		out.Truncate(bufLimit)
+		stdout.Truncate(bufLimit)
+	}
+	if stderr.Len() > bufLimit {
+		stderr.Truncate(bufLimit)
 	}
 
 	// Important: if the command times out, we may see a misleading error like
 	// "exit status 1", so it's important to include the context error.
 	err = errors.Join(err, ctx.Err())
 	if err != nil {
+		if stderr.Len() > 0 {
+			err = errors.Join(err, xerrors.Errorf("stderr: %s", strings.TrimSpace(stderr.String())))
+		}
 		result.Error = fmt.Sprintf("run cmd: %+v", err)
 	}
-	result.Value = out.String()
+	result.Value = stdout.String()
 	return result
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1842,6 +1842,11 @@ func TestAgent_Metadata(t *testing.T) {
 					Interval: 0,
 					Script:   "echo 'permission denied' >&2; exit 1",
 				},
+				{
+					Key:      "long_stderr",
+					Interval: 0,
+					Script:   "echo 'permission denied: " + strings.Repeat("界", 4096) + "' >&2; echo 'hello'; exit 1",
+				},
 			},
 		}, 0, func(_ *agenttest.Client, opts *agent.Options) {
 			opts.ReportMetadataInterval = testutil.IntervalFast
@@ -1850,7 +1855,7 @@ func TestAgent_Metadata(t *testing.T) {
 		var gotMd map[string]agentsdk.Metadata
 		require.Eventually(t, func() bool {
 			gotMd = client.GetMetadata()
-			return len(gotMd) == 2
+			return len(gotMd) == 3
 		}, testutil.WaitShort, testutil.IntervalFast/2)
 
 		// A script that succeeds reports stdout only, even when the shell
@@ -1862,6 +1867,14 @@ func TestAgent_Metadata(t *testing.T) {
 		// explain the failure.
 		require.Empty(t, strings.TrimSpace(gotMd["failing"].Value))
 		require.Contains(t, gotMd["failing"].Error, "permission denied")
+
+		// Keep diagnostics within the server's error budget, including the marker.
+		require.Equal(t, "hello", strings.TrimSpace(gotMd["long_stderr"].Value))
+		require.Contains(t, gotMd["long_stderr"].Error, "exit status 1")
+		require.Contains(t, gotMd["long_stderr"].Error, "permission denied")
+		require.LessOrEqual(t, len(gotMd["long_stderr"].Error), 2048)
+		require.True(t, strings.HasSuffix(gotMd["long_stderr"].Error, " [truncated]"))
+		require.Equal(t, strings.ToValidUTF8(gotMd["long_stderr"].Error, ""), gotMd["long_stderr"].Error)
 	})
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1821,6 +1821,48 @@ func TestAgent_Metadata(t *testing.T) {
 			t.Fatalf("expected metadata to be collected again")
 		}
 	})
+
+	t.Run("Stderr", func(t *testing.T) {
+		t.Parallel()
+
+		if runtime.GOOS == "windows" {
+			t.Skip("stderr redirection test uses sh syntax")
+		}
+
+		//nolint:dogsled
+		_, client, _, _, _ := setupAgent(t, agentsdk.Manifest{
+			Metadata: []codersdk.WorkspaceAgentMetadataDescription{
+				{
+					Key:      "noisy",
+					Interval: 0,
+					Script:   "echo 'shell startup noise' >&2; echo 'hello'",
+				},
+				{
+					Key:      "failing",
+					Interval: 0,
+					Script:   "echo 'permission denied' >&2; exit 1",
+				},
+			},
+		}, 0, func(_ *agenttest.Client, opts *agent.Options) {
+			opts.ReportMetadataInterval = testutil.IntervalFast
+		})
+
+		var gotMd map[string]agentsdk.Metadata
+		require.Eventually(t, func() bool {
+			gotMd = client.GetMetadata()
+			return len(gotMd) == 2
+		}, testutil.WaitShort, testutil.IntervalFast/2)
+
+		// A script that succeeds reports stdout only, even when the shell
+		// wrote to stderr on startup.
+		require.Equal(t, "hello", strings.TrimSpace(gotMd["noisy"].Value))
+		require.Empty(t, gotMd["noisy"].Error)
+
+		// A script that fails reports stderr in the error, where it can
+		// explain the failure.
+		require.Empty(t, strings.TrimSpace(gotMd["failing"].Value))
+		require.Contains(t, gotMd["failing"].Error, "permission denied")
+	})
 }
 
 func TestAgentMetadata_Timing(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/coder/terraform-provider-coder/issues/208

Metadata values currently include stderr, so shell startup warnings can appear beside the actual value. This change separates them. It reports stdout as the value and keeps stderr in the error when a script fails. Test covers both cases.

I reproduced this with a minimal Terraform template whose metadata script writes `demo warning` to stderr and `hello` to stdout. With the same template, the agent on `main` showed `demo warning hello`; the fixed agent showed `hello`.

```terraform
....
metadata {
      display_name = "Greeting"
      key          = "greeting"
      script       = "printf 'demo warning\\n' >&2; printf 'hello\\n'"
      interval     = 5
      timeout      = 5
    }
...
```

**Before:**

<img width="1493" height="571" alt="Screenshot 2026-09-07 at 10 05 32 PM" src="https://github.com/user-attachments/assets/d8b169f7-8ab7-4d2e-8e1d-6bc115c281f9" />

**After:**
<img width="1496" height="569" alt="Screenshot 2026-09-07 at 10 07 15 PM" src="https://github.com/user-attachments/assets/a864d28e-b0fb-46b3-b22a-7065f7e46a7e" />

This uses the same approach as the closed PR #25101. I did not copy its code.

## Open Question:
StdErr values is not displayed. It remains available through the API. 
Showing the error text would need a separate UI change.

AI disclosure: I used AI to research the code path, review the fix, run checks, and help write this PR. I also reproduced the before/after behavior locally myself and take responsibility for this contribution.
