### PR TITLE
refactor: read send shortcut from AgentChatInput

### DIFF
--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -403,12 +403,12 @@ export const updateAppearanceSettings = (
 	};
 };
 
-const myPreferencesKey = ["me", "preferences"];
+export const preferenceSettingsKey = ["me", "preferences"] as const;
 
 export const preferenceSettings =
 	(): UseQueryOptions<UserPreferenceSettings> => {
 		return {
-			queryKey: myPreferencesKey,
+			queryKey: preferenceSettingsKey,
 			queryFn: () => API.getUserPreferenceSettings(),
 		};
 	};
@@ -425,7 +425,7 @@ export const updatePreferenceSettings = (
 		mutationFn: (req) => API.updateUserPreferenceSettings(req),
 		onSuccess: async () =>
 			await queryClient.invalidateQueries({
-				queryKey: myPreferencesKey,
+				queryKey: preferenceSettingsKey,
 			}),
 	};
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -21,6 +21,7 @@ import {
 	toChatListParams,
 	userChatProviderConfigsKey,
 } from "#/api/queries/chats";
+import { preferenceSettings } from "#/api/queries/users";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
@@ -38,6 +39,7 @@ import {
 	MockOrganizationMember,
 	MockOrganizationMember2,
 	MockUserOwner,
+	MockUserPreferenceSettings,
 	MockWorkspace,
 	MockWorkspaceAgent,
 	mockApiError,
@@ -380,6 +382,10 @@ const buildQueries = (
 				allowed: chat.owner_id === MockUserOwner.id && !chat.parent_chat_id,
 			},
 		}),
+		{
+			key: preferenceSettings().queryKey,
+			data: MockUserPreferenceSettings,
+		},
 	];
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -21,7 +21,7 @@ import {
 	toChatListParams,
 	userChatProviderConfigsKey,
 } from "#/api/queries/chats";
