### PR TITLE
refactor(site/src/pages/AgentsPage): treat route agentId as required

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -158,7 +158,7 @@ const buildAttachmentMediaTypes = (
 };
 
 const AgentChatPage: FC = () => {
-	const { agentId } = useParams<{ agentId: string }>();
+	const { agentId } = useParams() as { agentId: string };
 	const {
 		chatErrorReasons,
 		setChatErrorReason,
@@ -174,19 +174,16 @@ const AgentChatPage: FC = () => {
 	const isEditReasoningEffortDirtyRef = useRef(false);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
-		agentId
-			? parseStoredDraft(
-					localStorage.getItem(`${draftInputStorageKeyPrefix}${agentId}`),
-				).text
-			: "",
+		parseStoredDraft(
+			localStorage.getItem(`${draftInputStorageKeyPrefix}${agentId}`),
+		).text,
 	);
 
 	const { showSidebarPanel, handleSetShowSidebarPanel } =
 		useAgentChatPanelPreference();
 
 	const chatQuery = useQuery({
-		...openChat(agentId ?? ""),
-		enabled: Boolean(agentId),
+		...openChat(agentId),
 		// Poll while the chat runs (this override replaces openChat's
 		// interval, and queued_for_capacity depends on the poll) or while
 		// the binding is unresolved: repair happens on chat reads and watch
@@ -210,15 +207,15 @@ const AgentChatPage: FC = () => {
 		refetchIntervalInBackground: false,
 	});
 	const chatOrganizationId = chatQuery.data?.organization_id ?? "";
-	const chatMessagesQuery = useInfiniteQuery({
-		...chatMessagesForInfiniteScroll(agentId ?? ""),
-		enabled: Boolean(agentId),
-	});
+	const chatMessagesQuery = useInfiniteQuery(
+		chatMessagesForInfiniteScroll(agentId),
+	);
 	const parentChatID = getParentChatID(chatQuery.data);
 	const parentChatQuery = useQuery({
 		...chatById(parentChatID ?? ""),
 		enabled: Boolean(parentChatID),
 	});
+	const parentChat = parentChatQuery.data;
 	const workspaceId = chatQuery.data?.workspace_id;
 	const chatAgentId = chatQuery.data?.agent_id;
 	const workspaceQuery = useQuery({
@@ -340,7 +337,6 @@ const AgentChatPage: FC = () => {
 		if (chat?.mcp_server_ids) {
 			return chat.mcp_server_ids;
 		}
-		// Check for a previously saved selection in localStorage.
 		const saved = chatOrganizationId
 			? getSavedMCPSelection(
 					chatOrganizationId,
@@ -395,29 +391,29 @@ const AgentChatPage: FC = () => {
 	// spread). Keeping no intermediate variable prevents future code
 	// from accidentally closing over the unstable object.
 	const { isPending: isSendPending, mutateAsync: sendMessage } = useMutation(
-		createChatMessage(queryClient, agentId ?? ""),
+		createChatMessage(queryClient, agentId),
 	);
 	const { isPending: isEditPending, mutateAsync: editMessage } = useMutation(
-		editChatMessage(queryClient, agentId ?? ""),
+		editChatMessage(queryClient, agentId),
 	);
 	const { isPending: isInterruptPending, mutateAsync: interrupt } = useMutation(
-		interruptChat(queryClient, agentId ?? ""),
+		interruptChat(queryClient, agentId),
 	);
 	const { isPending: isCompactPending, mutateAsync: compact } = useMutation(
-		compactChat(queryClient, agentId ?? ""),
+		compactChat(queryClient, agentId),
 	);
 	const { isPending: isClearPending, mutateAsync: clearChatContext } =
-		useMutation(clearChat(queryClient, agentId ?? ""));
+		useMutation(clearChat(queryClient, agentId));
 	const personalSkillsQuery = useQuery({
 		...userSkills(),
 		staleTime: 60_000,
 	});
 	const chatWorkspaceSkills = workspaceSkillsFromChat(chatQuery.data);
 	const { mutateAsync: deleteQueuedMessage } = useMutation(
-		deleteChatQueuedMessage(queryClient, agentId ?? ""),
+		deleteChatQueuedMessage(queryClient, agentId),
 	);
 	const { mutateAsync: promoteQueuedMessage } = useMutation(
-		promoteChatQueuedMessage(queryClient, agentId ?? ""),
+		promoteChatQueuedMessage(queryClient, agentId),
 	);
 	const updateChatWorkspaceBase = updateChatWorkspace(queryClient);
 	const {
@@ -497,7 +493,7 @@ const AgentChatPage: FC = () => {
 	const persistedError = getPersistedDetailError({
 		chatStatus: liveChatStatus,
 		chatRecord: chat,
-		cachedError: agentId ? chatErrorReasons[agentId] : undefined,
+		cachedError: chatErrorReasons[agentId],
 	});
 
 	// Git watcher: runs regardless of sidebar visibility, but only
@@ -624,7 +620,7 @@ const AgentChatPage: FC = () => {
 	const isWorkspaceLoading =
 		workspacesQuery.isLoading || isUpdateChatWorkspacePending;
 	const handlePlanModeToggle = (enabled: boolean) => {
-		if (!agentId || enabled === planModeEnabled) {
+		if (enabled === planModeEnabled) {
 			return;
 		}
 		trackPendingChatSettingSync(
@@ -637,7 +633,7 @@ const AgentChatPage: FC = () => {
 	};
 
 	const handleRequestError = (error: unknown): void => {
-		if (!agentId || !isApiError(error)) {
+		if (!isApiError(error)) {
 			return;
 		}
 		const detail = error.response?.data?.detail?.trim() || undefined;
@@ -656,14 +652,14 @@ const AgentChatPage: FC = () => {
 	};
 
 	const handleInterrupt = () => {
-		if (!agentId || isInterruptPending) {
+		if (isInterruptPending) {
 			return;
 		}
 		void interrupt();
 	};
 
 	const handleWorkspaceChange = (nextWorkspaceId: string | null) => {
-		if (!agentId || nextWorkspaceId === selectedWorkspaceId) {
+		if (nextWorkspaceId === selectedWorkspaceId) {
 			return;
 		}
 		trackPendingChatSettingSync(
@@ -731,7 +727,7 @@ const AgentChatPage: FC = () => {
 		) {
 			return;
 		}
-		chatReadyFiredRef.current = agentId ?? null;
+		chatReadyFiredRef.current = agentId;
 		onChatReady();
 	}, [
 		onChatReady,
@@ -825,7 +821,7 @@ const AgentChatPage: FC = () => {
 			attachments,
 			useComposerContent,
 		});
-		if (!hasContent || isSubmissionPending || !agentId || !hasModelOptions) {
+		if (!hasContent || isSubmissionPending || !hasModelOptions) {
 			return;
 		}
 		// Wait for chat-setting mutations to settle before sending so the
@@ -1148,7 +1144,7 @@ const AgentChatPage: FC = () => {
 						}}
 					/>
 				)
-			) : !chat || !chatMessagesQuery.data?.pages?.length || !agentId ? (
+			) : !chat || !chatMessagesQuery.data?.pages?.length ? (
 				<AgentChatPageNotFoundView />
 			) : (
 				<AgentChatPageView
@@ -1158,7 +1154,7 @@ const AgentChatPage: FC = () => {
 						preferencesQuery.data?.agent_chat_send_shortcut,
 						preferencesQuery.isLoading,
 					)}
-					parentChat={parentChatQuery.data}
+					parentChat={parentChat}
 					persistedError={persistedError}
 					canShareChat={canShareChat}
 					workspace={workspace}
@@ -1231,6 +1227,9 @@ const AgentChatPage: FC = () => {
 // editing, queries, scroller) cleanly.
 const KeyedAgentChatPage: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
+	if (!agentId) {
+		return <AgentChatPageNotFoundView />;
+	}
 	return (
 		<MessageScroller.Provider
 			key={agentId}


### PR DESCRIPTION
AgentChatPage now treats the :agentId route param as required, matching WorkspacePage, instead of coercing a missing id to "". Queries and mutations take that string directly.

Depends on #29065

- KeyedAgentChatPage renders not-found when the param is missing
- Drop agentId ?? "" and enabled: Boolean(agentId) from chat queries
- Drop !agentId guards from send, interrupt, workspace, and plan-mode handlers