-import { preferenceSettings } from "#/api/queries/users";
+import { preferenceSettingsKey } from "#/api/queries/users";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
@@ -383,7 +383,7 @@ const buildQueries = (
 			},
 		}),
 		{
-			key: preferenceSettings().queryKey,
+			key: preferenceSettingsKey,
 			data: MockUserPreferenceSettings,
 		},
 	];

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -46,7 +46,6 @@ import {
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
 import { userSkills } from "#/api/queries/userSkills";
-import { preferenceSettings } from "#/api/queries/users";
 import {
 	workspaceById,
 	workspaceByIdKey,
@@ -112,7 +111,6 @@ import {
 	useConversationEditingState,
 } from "./hooks/useConversationEditingState";
 import { useGitWatcher } from "./hooks/useGitWatcher";
-import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
 import {
 	draftInputStorageKeyPrefix,
 	parseStoredDraft,
@@ -231,7 +229,6 @@ const AgentChatPage: FC = () => {
 		enabled: permissions.editDeploymentConfig,
 	});
 	const userThresholdsQuery = useQuery(userCompactionThresholds());
-	const preferencesQuery = useQuery(preferenceSettings());
 	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
 	const mcpServersQuery = useQuery({
 		...mcpServerConfigs(chatOrganizationId),
@@ -1104,10 +1101,6 @@ const AgentChatPage: FC = () => {
 			</title>
 			{chatQuery.isLoading || chatMessagesQuery.isLoading ? (
 				<AgentChatPageLoadingView
-					sendShortcut={getAgentChatSendShortcut(
-						preferencesQuery.data?.agent_chat_send_shortcut,
-						preferencesQuery.isLoading,
-					)}
 					inputRef={editing.chatInputRef}
 					initialValue={editing.editorInitialValue}
 					initialEditorState={editing.initialEditorState}
@@ -1150,10 +1143,6 @@ const AgentChatPage: FC = () => {
 				<AgentChatPageView
 					key={agentId}
 					chat={chat}
-					sendShortcut={getAgentChatSendShortcut(
-						preferencesQuery.data?.agent_chat_send_shortcut,
-						preferencesQuery.isLoading,
-					)}
 					parentChat={parentChat}
 					persistedError={persistedError}
 					canShareChat={canShareChat}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
-import { preferenceSettings } from "#/api/queries/users";
+import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
@@ -231,7 +231,7 @@ const meta: Meta<typeof AgentChatPageView> = {
 		user: MockUserOwner,
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 		],

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
@@ -24,6 +25,7 @@ import {
 	MockOrganizationMember,
 	MockOrganizationMember2,
 	MockUserOwner,
+	MockUserPreferenceSettings,
 	MockWorkspace,
 	MockWorkspaceAgent,
 	MockWorkspaceApp,
@@ -159,7 +161,6 @@ const StoryAgentChatPageView: FC<StoryProps> = ({
 
 	const props = {
 		chat: buildChat(chat),
-		sendShortcut: "enter" as const,
 		persistedError: undefined as ChatDetailError | undefined,
 		parentChat: undefined as TypesGen.Chat | undefined,
 		effectiveSelectedModel: defaultModelID,
@@ -228,6 +229,12 @@ const meta: Meta<typeof AgentChatPageView> = {
 	parameters: {
 		layout: "fullscreen",
 		user: MockUserOwner,
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
+		],
 		reactRouter: reactRouterParameters({
 			location: {
 				path: `/agents/${AGENT_ID}`,
@@ -939,7 +946,6 @@ export const WorkspaceNoAgent: Story = {
 export const Loading: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
-			sendShortcut="enter"
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -960,7 +966,6 @@ export const Loading: Story = {
 export const LoadingWithModelOptions: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
-			sendShortcut="enter"
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -980,7 +985,6 @@ export const LoadingWithModelOptions: Story = {
 export const LoadingWithRightPanel: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
-			sendShortcut="enter"
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}
@@ -1002,7 +1006,6 @@ export const LoadingSidebarCollapsed: Story = {
 	parameters: { reactRouter: collapsedSidebarRouter },
 	render: () => (
 		<AgentChatPageLoadingView
-			sendShortcut="enter"
 			inputRef={{ current: null }}
 			initialValue=""
 			initialEditorState={undefined}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -11,10 +11,7 @@ import { useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
 import { invalidateChatDiffContents } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
-import type {
-	AgentChatSendShortcut,
-	ChatMessagePart,
-} from "#/api/typesGenerated";
+import type { ChatMessagePart } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
@@ -109,7 +106,6 @@ interface EditingState {
 
 interface AgentChatPageViewProps {
 	chat: TypesGen.Chat;
-	sendShortcut: AgentChatSendShortcut;
 	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
 	canShareChat: boolean;
@@ -285,7 +281,6 @@ const UserTabContent: FC<UserTabContentProps> = ({
 
 export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	chat,
-	sendShortcut,
 	parentChat,
 	persistedError,
 	canShareChat,
@@ -928,7 +923,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 scrollbar-gutter-stable scrollbar-thin">
 								<ChatPageInput
 									chat={chat}
-									sendShortcut={sendShortcut}
 									store={store}
 									compressionThreshold={compressionThreshold}
 									onSend={editing.handleSendFromInput}
@@ -1016,7 +1010,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 };
 
 interface AgentChatPageLoadingViewProps {
-	sendShortcut: AgentChatSendShortcut;
 	inputRef: RefObject<ChatMessageInputRef | null>;
 	initialValue: string;
 	initialEditorState: string | undefined;
@@ -1039,7 +1032,6 @@ interface AgentChatPageLoadingViewProps {
 }
 
 export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
-	sendShortcut,
 	inputRef,
 	initialValue,
 	initialEditorState,
@@ -1086,7 +1078,6 @@ export const AgentChatPageLoadingView: FC<AgentChatPageLoadingViewProps> = ({
 				<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 scrollbar-gutter-stable scrollbar-thin">
 					<AgentChatInput
 						onSend={() => {}}
-						sendShortcut={sendShortcut}
 						inputRef={inputRef}
 						initialValue={initialValue}
 						initialEditorState={initialEditorState}

--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import { createChat } from "#/api/queries/chats";
-import { preferenceSettings } from "#/api/queries/users";
 import { workspaces } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import { useWebpushNotifications } from "#/contexts/useWebpushNotifications";
@@ -17,7 +16,6 @@ import {
 import { AgentPageHeader } from "./components/AgentPageHeader";
 import { ChimeButton } from "./components/ChimeButton";
 import { WebPushButton } from "./components/WebPushButton";
-import { getAgentChatSendShortcut } from "./utils/agentChatSendShortcut";
 import { getChimeEnabled, setChimeEnabled } from "./utils/chime";
 import { buildAgentChatPath } from "./utils/navigation";
 
@@ -29,7 +27,6 @@ const AgentCreatePage: FC = () => {
 	const navigate = useNavigate();
 	const { permissions } = useAuthenticated();
 	const aiGatewayDisabled = !useAIGatewayEnabled();
-	const preferencesQuery = useQuery(preferenceSettings());
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const createMutation = useMutation(createChat(queryClient));
 	const webPush = useWebpushNotifications();
@@ -108,10 +105,6 @@ const AgentCreatePage: FC = () => {
 			</AgentPageHeader>
 			<AgentCreateForm
 				onCreateChat={handleCreateChat}
-				sendShortcut={getAgentChatSendShortcut(
-					preferencesQuery.data?.agent_chat_send_shortcut,
-					preferencesQuery.isLoading,
-				)}
 				isCreating={createMutation.isPending}
 				createError={createMutation.error}
 				canCreateChat={permissions.createChat}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -3,12 +3,17 @@ import { MonitorDotIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	MockChatContextClean,
 	MockMCPServerConfig,
 } from "#/testHelpers/chatEntities";
-import { MockWorkspace, MockWorkspaceAgent } from "#/testHelpers/entities";
+import {
+	MockUserPreferenceSettings,
+	MockWorkspace,
+	MockWorkspaceAgent,
+} from "#/testHelpers/entities";
 import { createMockFile } from "#/testHelpers/files";
 import { withProxyProvider, withToaster } from "#/testHelpers/storybook";
 import {
@@ -33,9 +38,16 @@ const meta: Meta<typeof AgentChatInput> = {
 	title: "pages/AgentsPage/AgentChatInput",
 	component: AgentChatInput,
 	decorators: [withProxyProvider()],
+	parameters: {
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
+		],
+	},
 	args: {
 		onSend: fn(),
-		sendShortcut: "enter",
 		onContentChange: fn(),
 		onModelChange: fn(),
 		initialValue: "",
@@ -239,9 +251,19 @@ export const EnterSendsByDefault: Story = {
 };
 
 export const ModifierEnterSendsWhenRequired: Story = {
+	parameters: {
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: {
+					...MockUserPreferenceSettings,
+					agent_chat_send_shortcut: "modifier_enter",
+				},
+			},
+		],
+	},
 	args: {
 		onSend: fn(),
-		sendShortcut: "modifier_enter",
 		initialValue: "Run focused tests",
 	},
 	play: async ({ canvasElement, args }) => {

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -3,7 +3,7 @@ import { MonitorDotIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
-import { preferenceSettings } from "#/api/queries/users";
+import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
 	MockChatContextClean,
@@ -41,7 +41,7 @@ const meta: Meta<typeof AgentChatInput> = {
 	parameters: {
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 		],
@@ -254,7 +254,7 @@ export const ModifierEnterSendsWhenRequired: Story = {
 	parameters: {
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: {
 					...MockUserPreferenceSettings,
 					agent_chat_send_shortcut: "modifier_enter",

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -22,16 +22,14 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { useMutation, useQueryClient } from "react-query";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { getErrorMessage } from "#/api/errors";
 import { disconnectMCPServerOAuth2 } from "#/api/queries/chats";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
-import type {
-	AgentChatSendShortcut,
-	ChatQueuedMessage,
-} from "#/api/typesGenerated";
+import type { ChatQueuedMessage } from "#/api/typesGenerated";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import {
@@ -69,7 +67,7 @@ import { useMCPOAuthFlow } from "../hooks/useMCPOAuthFlow";
 import { useOverflowCount } from "../hooks/useOverflowCount";
 import { useSpeechRecognition } from "../hooks/useSpeechRecognition";
 import {
-	DEFAULT_AGENT_CHAT_SEND_SHORTCUT,
+	getAgentChatSendShortcut,
 	MODIFIER_AGENT_CHAT_SEND_SHORTCUT,
 } from "../utils/agentChatSendShortcut";
 import {
@@ -105,7 +103,6 @@ export type { AgentContextUsage } from "./ContextUsageIndicator";
 
 interface AgentChatInputProps {
 	onSend: (message: string) => void;
-	sendShortcut?: AgentChatSendShortcut;
 	placeholder?: string;
 	isDisabled: boolean;
 	isLoading: boolean;
@@ -363,7 +360,6 @@ const ToolBadge: FC<{
 
 export const AgentChatInput: FC<AgentChatInputProps> = ({
 	onSend,
-	sendShortcut = DEFAULT_AGENT_CHAT_SEND_SHORTCUT,
 	placeholder = "Type a message...",
 	isDisabled,
 	isLoading,
@@ -424,6 +420,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	aiGatewayDisabled,
 	slashCommands,
 }) => {
+	const preferencesQuery = useQuery(preferenceSettings());
+	const sendShortcut = getAgentChatSendShortcut(
+		preferencesQuery.data?.agent_chat_send_shortcut,
+		preferencesQuery.isLoading,
+	);
 	const [chatFullWidth] = useChatFullWidth();
 	const showAgentSetupNotice =
 		aiGatewayDisabled ||

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -20,7 +20,7 @@ import {
 	userChatProviderConfigsKey,
 } from "#/api/queries/chats";
 import { permittedOrganizationsKey } from "#/api/queries/organizations";
-import { preferenceSettings } from "#/api/queries/users";
+import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import {
@@ -288,7 +288,7 @@ const meta: Meta<typeof AgentCreateForm> = {
 				data: buildPersonalModelOverridesResponse(),
 			},
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 		],

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -20,6 +20,7 @@ import {
 	userChatProviderConfigsKey,
 } from "#/api/queries/chats";
 import { permittedOrganizationsKey } from "#/api/queries/organizations";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
 import {
@@ -30,6 +31,7 @@ import { createDeferred, type Deferred } from "#/testHelpers/deferred";
 import {
 	MockDefaultOrganization,
 	MockOrganization2,
+	MockUserPreferenceSettings,
 	MockWorkspace,
 } from "#/testHelpers/entities";
 import { withDashboardProvider } from "#/testHelpers/storybook";
@@ -262,7 +264,6 @@ const meta: Meta<typeof AgentCreateForm> = {
 	decorators: [withDashboardProvider],
 	args: {
 		onCreateChat: fn(),
-		sendShortcut: "enter",
 		isCreating: false,
 		createError: undefined,
 		canCreateChat: true,
@@ -286,6 +287,10 @@ const meta: Meta<typeof AgentCreateForm> = {
 					.queryKey,
 				data: buildPersonalModelOverridesResponse(),
 			},
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
 		],
 	},
 	beforeEach: () => {
@@ -298,6 +303,9 @@ const meta: Meta<typeof AgentCreateForm> = {
 			API.experimental,
 			"getUserChatPersonalModelOverrides",
 		).mockResolvedValue(buildPersonalModelOverridesResponse());
+		spyOn(API, "getUserPreferenceSettings").mockResolvedValue(
+			MockUserPreferenceSettings,
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -10,7 +10,6 @@ import {
 } from "#/api/queries/chats";
 import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
-import type { AgentChatSendShortcut } from "#/api/typesGenerated";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { ConfirmDialog } from "#/components/Dialog/ConfirmDialog/ConfirmDialog";
@@ -132,7 +131,6 @@ export function useEmptyStateDraft() {
 
 interface AgentCreateFormProps {
 	onCreateChat: (options: CreateChatOptions) => Promise<void>;
-	sendShortcut: AgentChatSendShortcut;
 	isCreating: boolean;
 	createError: unknown;
 	canCreateChat: boolean;
@@ -146,7 +144,6 @@ interface AgentCreateFormProps {
 
 export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	onCreateChat,
-	sendShortcut,
 	isCreating,
 	createError,
 	canCreateChat,
@@ -636,7 +633,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						)}
 					<AgentChatInput
 						onSend={handleSendWithAttachments}
-						sendShortcut={sendShortcut}
 						placeholder="Ask Coder to build, fix bugs, or explore your project..."
 						isDisabled={
 							isCreating ||

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -2,7 +2,7 @@ import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
-import { preferenceSettings } from "#/api/queries/users";
+import { preferenceSettingsKey } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
 import { MockUserPreferenceSettings } from "#/testHelpers/entities";
@@ -34,7 +34,7 @@ const meta = {
 	parameters: {
 		queries: [
 			{
-				key: preferenceSettings().queryKey,
+				key: preferenceSettingsKey,
 				data: MockUserPreferenceSettings,
 			},
 		],

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -2,8 +2,10 @@ import { MessageScroller } from "@shadcn/react/message-scroller";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { MockChat, MockChatQueuedMessage } from "#/testHelpers/chatEntities";
+import { MockUserPreferenceSettings } from "#/testHelpers/entities";
 import { ChatWorkspaceContext } from "../context/ChatWorkspaceContext";
 import { createChatStore } from "./ChatConversation/chatStore";
 import { FIXTURE_NOW } from "./ChatConversation/storyFixtures";
@@ -29,6 +31,14 @@ const StoryChatPageTimeline: FC<{
 
 const meta = {
 	title: "pages/AgentsPage/ChatPageContent",
+	parameters: {
+		queries: [
+			{
+				key: preferenceSettings().queryKey,
+				data: MockUserPreferenceSettings,
+			},
+		],
+	},
 } satisfies Meta;
 
 export default meta;
@@ -48,7 +58,6 @@ const StoryChatPageInput: FC<{
 			store={store}
 			compressionThreshold={undefined}
 			onSend={fn()}
-			sendShortcut="enter"
 			onDeleteQueuedMessage={fn()}
 			onPromoteQueuedMessage={fn()}
 			onInterrupt={onInterrupt ?? fn()}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -5,7 +5,6 @@ import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
 import { chatPromptsQuery, refreshChatContext } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
-import type { AgentChatSendShortcut } from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/modules/aiModels/ModelSelector";
 import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
@@ -245,7 +244,6 @@ interface ChatPageInputProps {
 		message: string,
 		attachments?: readonly PendingAttachment[],
 	) => Promise<void> | void;
-	sendShortcut: AgentChatSendShortcut;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
 	onInterrupt: () => void;
@@ -306,7 +304,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	store,
 	compressionThreshold,
 	onSend,
-	sendShortcut,
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
 	onInterrupt,
@@ -544,7 +541,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 					}
 				})();
 			}}
-			sendShortcut={sendShortcut}
 			attachments={attachments}
 			onAttach={handleAttach}
 			onRemoveAttachment={handleRemoveAttachment}

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -505,6 +505,14 @@ export const MockSiteRoles = [
 	MockWorkspaceCreationBanRole,
 ];
 
+export const MockUserPreferenceSettings: TypesGen.UserPreferenceSettings = {
+	task_notification_alert_dismissed: false,
+	thinking_display_mode: "auto",
+	shell_tool_display_mode: "auto",
+	code_diff_display_mode: "auto",
+	agent_chat_send_shortcut: "enter",
+};
+
 export const MockUserOwner: TypesGen.User = {
 	id: "test-user",
 	username: "TestUser",


### PR DESCRIPTION
AgentChatInput now loads the send shortcut preference itself instead of taking it from AgentChatPage, AgentCreatePage, the view, ChatPageContent, and AgentCreateForm. Loading still uses modifier_enter so Enter cannot send a draft before the stored preference lands.

Depends on #29067

- Drop sendShortcut from AgentChatPage, AgentCreatePage, AgentChatPageView, ChatPageContent, and AgentCreateForm
- AgentChatInput reads preferenceSettings through getAgentChatSendShortcut
- Stories seed MockUserPreferenceSettings on the preference query